### PR TITLE
Add UseBusinessPortal to OrgUserOrgDetails.

### DIFF
--- a/src/Core/Models/Data/OrganizationUserOrganizationDetails.cs
+++ b/src/Core/Models/Data/OrganizationUserOrganizationDetails.cs
@@ -15,6 +15,7 @@ namespace Bit.Core.Models.Data
         public bool UseTotp { get; set; }
         public bool Use2fa { get; set; }
         public bool UseApi{ get; set; }
+        public bool UseBusinessPortal => UsePolicies || UseSso;
         public bool SelfHost { get; set; }
         public bool UsersGetPremium { get; set; }
         public int Seats { get; set; }


### PR DESCRIPTION
## Objective

Need UseBusinessPortal on the OrganizationUserOrganizationDetails model. This is the model used for the Organization drop down in the Enterprise portal. 

## Code Change

**src/Core/Models/Data/OrganizationUserOrganizationDetails.cs**

Added property. This logic is the same logic incorporated in ProfileOrganizationResponseModel.cs.