### PR TITLE
Extracted logic to get Identity cert

### DIFF
--- a/src/Core/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Core/Utilities/ServiceCollectionExtensions.cs
@@ -375,28 +375,10 @@ namespace Bit.Core.Utilities
         public static IIdentityServerBuilder AddIdentityServerCertificate(
             this IIdentityServerBuilder identityServerBuilder, IWebHostEnvironment env, GlobalSettings globalSettings)
         {
-            if (globalSettings.SelfHosted &&
-                CoreHelpers.SettingHasValue(globalSettings.IdentityServer.CertificatePassword)
-                && File.Exists("identity.pfx"))
+            var certificate = CoreHelpers.GetIdentityServerCertificate(globalSettings);
+            if (certificate != null)
             {
-                var identityServerCert = CoreHelpers.GetCertificate("identity.pfx",
-                    globalSettings.IdentityServer.CertificatePassword);
-                identityServerBuilder.AddSigningCredential(identityServerCert);
-            }
-            else if (CoreHelpers.SettingHasValue(globalSettings.IdentityServer.CertificateThumbprint))
-            {
-                var identityServerCert = CoreHelpers.GetCertificate(
-                    globalSettings.IdentityServer.CertificateThumbprint);
-                identityServerBuilder.AddSigningCredential(identityServerCert);
-            }
-            else if (!globalSettings.SelfHosted &&
-                CoreHelpers.SettingHasValue(globalSettings.Storage?.ConnectionString) &&
-                CoreHelpers.SettingHasValue(globalSettings.IdentityServer.CertificatePassword))
-            {
-                var storageAccount = CloudStorageAccount.Parse(globalSettings.Storage.ConnectionString);
-                var identityServerCert = CoreHelpers.GetBlobCertificateAsync(storageAccount, "certificates",
-                    "identity.pfx", globalSettings.IdentityServer.CertificatePassword).GetAwaiter().GetResult();
-                identityServerBuilder.AddSigningCredential(identityServerCert);
+                identityServerBuilder.AddSigningCredential(certificate);
             }
             else if (env.IsDevelopment())
             {


### PR DESCRIPTION
## Overview
Extract and encapsulate the logic for getting the Identity signing certificate since it will be used in multiple locations including for SSO. see: https://github.com/bitwarden/enterprise/pull/30#discussion_r476531890

## Changes
* **CoreHelpers.cs**: Added method for getting the identity cert from the global settings extracted from the services middleware previously. Also added `.ConfigureAwait(false)` on the async methods in that async method to ensure that the synchronous methods that call it using `.GetAwaiter().GetResult()` will prevent potential deadlock.
* **ServiceCollectionExtensions.cs**: Use new helper method