### PR TITLE
Use correct sentry integration package. Fixes #669

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.AzureDocumentDB" Version="3.8.0" />
-    <PackageReference Include="Serilog.Sinks.Sentry.AspNetCore" Version="2.4.2" />
+    <PackageReference Include="Sentry.Serilog" Version="2.1.0" />
     <PackageReference Include="IdentityServer4" Version="3.1.2" />
     <PackageReference Include="Dapper" Version="2.0.30" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/Core/Utilities/LoggerFactoryExtensions.cs
+++ b/src/Core/Utilities/LoggerFactoryExtensions.cs
@@ -22,10 +22,6 @@ namespace Bit.Core.Utilities
                 return;
             }
 
-            if(CoreHelpers.SettingHasValue(globalSettings?.Sentry.Dsn))
-            {
-                appBuilder.AddSentryContext();
-            }
             applicationLifetime.ApplicationStopped.Register(Log.CloseAndFlush);
         }
 
@@ -72,9 +68,7 @@ namespace Bit.Core.Utilities
             {
                 config.WriteTo.Sentry(globalSettings.Sentry.Dsn)
                     .Enrich.FromLogContext()
-                    .Enrich.WithProperty("Project", globalSettings.ProjectName)
-                    .Destructure.With<HttpContextDestructingPolicy>()
-                    .Filter.ByExcluding(e => e.Exception?.CheckIfCaptured() == true);
+                    .Enrich.WithProperty("Project", globalSettings.ProjectName);
             }
             else if(CoreHelpers.SettingHasValue(globalSettings.LogDirectory))
             {


### PR DESCRIPTION
Replaced "Serilog.Sinks.Sentry.AspNetCore" with "Sentry.Serilog" because the former is not compatible with netcore 3.1.

See notes on https://github.com/olsh/serilog-sinks-sentry

> This is an unofficial library based on the old Raven SDK, the only use case for this is legacy projects (.NET Framework 4.5 to 4.6.0)
> For .NET Framework 4.6.1, .NET Core 2.0, Mono 5.4 or higher, please use the new SDK and the Serilog sink.