### PR TITLE
Feature/use docker compose file version 3 4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,11 @@ stack: node 10
 
 init:
 - ps: |
+    if($isWindows -and $env:DEBUG_RDP -eq "true") {
+      iex ((new-object net.webclient).DownloadString(`
+        'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+    }
+- ps: |
     if($isWindows) {
       Install-Product node 10
     }
@@ -86,3 +91,11 @@ test_script:
     if($isWindows) {
       dotnet test .\test\Core.Test\Core.Test.csproj --configuration Debug --no-build
     }
+
+on_finish:
+  - ps: |
+      if($isWindows -and $env:DEBUG_RDP -eq "true") {
+        $blockRdp = $true
+        iex ((new-object net.webclient).DownloadString(`
+          'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+      }

--- a/util/Setup/DockerComposeBuilder.cs
+++ b/util/Setup/DockerComposeBuilder.cs
@@ -62,7 +62,7 @@ namespace Bit.Setup
                 }
             }
 
-            public string ComposeVersion { get; set; } = "3";
+            public string ComposeVersion { get; set; } = "3.4";
             public bool MssqlDataDockerVolume { get; set; }
             public string HttpPort { get; set; }
             public string HttpsPort { get; set; }


### PR DESCRIPTION
To be able to run bitwarden on AWS ECS FARGATE for example, I need to copy all project files into the container images (there is no accessible host filesystem as this is "serverless").

To achieve that we need to add a `Dockerfile` to `bwdata` and a `docker-compose.override.yml` file to `bwdata/docker`.

To keep that manageable we'd like to specify multiple targets in the `Dockerfile` (for every image), which we can reference from the `docker-compose.override.yml` file.

Specifying targets in a `Dockerfile` can only be done from Compose file version `3.4`, hence this PR. :smile: 