### PR TITLE
Updated Stripe API SDK version to 36.9.0

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -52,7 +52,7 @@
     <PackageReference Include="System.Text.Json" Version="4.7.1" />
     <PackageReference Include="AspNetCoreRateLimit" Version="2.1.0" />
     <PackageReference Include="Braintree" Version="4.17.0" />
-    <PackageReference Include="Stripe.net" Version="28.8.0" />
+    <PackageReference Include="Stripe.net" Version="36.9.0" />
     <PackageReference Include="U2F.Core" Version="1.0.4" />
     <PackageReference Include="Otp.NET" Version="1.2.2" />
     <PackageReference Include="YubicoDotNetClient" Version="1.2.0" />

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -339,7 +339,7 @@ namespace Bit.Core.Services
                 .Select(i => new InvoiceSubscriptionItemOptions
                 {
                     Id = i.Id,
-                    PlanId = i.Plan.Id,
+                    Plan = i.Plan.Id,
                     Quantity = i.Quantity,
                 }).ToList();
 
@@ -347,16 +347,16 @@ namespace Bit.Core.Services
             {
                 subItemOptions.Add(new InvoiceSubscriptionItemOptions
                 {
-                    PlanId = plan.StripeSeatPlanId,
+                    Plan = plan.StripeSeatPlanId,
                     Quantity = additionalSeats,
                 });
                 subUpdateAction = (prorate) => subscriptionItemService.CreateAsync(
                     new SubscriptionItemCreateOptions
                     {
-                        PlanId = plan.StripeSeatPlanId,
+                        Plan = plan.StripeSeatPlanId,
                         Quantity = additionalSeats,
                         Prorate = prorate,
-                        SubscriptionId = sub.Id
+                        Subscription = sub.Id
                     });
             }
             else if (additionalSeats > 0 && seatItem != null)
@@ -364,13 +364,13 @@ namespace Bit.Core.Services
                 subItemOptions.Add(new InvoiceSubscriptionItemOptions
                 {
                     Id = seatItem.Id,
-                    PlanId = plan.StripeSeatPlanId,
+                    Plan = plan.StripeSeatPlanId,
                     Quantity = additionalSeats,
                 });
                 subUpdateAction = (prorate) => subscriptionItemService.UpdateAsync(seatItem.Id,
                     new SubscriptionItemUpdateOptions
                     {
-                        PlanId = plan.StripeSeatPlanId,
+                        Plan = plan.StripeSeatPlanId,
                         Quantity = additionalSeats,
                         Prorate = prorate
                     });
@@ -382,7 +382,8 @@ namespace Bit.Core.Services
                     Id = seatItem.Id,
                     Deleted = true
                 });
-                subUpdateAction = (prorate) => subscriptionItemService.DeleteAsync(seatItem.Id);
+                subUpdateAction = (prorate) => subscriptionItemService.DeleteAsync(seatItem.Id,
+                    new SubscriptionItemDeleteOptions());
             }
 
             string paymentIntentClientSecret = null;

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -102,7 +102,7 @@ namespace Bit.Core.Services
             {
                 OffSession = true,
                 TrialPeriodDays = plan.TrialPeriodDays,
-                Items = new List<SubscriptionItemOption>(),
+                Items = new List<SubscriptionItemOptions>(),
                 Metadata = new Dictionary<string, string>
                 {
                     [org.GatewayIdField()] = org.Id.ToString()
@@ -111,36 +111,36 @@ namespace Bit.Core.Services
 
             if (plan.StripePlanId != null)
             {
-                subCreateOptions.Items.Add(new SubscriptionItemOption
+                subCreateOptions.Items.Add(new SubscriptionItemOptions
                 {
-                    PlanId = plan.StripePlanId,
+                    Plan = plan.StripePlanId,
                     Quantity = 1
                 });
             }
 
             if (additionalSeats > 0 && plan.StripeSeatPlanId != null)
             {
-                subCreateOptions.Items.Add(new SubscriptionItemOption
+                subCreateOptions.Items.Add(new SubscriptionItemOptions
                 {
-                    PlanId = plan.StripeSeatPlanId,
+                    Plan = plan.StripeSeatPlanId,
                     Quantity = additionalSeats
                 });
             }
 
             if (additionalStorageGb > 0)
             {
-                subCreateOptions.Items.Add(new SubscriptionItemOption
+                subCreateOptions.Items.Add(new SubscriptionItemOptions
                 {
-                    PlanId = plan.StripeStoragePlanId,
+                    Plan = plan.StripeStoragePlanId,
                     Quantity = additionalStorageGb
                 });
             }
 
             if (premiumAccessAddon && plan.StripePremiumAccessPlanId != null)
             {
-                subCreateOptions.Items.Add(new SubscriptionItemOption
+                subCreateOptions.Items.Add(new SubscriptionItemOptions
                 {
-                    PlanId = plan.StripePremiumAccessPlanId,
+                    Plan = plan.StripePremiumAccessPlanId,
                     Quantity = 1
                 });
             }
@@ -154,15 +154,15 @@ namespace Bit.Core.Services
                     Description = org.BusinessName,
                     Email = org.BillingEmail,
                     Source = stipeCustomerSourceToken,
-                    PaymentMethodId = stipeCustomerPaymentMethodId,
+                    PaymentMethod = stipeCustomerPaymentMethodId,
                     Metadata = stripeCustomerMetadata,
                     InvoiceSettings = new CustomerInvoiceSettingsOptions
                     {
-                        DefaultPaymentMethodId = stipeCustomerPaymentMethodId
+                        DefaultPaymentMethod = stipeCustomerPaymentMethodId
                     }
                 });
                 subCreateOptions.AddExpand("latest_invoice.payment_intent");
-                subCreateOptions.CustomerId = customer.Id;
+                subCreateOptions.Customer = customer.Id;
                 var subscriptionService = new SubscriptionService();
                 subscription = await subscriptionService.CreateAsync(subCreateOptions);
                 if (subscription.Status == "incomplete" && subscription.LatestInvoice?.PaymentIntent != null)
@@ -225,8 +225,8 @@ namespace Bit.Core.Services
 
             var subCreateOptions = new SubscriptionCreateOptions
             {
-                CustomerId = customer.Id,
-                Items = new List<SubscriptionItemOption>(),
+                Customer = customer.Id,
+                Items = new List<SubscriptionItemOptions>(),
                 Metadata = new Dictionary<string, string>
                 {
                     [org.GatewayIdField()] = org.Id.ToString()
@@ -235,36 +235,36 @@ namespace Bit.Core.Services
 
             if (plan.StripePlanId != null)
             {
-                subCreateOptions.Items.Add(new SubscriptionItemOption
+                subCreateOptions.Items.Add(new SubscriptionItemOptions
                 {
-                    PlanId = plan.StripePlanId,
+                    Plan = plan.StripePlanId,
                     Quantity = 1
                 });
             }
 
             if (additionalSeats > 0 && plan.StripeSeatPlanId != null)
             {
-                subCreateOptions.Items.Add(new SubscriptionItemOption
+                subCreateOptions.Items.Add(new SubscriptionItemOptions
                 {
-                    PlanId = plan.StripeSeatPlanId,
+                    Plan = plan.StripeSeatPlanId,
                     Quantity = additionalSeats
                 });
             }
 
             if (additionalStorageGb > 0)
             {
-                subCreateOptions.Items.Add(new SubscriptionItemOption
+                subCreateOptions.Items.Add(new SubscriptionItemOptions
                 {
-                    PlanId = plan.StripeStoragePlanId,
+                    Plan = plan.StripeStoragePlanId,
                     Quantity = additionalStorageGb
                 });
             }
 
             if (premiumAccessAddon && plan.StripePremiumAccessPlanId != null)
             {
-                subCreateOptions.Items.Add(new SubscriptionItemOption
+                subCreateOptions.Items.Add(new SubscriptionItemOptions
                 {
-                    PlanId = plan.StripePremiumAccessPlanId,
+                    Plan = plan.StripePremiumAccessPlanId,
                     Quantity = 1
                 });
             }
@@ -303,7 +303,7 @@ namespace Bit.Core.Services
                     {
                         paymentMethodType = PaymentMethodType.Card;
                         stripePaymentMethod = true;
-                        subCreateOptions.DefaultPaymentMethodId = paymentMethod.Id;
+                        subCreateOptions.DefaultPaymentMethod = paymentMethod.Id;
                     }
                 }
             }
@@ -440,11 +440,11 @@ namespace Bit.Core.Services
                     Description = user.Name,
                     Email = user.Email,
                     Metadata = stripeCustomerMetadata,
-                    PaymentMethodId = stipeCustomerPaymentMethodId,
+                    PaymentMethod = stipeCustomerPaymentMethodId,
                     Source = stipeCustomerSourceToken,
                     InvoiceSettings = new CustomerInvoiceSettingsOptions
                     {
-                        DefaultPaymentMethodId = stipeCustomerPaymentMethodId
+                        DefaultPaymentMethod = stipeCustomerPaymentMethodId
                     }
                 });
                 createdStripeCustomer = true;
@@ -457,25 +457,25 @@ namespace Bit.Core.Services
 
             var subCreateOptions = new SubscriptionCreateOptions
             {
-                CustomerId = customer.Id,
-                Items = new List<SubscriptionItemOption>(),
+                Customer = customer.Id,
+                Items = new List<SubscriptionItemOptions>(),
                 Metadata = new Dictionary<string, string>
                 {
                     [user.GatewayIdField()] = user.Id.ToString()
                 }
             };
 
-            subCreateOptions.Items.Add(new SubscriptionItemOption
+            subCreateOptions.Items.Add(new SubscriptionItemOptions
             {
-                PlanId = paymentMethodType == PaymentMethodType.AppleInApp ? PremiumPlanAppleIapId : PremiumPlanId,
+                Plan = paymentMethodType == PaymentMethodType.AppleInApp ? PremiumPlanAppleIapId : PremiumPlanId,
                 Quantity = 1,
             });
 
             if (additionalStorageGb > 0)
             {
-                subCreateOptions.Items.Add(new SubscriptionItemOption
+                subCreateOptions.Items.Add(new SubscriptionItemOptions
                 {
-                    PlanId = StoragePlanId,
+                    Plan = StoragePlanId,
                     Quantity = additionalStorageGb
                 });
             }
@@ -518,7 +518,7 @@ namespace Bit.Core.Services
                 {
                     var previewInvoice = await invoiceService.UpcomingAsync(new UpcomingInvoiceOptions
                     {
-                        CustomerId = customer.Id,
+                        Customer = customer.Id,
                         SubscriptionItems = ToInvoiceSubscriptionItemOptions(subCreateOptions.Items)
                     });
 
@@ -604,7 +604,7 @@ namespace Bit.Core.Services
                 {
                     var previewInvoice = await invoiceService.UpcomingAsync(new UpcomingInvoiceOptions
                     {
-                        CustomerId = customer.Id,
+                        Customer = customer.Id,
                         SubscriptionItems = ToInvoiceSubscriptionItemOptions(subCreateOptions.Items)
                     });
                     if (previewInvoice.AmountDue > 0)
@@ -630,7 +630,7 @@ namespace Bit.Core.Services
                 {
                     var invoices = await invoiceService.ListAsync(new InvoiceListOptions
                     {
-                        SubscriptionId = subscription.Id
+                        Subscription = subscription.Id
                     });
 
                     var invoice = invoices?.FirstOrDefault();
@@ -687,11 +687,11 @@ namespace Bit.Core.Services
         }
 
         private List<InvoiceSubscriptionItemOptions> ToInvoiceSubscriptionItemOptions(
-            List<SubscriptionItemOption> subItemOptions)
+            List<SubscriptionItemOptions> subItemOptions)
         {
             return subItemOptions.Select(si => new InvoiceSubscriptionItemOptions
             {
-                PlanId = si.PlanId,
+                Plan = si.Plan,
                 Quantity = si.Quantity
             }).ToList();
         }
@@ -713,7 +713,7 @@ namespace Bit.Core.Services
                 .Select(i => new InvoiceSubscriptionItemOptions
                 {
                     Id = i.Id,
-                    PlanId = i.Plan.Id,
+                    Plan = i.Plan.Id,
                     Quantity = i.Quantity,
                 }).ToList();
 
@@ -721,15 +721,15 @@ namespace Bit.Core.Services
             {
                 subItemOptions.Add(new InvoiceSubscriptionItemOptions
                 {
-                    PlanId = storagePlanId,
+                    Plan = storagePlanId,
                     Quantity = additionalStorage,
                 });
                 subUpdateAction = (prorate) => subscriptionItemService.CreateAsync(
                     new SubscriptionItemCreateOptions
                     {
-                        PlanId = storagePlanId,
+                        Plan = storagePlanId,
                         Quantity = additionalStorage,
-                        SubscriptionId = sub.Id,
+                        Subscription = sub.Id,
                         Prorate = prorate
                     });
             }
@@ -738,13 +738,13 @@ namespace Bit.Core.Services
                 subItemOptions.Add(new InvoiceSubscriptionItemOptions
                 {
                     Id = storageItem.Id,
-                    PlanId = storagePlanId,
+                    Plan = storagePlanId,
                     Quantity = additionalStorage,
                 });
                 subUpdateAction = (prorate) => subscriptionItemService.UpdateAsync(storageItem.Id,
                     new SubscriptionItemUpdateOptions
                     {
-                        PlanId = storagePlanId,
+                        Plan = storagePlanId,
                         Quantity = additionalStorage,
                         Prorate = prorate
                     });
@@ -756,7 +756,8 @@ namespace Bit.Core.Services
                     Id = storageItem.Id,
                     Deleted = true
                 });
-                subUpdateAction = (prorate) => subscriptionItemService.DeleteAsync(storageItem.Id);
+                subUpdateAction = (prorate) => subscriptionItemService.DeleteAsync(storageItem.Id,
+                    new SubscriptionItemDeleteOptions());
             }
 
             string paymentIntentClientSecret = null;
@@ -819,7 +820,7 @@ namespace Bit.Core.Services
                 var chargeService = new ChargeService();
                 var charges = await chargeService.ListAsync(new ChargeListOptions
                 {
-                    CustomerId = subscriber.GatewayCustomerId
+                    Customer = subscriber.GatewayCustomerId
                 });
 
                 if (charges?.Data != null)
@@ -827,7 +828,7 @@ namespace Bit.Core.Services
                     var refundService = new RefundService();
                     foreach (var charge in charges.Data.Where(c => c.Captured.GetValueOrDefault() && !c.Refunded))
                     {
-                        await refundService.CreateAsync(new RefundCreateOptions { ChargeId = charge.Id });
+                        await refundService.CreateAsync(new RefundCreateOptions { Charge = charge.Id });
                     }
                 }
             }
@@ -856,14 +857,14 @@ namespace Bit.Core.Services
 
             var pendingInvoiceItems = invoiceItemService.ListAutoPaging(new InvoiceItemListOptions
             {
-                CustomerId = subscriber.GatewayCustomerId
+                Customer = subscriber.GatewayCustomerId
             }).ToList().Where(i => i.InvoiceId == null);
             var pendingInvoiceItemsDict = pendingInvoiceItems.ToDictionary(pii => pii.Id);
 
             var upcomingPreview = await invoiceService.UpcomingAsync(new UpcomingInvoiceOptions
             {
-                CustomerId = subscriber.GatewayCustomerId,
-                SubscriptionId = subscriber.GatewaySubscriptionId,
+                Customer = subscriber.GatewayCustomerId,
+                Subscription = subscriber.GatewaySubscriptionId,
                 SubscriptionItems = subItemOptions
             });
 
@@ -908,8 +909,8 @@ namespace Bit.Core.Services
                         {
                             Currency = ii.Currency,
                             Description = ii.Description,
-                            CustomerId = subscriber.GatewayCustomerId,
-                            SubscriptionId = ii.SubscriptionId,
+                            Customer = subscriber.GatewayCustomerId,
+                            Subscription = ii.SubscriptionId,
                             Discountable = ii.Discountable,
                             Amount = ii.Amount
                         });
@@ -920,9 +921,9 @@ namespace Bit.Core.Services
                     {
                         CollectionMethod = "send_invoice",
                         DaysUntilDue = 1,
-                        CustomerId = subscriber.GatewayCustomerId,
-                        SubscriptionId = subscriber.GatewaySubscriptionId,
-                        DefaultPaymentMethodId = cardPaymentMethodId
+                        Customer = subscriber.GatewayCustomerId,
+                        Subscription = subscriber.GatewaySubscriptionId,
+                        DefaultPaymentMethod = cardPaymentMethodId
                     });
 
                     var invoicePayOptions = new InvoicePayOptions();
@@ -970,7 +971,7 @@ namespace Bit.Core.Services
                         else
                         {
                             invoicePayOptions.OffSession = true;
-                            invoicePayOptions.PaymentMethodId = cardPaymentMethodId;
+                            invoicePayOptions.PaymentMethod = cardPaymentMethodId;
                         }
                     }
 
@@ -1019,8 +1020,8 @@ namespace Bit.Core.Services
                             {
                                 Currency = item.Currency,
                                 Description = item.Description,
-                                CustomerId = item.CustomerId,
-                                SubscriptionId = item.SubscriptionId,
+                                Customer = item.CustomerId,
+                                Subscription = item.SubscriptionId,
                                 Discountable = item.Discountable,
                                 Metadata = item.Metadata,
                                 Quantity = item.Proration ? 1 : item.Quantity,
@@ -1324,10 +1325,10 @@ namespace Bit.Core.Services
                         Email = subscriber.BillingEmailAddress(),
                         Metadata = stripeCustomerMetadata,
                         Source = stipeCustomerSourceToken,
-                        PaymentMethodId = stipeCustomerPaymentMethodId,
+                        PaymentMethod = stipeCustomerPaymentMethodId,
                         InvoiceSettings = new CustomerInvoiceSettingsOptions
                         {
-                            DefaultPaymentMethodId = stipeCustomerPaymentMethodId
+                            DefaultPaymentMethod = stipeCustomerPaymentMethodId
                         }
                     });
 
@@ -1353,7 +1354,7 @@ namespace Bit.Core.Services
                         else if (!string.IsNullOrWhiteSpace(stipeCustomerPaymentMethodId))
                         {
                             await paymentMethodService.AttachAsync(stipeCustomerPaymentMethodId,
-                                new PaymentMethodAttachOptions { CustomerId = customer.Id });
+                                new PaymentMethodAttachOptions { Customer = customer.Id });
                             defaultPaymentMethodId = stipeCustomerPaymentMethodId;
                         }
                     }
@@ -1372,7 +1373,7 @@ namespace Bit.Core.Services
 
                     var cardPaymentMethods = paymentMethodService.ListAutoPaging(new PaymentMethodListOptions
                     {
-                        CustomerId = customer.Id,
+                        Customer = customer.Id,
                         Type = "card"
                     });
                     foreach (var cardMethod in cardPaymentMethods.Where(m => m.Id != defaultPaymentMethodId))
@@ -1386,7 +1387,7 @@ namespace Bit.Core.Services
                         DefaultSource = defaultSourceId,
                         InvoiceSettings = new CustomerInvoiceSettingsOptions
                         {
-                            DefaultPaymentMethodId = defaultPaymentMethodId
+                            DefaultPaymentMethod = defaultPaymentMethodId
                         }
                     });
                 }
@@ -1509,7 +1510,7 @@ namespace Bit.Core.Services
 
                     var invoices = await invoiceService.ListAsync(new InvoiceListOptions
                     {
-                        CustomerId = customer.Id,
+                        Customer = customer.Id,
                         Limit = 50
                     });
                     billingInfo.Invoices = invoices.Data.Where(i => i.Status != "void" && i.Status != "draft")
@@ -1547,7 +1548,7 @@ namespace Bit.Core.Services
                     try
                     {
                         var upcomingInvoice = await invoiceService.UpcomingAsync(
-                            new UpcomingInvoiceOptions { CustomerId = subscriber.GatewayCustomerId });
+                            new UpcomingInvoiceOptions { Customer = subscriber.GatewayCustomerId });
                         if (upcomingInvoice != null)
                         {
                             subscriptionInfo.UpcomingInvoice =
@@ -1565,7 +1566,7 @@ namespace Bit.Core.Services
         {
             var paymentMethodService = new PaymentMethodService();
             var cardPaymentMethods = paymentMethodService.ListAutoPaging(
-                new PaymentMethodListOptions { CustomerId = customerId, Type = "card" });
+                new PaymentMethodListOptions { Customer = customerId, Type = "card" });
             return cardPaymentMethods.OrderByDescending(m => m.Created).FirstOrDefault();
         }
 


### PR DESCRIPTION
Stripe also changes their SDK code removing `*Id` suffix from most of the property names and changed the `DeleteAsync()` methods to require a not-null `*DeleteOptions` object to be passed.