### PR TITLE
Add all missing entries to Ebay equivalent domains

### DIFF
--- a/src/Core/Utilities/StaticStore.cs
+++ b/src/Core/Utilities/StaticStore.cs
@@ -76,7 +76,7 @@ namespace Bit.Core.Utilities
             GlobalDomains.Add(GlobalEquivalentDomainsType.Belkin, new List<string> { "belkin.com", "seedonk.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Turbotax, new List<string> { "turbotax.com", "intuit.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Shopify, new List<string> { "shopify.com", "myshopify.com" });
-            GlobalDomains.Add(GlobalEquivalentDomainsType.Ebay, new List<string> { "ebay.com", "ebay.de", "ebay.ca", "ebay.in", "ebay.co.uk", "ebay.com.au" });
+            GlobalDomains.Add(GlobalEquivalentDomainsType.Ebay, new List<string> { "ebay.com", "ebay.at", "ebay.be", "ebay.ca", "ebay.ch", "ebay.cn", "ebay.co.jp", "ebay.co.th", "ebay.co.uk", "ebay.com.au", "ebay.com.hk", "ebay.com.my", "ebay.com.sg", "ebay.com.tw", "ebay.de", "ebay.es", "ebay.fr", "ebay.ie", "ebay.it", "ebay.nl", "ebay.ph", "ebay.pl" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Techdata, new List<string> { "techdata.com", "techdata.ch" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Schwab, new List<string> { "schwab.com", "schwabplan.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Tesla, new List<string> { "tesla.com", "teslamotors.com" });


### PR DESCRIPTION
_Based on my research for a recent PR for **mobile** — see https://github.com/bitwarden/mobile/pull/1034#issuecomment-670058387._
&nbsp;
&nbsp;
:bulb: We should now normally have an up-to-date `Ebay` list. :thumbsup:
___
&nbsp;

# This PR:
&nbsp;
- adds all missing entries to the `Ebay` list:
&nbsp;

<details>
<summary>View me ...</summary>
&nbsp;

:arrow_right: _As you can see, I can log into all these websites with an eBay login created on `ebay.be`:_

![www.ebay.com](https://user-images.githubusercontent.com/4764956/90192387-278af200-ddc3-11ea-953d-03ffd93c0347.png)

![www.ebay.at](https://user-images.githubusercontent.com/4764956/90192164-ae8b9a80-ddc2-11ea-8e3b-c9a6a81d7c17.png)

:diamonds: About eBay Belgium, see these screenshots:
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[www.ebay.be](https://user-images.githubusercontent.com/4764956/90192192-bea37a00-ddc2-11ea-914b-d90f895f1e47.png) which leads you to [www.befr.ebay.be](https://user-images.githubusercontent.com/4764956/90192212-c8c57880-ddc2-11ea-80dd-ad2cf8ff72e5.png) or [www.benl.ebay.be](https://user-images.githubusercontent.com/4764956/90192238-d7139480-ddc2-11ea-8cbf-e8989bd9c91f.png).

![www.ebay.ca](https://user-images.githubusercontent.com/4764956/90192296-fc080780-ddc2-11ea-8548-aedaf8884b11.png)
:arrow_right_hook: _About eBay Canada, the default access (`www.ebay.ca`) is in English.
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Access in French is via another subdomain: [www.cafr.ebay.ca](https://user-images.githubusercontent.com/4764956/90192311-03c7ac00-ddc3-11ea-8256-6db1629f3798.png)_.

![www.ebay.ch](https://user-images.githubusercontent.com/4764956/90192345-10e49b00-ddc3-11ea-814a-9528d4011461.png)

![www.ebay.co.uk](https://user-images.githubusercontent.com/4764956/90192360-17731280-ddc3-11ea-8e1d-4b44f6cec326.png)

![www.ebay.com.au](https://user-images.githubusercontent.com/4764956/90192413-3671a480-ddc3-11ea-9a0a-6e442fd41f86.png)

![www.ebay.com.hk](https://user-images.githubusercontent.com/4764956/90192422-3bceef00-ddc3-11ea-967a-bb2e798078f2.png)

![www.ebay.com.my](https://user-images.githubusercontent.com/4764956/90192428-412c3980-ddc3-11ea-8f23-07c67e6c6f81.png)

![www.ebay.com.sg](https://user-images.githubusercontent.com/4764956/90192444-47bab100-ddc3-11ea-97e9-ab2544d91dfa.png)

![www.ebay.de](https://user-images.githubusercontent.com/4764956/90194673-0ed10b00-ddc8-11ea-9d8e-262e765640e5.png)
:arrow_right_hook: _The black sheep … the only one that displays the nickname instead of the first name … :smile:_

![www.ebay.es](https://user-images.githubusercontent.com/4764956/90192480-55703680-ddc3-11ea-9c7a-e127026fa43b.png)

![www.ebay.fr](https://user-images.githubusercontent.com/4764956/90192495-5a34ea80-ddc3-11ea-923e-d95da2ec808f.png)

![www.ebay.ie](https://user-images.githubusercontent.com/4764956/90192511-602acb80-ddc3-11ea-895b-ab26a0c0c438.png)

![www.ebay.it](https://user-images.githubusercontent.com/4764956/90192525-6620ac80-ddc3-11ea-936f-c1046b507112.png)

![www.ebay.nl](https://user-images.githubusercontent.com/4764956/90192537-6ae56080-ddc3-11ea-96c7-03dd11625cab.png)

![www.ebay.ph](https://user-images.githubusercontent.com/4764956/90192554-733d9b80-ddc3-11ea-88c2-96631891281f.png)

![www.ebay.pl](https://user-images.githubusercontent.com/4764956/90192562-7769b900-ddc3-11ea-87fc-17e1cbcb7586.png)
&nbsp;

:bulb: **+** special cases which use a generic `signin.` or similar (`signin.ebay.com`, `signin.ebay.com.hk` — or a variant from `ebay.com.hk` —, etc.), all also tested (note that these 4 below are **intended for sellers** as [described here](https://github.com/bitwarden/mobile/pull/1034#issuecomment-670058387) in the last section):
- [www.ebay.cn](https://www.ebay.cn/)
- [www.ebay.co.jp](https://www.ebay.co.jp/)
- [www.ebay.co.th](https://www.ebay.co.th/)
- [www.ebay.com.tw](https://www.ebay.com.tw/)
&nbsp;

:information_source: Entries for **Turkey** ([www.gittigidiyor.com](https://www.gittigidiyor.com/)) and **Korea** ([global.gmarket.co.kr/Home/Main](https://global.gmarket.co.kr/Home/Main)) _— from the list available in the footer of `www.ebay.com` —_ have not been added as they are incompatible with a classic eBay login.
&nbsp;

:information_source: All other eBay _— from the list available in the footer of `www.ebay.com` —_ have not been added because either redirect to `ebay.com`:
<details>
<summary>View the list ...</summary>
&nbsp;

- [www.ebay.in](https://www.ebay.in/) **redirects to** [in.ebay.com](https://in.ebay.com/)
- [www.ebay.se](https://www.ebay.se/) **redirects to** [www.ebay.com](https://www.ebay.com/)
</details>

... or are subdomains of `ebay.com`:
<details>
<summary>View the list ...</summary>
&nbsp;

- [ar.ebay.com](https://ar.ebay.com/)
- [bo.ebay.com](https://bo.ebay.com/)
- [br.ebay.com](https://br.ebay.com/)
- [by.ebay.com](https://by.ebay.com/)
- [cl.ebay.com](https://cl.ebay.com/)
- [co.ebay.com](https://co.ebay.com/)
- [cr.ebay.com](https://cr.ebay.com/)
- [do.ebay.com](https://do.ebay.com/)
- [ec.ebay.com](https://ec.ebay.com/)
- [gt.ebay.com](https://gt.ebay.com/)
- [hn.ebay.com](https://hn.ebay.com/)
- [il.ebay.com](https://il.ebay.com/)
- [kz.ebay.com](https://kz.ebay.com/)
- [mx.ebay.com](https://mx.ebay.com/)
- [ni.ebay.com](https://ni.ebay.com/)
- [pa.ebay.com](https://pa.ebay.com/)
- [pe.ebay.com](https://pe.ebay.com/)
- [pr.ebay.com](https://pr.ebay.com/)
- [pt.ebay.com](https://pt.ebay.com/)
- [py.ebay.com](https://py.ebay.com/)
- [ru.ebay.com](https://ru.ebay.com/)
- [sv.ebay.com](https://sv.ebay.com/)
- [uy.ebay.com](https://uy.ebay.com/)
</details>
</details>
&nbsp;
&nbsp;

- sorts the `Ebay` list alphabetically, keeping `ebay.com` in first position.
&nbsp;
&nbsp;