### PR TITLE
[Soft Delete] deleted date null failure in DataTable

### DIFF
--- a/src/Core/Repositories/SqlServer/CipherRepository.cs
+++ b/src/Core/Repositories/SqlServer/CipherRepository.cs
@@ -629,7 +629,7 @@ namespace Bit.Core.Repositories.SqlServer
             ciphersTable.Columns.Add(creationDateColumn);
             var revisionDateColumn = new DataColumn(nameof(c.RevisionDate), c.RevisionDate.GetType());
             ciphersTable.Columns.Add(revisionDateColumn);
-            var deletedDateColumn = new DataColumn(nameof(c.DeletedDate), c.DeletedDate.GetType());
+            var deletedDateColumn = new DataColumn(nameof(c.DeletedDate), typeof(DateTime));
             ciphersTable.Columns.Add(deletedDateColumn);
 
             foreach (DataColumn col in ciphersTable.Columns)
@@ -655,7 +655,7 @@ namespace Bit.Core.Repositories.SqlServer
                 row[attachmentsColumn] = cipher.Attachments;
                 row[creationDateColumn] = cipher.CreationDate;
                 row[revisionDateColumn] = cipher.RevisionDate;
-                row[deletedDateColumn] = cipher.DeletedDate;
+                row[deletedDateColumn] = cipher.DeletedDate.HasValue ? (object)cipher.DeletedDate : DBNull.Value;
 
                 ciphersTable.Rows.Add(row);
             }

--- a/src/Sql/dbo/Stored Procedures/Cipher_Restore.sql
+++ b/src/Sql/dbo/Stored Procedures/Cipher_Restore.sql
@@ -23,7 +23,7 @@ BEGIN
         [Edit] = 1
         AND [DeletedDate] IS NOT NULL
         AND [Id] IN (SELECT * FROM @Ids)
-    
+
     DECLARE @UtcNow DATETIME2(7) = GETUTCDATE();
     UPDATE
         [dbo].[Cipher]

--- a/src/Sql/dbo/Stored Procedures/Cipher_Restore.sql
+++ b/src/Sql/dbo/Stored Procedures/Cipher_Restore.sql
@@ -21,8 +21,9 @@ BEGIN
         [dbo].[UserCipherDetails](@UserId)
     WHERE
         [Edit] = 1
+        AND [DeletedDate] IS NOT NULL
         AND [Id] IN (SELECT * FROM @Ids)
-	
+    
     DECLARE @UtcNow DATETIME2(7) = GETUTCDATE();
     UPDATE
         [dbo].[Cipher]

--- a/src/Sql/dbo/Stored Procedures/Cipher_SoftDelete.sql
+++ b/src/Sql/dbo/Stored Procedures/Cipher_SoftDelete.sql
@@ -21,6 +21,7 @@ BEGIN
         [dbo].[UserCipherDetails](@UserId)
     WHERE
         [Edit] = 1
+        AND [DeletedDate] IS NULL
         AND [Id] IN (SELECT * FROM @Ids)
 
     -- Delete ciphers

--- a/util/Migrator/DbScripts/2020-04-02_00_CipherSoftDelete.sql
+++ b/util/Migrator/DbScripts/2020-04-02_00_CipherSoftDelete.sql
@@ -30,7 +30,7 @@ BEGIN
     WHERE
         [Edit] = 1
         AND [Id] IN (SELECT * FROM @Ids)
-	
+
     DECLARE @UtcNow DATETIME2(7) = GETUTCDATE();
     UPDATE
         [dbo].[Cipher]

--- a/util/Migrator/DbScripts/2020-04-09_00_CipherSoftDelete.sql
+++ b/util/Migrator/DbScripts/2020-04-09_00_CipherSoftDelete.sql
@@ -1,0 +1,136 @@
+﻿/**
+ * Fix bulk Restore/Soft Delete sprocs for DateTime assignment
+ */
+IF OBJECT_ID('[dbo].[Cipher_Restore]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Cipher_Restore];
+END
+GO
+CREATE PROCEDURE [dbo].[Cipher_Restore]
+    @Ids AS [dbo].[GuidIdArray] READONLY,
+    @UserId AS UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #Temp
+    ( 
+        [Id] UNIQUEIDENTIFIER NOT NULL,
+        [UserId] UNIQUEIDENTIFIER NULL,
+        [OrganizationId] UNIQUEIDENTIFIER NULL
+    )
+
+    INSERT INTO #Temp
+    SELECT
+        [Id],
+        [UserId],
+        [OrganizationId]
+    FROM
+        [dbo].[UserCipherDetails](@UserId)
+    WHERE
+        [Edit] = 1
+        AND [DeletedDate] IS NOT NULL
+        AND [Id] IN (SELECT * FROM @Ids)
+    
+    DECLARE @UtcNow DATETIME2(7) = GETUTCDATE();
+    UPDATE
+        [dbo].[Cipher]
+    SET
+        [DeletedDate] = NULL,
+        [RevisionDate] = @UtcNow
+    WHERE
+        [Id] IN (SELECT [Id] FROM #Temp)
+
+    -- Bump orgs
+    DECLARE @OrgId UNIQUEIDENTIFIER
+    DECLARE [OrgCursor] CURSOR FORWARD_ONLY FOR
+        SELECT
+            [OrganizationId]
+        FROM
+            #Temp
+        WHERE
+            [OrganizationId] IS NOT NULL
+        GROUP BY
+            [OrganizationId]
+    OPEN [OrgCursor]
+    FETCH NEXT FROM [OrgCursor] INTO @OrgId
+    WHILE @@FETCH_STATUS = 0 BEGIN
+        EXEC [dbo].[User_BumpAccountRevisionDateByOrganizationId] @OrgId
+        FETCH NEXT FROM [OrgCursor] INTO @OrgId
+    END
+    CLOSE [OrgCursor]
+    DEALLOCATE [OrgCursor]
+
+    -- Bump user
+    EXEC [dbo].[User_BumpAccountRevisionDate] @UserId
+
+    DROP TABLE #Temp
+END
+GO
+
+IF OBJECT_ID('[dbo].[Cipher_SoftDelete]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Cipher_SoftDelete];
+END
+GO
+CREATE PROCEDURE [dbo].[Cipher_SoftDelete]
+    @Ids AS [dbo].[GuidIdArray] READONLY,
+    @UserId AS UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #Temp
+    ( 
+        [Id] UNIQUEIDENTIFIER NOT NULL,
+        [UserId] UNIQUEIDENTIFIER NULL,
+        [OrganizationId] UNIQUEIDENTIFIER NULL
+    )
+
+    INSERT INTO #Temp
+    SELECT
+        [Id],
+        [UserId],
+        [OrganizationId]
+    FROM
+        [dbo].[UserCipherDetails](@UserId)
+    WHERE
+        [Edit] = 1
+        AND [DeletedDate] IS NULL
+        AND [Id] IN (SELECT * FROM @Ids)
+
+    -- Delete ciphers
+    DECLARE @UtcNow DATETIME2(7) = GETUTCDATE();
+    UPDATE
+        [dbo].[Cipher]
+    SET
+        [DeletedDate] = @UtcNow,
+        [RevisionDate] = @UtcNow
+    WHERE
+        [Id] IN (SELECT [Id] FROM #Temp)
+
+    -- Cleanup orgs
+    DECLARE @OrgId UNIQUEIDENTIFIER
+    DECLARE [OrgCursor] CURSOR FORWARD_ONLY FOR
+        SELECT
+            [OrganizationId]
+        FROM
+            #Temp
+        WHERE
+            [OrganizationId] IS NOT NULL
+        GROUP BY
+            [OrganizationId]
+    OPEN [OrgCursor]
+    FETCH NEXT FROM [OrgCursor] INTO @OrgId
+    WHILE @@FETCH_STATUS = 0 BEGIN
+        EXEC [dbo].[User_BumpAccountRevisionDateByOrganizationId] @OrgId
+        FETCH NEXT FROM [OrgCursor] INTO @OrgId
+    END
+    CLOSE [OrgCursor]
+    DEALLOCATE [OrgCursor]
+
+    EXEC [dbo].[User_BumpAccountRevisionDate] @UserId
+
+    DROP TABLE #Temp
+END
+GO


### PR DESCRIPTION
SQL whitespace cleanup and deleted date being null will cause bulk import/export operations that rely on `DataTable` to fail.