### PR TITLE
DB backups without cron

### DIFF
--- a/util/MsSql/Dockerfile
+++ b/util/MsSql/Dockerfile
@@ -4,12 +4,9 @@ LABEL com.bitwarden.product="bitwarden"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        cron \
         gosu \
     && rm -rf /var/lib/apt/lists/*
 
-COPY crontab /etc/cron.d/bitwarden-cron
-RUN chmod 0644 /etc/cron.d/bitwarden-cron
 COPY backup-db.sql /
 COPY backup-db.sh /
 COPY entrypoint.sh /
@@ -17,6 +14,7 @@ COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh \
     && chmod +x /backup-db.sh
 
+# Does not work unfortunately (https://github.com/bitwarden/server/issues/286)
 RUN /opt/mssql/bin/mssql-conf set telemetry.customerfeedback false
 
 HEALTHCHECK --timeout=3s CMD /opt/mssql-tools/bin/sqlcmd \

--- a/util/MsSql/backup-db.sh
+++ b/util/MsSql/backup-db.sh
@@ -9,17 +9,14 @@ do
   export now=$(date +%Y%m%d_%H%M%S)
 
   # Do a new backup
-  /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -i /backup-db.sql 2>&1 | tee /var/log/backup-db_$now.log
+  /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -i /backup-db.sql 2>&1 | tee /var/opt/mssql/log/backup-db_$now.log
 
   # Delete backup files older than 30 days
   grep -B1 "BACKUP DATABASE successfully" /var/opt/mssql/log/errorlog | grep -q _$now.BAK &&
   find /etc/bitwarden/mssql/backups/ -mindepth 1 -type f -name '*.BAK' -mtime +32 -delete
 
-  # Purge log files
-  find /var/log/ -mindepth 1 -type f -name 'backup-db_*.log' -mtime +32 -delete
-
-  # Remove the old cron log file (remove one day, as it will become useless)
-  find /var/log/ -mindepth 1 -type f -name 'cron.log' -mtime +32 -delete
+  # Purge our log files
+  find /var/opt/mssql/log/ -mindepth 1 -type f -name 'backup-db_*.log' -mtime +32 -delete
 
   # Break if called manually (without loop option)
   [ "$1" != "loop" ] && break

--- a/util/MsSql/backup-db.sh
+++ b/util/MsSql/backup-db.sh
@@ -1,11 +1,26 @@
 #!/bin/sh
 
-# Backup timestamp
-export now=${1:-$(date +%Y%m%d_%H%M%S)}
+while true
+do
+  # Sleep until next day
+  [ "$1" == "loop" ] && sleep $((24 * 3600 - (`date +%H` * 3600 + `date +%M` * 60 + `date +%S`)))
 
-# Do a new backup
-/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -i /backup-db.sql
+  # Backup timestamp
+  export now=$(date +%Y%m%d_%H%M%S)
 
-# Delete backup files older than 30 days
-grep -B1 "BACKUP DATABASE successfully" /var/opt/mssql/log/errorlog | grep -q _$now.BAK &&
-find /etc/bitwarden/mssql/backups/ -mindepth 1 -type f -name '*.BAK' -mtime +32 -delete
+  # Do a new backup
+  /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -i /backup-db.sql 2>&1 | tee /var/log/backup-db_$now.log
+
+  # Delete backup files older than 30 days
+  grep -B1 "BACKUP DATABASE successfully" /var/opt/mssql/log/errorlog | grep -q _$now.BAK &&
+  find /etc/bitwarden/mssql/backups/ -mindepth 1 -type f -name '*.BAK' -mtime +32 -delete
+
+  # Purge log files
+  find /var/log/ -mindepth 1 -type f -name 'backup-db_*.log' -mtime +32 -delete
+
+  # Remove the old cron log file (remove one day, as it will become useless)
+  find /var/log/ -mindepth 1 -type f -name 'cron.log' -mtime +32 -delete
+
+  # Break if called manually (without loop option)
+  [ "$1" != "loop" ] && break
+done

--- a/util/MsSql/backup-db.sh
+++ b/util/MsSql/backup-db.sh
@@ -9,14 +9,11 @@ do
   export now=$(date +%Y%m%d_%H%M%S)
 
   # Do a new backup
-  /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -i /backup-db.sql 2>&1 | tee /var/opt/mssql/log/backup-db_$now.log
+  /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -i /backup-db.sql
 
   # Delete backup files older than 30 days
   grep -B1 "BACKUP DATABASE successfully" /var/opt/mssql/log/errorlog | grep -q _$now.BAK &&
   find /etc/bitwarden/mssql/backups/ -mindepth 1 -type f -name '*.BAK' -mtime +32 -delete
-
-  # Purge our log files
-  find /var/opt/mssql/log/ -mindepth 1 -type f -name 'backup-db_*.log' -mtime +32 -delete
 
   # Break if called manually (without loop option)
   [ "$1" != "loop" ] && break

--- a/util/MsSql/crontab
+++ b/util/MsSql/crontab
@@ -1,3 +1,0 @@
-59 23 * * * bitwarden /backup-db.sh >> /var/log/cron.log 2>&1
-
-# An empty line is required at the end of this file for a valid cron file.

--- a/util/MsSql/entrypoint.sh
+++ b/util/MsSql/entrypoint.sh
@@ -42,9 +42,6 @@ fi
 
 # The rest...
 
-# ref: https://stackoverflow.com/a/38850273
-touch /var/log/cron.log /etc/crontab /etc/cron.*/*
-chown $USERNAME:$GROUPNAME /var/log/cron.log
 mkdir -p /etc/bitwarden/mssql/backups
 chown -R $USERNAME:$GROUPNAME /etc/bitwarden
 mkdir -p /var/opt/mssql/data
@@ -52,8 +49,10 @@ chown -R $USERNAME:$GROUPNAME /var/opt/mssql
 chown $USERNAME:$GROUPNAME /backup-db.sh
 chown $USERNAME:$GROUPNAME /backup-db.sql
 
-# Sounds like gosu keeps env when switching, but of course cron does not
-env > /etc/environment
-cron
+# Launch a loop to backup database on a daily basis
+if [ "$BACKUP_DB" != "0" ]
+then
+    su - bitwarden -s /bin/sh -c "/backup-db.sh loop >/dev/null 2>&1 &"
+fi
 
 exec gosu $USERNAME:$GROUPNAME /opt/mssql/bin/sqlservr

--- a/util/MsSql/entrypoint.sh
+++ b/util/MsSql/entrypoint.sh
@@ -52,7 +52,7 @@ chown $USERNAME:$GROUPNAME /backup-db.sql
 # Launch a loop to backup database on a daily basis
 if [ "$BACKUP_DB" != "0" ]
 then
-    su - bitwarden -s /bin/sh -c "/backup-db.sh loop >/dev/null 2>&1 &"
+    gosu $USERNAME:$GROUPNAME /bin/sh -c "/backup-db.sh loop >/dev/null 2>&1 &"
 fi
 
 exec gosu $USERNAME:$GROUPNAME /opt/mssql/bin/sqlservr


### PR DESCRIPTION
Hi,

As in #601, let's get rid of `cron` for database backups.
`cron` was the last process running as root in Bitwarden.
In addition, we don't need it for a unique daily simple task.

Some small additional features :
- admin can disable these daily backups setting env `BACKUP_DB=0` ;
- `backup-db.sh` can still be executed manually to perform a backup whenever admin wants.

Thank you 👍 