### PR TITLE
Move SSO core to Core lib, new resource strings

### DIFF
--- a/src/Core/Enums/Saml2BindingType.cs
+++ b/src/Core/Enums/Saml2BindingType.cs
@@ -1,0 +1,9 @@
+﻿namespace Bit.Core.Enums
+{
+    public enum Saml2BindingType : byte
+    {
+        HttpRedirect = 1,
+        HttpPost = 2,
+        Artifact = 4
+    }
+}

--- a/src/Core/Enums/SsoType.cs
+++ b/src/Core/Enums/SsoType.cs
@@ -1,0 +1,8 @@
+﻿namespace Bit.Core.Enums
+{
+    public enum SsoType : byte
+    {
+        OpenIdConnect = 1,
+        Saml2 = 2,
+    }
+}

--- a/src/Core/GlobalSettings.cs
+++ b/src/Core/GlobalSettings.cs
@@ -279,18 +279,6 @@ namespace Bit.Core
         public class SsoSettings
         {
             public int CacheLifetimeInSeconds { get; set; } = 60;
-            public virtual SamlSettings Saml { get; set; } = new SamlSettings();
-
-            public class SamlSettings
-            {
-                public Saml2NameIdFormat NameIdFormat { get; set; } =
-                    Saml2NameIdFormat.Persistent;
-                public bool WantAssertionsSigned { get; set; }
-                public string OutboundSigningAlgorithm { get; set; }
-                public Saml2SigningBehavior SigningBehavior { get; set; } =
-                    Saml2SigningBehavior.IfIdpWantAuthnRequestsSigned;
-                public bool ValidateCertificates { get; set; }
-            }
         }
     }
 }

--- a/src/Core/Models/Data/SsoConfigurationData.cs
+++ b/src/Core/Models/Data/SsoConfigurationData.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Bit.Core.Enums;
+using Bit.Core.Sso;
+
+namespace Bit.Core.Models.Data
+{
+    public class SsoConfigurationData
+    {
+        private const string _oidcSigninPath = "/oidc-signin";
+        private const string _oidcSignedOutPath = "/oidc-signedout";
+        private const string _saml2ModulePath = "/saml2";
+
+        public SsoType ConfigType { get; set; }
+
+        // OIDC
+        public string Authority { get; set; }
+        public string ClientId { get; set; }
+        public string ClientSecret { get; set; }
+        public string MetadataAddress { get; set; }
+        public bool GetClaimsFromUserInfoEndpoint { get; set; }
+
+        // SAML2 IDP
+        public string IdpEntityId { get; set; }
+        public string IdpSingleSignOnServiceUrl { get; set; }
+        public string IdpSingleLogoutServiceUrl { get; set; }
+        public string IdpX509PublicCert { get; set; }
+        public Saml2BindingType IdpBindingType { get; set; }
+        public bool IdpAllowUnsolicitedAuthnResponse { get; set; }
+        public string IdpArtifactResolutionServiceUrl { get; set; }
+        public bool IdpDisableOutboundLogoutRequests { get; set; }
+        public string IdpOutboundSigningAlgorithm { get; set; }
+        public bool IdpWantAuthnRequestsSigned { get; set; }
+
+        // SAML2 SP
+        public Saml2NameIdFormat SpNameIdFormat { get; set; } = Saml2NameIdFormat.Persistent;
+        public string SpOutboundSigningAlgorithm { get; set; } = SamlSigningAlgorithms.Sha256;
+        public Saml2SigningBehavior SpSigningBehavior { get; set; } = Saml2SigningBehavior.IfIdpWantAuthnRequestsSigned;
+        public bool SpWantAssertionsSigned { get; set; }
+        public bool SpValidateCertificates { get; set; }
+
+        public string BuildCallbackPath(string ssoUri = null)
+        {
+            return BuildSsoUrl(_oidcSigninPath, ssoUri);
+        }
+
+        public string BuildSignedOutCallbackPath(string ssoUri = null)
+        {
+            return BuildSsoUrl(_oidcSignedOutPath, ssoUri);
+        }
+
+        public string BuildSaml2ModulePath(string ssoUri = null)
+        {
+            return BuildSsoUrl(_saml2ModulePath, ssoUri);
+        }
+
+        private string BuildSsoUrl(string relativePath, string ssoUri)
+        {
+            if (string.IsNullOrWhiteSpace(ssoUri) ||
+                !Uri.IsWellFormedUriString(ssoUri, UriKind.Absolute))
+            {
+                return relativePath;
+            }
+            if (Uri.TryCreate(string.Concat(ssoUri.TrimEnd('/'), relativePath), UriKind.Absolute, out var newUri))
+            {
+                return newUri.ToString();
+            }
+            return relativePath;
+        }
+    }
+}

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -433,4 +433,13 @@
   <data name="RedirectingMessage">
     <value>You are now being returned to the application. Once complete, you may close this tab.</value>
   </data>
+  <data name="IfIdpWantAuthnRequestsSigned">
+    <value>If IdP Wants Authn Requests Signed</value>
+  </data>
+  <data name="Always">
+    <value>Always</value>
+  </data>
+  <data name="Never">
+    <value>Never</value>
+  </data>
 </root>

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -265,6 +265,9 @@
   <data name="SpEntityId" xml:space="preserve">
     <value>SP Entity ID</value>
   </data>
+  <data name="SpValidateCertificates" xml:space="preserve">
+    <value>Validate Certificates</value>
+  </data>
   <data name="NameIdFormat" xml:space="preserve">
     <value>Name ID Format</value>
   </data>
@@ -311,7 +314,7 @@
     <value>Public Key</value>
   </data>
   <data name="SpWantAssertionsSigned" xml:space="preserve">
-    <value>Sign Assertions</value>
+    <value>Want Assertions Signed</value>
   </data>
   <data name="SigningAlgorithm" xml:space="preserve">
     <value>Signing Algorithm</value>

--- a/src/Core/Sso/SamlSigningAlgorithms.cs
+++ b/src/Core/Sso/SamlSigningAlgorithms.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+
+namespace Bit.Core.Sso
+{
+    public static class SamlSigningAlgorithms
+    {
+        public const string Default = Sha256;
+        public const string Sha256 = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+        public const string Sha384 = "http://www.w3.org/2000/09/xmldsig#rsa-sha384";
+        public const string Sha512 = "http://www.w3.org/2000/09/xmldsig#rsa-sha512";
+        public const string Sha1 = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+
+        public static IEnumerable<string> GetEnumerable()
+        {
+            yield return Sha256;
+            yield return Sha384;
+            yield return Sha512;
+            yield return Sha1;
+        }
+    }
+}


### PR DESCRIPTION
## Overview
This eliminates one of the the "common" libraries that was down to just a couple of enums and 2 classes and moves those into Core for SSO. Also added and updates some resource strings for the Business Portal.

This also updates the global settings' SSO SAML configuration to remove that since it should live back in each organization's IdP configuration data itself.