### PR TITLE
Reference event changes and cleanup

### DIFF
--- a/src/Core/Enums/ReferenceEventType.cs
+++ b/src/Core/Enums/ReferenceEventType.cs
@@ -18,5 +18,11 @@ namespace Bit.Core.Enums
         ReinstateSubscription,
         [EnumMember(Value = "delete-account")]
         DeleteAccount,
+        [EnumMember(Value = "confirm-email")]
+        ConfirmEmailAddress,
+        [EnumMember(Value = "invited-users")]
+        InvitedUsers,
+        [EnumMember(Value = "rebilled")]
+        Rebilled,
     }
 }

--- a/src/Core/Models/Business/ReferenceEvent.cs
+++ b/src/Core/Models/Business/ReferenceEvent.cs
@@ -34,6 +34,8 @@ namespace Bit.Core.Models.Business
 
         public DateTime EventDate { get; set; } = DateTime.UtcNow;
 
+        public int? Users { get; set; }
+
         public bool? EndOfPeriod { get; set; }
 
         public string PlanName { get; set; }

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -1135,5 +1135,16 @@ namespace Bit.Core.Services
                 }
             }
         }
+
+        public override async Task<IdentityResult> ConfirmEmailAsync(User user, string token)
+        {
+            var result = await base.ConfirmEmailAsync(user, token);
+            if (result.Succeeded)
+            {
+                await _referenceEventService.RaiseEventAsync(
+                    new ReferenceEvent(ReferenceEventType.ConfirmEmailAddress, user));
+            }
+            return result;
+        }
     }
 }


### PR DESCRIPTION
## Overview
Needed to add the `Users` count parameter to our reference events model, as well as handle some additional event types that required hooks in additional places.

## Changes
**StripeController.cs** - Billing service needs to handle webhook for subscription renewals to reference event
**ReferenceEventType.cs** - New reference event types
**ReferenceEvent.cs** - new Users property
**OrganizationService.cs** - User invitation event with user count, as well as removal of redundant call to get org from DB when we already have it in memory/scope
**UserService.cs** - override confirm email method from the underlying provider and raise reference event accordingly