### PR TITLE
Added get for sso config repo by revision date

### DIFF
--- a/src/Core/Repositories/ISsoConfigRepository.cs
+++ b/src/Core/Repositories/ISsoConfigRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Bit.Core.Models.Table;
 
@@ -8,5 +9,6 @@ namespace Bit.Core.Repositories
     {
         Task<SsoConfig> GetByOrganizationIdAsync(Guid organizationId);
         Task<SsoConfig> GetByIdentifierAsync(string identifier);
+        Task<ICollection<SsoConfig>> GetManyByRevisionNotBeforeDate(DateTime? notBefore);
     }
 }

--- a/src/Core/Repositories/SqlServer/SsoConfigRepository.cs
+++ b/src/Core/Repositories/SqlServer/SsoConfigRepository.cs
@@ -5,6 +5,7 @@ using System.Data.SqlClient;
 using System.Data;
 using Dapper;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace Bit.Core.Repositories.SqlServer
 {
@@ -41,6 +42,19 @@ namespace Bit.Core.Repositories.SqlServer
                     commandType: CommandType.StoredProcedure);
 
                 return results.SingleOrDefault();
+            }
+        }
+
+        public async Task<ICollection<SsoConfig>> GetManyByRevisionNotBeforeDate(DateTime? notBefore)
+        {
+            using (var connection = new SqlConnection(ConnectionString))
+            {
+                var results = await connection.QueryAsync<SsoConfig>(
+                    $"[{Schema}].[{Table}_ReadManyByNotBeforeRevisionDate]",
+                    new { NotBefore = notBefore },
+                    commandType: CommandType.StoredProcedure);
+
+                return results.ToList();
             }
         }
     }

--- a/src/Sql/dbo/Stored Procedures/SsoConfig_ReadManyByNotBeforeRevisionDate.sql
+++ b/src/Sql/dbo/Stored Procedures/SsoConfig_ReadManyByNotBeforeRevisionDate.sql
@@ -1,0 +1,14 @@
+CREATE PROCEDURE [dbo].[SsoConfig_ReadManyByNotBeforeRevisionDate]
+    @NotBefore DATETIME2(7)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        *
+    FROM
+        [dbo].[SsoConfigView]
+    WHERE
+        [Enabled] = 1
+        AND [RevisionDate] >= COALESCE(@NotBefore, [RevisionDate]);
+END

--- a/util/Migrator/DbScripts/2020-08-19_00_SsoConfigGetAll.sql
+++ b/util/Migrator/DbScripts/2020-08-19_00_SsoConfigGetAll.sql
@@ -1,0 +1,21 @@
+IF OBJECT_ID('[dbo].[SsoConfig_ReadManyByNotBeforeRevisionDate]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[SsoConfig_ReadManyByNotBeforeRevisionDate]
+END
+GO
+
+CREATE PROCEDURE [dbo].[SsoConfig_ReadManyByNotBeforeRevisionDate]
+    @NotBefore DATETIME2(7)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        *
+    FROM
+        [dbo].[SsoConfigView]
+    WHERE
+        [Enabled] = 1
+        AND [RevisionDate] >= COALESCE(@NotBefore, [RevisionDate]);
+END
+GO


### PR DESCRIPTION
## Overview
In order to handle SSO configuration and scheme provider cache in an efficient way and also to handle concepts like load balancing, etc. we need a means to read **all** enabled SSO configurations from the DB in one shot. This may be called upon service startup as well as any time the provider is accessed and the cache has been invalidated.

The new parameter for `@NotBefore` allows us to pass in the last loaded date when that specific instance of the provider/sso service checked for updates, and then we'll only load, parse and re-set updated or new configurations (vs. reloading the entire list every time).

Therefore initial startup may be slower (expected), however subsequent loads, especially when services are under load, even with frequent changes, won't affect performance as much, especially since the provider is a Singleton instance and must be thread-safe in it's handling of cache.