### PR TITLE
Stop mssql gently

### DIFF
--- a/util/Setup/Templates/DockerCompose.hbs
+++ b/util/Setup/Templates/DockerCompose.hbs
@@ -20,6 +20,7 @@ services:
     image: bitwarden/mssql:{{{CoreVersion}}}
     container_name: bitwarden-mssql
     restart: always
+    stop_grace_period: 60s
     volumes:
 {{#if MssqlDataDockerVolume}}
       - mssql_data:/var/opt/mssql/data


### PR DESCRIPTION
Hi,
Let's gently wait for mssql to stop properly, during 60 seconds, instead of killing it after the default 10 seconds.
Worth it to wait instead of taking the risk to corrupt data.
Thank you 👍 