### PR TITLE
Only set channel prefix. Use machine name on counter

### DIFF
--- a/src/Notifications/Jobs/LogConnectionCounterJob.cs
+++ b/src/Notifications/Jobs/LogConnectionCounterJob.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Bit.Core;
 using Bit.Core.Jobs;
 using Microsoft.Extensions.Logging;
@@ -21,7 +22,7 @@ namespace Bit.Notifications.Jobs
         protected override Task ExecuteJobAsync(IJobExecutionContext context)
         {
             _logger.LogInformation(Constants.BypassFiltersEventId,
-                "Connection count: {0}", _connectionCounter.GetCount());
+                "Connection count for server {0}: {1}", Environment.MachineName, _connectionCounter.GetCount());
             return Task.FromResult(0);
         }
     }

--- a/src/Notifications/Startup.cs
+++ b/src/Notifications/Startup.cs
@@ -62,7 +62,6 @@ namespace Bit.Notifications
                 signalRServerBuilder.AddStackExchangeRedis(globalSettings.Notifications.RedisConnectionString,
                     options =>
                     {
-                        options.Configuration.ClientName = "Notifications";
                         options.Configuration.ChannelPrefix = "Notifications";
                     });
             }


### PR DESCRIPTION
- Include machine name in connected client count
- Only set channel prefix for SignalR Redis configuration