### PR TITLE
Ref event should be base64 encoded

### DIFF
--- a/src/Core/Services/Implementations/AzureQueueReferenceEventService.cs
+++ b/src/Core/Services/Implementations/AzureQueueReferenceEventService.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
 using Azure.Storage.Queues;
 using Bit.Core.Models.Business;
 using Newtonsoft.Json;
@@ -38,7 +40,9 @@ namespace Bit.Core.Services
             try
             {
                 var message = JsonConvert.SerializeObject(referenceEvent, _jsonSerializerSettings);
-                await _queueClient.SendMessageAsync(message);
+                // Messages need to be base64 encoded
+                var encodedMessage = Convert.ToBase64String(Encoding.UTF8.GetBytes(message));
+                await _queueClient.SendMessageAsync(encodedMessage);
             }
             catch
             {


### PR DESCRIPTION
## Overview

Downstream dependencies on this queue apparently need messages to be base64 encoded vs. plain-text JSON. Azure's SDK does not offer this type of message encoder out of the box for dotnet core.