### PR TITLE
fixed syntax error in migration

### DIFF
--- a/util/Migrator/DbScripts/2020-06-23_01_SsoConfig.sql
+++ b/util/Migrator/DbScripts/2020-06-23_01_SsoConfig.sql
@@ -26,6 +26,7 @@ SELECT
     *
 FROM
     [dbo].[SsoConfig]
+GO
 
 IF OBJECT_ID('[dbo].[SsoConfig_ReadByIdentifier]') IS NOT NULL
 BEGIN

--- a/util/Migrator/DbScripts/2020-06-23_01_SsoConfig.sql
+++ b/util/Migrator/DbScripts/2020-06-23_01_SsoConfig.sql
@@ -14,7 +14,7 @@ BEGIN
 END
 GO
 
-IF EXISTS(SELECT * FROM sys.views WHERE [Name] = 'SsoConfig')
+IF EXISTS(SELECT * FROM sys.views WHERE [Name] = 'SsoConfigView')
 BEGIN
     DROP VIEW [dbo].[SsoConfigView]
 END


### PR DESCRIPTION
- Accidentally removed `GO` in previous adjustment
- View name was wrong when checking for existence, threw an error on subsequent runs