### PR TITLE
Use NGINX version 1.17 as base image

### DIFF
--- a/util/Nginx/Dockerfile
+++ b/util/Nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.16
+FROM nginx:1.17
 
 LABEL com.bitwarden.product="bitwarden"
 


### PR DESCRIPTION
Updated to use NGINX version 1.17 as base image instead of 1.16