### PR TITLE
Add support collection access, hide passwords

### DIFF
--- a/src/Core/Models/Api/Request/SelectionReadOnlyRequestModel.cs
+++ b/src/Core/Models/Api/Request/SelectionReadOnlyRequestModel.cs
@@ -19,7 +19,7 @@ namespace Bit.Core.Models.Api
             {
                 Id = new Guid(Id),
                 ReadOnly = ReadOnly,
-                HidePasswords = HidePasswords
+                HidePasswords = HidePasswords,
             };
         }
     }

--- a/src/Core/Models/Api/Request/SelectionReadOnlyRequestModel.cs
+++ b/src/Core/Models/Api/Request/SelectionReadOnlyRequestModel.cs
@@ -11,13 +11,15 @@ namespace Bit.Core.Models.Api
         [Required]
         public string Id { get; set; }
         public bool ReadOnly { get; set; }
+        public bool HidePasswords { get; set; }
 
         public SelectionReadOnly ToSelectionReadOnly()
         {
             return new SelectionReadOnly
             {
                 Id = new Guid(Id),
-                ReadOnly = ReadOnly
+                ReadOnly = ReadOnly,
+                HidePasswords = HidePasswords
             };
         }
     }

--- a/src/Core/Models/Api/Response/CipherResponseModel.cs
+++ b/src/Core/Models/Api/Response/CipherResponseModel.cs
@@ -89,11 +89,13 @@ namespace Bit.Core.Models.Api
             FolderId = cipher.FolderId?.ToString();
             Favorite = cipher.Favorite;
             Edit = cipher.Edit;
+            ViewPassword = cipher.ViewPassword;
         }
 
         public string FolderId { get; set; }
         public bool Favorite { get; set; }
         public bool Edit { get; set; }
+        public bool ViewPassword { get; set; }
     }
 
     public class CipherDetailsResponseModel : CipherResponseModel

--- a/src/Core/Models/Api/Response/CollectionResponseModel.cs
+++ b/src/Core/Models/Api/Response/CollectionResponseModel.cs
@@ -34,9 +34,11 @@ namespace Bit.Core.Models.Api
             : base(collectionDetails, "collectionDetails")
         {
             ReadOnly = collectionDetails.ReadOnly;
+            HidePasswords = collectionDetails.HidePasswords;
         }
 
         public bool ReadOnly { get; set; }
+        public bool HidePasswords { get; set; }
     }
 
     public class CollectionGroupDetailsResponseModel : CollectionResponseModel

--- a/src/Core/Models/Api/Response/SelectionReadOnlyResponseModel.cs
+++ b/src/Core/Models/Api/Response/SelectionReadOnlyResponseModel.cs
@@ -14,9 +14,11 @@ namespace Bit.Core.Models.Api
 
             Id = selection.Id.ToString();
             ReadOnly = selection.ReadOnly;
+            HidePasswords = selection.HidePasswords;
         }
 
         public string Id { get; set; }
         public bool ReadOnly { get; set; }
+        public bool HidePasswords { get; set; }
     }
 }

--- a/src/Core/Models/Data/CipherDetails.cs
+++ b/src/Core/Models/Data/CipherDetails.cs
@@ -7,5 +7,6 @@ namespace Core.Models.Data
         public Guid? FolderId { get; set; }
         public bool Favorite { get; set; }
         public bool Edit { get; set; }
+        public bool ViewPassword { get; set; }
     }
 }

--- a/src/Core/Models/Data/CollectionDetails.cs
+++ b/src/Core/Models/Data/CollectionDetails.cs
@@ -5,5 +5,6 @@ namespace Bit.Core.Models.Data
     public class CollectionDetails : Collection
     {
         public bool ReadOnly { get; set; }
+        public bool HidePasswords { get; set; }
     }
 }

--- a/src/Core/Models/Data/SelectionReadOnly.cs
+++ b/src/Core/Models/Data/SelectionReadOnly.cs
@@ -6,5 +6,6 @@ namespace Bit.Core.Models.Data
     {
         public Guid Id { get; set; }
         public bool ReadOnly { get; set; }
+        public bool HidePasswords { get; set; }
     }
 }

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -125,6 +125,8 @@ namespace Bit.Core.Utilities
             table.Columns.Add(idColumn);
             var readOnlyColumn = new DataColumn("ReadOnly", typeof(bool));
             table.Columns.Add(readOnlyColumn);
+            var hidePasswordsColumn = new DataColumn("HidePasswords", typeof(bool));
+            table.Columns.Add(hidePasswordsColumn);
 
             if (values != null)
             {
@@ -133,6 +135,7 @@ namespace Bit.Core.Utilities
                     var row = table.NewRow();
                     row[idColumn] = value.Id;
                     row[readOnlyColumn] = value.ReadOnly;
+                    row[hidePasswordsColumn] = value.HidePasswords;
                     table.Rows.Add(row);
                 }
             }

--- a/src/Sql/dbo/Functions/UserCipherDetails.sql
+++ b/src/Sql/dbo/Functions/UserCipherDetails.sql
@@ -24,6 +24,13 @@ SELECT
         ELSE 0
     END [Edit],
     CASE
+        WHEN
+            CU.[HidePasswords] = 0
+            OR CG.[HidePasswords] = 0
+        THEN 1
+        ELSE 0
+    END [ViewPassword],
+    CASE
         WHEN O.[UseTotp] = 1
         THEN 1
         ELSE 0
@@ -55,6 +62,7 @@ UNION ALL
 SELECT
     *,
     1 [Edit],
+    1 [ViewPassword],
     0 [OrganizationUseTotp]
 FROM
     [dbo].[CipherDetails](@UserId)

--- a/src/Sql/dbo/Functions/UserCipherDetails.sql
+++ b/src/Sql/dbo/Functions/UserCipherDetails.sql
@@ -24,7 +24,9 @@ SELECT
     END [Edit],
     CASE
         WHEN
-            COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
+            OU.[AccessAll] = 1
+            OR G.[AccessAll] = 1
+            OR COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
         THEN 1
         ELSE 0
     END [ViewPassword],

--- a/src/Sql/dbo/Functions/UserCipherDetails.sql
+++ b/src/Sql/dbo/Functions/UserCipherDetails.sql
@@ -17,16 +17,14 @@ SELECT
     CASE
         WHEN
             OU.[AccessAll] = 1
-            OR CU.[ReadOnly] = 0
             OR G.[AccessAll] = 1
-            OR CG.[ReadOnly] = 0
+            OR COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) = 0
         THEN 1
         ELSE 0
     END [Edit],
     CASE
         WHEN
-            CU.[HidePasswords] = 0
-            OR CG.[HidePasswords] = 0
+            COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
         THEN 1
         ELSE 0
     END [ViewPassword],

--- a/src/Sql/dbo/Functions/UserCollectionDetails.sql
+++ b/src/Sql/dbo/Functions/UserCollectionDetails.sql
@@ -3,7 +3,14 @@ RETURNS TABLE
 AS RETURN
 SELECT
     C.*,
-    COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) AS [ReadOnly],
+    CASE
+        WHEN
+            OU.[AccessAll] = 1
+            OR G.[AccessAll] = 1
+            OR COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) = 0
+        THEN 0
+        ELSE 1
+    END [ReadOnly],
     COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) AS [HidePasswords]
 FROM
     [dbo].[CollectionView] C

--- a/src/Sql/dbo/Functions/UserCollectionDetails.sql
+++ b/src/Sql/dbo/Functions/UserCollectionDetails.sql
@@ -3,22 +3,8 @@ RETURNS TABLE
 AS RETURN
 SELECT
     C.*,
-    CASE
-        WHEN
-            OU.[AccessAll] = 1
-            OR G.[AccessAll] = 1
-            OR CU.[ReadOnly] = 0
-            OR CG.[ReadOnly] = 0
-        THEN 0
-        ELSE 1
-    END [ReadOnly],
-    CASE
-        WHEN
-            CU.[HidePasswords] = 0
-            OR CG.[HidePasswords] = 0
-        THEN 0
-        ELSE 1
-    END [HidePasswords]
+    COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) AS [ReadOnly],
+    COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) AS [HidePasswords]
 FROM
     [dbo].[CollectionView] C
 INNER JOIN

--- a/src/Sql/dbo/Functions/UserCollectionDetails.sql
+++ b/src/Sql/dbo/Functions/UserCollectionDetails.sql
@@ -11,7 +11,14 @@ SELECT
         THEN 0
         ELSE 1
     END [ReadOnly],
-    COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) AS [HidePasswords]
+    CASE
+        WHEN
+            OU.[AccessAll] = 1
+            OR G.[AccessAll] = 1
+            OR COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
+        THEN 0
+        ELSE 1
+    END [HidePasswords]
 FROM
     [dbo].[CollectionView] C
 INNER JOIN

--- a/src/Sql/dbo/Functions/UserCollectionDetails.sql
+++ b/src/Sql/dbo/Functions/UserCollectionDetails.sql
@@ -11,7 +11,14 @@ SELECT
             OR CG.[ReadOnly] = 0
         THEN 0
         ELSE 1
-    END [ReadOnly]
+    END [ReadOnly],
+    CASE
+        WHEN
+            CU.[HidePasswords] = 0
+            OR CG.[HidePasswords] = 0
+        THEN 0
+        ELSE 1
+    END [HidePasswords]
 FROM
     [dbo].[CollectionView] C
 INNER JOIN

--- a/src/Sql/dbo/Stored Procedures/CipherDetails_Create.sql
+++ b/src/Sql/dbo/Stored Procedures/CipherDetails_Create.sql
@@ -12,6 +12,7 @@
     @FolderId UNIQUEIDENTIFIER,
     @Favorite BIT,
     @Edit BIT, -- not used
+    @ViewPassword BIT, -- not used
     @OrganizationUseTotp BIT, -- not used
     @DeletedDate DATETIME2(7)
 AS

--- a/src/Sql/dbo/Stored Procedures/CipherDetails_CreateWithCollections.sql
+++ b/src/Sql/dbo/Stored Procedures/CipherDetails_CreateWithCollections.sql
@@ -12,6 +12,7 @@
     @FolderId UNIQUEIDENTIFIER,
     @Favorite BIT,
     @Edit BIT, -- not used
+    @ViewPassword BIT, -- not used
     @OrganizationUseTotp BIT, -- not used
     @DeletedDate DATETIME2(7),
     @CollectionIds AS [dbo].[GuidIdArray] READONLY
@@ -20,7 +21,8 @@ BEGIN
     SET NOCOUNT ON
 
     EXEC [dbo].[CipherDetails_Create] @Id, @UserId, @OrganizationId, @Type, @Data, @Favorites, @Folders,
-        @Attachments, @CreationDate, @RevisionDate, @FolderId, @Favorite, @Edit, @OrganizationUseTotp, @DeletedDate
+        @Attachments, @CreationDate, @RevisionDate, @FolderId, @Favorite, @Edit, @ViewPassword,
+        @OrganizationUseTotp, @DeletedDate
 
     DECLARE @UpdateCollectionsSuccess INT
     EXEC @UpdateCollectionsSuccess = [dbo].[Cipher_UpdateCollections] @Id, @UserId, @OrganizationId, @CollectionIds

--- a/src/Sql/dbo/Stored Procedures/CipherDetails_Update.sql
+++ b/src/Sql/dbo/Stored Procedures/CipherDetails_Update.sql
@@ -12,6 +12,7 @@
     @FolderId UNIQUEIDENTIFIER,
     @Favorite BIT,
     @Edit BIT, -- not used
+    @ViewPassword BIT, -- not used
     @OrganizationUseTotp BIT, -- not used
     @DeletedDate DATETIME2(2)
 AS

--- a/src/Sql/dbo/Stored Procedures/CollectionUser_ReadByCollectionId.sql
+++ b/src/Sql/dbo/Stored Procedures/CollectionUser_ReadByCollectionId.sql
@@ -6,7 +6,8 @@ BEGIN
 
     SELECT
         [OrganizationUserId] [Id],
-        [ReadOnly]
+        [ReadOnly],
+        [HidePasswords]
     FROM
         [dbo].[CollectionUser]
     WHERE

--- a/src/Sql/dbo/Stored Procedures/CollectionUser_UpdateUsers.sql
+++ b/src/Sql/dbo/Stored Procedures/CollectionUser_UpdateUsers.sql
@@ -35,10 +35,15 @@ BEGIN
         (
             @CollectionId,
             [Source].[Id],
-            [Source].[ReadOnly]
+            [Source].[ReadOnly],
+            [Source].[HidePasswords]
         )
-    WHEN MATCHED AND [Target].[ReadOnly] != [Source].[ReadOnly] THEN
-        UPDATE SET [Target].[ReadOnly] = [Source].[ReadOnly]
+    WHEN MATCHED AND (
+        [Target].[ReadOnly] != [Source].[ReadOnly]
+        OR [Target].[HidePasswords] != [Source].[HidePasswords]
+    ) THEN
+        UPDATE SET [Target].[ReadOnly] = [Source].[ReadOnly],
+                   [Target].[HidePasswords] = [Source].[HidePasswords]
     WHEN NOT MATCHED BY SOURCE
     AND [Target].[CollectionId] = @CollectionId THEN
         DELETE

--- a/src/Sql/dbo/Stored Procedures/Collection_CreateWithGroups.sql
+++ b/src/Sql/dbo/Stored Procedures/Collection_CreateWithGroups.sql
@@ -24,12 +24,14 @@ BEGIN
     (
         [CollectionId],
         [GroupId],
-        [ReadOnly]
+        [ReadOnly],
+        [HidePasswords]
     )
     SELECT
         @Id,
         [Id],
-        [ReadOnly]
+        [ReadOnly],
+        [HidePasswords]
     FROM
         @Groups
     WHERE

--- a/src/Sql/dbo/Stored Procedures/Collection_ReadWithGroupsById.sql
+++ b/src/Sql/dbo/Stored Procedures/Collection_ReadWithGroupsById.sql
@@ -8,7 +8,8 @@ BEGIN
 
     SELECT
         [GroupId] [Id],
-        [ReadOnly]
+        [ReadOnly],
+        [HidePasswords]
     FROM
         [dbo].[CollectionGroup]
     WHERE

--- a/src/Sql/dbo/Stored Procedures/Collection_ReadWithGroupsByIdUserId.sql
+++ b/src/Sql/dbo/Stored Procedures/Collection_ReadWithGroupsByIdUserId.sql
@@ -9,7 +9,8 @@ BEGIN
 
     SELECT
         [GroupId] [Id],
-        [ReadOnly]
+        [ReadOnly],
+        [HidePasswords]
     FROM
         [dbo].[CollectionGroup]
     WHERE

--- a/src/Sql/dbo/Stored Procedures/Collection_UpdateWithGroups.sql
+++ b/src/Sql/dbo/Stored Procedures/Collection_UpdateWithGroups.sql
@@ -33,10 +33,15 @@ BEGIN
         (
             @Id,
             [Source].[Id],
-            [Source].[ReadOnly]
+            [Source].[ReadOnly],
+            [Source].[HidePasswords]
         )
-    WHEN MATCHED AND [Target].[ReadOnly] != [Source].[ReadOnly] THEN
-        UPDATE SET [Target].[ReadOnly] = [Source].[ReadOnly]
+    WHEN MATCHED AND (
+        [Target].[ReadOnly] != [Source].[ReadOnly]
+        OR [Target].[HidePasswords] != [Source].[HidePasswords]
+    ) THEN
+        UPDATE SET [Target].[ReadOnly] = [Source].[ReadOnly],
+                   [Target].[HidePasswords] = [Source].[HidePasswords]
     WHEN NOT MATCHED BY SOURCE
     AND [Target].[CollectionId] = @Id THEN
         DELETE

--- a/src/Sql/dbo/Stored Procedures/Group_CreateWithCollections.sql
+++ b/src/Sql/dbo/Stored Procedures/Group_CreateWithCollections.sql
@@ -25,12 +25,14 @@ BEGIN
     (
         [CollectionId],
         [GroupId],
-        [ReadOnly]
+        [ReadOnly],
+        [HidePasswords]
     )
     SELECT
         [Id],
         @Id,
-        [ReadOnly]
+        [ReadOnly],
+        [HidePasswords]
     FROM
         @Collections
     WHERE

--- a/src/Sql/dbo/Stored Procedures/Group_ReadWithCollectionsById.sql
+++ b/src/Sql/dbo/Stored Procedures/Group_ReadWithCollectionsById.sql
@@ -8,7 +8,8 @@ BEGIN
 
     SELECT
         [CollectionId] [Id],
-        [ReadOnly]
+        [ReadOnly],
+        [HidePasswords]
     FROM
         [dbo].[CollectionGroup]
     WHERE

--- a/src/Sql/dbo/Stored Procedures/Group_UpdateWithCollections.sql
+++ b/src/Sql/dbo/Stored Procedures/Group_UpdateWithCollections.sql
@@ -34,10 +34,15 @@ BEGIN
         (
             [Source].[Id],
             @Id,
-            [Source].[ReadOnly]
+            [Source].[ReadOnly],
+            [Source].[HidePasswords]
         )
-    WHEN MATCHED AND [Target].[ReadOnly] != [Source].[ReadOnly] THEN
-        UPDATE SET [Target].[ReadOnly] = [Source].[ReadOnly]
+    WHEN MATCHED AND (
+        [Target].[ReadOnly] != [Source].[ReadOnly]
+        OR [Target].[HidePasswords] != [Source].[HidePasswords]
+    ) THEN
+        UPDATE SET [Target].[ReadOnly] = [Source].[ReadOnly],
+                   [Target].[HidePasswords] = [Source].[HidePasswords]
     WHEN NOT MATCHED BY SOURCE
     AND [Target].[GroupId] = @Id THEN
         DELETE

--- a/src/Sql/dbo/Stored Procedures/OrganizationUserUserDetails_ReadWithCollectionsById.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationUserUserDetails_ReadWithCollectionsById.sql
@@ -8,7 +8,8 @@ BEGIN
 
     SELECT
         CU.[CollectionId] Id,
-        CU.[ReadOnly]
+        CU.[ReadOnly],
+        CU.[HidePasswords]
     FROM
         [dbo].[OrganizationUser] OU
     INNER JOIN

--- a/src/Sql/dbo/Stored Procedures/OrganizationUser_CreateWithCollections.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationUser_CreateWithCollections.sql
@@ -29,12 +29,14 @@ BEGIN
     (
         [CollectionId],
         [OrganizationUserId],
-        [ReadOnly]
+        [ReadOnly],
+        [HidePasswords]
     )
     SELECT
         [Id],
         @Id,
-        [ReadOnly]
+        [ReadOnly],
+        [HidePasswords]
     FROM
         @Collections
     WHERE

--- a/src/Sql/dbo/Stored Procedures/OrganizationUser_ReadWithCollectionsById.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationUser_ReadWithCollectionsById.sql
@@ -8,7 +8,8 @@ BEGIN
 
     SELECT
         CU.[CollectionId] Id,
-        CU.[ReadOnly]
+        CU.[ReadOnly],
+        CU.[HidePasswords]
     FROM
         [dbo].[OrganizationUser] OU
     INNER JOIN

--- a/src/Sql/dbo/Stored Procedures/OrganizationUser_UpdateWithCollections.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationUser_UpdateWithCollections.sql
@@ -38,10 +38,15 @@ BEGIN
         (
             [Source].[Id],
             @Id,
-            [Source].[ReadOnly]
+            [Source].[ReadOnly],
+            [Source].[HidePasswords]
         )
-    WHEN MATCHED AND [Target].[ReadOnly] != [Source].[ReadOnly] THEN
-        UPDATE SET [Target].[ReadOnly] = [Source].[ReadOnly]
+    WHEN MATCHED AND (
+        [Target].[ReadOnly] != [Source].[ReadOnly]
+        OR [Target].[HidePasswords] != [Source].[HidePasswords]
+    ) THEN
+        UPDATE SET [Target].[ReadOnly] = [Source].[ReadOnly],
+                   [Target].[HidePasswords] = [Source].[HidePasswords]
     WHEN NOT MATCHED BY SOURCE
     AND [Target].[OrganizationUserId] = @Id THEN
         DELETE

--- a/src/Sql/dbo/Tables/CollectionGroup.sql
+++ b/src/Sql/dbo/Tables/CollectionGroup.sql
@@ -2,7 +2,7 @@
     [CollectionId]  UNIQUEIDENTIFIER NOT NULL,
     [GroupId]       UNIQUEIDENTIFIER NOT NULL,
     [ReadOnly]      BIT              NOT NULL,
-    [HidePasswords] BIT              NOT NULL DEFAULT 0,
+    [HidePasswords] BIT              NOT NULL,
     CONSTRAINT [PK_CollectionGroup] PRIMARY KEY CLUSTERED ([CollectionId] ASC, [GroupId] ASC),
     CONSTRAINT [FK_CollectionGroup_Collection] FOREIGN KEY ([CollectionId]) REFERENCES [dbo].[Collection] ([Id]),
     CONSTRAINT [FK_CollectionGroup_Group] FOREIGN KEY ([GroupId]) REFERENCES [dbo].[Group] ([Id]) ON DELETE CASCADE

--- a/src/Sql/dbo/Tables/CollectionGroup.sql
+++ b/src/Sql/dbo/Tables/CollectionGroup.sql
@@ -1,7 +1,8 @@
 ﻿CREATE TABLE [dbo].[CollectionGroup] (
-    [CollectionId] UNIQUEIDENTIFIER NOT NULL,
-    [GroupId]      UNIQUEIDENTIFIER NOT NULL,
-    [ReadOnly]     BIT              NOT NULL,
+    [CollectionId]  UNIQUEIDENTIFIER NOT NULL,
+    [GroupId]       UNIQUEIDENTIFIER NOT NULL,
+    [ReadOnly]      BIT              NOT NULL,
+    [HidePasswords] BIT              NOT NULL DEFAULT 0,
     CONSTRAINT [PK_CollectionGroup] PRIMARY KEY CLUSTERED ([CollectionId] ASC, [GroupId] ASC),
     CONSTRAINT [FK_CollectionGroup_Collection] FOREIGN KEY ([CollectionId]) REFERENCES [dbo].[Collection] ([Id]),
     CONSTRAINT [FK_CollectionGroup_Group] FOREIGN KEY ([GroupId]) REFERENCES [dbo].[Group] ([Id]) ON DELETE CASCADE

--- a/src/Sql/dbo/Tables/CollectionUser.sql
+++ b/src/Sql/dbo/Tables/CollectionUser.sql
@@ -2,7 +2,7 @@
     [CollectionId]       UNIQUEIDENTIFIER NOT NULL,
     [OrganizationUserId] UNIQUEIDENTIFIER NOT NULL,
     [ReadOnly]           BIT              NOT NULL,
-    [HidePasswords]      BIT              NOT NULL DEFAULT 0,
+    [HidePasswords]      BIT              NOT NULL,
     CONSTRAINT [PK_CollectionUser] PRIMARY KEY CLUSTERED ([CollectionId] ASC, [OrganizationUserId] ASC),
     CONSTRAINT [FK_CollectionUser_Collection] FOREIGN KEY ([CollectionId]) REFERENCES [dbo].[Collection] ([Id]) ON DELETE CASCADE,
     CONSTRAINT [FK_CollectionUser_OrganizationUser] FOREIGN KEY ([OrganizationUserId]) REFERENCES [dbo].[OrganizationUser] ([Id])

--- a/src/Sql/dbo/Tables/CollectionUser.sql
+++ b/src/Sql/dbo/Tables/CollectionUser.sql
@@ -2,6 +2,7 @@
     [CollectionId]       UNIQUEIDENTIFIER NOT NULL,
     [OrganizationUserId] UNIQUEIDENTIFIER NOT NULL,
     [ReadOnly]           BIT              NOT NULL,
+    [HidePasswords]      BIT              NOT NULL DEFAULT 0,
     CONSTRAINT [PK_CollectionUser] PRIMARY KEY CLUSTERED ([CollectionId] ASC, [OrganizationUserId] ASC),
     CONSTRAINT [FK_CollectionUser_Collection] FOREIGN KEY ([CollectionId]) REFERENCES [dbo].[Collection] ([Id]) ON DELETE CASCADE,
     CONSTRAINT [FK_CollectionUser_OrganizationUser] FOREIGN KEY ([OrganizationUserId]) REFERENCES [dbo].[OrganizationUser] ([Id])

--- a/src/Sql/dbo/User Defined Types/SelectionReadOnlyArray.sql
+++ b/src/Sql/dbo/User Defined Types/SelectionReadOnlyArray.sql
@@ -1,4 +1,5 @@
 ﻿CREATE TYPE [dbo].[SelectionReadOnlyArray] AS TABLE (
-    [Id]       UNIQUEIDENTIFIER NOT NULL,
-    [ReadOnly] BIT              NOT NULL);
+    [Id]            UNIQUEIDENTIFIER NOT NULL,
+    [ReadOnly]      BIT              NOT NULL,
+    [HidePasswords] BIT              NOT NULL);
 

--- a/util/Migrator/DbScripts/2020-05-22_00_HiddenPassword.sql
+++ b/util/Migrator/DbScripts/2020-05-22_00_HiddenPassword.sql
@@ -54,6 +54,7 @@ CREATE TYPE [dbo].[SelectionReadOnlyArray] AS TABLE (
     [Id]            UNIQUEIDENTIFIER NOT NULL,
     [ReadOnly]      BIT              NOT NULL,
     [HidePasswords] BIT              NOT NULL);
+GO
 
 IF COL_LENGTH('[dbo].[CollectionGroup]', 'HidePasswords') IS NULL
 BEGIN

--- a/util/Migrator/DbScripts/2020-05-22_00_HiddenPassword.sql
+++ b/util/Migrator/DbScripts/2020-05-22_00_HiddenPassword.sql
@@ -949,3 +949,4 @@ BEGIN
     DECLARE @UpdateCollectionsSuccess INT
     EXEC @UpdateCollectionsSuccess = [dbo].[Cipher_UpdateCollections] @Id, @UserId, @OrganizationId, @CollectionIds
 END
+GO

--- a/util/Migrator/DbScripts/2020-05-22_00_HiddenPassword.sql
+++ b/util/Migrator/DbScripts/2020-05-22_00_HiddenPassword.sql
@@ -87,7 +87,9 @@ SELECT
     END [Edit],
     CASE
         WHEN
-            COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
+            OU.[AccessAll] = 1
+            OR G.[AccessAll] = 1
+            OR COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
         THEN 1
         ELSE 0
     END [ViewPassword],
@@ -150,7 +152,14 @@ SELECT
         THEN 0
         ELSE 1
     END [ReadOnly],
-    COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) AS [HidePasswords]
+    CASE
+        WHEN
+            OU.[AccessAll] = 1
+            OR G.[AccessAll] = 1
+            OR COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
+        THEN 0
+        ELSE 1
+    END [HidePasswords]
 FROM
     [dbo].[CollectionView] C
 INNER JOIN
@@ -905,9 +914,9 @@ BEGIN
 END
 GO
 
-IF OBJECT_ID('[dbo].[CipherDetails_Create]') IS NOT NULL
+IF OBJECT_ID('[dbo].[CipherDetails_CreateWithCollections]') IS NOT NULL
 BEGIN
-    DROP PROCEDURE [dbo].[CipherDetails_Create]
+    DROP PROCEDURE [dbo].[CipherDetails_CreateWithCollections]
 END
 GO
 

--- a/util/Migrator/DbScripts/2020-05-22_00_HiddenPassword.sql
+++ b/util/Migrator/DbScripts/2020-05-22_00_HiddenPassword.sql
@@ -1,0 +1,761 @@
+﻿/*
+ * Add HiddenPassword support to collections
+ */
+
+IF TYPE_ID('[dbo].[SelectionReadOnlyArray]') IS NOT NULL
+BEGIN
+    DROP TYPE [dbo].[SelectionReadOnlyArray]
+END
+GO
+
+CREATE TYPE [dbo].[SelectionReadOnlyArray] AS TABLE (
+    [Id]            UNIQUEIDENTIFIER NOT NULL,
+    [ReadOnly]      BIT              NOT NULL,
+    [HidePasswords] BIT              NOT NULL);
+
+IF COL_LENGTH('[dbo].[CollectionGroup]', 'HidePasswords') IS NULL
+BEGIN
+    ALTER TABLE
+        [dbo].[CollectionGroup]
+    ADD
+        [HidePasswords] BIT NULL
+END
+GO
+
+UPDATE
+    [dbo].[CollectionGroup]
+SET
+    [HidePasswords] = 0
+GO
+
+ALTER TABLE
+    [dbo].[CollectionGroup]
+ALTER COLUMN
+    [HidePasswords] BIT NOT NULL
+GO
+
+IF COL_LENGTH('[dbo].[CollectionUser]', 'HidePasswords') IS NULL
+BEGIN
+    ALTER TABLE
+        [dbo].[CollectionUser]
+    ADD
+        [HidePasswords] BIT NULL
+END
+GO
+
+UPDATE
+    [dbo].[CollectionUser]
+SET
+    [HidePasswords] = 0
+GO
+
+ALTER TABLE
+    [dbo].[CollectionUser]
+ALTER COLUMN
+    [HidePasswords] BIT NOT NULL
+GO
+
+IF OBJECT_ID('[dbo].[UserCipherDetails]') IS NOT NULL
+BEGIN
+    DROP FUNCTION [dbo].[UserCipherDetails]
+END
+GO
+
+CREATE FUNCTION [dbo].[UserCipherDetails](@UserId UNIQUEIDENTIFIER)
+RETURNS TABLE
+AS RETURN
+WITH [CTE] AS (
+    SELECT
+        [Id],
+        [OrganizationId],
+        [AccessAll]
+    FROM
+        [OrganizationUser]
+    WHERE
+        [UserId] = @UserId
+        AND [Status] = 2 -- Confirmed
+)
+SELECT
+    C.*,
+    CASE
+        WHEN
+            OU.[AccessAll] = 1
+            OR CU.[ReadOnly] = 0
+            OR G.[AccessAll] = 1
+            OR CG.[ReadOnly] = 0
+        THEN 1
+        ELSE 0
+    END [Edit],
+    CASE
+        WHEN
+            CU.[HidePasswords] = 0
+            OR CG.[HidePasswords] = 0
+        THEN 1
+        ELSE 0
+    END [ViewPassword],
+    CASE
+        WHEN O.[UseTotp] = 1
+        THEN 1
+        ELSE 0
+    END [OrganizationUseTotp]
+FROM
+    [dbo].[CipherDetails](@UserId) C
+INNER JOIN
+    [CTE] OU ON C.[UserId] IS NULL AND C.[OrganizationId] IN (SELECT [OrganizationId] FROM [CTE])
+INNER JOIN
+    [dbo].[Organization] O ON O.[Id] = OU.[OrganizationId] AND O.[Id] = C.[OrganizationId] AND O.[Enabled] = 1
+LEFT JOIN
+    [dbo].[CollectionCipher] CC ON OU.[AccessAll] = 0 AND CC.[CipherId] = C.[Id]
+LEFT JOIN
+    [dbo].[CollectionUser] CU ON CU.[CollectionId] = CC.[CollectionId] AND CU.[OrganizationUserId] = OU.[Id]
+LEFT JOIN
+    [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND OU.[AccessAll] = 0 AND GU.[OrganizationUserId] = OU.[Id]
+LEFT JOIN
+    [dbo].[Group] G ON G.[Id] = GU.[GroupId]
+LEFT JOIN
+    [dbo].[CollectionGroup] CG ON G.[AccessAll] = 0 AND CG.[CollectionId] = CC.[CollectionId] AND CG.[GroupId] = GU.[GroupId]
+WHERE
+    OU.[AccessAll] = 1
+    OR CU.[CollectionId] IS NOT NULL
+    OR G.[AccessAll] = 1
+    OR CG.[CollectionId] IS NOT NULL
+
+UNION ALL
+
+SELECT
+    *,
+    1 [Edit],
+    1 [ViewPassword],
+    0 [OrganizationUseTotp]
+FROM
+    [dbo].[CipherDetails](@UserId)
+WHERE
+    [UserId] = @UserId
+GO
+
+IF OBJECT_ID('[dbo].[UserCollectionDetails]') IS NOT NULL
+BEGIN
+    DROP FUNCTION [dbo].[UserCollectionDetails]
+END
+GO
+
+CREATE FUNCTION [dbo].[UserCollectionDetails](@UserId UNIQUEIDENTIFIER)
+RETURNS TABLE
+AS RETURN
+SELECT
+    C.*,
+    COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) AS [ReadOnly],
+    COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) AS [HidePasswords]
+FROM
+    [dbo].[CollectionView] C
+INNER JOIN
+    [dbo].[OrganizationUser] OU ON C.[OrganizationId] = OU.[OrganizationId]
+INNER JOIN
+    [dbo].[Organization] O ON O.[Id] = C.[OrganizationId]
+LEFT JOIN
+    [dbo].[CollectionUser] CU ON OU.[AccessAll] = 0 AND CU.[CollectionId] = C.[Id] AND CU.[OrganizationUserId] = [OU].[Id]
+LEFT JOIN
+    [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND OU.[AccessAll] = 0 AND GU.[OrganizationUserId] = OU.[Id]
+LEFT JOIN
+    [dbo].[Group] G ON G.[Id] = GU.[GroupId]
+LEFT JOIN
+    [dbo].[CollectionGroup] CG ON G.[AccessAll] = 0 AND CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
+WHERE
+    OU.[UserId] = @UserId
+    AND OU.[Status] = 2 -- 2 = Confirmed
+    AND O.[Enabled] = 1
+    AND (
+        OU.[AccessAll] = 1
+        OR CU.[CollectionId] IS NOT NULL
+        OR G.[AccessAll] = 1
+        OR CG.[CollectionId] IS NOT NULL
+    )
+GO
+
+IF OBJECT_ID('[dbo].[Collection_ReadWithGroupsById]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Collection_ReadWithGroupsById]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Collection_ReadWithGroupsById]
+    @Id UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    EXEC [dbo].[Collection_ReadById] @Id
+
+    SELECT
+        [GroupId] [Id],
+        [ReadOnly],
+        [HidePasswords]
+    FROM
+        [dbo].[CollectionGroup]
+    WHERE
+        [CollectionId] = @Id
+END
+GO
+
+IF OBJECT_ID('[dbo].[Group_CreateWithCollections]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Group_CreateWithCollections]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Group_CreateWithCollections]
+    @Id UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @Name NVARCHAR(100),
+    @AccessAll BIT,
+    @ExternalId NVARCHAR(300),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @Collections AS [dbo].[SelectionReadOnlyArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    EXEC [dbo].[Group_Create] @Id, @OrganizationId, @Name, @AccessAll, @ExternalId, @CreationDate, @RevisionDate
+
+    ;WITH [AvailableCollectionsCTE] AS(
+        SELECT
+            [Id]
+        FROM
+            [dbo].[Collection]
+        WHERE
+            [OrganizationId] = @OrganizationId
+    )
+    INSERT INTO [dbo].[CollectionGroup]
+    (
+        [CollectionId],
+        [GroupId],
+        [ReadOnly],
+        [HidePasswords]
+    )
+    SELECT
+        [Id],
+        @Id,
+        [ReadOnly],
+        [HidePasswords]
+    FROM
+        @Collections
+    WHERE
+        [Id] IN (SELECT [Id] FROM [AvailableCollectionsCTE])
+
+    EXEC [dbo].[User_BumpAccountRevisionDateByOrganizationId] @OrganizationId
+END
+GO
+
+IF OBJECT_ID('[dbo].[Group_ReadWithCollectionsById]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Group_ReadWithCollectionsById]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Group_ReadWithCollectionsById]
+    @Id UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    EXEC [dbo].[Group_ReadById] @Id
+
+    SELECT
+        [CollectionId] [Id],
+        [ReadOnly],
+        [HidePasswords]
+    FROM
+        [dbo].[CollectionGroup]
+    WHERE
+        [GroupId] = @Id
+END
+GO
+
+IF OBJECT_ID('[dbo].[Group_UpdateWithCollections]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Group_UpdateWithCollections]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Group_UpdateWithCollections]
+    @Id UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @Name NVARCHAR(100),
+    @AccessAll BIT,
+    @ExternalId NVARCHAR(300),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @Collections AS [dbo].[SelectionReadOnlyArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    EXEC [dbo].[Group_Update] @Id, @OrganizationId, @Name, @AccessAll, @ExternalId, @CreationDate, @RevisionDate
+
+    ;WITH [AvailableCollectionsCTE] AS(
+        SELECT
+            Id
+        FROM
+            [dbo].[Collection]
+        WHERE
+            OrganizationId = @OrganizationId
+    )
+    MERGE
+        [dbo].[CollectionGroup] AS [Target]
+    USING 
+        @Collections AS [Source]
+    ON
+        [Target].[CollectionId] = [Source].[Id]
+        AND [Target].[GroupId] = @Id
+    WHEN NOT MATCHED BY TARGET
+    AND [Source].[Id] IN (SELECT [Id] FROM [AvailableCollectionsCTE]) THEN
+        INSERT VALUES
+        (
+            [Source].[Id],
+            @Id,
+            [Source].[ReadOnly],
+            [Source].[HidePasswords]
+        )
+    WHEN MATCHED AND (
+        [Target].[ReadOnly] != [Source].[ReadOnly]
+        OR [Target].[HidePasswords] != [Source].[HidePasswords]
+    ) THEN
+        UPDATE SET [Target].[ReadOnly] = [Source].[ReadOnly],
+                   [Target].[HidePasswords] = [Source].[HidePasswords]
+    WHEN NOT MATCHED BY SOURCE
+    AND [Target].[GroupId] = @Id THEN
+        DELETE
+    ;
+
+    EXEC [dbo].[User_BumpAccountRevisionDateByOrganizationId] @OrganizationId
+END
+GO
+
+IF OBJECT_ID('[dbo].[CollectionUser_UpdateUsers]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[CollectionUser_UpdateUsers]
+END
+GO
+
+CREATE PROCEDURE [dbo].[CollectionUser_UpdateUsers]
+    @CollectionId UNIQUEIDENTIFIER,
+    @Users AS [dbo].[SelectionReadOnlyArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    DECLARE @OrgId UNIQUEIDENTIFIER = (
+        SELECT TOP 1
+            [OrganizationId]
+        FROM
+            [dbo].[Collection]
+        WHERE
+            [Id] = @CollectionId
+    )
+
+    -- Update
+    UPDATE
+        [Target]
+    SET
+        [Target].[ReadOnly] = [Source].[ReadOnly],
+        [Target].[HidePasswords] = [Source].[HidePasswords]
+    FROM
+        [dbo].[CollectionUser] [Target]
+    INNER JOIN
+        @Users [Source] ON [Source].[Id] = [Target].[OrganizationUserId]
+    WHERE
+        [Target].[CollectionId] = @CollectionId
+        AND (
+            [Target].[ReadOnly] != [Source].[ReadOnly]
+            OR [Target].[HidePasswords] != [Source].[HidePasswords]
+        )
+
+    -- Insert
+    INSERT INTO
+        [dbo].[CollectionUser]
+    SELECT
+        @CollectionId,
+        [Source].[Id],
+        [Source].[ReadOnly],
+        [Source].[HidePasswords]
+    FROM
+        @Users [Source]
+    INNER JOIN
+        [dbo].[OrganizationUser] OU ON [Source].[Id] = OU.[Id] AND OU.[OrganizationId] = @OrgId
+    WHERE
+        NOT EXISTS (
+            SELECT
+                1
+            FROM
+                [dbo].[CollectionUser]
+            WHERE
+                [CollectionId] = @CollectionId
+                AND [OrganizationUserId] = [Source].[Id]
+        )
+    
+    -- Delete
+    DELETE
+        CU
+    FROM
+        [dbo].[CollectionUser] CU
+    WHERE
+        CU.[CollectionId] = @CollectionId
+        AND NOT EXISTS (
+            SELECT
+                1
+            FROM
+                @Users
+            WHERE
+                [Id] = CU.[OrganizationUserId]
+        )
+
+    EXEC [dbo].[User_BumpAccountRevisionDateByCollectionId] @CollectionId, @OrgId
+END
+GO
+
+IF OBJECT_ID('[dbo].[CollectionUser_ReadByCollectionId]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[CollectionUser_ReadByCollectionId]
+END
+GO
+
+CREATE PROCEDURE [dbo].[CollectionUser_ReadByCollectionId]
+    @CollectionId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        [OrganizationUserId] [Id],
+        [ReadOnly],
+        [HidePasswords]
+    FROM
+        [dbo].[CollectionUser]
+    WHERE
+        [CollectionId] = @CollectionId
+END
+GO
+
+IF OBJECT_ID('[dbo].[OrganizationUser_CreateWithCollections]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationUser_CreateWithCollections]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationUser_CreateWithCollections]
+    @Id UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @Email NVARCHAR(50),
+    @Key VARCHAR(MAX),
+    @Status TINYINT,
+    @Type TINYINT,
+    @AccessAll BIT,
+    @ExternalId NVARCHAR(300),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @Collections AS [dbo].[SelectionReadOnlyArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    EXEC [dbo].[OrganizationUser_Create] @Id, @OrganizationId, @UserId, @Email, @Key, @Status, @Type, @AccessAll, @ExternalId, @CreationDate, @RevisionDate
+
+    ;WITH [AvailableCollectionsCTE] AS(
+        SELECT
+            [Id]
+        FROM
+            [dbo].[Collection]
+        WHERE
+            [OrganizationId] = @OrganizationId
+    )
+    INSERT INTO [dbo].[CollectionUser]
+    (
+        [CollectionId],
+        [OrganizationUserId],
+        [ReadOnly],
+        [HidePasswords]
+    )
+    SELECT
+        [Id],
+        @Id,
+        [ReadOnly],
+        [HidePasswords]
+    FROM
+        @Collections
+    WHERE
+        [Id] IN (SELECT [Id] FROM [AvailableCollectionsCTE])
+END
+GO
+
+IF OBJECT_ID('[dbo].[OrganizationUser_ReadWithCollectionsById]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationUser_ReadWithCollectionsById]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationUser_ReadWithCollectionsById]
+    @Id UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    EXEC [OrganizationUser_ReadById] @Id
+
+    SELECT
+        CU.[CollectionId] Id,
+        CU.[ReadOnly],
+        CU.[HidePasswords]
+    FROM
+        [dbo].[OrganizationUser] OU
+    INNER JOIN
+        [dbo].[CollectionUser] CU ON OU.[AccessAll] = 0 AND CU.[OrganizationUserId] = [OU].[Id]
+    WHERE
+        [OrganizationUserId] = @Id
+END
+GO
+
+IF OBJECT_ID('[dbo].[OrganizationUser_UpdateWithCollections]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationUser_UpdateWithCollections]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationUser_UpdateWithCollections]
+    @Id UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @Email NVARCHAR(50),
+    @Key VARCHAR(MAX),
+    @Status TINYINT,
+    @Type TINYINT,
+    @AccessAll BIT,
+    @ExternalId NVARCHAR(300),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @Collections AS [dbo].[SelectionReadOnlyArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    EXEC [dbo].[OrganizationUser_Update] @Id, @OrganizationId, @UserId, @Email, @Key, @Status, @Type, @AccessAll, @ExternalId, @CreationDate, @RevisionDate
+
+    -- Update
+    UPDATE
+        [Target]
+    SET
+        [Target].[ReadOnly] = [Source].[ReadOnly],
+        [Target].[HidePasswords] = [Source].[HidePasswords]
+    FROM
+        [dbo].[CollectionUser] AS [Target]
+    INNER JOIN
+        @Collections AS [Source] ON [Source].[Id] = [Target].[CollectionId]
+    WHERE
+        [Target].[OrganizationUserId] = @Id
+        AND (
+            [Target].[ReadOnly] != [Source].[ReadOnly]
+            OR [Target].[HidePasswords] != [Source].[HidePasswords]
+        )
+
+    -- Insert
+    INSERT INTO
+        [dbo].[CollectionUser]
+    SELECT
+        [Source].[Id],
+        @Id,
+        [Source].[ReadOnly],
+        [Source].[HidePasswords]
+    FROM
+        @Collections AS [Source]
+    INNER JOIN
+        [dbo].[Collection] C ON C.[Id] = [Source].[Id] AND C.[OrganizationId] = @OrganizationId
+    WHERE
+        NOT EXISTS (
+            SELECT
+                1
+            FROM
+                [dbo].[CollectionUser]
+            WHERE
+                [CollectionId] = [Source].[Id]
+                AND [OrganizationUserId] = @Id
+        )
+    
+    -- Delete
+    DELETE
+        CU
+    FROM
+        [dbo].[CollectionUser] CU
+    WHERE
+        CU.[OrganizationUserId] = @Id
+        AND NOT EXISTS (
+            SELECT
+                1
+            FROM
+                @Collections
+            WHERE
+                [Id] = CU.[CollectionId]
+        )
+END
+GO
+
+IF OBJECT_ID('[dbo].[OrganizationUserUserDetails_ReadWithCollectionsById]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationUserUserDetails_ReadWithCollectionsById]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationUserUserDetails_ReadWithCollectionsById]
+    @Id UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    EXEC [OrganizationUserUserDetails_ReadById] @Id
+
+    SELECT
+        CU.[CollectionId] Id,
+        CU.[ReadOnly],
+        CU.[HidePasswords]
+    FROM
+        [dbo].[OrganizationUser] OU
+    INNER JOIN
+        [dbo].[CollectionUser] CU ON OU.[AccessAll] = 0 AND CU.[OrganizationUserId] = [OU].[Id]
+    WHERE
+        [OrganizationUserId] = @Id
+END
+GO
+
+IF OBJECT_ID('[dbo].[Collection_CreateWithGroups]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Collection_CreateWithGroups]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Collection_CreateWithGroups]
+    @Id UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @Name VARCHAR(MAX),
+    @ExternalId NVARCHAR(300),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @Groups AS [dbo].[SelectionReadOnlyArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    EXEC [dbo].[Collection_Create] @Id, @OrganizationId, @Name, @ExternalId, @CreationDate, @RevisionDate
+
+    ;WITH [AvailableGroupsCTE] AS(
+        SELECT
+            [Id]
+        FROM
+            [dbo].[Group]
+        WHERE
+            [OrganizationId] = @OrganizationId
+    )
+    INSERT INTO [dbo].[CollectionGroup]
+    (
+        [CollectionId],
+        [GroupId],
+        [ReadOnly],
+        [HidePasswords]
+    )
+    SELECT
+        @Id,
+        [Id],
+        [ReadOnly],
+        [HidePasswords]
+    FROM
+        @Groups
+    WHERE
+        [Id] IN (SELECT [Id] FROM [AvailableGroupsCTE])
+
+    EXEC [dbo].[User_BumpAccountRevisionDateByOrganizationId] @OrganizationId
+END
+GO
+
+IF OBJECT_ID('[dbo].[Collection_ReadWithGroupsByIdUserId]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Collection_ReadWithGroupsByIdUserId]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Collection_ReadWithGroupsByIdUserId]
+    @Id UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    EXEC [dbo].[Collection_ReadByIdUserId] @Id, @UserId
+
+    SELECT
+        [GroupId] [Id],
+        [ReadOnly],
+        [HidePasswords]
+    FROM
+        [dbo].[CollectionGroup]
+    WHERE
+        [CollectionId] = @Id
+END
+GO
+
+IF OBJECT_ID('[dbo].[Collection_UpdateWithGroups]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Collection_UpdateWithGroups]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Collection_UpdateWithGroups]
+    @Id UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @Name VARCHAR(MAX),
+    @ExternalId NVARCHAR(300),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @Groups AS [dbo].[SelectionReadOnlyArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    EXEC [dbo].[Collection_Update] @Id, @OrganizationId, @Name, @ExternalId, @CreationDate, @RevisionDate
+
+    ;WITH [AvailableGroupsCTE] AS(
+        SELECT
+            Id
+        FROM
+            [dbo].[Group]
+        WHERE
+            OrganizationId = @OrganizationId
+    )
+    MERGE
+        [dbo].[CollectionGroup] AS [Target]
+    USING 
+        @Groups AS [Source]
+    ON
+        [Target].[CollectionId] = @Id
+        AND [Target].[GroupId] = [Source].[Id]
+    WHEN NOT MATCHED BY TARGET
+    AND [Source].[Id] IN (SELECT [Id] FROM [AvailableGroupsCTE]) THEN
+        INSERT VALUES
+        (
+            @Id,
+            [Source].[Id],
+            [Source].[ReadOnly],
+            [Source].[HidePasswords]
+        )
+    WHEN MATCHED AND (
+        [Target].[ReadOnly] != [Source].[ReadOnly]
+        OR [Target].[HidePasswords] != [Source].[HidePasswords]
+    ) THEN
+        UPDATE SET [Target].[ReadOnly] = [Source].[ReadOnly],
+                   [Target].[HidePasswords] = [Source].[HidePasswords]
+    WHEN NOT MATCHED BY SOURCE
+    AND [Target].[CollectionId] = @Id THEN
+        DELETE
+    ;
+
+    EXEC [dbo].[User_BumpAccountRevisionDateByCollectionId] @Id, @OrganizationId
+END
+GO

--- a/util/Migrator/DbScripts/2020-05-22_00_HiddenPassword.sql
+++ b/util/Migrator/DbScripts/2020-05-22_00_HiddenPassword.sql
@@ -2,6 +2,48 @@
  * Add HiddenPassword support to collections
  */
 
+IF OBJECT_ID('[dbo].[Group_CreateWithCollections]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Group_CreateWithCollections]
+END
+GO
+
+IF OBJECT_ID('[dbo].[Group_UpdateWithCollections]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Group_UpdateWithCollections]
+END
+GO
+
+IF OBJECT_ID('[dbo].[CollectionUser_UpdateUsers]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[CollectionUser_UpdateUsers]
+END
+GO
+
+IF OBJECT_ID('[dbo].[OrganizationUser_CreateWithCollections]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationUser_CreateWithCollections]
+END
+GO
+
+IF OBJECT_ID('[dbo].[OrganizationUser_UpdateWithCollections]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationUser_UpdateWithCollections]
+END
+GO
+
+IF OBJECT_ID('[dbo].[Collection_CreateWithGroups]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Collection_CreateWithGroups]
+END
+GO
+
+IF OBJECT_ID('[dbo].[Collection_UpdateWithGroups]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Collection_UpdateWithGroups]
+END
+GO
+
 IF TYPE_ID('[dbo].[SelectionReadOnlyArray]') IS NOT NULL
 BEGIN
     DROP TYPE [dbo].[SelectionReadOnlyArray]
@@ -211,12 +253,6 @@ BEGIN
 END
 GO
 
-IF OBJECT_ID('[dbo].[Group_CreateWithCollections]') IS NOT NULL
-BEGIN
-    DROP PROCEDURE [dbo].[Group_CreateWithCollections]
-END
-GO
-
 CREATE PROCEDURE [dbo].[Group_CreateWithCollections]
     @Id UNIQUEIDENTIFIER,
     @OrganizationId UNIQUEIDENTIFIER,
@@ -286,12 +322,6 @@ BEGIN
 END
 GO
 
-IF OBJECT_ID('[dbo].[Group_UpdateWithCollections]') IS NOT NULL
-BEGIN
-    DROP PROCEDURE [dbo].[Group_UpdateWithCollections]
-END
-GO
-
 CREATE PROCEDURE [dbo].[Group_UpdateWithCollections]
     @Id UNIQUEIDENTIFIER,
     @OrganizationId UNIQUEIDENTIFIER,
@@ -343,12 +373,6 @@ BEGIN
     ;
 
     EXEC [dbo].[User_BumpAccountRevisionDateByOrganizationId] @OrganizationId
-END
-GO
-
-IF OBJECT_ID('[dbo].[CollectionUser_UpdateUsers]') IS NOT NULL
-BEGIN
-    DROP PROCEDURE [dbo].[CollectionUser_UpdateUsers]
 END
 GO
 
@@ -451,12 +475,6 @@ BEGIN
 END
 GO
 
-IF OBJECT_ID('[dbo].[OrganizationUser_CreateWithCollections]') IS NOT NULL
-BEGIN
-    DROP PROCEDURE [dbo].[OrganizationUser_CreateWithCollections]
-END
-GO
-
 CREATE PROCEDURE [dbo].[OrganizationUser_CreateWithCollections]
     @Id UNIQUEIDENTIFIER,
     @OrganizationId UNIQUEIDENTIFIER,
@@ -527,12 +545,6 @@ BEGIN
         [dbo].[CollectionUser] CU ON OU.[AccessAll] = 0 AND CU.[OrganizationUserId] = [OU].[Id]
     WHERE
         [OrganizationUserId] = @Id
-END
-GO
-
-IF OBJECT_ID('[dbo].[OrganizationUser_UpdateWithCollections]') IS NOT NULL
-BEGIN
-    DROP PROCEDURE [dbo].[OrganizationUser_UpdateWithCollections]
 END
 GO
 
@@ -640,12 +652,6 @@ BEGIN
 END
 GO
 
-IF OBJECT_ID('[dbo].[Collection_CreateWithGroups]') IS NOT NULL
-BEGIN
-    DROP PROCEDURE [dbo].[Collection_CreateWithGroups]
-END
-GO
-
 CREATE PROCEDURE [dbo].[Collection_CreateWithGroups]
     @Id UNIQUEIDENTIFIER,
     @OrganizationId UNIQUEIDENTIFIER,
@@ -712,12 +718,6 @@ BEGIN
         [dbo].[CollectionGroup]
     WHERE
         [CollectionId] = @Id
-END
-GO
-
-IF OBJECT_ID('[dbo].[Collection_UpdateWithGroups]') IS NOT NULL
-BEGIN
-    DROP PROCEDURE [dbo].[Collection_UpdateWithGroups]
 END
 GO
 


### PR DESCRIPTION
This PR adds support for a new collection access, `HidePasswords` which in some ways behaves similar to `ReadOnly`. Except instead of marking ciphers `ReadOnly` it toggles if the user can view passwords.

If the user has access to a collection with the flag `HidePasswords` each cipher belonging to the collection will have the flag `showPassword` set to false. It's then up to each client on how to deal with it.