### PR TITLE
Fixed validation error for Free org accounts

### DIFF
--- a/src/Core/Models/Api/Request/Organizations/OrganizationCreateRequestModel.cs
+++ b/src/Core/Models/Api/Request/Organizations/OrganizationCreateRequestModel.cs
@@ -37,7 +37,6 @@ namespace Bit.Core.Models.Api
         public string BillingAddressCity { get; set; }
         public string BillingAddressState { get; set; }
         public string BillingAddressPostalCode { get; set; }
-        [Required]
         [StringLength(2)]
         public string BillingAddressCountry { get; set; }
 


### PR DESCRIPTION
After performing some testing the `[Required]` attribute on the `BillingAddressCountry` property in `OrganizationCreateRequestModel` was causing Free Organization signups to fail due to a false-negative validation error.

![image](https://user-images.githubusercontent.com/3904944/85789726-198eee00-b6fd-11ea-8dbe-8db5509a77b8.png)

The Validation method itself already handles when Country must not be null/missing, therefore the `[Required]` attribute simply needed to be removed.