### PR TITLE
Only apply count restriction to non-deleted users

### DIFF
--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -374,7 +374,8 @@ namespace Bit.Api.Controllers
         [HttpPost("{id}/import")]
         public async Task Import(string id, [FromBody]ImportOrganizationUsersRequestModel model)
         {
-            if (!_globalSettings.SelfHosted && (model.Groups.Count() > 200 || model.Users.Count() > 1000))
+            if (!_globalSettings.SelfHosted &&
+                (model.Groups.Count() > 200 || model.Users.Count(u => !u.Deleted) > 1000))
             {
                 throw new BadRequestException("You cannot import this much data at once.");
             }


### PR DESCRIPTION
We have sanity checks on some import operations related to the directory connector tool. We've had a customer email in that is trying to import 16 users, but is still hitting this limit because he has a large database of deleted users in his directory. Since queries to the tombstone (deleted users in LDAP) returns all deleted users in the directory, it is possible that this list is quite large. This change lifts that restriction on the deleted users.