### PR TITLE
Create missing folders (synology support)

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -39,7 +39,7 @@ then
     LGID="LOCAL_GID=`id -g $USER`"
     [ "$LGID" == "LOCAL_GID=0" ] && LGID="LOCAL_GID=65534"
     mkdir -p $ENV_DIR
-    chmod 0755 $ENV_DIR
+    chmod 0755 $OUTPUT_DIR
     echo $LUID >$ENV_DIR/uid.env
     echo $LGID >>$ENV_DIR/uid.env
 fi

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -39,6 +39,7 @@ then
     LGID="LOCAL_GID=`id -g $USER`"
     [ "$LGID" == "LOCAL_GID=0" ] && LGID="LOCAL_GID=65534"
     mkdir -p $ENV_DIR
+    chmod 0755 $ENV_DIR
     echo $LUID >$ENV_DIR/uid.env
     echo $LGID >>$ENV_DIR/uid.env
 fi
@@ -47,18 +48,10 @@ fi
 
 function install() {
     mkdir -p $OUTPUT_DIR/ca-certificates/
-    mkdir -p $OUTPUT_DIR/core/attachments
+    mkdir -p $OUTPUT_DIR/core/attachments/
     mkdir -p $OUTPUT_DIR/identity/
-    mkdir -p $OUTPUT_DIR/logs/admin
-    mkdir -p $OUTPUT_DIR/logs/api
-    mkdir -p $OUTPUT_DIR/logs/events
-    mkdir -p $OUTPUT_DIR/logs/icons
-    mkdir -p $OUTPUT_DIR/logs/identity
-    mkdir -p $OUTPUT_DIR/logs/mssql
-    mkdir -p $OUTPUT_DIR/logs/nginx
-    mkdir -p $OUTPUT_DIR/logs/notifications
-    mkdir -p $OUTPUT_DIR/mssql/backups
-    mkdir -p $OUTPUT_DIR/mssql/data
+    mkdir -p $OUTPUT_DIR/logs/{admin,api,events,icons,identity,mssql,nginx,notifications}/
+    mkdir -p $OUTPUT_DIR/mssql/{backups,data}/
     mkdir -p $OUTPUT_DIR/ssl/
 
     LETS_ENCRYPT="n"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -46,6 +46,21 @@ fi
 # Functions
 
 function install() {
+    mkdir -p $OUTPUT_DIR/ca-certificates/
+    mkdir -p $OUTPUT_DIR/core/attachments
+    mkdir -p $OUTPUT_DIR/identity/
+    mkdir -p $OUTPUT_DIR/logs/admin
+    mkdir -p $OUTPUT_DIR/logs/api
+    mkdir -p $OUTPUT_DIR/logs/events
+    mkdir -p $OUTPUT_DIR/logs/icons
+    mkdir -p $OUTPUT_DIR/logs/identity
+    mkdir -p $OUTPUT_DIR/logs/mssql
+    mkdir -p $OUTPUT_DIR/logs/nginx
+    mkdir -p $OUTPUT_DIR/logs/notifications
+    mkdir -p $OUTPUT_DIR/mssql/backups
+    mkdir -p $OUTPUT_DIR/mssql/data
+    mkdir -p $OUTPUT_DIR/ssl/
+
     LETS_ENCRYPT="n"
     echo -e -n "${CYAN}(!)${NC} Enter the domain name for your Bitwarden instance (ex. bitwarden.example.com): "
     read DOMAIN

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -39,7 +39,6 @@ then
     LGID="LOCAL_GID=`id -g $USER`"
     [ "$LGID" == "LOCAL_GID=0" ] && LGID="LOCAL_GID=65534"
     mkdir -p $ENV_DIR
-    chmod 0755 $OUTPUT_DIR
     echo $LUID >$ENV_DIR/uid.env
     echo $LGID >>$ENV_DIR/uid.env
 fi
@@ -47,12 +46,15 @@ fi
 # Functions
 
 function install() {
-    mkdir -p $OUTPUT_DIR/ca-certificates/
-    mkdir -p $OUTPUT_DIR/core/attachments/
-    mkdir -p $OUTPUT_DIR/identity/
-    mkdir -p $OUTPUT_DIR/logs/{admin,api,events,icons,identity,mssql,nginx,notifications}/
-    mkdir -p $OUTPUT_DIR/mssql/{backups,data}/
-    mkdir -p $OUTPUT_DIR/ssl/
+    # If synology device ~ https://xpenology.com/forum/topic/12455-bitwarden-self-hosted-password-manager-on-docker/
+    if uname -a | grep -q " synology_"; then
+        mkdir -p $OUTPUT_DIR/ca-certificates/
+        mkdir -p $OUTPUT_DIR/core/attachments/
+        mkdir -p $OUTPUT_DIR/identity/
+        mkdir -p $OUTPUT_DIR/logs/{admin,api,events,icons,identity,mssql,nginx,notifications}/
+        mkdir -p $OUTPUT_DIR/mssql/{backups,data}/
+        mkdir -p $OUTPUT_DIR/ssl/
+    fi
 
     LETS_ENCRYPT="n"
     echo -e -n "${CYAN}(!)${NC} Enter the domain name for your Bitwarden instance (ex. bitwarden.example.com): "


### PR DESCRIPTION
Guide: https://xpenology.com/forum/topic/12455-bitwarden-self-hosted-password-manager-on-docker/

```
- Once setup is complete you will need to create some missing folders (this is due to the docker version on synology not creating bind mount locations on container creation, likely a version bug)
    - there should be a new folder creating in your /volume1/docker location called /volume1/docker/bwdata
    - create the following folders in the bwdata directory from your current location (/volume1/docker location)
        - command: mkdir bwdata/core bwdata/core/attachments
        - command: mkdir bwdata/ca-certificates
        - command: mkdir bwdata/logs bwdata/logs/admin bwdata/logs/api bwdata/logs/identity bwdata/logs/mssql bwdata/logs/nginx bwdata/logs/notifications bwdata/logs/icons
        - command: mkdir bwdata/mssql bwdata/mssql/data bwdata/mssql/backups
    - If there are any failures on the ./bitwarden.sh start stating "ERROR: for <container name> Cannot start service <container name>: Bind mount failed: '/volume1/docker/bwdata/<path>' does not exists" make sure to create that missing <path> specified in the error
```

- - - 

## Issue 1

- Needs permissions set on `bwdata`
- _not sure if folder(s) needs to be made at this stage_

```
root@synology:/volume1/docker# rm -rf bwdata
root@synology:/volume1/docker# ./bitwarden.sh install
 _     _ _                         _
| |__ (_) |___      ____ _ _ __ __| | ___ _ __
| '_ \| | __\ \ /\ / / _` | '__/ _` |/ _ \ '_ \
| |_) | | |_ \ V  V / (_| | | | (_| |  __/ | | |
|_.__/|_|\__| \_/\_/ \__,_|_|  \__,_|\___|_| |_|

Open source password management solutions
Copyright 2015-2020, 8bit Solutions LLC
https://bitwarden.com, https://github.com/bitwarden

===================================================

Docker version 18.09.8, build 2c0a67b
docker-compose version 1.24.0, build 0aa59064

(!) Enter the domain name for your Bitwarden instance (ex. bitwarden.example.com): localhost

1.33.1: Pulling from bitwarden/setup
Digest: sha256:ceaaa30350dca9dac12bf43e888947cec87633da4f0ab125e89a3e6f9d64ecdb
Status: Image is up to date for bitwarden/setup:1.33.1

(!) Enter your installation id (get at https://bitwarden.com/host): **REMOVED**

(!) Enter your installation key: **REMOVED**

(!) Do you have a SSL certificate to use? (y/n): n

(!) Do you want to generate a self-signed SSL certificate? (y/n): n

Generating key for IdentityServer.
Unhandled exception. System.UnauthorizedAccessException: Access to the path '/bitwarden/identity/' is denied.
 ---> System.IO.IOException: Permission denied
   --- End of inner exception stack trace ---
   at System.IO.FileSystem.CreateDirectory(String fullPath)
   at System.IO.Directory.CreateDirectory(String path)
   at Bit.Setup.CertBuilder.BuildForInstall() in /home/appveyor/projects/server/util/Setup/CertBuilder.cs:line 72
   at Bit.Setup.Program.Install() in /home/appveyor/projects/server/util/Setup/Program.cs:line 93
   at Bit.Setup.Program.Main(String[] args) in /home/appveyor/projects/server/util/Setup/Program.cs:line 65
root@synology:/volume1/docker# rm -rf bwdata
root@synology:/volume1/docker# mkdir -p bwdata/identity
root@synology:/volume1/docker# ./bitwarden.sh install
 _     _ _                         _
| |__ (_) |___      ____ _ _ __ __| | ___ _ __
| '_ \| | __\ \ /\ / / _` | '__/ _` |/ _ \ '_ \
| |_) | | |_ \ V  V / (_| | | | (_| |  __/ | | |
|_.__/|_|\__| \_/\_/ \__,_|_|  \__,_|\___|_| |_|

Open source password management solutions
Copyright 2015-2020, 8bit Solutions LLC
https://bitwarden.com, https://github.com/bitwarden

===================================================

Docker version 18.09.8, build 2c0a67b
docker-compose version 1.24.0, build 0aa59064

(!) Enter the domain name for your Bitwarden instance (ex. bitwarden.example.com): localhost

1.33.1: Pulling from bitwarden/setup
Digest: sha256:ceaaa30350dca9dac12bf43e888947cec87633da4f0ab125e89a3e6f9d64ecdb
Status: Image is up to date for bitwarden/setup:1.33.1

(!) Enter your installation id (get at https://bitwarden.com/host): **REMOVED**

(!) Enter your installation key: **REMOVED**

(!) Do you have a SSL certificate to use? (y/n): n

(!) Do you want to generate a self-signed SSL certificate? (y/n): n

Generating key for IdentityServer.
Unhandled exception. System.UnauthorizedAccessException: Access to the path '/bitwarden/identity/' is denied.
 ---> System.IO.IOException: Permission denied
   --- End of inner exception stack trace ---
   at System.IO.FileSystem.CreateDirectory(String fullPath)
   at System.IO.Directory.CreateDirectory(String path)
   at Bit.Setup.CertBuilder.BuildForInstall() in /home/appveyor/projects/server/util/Setup/CertBuilder.cs:line 72
   at Bit.Setup.Program.Install() in /home/appveyor/projects/server/util/Setup/Program.cs:line 93
   at Bit.Setup.Program.Main(String[] args) in /home/appveyor/projects/server/util/Setup/Program.cs:line 65
root@synology:/volume1/docker# rm -rf bwdata
root@synology:/volume1/docker# mkdir -p bwdata/identity
root@synology:/volume1/docker# chmod -R 777 bwdata
root@synology:/volume1/docker# ./bitwarden.sh install
 _     _ _                         _
| |__ (_) |___      ____ _ _ __ __| | ___ _ __
| '_ \| | __\ \ /\ / / _` | '__/ _` |/ _ \ '_ \
| |_) | | |_ \ V  V / (_| | | | (_| |  __/ | | |
|_.__/|_|\__| \_/\_/ \__,_|_|  \__,_|\___|_| |_|

Open source password management solutions
Copyright 2015-2020, 8bit Solutions LLC
https://bitwarden.com, https://github.com/bitwarden

===================================================

Docker version 18.09.8, build 2c0a67b
docker-compose version 1.24.0, build 0aa59064

(!) Enter the domain name for your Bitwarden instance (ex. bitwarden.example.com): localhost

1.33.1: Pulling from bitwarden/setup
Digest: sha256:ceaaa30350dca9dac12bf43e888947cec87633da4f0ab125e89a3e6f9d64ecdb
Status: Image is up to date for bitwarden/setup:1.33.1

(!) Enter your installation id (get at https://bitwarden.com/host): **REMOVED**

(!) Enter your installation key: **REMOVED**

(!) Do you have a SSL certificate to use? (y/n): n

(!) Do you want to generate a self-signed SSL certificate? (y/n): y

Generating self signed SSL certificate.
Generating a RSA private key
..........................................................................................++++
................++++
writing new private key to '/bitwarden/ssl/self/localhost/private.key'
-----
Generating key for IdentityServer.
Generating a RSA private key
....................++++
......................................................................................................................................................++++
writing new private key to 'identity.key'
-----

!!!!!!!!!! WARNING !!!!!!!!!!
You are using an untrusted SSL certificate. This certificate will not be
trusted by Bitwarden client applications. You must add this certificate to
the trusted store on each device or else you will receive errors when trying
to connect to your installation.

Building nginx config.
Building docker environment files.
Building docker environment override files.
Building FIDO U2F app id.
Building docker-compose.yml.

Installation complete

If you need to make additional configuration changes, you can modify
the settings in `./bwdata/config.yml` and then run:
`./bitwarden.sh rebuild` or `./bitwarden.sh update`

Next steps, run:
`./bitwarden.sh start`

root@synology:/volume1/docker# mkdir test
root@synology:/volume1/docker# ls -la | grep test
d---------+ 1 root  root     0 Apr  7 10:28 test
root@synology:/volume1/docker# umask
0022
root@synology:/volume1/docker# synoacltool -get test
ACL version: 1
Archive: is_inherit,is_support_ACL
Owner: [root(user)]
---------------------
	 [0] user:**REMOVED**:deny::rwxpdDaARWcCo:fd--  (level:2)
	 [1] user:**REMOVED**:deny::rwxpdDaARWcCo:fd--  (level:2)
	 [2] user:**REMOVED**:deny:rwxpdDaARWcCo:fd--  (level:2)
	 [3] group:**REMOVED**:allow:rwxpdDaARWc--:fd--  (level:2)
	 [4] user:**REMOVED**:allow:rwxpdDaARWc--:fd--  (level:2)
root@synology:/volume1/docker# rm -rf test
```


## Issue 2

- Missing folders
- _synology was already using the port, not bitwarden issue_
- More missing folders

```
 ./bitwarden.sh start
 _     _ _                         _
| |__ (_) |___      ____ _ _ __ __| | ___ _ __
| '_ \| | __\ \ /\ / / _` | '__/ _` |/ _ \ '_ \
| |_) | | |_ \ V  V / (_| | | | (_| |  __/ | | |
|_.__/|_|\__| \_/\_/ \__,_|_|  \__,_|\___|_| |_|

Open source password management solutions
Copyright 2015-2020, 8bit Solutions LLC
https://bitwarden.com, https://github.com/bitwarden

===================================================

Docker version 18.09.8, build 2c0a67b
docker-compose version 1.24.0, build 0aa59064

Removing network docker_default
WARNING: Network docker_default not found.
Removing network docker_public
WARNING: Network docker_public not found.
Pulling mssql         ... done
Pulling web           ... done
Pulling attachments   ... done
Pulling api           ... done
Pulling identity      ... done
Pulling admin         ... done
Pulling icons         ... done
Pulling notifications ... done
Pulling events        ... done
Pulling nginx         ... done
Creating network "docker_default" with the default driver
Creating network "docker_public" with the default driver
Creating bitwarden-identity ...
Creating bitwarden-web           ... done
mkdir -p /volume1/docker/bwdata/mssql/data /volume1/docker/bwdata/logs/api /volume1/docker/bwdata/logs/notifications /volume1/docker/bwdata/logs/events /volume1/docker/bwdata/logs/iconCreating bitwarden-attachments   ... error
Creating bitwarden-notifications ...
Creating bitwarden-api           ...
Creating bitwarden-icons         ...
Creating bitwarden-events        ...
Creating bitwarden-mssql         ...
Creating bitwarden-identity      ... error
Creating bitwarden-notifications ... error

ERROR: for bitwarden-mssql  Cannot start service mssql: Bind mount failed: '/volume1/docker/bwdata/mssql/data' does not exists

ERROR: for bitwarden-api  Cannot start service api: Bind mount failed: '/volume1/docker/bwdata/logs/api' does not exists

ERROR: for bitwarden-notifications  Cannot start service notifications: Bind mount failed: '/volume1/docker/bwdata/logs/notifications' does not exists
Creating bitwarden-events        ... error
Creating bitwarden-icons         ... error

ERROR: for bitwarden-events  Cannot start service events: Bind mount failed: '/volume1/docker/bwdata/logs/events' does not exists

ERROR: for bitwarden-icons  Cannot start service icons: Bind mount failed: '/volume1/docker/bwdata/logs/icons' does not exists

ERROR: for attachments  Cannot start service attachments: Bind mount failed: '/volume1/docker/bwdata/core/attachments' does not exists

ERROR: for mssql  Cannot start service mssql: Bind mount failed: '/volume1/docker/bwdata/mssql/data' does not exists

ERROR: for api  Cannot start service api: Bind mount failed: '/volume1/docker/bwdata/logs/api' does not exists

ERROR: for notifications  Cannot start service notifications: Bind mount failed: '/volume1/docker/bwdata/logs/notifications' does not exists

ERROR: for identity  Cannot start service identity: Bind mount failed: '/volume1/docker/bwdata/core' does not exists

ERROR: for events  Cannot start service events: Bind mount failed: '/volume1/docker/bwdata/logs/events' does not exists

ERROR: for icons  Cannot start service icons: Bind mount failed: '/volume1/docker/bwdata/logs/icons' does not exists
ERROR: Encountered errors while bringing up the project.
root@synology:/volume1/docker# mkdir -p /volume1/docker/bwdata/core /volume1/docker/bwdata/core/attachments /volume1/docker/bwdata/logs/api /volume1/docker/bwdata/logs/events /volume1/docker/bwdata/logs/icons /volume1/docker/bwdata/logs/notifications /volume1/docker/bwdata/mssql/data
root@synology:/volume1/docker# ./bitwarden.sh start
 _     _ _                         _
| |__ (_) |___      ____ _ _ __ __| | ___ _ __
| '_ \| | __\ \ /\ / / _` | '__/ _` |/ _ \ '_ \
| |_) | | |_ \ V  V / (_| | | | (_| |  __/ | | |
|_.__/|_|\__| \_/\_/ \__,_|_|  \__,_|\___|_| |_|

Open source password management solutions
Copyright 2015-2020, 8bit Solutions LLC
https://bitwarden.com, https://github.com/bitwarden

===================================================

Docker version 18.09.8, build 2c0a67b
docker-compose version 1.24.0, build 0aa59064

Stopping bitwarden-web ... done
Removing bitwarden-mssql         ... done
Removing bitwarden-events        ... done
Removing bitwarden-icons         ... done
Removing bitwarden-api           ... done
Removing bitwarden-attachments   ... done
Removing bitwarden-notifications ... done
Removing bitwarden-identity      ... done
Removing bitwarden-web           ... done
Removing network docker_default
Removing network docker_public
Pulling mssql         ... done
Pulling web           ... done
Pulling attachments   ... done
Pulling api           ... done
Pulling identity      ... done
Pulling admin         ... done
Pulling icons         ... done
Pulling notifications ... done
Pulling events        ... done
Pulling nginx         ... done
Creating network "docker_default" with the default driver
Creating network "docker_public" with the default driver
Creating bitwarden-notifications ...
Creating bitwarden-api           ... done
Creating bitwarden-notifications ... done
Creating bitwarden-attachments   ... done
Creating bitwarden-identity      ...
Creating bitwarden-events        ...
Creating bitwarden-identity      ... error
Creating bitwarden-events        ... done
Creating bitwarden-web           ... done
Creating bitwarden-icons         ... done

ERROR: for bitwarden-identity  Cannot start service identity: Bind mount failed: '/volume1/docker/bwdata/logs/identity' does not exists

ERROR: for mssql  Cannot start service mssql: Bind mount failed: '/volume1/docker/bwdata/logs/mssql' does not exists

ERROR: for identity  Cannot start service identity: Bind mount failed: '/volume1/docker/bwdata/logs/identity' does not exists
ERROR: Encountered errors while bringing up the project.
root@synology:/volume1/docker# mkdir -p /volume1/docker/bwdata/logs/mssql /volume1/docker/bwdata/logs/identity
root@synology:/volume1/docker# ./bitwarden.sh start
 _     _ _                         _
| |__ (_) |___      ____ _ _ __ __| | ___ _ __
| '_ \| | __\ \ /\ / / _` | '__/ _` |/ _ \ '_ \
| |_) | | |_ \ V  V / (_| | | | (_| |  __/ | | |
|_.__/|_|\__| \_/\_/ \__,_|_|  \__,_|\___|_| |_|

Open source password management solutions
Copyright 2015-2020, 8bit Solutions LLC
https://bitwarden.com, https://github.com/bitwarden

===================================================

Docker version 18.09.8, build 2c0a67b
docker-compose version 1.24.0, build 0aa59064

Stopping bitwarden-icons         ... done
Stopping bitwarden-web           ... done
Stopping bitwarden-events        ... done
Stopping bitwarden-attachments   ... done
Stopping bitwarden-notifications ... done
Stopping bitwarden-api           ... done
Removing bitwarden-icons         ... done
Removing bitwarden-web           ... done
Removing bitwarden-events        ... done
Removing bitwarden-attachments   ... done
Removing bitwarden-mssql         ... done
Removing bitwarden-identity      ... done
Removing bitwarden-notifications ... done
Removing bitwarden-api           ... done
Removing network docker_default
Removing network docker_public
Pulling mssql         ... done
Pulling web           ... done
Pulling attachments   ... done
Pulling api           ... done
Pulling identity      ... done
Pulling admin         ... done
Pulling icons         ... done
Pulling notifications ... done
Pulling events        ... done
Pulling nginx         ... done
Creating network "docker_default" with the default driver
Creating network "docker_public" with the default driver
Creating bitwarden-notifications ...
Creating bitwarden-identity      ...
Creating bitwarden-notifications ... done
Creating bitwarden-identity      ... done
Creating bitwarden-icons         ...
Creating bitwarden-events        ...
Creating bitwarden-icons         ... done
Creating bitwarden-events        ... done
Creating bitwarden-api           ... done
ERROR: for bitwarden-mssql  Cannot start service mssql: Bind mount failed: '/volume1/docker/bwdata/mssql/backups' does not exists

ERROR: for mssql  Cannot start service mssql: Bind mount failed: '/volume1/docker/bwdata/mssql/backups' does not exists
ERROR: Encountered errors while bringing up the project.
root@synology:/volume1/docker# mkdir -p /volume1/docker/bwdata/mssql/backups
root@synology:/volume1/docker# ./bitwarden.sh start
 _     _ _                         _
| |__ (_) |___      ____ _ _ __ __| | ___ _ __
| '_ \| | __\ \ /\ / / _` | '__/ _` |/ _ \ '_ \
| |_) | | |_ \ V  V / (_| | | | (_| |  __/ | | |
|_.__/|_|\__| \_/\_/ \__,_|_|  \__,_|\___|_| |_|

Open source password management solutions
Copyright 2015-2020, 8bit Solutions LLC
https://bitwarden.com, https://github.com/bitwarden

===================================================

Docker version 18.09.8, build 2c0a67b
docker-compose version 1.24.0, build 0aa59064

Stopping bitwarden-api           ... done
Stopping bitwarden-icons         ... done
Stopping bitwarden-events        ... done
Stopping bitwarden-attachments   ... done
Stopping bitwarden-notifications ... done
Stopping bitwarden-identity      ... done
Stopping bitwarden-web           ... done
Removing bitwarden-mssql         ... done
Removing bitwarden-api           ... done
Removing bitwarden-icons         ... done
Removing bitwarden-events        ... done
Removing bitwarden-attachments   ... done
Removing bitwarden-notifications ... done
Removing bitwarden-identity      ... done
Removing bitwarden-web           ... done
Removing network docker_default
Removing network docker_public
Pulling mssql         ... done
Pulling web           ... done
Pulling attachments   ... done
Pulling api           ... done
Pulling identity      ... done
Pulling admin         ... done
Pulling icons         ... done
Pulling notifications ... done
Pulling events        ... done
Pulling nginx         ... done
Creating network "docker_default" with the default driver
Creating network "docker_public" with the default driver
Creating bitwarden-identity      ... done
Creating bitwarden-web           ... done
Creating bitwarden-notifications ... done
Creating bitwarden-attachments   ... done
Creating bitwarden-icons         ... done
Creating bitwarden-api           ... done
Creating bitwarden-events        ... done
Creating bitwarden-mssql         ... done
Creating bitwarden-admin         ... error

ERROR: for bitwarden-admin  Cannot start service admin: Bind mount failed: '/volume1/docker/bwdata/logs/admin' does not exists

ERROR: for admin  Cannot start service admin: Bind mount failed: '/volume1/docker/bwdata/logs/admin' does not exists
ERROR: Encountered errors while bringing up the project.
root@synology:/volume1/docker# mkdir -p /volume1/docker/bwdata/logs/admin
root@synology:/volume1/docker# ./bitwarden.sh start
 _     _ _                         _
| |__ (_) |___      ____ _ _ __ __| | ___ _ __
| '_ \| | __\ \ /\ / / _` | '__/ _` |/ _ \ '_ \
| |_) | | |_ \ V  V / (_| | | | (_| |  __/ | | |
|_.__/|_|\__| \_/\_/ \__,_|_|  \__,_|\___|_| |_|

Open source password management solutions
Copyright 2015-2020, 8bit Solutions LLC
https://bitwarden.com, https://github.com/bitwarden

===================================================

Docker version 18.09.8, build 2c0a67b
docker-compose version 1.24.0, build 0aa59064

Stopping bitwarden-mssql         ... done
Stopping bitwarden-api           ... done
Stopping bitwarden-attachments   ... done
Stopping bitwarden-events        ... done
Stopping bitwarden-icons         ... done
Stopping bitwarden-notifications ... done
Stopping bitwarden-identity      ... done
Stopping bitwarden-web           ... done
Removing bitwarden-admin         ... done
Removing bitwarden-mssql         ... done
Removing bitwarden-api           ... done
Removing bitwarden-attachments   ... done
Removing bitwarden-events        ... done
Removing bitwarden-icons         ... done
Removing bitwarden-notifications ... done
Removing bitwarden-identity      ... done
Removing bitwarden-web           ... done
Removing network docker_default
Removing network docker_public
Pulling mssql         ... done
Pulling web           ... done
Pulling attachments   ... done
Pulling api           ... done
Pulling identity      ... done
Pulling admin         ... done
Pulling icons         ... done
Pulling notifications ... done
Pulling events        ... done
Pulling nginx         ... done
Creating network "docker_default" with the default driver
Creating network "docker_public" with the default driver
Creating bitwarden-api           ... done
Creating bitwarden-notifications ... done
Creating bitwarden-mssql         ... done
Creating bitwarden-attachments   ... done
Creating bitwarden-identity      ... done
Creating bitwarden-events        ... done
Creating bitwarden-web           ... done
Creating bitwarden-icons         ... done
Creating bitwarden-admin         ... done
Creating bitwarden-nginx         ... error

ERROR: for bitwarden-nginx  Cannot start service nginx: driver failed programming external connectivity on endpoint bitwarden-nginx (02536b18cff80d3c66ab1dd3bfdb2261649d139415304bad441e36c71ad544bc): Error starting userland proxy: listen tcp 0.0.0.0:443: bind: address already in use

ERROR: for nginx  Cannot start service nginx: driver failed programming external connectivity on endpoint bitwarden-nginx (02536b18cff80d3c66ab1dd3bfdb2261649d139415304bad441e36c71ad544bc): Error starting userland proxy: listen tcp 0.0.0.0:443: bind: address already in use
ERROR: Encountered errors while bringing up the project.
root@synology:/volume1/docker# vim bwdata/config.yml
root@synology:/volume1/docker# ./bitwarden.sh rebuild
 _     _ _                         _
| |__ (_) |___      ____ _ _ __ __| | ___ _ __
| '_ \| | __\ \ /\ / / _` | '__/ _` |/ _ \ '_ \
| |_) | | |_ \ V  V / (_| | | | (_| |  __/ | | |
|_.__/|_|\__| \_/\_/ \__,_|_|  \__,_|\___|_| |_|

Open source password management solutions
Copyright 2015-2020, 8bit Solutions LLC
https://bitwarden.com, https://github.com/bitwarden

===================================================

Docker version 18.09.8, build 2c0a67b
docker-compose version 1.24.0, build 0aa59064

Stopping bitwarden-admin         ... done
Stopping bitwarden-attachments   ... done
Stopping bitwarden-icons         ... done
Stopping bitwarden-identity      ... done
Stopping bitwarden-notifications ... done
Stopping bitwarden-mssql         ... done
Stopping bitwarden-web           ... done
Stopping bitwarden-api           ... done
Stopping bitwarden-events        ... done
Removing bitwarden-admin         ... done
Removing bitwarden-attachments   ... done
Removing bitwarden-icons         ... done
Removing bitwarden-identity      ... done
Removing bitwarden-notifications ... done
Removing bitwarden-mssql         ... done
Removing bitwarden-web           ... done
Removing bitwarden-api           ... done
Removing bitwarden-events        ... done
Removing network docker_default
Removing network docker_public

Building docker environment files.
Building docker environment override files.
Building nginx config.
Building FIDO U2F app id.
Building docker-compose.yml.

root@synology:/volume1/docker# ./bitwarden.sh start
 _     _ _                         _
| |__ (_) |___      ____ _ _ __ __| | ___ _ __
| '_ \| | __\ \ /\ / / _` | '__/ _` |/ _ \ '_ \
| |_) | | |_ \ V  V / (_| | | | (_| |  __/ | | |
|_.__/|_|\__| \_/\_/ \__,_|_|  \__,_|\___|_| |_|

Open source password management solutions
Copyright 2015-2020, 8bit Solutions LLC
https://bitwarden.com, https://github.com/bitwarden

===================================================

Docker version 18.09.8, build 2c0a67b
docker-compose version 1.24.0, build 0aa59064

Removing network docker_default
WARNING: Network docker_default not found.
Removing network docker_public
WARNING: Network docker_public not found.
Pulling mssql         ... done
Pulling web           ... done
Pulling attachments   ... done
Pulling api           ... done
Pulling identity      ... done
Pulling admin         ... done
Pulling icons         ... done
Pulling notifications ... done
Pulling events        ... done
Pulling nginx         ... done
Creating network "docker_default" with the default driver
Creating network "docker_public" with the default driver
Creating bitwarden-web           ... done
Creating bitwarden-mssql         ... done
Creating bitwarden-events        ... done
Creating bitwarden-api           ... done
Creating bitwarden-notifications ... done
Creating bitwarden-attachments   ... done
Creating bitwarden-identity      ... done
Creating bitwarden-icons         ... done
Creating bitwarden-admin         ... done
Creating bitwarden-nginx         ... error

ERROR: for bitwarden-nginx  Cannot start service nginx: Bind mount failed: '/volume1/docker/bwdata/logs/nginx' does not exists

ERROR: for nginx  Cannot start service nginx: Bind mount failed: '/volume1/docker/bwdata/logs/nginx' does not exists
ERROR: Encountered errors while bringing up the project.
root@synology:/volume1/docker# mkdir -p /volume1/docker/bwdata/logs/nginx
root@synology:/volume1/docker# ./bitwarden.sh start
 _     _ _                         _
| |__ (_) |___      ____ _ _ __ __| | ___ _ __
| '_ \| | __\ \ /\ / / _` | '__/ _` |/ _ \ '_ \
| |_) | | |_ \ V  V / (_| | | | (_| |  __/ | | |
|_.__/|_|\__| \_/\_/ \__,_|_|  \__,_|\___|_| |_|

Open source password management solutions
Copyright 2015-2020, 8bit Solutions LLC
https://bitwarden.com, https://github.com/bitwarden

===================================================

Docker version 18.09.8, build 2c0a67b
docker-compose version 1.24.0, build 0aa59064

Stopping bitwarden-admin         ... done
Stopping bitwarden-icons         ... done
Stopping bitwarden-identity      ... done
Stopping bitwarden-attachments   ... done
Stopping bitwarden-notifications ... done
Stopping bitwarden-api           ... done
Stopping bitwarden-events        ... done
Stopping bitwarden-mssql         ... done
Stopping bitwarden-web           ... done
Removing bitwarden-nginx         ... done
Removing bitwarden-admin         ... done
Removing bitwarden-icons         ... done
Removing bitwarden-identity      ... done
Removing bitwarden-attachments   ... done
Removing bitwarden-notifications ... done
Removing bitwarden-api           ... done
Removing bitwarden-events        ... done
Removing bitwarden-mssql         ... done
Removing bitwarden-web           ... done
Removing network docker_default
Removing network docker_public
Pulling mssql         ... done
Pulling web           ... done
Pulling attachments   ... done
Pulling api           ... done
Pulling identity      ... done
Pulling admin         ... done
Pulling icons         ... done
Pulling notifications ... done
Pulling events        ... done
Pulling nginx         ... done
Creating network "docker_default" with the default driver
Creating network "docker_public" with the default driver
Creating bitwarden-web           ... done
Creating bitwarden-mssql         ... done
Creating bitwarden-events        ... done
Creating bitwarden-api           ... done
Creating bitwarden-attachments   ... done
Creating bitwarden-identity      ... done
Creating bitwarden-notifications ... done
Creating bitwarden-icons         ... done
Creating bitwarden-admin         ... done
Creating bitwarden-nginx         ... done
1.33.1: Pulling from bitwarden/setup
Digest: sha256:ceaaa30350dca9dac12bf43e888947cec87633da4f0ab125e89a3e6f9d64ecdb
Status: Image is up to date for bitwarden/setup:1.33.1


Bitwarden is up and running!
===================================================

visit https://localhost
to update, run `./bitwarden.sh updateself` and then `./bitwarden.sh update`
```