### PR TITLE
Add email notification on Two Factor recovery use

### DIFF
--- a/src/Core/MailTemplates/Handlebars/RecoverTwoFactor.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/RecoverTwoFactor.html.hbs
@@ -1,0 +1,20 @@
+﻿{{#>FullHtmlLayout}}
+<table width="100%" cellpadding="0" cellspacing="0" style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;" valign="top">
+            Your Bitwarden account Two Factor was just reset.
+        </td>
+    </tr>
+    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;" valign="top">
+            <b style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">Date:</b> {{TheDate}} at {{TheTime}} {{TimeZone}}<br style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;" />
+            <b style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">IP Address:</b> {{IpAddress}}
+        </td>
+    </tr>
+    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        <td class="content-block last" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0; -webkit-text-size-adjust: none;" valign="top">
+            If this was not you, you should immediately log in and secure your account.
+        </td>
+    </tr>
+</table>
+{{/FullHtmlLayout}}

--- a/src/Core/MailTemplates/Handlebars/RecoverTwoFactor.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/RecoverTwoFactor.text.hbs
@@ -1,0 +1,8 @@
+﻿{{#>BasicTextLayout}}
+Your Bitwarden account Two Factor was just reset.
+
+Date: {{TheDate}} at {{TheTime}} {{TimeZone}}
+IP Address: {{IpAddress}}
+
+If this was not you, you should immediately log in and secure your account.
+{{/BasicTextLayout}}

--- a/src/Core/Models/Mail/RecoverTwoFactorModel.cs
+++ b/src/Core/Models/Mail/RecoverTwoFactorModel.cs
@@ -1,0 +1,10 @@
+﻿namespace Bit.Core.Models.Mail
+{
+    public class RecoverTwoFactorModel : BaseMailModel
+    {
+        public string TheDate { get; set; }
+        public string TheTime { get; set; }
+        public string TimeZone { get; set; }
+        public string IpAddress { get; set; }
+    }
+}

--- a/src/Core/Services/IMailService.cs
+++ b/src/Core/Services/IMailService.cs
@@ -25,5 +25,6 @@ namespace Bit.Core.Services
         Task SendPaymentFailedAsync(string email, decimal amount, bool mentionInvoices);
         Task SendAddedCreditAsync(string email, decimal amount);
         Task SendNewDeviceLoggedInEmail(string email, string deviceType, DateTime timestamp, string ip);
+        Task SendRecoverTwoFactorEmail(string email, DateTime timestamp, string ip);
     }
 }

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -283,6 +283,23 @@ namespace Bit.Core.Services
             await _mailDeliveryService.SendEmailAsync(message);
         }
 
+        public async Task SendRecoverTwoFactorEmail(string email, DateTime timestamp, string ip)
+        {
+            var message = CreateDefaultMessage($"Recover 2FA From {ip}", email);
+            var model = new RecoverTwoFactorModel
+            {
+                WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
+                SiteName = _globalSettings.SiteName,
+                TheDate = timestamp.ToLongDateString(),
+                TheTime = timestamp.ToShortTimeString(),
+                TimeZone = "UTC",
+                IpAddress = ip
+            };
+            await AddMessageContentAsync(message, "RecoverTwoFactor", model);
+            message.Category = "RecoverTwoFactor";
+            await _mailDeliveryService.SendEmailAsync(message);
+        }
+
         private MailMessage CreateDefaultMessage(string subject, string toEmail)
         {
             return CreateDefaultMessage(subject, new List<string> { toEmail });

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -674,6 +674,7 @@ namespace Bit.Core.Services
             user.TwoFactorProviders = null;
             user.TwoFactorRecoveryCode = CoreHelpers.SecureRandomString(32, upper: false, special: false);
             await SaveUserAsync(user);
+            await _mailService.SendRecoverTwoFactorEmail(user.Email, DateTime.UtcNow, _currentContext.IpAddress);
             await _eventService.LogUserEventAsync(user.Id, EventType.User_Recovered2fa);
 
             return true;

--- a/src/Core/Services/NoopImplementations/NoopMailService.cs
+++ b/src/Core/Services/NoopImplementations/NoopMailService.cs
@@ -87,5 +87,10 @@ namespace Bit.Core.Services
         {
             return Task.FromResult(0);
         }
+
+        public Task SendRecoverTwoFactorEmail(string email, DateTime timestamp, string ip)
+        {
+            return Task.FromResult(0);
+        }
     }
 }


### PR DESCRIPTION
**DISCLAIMER** I could not get a local dev environment running so this has not been tested.  Both api and identity build successfully.  It would be great if more detailed instructions could be provided to get a local dev environment running.

* A user who has lost their 2fa device can clear out the
  2fa settings using a recovery code.  When this happens
  it gets logged but no notification to the user occurs.
* Add a notification to be sent when 2fa recovery code is
  used