### PR TITLE
Revise hard-coded ssl resolver to Cloudflare & Quad9

### DIFF
--- a/util/Setup/Templates/NginxConfig.hbs
+++ b/util/Setup/Templates/NginxConfig.hbs
@@ -43,7 +43,7 @@ server {
 
   # Verify chain of trust of OCSP response using Root CA and Intermediate certs
   ssl_trusted_certificate {{{CaPath}}};
-  resolver 8.8.8.8 8.8.4.4 208.67.222.222 208.67.220.220 valid=300s;
+  resolver 1.1.1.1 1.0.0.1 9.9.9.9 valid=300s;
 {{/if}}
 
   include /etc/nginx/security-headers-ssl.conf;


### PR DESCRIPTION
Google (terrible) and OpenDNS (questionable at best) are not ideal for privacy-minded users.  Both Cloudflare DNS and Quad9 at least claim to drop logs, each of them have widely-reported response times, and they're sufficiently established with over a year of service.