### PR TITLE
License expiration email for self-hosted org/premium accounts

### DIFF
--- a/src/Core/MailTemplates/Handlebars/LicenseExpired.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/LicenseExpired.html.hbs
@@ -3,7 +3,7 @@
     <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
         <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;" valign="top">
             {{#if IsOrganization}}
-            This email is to notify you that your Bitwarden organization license has expired and must be updated for continued use. See the following article for details about replacing your license file:
+            This email is to notify you that your Bitwarden organization license for <b style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">{{OrganizationName}}</b> has expired and must be updated for continued use. See the following article for details about replacing your license file:
             {{else}}
             This email is to notify you that your Bitwarden premium license has expired and must be updated for continued use. See the following article for details about replacing your license file:
             {{/if}}

--- a/src/Core/MailTemplates/Handlebars/LicenseExpired.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/LicenseExpired.html.hbs
@@ -1,0 +1,18 @@
+﻿{{#>FullHtmlLayout}}
+<table width="100%" cellpadding="0" cellspacing="0" style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;" valign="top">
+            {{#if IsOrganization}}
+            This email is to notify you that your Bitwarden organization license has expired and must be updated for continued use. See the following article for details about replacing your license file:
+            {{else}}
+            This email is to notify you that your Bitwarden premium license has expired and must be updated for continued use. See the following article for details about replacing your license file:
+            {{/if}}
+        </td>
+    </tr>
+    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        <td class="content-block last" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0; -webkit-text-size-adjust: none;" valign="top">
+            {{{link 'https://bitwarden.com/help/article/licensing-on-premise/'}}}
+        </td>
+    </tr>
+</table>
+{{/FullHtmlLayout}}

--- a/src/Core/MailTemplates/Handlebars/LicenseExpired.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/LicenseExpired.text.hbs
@@ -1,7 +1,9 @@
 ﻿{{#>BasicTextLayout}}
 {{#if IsOrganization}}
+
 This email is to notify you that your Bitwarden organization license has expired and must be updated for continued use. See the following article for details about replacing your license file:
 {{else}}
+
 This email is to notify you that your Bitwarden premium license has expired and must be updated for continued use. See the following article for details about replacing your license file:
 {{/if}}
 

--- a/src/Core/MailTemplates/Handlebars/LicenseExpired.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/LicenseExpired.text.hbs
@@ -1,0 +1,9 @@
+﻿{{#>BasicTextLayout}}
+{{#if IsOrganization}}
+This email is to notify you that your Bitwarden organization license has expired and must be updated for continued use. See the following article for details about replacing your license file:
+{{else}}
+This email is to notify you that your Bitwarden premium license has expired and must be updated for continued use. See the following article for details about replacing your license file:
+{{/if}}
+
+https://bitwarden.com/help/article/licensing-on-premise/
+{{/BasicTextLayout}}

--- a/src/Core/MailTemplates/Handlebars/LicenseExpired.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/LicenseExpired.text.hbs
@@ -1,9 +1,7 @@
 ﻿{{#>BasicTextLayout}}
 {{#if IsOrganization}}
-
-This email is to notify you that your Bitwarden organization license has expired and must be updated for continued use. See the following article for details about replacing your license file:
+This email is to notify you that your Bitwarden organization license for {{OrganizationName}} has expired and must be updated for continued use. See the following article for details about replacing your license file:
 {{else}}
-
 This email is to notify you that your Bitwarden premium license has expired and must be updated for continued use. See the following article for details about replacing your license file:
 {{/if}}
 

--- a/src/Core/Models/Mail/LicenseExpiredViewModel.cs
+++ b/src/Core/Models/Mail/LicenseExpiredViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace Bit.Core.Models.Mail
+{
+    public class LicenseExpiredViewModel : BaseMailModel
+    {
+        public bool IsOrganization { get; set; }
+    }
+}

--- a/src/Core/Models/Mail/LicenseExpiredViewModel.cs
+++ b/src/Core/Models/Mail/LicenseExpiredViewModel.cs
@@ -2,6 +2,7 @@
 {
     public class LicenseExpiredViewModel : BaseMailModel
     {
-        public bool IsOrganization { get; set; }
+        public string OrganizationName { get; set; }
+        public bool IsOrganization => !string.IsNullOrWhiteSpace(OrganizationName);
     }
 }

--- a/src/Core/Services/IMailService.cs
+++ b/src/Core/Services/IMailService.cs
@@ -25,6 +25,7 @@ namespace Bit.Core.Services
             bool mentionInvoices);
         Task SendPaymentFailedAsync(string email, decimal amount, bool mentionInvoices);
         Task SendAddedCreditAsync(string email, decimal amount);
+        Task SendLicenseExpiredAsync(IEnumerable<string> emails, bool isOrganization);
         Task SendNewDeviceLoggedInEmail(string email, string deviceType, DateTime timestamp, string ip);
         Task SendRecoverTwoFactorEmail(string email, DateTime timestamp, string ip);
     }

--- a/src/Core/Services/IMailService.cs
+++ b/src/Core/Services/IMailService.cs
@@ -25,7 +25,7 @@ namespace Bit.Core.Services
             bool mentionInvoices);
         Task SendPaymentFailedAsync(string email, decimal amount, bool mentionInvoices);
         Task SendAddedCreditAsync(string email, decimal amount);
-        Task SendLicenseExpiredAsync(IEnumerable<string> emails, bool isOrganization);
+        Task SendLicenseExpiredAsync(IEnumerable<string> emails, string organizationName = null);
         Task SendNewDeviceLoggedInEmail(string email, string deviceType, DateTime timestamp, string ip);
         Task SendRecoverTwoFactorEmail(string email, DateTime timestamp, string ip);
     }

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -278,6 +278,18 @@ namespace Bit.Core.Services
             message.Category = "AddedCredit";
             await _mailDeliveryService.SendEmailAsync(message);
         }
+        
+        public async Task SendLicenseExpiredAsync(IEnumerable<string> emails, bool isOrganization)
+        {
+            var message = CreateDefaultMessage("License Expired", emails);
+            var model = new LicenseExpiredViewModel
+            {
+                IsOrganization = isOrganization
+            };
+            await AddMessageContentAsync(message, "LicenseExpired", model);
+            message.Category = "LicenseExpired";
+            await _mailDeliveryService.SendEmailAsync(message);
+        }
 
         public async Task SendNewDeviceLoggedInEmail(string email, string deviceType, DateTime timestamp, string ip)
         {

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -279,12 +279,12 @@ namespace Bit.Core.Services
             await _mailDeliveryService.SendEmailAsync(message);
         }
         
-        public async Task SendLicenseExpiredAsync(IEnumerable<string> emails, bool isOrganization)
+        public async Task SendLicenseExpiredAsync(IEnumerable<string> emails, string organizationName = null)
         {
             var message = CreateDefaultMessage("License Expired", emails);
             var model = new LicenseExpiredViewModel
             {
-                IsOrganization = isOrganization
+                OrganizationName = organizationName,
             };
             await AddMessageContentAsync(message, "LicenseExpired", model);
             message.Category = "LicenseExpired";

--- a/src/Core/Services/Implementations/LicensingService.cs
+++ b/src/Core/Services/Implementations/LicensingService.cs
@@ -128,7 +128,7 @@ namespace Bit.Core.Services
             org.RevisionDate = DateTime.UtcNow;
             await _organizationRepository.ReplaceAsync(org);
 
-            await _mailService.SendLicenseExpiredAsync(new List<string> { org.BillingEmail }, true);
+            await _mailService.SendLicenseExpiredAsync(new List<string> { org.BillingEmail }, org.Name);
         }
 
         public async Task ValidateUsersAsync()
@@ -219,7 +219,7 @@ namespace Bit.Core.Services
             user.RevisionDate = DateTime.UtcNow;
             await _userRepository.ReplaceAsync(user);
 
-            await _mailService.SendLicenseExpiredAsync(new List<string> { user.Email }, false);
+            await _mailService.SendLicenseExpiredAsync(new List<string> { user.Email });
         }
 
         public bool VerifyLicense(ILicense license)

--- a/src/Core/Services/Implementations/LicensingService.cs
+++ b/src/Core/Services/Implementations/LicensingService.cs
@@ -128,7 +128,7 @@ namespace Bit.Core.Services
             org.RevisionDate = DateTime.UtcNow;
             await _organizationRepository.ReplaceAsync(org);
 
-            await _mailService.SendLicenseExpiredAsync(new List<string> {org.BillingEmail}, true);
+            await _mailService.SendLicenseExpiredAsync(new List<string> { org.BillingEmail }, true);
         }
 
         public async Task ValidateUsersAsync()
@@ -219,7 +219,7 @@ namespace Bit.Core.Services
             user.RevisionDate = DateTime.UtcNow;
             await _userRepository.ReplaceAsync(user);
 
-            await _mailService.SendLicenseExpiredAsync(new List<string> {user.Email}, false);
+            await _mailService.SendLicenseExpiredAsync(new List<string> { user.Email }, false);
         }
 
         public bool VerifyLicense(ILicense license)

--- a/src/Core/Services/Implementations/LicensingService.cs
+++ b/src/Core/Services/Implementations/LicensingService.cs
@@ -24,6 +24,7 @@ namespace Bit.Core.Services
         private readonly IUserRepository _userRepository;
         private readonly IOrganizationRepository _organizationRepository;
         private readonly IOrganizationUserRepository _organizationUserRepository;
+        private readonly IMailService _mailService;
         private readonly ILogger<LicensingService> _logger;
 
         private IDictionary<Guid, DateTime> _userCheckCache = new Dictionary<Guid, DateTime>();
@@ -32,6 +33,7 @@ namespace Bit.Core.Services
             IUserRepository userRepository,
             IOrganizationRepository organizationRepository,
             IOrganizationUserRepository organizationUserRepository,
+            IMailService mailService,
             IWebHostEnvironment environment,
             ILogger<LicensingService> logger,
             GlobalSettings globalSettings)
@@ -39,6 +41,7 @@ namespace Bit.Core.Services
             _userRepository = userRepository;
             _organizationRepository = organizationRepository;
             _organizationUserRepository = organizationUserRepository;
+            _mailService = mailService;
             _logger = logger;
             _globalSettings = globalSettings;
 
@@ -124,6 +127,8 @@ namespace Bit.Core.Services
             org.ExpirationDate = license?.Expires ?? DateTime.UtcNow;
             org.RevisionDate = DateTime.UtcNow;
             await _organizationRepository.ReplaceAsync(org);
+
+            await _mailService.SendLicenseExpiredAsync(new List<string> {org.BillingEmail}, true);
         }
 
         public async Task ValidateUsersAsync()
@@ -213,6 +218,8 @@ namespace Bit.Core.Services
             user.PremiumExpirationDate = license?.Expires ?? DateTime.UtcNow;
             user.RevisionDate = DateTime.UtcNow;
             await _userRepository.ReplaceAsync(user);
+
+            await _mailService.SendLicenseExpiredAsync(new List<string> {user.Email}, false);
         }
 
         public bool VerifyLicense(ILicense license)

--- a/src/Core/Services/NoopImplementations/NoopMailService.cs
+++ b/src/Core/Services/NoopImplementations/NoopMailService.cs
@@ -88,7 +88,7 @@ namespace Bit.Core.Services
             return Task.FromResult(0);
         }
 
-        public Task SendLicenseExpiredAsync(IEnumerable<string> emails, bool isOrganization)
+        public Task SendLicenseExpiredAsync(IEnumerable<string> emails, string organizationName = null)
         {
             return Task.FromResult(0);
         }

--- a/src/Core/Services/NoopImplementations/NoopMailService.cs
+++ b/src/Core/Services/NoopImplementations/NoopMailService.cs
@@ -88,6 +88,11 @@ namespace Bit.Core.Services
             return Task.FromResult(0);
         }
 
+        public Task SendLicenseExpiredAsync(IEnumerable<string> emails, bool isOrganization)
+        {
+            return Task.FromResult(0);
+        }
+
         public Task SendNewDeviceLoggedInEmail(string email, string deviceType, DateTime timestamp, string ip)
         {
             return Task.FromResult(0);

--- a/test/Core.Test/Services/LicensingServiceTests.cs
+++ b/test/Core.Test/Services/LicensingServiceTests.cs
@@ -16,6 +16,7 @@ namespace Bit.Core.Test.Services
         private readonly IUserRepository _userRepository;
         private readonly IOrganizationRepository _organizationRepository;
         private readonly IOrganizationUserRepository _organizationUserRepository;
+        private readonly IMailService _mailService;
         private readonly IWebHostEnvironment _hostingEnvironment;
         private readonly ILogger<LicensingService> _logger;
 
@@ -24,6 +25,7 @@ namespace Bit.Core.Test.Services
             _userRepository = Substitute.For<IUserRepository>();
             _organizationRepository = Substitute.For<IOrganizationRepository>();
             _organizationUserRepository = Substitute.For<IOrganizationUserRepository>();
+            _mailService = Substitute.For<IMailService>();
             _hostingEnvironment = Substitute.For<IWebHostEnvironment>();
             _logger = Substitute.For<ILogger<LicensingService>>();
             _globalSettings = new GlobalSettings();
@@ -32,6 +34,7 @@ namespace Bit.Core.Test.Services
                 _userRepository,
                 _organizationRepository,
                 _organizationUserRepository,
+                _mailService,
                 _hostingEnvironment,
                 _logger,
                 _globalSettings


### PR DESCRIPTION
Added support for sending license expiration email for organization and premium accounts.  Email transmission is tied to `DisableOrganizationAsync` and `DisablePremiumAsync` tasks in `LicensingService.cs`.  Multiple mail recipients are supported though we're currently only using `org.BillingEmail` and `user.Email` for org and premium accounts respectively. 