### PR TITLE
Add syslog suport for sending application logs to a Syslog server

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -49,6 +49,7 @@
     <PackageReference Include="IdentityServer4" Version="3.1.2" />
     <PackageReference Include="Dapper" Version="2.0.30" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Serilog.Sinks.SyslogMessages" Version="1.0.5" />
     <PackageReference Include="System.Text.Json" Version="4.7.1" />
     <PackageReference Include="AspNetCoreRateLimit" Version="2.1.0" />
     <PackageReference Include="Braintree" Version="4.17.0" />

--- a/src/Core/GlobalSettings.cs
+++ b/src/Core/GlobalSettings.cs
@@ -190,9 +190,9 @@ namespace Bit.Core
             /// The certificate path and <see cref="CertificatePassword"/> are passed into the <see cref="System.Security.Cryptography.X509Certificates.X509Certificate2.X509Certificate2(string, string)" />.
             /// The file format of the certificate may be binary encded (DER) or base64. If the private key is encrypted, provide the password in <see cref="CertificatePassword"/>,
             /// </remarks>
-            public string Certificate { get; set; }
+            public string CertificatePath { get; set; }
             /// <summary>
-            /// The password for the encrypted private key in the certificate supplied in <see cref="Certificate" />.
+            /// The password for the encrypted private key in the certificate supplied in <see cref="CertificatePath" />.
             /// </summary>
             /// <value></value>
             public string CertificatePassword { get; set; }

--- a/src/Core/GlobalSettings.cs
+++ b/src/Core/GlobalSettings.cs
@@ -32,6 +32,7 @@ namespace Bit.Core
         public virtual DataProtectionSettings DataProtection { get; set; } = new DataProtectionSettings();
         public virtual DocumentDbSettings DocumentDb { get; set; } = new DocumentDbSettings();
         public virtual SentrySettings Sentry { get; set; } = new SentrySettings();
+        public virtual SyslogSettings Syslog { get; set; } = new SyslogSettings();
         public virtual NotificationHubSettings NotificationHub { get; set; } = new NotificationHubSettings();
         public virtual YubicoSettings Yubico { get; set; } = new YubicoSettings();
         public virtual DuoSettings Duo { get; set; } = new DuoSettings();
@@ -157,6 +158,49 @@ namespace Bit.Core
         public class NotificationsSettings : ConnectionStringSettings
         {
             public string RedisConnectionString { get; set; }
+        }
+
+        public class SyslogSettings
+        {
+            /// <summary>
+            /// The connection string used to connect to a remote syslog server over TCP or UDP, or to connect locally.
+            /// </summary>
+            /// <remarks>
+            /// <para>The connection string will be parsed using <see cref="System.Uri" /> to extract the protocol, host name and port number.
+            /// </para>
+            /// <para>
+            /// Supported protocols are:
+            /// <list type="bullet">
+            /// <item>UDP (use <code>udp://</code>)</item>
+            /// <item>TCP (use <code>tcp://</code>)</item>
+            /// <item>TLS over TCP (use <code>tls://</code>)</item>
+            /// </list>
+            /// </para>
+            /// </remarks>
+            /// <example>
+            /// A remote server (logging.dev.example.com) is listening on UDP (port 514):
+            /// <code>
+            /// udp://logging.dev.example.com:514</code>.
+            /// </example>
+            public string Destination { get; set; }
+            /// <summary>
+            /// The absolute path to a Certificate (DER or Base64 encoded with private key).
+            /// </summary>
+            /// <remarks>
+            /// The certificate path and <see cref="CertificatePassword"/> are passed into the <see cref="System.Security.Cryptography.X509Certificates.X509Certificate2.X509Certificate2(string, string)" />.
+            /// The file format of the certificate may be binary encded (DER) or base64. If the private key is encrypted, provide the password in <see cref="CertificatePassword"/>,
+            /// </remarks>
+            public string Certificate { get; set; }
+            /// <summary>
+            /// The password for the encrypted private key in the certificate supplied in <see cref="Certificate" />.
+            /// </summary>
+            /// <value></value>
+            public string CertificatePassword { get; set; }
+            /// <summary>
+            /// The thumbprint of the certificate in the X.509 certificate store for personal certificates for the user account running Bitwarden. 
+            /// </summary>
+            /// <value></value>
+            public string CertificateThumbprint { get; set; }
         }
 
         public class NotificationHubSettings

--- a/src/Core/Utilities/LoggerFactoryExtensions.cs
+++ b/src/Core/Utilities/LoggerFactoryExtensions.cs
@@ -112,7 +112,7 @@ namespace Bit.Core.Utilities
                         {
                             config.WriteTo.TcpSyslog(syslogAddress.Host, port, appName,
                                 secureProtocols: protocols,
-                                certProvider: new CertificateFileProvider(globalSettings.Syslog.Certificate,
+                                certProvider: new CertificateFileProvider(globalSettings.Syslog.CertificatePath,
                                                                           globalSettings.Syslog?.CertificatePassword ?? string.Empty));
                         }
 

--- a/src/Core/Utilities/LoggerFactoryExtensions.cs
+++ b/src/Core/Utilities/LoggerFactoryExtensions.cs
@@ -5,7 +5,10 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Events;
+using Serilog.Sinks.Syslog;
 using System;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Bit.Core.Utilities
 {
@@ -69,6 +72,52 @@ namespace Bit.Core.Utilities
                 config.WriteTo.Sentry(globalSettings.Sentry.Dsn)
                     .Enrich.FromLogContext()
                     .Enrich.WithProperty("Project", globalSettings.ProjectName);
+            }
+            else if (CoreHelpers.SettingHasValue(globalSettings?.Syslog.Destination))
+            {
+                // appending sitename to project name to allow eaiser identification in syslog.
+                var appName = $"{globalSettings.SiteName}-{globalSettings.ProjectName}";
+                if (globalSettings.Syslog.Destination.Equals("local", StringComparison.OrdinalIgnoreCase))
+                {
+                    config.WriteTo.LocalSyslog(appName);
+                }
+                else if (Uri.TryCreate(globalSettings.Syslog.Destination,UriKind.Absolute, out var syslogAddress))
+                {
+                    // Syslog's standard port is 514 (both UDP and TCP). TLS does not have a standard port, so assume 514.
+                    int port = syslogAddress.Port >= 0
+                        ? syslogAddress.Port
+                        : 514;
+
+                    if (syslogAddress.Scheme.Equals("udp"))
+                    {
+                        config.WriteTo.UdpSyslog(syslogAddress.Host, port, appName);
+                    }
+                    else if (syslogAddress.Scheme.Equals("tcp"))
+                    {
+                        config.WriteTo.TcpSyslog(syslogAddress.Host, port, appName);
+                    }
+                    else if (syslogAddress.Scheme.Equals("tls"))
+                    {
+                        // TLS v1.1, v1.2 and v1.3 are explicitly selected (leaving out TLS v1.0)
+                        const SslProtocols protocols = SslProtocols.Tls11 | SslProtocols.Tls12 | SslProtocols.Tls13;
+
+                        if (CoreHelpers.SettingHasValue(globalSettings.Syslog.CertificateThumbprint))
+                        {
+                            config.WriteTo.TcpSyslog(syslogAddress.Host, port, appName,
+                                secureProtocols: protocols,
+                                certProvider: new CertificateStoreProvider(StoreName.My, StoreLocation.CurrentUser, 
+                                                                           globalSettings.Syslog.CertificateThumbprint));
+                        }
+                        else
+                        {
+                            config.WriteTo.TcpSyslog(syslogAddress.Host, port, appName,
+                                secureProtocols: protocols,
+                                certProvider: new CertificateFileProvider(globalSettings.Syslog.Certificate,
+                                                                          globalSettings.Syslog?.CertificatePassword ?? string.Empty));
+                        }
+
+                    }
+                }
             }
             else if (CoreHelpers.SettingHasValue(globalSettings.LogDirectory))
             {


### PR DESCRIPTION
Bitwarden supports sending its logs to
- Azure DocumentDB
- Sentry
- Log files on disk

This pull request adds Syslog as a destination for logging through either
- local Syslog server
- UDP syslog endpoint
- TCP syslog endpoint
- or TLS syslog endpoint using a certificate from
  - a PFX file on disk
  - Certificate from the `My` certificate store under `Current User`

The syslog entries are named using the template: `{globalSettings.SiteName}-{globalSettings.ProjectName}"` (e.g. `Bitwarden-Admin`). This is to increate clarity when identifying where the log entries originated from

I'm not sure where to document this feature, so i've included what I can into the DocXML in `Bit.Core.GlobalSettings.SyslogSettings`.

Usage Examples:

1. Syslog server on localhost
```json
{
  "globalSettings": {
    "syslog": {
      "destination": "local",
    }
  }
}
```


2. Syslog server on `example.com`, port `514` using UDP
```json
{
  "globalSettings": {
    "syslog": {
      "destination": "udp://example.com:514"
    }
  }
}
```

3. Syslog server on `example.com`, port `514` using TCP
```json
{
  "globalSettings": {
    "syslog": {
      "destination": "tcp://example.com:514"
    }
  }
}
```

4. Syslog server on `example.com`, port `514` using TLS with certificate file
```json
{
  "globalSettings": {
    "syslog": {
      "destination": "tls://example.com:514",
      "certificatePath": "/path-to-certificate.pfx",
      "certificatePassword": "password123"
    }
  }
}
```


5. Syslog server on `example.com`, port `514` using TLS stored in certificate store
```json
{
  "globalSettings": {
    "syslog": {
      "destination": "tls://example.com:514",
      "certificateThumbprint": "3232C26DCDF758FF3BEA79ED25C08656F4A0D63D"
    }
  }
}
```