### PR TITLE
Reference event service implementation

### DIFF
--- a/src/Core/Enums/ReferenceEventSource.cs
+++ b/src/Core/Enums/ReferenceEventSource.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.Serialization;
+
+namespace Bit.Core.Enums
+{
+    public enum ReferenceEventSource
+    {
+        [EnumMember(Value = "organization")]
+        Organization,
+        [EnumMember(Value = "user")]
+        User,
+    }
+}

--- a/src/Core/Enums/ReferenceEventType.cs
+++ b/src/Core/Enums/ReferenceEventType.cs
@@ -1,0 +1,22 @@
+﻿using System.Runtime.Serialization;
+
+namespace Bit.Core.Enums
+{
+    public enum ReferenceEventType
+    {
+        [EnumMember(Value = "signup")]
+        Signup,
+        [EnumMember(Value = "upgrade-plan")]
+        UpgradePlan,
+        [EnumMember(Value = "adjust-storage")]
+        AdjustStorage,
+        [EnumMember(Value = "adjust-seats")]
+        AdjustSeats,
+        [EnumMember(Value = "cancel-subscription")]
+        CancelSubscription,
+        [EnumMember(Value = "reinstate-subscription")]
+        ReinstateSubscription,
+        [EnumMember(Value = "delete-account")]
+        DeleteAccount,
+    }
+}

--- a/src/Core/Models/Business/ReferenceEvent.cs
+++ b/src/Core/Models/Business/ReferenceEvent.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Bit.Core.Enums;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+
+namespace Bit.Core.Models.Business
+{
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+    public class ReferenceEvent
+    {
+        public ReferenceEvent() { }
+
+        public ReferenceEvent(ReferenceEventType type, IReferenceable source)
+        {
+            Type = type;
+            if (source != null)
+            {
+                Source = source.IsUser() ? ReferenceEventSource.User : ReferenceEventSource.Organization;
+                Id = source.Id;
+                ReferenceId = source.ReferenceId;
+            }
+        }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ReferenceEventType Type { get; set; }
+        
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ReferenceEventSource Source { get; set; }
+
+        public Guid Id { get; set; }
+
+        public string ReferenceId { get; set; }
+
+        public DateTime EventDate { get; set; } = DateTime.UtcNow;
+
+        public bool? EndOfPeriod { get; set; }
+
+        public string PlanName { get; set; }
+
+        public PlanType? PlanType { get; set; }
+
+        public short? Seats { get; set; }
+
+        public short? Storage { get; set; }
+    }
+}

--- a/src/Core/Models/Table/IReferenceable.cs
+++ b/src/Core/Models/Table/IReferenceable.cs
@@ -1,0 +1,9 @@
+﻿namespace Bit.Core.Models
+{
+    public interface IReferenceable
+    {
+        string Id { get; set; }
+        string ReferenceId { get; set; }
+        bool IsUser();
+    }
+}

--- a/src/Core/Models/Table/IReferenceable.cs
+++ b/src/Core/Models/Table/IReferenceable.cs
@@ -1,8 +1,10 @@
-﻿namespace Bit.Core.Models
+﻿using System;
+
+namespace Bit.Core.Models
 {
     public interface IReferenceable
     {
-        string Id { get; set; }
+        Guid Id { get; set; }
         string ReferenceId { get; set; }
         bool IsUser();
     }

--- a/src/Core/Models/Table/Organization.cs
+++ b/src/Core/Models/Table/Organization.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Bit.Core.Models.Table
 {
-    public class Organization : ITableObject<Guid>, ISubscriber, IStorable, IStorableSubscriber, IRevisable
+    public class Organization : ITableObject<Guid>, ISubscriber, IStorable, IStorableSubscriber, IRevisable, IReferenceable
     {
         private Dictionary<TwoFactorProviderType, TwoFactorProvider> _twoFactorProviders;
 

--- a/src/Core/Models/Table/User.cs
+++ b/src/Core/Models/Table/User.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Identity;
 
 namespace Bit.Core.Models.Table
 {
-    public class User : ITableObject<Guid>, ISubscriber, IStorable, IStorableSubscriber, IRevisable, ITwoFactorProvidersUser
+    public class User : ITableObject<Guid>, ISubscriber, IStorable, IStorableSubscriber, IRevisable, ITwoFactorProvidersUser, IReferenceable
     {
         private Dictionary<TwoFactorProviderType, TwoFactorProvider> _twoFactorProviders;
 

--- a/src/Core/Services/IReferenceEventService.cs
+++ b/src/Core/Services/IReferenceEventService.cs
@@ -1,11 +1,10 @@
 ﻿using System.Threading.Tasks;
-using Bit.Core.Models;
+using Bit.Core.Models.Business;
 
 namespace Bit.Core.Services
 {
     public interface IReferenceEventService
     {
-        Task RaiseEventAsync(IReferenceable reference, string eventType,
-            object additionalInfo = null);
+        Task RaiseEventAsync(ReferenceEvent referenceEvent);
     }
 }

--- a/src/Core/Services/IReferenceEventService.cs
+++ b/src/Core/Services/IReferenceEventService.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+using Bit.Core.Models;
+
+namespace Bit.Core.Services
+{
+    public interface IReferenceEventService
+    {
+        Task RaiseEventAsync(IReferenceable reference, string eventType,
+            object additionalInfo = null);
+    }
+}

--- a/src/Core/Services/Implementations/AzureQueueReferenceEventService.cs
+++ b/src/Core/Services/Implementations/AzureQueueReferenceEventService.cs
@@ -1,0 +1,53 @@
+﻿using System.Threading.Tasks;
+using Azure.Storage.Queues;
+using Bit.Core.Models;
+using Newtonsoft.Json;
+
+namespace Bit.Core.Services
+{
+    public class AzureQueueReferenceEventService : IReferenceEventService
+    {
+        private const string QueueName = "reference-events";
+
+        private readonly QueueClient _queueClient;
+        private readonly GlobalSettings _globalSettings;
+
+        public AzureQueueReferenceEventService (
+            GlobalSettings globalSettings)
+        {
+            _queueClient = new QueueClient(globalSettings.Storage.ConnectionString, QueueName);
+            _globalSettings = globalSettings;
+        }
+
+        public async Task RaiseEventAsync(IReferenceable reference, string eventType,
+            object additionalInfo = null)
+        {
+            await SendMessageAsync(reference, eventType, additionalInfo);
+        }
+
+        private async Task SendMessageAsync(IReferenceable reference, string eventType,
+            object additionalInfo)
+        {
+            if (_globalSettings.SelfHosted)
+            {
+                return;
+            }
+            try
+            {
+                var message = JsonConvert.SerializeObject(new
+                {
+                    id = reference.Id,
+                    type = reference.IsUser() ? "user" : "organization",
+                    eventType,
+                    referenceId = reference?.ReferenceId,
+                    info = additionalInfo,
+                });
+                await _queueClient.SendMessageAsync(message);
+            }
+            catch
+            {
+                // Ignore failure
+            }
+        }
+    }
+}

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -34,6 +34,7 @@ namespace Bit.Core.Services
         private readonly IApplicationCacheService _applicationCacheService;
         private readonly IPaymentService _paymentService;
         private readonly IPolicyRepository _policyRepository;
+        private readonly IReferenceEventService _referenceEventService;
         private readonly GlobalSettings _globalSettings;
 
         public OrganizationService(
@@ -53,6 +54,7 @@ namespace Bit.Core.Services
             IApplicationCacheService applicationCacheService,
             IPaymentService paymentService,
             IPolicyRepository policyRepository,
+            IReferenceEventService referenceEventService,
             GlobalSettings globalSettings)
         {
             _organizationRepository = organizationRepository;
@@ -71,6 +73,7 @@ namespace Bit.Core.Services
             _applicationCacheService = applicationCacheService;
             _paymentService = paymentService;
             _policyRepository = policyRepository;
+            _referenceEventService = referenceEventService;
             _globalSettings = globalSettings;
         }
 
@@ -108,6 +111,10 @@ namespace Bit.Core.Services
             }
 
             await _paymentService.CancelSubscriptionAsync(organization, eop);
+            await _referenceEventService.RaiseEventAsync(organization, "cancel", new
+            {
+                endOfPeriod,
+            });
         }
 
         public async Task ReinstateSubscriptionAsync(Guid organizationId)
@@ -119,6 +126,7 @@ namespace Bit.Core.Services
             }
 
             await _paymentService.ReinstateSubscriptionAsync(organization);
+            await _referenceEventService.RaiseEventAsync(organization, "resintate");
         }
 
         public async Task<Tuple<bool, string>> UpgradePlanAsync(Guid organizationId, OrganizationUpgrade upgrade)
@@ -240,6 +248,16 @@ namespace Bit.Core.Services
             organization.Plan = newPlan.Name;
             organization.Enabled = success;
             await ReplaceAndUpdateCache(organization);
+            if (success)
+            {
+                await _referenceEventService.RaiseEventAsync(organization, "upgrade-plan", new
+                {
+                    plan = newPlan.Name,
+                    planType = newPlan.Type,
+                    seats = organization.Seats,
+                    storage = organization.MaxStorageGb,
+                });
+            }
 
             return new Tuple<bool, string>(success, paymentIntentClientSecret);
         }
@@ -265,6 +283,12 @@ namespace Bit.Core.Services
 
             var secret = await BillingHelpers.AdjustStorageAsync(_paymentService, organization, storageAdjustmentGb,
                 plan.StripeStoragePlanId);
+            await _referenceEventService.RaiseEventAsync(organization, "adjust-storage", new
+            {
+                plan = plan.Name,
+                planType = plan.Type,
+                storage = storageAdjustmentGb,
+            });
             await ReplaceAndUpdateCache(organization);
             return secret;
         }
@@ -399,6 +423,12 @@ namespace Bit.Core.Services
             }
 
             organization.Seats = (short?)newSeatTotal;
+            await _referenceEventService.RaiseEventAsync(organization, "adjust-seats", new
+            {
+                plan = plan.Name,
+                planType = plan.Type,
+                seats = organization.Seats,
+            });
             await ReplaceAndUpdateCache(organization);
             return paymentIntentClientSecret;
         }
@@ -503,7 +533,15 @@ namespace Bit.Core.Services
                     signup.PremiumAccessAddon, signup.TaxInfo);
             }
 
-            return await SignUpAsync(organization, signup.Owner.Id, signup.OwnerKey, signup.CollectionName, true);
+            var returnValue = await SignUpAsync(organization, signup.Owner.Id, signup.OwnerKey, signup.CollectionName, true);
+            await _referenceEventService.RaiseEventAsync(organization, "signup", new
+            {
+                plan = plan.Name,
+                planType = plan.Type,
+                seats = returnValue.Item1.Seats,
+                storage = returnValue.Item1.MaxStorageGb,
+            });
+            return returnValue;
         }
 
         public async Task<Tuple<Organization, OrganizationUser>> SignUpAsync(
@@ -741,6 +779,7 @@ namespace Bit.Core.Services
                     var eop = !organization.ExpirationDate.HasValue ||
                         organization.ExpirationDate.Value >= DateTime.UtcNow;
                     await _paymentService.CancelSubscriptionAsync(organization, eop);
+                    await _referenceEventService.RaiseEventAsync(organization, "delete");
                 }
                 catch (GatewayException) { }
             }

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -222,6 +222,8 @@ namespace Bit.Core.Services
             }
 
             await _userRepository.DeleteAsync(user);
+            await _referenceEventService.RaiseEventAsync(
+                new ReferenceEvent(ReferenceEventType.DeleteAccount, user));
             await _pushService.PushLogOutAsync(user.Id);
             return IdentityResult.Success;
         }
@@ -291,6 +293,8 @@ namespace Bit.Core.Services
             if (result == IdentityResult.Success)
             {
                 await _mailService.SendWelcomeEmailAsync(user);
+                await _referenceEventService.RaiseEventAsync(
+                    new ReferenceEvent(ReferenceEventType.Signup, user));
             }
 
             return result;
@@ -768,6 +772,12 @@ namespace Bit.Core.Services
             {
                 await SaveUserAsync(user);
                 await _pushService.PushSyncVaultAsync(user.Id);
+                await _referenceEventService.RaiseEventAsync(
+                    new ReferenceEvent(ReferenceEventType.UpgradePlan, user)
+                    {
+                        Storage = user.MaxStorageGb,
+                        PlanName = PremiumPlanId,
+                    });
             }
             catch when(!_globalSettings.SelfHosted)
             {
@@ -844,6 +854,12 @@ namespace Bit.Core.Services
 
             var secret = await BillingHelpers.AdjustStorageAsync(_paymentService, user, storageAdjustmentGb,
                 StoragePlanId);
+            await _referenceEventService.RaiseEventAsync(
+                new ReferenceEvent(ReferenceEventType.AdjustStorage, user)
+                {
+                    Storage = storageAdjustmentGb,
+                    PlanName = StoragePlanId,
+                });
             await SaveUserAsync(user);
             return secret;
         }
@@ -871,11 +887,18 @@ namespace Bit.Core.Services
                 eop = false;
             }
             await _paymentService.CancelSubscriptionAsync(user, eop, accountDelete);
+            await _referenceEventService.RaiseEventAsync(
+                new ReferenceEvent(ReferenceEventType.CancelSubscription, user)
+                {
+                    EndOfPeriod = eop,
+                });
         }
 
         public async Task ReinstatePremiumAsync(User user)
         {
             await _paymentService.ReinstateSubscriptionAsync(user);
+            await _referenceEventService.RaiseEventAsync(
+                new ReferenceEvent(ReferenceEventType.ReinstateSubscription, user));
         }
 
         public async Task EnablePremiumAsync(Guid userId, DateTime? expirationDate)

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -45,6 +45,7 @@ namespace Bit.Core.Services
         private readonly IPaymentService _paymentService;
         private readonly IPolicyRepository _policyRepository;
         private readonly IDataProtector _organizationServiceDataProtector;
+        private readonly IReferenceEventService _referenceEventService;
         private readonly CurrentContext _currentContext;
         private readonly GlobalSettings _globalSettings;
 
@@ -71,6 +72,7 @@ namespace Bit.Core.Services
             IDataProtectionProvider dataProtectionProvider,
             IPaymentService paymentService,
             IPolicyRepository policyRepository,
+            IReferenceEventService referenceEventService,
             CurrentContext currentContext,
             GlobalSettings globalSettings)
             : base(
@@ -102,6 +104,7 @@ namespace Bit.Core.Services
             _policyRepository = policyRepository;
             _organizationServiceDataProtector = dataProtectionProvider.CreateProtector(
                 "OrganizationServiceDataProtector");
+            _referenceEventService = referenceEventService;
             _currentContext = currentContext;
             _globalSettings = globalSettings;
         }

--- a/src/Core/Services/NoopImplementations/NoopReferenceEventService.cs
+++ b/src/Core/Services/NoopImplementations/NoopReferenceEventService.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading.Tasks;
+using Bit.Core.Models;
+
+namespace Bit.Core.Services
+{
+    public class NoopReferenceEventService : IReferenceEventService
+    {
+        public Task RaiseEventAsync(IReferenceable reference, string eventType,
+            object additionalInfo = null)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Core/Services/NoopImplementations/NoopReferenceEventService.cs
+++ b/src/Core/Services/NoopImplementations/NoopReferenceEventService.cs
@@ -1,12 +1,11 @@
 ﻿using System.Threading.Tasks;
-using Bit.Core.Models;
+using Bit.Core.Models.Business;
 
 namespace Bit.Core.Services
 {
     public class NoopReferenceEventService : IReferenceEventService
     {
-        public Task RaiseEventAsync(IReferenceable reference, string eventType,
-            object additionalInfo = null)
+        public Task RaiseEventAsync(ReferenceEvent referenceEvent)
         {
             return Task.CompletedTask;
         }

--- a/src/Core/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Core/Utilities/ServiceCollectionExtensions.cs
@@ -196,6 +196,15 @@ namespace Bit.Core.Utilities
             {
                 services.AddSingleton<IAttachmentStorageService, NoopAttachmentStorageService>();
             }
+
+            if (globalSettings.SelfHosted)
+            {
+                services.AddSingleton<IReferenceEventService, NoopReferenceEventService>();
+            }
+            else
+            {
+                services.AddSingleton<IReferenceEventService, AzureQueueReferenceEventService>();
+            }
         }
 
         public static void AddNoopServices(this IServiceCollection services)


### PR DESCRIPTION
## Objective
To extend the server's Organization and User services for publishing subscription events to a queue for cloud customers.

## Files
* **IReferenceable.cs** - Interface that represents a value with a `ReferenceId` and like `ISubscriber` pulls in shared/common properties that are needed such as `Id` and `IsUser()`
* **Organization.cs** and **User.cs** - Table classes to implement the `IReferenceable` interface
* **I/ReferenceEventService.cs** - Interface and service class for publishing events to the new queue, "reference-events"
* **OrganizationService.cs** - Call the new reference event service with events as they occur successfully in the service
* **UserService.cs** - Setup for future user events to also publish to the new service
* **NoopReferenceEventService.cs** - For self-hosted deployments/instances
* **ServiceCollectionExtensions.cs** - Ensure proper singleton service instance for DI is created based on self-hosted or not
