### PR TITLE
Correct connection string for res queue

### DIFF
--- a/src/Core/Services/Implementations/AzureQueueReferenceEventService.cs
+++ b/src/Core/Services/Implementations/AzureQueueReferenceEventService.cs
@@ -19,7 +19,7 @@ namespace Bit.Core.Services
         public AzureQueueReferenceEventService (
             GlobalSettings globalSettings)
         {
-            _queueClient = new QueueClient(globalSettings.Storage.ConnectionString, _queueName);
+            _queueClient = new QueueClient(globalSettings.Events.ConnectionString, _queueName);
             _globalSettings = globalSettings;
         }
 


### PR DESCRIPTION
## Overview
Fixed the connection string used for events from `Storage` to `Events`