### PR TITLE
Subscription change, invoice process update

### DIFF
--- a/src/Billing/Controllers/StripeController.cs
+++ b/src/Billing/Controllers/StripeController.cs
@@ -204,7 +204,7 @@ namespace Bit.Billing.Controllers
                 {
                     var subscriptions = await subscriptionService.ListAsync(new SubscriptionListOptions
                     {
-                        CustomerId = charge.CustomerId
+                        Customer = charge.CustomerId
                     });
                     foreach (var sub in subscriptions)
                     {

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -336,7 +336,7 @@ namespace Bit.Core.Services
             var prorationDate = DateTime.UtcNow;
             var seatItem = sub.Items?.Data?.FirstOrDefault(i => i.Plan.Id == plan.StripeSeatPlanId);
 
-            var subResponse = await subscriptionService.UpdateAsync(sub.Id, new SubscriptionUpdateOptions()
+            var subResponse = await subscriptionService.UpdateAsync(sub.Id, new SubscriptionUpdateOptions
             {
                 Items = new List<SubscriptionItemOptions>
                 {
@@ -349,7 +349,6 @@ namespace Bit.Core.Services
                     }
                 },
                 ProrationBehavior = "always_invoice",
-                PaymentBehavior = "allow_incomplete",
                 DaysUntilDue = 1,
                 CollectionMethod = "send_invoice",
                 ProrationDate = prorationDate,

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -338,9 +338,9 @@ namespace Bit.Core.Services
 
             var subResponse = await subscriptionService.UpdateAsync(sub.Id, new SubscriptionUpdateOptions()
             {
-                Items = new List<SubscriptionItemOptions>()
+                Items = new List<SubscriptionItemOptions>
                 {
-                    new SubscriptionItemOptions()
+                    new SubscriptionItemOptions
                     {
                         Id = seatItem?.Id,
                         Plan = plan.StripeSeatPlanId,
@@ -361,21 +361,21 @@ namespace Bit.Core.Services
                 try
                 {
                     paymentIntentClientSecret = await (_paymentService as StripePaymentService)
-                        .PayInvoiceAfterSubscriptionChangeAsync(organization, subResponse?.LatestInvoiceId);
+                        .PayInvoiceAfterSubscriptionChangeAsync(organization, subResponse.LatestInvoiceId);
                 }
                 catch
                 {
                     // Need to revert the subscription
-                    await subscriptionService.UpdateAsync(sub.Id, new SubscriptionUpdateOptions()
+                    await subscriptionService.UpdateAsync(sub.Id, new SubscriptionUpdateOptions
                     {
-                        Items = new List<SubscriptionItemOptions>()
+                        Items = new List<SubscriptionItemOptions>
                         {
-                            new SubscriptionItemOptions()
+                            new SubscriptionItemOptions
                             {
                                 Id = seatItem?.Id,
                                 Plan = plan.StripeSeatPlanId,
                                 Quantity = organization.Seats,
-                                Deleted = (seatItem?.Id == null || organization.Seats == 0) ? true : (bool?)null
+                                Deleted = seatItem?.Id == null ? true : (bool?)null
                             }
                         },
                         // This proration behavior prevents a false "credit" from

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -709,11 +709,11 @@ namespace Bit.Core.Services
             var prorationDate = DateTime.UtcNow;
             var storageItem = sub.Items?.FirstOrDefault(i => i.Plan.Id == storagePlanId);
             
-            var subResponse = await subscriptionService.UpdateAsync(sub.Id, new SubscriptionUpdateOptions()
+            var subResponse = await subscriptionService.UpdateAsync(sub.Id, new SubscriptionUpdateOptions
             {
-                Items = new List<SubscriptionItemOptions>()
+                Items = new List<SubscriptionItemOptions>
                 {
-                    new SubscriptionItemOptions()
+                    new SubscriptionItemOptions
                     {
                         Id = storageItem?.Id,
                         Plan = storagePlanId,
@@ -739,11 +739,11 @@ namespace Bit.Core.Services
                 catch
                 {
                     // Need to revert the subscription
-                    await subscriptionService.UpdateAsync(sub.Id, new SubscriptionUpdateOptions()
+                    await subscriptionService.UpdateAsync(sub.Id, new SubscriptionUpdateOptions
                     {
-                        Items = new List<SubscriptionItemOptions>()
+                        Items = new List<SubscriptionItemOptions>
                         {
-                            new SubscriptionItemOptions()
+                            new SubscriptionItemOptions
                             {
                                 Id = storageItem?.Id,
                                 Plan = storagePlanId,

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -705,7 +705,7 @@ namespace Bit.Core.Services
             {
                 throw new GatewayException("Subscription not found.");
             }
-            
+
             var prorationDate = DateTime.UtcNow;
             var storageItem = sub.Items?.FirstOrDefault(i => i.Plan.Id == storagePlanId);
             
@@ -722,7 +722,6 @@ namespace Bit.Core.Services
                     }
                 },
                 ProrationBehavior = "always_invoice",
-                PaymentBehavior = "allow_incomplete",
                 DaysUntilDue = 1,
                 CollectionMethod = "send_invoice",
                 ProrationDate = prorationDate,
@@ -870,11 +869,11 @@ namespace Bit.Core.Services
             {
                 // Finalize the invoice (from Draft) w/o auto-advance so we
                 //  can attempt payment manually.
-                invoice = await invoiceService.FinalizeInvoiceAsync(invoice.Id, new InvoiceFinalizeOptions()
+                invoice = await invoiceService.FinalizeInvoiceAsync(invoice.Id, new InvoiceFinalizeOptions
                 {
                     AutoAdvance = false,
                 });
-                var invoicePayOptions = new InvoicePayOptions()
+                var invoicePayOptions = new InvoicePayOptions
                 {
                     PaymentMethod = cardPaymentMethodId,
                 };


### PR DESCRIPTION
## Objective

- Simplify the billing process when a subscription's seats/storage quantity is increased/decreased through Stripe's API/SDK to utilize the new Proration Behavior flag.
- Use Stripe's subscription process to generate invoices (vs. manually creating invoices)
- Retain Plan IDs on Invoices to correctly trace plans to subscription billing line items on invoices
- Handle failure scenarios in billing with both Stripe and PayPal accordingly
- Remove the "threshold" for immediate payment, therefore reducing the complexity in handling billing faults/failures in subsequent changes before the next billing cycle (marginal increase in charge fees and frequency of charges or reduction in complexity, billing errors and omissions/misses)

## Changes
*StripePaymentService.cs* - Renamed the method `PreviewUpcomingInvoiceAndPayAsync()` to `PayInvoiceAfterSubscriptionChangeAsync()` and reduced the method parameters (and return value).

Both code files update methods (seats / storage) will perform validation (as before), change the subscription in one operation (simplified code structure to a single Update call against Stripe's API), and attempt payment (call to `PayInvoiceAfterSubscriptionChangeAsync()`). If there's an exception, will rollback the subscription to the prior quantity (or delete if it was a new subscription item).