### PR TITLE
Added permission check before chown on ssl certificates directories

### DIFF
--- a/util/Nginx/entrypoint.sh
+++ b/util/Nginx/entrypoint.sh
@@ -31,10 +31,16 @@ mkhomedir_helper $USERNAME
 
 chown -R $USERNAME:$GROUPNAME /etc/bitwarden
 cp /etc/bitwarden/nginx/default.conf /etc/nginx/conf.d/default.conf
-mkdir -p /etc/letsencrypt
-chown -R $USERNAME:$GROUPNAME /etc/letsencrypt
-mkdir -p /etc/ssl
-chown -R $USERNAME:$GROUPNAME /etc/ssl
+if ! gosu $USERNAME:$GROUPNAME test -r /etc/letsencrypt/live
+then
+    mkdir -p /etc/letsencrypt
+    chown -R $USERNAME:$GROUPNAME /etc/letsencrypt
+fi
+if ! gosu $USERNAME:$GROUPNAME test -r /etc/ssl
+then
+    mkdir -p /etc/ssl
+    chown -R $USERNAME:$GROUPNAME /etc/ssl
+fi
 mkdir -p /var/run/nginx
 touch /var/run/nginx/nginx.pid
 chown -R $USERNAME:$GROUPNAME /var/run/nginx


### PR DESCRIPTION
On installations with custom ssl management (/etc/ssl or /etc/letsencrypt in docker mapped to another folder in host), the bitwarden user takes ownership of all the certificates in the folder.

By checking if the bitwarden user can access the certificates folders before chowning it and only doing it when we cannot access them, we can avoid breaking other services on the host.