### PR TITLE
Get container name from docker-compose.override.yml

### DIFF
--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -115,7 +115,9 @@ function Update-Lets-Encrypt {
 
 function Update-Database {
     Pull-Setup
-    docker run -it --rm --name setup --network container:bitwarden-mssql `
+    Docker-Compose-Files
+    $mssqlId = docker-compose ps -q mssql
+    docker run -it --rm --name setup --network container:$mssqlId `
         -v ${outputDir}:/bitwarden bitwarden/setup:$coreVersion `
         dotnet Setup.dll -update 1 -db 1 -os win -corev $coreVersion -webv $webVersion -q $setupQuiet
     Write-Line "Database update complete"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -140,9 +140,8 @@ function updateLetsEncrypt() {
 
 function updateDatabase() {
     pullSetup
-    # Admin may have tuned the container name
-    MSSQL_NAME=$(awk -F': *' '/^  mssql:/ {r=1; next} {if(r==1 && ! /^    /){r=0}; if(r==1 && /^    container_name:/) {print $2}}' $DOCKER_DIR/docker-compose.override.yml 2>/dev/null)
-    [ ! "$MSSQL_NAME" ] && MSSQL_NAME=bitwarden-mssql
+    dockerComposeFiles
+    MSSQL_NAME=$(docker-compose ps -q mssql)
     docker run -i --rm --name setup --network container:$MSSQL_NAME \
         -v $OUTPUT_DIR:/bitwarden --env-file $ENV_DIR/uid.env bitwarden/setup:$COREVERSION \
         dotnet Setup.dll -update 1 -db 1 -os $OS -corev $COREVERSION -webv $WEBVERSION

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -140,7 +140,10 @@ function updateLetsEncrypt() {
 
 function updateDatabase() {
     pullSetup
-    docker run -i --rm --name setup --network container:bitwarden-mssql \
+    # Admin may have tuned the container name
+    MSSQL_NAME=$(awk -F': *' '/^  mssql:/ {r=1; next} {if(r==1 && ! /^    /){r=0}; if(r==1 && /^    container_name:/) {print $2}}' $DOCKER_DIR/docker-compose.override.yml 2>/dev/null)
+    [ ! "$MSSQL_NAME" ] && MSSQL_NAME=bitwarden-mssql
+    docker run -i --rm --name setup --network container:$MSSQL_NAME \
         -v $OUTPUT_DIR:/bitwarden --env-file $ENV_DIR/uid.env bitwarden/setup:$COREVERSION \
         dotnet Setup.dll -update 1 -db 1 -os $OS -corev $COREVERSION -webv $WEBVERSION
     echo "Database update complete"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -141,8 +141,8 @@ function updateLetsEncrypt() {
 function updateDatabase() {
     pullSetup
     dockerComposeFiles
-    MSSQL_NAME=$(docker-compose ps -q mssql)
-    docker run -i --rm --name setup --network container:$MSSQL_NAME \
+    MSSQL_ID=$(docker-compose ps -q mssql)
+    docker run -i --rm --name setup --network container:$MSSQL_ID \
         -v $OUTPUT_DIR:/bitwarden --env-file $ENV_DIR/uid.env bitwarden/setup:$COREVERSION \
         dotnet Setup.dll -update 1 -db 1 -os $OS -corev $COREVERSION -webv $WEBVERSION
     echo "Database update complete"


### PR DESCRIPTION
Hi,

It is possible that admin may have tuned the containers' name in `docker-compose.override.yml` file.
In this case, `run.sh` will fail to update database (as docker will not find the proper container).

Here is then a fix which gets mssql container's ID using docker-compose.

Thank you 👍