### PR TITLE
use custom DiscoveryResponseGenerator on cloud too

### DIFF
--- a/bitwarden_license/src/Sso/Utilities/ServiceCollectionExtensions.cs
+++ b/bitwarden_license/src/Sso/Utilities/ServiceCollectionExtensions.cs
@@ -46,10 +46,7 @@ namespace Bit.Sso.Utilities
         public static IIdentityServerBuilder AddSsoIdentityServerServices(this IServiceCollection services,
             IWebHostEnvironment env, GlobalSettings globalSettings)
         {
-            if (globalSettings.SelfHosted)
-            {
-                services.AddTransient<IDiscoveryResponseGenerator, DiscoveryResponseGenerator>();
-            }
+            services.AddTransient<IDiscoveryResponseGenerator, DiscoveryResponseGenerator>();
 
             var issuerUri = new Uri(globalSettings.BaseServiceUri.InternalSso);
             var identityServerBuilder = services

--- a/src/Identity/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Identity/Utilities/ServiceCollectionExtensions.cs
@@ -16,10 +16,7 @@ namespace Bit.Identity.Utilities
         public static IIdentityServerBuilder AddCustomIdentityServerServices(this IServiceCollection services,
             IWebHostEnvironment env, GlobalSettings globalSettings)
         {
-            if (globalSettings.SelfHosted)
-            {
-                services.AddTransient<IDiscoveryResponseGenerator, DiscoveryResponseGenerator>();
-            }
+            services.AddTransient<IDiscoveryResponseGenerator, DiscoveryResponseGenerator>();
 
             services.AddSingleton<StaticClientStore>();
             services.AddTransient<IAuthorizationCodeStore, AuthorizationCodeStore>();


### PR DESCRIPTION
This allows openid configuration generator to use proper URLs, even when behind a proxy.