### PR TITLE
Add ubisoft.com and ubi.com as equivalent domains

### DIFF
--- a/src/Core/Enums/GlobalEquivalentDomainsType.cs
+++ b/src/Core/Enums/GlobalEquivalentDomainsType.cs
@@ -77,5 +77,6 @@
         Airbnb = 72,
         Eventbrite = 73,
         StackExchange = 74,
+        Ubisoft = 75,
     }
 }


### PR DESCRIPTION
Sorry, not sure how to do this as 1 pull request using GitHub web interface.  If you know how, please advise.