### PR TITLE
change response mode to form_post

### DIFF
--- a/src/Identity/Startup.cs
+++ b/src/Identity/Startup.cs
@@ -89,6 +89,7 @@ namespace Bit.Identity
                         globalSettings.BaseServiceUri.InternalIdentity.StartsWith("https");
                     options.ClientId = "oidc-identity";
                     options.ClientSecret = globalSettings.OidcIdentityClientKey;
+                    options.ResponseMode = "form_post";
 
                     options.SignInScheme = IdentityServer4.IdentityServerConstants.ExternalCookieAuthenticationScheme;
                     options.ResponseType = "code";


### PR DESCRIPTION
URLs can get too large, so this changes the response mode for Identity <=> SSO communication to form_post.