### PR TITLE
Combined tax updates with other operations

### DIFF
--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -208,7 +208,7 @@ namespace Bit.Api.Controllers
             {
                 throw new NotFoundException();
             }
-            
+
             await _organizationService.ReplacePaymentMethodAsync(orgIdGuid, model.PaymentToken,
                 model.PaymentMethodType.Value, new TaxInfo
                 {

--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -208,9 +208,18 @@ namespace Bit.Api.Controllers
             {
                 throw new NotFoundException();
             }
-
+            
             await _organizationService.ReplacePaymentMethodAsync(orgIdGuid, model.PaymentToken,
-                model.PaymentMethodType.Value);
+                model.PaymentMethodType.Value, new TaxInfo
+                {
+                    BillingAddressLine1 = model.Line1,
+                    BillingAddressLine2 = model.Line2,
+                    BillingAddressState = model.State,
+                    BillingAddressCity = model.City,
+                    BillingAddressPostalCode = model.PostalCode,
+                    BillingAddressCountry = model.Country,
+                    TaxIdNumber = model.TaxId,
+                });
         }
 
         [HttpPost("{id}/upgrade")]

--- a/src/Core/Models/Api/Request/Accounts/PremiumRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/PremiumRequestModel.cs
@@ -13,11 +13,17 @@ namespace Bit.Core.Models.Api
         [Range(0, 99)]
         public short? AdditionalStorageGb { get; set; }
         public IFormFile License { get; set; }
+        public string Country { get; set; }
+        public string PostalCode { get; set; }
 
         public bool Validate(GlobalSettings globalSettings)
         {
-            return (License == null && !globalSettings.SelfHosted) ||
-                (License != null && globalSettings.SelfHosted);
+            if (!(License == null && !globalSettings.SelfHosted) ||
+                (License != null && globalSettings.SelfHosted))
+            {
+                return false;
+            }
+            return globalSettings.SelfHosted || !string.IsNullOrWhiteSpace(Country);
         }
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
@@ -26,6 +32,11 @@ namespace Bit.Core.Models.Api
             if (string.IsNullOrWhiteSpace(PaymentToken) && !creditType && License == null)
             {
                 yield return new ValidationResult("Payment token or license is required.");
+            }
+            if (Country == "US" && string.IsNullOrWhiteSpace(PostalCode))
+            {
+                yield return new ValidationResult("Zip / postal code is required.",
+                    new string[] { nameof(PostalCode) });
             }
         }
     }

--- a/src/Core/Models/Api/Request/PaymentRequestModel.cs
+++ b/src/Core/Models/Api/Request/PaymentRequestModel.cs
@@ -3,7 +3,7 @@ using Bit.Core.Enums;
 
 namespace Bit.Core.Models.Api
 {
-    public class PaymentRequestModel
+    public class PaymentRequestModel : OrganizationTaxInfoUpdateRequestModel
     {
         [Required]
         public PaymentMethodType? PaymentMethodType { get; set; }

--- a/src/Core/Services/IOrganizationService.cs
+++ b/src/Core/Services/IOrganizationService.cs
@@ -10,7 +10,8 @@ namespace Bit.Core.Services
 {
     public interface IOrganizationService
     {
-        Task ReplacePaymentMethodAsync(Guid organizationId, string paymentToken, PaymentMethodType paymentMethodType);
+        Task ReplacePaymentMethodAsync(Guid organizationId, string paymentToken, PaymentMethodType paymentMethodType,
+            TaxInfo taxInfo);
         Task CancelSubscriptionAsync(Guid organizationId, bool? endOfPeriod = null);
         Task ReinstateSubscriptionAsync(Guid organizationId);
         Task<Tuple<bool, string>> UpgradePlanAsync(Guid organizationId, OrganizationUpgrade upgrade);

--- a/src/Core/Services/IPaymentService.cs
+++ b/src/Core/Services/IPaymentService.cs
@@ -14,7 +14,7 @@ namespace Bit.Core.Services
         Task<string> UpgradeFreeOrganizationAsync(Organization org, Models.StaticStore.Plan plan,
            short additionalStorageGb, short additionalSeats, bool premiumAccessAddon);
         Task<string> PurchasePremiumAsync(User user, PaymentMethodType paymentMethodType, string paymentToken,
-            short additionalStorageGb);
+            short additionalStorageGb, string country, string postalCode);
         Task<string> AdjustStorageAsync(IStorableSubscriber storableSubscriber, int additionalStorage, string storagePlanId);
         Task CancelSubscriptionAsync(ISubscriber subscriber, bool endOfPeriod = false,
             bool skipInAppPurchaseCheck = false);

--- a/src/Core/Services/IPaymentService.cs
+++ b/src/Core/Services/IPaymentService.cs
@@ -14,13 +14,13 @@ namespace Bit.Core.Services
         Task<string> UpgradeFreeOrganizationAsync(Organization org, Models.StaticStore.Plan plan,
            short additionalStorageGb, short additionalSeats, bool premiumAccessAddon);
         Task<string> PurchasePremiumAsync(User user, PaymentMethodType paymentMethodType, string paymentToken,
-            short additionalStorageGb, string country, string postalCode);
+            short additionalStorageGb, TaxInfo taxInfo);
         Task<string> AdjustStorageAsync(IStorableSubscriber storableSubscriber, int additionalStorage, string storagePlanId);
         Task CancelSubscriptionAsync(ISubscriber subscriber, bool endOfPeriod = false,
             bool skipInAppPurchaseCheck = false);
         Task ReinstateSubscriptionAsync(ISubscriber subscriber);
         Task<bool> UpdatePaymentMethodAsync(ISubscriber subscriber, PaymentMethodType paymentMethodType,
-            string paymentToken, bool allowInAppPurchases = false);
+            string paymentToken, bool allowInAppPurchases = false, TaxInfo taxInfo = null);
         Task<bool> CreditAccountAsync(ISubscriber subscriber, decimal creditAmount);
         Task<BillingInfo> GetBillingAsync(ISubscriber subscriber);
         Task<SubscriptionInfo> GetSubscriptionAsync(ISubscriber subscriber);

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -46,7 +46,8 @@ namespace Bit.Core.Services
         Task<IdentityResult> DeleteAsync(User user, string token);
         Task SendDeleteConfirmationAsync(string email);
         Task<Tuple<bool, string>> SignUpPremiumAsync(User user, string paymentToken,
-            PaymentMethodType paymentMethodType, short additionalStorageGb, UserLicense license);
+            PaymentMethodType paymentMethodType, short additionalStorageGb, UserLicense license,
+            string country, string postalCode);
         Task IapCheckAsync(User user, PaymentMethodType paymentMethodType);
         Task UpdateLicenseAsync(User user, UserLicense license);
         Task<string> AdjustStorageAsync(User user, short storageAdjustmentGb);

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -47,11 +47,11 @@ namespace Bit.Core.Services
         Task SendDeleteConfirmationAsync(string email);
         Task<Tuple<bool, string>> SignUpPremiumAsync(User user, string paymentToken,
             PaymentMethodType paymentMethodType, short additionalStorageGb, UserLicense license,
-            string country, string postalCode);
+            TaxInfo taxInfo);
         Task IapCheckAsync(User user, PaymentMethodType paymentMethodType);
         Task UpdateLicenseAsync(User user, UserLicense license);
         Task<string> AdjustStorageAsync(User user, short storageAdjustmentGb);
-        Task ReplacePaymentMethodAsync(User user, string paymentToken, PaymentMethodType paymentMethodType);
+        Task ReplacePaymentMethodAsync(User user, string paymentToken, PaymentMethodType paymentMethodType, TaxInfo taxInfo);
         Task CancelPremiumAsync(User user, bool? endOfPeriod = null, bool accountDelete = false);
         Task ReinstatePremiumAsync(User user);
         Task EnablePremiumAsync(Guid userId, DateTime? expirationDate);

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -75,7 +75,7 @@ namespace Bit.Core.Services
         }
 
         public async Task ReplacePaymentMethodAsync(Guid organizationId, string paymentToken,
-            PaymentMethodType paymentMethodType)
+            PaymentMethodType paymentMethodType, TaxInfo taxInfo)
         {
             var organization = await GetOrgById(organizationId);
             if (organization == null)
@@ -83,6 +83,7 @@ namespace Bit.Core.Services
                 throw new NotFoundException();
             }
 
+            await _paymentService.SaveTaxInfoAsync(organization, taxInfo);
             var updated = await _paymentService.UpdatePaymentMethodAsync(organization,
                 paymentMethodType, paymentToken);
             if (updated)

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -345,7 +345,7 @@ namespace Bit.Core.Services
         }
 
         public async Task<string> PurchasePremiumAsync(User user, PaymentMethodType paymentMethodType,
-            string paymentToken, short additionalStorageGb, string country, string postalCode)
+            string paymentToken, short additionalStorageGb, TaxInfo taxInfo)
         {
             if (paymentMethodType != PaymentMethodType.Credit && string.IsNullOrWhiteSpace(paymentToken))
             {
@@ -393,7 +393,7 @@ namespace Bit.Core.Services
                 {
                     try
                     {
-                        await UpdatePaymentMethodAsync(user, paymentMethodType, paymentToken, true);
+                        await UpdatePaymentMethodAsync(user, paymentMethodType, paymentToken, true, taxInfo);
                     }
                     catch (Exception e)
                     {
@@ -467,23 +467,11 @@ namespace Bit.Core.Services
                     Address = new AddressOptions
                     {
                         Line1 = string.Empty,
-                        Country = country,
-                        PostalCode = postalCode,
+                        Country = taxInfo.BillingAddressCountry,
+                        PostalCode = taxInfo.BillingAddressPostalCode,
                     },
                 });
                 createdStripeCustomer = true;
-            }
-            else if (customer != null)
-            {
-                await customerService.UpdateAsync(customer.Id, new CustomerUpdateOptions
-                {
-                    Address = new AddressOptions
-                    {
-                        Line1 = string.Empty,
-                        Country = country,
-                        PostalCode = postalCode,
-                    }
-                });
             }
 
             if (customer == null)
@@ -1116,7 +1104,7 @@ namespace Bit.Core.Services
         }
 
         public async Task<bool> UpdatePaymentMethodAsync(ISubscriber subscriber, PaymentMethodType paymentMethodType,
-            string paymentToken, bool allowInAppPurchases = false)
+            string paymentToken, bool allowInAppPurchases = false, TaxInfo taxInfo = null)
         {
             if (subscriber == null)
             {
@@ -1304,7 +1292,16 @@ namespace Bit.Core.Services
                         InvoiceSettings = new CustomerInvoiceSettingsOptions
                         {
                             DefaultPaymentMethod = stipeCustomerPaymentMethodId
-                        }
+                        },
+                        Address = taxInfo == null ? null : new AddressOptions
+                        {
+                            Country = taxInfo.BillingAddressCountry,
+                            PostalCode = taxInfo.BillingAddressPostalCode,
+                            Line1 = taxInfo.BillingAddressLine1 ?? string.Empty,
+                            Line2 = taxInfo.BillingAddressLine2,
+                            City = taxInfo.BillingAddressCity,
+                            State = taxInfo.BillingAddressState,
+                        },
                     });
 
                     subscriber.Gateway = GatewayType.Stripe;
@@ -1363,7 +1360,16 @@ namespace Bit.Core.Services
                         InvoiceSettings = new CustomerInvoiceSettingsOptions
                         {
                             DefaultPaymentMethod = defaultPaymentMethodId
-                        }
+                        },
+                        Address = taxInfo == null ? null : new AddressOptions
+                        {
+                            Country = taxInfo.BillingAddressCountry,
+                            PostalCode = taxInfo.BillingAddressPostalCode,
+                            Line1 = taxInfo.BillingAddressLine1 ?? string.Empty,
+                            Line2 = taxInfo.BillingAddressLine2,
+                            City = taxInfo.BillingAddressCity,
+                            State = taxInfo.BillingAddressState,
+                        },
                     });
                 }
             }

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -345,7 +345,7 @@ namespace Bit.Core.Services
         }
 
         public async Task<string> PurchasePremiumAsync(User user, PaymentMethodType paymentMethodType,
-            string paymentToken, short additionalStorageGb)
+            string paymentToken, short additionalStorageGb, string country, string postalCode)
         {
             if (paymentMethodType != PaymentMethodType.Credit && string.IsNullOrWhiteSpace(paymentToken))
             {
@@ -463,9 +463,27 @@ namespace Bit.Core.Services
                     InvoiceSettings = new CustomerInvoiceSettingsOptions
                     {
                         DefaultPaymentMethod = stipeCustomerPaymentMethodId
-                    }
+                    },
+                    Address = new AddressOptions
+                    {
+                        Line1 = string.Empty,
+                        Country = country,
+                        PostalCode = postalCode,
+                    },
                 });
                 createdStripeCustomer = true;
+            }
+            else if (customer != null)
+            {
+                await customerService.UpdateAsync(customer.Id, new CustomerUpdateOptions
+                {
+                    Address = new AddressOptions
+                    {
+                        Line1 = string.Empty,
+                        Country = country,
+                        PostalCode = postalCode,
+                    }
+                });
             }
 
             if (customer == null)

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -704,7 +704,7 @@ namespace Bit.Core.Services
 
         public async Task<Tuple<bool, string>> SignUpPremiumAsync(User user, string paymentToken,
             PaymentMethodType paymentMethodType, short additionalStorageGb, UserLicense license,
-            string country, string postalCode)
+            TaxInfo taxInfo)
         {
             if (user.Premium)
             {
@@ -743,7 +743,7 @@ namespace Bit.Core.Services
             else
             {
                 paymentIntentClientSecret = await _paymentService.PurchasePremiumAsync(user, paymentMethodType,
-                    paymentToken, additionalStorageGb, country, postalCode);
+                    paymentToken, additionalStorageGb, taxInfo);
             }
 
             user.Premium = true;
@@ -845,14 +845,14 @@ namespace Bit.Core.Services
             return secret;
         }
 
-        public async Task ReplacePaymentMethodAsync(User user, string paymentToken, PaymentMethodType paymentMethodType)
+        public async Task ReplacePaymentMethodAsync(User user, string paymentToken, PaymentMethodType paymentMethodType, TaxInfo taxInfo)
         {
             if (paymentToken.StartsWith("btok_"))
             {
                 throw new BadRequestException("Invalid token.");
             }
 
-            var updated = await _paymentService.UpdatePaymentMethodAsync(user, paymentMethodType, paymentToken);
+            var updated = await _paymentService.UpdatePaymentMethodAsync(user, paymentMethodType, paymentToken, taxInfo: taxInfo);
             if (updated)
             {
                 await SaveUserAsync(user);

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -703,7 +703,8 @@ namespace Bit.Core.Services
         }
 
         public async Task<Tuple<bool, string>> SignUpPremiumAsync(User user, string paymentToken,
-            PaymentMethodType paymentMethodType, short additionalStorageGb, UserLicense license)
+            PaymentMethodType paymentMethodType, short additionalStorageGb, UserLicense license,
+            string country, string postalCode)
         {
             if (user.Premium)
             {
@@ -742,7 +743,7 @@ namespace Bit.Core.Services
             else
             {
                 paymentIntentClientSecret = await _paymentService.PurchasePremiumAsync(user, paymentMethodType,
-                    paymentToken, additionalStorageGb);
+                    paymentToken, additionalStorageGb, country, postalCode);
             }
 
             user.Premium = true;


### PR DESCRIPTION
## Objective

Combine updating users and organization's tax information with existing calls through the API such as when changing a payment method or upgrading to premium.

## Files

* **AccountsController.cs** - Added validation, Ensure country is provided at the least if not self-hosted; pass additional tax info to the premium signup service method, and save tax info when posting a payment
**OrganizationsController.cs** - Pass tax info to the call to replace payment method
**PremiumRequestModel.cs** - Extend the model to include country and zip for tax purposes and added validation for when a user upgrades to premium
**PaymentRequestModel.cs** - Extend the model with the full tax info request model which can handle individual and organization tax info (with proper validation regardless).
**IOrganizationService.cs, OrganizationService.cs** - Added tax info collection and update to the `ReplacePaymentMethodAsync` method
**IPaymentService.cs, StripePaymentService.cs** - Added country and postal code for tax to the `PurchasePremiumAsync` method
**IUserService.cs, UserService.cs** - Added country and postal code for tax to the `SignUpPremiumAsync` method (pass-through to the PaymentService `PurchasePremiumAsync` method)

Based on feedback from PR https://github.com/bitwarden/web/pull/558#discussion_r441563500