### PR TITLE
allows dev runs to load a common idserv cert

### DIFF
--- a/src/Core/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Core/Utilities/ServiceCollectionExtensions.cs
@@ -375,11 +375,7 @@ namespace Bit.Core.Utilities
         public static IIdentityServerBuilder AddIdentityServerCertificate(
             this IIdentityServerBuilder identityServerBuilder, IWebHostEnvironment env, GlobalSettings globalSettings)
         {
-            if (env.IsDevelopment())
-            {
-                identityServerBuilder.AddDeveloperSigningCredential(false);
-            }
-            else if (globalSettings.SelfHosted &&
+            if (globalSettings.SelfHosted &&
                 CoreHelpers.SettingHasValue(globalSettings.IdentityServer.CertificatePassword)
                 && File.Exists("identity.pfx"))
             {
@@ -401,6 +397,10 @@ namespace Bit.Core.Utilities
                 var identityServerCert = CoreHelpers.GetBlobCertificateAsync(storageAccount, "certificates",
                     "identity.pfx", globalSettings.IdentityServer.CertificatePassword).GetAwaiter().GetResult();
                 identityServerBuilder.AddSigningCredential(identityServerCert);
+            }
+            else if (env.IsDevelopment())
+            {
+                identityServerBuilder.AddDeveloperSigningCredential(false);
             }
             else
             {


### PR DESCRIPTION
Identity server needs a signing certificate for our Identity and SSO projects.

Currently in dev mode, it always uses `AddDeveloperSigningCredential`, which generates a new temporary key each time the application is started. This can be annoying since it will invalidate previously signed things each time you restart the projects.

This change moves `AddDeveloperSigningCredential` further down the logic chain which will allow developers to specify their own dev cert certificate to use via user secrets.