### PR TITLE
GlobalSettings SSO cache timeout setting in sec

### DIFF
--- a/src/Core/GlobalSettings.cs
+++ b/src/Core/GlobalSettings.cs
@@ -278,7 +278,7 @@ namespace Bit.Core
 
         public class SsoSettings
         {
-            public int CacheExpiresInSeconds { get; set; } = 60;
+            public int CacheLifetimeInSeconds { get; set; } = 60;
             public virtual SamlSettings Saml { get; set; } = new SamlSettings();
 
             public class SamlSettings

--- a/src/Core/GlobalSettings.cs
+++ b/src/Core/GlobalSettings.cs
@@ -278,6 +278,7 @@ namespace Bit.Core
 
         public class SsoSettings
         {
+            public int CacheExpiresInSeconds { get; set; } = 60;
             public virtual SamlSettings Saml { get; set; } = new SamlSettings();
 
             public class SamlSettings


### PR DESCRIPTION
## Overview
Need a global setting for the SSO service to use for setting the cache expiration duration in seconds. Will default to 60 seconds (1 minute).