### PR TITLE
Install tzdata package

### DIFF
--- a/util/MsSql/Dockerfile
+++ b/util/MsSql/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         cron \
         gosu \
+        tzdata \
     && rm -rf /var/lib/apt/lists/*
 
 COPY crontab /etc/cron.d/bitwarden-cron


### PR DESCRIPTION
Hi,

We need `tzdata` package to properly set containers time / timezone.
It's in every container but in `mssql` one.

As a test I manually installed it and once timezone set, time was correct, as in other containers.
Impact is rather low :
`After this operation, 2867 kB of additional disk space will be used.`

Thank you 👍