### PR TITLE
Added new SAML2 enums for configuration

### DIFF
--- a/src/Core/Enums/Saml2BindingType.cs
+++ b/src/Core/Enums/Saml2BindingType.cs
@@ -1,0 +1,9 @@
+﻿namespace Bit.Core.Enums
+{
+    public enum Saml2BindingType : byte
+	{
+		HttpRedirect = 1,
+		HttpPost = 2,
+		Artifact = 4
+	}
+}

--- a/src/Core/Enums/Saml2SigningBehavior.cs
+++ b/src/Core/Enums/Saml2SigningBehavior.cs
@@ -1,0 +1,9 @@
+﻿namespace Bit.Core.Enums
+{
+    public enum Saml2SigningBehavior : byte
+    {
+		IfIdpWantAuthnRequestsSigned = 0,
+		Always = 1,
+		Never = 3
+    }
+}


### PR DESCRIPTION
## Overview
Rounding out the full SAML2 configuration needs, added 2 "mirror" enums for the Systainsys configuration needs so we can configure natively in Bitwarden.

### Saml2BindingType
Ensures we're not hard-coding to `POST` as our only supporting SAML2 binding.

### Saml2SigningBehavior
Signifies both the SP and IDP's desire for how to handle signing (outbound from the SP).