### PR TITLE
map plantype to old strings for license hash

### DIFF
--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -442,6 +442,21 @@ namespace Bit.Core.Utilities
                 return val.ToString().ToLowerInvariant();
             }
 
+            if (val is PlanType planType)
+            {
+                return planType switch
+                {
+                    PlanType.Free => "Free",
+                    PlanType.FamiliesAnnually2019 => "FamiliesAnnually",
+                    PlanType.TeamsMonthly2019 => "TeamsMonthly",
+                    PlanType.TeamsAnnually2019 => "TeamsAnnually",
+                    PlanType.EnterpriseMonthly2019 => "EnterpriseMonthly",
+                    PlanType.EnterpriseAnnually2019 => "EnterpriseAnnually",
+                    PlanType.Custom => "Custom",
+                    _ => ((byte)planType).ToString(),
+                };
+            }
+
             return val.ToString();
         }
 


### PR DESCRIPTION
When a license signature is generated, one of the properties included in the signature is the PlanType enum. When we toString() this enum, it has always been using the string *name* of the Enum rather than the *byte value*. This poses an issue with the recent plan changes, in which we renamed the enums. This next server version would then generate license signatures that would be invalid with older servers.

This PR normalizes the original PlanType enum values back to their string names when generating license hash values, while also using the byte value going forward so that we can freely rename these enums as we need now and for any future plan changes.