### PR TITLE
Support reading a file for the SA_PASSWORD for swarm security.

### DIFF
--- a/util/MsSql/entrypoint.sh
+++ b/util/MsSql/entrypoint.sh
@@ -27,6 +27,17 @@ useradd -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1 ||
 usermod -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1
 mkhomedir_helper $USERNAME
 
+# Read the SA_PASSWORD value from a file for swarm environments.
+# See https://github.com/Microsoft/mssql-docker/issues/326
+if [ ! -z "$SA_PASSWORD" ] && [ ! -z "$SA_PASSWORD_FILE" ]; then
+    echo "Provided both SA_PASSWORD and SA_PASSWORD_FILE environment variables. Please only use one."
+    exit 1
+fi
+if [ ! -z "$SA_PASSWORD_FILE" ]; then
+    # It should be exported, so it is available to the env command below.
+    export SA_PASSWORD=$(cat $SA_PASSWORD_FILE)
+fi
+
 # The rest...
 
 # ref: https://stackoverflow.com/a/38850273


### PR DESCRIPTION
As pointed out at https://github.com/Microsoft/mssql-docker/issues/326
And explained in detail at https://blog.dbi-services.com/managing-sql-server-sa-credentials-with-docker-secrets-on-swarm/

Swarms should use secrets and not ENV vars.
The MSSQL image doesn't support this out of the box (it should though) so it needs to be worked around in the entrypoint.

This behavior can be tested with the docker stack and expermental build `beanow/bitwarden-mssql:latest` below:
```yml
version: '3.4'
services:
  mssql:
    image: beanow/bitwarden-mssql:latest
    environment:
      ACCEPT_EULA: 'Y'
      MSSQL_PID: Express
      # This is new and will require a change to this image's entrypoint.
      SA_PASSWORD_FILE: /run/secrets/sa_password
    secrets:
      - uid: 65534
        gid: 65534
        mode: 0400
        source: bitwarden_mssql_sa_password.1.txt
        target: sa_password

# ...

secrets:
  bitwarden_mssql_sa_password.1.txt:
    external: true
```