### PR TITLE
[Equivalent domains] Fix for the special case "eBay India"

### DIFF
--- a/src/Core/Utilities/StaticStore.cs
+++ b/src/Core/Utilities/StaticStore.cs
@@ -76,7 +76,7 @@ namespace Bit.Core.Utilities
             GlobalDomains.Add(GlobalEquivalentDomainsType.Belkin, new List<string> { "belkin.com", "seedonk.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Turbotax, new List<string> { "turbotax.com", "intuit.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Shopify, new List<string> { "shopify.com", "myshopify.com" });
-            GlobalDomains.Add(GlobalEquivalentDomainsType.Ebay, new List<string> { "ebay.com", "ebay.at", "ebay.be", "ebay.ca", "ebay.ch", "ebay.cn", "ebay.co.jp", "ebay.co.th", "ebay.co.uk", "ebay.com.au", "ebay.com.hk", "ebay.com.my", "ebay.com.sg", "ebay.com.tw", "ebay.de", "ebay.es", "ebay.fr", "ebay.ie", "ebay.it", "ebay.nl", "ebay.ph", "ebay.pl" });
+            GlobalDomains.Add(GlobalEquivalentDomainsType.Ebay, new List<string> { "ebay.com", "ebay.at", "ebay.be", "ebay.ca", "ebay.ch", "ebay.cn", "ebay.co.jp", "ebay.co.th", "ebay.co.uk", "ebay.com.au", "ebay.com.hk", "ebay.com.my", "ebay.com.sg", "ebay.com.tw", "ebay.de", "ebay.es", "ebay.fr", "ebay.ie", "ebay.in", "ebay.it", "ebay.nl", "ebay.ph", "ebay.pl" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Techdata, new List<string> { "techdata.com", "techdata.ch" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Schwab, new List<string> { "schwab.com", "schwabplan.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Tesla, new List<string> { "tesla.com", "teslamotors.com" });


### PR DESCRIPTION
# Spotted a special case, that of **eBay India**.
&nbsp;

As a reminder, `www.ebay.in` is the only one in the list — available in the footer of `www.ebay.com` — with `www.ebay.se` to have their domain name redirecting to `ebay.com`.

**But** unlike the `.se` where the `signin.ebay.se` does not exist or no longer exists, the `.in` still has it: `signin.ebay.in`. With a message indicating this **transition period**, though.

:arrow_right_hook: _Although inaccessible from the home page because now redirected to `in.ebay.com` (which uses `signin.ebay.com`)._
&nbsp;
&nbsp;

## Screenshots

**Main URL:**

![signin.ebay.in_main](https://user-images.githubusercontent.com/4764956/90286997-3c28c200-de77-11ea-80ce-638ec2166a2c.png)

**Alternative URL:**

![signin.ebay.in_alt](https://user-images.githubusercontent.com/4764956/90287001-3e8b1c00-de77-11ea-8612-a1157bad14c3.png)

> To buy and sell on www.ebay.com or other eBay sites internationally, existing users can login using their credentials or new users can register an eBay account on ebay.in. **Kindly note you can no longer buy or sell on eBay.in.**

&nbsp;

## Action taken

:arrow_right: Added `ebay.in`.

:bulb: An account created for example on `ebay.be` is compatible on `signin.ebay.in` (tested). :heavy_check_mark:

## Information

Note that, due to this **transition period**, although an account created for example on `ebay.be` is compatible on `signin.ebay.in` and therefore allows you to log in, once logged in you are immediately redirected to `in.ebay.com` anyway where ... you need to authenticate again (unless you were already logged on the `ebay.com` domain) ...
<details>
<summary>See screenshot taken just after logging in to `signin.ebay.in` ...</summary>
&nbsp;

![ebay_india_special_case](https://user-images.githubusercontent.com/4764956/90315855-f6273900-df1e-11ea-8514-2ea007c29e5d.png)
:information_source: _The "Sign in" link leads to `signin.ebay.com` there._
</details>