### PR TITLE
Add Envato network to equivalent domain sets

### DIFF
--- a/src/Core/Enums/GlobalEquivalentDomainsType.cs
+++ b/src/Core/Enums/GlobalEquivalentDomainsType.cs
@@ -78,5 +78,6 @@
         Eventbrite = 73,
         StackExchange = 74,
         Docusign = 75,
+        Envato = 76,
     }
 }

--- a/src/Core/Utilities/StaticStore.cs
+++ b/src/Core/Utilities/StaticStore.cs
@@ -87,6 +87,7 @@ namespace Bit.Core.Utilities
             GlobalDomains.Add(GlobalEquivalentDomainsType.Eventbrite, new List<string> { "eventbrite.at", "eventbrite.be", "eventbrite.ca", "eventbrite.ch", "eventbrite.cl", "eventbrite.co.id", "eventbrite.co.in", "eventbrite.co.kr", "eventbrite.co.nz", "eventbrite.co.uk", "eventbrite.co.ve", "eventbrite.com", "eventbrite.com.au", "eventbrite.com.bo", "eventbrite.com.br", "eventbrite.com.co", "eventbrite.com.hk", "eventbrite.com.hn", "eventbrite.com.pe", "eventbrite.com.sg", "eventbrite.com.tr", "eventbrite.com.tw", "eventbrite.cz", "eventbrite.de", "eventbrite.dk", "eventbrite.fi", "eventbrite.fr", "eventbrite.gy", "eventbrite.hu", "eventbrite.ie", "eventbrite.is", "eventbrite.it", "eventbrite.jp", "eventbrite.mx", "eventbrite.nl", "eventbrite.no", "eventbrite.pl", "eventbrite.pt", "eventbrite.ru", "eventbrite.se" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.StackExchange, new List<string> { "stackexchange.com", "superuser.com", "stackoverflow.com", "serverfault.com", "mathoverflow.net", "askubuntu.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Docusign, new List<string> { "docusign.com", "docusign.net" });
+            GlobalDomains.Add(GlobalEquivalentDomainsType.Envato, new List<string> { "envato.com", "themeforest.net", "codecanyon.net", "videohive.net", "audiojungle.net", "graphicriver.net", "photodune.net", "3docean.net" });
 
             #endregion
 


### PR DESCRIPTION
Envato is an Alexa top 500 website that asks you to use the same login on many different domains. The login forms are on those domains, not envato.com.

For my use case, account-level domain equivalence rules don’t work because I want to share this with a team, and multiple URLs per login is duplicative because we have multiple Envato logins.

tutsplus.com is another Envato domain that accepts Envato logins, but I believe it also accepts tutsplus.com-specific logins, making it not fully equivalent.