### PR TITLE
Defaults Admins for all organisations on self-hosted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,5 +207,3 @@ src/Core/Properties/launchSettings.json
 **/*.DS_Store
 src/Admin/wwwroot/lib
 src/Admin/wwwroot/css
-scripts/bwdata
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,5 @@ src/Core/Properties/launchSettings.json
 **/*.DS_Store
 src/Admin/wwwroot/lib
 src/Admin/wwwroot/css
+scripts/bwdata
+.vscode

--- a/src/Admin/Models/OrganizationViewModel.cs
+++ b/src/Admin/Models/OrganizationViewModel.cs
@@ -11,7 +11,8 @@ namespace Bit.Admin.Models
     {
         public OrganizationViewModel() { }
 
-        public OrganizationViewModel(Organization org, IEnumerable<OrganizationUserUserDetails> orgUsers)
+        public OrganizationViewModel(Organization org, IEnumerable<OrganizationUserUserDetails> orgUsers,
+            bool selfHosted = false, string adminEmail = null)
         {
             Organization = org;
             UserCount = orgUsers.Count();
@@ -23,11 +24,13 @@ namespace Bit.Admin.Models
                 orgUsers
                 .Where(u => u.Type == OrganizationUserType.Admin && u.Status == OrganizationUserStatusType.Confirmed)
                 .Select(u => u.Email));
+            CanInviteMyself = selfHosted && orgUsers.Where(u => u.Email.Equals(adminEmail)).Count() == 0;
         }
 
         public Organization Organization { get; set; }
         public string Owners { get; set; }
         public string Admins { get; set; }
         public int UserCount { get; set; }
+        public bool CanInviteMyself { get; set; }
     }
 }

--- a/src/Admin/Views/Organizations/View.cshtml
+++ b/src/Admin/Views/Organizations/View.cshtml
@@ -11,3 +11,9 @@
       onsubmit="return confirm('Are you sure you want to delete this organization (@Model.Organization.Name)?')">
     <button class="btn btn-danger" type="submit">Delete</button>
 </form>
+@if(Model.CanInviteMyself)
+{
+    <form asp-action="InviteMyself" asp-route-id="@Model.Organization.Id">
+        <button class="btn btn-primary" type="submit">Invite myself</button>
+    </form>
+}

--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -172,6 +172,11 @@ namespace Bit.Api.Controllers
             }
 
             var result = await _organizationService.SignUpAsync(license, user, model.Key, model.CollectionName);
+            if (_globalSettings.SelfHosted)
+            {
+                await _organizationService.InviteUserAsync(result.Item1.Id, user.Id,
+                    _globalSettings.OrgAdmins.Split(","), Core.Enums.OrganizationUserType.Admin, true, null, null);
+            }
             return new OrganizationResponseModel(result.Item1);
         }
 

--- a/src/Core/GlobalSettings.cs
+++ b/src/Core/GlobalSettings.cs
@@ -40,6 +40,7 @@ namespace Bit.Core
         public virtual AmazonSettings Amazon { get; set; } = new AmazonSettings();
         public virtual ServiceBusSettings ServiceBus { get; set; } = new ServiceBusSettings();
         public virtual AppleIapSettings AppleIap { get; set; } = new AppleIapSettings();
+        public virtual string OrgAdmins { get; set; }
 
         public class BaseServiceUriSettings
         {


### PR DESCRIPTION
I'm not sure this is a useful change for upstream, but thought I'd share it and let you reject it.

Basically the idea is that I want to be the admin for all organsiations created on my server.

So the admins from the config are added to all new organsiations, and when i login to the admin panel i can invite myself to any organsiation on my server.