### PR TITLE
New updateconf scripts method

### DIFF
--- a/scripts/bitwarden.ps1
+++ b/scripts/bitwarden.ps1
@@ -5,6 +5,7 @@ param (
     [switch] $stop,
     [switch] $update,
     [switch] $rebuild,
+    [switch] $updateconf,
     [switch] $updatedb,
     [switch] $updateself,
     [string] $output = ""
@@ -101,6 +102,10 @@ elseif ($update) {
 elseif ($rebuild) {
     Check-Output-Dir-Exists
     Invoke-Expression "& `"$scriptsDir\run.ps1`" -rebuild -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion"
+}
+elseif ($updateconf) {
+    Check-Output-Dir-Exists
+    Invoke-Expression "& `"$scriptsDir\run.ps1`" -updateconf -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion"
 }
 elseif ($updatedb) {
     Check-Output-Dir-Exists

--- a/scripts/bitwarden.sh
+++ b/scripts/bitwarden.sh
@@ -94,6 +94,10 @@ elif [ "$1" == "rebuild" ]
 then
     checkOutputDirExists
     $SCRIPTS_DIR/run.sh rebuild $OUTPUT $COREVERSION $WEBVERSION
+elif [ "$1" == "updateconf" ]
+then
+    checkOutputDirExists
+    $SCRIPTS_DIR/run.sh updateconf $OUTPUT $COREVERSION $WEBVERSION
 elif [ "$1" == "updatedb" ]
 then
     checkOutputDirExists

--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -7,6 +7,7 @@ param (
     [switch] $restart,
     [switch] $stop,
     [switch] $pull,
+    [switch] $updateconf,
     [switch] $updatedb,
     [switch] $update
 )
@@ -168,6 +169,10 @@ elseif ($pull) {
 }
 elseif ($stop) {
     Docker-Compose-Down
+}
+elseif ($updateconf) {
+    Docker-Compose-Down
+    Update -withpull
 }
 elseif ($updatedb) {
     Update-Database

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -176,6 +176,10 @@ then
 elif [ "$1" == "stop" ]
 then
     dockerComposeDown
+elif [ "$1" == "updateconf" ]
+then
+    dockerComposeDown
+    update withpull
 elif [ "$1" == "updatedb" ]
 then
     updateDatabase


### PR DESCRIPTION
Hi,

Here is a PR which brings a new scripts' option, `updateconf`, which updates configuration only, without restarting the containers.
This is useful if admin tuned the default configuration (through `docker-compose.override.yml` for example), he can then quietly check whether or not his tuning is still OK with the new default configuration.
After that he can restart the containers (`start`) and update the database (`updatedb`).

Many thanks 👍 