### PR TITLE
Add proxy_set_header to nginx template to fix redirection problem

### DIFF
--- a/util/Setup/Templates/NginxConfig.hbs
+++ b/util/Setup/Templates/NginxConfig.hbs
@@ -129,5 +129,6 @@ server {
 {{/if}}
     include /etc/nginx/security-headers.conf;
     add_header X-Frame-Options SAMEORIGIN;
+    proxy_set_header Host $host:$server_port;
   }
 }


### PR DESCRIPTION
Without proxy_set_header there was a redirection from host:8443/admin to host:443/admin .
Therefore the admin page was not accessible.