### PR TITLE
public API for organization import

### DIFF
--- a/src/Api/Public/Controllers/OrganizationController.cs
+++ b/src/Api/Public/Controllers/OrganizationController.cs
@@ -1,0 +1,59 @@
+﻿using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Bit.Core;
+using Bit.Core.Exceptions;
+using Bit.Core.Models.Api.Public;
+using Bit.Core.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bit.Api.Public.Controllers
+{
+    [Route("public/organization")]
+    [Authorize("Organization")]
+    public class OrganizationController : Controller
+    {
+        private readonly IOrganizationService _organizationService;
+        private readonly CurrentContext _currentContext;
+        private readonly GlobalSettings _globalSettings;
+
+        public OrganizationController(
+            IOrganizationService organizationService,
+            CurrentContext currentContext,
+            GlobalSettings globalSettings)
+        {
+            _organizationService = organizationService;
+            _currentContext = currentContext;
+            _globalSettings = globalSettings;
+        }
+
+        /// <summary>
+        /// Import members and groups.
+        /// </summary>
+        /// <remarks>
+        /// Import members and groups from an external system.
+        /// </remarks>
+        /// <param name="model">The request model.</param>
+        [HttpPost("import")]
+        [ProducesResponseType(typeof(MemberResponseModel), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
+        public async Task<IActionResult> Import([FromBody]OrganizationImportRequestModel model)
+        {
+            if (!_globalSettings.SelfHosted &&
+                (model.Groups.Count() > 200 || model.Members.Count(u => !u.Deleted) > 1000))
+            {
+                throw new BadRequestException("You cannot import this much data at once.");
+            }
+
+            await _organizationService.ImportAsync(
+                _currentContext.OrganizationId.Value,
+                null,
+                model.Groups.Select(g => g.ToImportedGroup(_currentContext.OrganizationId.Value)),
+                model.Members.Where(u => !u.Deleted).Select(u => u.ToImportedOrganizationUser()),
+                model.Members.Where(u => u.Deleted).Select(u => u.ExternalId),
+                model.OverwriteExisting.GetValueOrDefault());
+            return new OkResult();
+        }
+    }
+}

--- a/src/Core/Models/Api/Public/Request/OrganizationImportRequestModel.cs
+++ b/src/Core/Models/Api/Public/Request/OrganizationImportRequestModel.cs
@@ -1,0 +1,104 @@
+﻿using Bit.Core.Models.Business;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Bit.Core.Models.Api.Public
+{
+    public class OrganizationImportRequestModel
+    {
+        /// <summary>
+        /// Groups to import.
+        /// </summary>
+        public OrganizationImportGroupRequestModel[] Groups { get; set; }
+        /// <summary>
+        /// Members to import.
+        /// </summary>
+        public OrganizationImportMemberRequestModel[] Members { get; set; }
+        /// <summary>
+        /// Determines if the data in this request should overwrite or append to the existing organization data.
+        /// </summary>
+        [Required]
+        public bool? OverwriteExisting { get; set; }
+
+        public class OrganizationImportGroupRequestModel
+        {
+            /// <summary>
+            /// The name of the group.
+            /// </summary>
+            /// <example>Development Team</example>
+            [Required]
+            [StringLength(100)]
+            public string Name { get; set; }
+            /// <summary>
+            /// External identifier for reference or linking this group to another system, such as a user directory.
+            /// </summary>
+            /// <example>external_id_123456</example>
+            [Required]
+            [StringLength(300)]
+            public string ExternalId { get; set; }
+            /// <summary>
+            /// The associated external ids for members in this group.
+            /// </summary>
+            public IEnumerable<string> MemberExternalIds { get; set; }
+
+            public ImportedGroup ToImportedGroup(Guid organizationId)
+            {
+                var importedGroup = new ImportedGroup
+                {
+                    Group = new Table.Group
+                    {
+                        OrganizationId = organizationId,
+                        Name = Name,
+                        ExternalId = ExternalId
+                    },
+                    ExternalUserIds = new HashSet<string>(MemberExternalIds)
+                };
+
+                return importedGroup;
+            }
+        }
+
+        public class OrganizationImportMemberRequestModel : IValidatableObject
+        {
+            /// <summary>
+            /// The member's email address. Required for non-deleted users.
+            /// </summary>
+            /// <example>jsmith@example.com</example>
+            [EmailAddress]
+            [StringLength(50)]
+            public string Email { get; set; }
+            /// <summary>
+            /// External identifier for reference or linking this member to another system, such as a user directory.
+            /// </summary>
+            /// <example>external_id_123456</example>
+            [Required]
+            [StringLength(300)]
+            public string ExternalId { get; set; }
+            /// <summary>
+            /// Determines if this member should be removed from the organization during import.
+            /// </summary>
+            public bool Deleted { get; set; }
+
+            public ImportedOrganizationUser ToImportedOrganizationUser()
+            {
+                var importedUser = new ImportedOrganizationUser
+                {
+                    Email = Email.ToLowerInvariant(),
+                    ExternalId = ExternalId
+                };
+
+                return importedUser;
+            }
+
+            public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+            {
+                if (string.IsNullOrWhiteSpace(Email) && !Deleted)
+                {
+                    yield return new ValidationResult("Email is required for enabled members.",
+                        new string[] { nameof(Email) });
+                }
+            }
+        }
+    }
+}

--- a/src/Core/Services/IOrganizationService.cs
+++ b/src/Core/Services/IOrganizationService.cs
@@ -45,7 +45,7 @@ namespace Bit.Core.Services
         Task UpdateUserGroupsAsync(OrganizationUser organizationUser, IEnumerable<Guid> groupIds);
         Task<OrganizationLicense> GenerateLicenseAsync(Guid organizationId, Guid installationId);
         Task<OrganizationLicense> GenerateLicenseAsync(Organization organization, Guid installationId);
-        Task ImportAsync(Guid organizationId, Guid importingUserId, IEnumerable<ImportedGroup> groups,
+        Task ImportAsync(Guid organizationId, Guid? importingUserId, IEnumerable<ImportedGroup> groups,
             IEnumerable<ImportedOrganizationUser> newUsers, IEnumerable<string> removeUserExternalIds,
             bool overwriteExisting);
         Task RotateApiKeyAsync(Organization organization);

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1214,7 +1214,7 @@ namespace Bit.Core.Services
         }
 
         public async Task ImportAsync(Guid organizationId,
-            Guid importingUserId,
+            Guid? importingUserId,
             IEnumerable<ImportedGroup> groups,
             IEnumerable<ImportedOrganizationUser> newUsers,
             IEnumerable<string> removeUserExternalIds,


### PR DESCRIPTION
Public APIs should give organizations the ability to do their own directory imports. As we discussed with one of our tasks yesterday, this could also be used by the directory connector itself in the future with API key authentication.