### PR TITLE
Subscription update to maintain auto charge

### DIFF
--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -381,10 +381,17 @@ namespace Bit.Core.Services
                         // This proration behavior prevents a false "credit" from
                         //  being applied forward to the next month's invoice
                         ProrationBehavior = "none",
+                        CollectionMethod = "charge_automatically",
                     });
                     throw;
                 }
             }
+
+            // Change back the subscription collection method
+            await subscriptionService.UpdateAsync(sub.Id, new SubscriptionUpdateOptions
+            {
+                CollectionMethod = "charge_automatically",
+            });
 
             organization.Seats = (short?)newSeatTotal;
             await ReplaceAndUpdateCache(organization);

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -778,10 +778,17 @@ namespace Bit.Core.Services
                         // This proration behavior prevents a false "credit" from
                         //  being applied forward to the next month's invoice
                         ProrationBehavior = "none",
+                        CollectionMethod = "charge_automatically",
                     });
                     throw;
                 }
             }
+
+            // Change back the subscription collection method
+            await subscriptionService.UpdateAsync(sub.Id, new SubscriptionUpdateOptions
+            {
+                CollectionMethod = "charge_automatically",
+            });
 
             return paymentIntentClientSecret;
         }


### PR DESCRIPTION
## Objective
Resolves https://github.com/bitwarden/server/issues/802 by ensuring that after the 1-off immediate payment invoice for prorated changes (which must be set in the subscription update as send_invoice for BT charges and manual invoice payment), we go back and update the customer's subscription to be "charge_automatically" to ensure continuity and expected behavior of the webhooks.