### PR TITLE
use message codes in query string

### DIFF
--- a/src/Admin/Controllers/LoginController.cs
+++ b/src/Admin/Controllers/LoginController.cs
@@ -16,19 +16,19 @@ namespace Bit.Admin.Controllers
             _signInManager = signInManager;
         }
 
-        public IActionResult Index(string returnUrl = null, string error = null, string success = null,
+        public IActionResult Index(string returnUrl = null, int? error = null, int? success = null,
             bool accessDenied = false)
         {
-            if (string.IsNullOrWhiteSpace(error) && accessDenied)
+            if (!error.HasValue && accessDenied)
             {
-                error = "Access denied. Please log in.";
+                error = 4;
             }
 
             return View(new LoginModel
             {
                 ReturnUrl = returnUrl,
-                Error = error,
-                Success = success
+                Error = GetMessage(error),
+                Success = GetMessage(success)
             });
         }
 
@@ -41,8 +41,7 @@ namespace Bit.Admin.Controllers
                 await _signInManager.PasswordlessSignInAsync(model.Email, model.ReturnUrl);
                 return RedirectToAction("Index", new
                 {
-                    success = "If a valid admin user with this email address exists, " +
-                        "we've sent you an email with a secure link to log in."
+                    success = 3
                 });
             }
 
@@ -56,7 +55,7 @@ namespace Bit.Admin.Controllers
             {
                 return RedirectToAction("Index", new
                 {
-                    error = "This login confirmation link is invalid. Try logging in again."
+                    error = 2
                 });
             }
 
@@ -75,8 +74,21 @@ namespace Bit.Admin.Controllers
             await _signInManager.SignOutAsync();
             return RedirectToAction("Index", new
             {
-                success = "You have been logged out."
+                success = 1
             });
+        }
+
+        private string GetMessage(int? messageCode)
+        {
+            return messageCode switch
+            {
+                1 => "You have been logged out.",
+                2 => "This login confirmation link is invalid. Try logging in again.",
+                3 => "If a valid admin user with this email address exists, " +
+                    "we've sent you an email with a secure link to log in.",
+                4 => "Access denied. Please log in.",
+                _ => null,
+            };
         }
     }
 }


### PR DESCRIPTION
This issue was brought up by a security researcher that contacted us as a potential way for a malicious actor to inject whatever string they want into our admin login page. Possible abuse cases include the actor including directives for a user to do something to their liking.

