### PR TITLE
On create default ViewPassword to true

### DIFF
--- a/src/Core/Models/Api/Request/CipherRequestModel.cs
+++ b/src/Core/Models/Api/Request/CipherRequestModel.cs
@@ -47,7 +47,8 @@ namespace Bit.Core.Models.Api
                 Type = Type,
                 UserId = !hasOrgId ? (Guid?)userId : null,
                 OrganizationId = allowOrgIdSet && hasOrgId ? new Guid(OrganizationId) : (Guid?)null,
-                Edit = true
+                Edit = true,
+                ViewPassword = true,
             };
             ToCipherDetails(cipher);
             return cipher;


### PR DESCRIPTION
Resolves an issue where ViewPassword would default to false for newly created users. This caused items in clients to be non-editable until a sync which corrected the attribute.