### PR TITLE
SAML NameID Policy AllowCreate should be null

### DIFF
--- a/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
+++ b/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
@@ -331,11 +331,16 @@ namespace Bit.Core.Business.Sso
 
             var spEntityId = new Sustainsys.Saml2.Metadata.EntityId(
                 config.BuildSaml2ModulePath(_globalSettings.BaseServiceUri.Sso));
+            bool? allowCreate = null;
+            if (config.SpNameIdFormat != Saml2NameIdFormat.Transient)
+            {
+                allowCreate = true;
+            }
             var spOptions = new SPOptions
             {
                 EntityId = spEntityId,
                 ModulePath = config.BuildSaml2ModulePath(),
-                NameIdPolicy = new Saml2NameIdPolicy(null, GetNameIdFormat(config.SpNameIdFormat)),
+                NameIdPolicy = new Saml2NameIdPolicy(allowCreate, GetNameIdFormat(config.SpNameIdFormat)),
                 WantAssertionsSigned = config.SpWantAssertionsSigned,
                 AuthenticateRequestSigningBehavior = GetSigningBehavior(config.SpSigningBehavior),
                 ValidateCertificates = config.SpValidateCertificates,

--- a/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
+++ b/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
@@ -335,7 +335,7 @@ namespace Bit.Core.Business.Sso
             {
                 EntityId = spEntityId,
                 ModulePath = config.BuildSaml2ModulePath(),
-                NameIdPolicy = new Saml2NameIdPolicy(true, GetNameIdFormat(config.SpNameIdFormat)),
+                NameIdPolicy = new Saml2NameIdPolicy(null, GetNameIdFormat(config.SpNameIdFormat)),
                 WantAssertionsSigned = config.SpWantAssertionsSigned,
                 AuthenticateRequestSigningBehavior = GetSigningBehavior(config.SpSigningBehavior),
                 ValidateCertificates = config.SpValidateCertificates,


### PR DESCRIPTION
## Overview
Turns out our SAML library doesn't like it very much when a Name ID policy is set to Transient and also has `AllowCreate: true` set. The recommended setting is to leave this as `null` when transient (unset).

## Exception
```
System.InvalidOperationException: When NameIdPolicy/Format is set to Transient, it is not permitted to specify AllowCreate. Change Format or leave AllowCreate as null.
   at Sustainsys.Saml2.Saml2P.Saml2AuthenticationRequest.AddNameIdPolicy(XElement xElement)
   at Sustainsys.Saml2.Saml2P.Saml2AuthenticationRequest.ToXElement()
   at Sustainsys.Saml2.Saml2P.Saml2MessageExtensions.ToXml[TMessage](TMessage message, Action`1 xmlCreatedNotification)
   at Sustainsys.Saml2.WebSso.Saml2PostBinding.Bind[TMessage](TMessage message, ILoggerAdapter logger, Action`3 xmlCreatedNotification)
   at Sustainsys.Saml2.IdentityProvider.Bind[TMessage](TMessage message, Action`3 xmlCreatedNotification)
   at Sustainsys.Saml2.WebSso.SignInCommand.InitiateLoginToIdp(IOptions options, IDictionary`2 relayData, Saml2Urls urls, IdentityProvider idp, Uri returnUrl, HttpRequestData re  quest)
   at Sustainsys.Saml2.WebSso.SignInCommand.Run(EntityId idpEntityId, String returnPath, HttpRequestData request, IOptions options, IDictionary`2 relayData)
   at Sustainsys.Saml2.AspNetCore2.Saml2Handler.ChallengeAsync(AuthenticationProperties properties)
   at Microsoft.AspNetCore.Authentication.AuthenticationService.ChallengeAsync(HttpContext context, String scheme, AuthenticationProperties properties)
   at Microsoft.AspNetCore.Mvc.ChallengeResult.ExecuteResultAsync(ActionContext context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResultFilterAsync>g__Awaited|29_0[TFilter,TFilterAsync](ResourceInvoker invoker, Task lastTask, State ne  xt, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResultExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.ResultNext[TFilter,TFilterAsync](State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeResultFilters()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object s  tate, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
   at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
   at IdentityServer4.Hosting.IdentityServerMiddleware.Invoke(HttpContext context, IEndpointRouter router, IUserSession session, IEventService events, IBackChannelLogoutService   backChannelLogoutService)
   at IdentityServer4.Hosting.MutualTlsEndpointMiddleware.Invoke(HttpContext context, IAuthenticationSchemeProvider schemes)
   at Bit.Sso.Utilities.SsoAuthenticationMiddleware.Invoke(HttpContext context) in /home/runner/work/enterprise/enterprise/enterprise/src/Sso/Utilities/SsoAuthenticationMiddlewa  re.cs:line 80
   at IdentityServer4.Hosting.BaseUrlMiddleware.Invoke(HttpContext context)
   at Bit.Core.Utilities.CurrentContextMiddleware.Invoke(HttpContext httpContext, CurrentContext currentContext, GlobalSettings globalSettings) in /home/runner/work/enterprise/e  nterprise/server/src/Core/Utilities/CurrentContextMiddleware.cs:line 19
   at Microsoft.AspNetCore.Localization.RequestLocalizationMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Builder.Extensions.UsePathBaseMiddleware.Invoke(HttpContext context)
   at Bit.Sso.Startup.<>c__DisplayClass9_1.<<Configure>b__2>d.MoveNext() in /home/runner/work/enterprise/enterprise/enterprise/src/Sso/Startup.cs:line 94
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application)
```