### PR TITLE
Add Yandex to global equivalent domains list

### DIFF
--- a/src/Core/Enums/GlobalEquivalentDomainsType.cs
+++ b/src/Core/Enums/GlobalEquivalentDomainsType.cs
@@ -85,5 +85,6 @@
         Ubiquiti = 80,
         Discord = 81,
         Netcup = 82,
+        Yandex = 83,
     }
 }

--- a/src/Core/Utilities/StaticStore.cs
+++ b/src/Core/Utilities/StaticStore.cs
@@ -94,6 +94,7 @@ namespace Bit.Core.Utilities
             GlobalDomains.Add(GlobalEquivalentDomainsType.Ubiquiti, new List<string> { "ubnt.com", "ui.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Discord, new List<string> { "discordapp.com", "discord.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Netcup, new List<string> { "netcup.de", "netcup.eu", "customercontrolpanel.de" });
+            GlobalDomains.Add(GlobalEquivalentDomainsType.Yandex, new List<string> { "yandex.com", "ya.ru", "yandex.az", "yandex.by", "yandex.co.il", "yandex.com.am", "yandex.com.ge", "yandex.com.tr", "yandex.ee", "yandex.fi", "yandex.fr", "yandex.kg", "yandex.kz", "yandex.lt", "yandex.lv", "yandex.md", "yandex.pl", "yandex.ru", "yandex.tj", "yandex.tm", "yandex.ua", "yandex.uz" });
             #endregion
 
             #region Plans


### PR DESCRIPTION
### This:
- adds `Yandex` to global equivalent domains list.
:arrow_right_hook: _(Exhaustive list of Yandex domain names obtained by contacting their support.)_
&nbsp;
&nbsp;

# Yandex support response

<details>
<summary>Part of mail 1 (list of Yandex TLDs) ...</summary>
&nbsp;

> Here is a list of all domain zones used by Yandex:
> az, co.il, com, com.am, com.ge, com.tr, ee, fi, fr, pl, ru, ua, by, kg, kz, lt, lv, md, tj, tm, uz
>
> If you have any questions, please contact us and we will try to help!
</details>
&nbsp;

<details>
<summary>Part of mail 2 (intercompatibility) ...</summary>
&nbsp;

> The user can log in to an account in any domain zone. In fact, the authorization requires only username, so you can enter with any email alias.
</details>
&nbsp;

<details>
<summary>Part of mail 3 (various) ...</summary>
&nbsp;

> **1) Just for information: for each TLD you listed, is an email address from the SAME TLD creatable? e.g. https://passport.yandex.md -> user_nickname@yandex.md**
>
> Actually yes, but in some regions, such as Russia, we offer users several additional aliases, that the user can use after registration at their own discretion.
> In other words, the user can use the following email addresses login@yandex.ua, but using yandex.ru and living in Russia.

> **2) Are there other domain names "of the Yandex universe" that can be associated to all these numerous "yandex.tld" domains to signal to Bitwarden users that a login is "compatible with this universe"? I already see at least one: https://ya.ru. Others, according to you? Note: I am talking about domains here, not subdomains.**
>
> Apparently, only the TLDs that I specified earlier are used for logging in, as well as a shorter domain "ya.ru".


> **3) Finally, may I also quote you regarding your upcoming answer (or any other subsequent answers to our conversation)?**
>
> Support responses are public, so you can quote us at your discretion :)

&nbsp;
:bulb: Note that regarding the second question, the `ya.ru` will only be added to the PR "server/EquivalentDomains" and not to the PR "mobile/KnownUsernameField".
:arrow_right_hook: Because there is no login page on the shorter domain name `ya.ru` (i.e. no `passport.ya.ru`).
</details>
&nbsp;

# Proof of proper functioning

### Bash script to test (one line version)
<details>
<summary>View me ...</summary>
&nbsp;

```bash
UA_DESKTOP="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.135 Safari/537.36"; UA_MOBILE="Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36"; UA_LIST=(UA_DESKTOP UA_MOBILE); TLDs=(az by co.il com com.am com.ge com.tr ee fi fr kg kz lt lv md pl ru tj tm ua uz); for TLD in "${TLDs[@]}"; do echo -e "\nTesting https://passport.yandex.${TLD}/auth ..."; for UA in "${UA_LIST[@]}"; do echo "> using ${UA}:"; wget -qO- "https://passport.yandex.${TLD}/auth" -U "${!UA}" | grep -P -o '<input[^>]*name="login"[^>]*>' | grep -P -o ' id="[^"]+"'; sleep 2; done; done;
```
</details>

### Bash script to test (readable version)
<details>
<summary>View me ...</summary>
&nbsp;

```bash
#!/bin/bash

UA_DESKTOP="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.135 Safari/537.36"
UA_MOBILE="Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36"
UA_LIST=(UA_DESKTOP UA_MOBILE)
TLDs=(az by co.il com com.am com.ge com.tr ee fi fr kg kz lt lv md pl ru tj tm ua uz)

for TLD in "${TLDs[@]}"; do
  echo -e "\nTesting https://passport.yandex.${TLD}/auth ..."

  for UA in "${UA_LIST[@]}"; do
    echo "> using ${UA}:"
    wget -qO- "https://passport.yandex.${TLD}/auth" -U "${!UA}" | grep -P -o '<input[^>]*name="login"[^>]*>' | grep -P -o ' id="[^"]+"'
    sleep 2
  done
done
```
</details>

### Result of the Bash script
<details>
<summary>View me ...</summary>
&nbsp;

```bash
Testing https://passport.yandex.az/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.by/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.co.il/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.com/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.com.am/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.com.ge/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.com.tr/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.ee/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.fi/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.fr/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.kg/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.kz/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.lt/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.lv/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.md/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.pl/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.ru/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.tj/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.tm/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.ua/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"

Testing https://passport.yandex.uz/auth ...
> using UA_DESKTOP:
 id="passp-field-login"
> using UA_MOBILE:
 id="passp-field-login"
```
</details>

### Others
<details>
<summary>View me ...</summary>

#### User agents used coming from:
:arrow_right: https://www.whatismybrowser.com/guides/the-latest-user-agent/chrome

#### List of the 21 Yandex Passport links _(+ the shorter domain name ya.ru)_:
https://passport.yandex.az
https://passport.yandex.by
https://passport.yandex.co.il
https://passport.yandex.com
https://passport.yandex.com.am
https://passport.yandex.com.ge
https://passport.yandex.com.tr
https://passport.yandex.ee
https://passport.yandex.fi
https://passport.yandex.fr
https://passport.yandex.kg
https://passport.yandex.kz
https://passport.yandex.lt
https://passport.yandex.lv
https://passport.yandex.md
https://passport.yandex.pl
https://passport.yandex.ru
https://passport.yandex.tj
https://passport.yandex.tm
https://passport.yandex.ua
https://passport.yandex.uz

**+** ... https://ya.ru
</details>
&nbsp;