### PR TITLE
Create missing container volume directories if/when docker-compose fails to

### DIFF
--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -76,6 +76,7 @@ function Install() {
 
 function Docker-Compose-Up {
     Docker-Compose-Files
+    Docker-Compose-Volumes
     Invoke-Expression ("docker-compose up -d{0}" -f $quietPullFlag)
 }
 
@@ -97,6 +98,30 @@ function Docker-Compose-Files {
         $env:COMPOSE_FILE = "${dockerDir}\docker-compose.yml"
     }
     $env:COMPOSE_HTTP_TIMEOUT = "300"
+}
+
+function Docker-Compose-Volumes {
+    Create-Dir "core"
+    Create-Dir "core/attachments"
+    Create-Dir "logs"
+    Create-Dir "logs/admin"
+    Create-Dir "logs/api"
+    Create-Dir "logs/events"
+    Create-Dir "logs/icons"
+    Create-Dir "logs/identity"
+    Create-Dir "logs/mssql"
+    Create-Dir "logs/nginx"
+    Create-Dir "logs/notifications"
+    Create-Dir "mssql/backups"
+    Create-Dir "mssql/data"
+}
+
+function Create-Dir($str) {
+    $outPath = "${outputDir}/$str"
+    if (!(Test-Path -Path $outPath )) {
+        Write-Line "Creating directory $outPath"
+        New-Item -ItemType directory -Path $outPath | Out-Null
+    }
 }
 
 function Docker-Prune {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -85,6 +85,7 @@ function install() {
 
 function dockerComposeUp() {
     dockerComposeFiles
+    dockerComposeVolumes
     docker-compose up -d
 }
 
@@ -106,6 +107,30 @@ function dockerComposeFiles() {
         export COMPOSE_FILE="$DOCKER_DIR/docker-compose.yml"
     fi
     export COMPOSE_HTTP_TIMEOUT="300"
+}
+
+function dockerComposeVolumes() {
+    createDir "core"
+    createDir "core/attachments"
+    createDir "logs"
+    createDir "logs/admin"
+    createDir "logs/api"
+    createDir "logs/events"
+    createDir "logs/icons"
+    createDir "logs/identity"
+    createDir "logs/mssql"
+    createDir "logs/nginx"
+    createDir "logs/notifications"
+    createDir "mssql/backups"
+    createDir "mssql/data"
+}
+
+function createDir() {
+    if [ ! -d "${OUTPUT_DIR}/$1" ]
+    then
+        echo "Creating directory $OUTPUT_DIR/$1"
+        mkdir -p $OUTPUT_DIR/$1
+    fi
 }
 
 function dockerPrune() {


### PR DESCRIPTION
Some platforms/devices ship with a built-in version of docker-compose that fails to create the container volume directories on 'up' (looking at you, Synology DSM).  This PR simply checks for the presence of those missing directories and creates them if they don't exist.  This allows for a much better install experience on those devices.

![Screen Shot 2020-05-29 at 6 14 30 PM](https://user-images.githubusercontent.com/59324545/83309952-98653980-a1d8-11ea-84f9-ea5a2f5ad8a9.png)

![Screen Shot 2020-05-29 at 6 15 01 PM](https://user-images.githubusercontent.com/59324545/83309960-9bf8c080-a1d8-11ea-9dae-248653b45ac5.png)
