### PR TITLE
Feature/tax info collection

### DIFF
--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -634,7 +634,6 @@ namespace Bit.Api.Controllers
         }
         
         [HttpPut("tax")]
-        [HttpPost("tax")]
         [SelfHosted(NotSelfHostedOnly = true)]
         public async Task PutTaxInfo([FromBody]TaxInfoUpdateRequestModel model)
         {

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -618,5 +618,38 @@ namespace Bit.Api.Controllers
 
             return token;
         }
+        
+        [HttpGet("tax")]
+        [SelfHosted(NotSelfHostedOnly = true)]
+        public async Task<TaxInfoResponseModel> GetTaxInfo()
+        {
+            var user = await _userService.GetUserByPrincipalAsync(User);
+            if (user == null)
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            var taxInfo = await _paymentService.GetTaxInfoAsync(user);
+            return new TaxInfoResponseModel(taxInfo);
+        }
+        
+        [HttpPut("tax")]
+        [HttpPost("tax")]
+        [SelfHosted(NotSelfHostedOnly = true)]
+        public async Task PutTaxInfo([FromBody]TaxInfoUpdateRequestModel model)
+        {
+            var user = await _userService.GetUserByPrincipalAsync(User);
+            if (user == null)
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            var taxInfo = new TaxInfo
+            {
+                BillingAddressPostalCode = model.PostalCode,
+                BillingAddressCountry = model.Country,
+            };
+            await _paymentService.SaveTaxInfoAsync(user, taxInfo);
+        }
     }
 }

--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -484,7 +484,6 @@ namespace Bit.Api.Controllers
         }
         
         [HttpPut("{id}/tax")]
-        [HttpPost("{id}/tax")]
         [SelfHosted(NotSelfHostedOnly = true)]
         public async Task PutTaxInfo(string id, [FromBody]OrganizationTaxInfoUpdateRequestModel model)
         {

--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -462,5 +462,55 @@ namespace Bit.Api.Controllers
                 return response;
             }
         }
+        
+        [HttpGet("{id}/tax")]
+        [SelfHosted(NotSelfHostedOnly = true)]
+        public async Task<TaxInfoResponseModel> GetTaxInfo(string id)
+        {
+            var orgIdGuid = new Guid(id);
+            if (!_currentContext.OrganizationOwner(orgIdGuid))
+            {
+                throw new NotFoundException();
+            }
+
+            var organization = await _organizationRepository.GetByIdAsync(orgIdGuid);
+            if (organization == null)
+            {
+                throw new NotFoundException();
+            }
+
+            var taxInfo = await _paymentService.GetTaxInfoAsync(organization);
+            return new TaxInfoResponseModel(taxInfo);
+        }
+        
+        [HttpPut("{id}/tax")]
+        [HttpPost("{id}/tax")]
+        [SelfHosted(NotSelfHostedOnly = true)]
+        public async Task PutTaxInfo(string id, [FromBody]OrganizationTaxInfoUpdateRequestModel model)
+        {
+            var orgIdGuid = new Guid(id);
+            if (!_currentContext.OrganizationOwner(orgIdGuid))
+            {
+                throw new NotFoundException();
+            }
+
+            var organization = await _organizationRepository.GetByIdAsync(orgIdGuid);
+            if (organization == null)
+            {
+                throw new NotFoundException();
+            }
+
+            var taxInfo = new TaxInfo
+            {
+                TaxIdNumber = model.TaxId,
+                BillingAddressLine1 = model.Line1,
+                BillingAddressLine2 = model.Line2,
+                BillingAddressCity = model.City,
+                BillingAddressState = model.State,
+                BillingAddressPostalCode = model.PostalCode,
+                BillingAddressCountry = model.Country,
+            };
+            await _paymentService.SaveTaxInfoAsync(organization, taxInfo);
+        }
     }
 }

--- a/src/Core/Models/Api/Request/Accounts/TaxInfoUpdateRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/TaxInfoUpdateRequestModel.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Bit.Core.Models.Api
+{
+    public class TaxInfoUpdateRequestModel : IValidatableObject
+    {
+        [Required]
+        public string Country { get; set; }
+        public string PostalCode { get; set; }
+
+        public virtual IEnumerable<ValidationResult> Validate (ValidationContext validationContext)
+        {
+            if (Country == "US" && string.IsNullOrWhiteSpace(PostalCode))
+            {
+                yield return new ValidationResult("Zip / postal code is required.",
+                    new string[] { nameof(PostalCode) });
+            }
+        }
+    }
+}

--- a/src/Core/Models/Api/Request/Organizations/OrganizationCreateRequestModel.cs
+++ b/src/Core/Models/Api/Request/Organizations/OrganizationCreateRequestModel.cs
@@ -31,6 +31,15 @@ namespace Bit.Core.Models.Api
         [EncryptedString]
         [EncryptedStringLength(1000)]
         public string CollectionName { get; set; }
+        public string TaxIdNumber { get; set; }
+        public string BillingAddressLine1 { get; set; }
+        public string BillingAddressLine2 { get; set; }
+        public string BillingAddressCity { get; set; }
+        public string BillingAddressState { get; set; }
+        public string BillingAddressPostalCode { get; set; }
+        [Required]
+        [StringLength(2)]
+        public string BillingAddressCountry { get; set; }
 
         public virtual OrganizationSignup ToOrganizationSignup(User user)
         {
@@ -47,7 +56,17 @@ namespace Bit.Core.Models.Api
                 PremiumAccessAddon = PremiumAccessAddon,
                 BillingEmail = BillingEmail,
                 BusinessName = BusinessName,
-                CollectionName = CollectionName
+                CollectionName = CollectionName,
+                TaxInfo = new TaxInfo
+                {
+                    TaxIdNumber = TaxIdNumber,
+                    BillingAddressLine1 = BillingAddressLine1,
+                    BillingAddressLine2 = BillingAddressLine2,
+                    BillingAddressCity = BillingAddressCity,
+                    BillingAddressState = BillingAddressState,
+                    BillingAddressPostalCode = BillingAddressPostalCode,
+                    BillingAddressCountry = BillingAddressCountry,
+                },
             };
         }
 
@@ -61,6 +80,17 @@ namespace Bit.Core.Models.Api
             {
                 yield return new ValidationResult("Payment method type required.",
                     new string[] { nameof(PaymentMethodType) });
+            }
+            if (PlanType != PlanType.Free && string.IsNullOrWhiteSpace(BillingAddressCountry))
+            {
+                yield return new ValidationResult("Country required.",
+                    new string[] { nameof(BillingAddressCountry) });
+            }
+            if (PlanType != PlanType.Free && BillingAddressCountry == "US" &&
+                string.IsNullOrWhiteSpace(BillingAddressPostalCode))
+            {
+                yield return new ValidationResult("Zip / postal code is required.",
+                    new string[] { nameof(BillingAddressPostalCode) });
             }
         }
     }

--- a/src/Core/Models/Api/Request/Organizations/OrganizationTaxInfoUpdateRequestModel.cs
+++ b/src/Core/Models/Api/Request/Organizations/OrganizationTaxInfoUpdateRequestModel.cs
@@ -1,0 +1,11 @@
+﻿namespace Bit.Core.Models.Api
+{
+    public class OrganizationTaxInfoUpdateRequestModel : TaxInfoUpdateRequestModel
+    {
+        public string TaxId { get; set; }
+        public string Line1 { get; set; }
+        public string Line2 { get; set; }
+        public string City { get; set; }
+        public string State { get; set; }
+    }
+}

--- a/src/Core/Models/Api/Response/TaxInfoResponseModel.cs
+++ b/src/Core/Models/Api/Response/TaxInfoResponseModel.cs
@@ -4,7 +4,8 @@ namespace Bit.Core.Models.Api
 {
     public class TaxInfoResponseModel
     {
-        public TaxInfoResponseModel () { }
+        public TaxInfoResponseModel() { }
+
         public TaxInfoResponseModel(TaxInfo taxInfo)
         {
             if (taxInfo == null)

--- a/src/Core/Models/Api/Response/TaxInfoResponseModel.cs
+++ b/src/Core/Models/Api/Response/TaxInfoResponseModel.cs
@@ -1,0 +1,34 @@
+﻿using Bit.Core.Models.Business;
+
+namespace Bit.Core.Models.Api
+{
+    public class TaxInfoResponseModel
+    {
+        public TaxInfoResponseModel () { }
+        public TaxInfoResponseModel(TaxInfo taxInfo)
+        {
+            if (taxInfo == null)
+            {
+                return;
+            }
+
+            TaxIdNumber = taxInfo.TaxIdNumber;
+            TaxIdType = taxInfo.TaxIdType;
+            Line1 = taxInfo.BillingAddressLine1;
+            Line2 = taxInfo.BillingAddressLine2;
+            City = taxInfo.BillingAddressCity;
+            State = taxInfo.BillingAddressState;
+            PostalCode = taxInfo.BillingAddressPostalCode;
+            Country = taxInfo.BillingAddressCountry;
+        }
+
+        public string TaxIdNumber { get; set; }
+        public string TaxIdType { get; set; }
+        public string Line1 { get; set; }
+        public string Line2 { get; set; }
+        public string City { get; set; }
+        public string State { get; set; }
+        public string PostalCode { get; set; }
+        public string Country { get; set; }
+    }
+}

--- a/src/Core/Models/Business/OrganizationSignup.cs
+++ b/src/Core/Models/Business/OrganizationSignup.cs
@@ -12,5 +12,6 @@ namespace Bit.Core.Models.Business
         public string CollectionName { get; set; }
         public PaymentMethodType? PaymentMethodType { get; set; }
         public string PaymentToken { get; set; }
+        public TaxInfo TaxInfo { get; set; }
     }
 }

--- a/src/Core/Models/Business/TaxInfo.cs
+++ b/src/Core/Models/Business/TaxInfo.cs
@@ -26,9 +26,13 @@
             {
                 if (string.IsNullOrWhiteSpace(BillingAddressCountry) ||
                     string.IsNullOrWhiteSpace(TaxIdNumber))
+                {
                     return null;
+                }
                 if (!string.IsNullOrWhiteSpace(_taxIdType))
+                {
                     return _taxIdType;
+                }
 
                 switch (BillingAddressCountry)
                 {
@@ -44,7 +48,9 @@
                     case "CA":
                         // May break for those in Québec given the assumption of QST
                         if (BillingAddressState?.Contains("bec") ?? false)
+                        {
                             _taxIdType = "ca_qst";
+                        }
                         _taxIdType = "ca_bn";
                         break;
                     case "CL":

--- a/src/Core/Models/Business/TaxInfo.cs
+++ b/src/Core/Models/Business/TaxInfo.cs
@@ -1,0 +1,140 @@
+﻿namespace Bit.Core.Models.Business
+{
+    public class TaxInfo
+    {
+        private string _taxIdNumber = null;
+        private string _taxIdType = null;
+
+        public string TaxIdNumber
+        {
+            get => _taxIdNumber;
+            set
+            {
+                _taxIdNumber = value;
+                _taxIdType = null;
+            }
+        }
+        public string BillingAddressLine1 { get; set; }
+        public string BillingAddressLine2 { get; set; }
+        public string BillingAddressCity { get; set; }
+        public string BillingAddressState { get; set; }
+        public string BillingAddressPostalCode { get; set; }
+        public string BillingAddressCountry { get; set; } = "US";
+        public string TaxIdType
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(BillingAddressCountry) ||
+                    string.IsNullOrWhiteSpace(TaxIdNumber))
+                    return null;
+                if (!string.IsNullOrWhiteSpace(_taxIdType))
+                    return _taxIdType;
+
+                switch (BillingAddressCountry)
+                {
+                    case "AE":
+                        _taxIdType = "ae_trn";
+                        break;
+                    case "AU":
+                        _taxIdType = "au_abn";
+                        break;
+                    case "BR":
+                        _taxIdType = "br_cnpj";
+                        break;
+                    case "CA":
+                        // May break for those in Québec given the assumption of QST
+                        if (BillingAddressState?.Contains("bec") ?? false)
+                            _taxIdType = "ca_qst";
+                        _taxIdType = "ca_bn";
+                        break;
+                    case "CL":
+                        _taxIdType = "cl_tin";
+                        break;
+                    case "AT":
+                    case "BE":
+                    case "BG":
+                    case "CY":
+                    case "CZ":
+                    case "DE":
+                    case "DK":
+                    case "EE":
+                    case "ES":
+                    case "FI":
+                    case "FR":
+                    case "GB":
+                    case "GR":
+                    case "HR":
+                    case "HU":
+                    case "IE":
+                    case "IT":
+                    case "LT":
+                    case "LU":
+                    case "LV":
+                    case "MT":
+                    case "NL":
+                    case "PL":
+                    case "PT":
+                    case "RO":
+                    case "SE":
+                    case "SI":
+                    case "SK":
+                        _taxIdType = "eu_vat";
+                        break;
+                    case "HK":
+                        _taxIdType = "hk_br";
+                        break;
+                    case "IN":
+                        _taxIdType = "in_gst";
+                        break;
+                    case "JP":
+                        _taxIdType = "jp_cn";
+                        break;
+                    case "KR":
+                        _taxIdType = "kr_brn";
+                        break;
+                    case "LI":
+                        _taxIdType = "li_uid";
+                        break;
+                    case "MX":
+                        _taxIdType = "mx_rfc";
+                        break;
+                    case "MY":
+                        _taxIdType = "my_sst";
+                        break;
+                    case "NO":
+                        _taxIdType = "no_vat";
+                        break;
+                    case "NZ":
+                        _taxIdType = "nz_gst";
+                        break;
+                    case "RU":
+                        _taxIdType = "ru_inn";
+                        break;
+                    case "SA":
+                        _taxIdType = "sa_vat";
+                        break;
+                    case "SG":
+                        _taxIdType = "sg_gst";
+                        break;
+                    case "TH":
+                        _taxIdType = "th_vat";
+                        break;
+                    case "TW":
+                        _taxIdType = "tw_vat";
+                        break;
+                    case "US":
+                        _taxIdType = "us_ein";
+                        break;
+                    case "ZA":
+                        _taxIdType = "za_vat";
+                        break;
+                    default:
+                        _taxIdType = null;
+                        break;
+                }
+
+                return _taxIdType;
+            }
+        }
+    }
+}

--- a/src/Core/Models/Business/TaxInfo.cs
+++ b/src/Core/Models/Business/TaxInfo.cs
@@ -136,5 +136,11 @@
                 return _taxIdType;
             }
         }
+
+        public bool HasTaxId
+        {
+            get => !string.IsNullOrWhiteSpace(TaxIdNumber) &&
+                !string.IsNullOrWhiteSpace(TaxIdType);
+        }
     }
 }

--- a/src/Core/Services/IPaymentService.cs
+++ b/src/Core/Services/IPaymentService.cs
@@ -10,7 +10,7 @@ namespace Bit.Core.Services
         Task CancelAndRecoverChargesAsync(ISubscriber subscriber);
         Task<string> PurchaseOrganizationAsync(Organization org, PaymentMethodType paymentMethodType,
             string paymentToken, Models.StaticStore.Plan plan, short additionalStorageGb, short additionalSeats,
-            bool premiumAccessAddon);
+            bool premiumAccessAddon, TaxInfo taxInfo);
         Task<string> UpgradeFreeOrganizationAsync(Organization org, Models.StaticStore.Plan plan,
            short additionalStorageGb, short additionalSeats, bool premiumAccessAddon);
         Task<string> PurchasePremiumAsync(User user, PaymentMethodType paymentMethodType, string paymentToken,
@@ -24,5 +24,7 @@ namespace Bit.Core.Services
         Task<bool> CreditAccountAsync(ISubscriber subscriber, decimal creditAmount);
         Task<BillingInfo> GetBillingAsync(ISubscriber subscriber);
         Task<SubscriptionInfo> GetSubscriptionAsync(ISubscriber subscriber);
+        Task<TaxInfo> GetTaxInfoAsync(ISubscriber subscriber);
+        Task SaveTaxInfoAsync(ISubscriber subscriber, TaxInfo taxInfo);
     }
 }

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -486,7 +486,7 @@ namespace Bit.Core.Services
             {
                 await _paymentService.PurchaseOrganizationAsync(organization, signup.PaymentMethodType.Value,
                     signup.PaymentToken, plan, signup.AdditionalStorageGb, signup.AdditionalSeats,
-                    signup.PremiumAccessAddon);
+                    signup.PremiumAccessAddon, signup.TaxInfo);
             }
 
             return await SignUpAsync(organization, signup.Owner.Id, signup.OwnerKey, signup.CollectionName, true);

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -165,7 +165,7 @@ namespace Bit.Core.Services
                         Country = taxInfo.BillingAddressCountry,
                         PostalCode = taxInfo.BillingAddressPostalCode,
                         // Line1 is required in Stripe's API, suggestion in Docs is to use Business Name intead.
-                        Line1 = taxInfo.BillingAddressLine1 ?? org.BusinessName,
+                        Line1 = taxInfo.BillingAddressLine1 ?? string.Empty,
                         Line2 = taxInfo.BillingAddressLine2,
                         City = taxInfo.BillingAddressCity,
                         State = taxInfo.BillingAddressState,
@@ -1536,7 +1536,7 @@ namespace Bit.Core.Services
 
                 // Line1 is required, so if missing we're using the subscriber name
                 // see: https://stripe.com/docs/api/customers/create#create_customer-address-line1
-                if (address != null && address.Line1 == subscriber.BillingName())
+                if (address != null && string.IsNullOrWhiteSpace(address.Line1))
                 {
                     address.Line1 = null;
                 }
@@ -1565,7 +1565,7 @@ namespace Bit.Core.Services
                 {
                     Address = new AddressOptions
                     {
-                        Line1 = taxInfo.BillingAddressLine1 ?? subscriber.BillingName(),
+                        Line1 = taxInfo.BillingAddressLine1 ?? string.Empty,
                         Line2 = taxInfo.BillingAddressLine2,
                         City = taxInfo.BillingAddressCity,
                         State = taxInfo.BillingAddressState,


### PR DESCRIPTION
## Objective

Provide new API endpoints for collecting and retrieving tax information to/from Stripe (or payments service). Tax information includes Country + Postal Code for billing (and tax calculation purposes [FUT]); as well as optional VAT/GST and address information for countries other than the US.

## Changes

* AccountsController.cs - added GetTaxInfo() and PutTaxInfo() methods for getting and saving tax information. PUT encapsulates an UPSERT operation.
* OrganizationsController.cs - same, however also maps additional tax information and tax ID.
* TaxInfoUpdateRequestModel.cs - Request model for updating consumer tax info.
* OrganizationCreateRequestModel.cs - Adds tax info to the create organization model to create an "atomic" operation for creating new organization (vs. chaining in the UI)
* OrganizationTaxInfoUpdateRequestModel.cs - Extends TaxInfoUpdateRequestModel to add remaining address fields and Tax ID.
* TaxInfoResponseModel.cs - The model for returning tax information (both consumer + org)
* OrganizationSignup.cs - Added tax info to the signup model (middle-tier pass-thru).
* TaxInfo.cs - Business class that encapsulates tax information and tax ID type lookup logic
* I/PaymentService.cs - Get/Set tax info methods, extended PurchaseOrganizationAsync() method to accept tax info as well.
* OrganizationService.cs - Fulfill requirement to pass through tax info ^^^
* StripePaymentService.cs - Map and implement billing address and tax ID requests against stripe's SDK/API.
