### PR TITLE
Increase limits set by importer to 2k

### DIFF
--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -375,7 +375,7 @@ namespace Bit.Api.Controllers
         public async Task Import(string id, [FromBody]ImportOrganizationUsersRequestModel model)
         {
             if (!_globalSettings.SelfHosted &&
-                (model.Groups.Count() > 200 || model.Users.Count(u => !u.Deleted) > 1000))
+                (model.Groups.Count() > 2000 || model.Users.Count(u => !u.Deleted) > 2000))
             {
                 throw new BadRequestException("You cannot import this much data at once.");
             }

--- a/src/Api/Public/Controllers/OrganizationController.cs
+++ b/src/Api/Public/Controllers/OrganizationController.cs
@@ -41,7 +41,7 @@ namespace Bit.Api.Public.Controllers
         public async Task<IActionResult> Import([FromBody]OrganizationImportRequestModel model)
         {
             if (!_globalSettings.SelfHosted &&
-                (model.Groups.Count() > 200 || model.Members.Count(u => !u.Deleted) > 1000))
+                (model.Groups.Count() > 2000 || model.Members.Count(u => !u.Deleted) > 2000))
             {
                 throw new BadRequestException("You cannot import this much data at once.");
             }


### PR DESCRIPTION
Increase the user/group import API limits to higher values since we are seeing use cases where they need to be this high now.