### PR TITLE
add missing [ViewPassword] true

### DIFF
--- a/src/Sql/dbo/Stored Procedures/CipherDetails_ReadWithoutOrganizationsByUserId.sql
+++ b/src/Sql/dbo/Stored Procedures/CipherDetails_ReadWithoutOrganizationsByUserId.sql
@@ -7,6 +7,7 @@ BEGIN
     SELECT
         *,
         1 [Edit],
+        1 [ViewPassword],
         0 [OrganizationUseTotp]
     FROM
         [dbo].[CipherDetails](@UserId)

--- a/util/Migrator/DbScripts/2020-05-22_00_HiddenPassword.sql
+++ b/util/Migrator/DbScripts/2020-05-22_00_HiddenPassword.sql
@@ -951,3 +951,27 @@ BEGIN
     EXEC @UpdateCollectionsSuccess = [dbo].[Cipher_UpdateCollections] @Id, @UserId, @OrganizationId, @CollectionIds
 END
 GO
+
+IF OBJECT_ID('[dbo].[CipherDetails_ReadWithoutOrganizationsByUserId]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[CipherDetails_ReadWithoutOrganizationsByUserId]
+END
+GO
+
+CREATE PROCEDURE [dbo].[CipherDetails_ReadWithoutOrganizationsByUserId]
+    @UserId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        *,
+        1 [Edit],
+        1 [ViewPassword],
+        0 [OrganizationUseTotp]
+    FROM
+        [dbo].[CipherDetails](@UserId)
+    WHERE
+        [UserId] = @UserId
+END
+GO


### PR DESCRIPTION
When people are not members or an org, an alternate proc is called. This sproc was missing the ViewPassword field in its response, which defaulted it to false in the mapped model.