### PR TITLE
[Soft Delete] - fix Upsert calls based on cipher supertype

### DIFF
--- a/src/Core/Services/Implementations/CipherService.cs
+++ b/src/Core/Services/Implementations/CipherService.cs
@@ -679,7 +679,14 @@ namespace Bit.Core.Services
 
             cipher.DeletedDate = cipher.RevisionDate = DateTime.UtcNow;
 
-            await _cipherRepository.UpsertAsync(cipher);
+            if (cipher is CipherDetails details)
+            {
+                await _cipherRepository.UpsertAsync(details);
+            }
+            else
+            {
+                await _cipherRepository.UpsertAsync(cipher);
+            }
             await _eventService.LogCipherEventAsync(cipher, EventType.Cipher_SoftDeleted);
 
             // push
@@ -721,7 +728,14 @@ namespace Bit.Core.Services
             cipher.DeletedDate = null;
             cipher.RevisionDate = DateTime.UtcNow;
 
-            await _cipherRepository.UpsertAsync(cipher);
+            if (cipher is CipherDetails details)
+            {
+                await _cipherRepository.UpsertAsync(details);
+            }
+            else
+            {
+                await _cipherRepository.UpsertAsync(cipher);
+            }
             await _eventService.LogCipherEventAsync(cipher, EventType.Cipher_Restored);
 
             // push


### PR DESCRIPTION
This corrects parameter mapping exceptions from Dapper when presenting a `CipherDetails` object to the Upsert method boxed as a `Cipher` (table) object. While it's assignable it was trying to map the extra parameters of the `CipherDetails` object to the basic `Cipher_Update` stored procedure causing exceptions.