### PR TITLE
Add basic Core.Services test files

### DIFF
--- a/test/Core.Test/Services/AmazonSesMailDeliveryServiceTests.cs
+++ b/test/Core.Test/Services/AmazonSesMailDeliveryServiceTests.cs
@@ -1,0 +1,43 @@
+using System;
+using Bit.Core.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class AmazonSesMailDeliveryServiceTests : IDisposable
+    {
+        private readonly AmazonSesMailDeliveryService _sut;
+
+        private readonly GlobalSettings _globalSettings;
+        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly ILogger<AmazonSesMailDeliveryService> _logger;
+
+        public AmazonSesMailDeliveryServiceTests()
+        {
+            _globalSettings = new GlobalSettings();
+            _hostingEnvironment = Substitute.For<IHostingEnvironment>();
+            _logger = Substitute.For<ILogger<AmazonSesMailDeliveryService>>();
+            _sut = new AmazonSesMailDeliveryService(
+                _globalSettings,
+                _hostingEnvironment,
+                _logger
+            );
+        }
+
+        public void Dispose()
+        {
+            _sut?.Dispose();
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact(Skip = "Needs additional work")]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/AmazonSqsBlockIpServiceTests.cs
+++ b/test/Core.Test/Services/AmazonSqsBlockIpServiceTests.cs
@@ -1,0 +1,34 @@
+using System;
+using Bit.Core.Services;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class AmazonSqsBlockIpServiceTests : IDisposable
+    {
+        private readonly AmazonSqsBlockIpService _sut;
+
+        private readonly GlobalSettings _globalSettings;
+
+        public AmazonSqsBlockIpServiceTests()
+        {
+            _globalSettings = new GlobalSettings();
+
+            _sut = new AmazonSqsBlockIpService(_globalSettings);
+        }
+
+        public void Dispose()
+        {
+            _sut?.Dispose();
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact(Skip = "Needs additional work")]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/AzureAttachmentStorageServiceTests.cs
+++ b/test/Core.Test/Services/AzureAttachmentStorageServiceTests.cs
@@ -1,0 +1,29 @@
+using System;
+using Bit.Core.Services;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class AzureAttachmentStorageServiceTests
+    {
+        private readonly AzureAttachmentStorageService _sut;
+
+        private readonly GlobalSettings _globalSettings;
+
+        public AzureAttachmentStorageServiceTests()
+        {
+            _globalSettings = new GlobalSettings();
+
+            _sut = new AzureAttachmentStorageService(_globalSettings);
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact(Skip = "Needs additional work")]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/AzureQueueBlockIpServiceTests.cs
+++ b/test/Core.Test/Services/AzureQueueBlockIpServiceTests.cs
@@ -1,0 +1,29 @@
+using System;
+using Bit.Core.Services;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class AzureQueueBlockIpServiceTests
+    {
+        private readonly AzureQueueBlockIpService _sut;
+
+        private readonly GlobalSettings _globalSettings;
+
+        public AzureQueueBlockIpServiceTests()
+        {
+            _globalSettings = new GlobalSettings();
+
+            _sut = new AzureQueueBlockIpService(_globalSettings);
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact(Skip = "Needs additional work")]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/AzureQueueEventWriteServiceTests.cs
+++ b/test/Core.Test/Services/AzureQueueEventWriteServiceTests.cs
@@ -1,0 +1,35 @@
+using System;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class AzureQueueEventWriteServiceTests
+    {
+        private readonly AzureQueueEventWriteService _sut;
+
+        private readonly GlobalSettings _globalSettings;
+        private readonly IEventRepository _eventRepository;
+
+        public AzureQueueEventWriteServiceTests()
+        {
+            _globalSettings = new GlobalSettings();
+            _eventRepository = Substitute.For<IEventRepository>();
+
+            _sut = new AzureQueueEventWriteService(
+                _eventRepository,
+                _globalSettings
+            );
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact(Skip = "Needs additional work")]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/AzureQueuePushNotificationServiceTests.cs
+++ b/test/Core.Test/Services/AzureQueuePushNotificationServiceTests.cs
@@ -1,0 +1,35 @@
+using System;
+using Bit.Core.Services;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class AzureQueuePushNotificationServiceTests
+    {
+        private readonly AzureQueuePushNotificationService _sut;
+
+        private readonly GlobalSettings _globalSettings;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public AzureQueuePushNotificationServiceTests()
+        {
+            _globalSettings = new GlobalSettings();
+            _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+
+            _sut = new AzureQueuePushNotificationService(
+                _globalSettings,
+                _httpContextAccessor
+            );
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact(Skip = "Needs additional work")]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/CipherServiceTests.cs
+++ b/test/Core.Test/Services/CipherServiceTests.cs
@@ -1,0 +1,65 @@
+using System;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class CipherServiceTests
+    {
+        private readonly CipherService _sut;
+
+        private readonly ICipherRepository _cipherRepository;
+        private readonly IFolderRepository _folderRepository;
+        private readonly ICollectionRepository _collectionRepository;
+        private readonly IUserRepository _userRepository;
+        private readonly IOrganizationRepository _organizationRepository;
+        private readonly IOrganizationUserRepository _organizationUserRepository;
+        private readonly ICollectionCipherRepository _collectionCipherRepository;
+        private readonly IPushNotificationService _pushService;
+        private readonly IAttachmentStorageService _attachmentStorageService;
+        private readonly IEventService _eventService;
+        private readonly IUserService _userService;
+        private readonly GlobalSettings _globalSettings;
+
+        public CipherServiceTests()
+        {
+            _cipherRepository = Substitute.For<ICipherRepository>();
+            _folderRepository = Substitute.For<IFolderRepository>();
+            _collectionRepository = Substitute.For<ICollectionRepository>();
+            _userRepository = Substitute.For<IUserRepository>();
+            _organizationRepository = Substitute.For<IOrganizationRepository>();
+            _organizationUserRepository = Substitute.For<IOrganizationUserRepository>();
+            _collectionCipherRepository = Substitute.For<ICollectionCipherRepository>();
+            _pushService = Substitute.For<IPushNotificationService>();
+            _attachmentStorageService = Substitute.For<IAttachmentStorageService>();
+            _eventService = Substitute.For<IEventService>();
+            _userService = Substitute.For<IUserService>();
+            _globalSettings = new GlobalSettings();
+
+            _sut = new CipherService(
+                _cipherRepository,
+                _folderRepository,
+                _collectionRepository,
+                _userRepository,
+                _organizationRepository,
+                _organizationUserRepository,
+                _collectionCipherRepository,
+                _pushService,
+                _attachmentStorageService,
+                _eventService,
+                _userService,
+                _globalSettings
+            );
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/EventServiceTests.cs
+++ b/test/Core.Test/Services/EventServiceTests.cs
@@ -1,0 +1,44 @@
+using System;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class EventServiceTests
+    {
+        private readonly EventService _sut;
+
+        private readonly IEventWriteService _eventWriteService;
+        private readonly IOrganizationUserRepository _organizationUserRepository;
+        private readonly IApplicationCacheService _applicationCacheService;
+        private readonly CurrentContext _currentContext;
+        private readonly GlobalSettings _globalSettings;
+
+        public EventServiceTests()
+        {
+            _eventWriteService = Substitute.For<IEventWriteService>();
+            _organizationUserRepository = Substitute.For<IOrganizationUserRepository>();
+            _applicationCacheService = Substitute.For<IApplicationCacheService>();
+            _currentContext = new CurrentContext();
+            _globalSettings = new GlobalSettings();
+
+            _sut = new EventService(
+                _eventWriteService,
+                _organizationUserRepository,
+                _applicationCacheService,
+                _currentContext,
+                _globalSettings
+            );
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/GroupServiceTests.cs
+++ b/test/Core.Test/Services/GroupServiceTests.cs
@@ -1,0 +1,41 @@
+using System;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class GroupServiceTests
+    {
+        private readonly GroupService _sut;
+
+        private readonly IEventService _eventService;
+        private readonly IOrganizationRepository _organizationRepository;
+        private readonly IOrganizationUserRepository _organizationUserRepository;
+        private readonly IGroupRepository _groupRepository;
+
+        public GroupServiceTests()
+        {
+            _eventService = Substitute.For<IEventService>();
+            _organizationRepository = Substitute.For<IOrganizationRepository>();
+            _organizationUserRepository = Substitute.For<IOrganizationUserRepository>();
+            _groupRepository = Substitute.For<IGroupRepository>();
+
+            _sut = new GroupService(
+                _eventService,
+                _organizationRepository,
+                _organizationUserRepository,
+                _groupRepository
+            );
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/HandlebarsMailServiceTests.cs
+++ b/test/Core.Test/Services/HandlebarsMailServiceTests.cs
@@ -1,0 +1,34 @@
+using System;
+using Bit.Core.Services;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class HandlebarsMailServiceTests
+    {
+        private readonly HandlebarsMailService _sut;
+
+        private readonly GlobalSettings _globalSettings;
+        private readonly IMailDeliveryService _mailDeliveryService;
+
+        public HandlebarsMailServiceTests()
+        {
+            _globalSettings = new GlobalSettings();
+            _mailDeliveryService = Substitute.For<IMailDeliveryService>();
+
+            _sut = new HandlebarsMailService(
+                _globalSettings,
+                _mailDeliveryService
+            );
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/InMemoryApplicationCacheServiceTests.cs
+++ b/test/Core.Test/Services/InMemoryApplicationCacheServiceTests.cs
@@ -1,0 +1,30 @@
+using System;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class InMemoryApplicationCacheServiceTests
+    {
+        private readonly InMemoryApplicationCacheService _sut;
+
+        private readonly IOrganizationRepository _organizationRepository;
+
+        public InMemoryApplicationCacheServiceTests()
+        {
+            _organizationRepository = Substitute.For<IOrganizationRepository>();
+
+            _sut = new InMemoryApplicationCacheService(_organizationRepository);
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/InMemoryServiceBusApplicationCacheServiceTests.cs
+++ b/test/Core.Test/Services/InMemoryServiceBusApplicationCacheServiceTests.cs
@@ -1,0 +1,35 @@
+using System;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class InMemoryServiceBusApplicationCacheServiceTests
+    {
+        private readonly InMemoryServiceBusApplicationCacheService _sut;
+
+        private readonly IOrganizationRepository _organizationRepository;
+        private readonly GlobalSettings _globalSettings;
+
+        public InMemoryServiceBusApplicationCacheServiceTests()
+        {
+            _organizationRepository = Substitute.For<IOrganizationRepository>();
+            _globalSettings = new GlobalSettings();
+
+            _sut = new InMemoryServiceBusApplicationCacheService(
+                _organizationRepository,
+                _globalSettings
+            );
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact(Skip = "Needs additional work")]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/LicensingServiceTests.cs
+++ b/test/Core.Test/Services/LicensingServiceTests.cs
@@ -1,0 +1,49 @@
+using System;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class LicensingServiceTests
+    {
+        private readonly LicensingService _sut;
+
+        private readonly GlobalSettings _globalSettings;
+        private readonly IUserRepository _userRepository;
+        private readonly IOrganizationRepository _organizationRepository;
+        private readonly IOrganizationUserRepository _organizationUserRepository;
+        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly ILogger<LicensingService> _logger;
+
+        public LicensingServiceTests()
+        {
+            _userRepository = Substitute.For<IUserRepository>();
+            _organizationRepository = Substitute.For<IOrganizationRepository>();
+            _organizationUserRepository = Substitute.For<IOrganizationUserRepository>();
+            _hostingEnvironment = Substitute.For<IHostingEnvironment>();
+            _logger = Substitute.For<ILogger<LicensingService>>();
+            _globalSettings = new GlobalSettings();
+
+            _sut = new LicensingService(
+                _userRepository,
+                _organizationRepository,
+                _organizationUserRepository,
+                _hostingEnvironment,
+                _logger,
+                _globalSettings
+            );
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact(Skip = "Needs additional work")]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/LocalAttachmentStorageServiceTests.cs
+++ b/test/Core.Test/Services/LocalAttachmentStorageServiceTests.cs
@@ -1,0 +1,29 @@
+using System;
+using Bit.Core.Services;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class LocalAttachmentStorageServiceTests
+    {
+        private readonly LocalAttachmentStorageService _sut;
+
+        private readonly GlobalSettings _globalSettings;
+
+        public LocalAttachmentStorageServiceTests()
+        {
+            _globalSettings = new GlobalSettings();
+
+            _sut = new LocalAttachmentStorageService(_globalSettings);
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/MailKitSmtpMailDeliveryServiceTests.cs
+++ b/test/Core.Test/Services/MailKitSmtpMailDeliveryServiceTests.cs
@@ -1,0 +1,38 @@
+using System;
+using Bit.Core.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class MailKitSmtpMailDeliveryServiceTests
+    {
+        private readonly MailKitSmtpMailDeliveryService _sut;
+
+        private readonly GlobalSettings _globalSettings;
+        private readonly ILogger<MailKitSmtpMailDeliveryService> _logger;
+
+        public MailKitSmtpMailDeliveryServiceTests()
+        {
+            _globalSettings = new GlobalSettings();
+            _logger = Substitute.For<ILogger<MailKitSmtpMailDeliveryService>>();
+
+            _globalSettings.Mail.Smtp.Host = "unittests.example.com";
+            _globalSettings.Mail.ReplyToEmail = "noreply@unittests.example.com";
+
+            _sut = new MailKitSmtpMailDeliveryService(
+                _globalSettings,
+                _logger
+            );
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/MultiServicePushNotificationServiceTests.cs
+++ b/test/Core.Test/Services/MultiServicePushNotificationServiceTests.cs
@@ -1,0 +1,52 @@
+using System;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class MultiServicePushNotificationServiceTests
+    {
+        private readonly MultiServicePushNotificationService _sut;
+
+        private readonly IDeviceRepository _deviceRepository;
+        private readonly IInstallationDeviceRepository _installationDeviceRepository;
+        private readonly GlobalSettings _globalSettings;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly ILogger<MultiServicePushNotificationService> _logger;
+        private readonly ILogger<RelayPushNotificationService> _relayLogger;
+        private readonly ILogger<NotificationsApiPushNotificationService> _hubLogger;
+
+        public MultiServicePushNotificationServiceTests()
+        {
+            _deviceRepository = Substitute.For<IDeviceRepository>();
+            _installationDeviceRepository = Substitute.For<IInstallationDeviceRepository>();
+            _globalSettings = new GlobalSettings();
+            _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+            _logger = Substitute.For<ILogger<MultiServicePushNotificationService>>();
+            _relayLogger = Substitute.For<ILogger<RelayPushNotificationService>>();
+            _hubLogger = Substitute.For<ILogger<NotificationsApiPushNotificationService>>();
+
+            _sut = new MultiServicePushNotificationService(
+                _deviceRepository,
+                _installationDeviceRepository,
+                _globalSettings,
+                _httpContextAccessor,
+                _logger,
+                _relayLogger,
+                _hubLogger
+            );
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/NotificationHubPushNotificationServiceTests.cs
+++ b/test/Core.Test/Services/NotificationHubPushNotificationServiceTests.cs
@@ -1,0 +1,39 @@
+using System;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class NotificationHubPushNotificationServiceTests
+    {
+        private readonly NotificationHubPushNotificationService _sut;
+
+        private readonly IInstallationDeviceRepository _installationDeviceRepository;
+        private readonly GlobalSettings _globalSettings;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public NotificationHubPushNotificationServiceTests()
+        {
+            _installationDeviceRepository = Substitute.For<IInstallationDeviceRepository>();
+            _globalSettings = new GlobalSettings();
+            _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+
+            _sut = new NotificationHubPushNotificationService(
+                _installationDeviceRepository,
+                _globalSettings,
+                _httpContextAccessor
+            );
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact(Skip = "Needs additional work")]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/NotificationHubPushRegistrationServiceTests.cs
+++ b/test/Core.Test/Services/NotificationHubPushRegistrationServiceTests.cs
@@ -1,0 +1,35 @@
+using System;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class NotificationHubPushRegistrationServiceTests
+    {
+        private readonly NotificationHubPushRegistrationService _sut;
+
+        private readonly IInstallationDeviceRepository _installationDeviceRepository;
+        private readonly GlobalSettings _globalSettings;
+
+        public NotificationHubPushRegistrationServiceTests()
+        {
+            _installationDeviceRepository = Substitute.For<IInstallationDeviceRepository>();
+            _globalSettings = new GlobalSettings();
+
+            _sut = new NotificationHubPushRegistrationService(
+                _installationDeviceRepository,
+                _globalSettings
+            );
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact(Skip = "Needs additional work")]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/NotificationsApiPushNotificationServiceTests.cs
+++ b/test/Core.Test/Services/NotificationsApiPushNotificationServiceTests.cs
@@ -1,0 +1,39 @@
+using System;
+using Bit.Core.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class NotificationsApiPushNotificationServiceTests
+    {
+        private readonly NotificationsApiPushNotificationService _sut;
+
+        private readonly GlobalSettings _globalSettings;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly ILogger<NotificationsApiPushNotificationService> _logger;
+
+        public NotificationsApiPushNotificationServiceTests()
+        {
+            _globalSettings = new GlobalSettings();
+            _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+            _logger = Substitute.For<ILogger<NotificationsApiPushNotificationService>>();
+
+            _sut = new NotificationsApiPushNotificationService(
+                _globalSettings,
+                _httpContextAccessor,
+                _logger
+            );
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact(Skip = "Needs additional work")]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/RelayPushNotificationServiceTests.cs
+++ b/test/Core.Test/Services/RelayPushNotificationServiceTests.cs
@@ -1,0 +1,43 @@
+using System;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class RelayPushNotificationServiceTests
+    {
+        private readonly RelayPushNotificationService _sut;
+
+        private readonly IDeviceRepository _deviceRepository;
+        private readonly GlobalSettings _globalSettings;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly ILogger<RelayPushNotificationService> _logger;
+
+        public RelayPushNotificationServiceTests()
+        {
+            _deviceRepository = Substitute.For<IDeviceRepository>();
+            _globalSettings = new GlobalSettings();
+            _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+            _logger = Substitute.For<ILogger<RelayPushNotificationService>>();
+
+            _sut = new RelayPushNotificationService(
+                _deviceRepository,
+                _globalSettings,
+                _httpContextAccessor,
+                _logger
+            );
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact(Skip = "Needs additional work")]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/RelayPushRegistrationServiceTests.cs
+++ b/test/Core.Test/Services/RelayPushRegistrationServiceTests.cs
@@ -1,0 +1,35 @@
+using System;
+using Bit.Core.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class RelayPushRegistrationServiceTests
+    {
+        private readonly RelayPushRegistrationService _sut;
+
+        private readonly GlobalSettings _globalSettings;
+        private readonly ILogger<RelayPushRegistrationService> _logger;
+
+        public RelayPushRegistrationServiceTests()
+        {
+            _globalSettings = new GlobalSettings();
+            _logger = Substitute.For<ILogger<RelayPushRegistrationService>>();
+
+            _sut = new RelayPushRegistrationService(
+                _globalSettings,
+                _logger
+            );
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact(Skip = "Needs additional work")]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/RepositoryEventWriteServiceTests.cs
+++ b/test/Core.Test/Services/RepositoryEventWriteServiceTests.cs
@@ -1,0 +1,30 @@
+using System;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class RepositoryEventWriteServiceTests
+    {
+        private readonly RepositoryEventWriteService _sut;
+
+        private readonly IEventRepository _eventRepository;
+
+        public RepositoryEventWriteServiceTests()
+        {
+            _eventRepository = Substitute.For<IEventRepository>();
+
+            _sut = new RepositoryEventWriteService(_eventRepository);
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/SendGridMailDeliveryServiceTests.cs
+++ b/test/Core.Test/Services/SendGridMailDeliveryServiceTests.cs
@@ -1,0 +1,29 @@
+using System;
+using Bit.Core.Services;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class SendGridMailDeliveryServiceTests
+    {
+        private readonly SendGridMailDeliveryService _sut;
+
+        private readonly GlobalSettings _globalSettings;
+
+        public SendGridMailDeliveryServiceTests()
+        {
+            _globalSettings = new GlobalSettings();
+
+            _sut = new SendGridMailDeliveryService(_globalSettings);
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact(Skip = "Needs additional work")]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/SmtpMailDeliveryServiceTests.cs
+++ b/test/Core.Test/Services/SmtpMailDeliveryServiceTests.cs
@@ -1,0 +1,35 @@
+using System;
+using Bit.Core.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class SmtpMailDeliveryServiceTests
+    {
+        private readonly SmtpMailDeliveryService _sut;
+
+        private readonly GlobalSettings _globalSettings;
+        private readonly ILogger<SmtpMailDeliveryService> _logger;
+
+        public SmtpMailDeliveryServiceTests()
+        {
+            _globalSettings = new GlobalSettings();
+            _logger = Substitute.For<ILogger<SmtpMailDeliveryService>>();
+
+            _globalSettings.Mail.Smtp.Host = "unittests.example.com";
+            _globalSettings.Mail.ReplyToEmail = "noreply@unittests.example.com";
+
+            _sut = new SmtpMailDeliveryService(_globalSettings, _logger);
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/StripePaymentServiceTests.cs
+++ b/test/Core.Test/Services/StripePaymentServiceTests.cs
@@ -1,0 +1,39 @@
+using System;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class StripePaymentServiceTests
+    {
+        private readonly StripePaymentService _sut;
+
+        private readonly ITransactionRepository _transactionRepository;
+        private readonly GlobalSettings _globalSettings;
+        private readonly ILogger<StripePaymentService> _logger;
+
+        public StripePaymentServiceTests()
+        {
+            _transactionRepository = Substitute.For<ITransactionRepository>();
+            _globalSettings = new GlobalSettings();
+            _logger = Substitute.For<ILogger<StripePaymentService>>();
+
+            _sut = new StripePaymentService(
+                _transactionRepository,
+                _globalSettings,
+                _logger
+            );
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}

--- a/test/Core.Test/Services/UserServiceTests.cs
+++ b/test/Core.Test/Services/UserServiceTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using Bit.Core.Models.Table;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class UserServiceTests
+    {
+        private readonly UserService _sut;
+
+        private readonly IUserRepository _userRepository;
+        private readonly ICipherRepository _cipherRepository;
+        private readonly IOrganizationUserRepository _organizationUserRepository;
+        private readonly IOrganizationRepository _organizationRepository;
+        private readonly IU2fRepository _u2fRepository;
+        private readonly IMailService _mailService;
+        private readonly IPushNotificationService _pushService;
+        private readonly IUserStore<User> _userStore;
+        private readonly IOptions<IdentityOptions> _optionsAccessor;
+        private readonly IPasswordHasher<User> _passwordHasher;
+        private readonly IEnumerable<IUserValidator<User>> _userValidators;
+        private readonly IEnumerable<IPasswordValidator<User>> _passwordValidators;
+        private readonly ILookupNormalizer _keyNormalizer;
+        private readonly IdentityErrorDescriber _errors;
+        private readonly IServiceProvider _services;
+        private readonly ILogger<UserManager<User>> _logger;
+        private readonly ILicensingService _licenseService;
+        private readonly IEventService _eventService;
+        private readonly IApplicationCacheService _applicationCacheService;
+        private readonly IDataProtectionProvider _dataProtectionProvider;
+        private readonly IPaymentService _paymentService;
+        private readonly CurrentContext _currentContext;
+        private readonly GlobalSettings _globalSettings;
+
+        public UserServiceTests()
+        {
+            _userRepository = Substitute.For<IUserRepository>();
+            _cipherRepository = Substitute.For<ICipherRepository>();
+            _organizationUserRepository = Substitute.For<IOrganizationUserRepository>();
+            _organizationRepository = Substitute.For<IOrganizationRepository>();
+            _u2fRepository = Substitute.For<IU2fRepository>();
+            _mailService = Substitute.For<IMailService>();
+            _pushService = Substitute.For<IPushNotificationService>();
+            _userStore = Substitute.For<IUserStore<User>>();
+            _optionsAccessor = Substitute.For<IOptions<IdentityOptions>>();
+            _passwordHasher = Substitute.For<IPasswordHasher<User>>();
+            _userValidators = new List<IUserValidator<User>>();
+            _passwordValidators = new List<IPasswordValidator<User>>();
+            _keyNormalizer = Substitute.For<ILookupNormalizer>();
+            _errors = new IdentityErrorDescriber();
+            _services = Substitute.For<IServiceProvider>();
+            _logger = Substitute.For<ILogger<UserManager<User>>>();
+            _licenseService = Substitute.For<ILicensingService>();
+            _eventService = Substitute.For<IEventService>();
+            _applicationCacheService = Substitute.For<IApplicationCacheService>();
+            _dataProtectionProvider = Substitute.For<IDataProtectionProvider>();
+            _paymentService = Substitute.For<IPaymentService>();
+            _currentContext = new CurrentContext();
+            _globalSettings = new GlobalSettings();
+
+            _sut = new UserService(
+                _userRepository,
+                _cipherRepository,
+                _organizationUserRepository,
+                _organizationRepository,
+                _u2fRepository,
+                _mailService,
+                _pushService,
+                _userStore,
+                _optionsAccessor,
+                _passwordHasher,
+                _userValidators,
+                _passwordValidators,
+                _keyNormalizer,
+                _errors,
+                _services,
+                _logger,
+                _licenseService,
+                _eventService,
+                _applicationCacheService,
+                _dataProtectionProvider,
+                _paymentService,
+                _currentContext,
+                _globalSettings
+            );
+        }
+
+        // Remove this test when we add actual tests. It only proves that
+        // we've properly constructed the system under test.
+        [Fact]
+        public void ServiceExists()
+        {
+            Assert.NotNull(_sut);
+        }
+    }
+}


### PR DESCRIPTION
Relates to #419.

Following the paradigms illustrated in "Working Effectively with Legacy
Code", this commit introduces at least one test for each service class
implementation. This test is a simple construction test -- we just
create each service and assert that it exists. Each test suite includes
a comment instructing the developer who comes next to remove the
constructor test. We don't want to keep these tests as the codebase
matures, as they aren't useful in the longterm. They only prove that we
have that class under test.

Where test suites failed to construct their associated classes, we skip
the test but leave behind the implementation. This is by design, so that
as the constructors for those classes change, we are forced to keep the
test suite current by leaning on the compiler.