### PR TITLE
Remove amazon.co.nz from Amazon equivalent domains (redirect)

### DIFF
--- a/src/Core/Utilities/StaticStore.cs
+++ b/src/Core/Utilities/StaticStore.cs
@@ -30,7 +30,7 @@ namespace Bit.Core.Utilities
             GlobalDomains.Add(GlobalEquivalentDomainsType.Avon, new List<string> { "avon.com", "youravon.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Diapers, new List<string> { "diapers.com", "soap.com", "wag.com", "yoyo.com", "beautybar.com", "casa.com", "afterschool.com", "vine.com", "bookworm.com", "look.com", "vinemarket.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Contacts, new List<string> { "1800contacts.com", "800contacts.com" });
-            GlobalDomains.Add(GlobalEquivalentDomainsType.Amazon, new List<string> { "amazon.com", "amazon.ae", "amazon.ca", "amazon.co.uk", "amazon.com.au", "amazon.com.br", "amazon.com.mx", "amazon.com.tr", "amazon.de", "amazon.es", "amazon.fr", "amazon.in", "amazon.it", "amazon.nl", "amazon.sa", "amazon.sg", "amazon.co.nz" });
+            GlobalDomains.Add(GlobalEquivalentDomainsType.Amazon, new List<string> { "amazon.com", "amazon.ae", "amazon.ca", "amazon.co.uk", "amazon.com.au", "amazon.com.br", "amazon.com.mx", "amazon.com.tr", "amazon.de", "amazon.es", "amazon.fr", "amazon.in", "amazon.it", "amazon.nl", "amazon.sa", "amazon.sg" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Cox, new List<string> { "cox.com", "cox.net", "coxbusiness.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Norton, new List<string> { "mynortonaccount.com", "norton.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Verizon, new List<string> { "verizon.com", "verizon.net" });


### PR DESCRIPTION
### This:
- removes `amazon.co.nz` from `Amazon` equivalent domains.
&nbsp;

:arrow_right_hook: After further research, according to `archive.org`, `amazon.co.nz` has never been more than **a redirect** ([to amazon.co.uk](https://web.archive.org/web/20120215000000*/www.amazon.co.nz) from 2012 to two-thirds of the year 2018, then [to amazon.com](https://web.archive.org/web/20180601000000*/www.amazon.co.nz)).
&nbsp;

## Support confirmation
A person from `Amazon.com` chat support also confirmed it to me (state before 2012 included):

> Jayshankar: Thank you for waiting,I really appreciate your patience. ​​
Upon checking the details,I see that they were always directed to amazon.com earlier too but the shipping fees was high so amazon.co.uk was introduced. After the international shipping became more cheap, it was brought back to amazon.com

and:

> Jayshankar: It was always on amazon.com earlier.

&nbsp;

## So ...
Apart from a few people who may have added it manually in their vault, it is therefore `amazon.co.uk` or `amazon.com` which has always been in the vault of people using this website anyway.
&nbsp;

## More generally ...
And if, more generally, in addition to Amazon's 18 main domain names _(currently, minus the `.cn` and the `.co.jp` where the classic Amazon login is incompatible)_, we start to manage domain names that are only redirects, the list may be very long (Amazon logically reserving almost all possible TLDs):
- amazon.ch **redirects to** amazon.de;
- amazon.lu **redirects to** amazon.de;
- amazon.no **redirects to** amazon.de;
- amazon.pl **redirects to** amazon.de;
- amazon.pt **redirects to** amazon.es;
- you can try so many TLDs from [this list](https://www.worldstandards.eu/other/tlds/) (for example) actually ...
&nbsp;

## Proposed action (via this PR)
Removing `amazon.co.nz` redirect from the list of `Amazon` equivalent domains.