### PR TITLE
generate signin token for enterprise portal

### DIFF
--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -599,5 +599,24 @@ namespace Bit.Api.Controllers
 
             await _userService.ReinstatePremiumAsync(user);
         }
+
+        [HttpGet("enterprise-portal-signin-token")]
+        [Authorize("Web")]
+        public async Task<string> GetEnterprisePortalSignInToken()
+        {
+            var user = await _userService.GetUserByPrincipalAsync(User);
+            if (user == null)
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            var token = await _userService.GenerateEnterprisePortalSignInTokenAsync(user);
+            if (token == null)
+            {
+                throw new BadRequestException("Cannot generate sign in token.");
+            }
+
+            return token;
+        }
     }
 }

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -63,5 +63,6 @@ namespace Bit.Core.Services
         Task<bool> CanAccessPremium(ITwoFactorProvidersUser user);
         Task<bool> TwoFactorIsEnabledAsync(ITwoFactorProvidersUser user);
         Task<bool> TwoFactorProviderIsEnabledAsync(TwoFactorProviderType provider, ITwoFactorProvidersUser user);
+        Task<string> GenerateEnterprisePortalSignInTokenAsync(User user);
     }
 }

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -1020,6 +1020,13 @@ namespace Bit.Core.Services
             return await CanAccessPremium(user);
         }
 
+        public async Task<string> GenerateEnterprisePortalSignInTokenAsync(User user)
+        {
+            var token = await GenerateUserTokenAsync(user, Options.Tokens.PasswordResetTokenProvider,
+                "EnterprisePortalTokenSignIn");
+            return token;
+        }
+
         private async Task<IdentityResult> UpdatePasswordHash(User user, string newPassword,
             bool validatePassword = true, bool refreshStamp = true)
         {

--- a/src/Core/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Core/Utilities/ServiceCollectionExtensions.cs
@@ -393,6 +393,7 @@ namespace Bit.Core.Utilities
         public static void AddCustomDataProtectionServices(
             this IServiceCollection services, IWebHostEnvironment env, GlobalSettings globalSettings)
         {
+            var builder = services.AddDataProtection().SetApplicationName("Bitwarden");
             if (env.IsDevelopment())
             {
                 return;
@@ -400,8 +401,7 @@ namespace Bit.Core.Utilities
 
             if (globalSettings.SelfHosted && CoreHelpers.SettingHasValue(globalSettings.DataProtection.Directory))
             {
-                services.AddDataProtection()
-                    .PersistKeysToFileSystem(new DirectoryInfo(globalSettings.DataProtection.Directory));
+                builder.PersistKeysToFileSystem(new DirectoryInfo(globalSettings.DataProtection.Directory));
             }
 
             if (!globalSettings.SelfHosted && CoreHelpers.SettingHasValue(globalSettings.Storage?.ConnectionString))
@@ -419,7 +419,7 @@ namespace Bit.Core.Utilities
                         "dataprotection.pfx", globalSettings.DataProtection.CertificatePassword)
                         .GetAwaiter().GetResult();
                 }
-                services.AddDataProtection()
+                builder
                     .PersistKeysToAzureBlobStorage(storageAccount, "aspnet-dataprotection/keys.xml")
                     .ProtectKeysWithCertificate(dataProtectionCert);
             }


### PR DESCRIPTION
Generate a token for the enterprise portal signin process.

Also set data protection application name. This will, unfortunately, invalidate existing tokens, meaning users will have to generate new ones. We'll need to make CS team aware. @sevensixseven 