### PR TITLE
downloadRunFile when updateself

### DIFF
--- a/scripts/bitwarden.ps1
+++ b/scripts/bitwarden.ps1
@@ -118,6 +118,7 @@ elseif ($start -Or $restart) {
 }
 elseif ($update) {
     Check-Output-Dir-Exists
+    Download-Run-File
     Invoke-Expression "& `"$scriptsDir\run.ps1`" -update -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion"
 }
 elseif ($rebuild) {

--- a/scripts/bitwarden.ps1
+++ b/scripts/bitwarden.ps1
@@ -7,6 +7,7 @@ param (
     [switch] $rebuild,
     [switch] $updateconf,
     [switch] $updatedb,
+    [switch] $updaterun,
     [switch] $updateself,
     [switch] $help,
     [string] $output = ""
@@ -60,6 +61,7 @@ Available commands:
 -stop
 -update
 -updatedb
+-updaterun
 -updateself
 -updateconf
 -rebuild
@@ -134,9 +136,11 @@ elseif ($stop) {
     Check-Output-Dir-Exists
     Invoke-Expression "& `"$scriptsDir\run.ps1`" -stop -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion"
 }
-elseif ($updateself) {
+elseif ($updaterun) {
     Check-Output-Dir-Exists
     Download-Run-File
+}
+elseif ($updateself) {
     Download-Self
     Write-Line "Updated self."
 }

--- a/scripts/bitwarden.ps1
+++ b/scripts/bitwarden.ps1
@@ -116,7 +116,6 @@ elseif ($start -Or $restart) {
 }
 elseif ($update) {
     Check-Output-Dir-Exists
-    Download-Run-File
     Invoke-Expression "& `"$scriptsDir\run.ps1`" -update -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion"
 }
 elseif ($rebuild) {
@@ -136,6 +135,8 @@ elseif ($stop) {
     Invoke-Expression "& `"$scriptsDir\run.ps1`" -stop -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion"
 }
 elseif ($updateself) {
+    Check-Output-Dir-Exists
+    Download-Run-File
     Download-Self
     Write-Line "Updated self."
 }

--- a/scripts/bitwarden.sh
+++ b/scripts/bitwarden.sh
@@ -108,7 +108,6 @@ then
 elif [ "$1" == "update" ]
 then
     checkOutputDirExists
-    downloadRunFile
     $SCRIPTS_DIR/run.sh update $OUTPUT $COREVERSION $WEBVERSION
 elif [ "$1" == "rebuild" ]
 then
@@ -128,6 +127,8 @@ then
     $SCRIPTS_DIR/run.sh stop $OUTPUT $COREVERSION $WEBVERSION
 elif [ "$1" == "updateself" ]
 then
+    checkOutputDirExists
+    downloadRunFile
     downloadSelf && echo "Updated self." && exit
 elif [ "$1" == "help" ]
 then

--- a/scripts/bitwarden.sh
+++ b/scripts/bitwarden.sh
@@ -109,6 +109,7 @@ then
 elif [ "$1" == "update" ]
 then
     checkOutputDirExists
+    downloadRunFile
     $SCRIPTS_DIR/run.sh update $OUTPUT $COREVERSION $WEBVERSION
 elif [ "$1" == "rebuild" ]
 then

--- a/scripts/bitwarden.sh
+++ b/scripts/bitwarden.sh
@@ -83,6 +83,7 @@ restart
 stop
 update
 updatedb
+updaterun
 updateself
 updateconf
 rebuild
@@ -125,10 +126,12 @@ elif [ "$1" == "stop" ]
 then
     checkOutputDirExists
     $SCRIPTS_DIR/run.sh stop $OUTPUT $COREVERSION $WEBVERSION
-elif [ "$1" == "updateself" ]
+elif [ "$1" == "updaterun" ]
 then
     checkOutputDirExists
     downloadRunFile
+elif [ "$1" == "updateself" ]
+then
     downloadSelf && echo "Updated self." && exit
 elif [ "$1" == "help" ]
 then


### PR DESCRIPTION
Hi,

This PR modifies when the run script is downloaded.
We can update Bitwarden using :
- `updateself`, `update`
or :
- `updateself`, `updateconf`, `start`, `updatedb`

With the second method, run file was not updated.
This PR then moves the the run file update into `updateself` option.
Which finally also looks more logical.

Thank you 👍 