### PR TITLE
Return continuation token in public events API

### DIFF
--- a/src/Api/Public/Controllers/EventsController.cs
+++ b/src/Api/Public/Controllers/EventsController.cs
@@ -66,7 +66,7 @@ namespace Bit.Api.Public.Controllers
             }
 
             var eventResponses = result.Data.Select(e => new EventResponseModel(e));
-            var response = new ListResponseModel<EventResponseModel>(eventResponses);
+            var response = new ListResponseModel<EventResponseModel>(eventResponses, result.ContinuationToken);
             return new JsonResult(response);
         }
     }


### PR DESCRIPTION
This resolves a bug reported by a customer that is expecting to receive a continuation token to page through events from our public API.