### PR TITLE
stopped manually encoding the SSO user_identifier

### DIFF
--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -374,8 +374,6 @@ namespace Bit.Sso.Controllers
             }
             else
             {
-                var bytes = System.Convert.FromBase64String(userIdentifier);
-                userIdentifier = System.Text.Encoding.UTF8.GetString(bytes);
                 var split = userIdentifier.Split(",");
                 if (split.Length < 2)
                 {

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -731,8 +731,7 @@ namespace Bit.Api.Controllers
         {
             var user = await _userService.GetUserByPrincipalAsync(User);
             var token = await _userService.GenerateSignInTokenAsync(user, TokenPurposes.LinkSso);
-            var bytes = Encoding.UTF8.GetBytes($"{user.Id},{token}");
-            var userIdentifier = Convert.ToBase64String(bytes);
+            var userIdentifier = $"{user.Id},{token}";
             return userIdentifier;
         }
     }


### PR DESCRIPTION
stopped manually encoding the SSO user_identifier in an attempt to bring URL size down