### PR TITLE
[SSO] Added change password API

### DIFF
--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -205,7 +205,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            var result = await _userService.ChangePasswordNoCompareAsync(user, model.NewMasterPasswordHash, model.Key);
+            var result = await _userService.SetPasswordAsync(user, model.NewMasterPasswordHash, model.Key);
             if (result.Succeeded)
             {
                 return;

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -14,6 +14,7 @@ using Bit.Core.Models.Business;
 using Bit.Api.Utilities;
 using Bit.Core.Models.Table;
 using System.Collections.Generic;
+using Bit.Core.Models.Api.Request.Accounts;
 using Bit.Core.Models.Data;
 
 namespace Bit.Api.Controllers
@@ -181,6 +182,30 @@ namespace Bit.Api.Controllers
 
             var result = await _userService.ChangePasswordAsync(user, model.MasterPasswordHash,
                 model.NewMasterPasswordHash, model.Key);
+            if (result.Succeeded)
+            {
+                return;
+            }
+
+            foreach (var error in result.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error.Description);
+            }
+
+            await Task.Delay(2000);
+            throw new BadRequestException(ModelState);
+        }
+        
+        [HttpPost("password-no-compare")]
+        public async Task PostPasswordNoCompare([FromBody]PasswordNoCompareRequestModel model)
+        {
+            var user = await _userService.GetUserByPrincipalAsync(User);
+            if (user == null)
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            var result = await _userService.ChangePasswordNoCompareAsync(user, model.NewMasterPasswordHash, model.Key);
             if (result.Succeeded)
             {
                 return;

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -196,8 +196,8 @@ namespace Bit.Api.Controllers
             throw new BadRequestException(ModelState);
         }
         
-        [HttpPost("password-no-compare")]
-        public async Task PostPasswordNoCompare([FromBody]PasswordNoCompareRequestModel model)
+        [HttpPost("set-password")]
+        public async Task SetPasswordAsync([FromBody]SetPasswordRequestModel model)
         {
             var user = await _userService.GetUserByPrincipalAsync(User);
             if (user == null)

--- a/src/Core/Models/Api/Request/Accounts/PasswordNoCompareRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/PasswordNoCompareRequestModel.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bit.Core.Models.Api.Request.Accounts
+{
+    public class PasswordNoCompareRequestModel
+    {
+        [Required]
+        [StringLength(300)]
+        public string NewMasterPasswordHash { get; set; }
+        [Required]
+        public string Key { get; set; }
+    }
+}

--- a/src/Core/Models/Api/Request/Accounts/SetPasswordRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/SetPasswordRequestModel.cs
@@ -2,7 +2,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Bit.Core.Models.Api.Request.Accounts
 {
-    public class PasswordNoCompareRequestModel
+    public class SetPasswordRequestModel
     {
         [Required]
         [StringLength(300)]

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -31,6 +31,7 @@ namespace Bit.Core.Services
         Task<IdentityResult> ChangeEmailAsync(User user, string masterPassword, string newEmail, string newMasterPassword,
             string token, string key);
         Task<IdentityResult> ChangePasswordAsync(User user, string masterPassword, string newMasterPassword, string key);
+        Task<IdentityResult> ChangePasswordNoCompareAsync(User user, string newMasterPassword, string key);
         Task<IdentityResult> ChangeKdfAsync(User user, string masterPassword, string newMasterPassword, string key,
             KdfType kdf, int kdfIterations);
         Task<IdentityResult> UpdateKeyAsync(User user, string masterPassword, string key, string privateKey,

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -31,7 +31,7 @@ namespace Bit.Core.Services
         Task<IdentityResult> ChangeEmailAsync(User user, string masterPassword, string newEmail, string newMasterPassword,
             string token, string key);
         Task<IdentityResult> ChangePasswordAsync(User user, string masterPassword, string newMasterPassword, string key);
-        Task<IdentityResult> ChangePasswordNoCompareAsync(User user, string newMasterPassword, string key);
+        Task<IdentityResult> SetPasswordAsync(User user, string newMasterPassword, string key);
         Task<IdentityResult> ChangeKdfAsync(User user, string masterPassword, string newMasterPassword, string key,
             KdfType kdf, int kdfIterations);
         Task<IdentityResult> UpdateKeyAsync(User user, string masterPassword, string key, string privateKey,

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -574,6 +574,12 @@ namespace Bit.Core.Services
             {
                 throw new ArgumentNullException(nameof(user));
             }
+
+            if (user.MasterPassword != null)
+            {
+                Logger.LogWarning("Change password failed for user {userId} - already has password.", user.Id);
+                return IdentityResult.Failed(_identityErrorDescriber.UserAlreadyHasPassword());
+            }
             
             var result = await UpdatePasswordHash(user, newMasterPassword);
             if (!result.Succeeded)

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -567,6 +567,28 @@ namespace Bit.Core.Services
             Logger.LogWarning("Change password failed for user {userId}.", user.Id);
             return IdentityResult.Failed(_identityErrorDescriber.PasswordMismatch());
         }
+        
+        public async Task<IdentityResult> ChangePasswordNoCompareAsync(User user, string newMasterPassword, string key)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+            
+            var result = await UpdatePasswordHash(user, newMasterPassword);
+            if (!result.Succeeded)
+            {
+                return result;
+            }
+
+            user.RevisionDate = user.AccountRevisionDate = DateTime.UtcNow;
+            user.Key = key;
+
+            await _userRepository.ReplaceAsync(user);
+            await _eventService.LogUserEventAsync(user.Id, EventType.User_ChangedPassword);
+
+            return IdentityResult.Success;
+        }
 
         public async Task<IdentityResult> ChangeKdfAsync(User user, string masterPassword, string newMasterPassword,
             string key, KdfType kdf, int kdfIterations)

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -568,14 +568,14 @@ namespace Bit.Core.Services
             return IdentityResult.Failed(_identityErrorDescriber.PasswordMismatch());
         }
         
-        public async Task<IdentityResult> ChangePasswordNoCompareAsync(User user, string newMasterPassword, string key)
+        public async Task<IdentityResult> SetPasswordAsync(User user, string newMasterPassword, string key)
         {
             if (user == null)
             {
                 throw new ArgumentNullException(nameof(user));
             }
 
-            if (user.MasterPassword != null)
+            if (!string.IsNullOrWhiteSpace(user.MasterPassword))
             {
                 Logger.LogWarning("Change password failed for user {userId} - already has password.", user.Id);
                 return IdentityResult.Failed(_identityErrorDescriber.UserAlreadyHasPassword());


### PR DESCRIPTION
## Objective
> Extend APIs to change password without current password comparison

## Code Changes
- **Api/AccountsController.cs**: Created method to call into the `user service` and update a user's password without current password comparison.
- **Core/SetPasswordRequestModel.cs**: Created request model to handle necessary params 
- **Core/IUserService.cs**: Created interface'd `ChangePasswordNoCompareAsync` method
- **Core/UserService.cs**: Created method that closely mimics the existing `ChangePasswordAsync` and will update a user's password - includes error flow for the user already having a password.

## Questions
- Is the `NoCompare` suffix an appropriate name? Honestly, just picked something and used it - wide open for suggestions
- This solution is very explicit - new api, new service method, new request model: these things *can* be reused/implicit.  What's the best approach here? 
    - **UserService**: Could create new overloaded method with a boolean that tracks whether or not the current password should be compared and **user is logged out.** NOTE: Logging out is the main difference between the methods. Sanity check: that should be removed for this implementation, correct?
        - Pros: Backwards compat for existing methods, keeps all logic in one method (less copied code)
        - Cons: Could get clunky fast with several spots of added conditionals
    - **PasswordNoCompareRequestModel**: This could easily use the existing `PasswordRequestModel` by making the `MasterPasswordHash` *optional*. However, this model is used in a couple places so making that changes could make unwanted implications (moreso on the `jslib` side).
    - **AccountsController**: Could reuse existing api method/request model (see above) and add conditional for based on the presence of the `MasterPasswordHash`.