### PR TITLE
Fix sleep calculation

### DIFF
--- a/util/MsSql/backup-db.sh
+++ b/util/MsSql/backup-db.sh
@@ -3,7 +3,7 @@
 while true
 do
   # Sleep until next day
-  [ "$1" = "loop" ] && sleep $((24 * 3600 - (`date +%H` * 3600 + `date +%M` * 60 + `date +%S`)))
+  [ "$1" = "loop" ] && sleep $((24 * 3600 - (`date +%_H` * 3600 + `date +%_M` * 60 + `date +%_S`)))
 
   # Backup timestamp
   export now=$(date +%Y%m%d_%H%M%S)

--- a/util/Nginx/logrotate.sh
+++ b/util/Nginx/logrotate.sh
@@ -2,7 +2,7 @@
 
 while true
 do
-  [ "$1" = "loop" ] && sleep $((24 * 3600 - (`date +%H` * 3600 + `date +%M` * 60 + `date +%S`)))
+  [ "$1" = "loop" ] && sleep $((24 * 3600 - (`date +%_H` * 3600 + `date +%_M` * 60 + `date +%_S`)))
   ts=$(date +%Y%m%d_%H%M%S)
   mv /var/log/nginx/access.log /var/log/nginx/access.$ts.log
   mv /var/log/nginx/error.log /var/log/nginx/error.$ts.log


### PR DESCRIPTION
Hi,

This PR fixes an issue with `sleep` duration calculation in `mssql` and `nginx` background tasks.
The `0` prefix `date` command adds to its output leads for example to the specific `08` result, which is considered as an octal prefix, and breaks the whole calculation.
Let's then ask `date` command to discard the `0` prefix.

This should then safely close #711.

Thx !