### PR TITLE
Replaced hardcoded sso domain hints with config loader

### DIFF
--- a/src/Core/Enums/Saml2NameIdFormat.cs
+++ b/src/Core/Enums/Saml2NameIdFormat.cs
@@ -1,0 +1,15 @@
+﻿namespace Bit.Core.Enums
+{
+    public enum Saml2NameIdFormat : byte
+    {
+        NotConfigured = 0,
+        Unspecified = 1,
+        EmailAddress = 2,
+        X509SubjectName = 3,
+        WindowsDomainQualifiedName = 4,
+        KerberosPrincipalName = 5,
+        EntityIdentifier = 6,
+        Persistent = 7,
+        Transient = 8,
+    }
+}

--- a/src/Identity/Controllers/AccountController.cs
+++ b/src/Identity/Controllers/AccountController.cs
@@ -56,19 +56,19 @@ namespace Bit.Identity.Controllers
         }
 
         [HttpGet]
-        public IActionResult ExternalChallenge(string organizationIdentifier, string returnUrl)
+        public async Task<IActionResult> ExternalChallenge(string organizationIdentifier, string returnUrl)
         {
             if (string.IsNullOrWhiteSpace(organizationIdentifier))
             {
                 throw new Exception("Invalid organization reference id.");
             }
 
-            var ssoConfig = _ssoConfigRepository.GetByIdentifierAsync(organizationIdentifier);
-            if (ssoConfig.Result == null || !ssoConfig.Result.Enabled)
+            var ssoConfig = await _ssoConfigRepository.GetByIdentifierAsync(organizationIdentifier);
+            if (ssoConfig == null || !ssoConfig.Enabled)
             {
                 throw new Exception("Organization not found or SSO configuration not enabled");
             }
-            var domainHint = ssoConfig.Result.OrganizationId.ToString();
+            var domainHint = ssoConfig.OrganizationId.ToString();
 
             var scheme = "sso";
             var props = new AuthenticationProperties


### PR DESCRIPTION
Changes required to make use of SSO configs in the enterprise portal

- `Saml2NameIdFormat`: enum used for SAML2 based dynamic auth scheme
- `AccountController`: replaced hardcoded sso domain hints with sso config loader.  The resulting `domain_hint` is the organization ID.