### PR TITLE
Add default log parameters

### DIFF
--- a/util/Setup/EnvironmentFileBuilder.cs
+++ b/util/Setup/EnvironmentFileBuilder.cs
@@ -96,7 +96,7 @@ namespace Bit.Setup
                 ["globalSettings__dataProtection__directory"] = $"{_context.OutputDir}/core/aspnet-dataprotection",
                 ["globalSettings__logDirectory"] = $"{_context.OutputDir}/logs",
                 ["globalSettings__logRollBySizeLimit"] = string.Empty,
-                ["globalSettings__Syslog__Destination"] = string.Empty,
+                ["globalSettings__syslog__destination"] = string.Empty,
                 ["globalSettings__licenseDirectory"] = $"{_context.OutputDir}/core/licenses",
                 ["globalSettings__internalIdentityKey"] = _context.Stub ? "RANDOM_IDENTITY_KEY" :
                     Helpers.SecureRandomString(64, alpha: true, numeric: true),

--- a/util/Setup/EnvironmentFileBuilder.cs
+++ b/util/Setup/EnvironmentFileBuilder.cs
@@ -95,6 +95,8 @@ namespace Bit.Setup
                 ["globalSettings__attachment__baseUrl"] = $"{_context.Config.Url}/attachments",
                 ["globalSettings__dataProtection__directory"] = $"{_context.OutputDir}/core/aspnet-dataprotection",
                 ["globalSettings__logDirectory"] = $"{_context.OutputDir}/logs",
+                ["globalSettings__logRollBySizeLimit"] = string.Empty,
+                ["globalSettings__Syslog__Destination"] = string.Empty,
                 ["globalSettings__licenseDirectory"] = $"{_context.OutputDir}/core/licenses",
                 ["globalSettings__internalIdentityKey"] = _context.Stub ? "RANDOM_IDENTITY_KEY" :
                     Helpers.SecureRandomString(64, alpha: true, numeric: true),


### PR DESCRIPTION
Hi,

This PR adds some new default log parameters.
This solves #668 for the `logRollBySizeLimit` parameter.
And completes #742 for the `Syslog.Destination` one.

Thank you 👍