### PR TITLE
Touch identity log.txt

### DIFF
--- a/src/Identity/entrypoint.sh
+++ b/src/Identity/entrypoint.sh
@@ -32,6 +32,7 @@ mkhomedir_helper $USERNAME
 mkdir -p /etc/bitwarden/identity
 mkdir -p /etc/bitwarden/core
 mkdir -p /etc/bitwarden/logs
+touch /etc/bitwarden/logs/log.txt
 mkdir -p /etc/bitwarden/ca-certificates
 chown -R $USERNAME:$GROUPNAME /etc/bitwarden
 

--- a/src/Identity/entrypoint.sh
+++ b/src/Identity/entrypoint.sh
@@ -31,8 +31,8 @@ mkhomedir_helper $USERNAME
 
 mkdir -p /etc/bitwarden/identity
 mkdir -p /etc/bitwarden/core
-mkdir -p /etc/bitwarden/logs
-touch /etc/bitwarden/logs/log.txt
+mkdir -p /etc/bitwarden/logs/Identity
+touch /etc/bitwarden/logs/Identity/log.txt
 mkdir -p /etc/bitwarden/ca-certificates
 chown -R $USERNAME:$GROUPNAME /etc/bitwarden
 


### PR DESCRIPTION
Hi,

Let's touch identity log.txt so that it's here as soon as the container starts, making Fail2Ban to detect / see it correctly.

Perhaps there's a better way though, for example logging a message when service starts...

Thx 👍