### PR TITLE
Added Discord to Global Equivalent Domain

### DIFF
--- a/src/Core/Enums/GlobalEquivalentDomainsType.cs
+++ b/src/Core/Enums/GlobalEquivalentDomainsType.cs
@@ -83,5 +83,6 @@
         Cisco = 78,
         CedarFair = 79,
         Ubiquiti = 80,
+        Discord = 81,
     }
 }

--- a/src/Core/Utilities/StaticStore.cs
+++ b/src/Core/Utilities/StaticStore.cs
@@ -92,6 +92,7 @@ namespace Bit.Core.Utilities
             GlobalDomains.Add(GlobalEquivalentDomainsType.Cisco, new List<string> { "dnsomatic.com", "opendns.com", "umbrella.com"});
             GlobalDomains.Add(GlobalEquivalentDomainsType.CedarFair, new List<string> {"cagreatamerica.com", "canadaswonderland.com", "carowinds.com", "cedarfair.com", "cedarpoint.com", "dorneypark.com", "kingsdominion.com", "knotts.com", "miadventure.com", "schlitterbahn.com", "valleyfair.com", "visitkingsisland.com", "worldsoffun.com"});
             GlobalDomains.Add(GlobalEquivalentDomainsType.Ubiquiti, new List<string> {"ubnt.com", "ui.com"});
+            GlobalDomains.Add(GlobalEquivalentDomainsType.Discord, new List<string> {"discordapp.com", "discord.com"});
             #endregion
 
             #region Plans


### PR DESCRIPTION
Recently Discord changed to discord.com instead of discordapp.com
This leaves all the saved passwords under discordapp.com (while you now use discord.com to access)

This will fix this: https://github.com/bitwarden/browser/issues/1248