### PR TITLE
Cloudflare Forever Load CSP Fix

### DIFF
--- a/util/Setup/Configuration.cs
+++ b/util/Setup/Configuration.cs
@@ -87,6 +87,11 @@ namespace Bit.Setup
             "Learn more: https://nginx.org/en/docs/http/ngx_http_realip_module.html")]
         public List<string> RealIps { get; set; }
 
+        [Description("Enables Cloudflare to be an exception in CSP. If you have the \n" +
+            "forever load issue while using cloudflare, enable this feature to possibly resolve.\n" +
+            "Learn more: https://github.com/bitwarden/server/issues/713")]
+        public bool EnableCloudflareCSP { get; set; } = false;
+
         [YamlIgnore]
         public string Domain
         {

--- a/util/Setup/NginxConfigBuilder.cs
+++ b/util/Setup/NginxConfigBuilder.cs
@@ -6,14 +6,6 @@ namespace Bit.Setup
     public class NginxConfigBuilder
     {
         private const string ConfFile = "/bitwarden/nginx/default.conf";
-        private const string ContentSecurityPolicy =
-            "default-src 'self'; style-src 'self' 'unsafe-inline'; " +
-            "img-src 'self' data: https://haveibeenpwned.com https://www.gravatar.com; " +
-            "child-src 'self' https://*.duosecurity.com; frame-src 'self' https://*.duosecurity.com; " +
-            "connect-src 'self' wss://{0} https://api.pwnedpasswords.com " +
-            "https://twofactorauth.org; " +
-            "object-src 'self' blob:; " +
-            "script-src 'self' https://ajax.cloudflare.com";
 
         private readonly Context _context;
 
@@ -119,6 +111,28 @@ namespace Bit.Setup
                 {
                     SslProtocols = "TLSv1.2";
                 }
+
+                if (context.Config.EnableCloudflareCSP)
+                {
+                    ContentSecurityPolicy =
+                        "default-src 'self'; style-src 'self' 'unsafe-inline'; " +
+                        "img-src 'self' data: https://haveibeenpwned.com https://www.gravatar.com; " +
+                        "child-src 'self' https://*.duosecurity.com; frame-src 'self' https://*.duosecurity.com; " +
+                        "connect-src 'self' wss://{0} https://api.pwnedpasswords.com " +
+                        "https://twofactorauth.org; " +
+                        "object-src 'self' blob:; " +
+                        "script-src 'self' https://ajax.cloudflare.com";
+                }
+                else
+                {
+                    ContentSecurityPolicy =
+                        "default-src 'self'; style-src 'self' 'unsafe-inline'; " +
+                        "img-src 'self' data: https://haveibeenpwned.com https://www.gravatar.com; " +
+                        "child-src 'self' https://*.duosecurity.com; frame-src 'self' https://*.duosecurity.com; " +
+                        "connect-src 'self' wss://{0} https://api.pwnedpasswords.com " +
+                        "https://twofactorauth.org; " +
+                        "object-src 'self' blob:;";
+                }
             }
 
             public bool Ssl { get; set; }
@@ -131,6 +145,7 @@ namespace Bit.Setup
             public string SslCiphers { get; set; }
             public string SslProtocols { get; set; }
             public string ContentSecurityPolicy => string.Format(NginxConfigBuilder.ContentSecurityPolicy, Domain);
+            public bool EnableCloudflareCSP { get; set; }
             public List<string> RealIps { get; set; }
         }
     }

--- a/util/Setup/NginxConfigBuilder.cs
+++ b/util/Setup/NginxConfigBuilder.cs
@@ -12,7 +12,8 @@ namespace Bit.Setup
             "child-src 'self' https://*.duosecurity.com; frame-src 'self' https://*.duosecurity.com; " +
             "connect-src 'self' wss://{0} https://api.pwnedpasswords.com " +
             "https://twofactorauth.org; " +
-            "object-src 'self' blob:;";
+            "object-src 'self' blob:; " +
+            "script-src 'self' https://ajax.cloudflare.com";
 
         private readonly Context _context;
 


### PR DESCRIPTION
This is in reference to #713 and #503. This fixes the "forever load" that happens when using Bitwarden & Cloudflare. I have tested and confirmed that this works. Additional Cloudflare CSP additions can be found at https://support.cloudflare.com/hc/en-us/articles/216537517-What-is-Content-Security-Policy-CSP-and-how-can-I-use-it-with-Cloudflare-