### PR TITLE
Added SP ACS URL to Config Screen

### DIFF
--- a/bitwarden_license/src/Portal/Models/SsoConfigDataViewModel.cs
+++ b/bitwarden_license/src/Portal/Models/SsoConfigDataViewModel.cs
@@ -24,6 +24,7 @@ namespace Bit.Portal.Models
             MetadataAddress = configurationData.MetadataAddress;
             GetClaimsFromUserInfoEndpoint = configurationData.GetClaimsFromUserInfoEndpoint;
             SpEntityId = configurationData.BuildSaml2ModulePath(globalSettings.BaseServiceUri.Sso);
+            SpAcsUrl = configurationData.BuildSaml2AcsUrl(globalSettings.BaseServiceUri.Sso);
             IdpEntityId = configurationData.IdpEntityId;
             IdpBindingType = configurationData.IdpBindingType;
             IdpSingleSignOnServiceUrl = configurationData.IdpSingleSignOnServiceUrl;
@@ -64,6 +65,8 @@ namespace Bit.Portal.Models
         // SAML2 SP
         [Display(Name = "SpEntityId")]
         public string SpEntityId { get; set; }
+        [Display(Name = "SpAcsUrl")]
+        public string SpAcsUrl { get; set; }
         [Display(Name = "NameIdFormat")]
         public Saml2NameIdFormat SpNameIdFormat { get; set; }
         [Display(Name = "OutboundSigningAlgorithm")]

--- a/bitwarden_license/src/Portal/Views/Sso/Index.cshtml
+++ b/bitwarden_license/src/Portal/Views/Sso/Index.cshtml
@@ -115,6 +115,12 @@
             </div>
             <div class="row">
                 <div class="col-6 form-group">
+                    <label asp-for="Data.SpAcsUrl">@i18nService.T("SpAcsUrl")</label>
+                    <input asp-for="Data.SpAcsUrl" class="form-control" readonly>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-6 form-group">
                     <label asp-for="Data.SpNameIdFormat">@i18nService.T("NameIdFormat")</label>
                     <select asp-for="Data.SpNameIdFormat" asp-items="Model.SpNameIdFormats"
                             class="form-control"></select>

--- a/src/Core/Models/Data/SsoConfigurationData.cs
+++ b/src/Core/Models/Data/SsoConfigurationData.cs
@@ -53,6 +53,11 @@ namespace Bit.Core.Models.Data
             return BuildSsoUrl(_saml2ModulePath, ssoUri);
         }
 
+        public string BuildSaml2AcsUrl(string ssoUri = null)
+        {
+            return string.Concat(BuildSaml2ModulePath(ssoUri), "/Acs");
+        }
+
         private string BuildSsoUrl(string relativePath, string ssoUri)
         {
             if (string.IsNullOrWhiteSpace(ssoUri) ||

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -265,6 +265,9 @@
   <data name="SpEntityId" xml:space="preserve">
     <value>SP Entity ID</value>
   </data>
+  <data name="SpAcsUrl" xml:space="preserve">
+    <value>Assertion Consumer Service (ACS) URL</value>
+  </data>
   <data name="SpValidateCertificates" xml:space="preserve">
     <value>Validate Certificates</value>
   </data>


### PR DESCRIPTION
## Overview
It's not obvious or apparent (mainly because I missed it in the documentation and prior screen implementation) that the ACS (assertion consumer service) URL that is sent in the AuthnRequest SAML envelope to the IdP does not match the SP Entity ID, because it has the path, `/Acs` at the end of it. I've added another field to the UI to make this more obvious and publish the actual URL to the SSO admin user during configuration to prevent issues going forward.

🗒️  We'll also need to do this again when we implement SLO (it'll have a different SLO Endpoint URL).