### PR TITLE
catch errors when trying to resolve DNS

### DIFF
--- a/src/Icons/Services/IconFetchingService.cs
+++ b/src/Icons/Services/IconFetchingService.cs
@@ -292,8 +292,15 @@ namespace Bit.Icons.Services
             }
 
             // Resolve host to make sure it is not an internal/private IP address
-            var hostEntry = Dns.GetHostEntry(uri.Host);
-            if (hostEntry?.AddressList.Any(ip => IsInternal(ip)) ?? true)
+            try
+            {
+                var hostEntry = Dns.GetHostEntry(uri.Host);
+                if (hostEntry?.AddressList.Any(ip => IsInternal(ip)) ?? true)
+                {
+                    return null;
+                }
+            }
+            catch
             {
                 return null;
             }


### PR DESCRIPTION
When the endpoint isn't reacahable, for example, this throws an exception. 