### PR TITLE
Filled custom error handling gaps for SSO

### DIFF
--- a/bitwarden_license/src/Sso/Controllers/HomeController.cs
+++ b/bitwarden_license/src/Sso/Controllers/HomeController.cs
@@ -6,20 +6,16 @@ using System.Threading.Tasks;
 using Bit.Sso.Models;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Diagnostics;
-using Microsoft.Extensions.Logging;
 
 namespace Bit.Sso.Controllers
 {
     public class HomeController : Controller
     {
         private readonly IIdentityServerInteractionService _interaction;
-        private readonly ILogger<HomeController> _logger;
 
-        public HomeController(IIdentityServerInteractionService interaction,
-            ILogger<HomeController> logger)
+        public HomeController(IIdentityServerInteractionService interaction)
         {
             _interaction = interaction;
-            _logger = logger;
         }
 
         [HttpGet("~/alive")]
@@ -49,10 +45,6 @@ namespace Bit.Sso.Controllers
                 vm.RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
                 var exceptionHandlerPathFeature = HttpContext.Features.Get<IExceptionHandlerPathFeature>();
                 var exception = exceptionHandlerPathFeature?.Error;
-                if (exception != null)
-                {
-                    _logger.LogError(exception, "Unhandled Exception in SSO Service");
-                }
                 if (exception is InvalidOperationException opEx && opEx.Message.Contains("schemes are: "))
                 {
                     // Messages coming from aspnetcore with a message

--- a/bitwarden_license/src/Sso/Models/ErrorViewModel.cs
+++ b/bitwarden_license/src/Sso/Models/ErrorViewModel.cs
@@ -5,11 +5,24 @@ namespace Bit.Sso.Models
 {
     public class ErrorViewModel
     {
+        private string _requestId;
+
         public ErrorMessage Error { get; set; }
+        public Exception Exception { get; set; }
 
         public string Message => Error?.Error;
-        public string Description => Error?.ErrorDescription;
-        public string RequestId => Error?.RequestId;
+        public string Description => Error?.ErrorDescription ?? Exception?.Message;
         public string RedirectUri => Error?.RedirectUri;
+        public string RequestId
+        {
+            get
+            {
+                return Error?.RequestId ?? _requestId;
+            }
+            set
+            {
+                _requestId = value;
+            }
+        }
     }
 }

--- a/bitwarden_license/src/Sso/Startup.cs
+++ b/bitwarden_license/src/Sso/Startup.cs
@@ -80,7 +80,10 @@ namespace Bit.Sso
             GlobalSettings globalSettings,
             ILogger<Startup> logger)
         {
-            IdentityModelEventSource.ShowPII = true;
+            if (env.IsDevelopment() || globalSettings.SelfHosted)
+            {
+                IdentityModelEventSource.ShowPII = true;
+            }
 
             app.UseSerilog(env, appLifetime, globalSettings);
 
@@ -100,6 +103,10 @@ namespace Bit.Sso
             {
                 app.UseDeveloperExceptionPage();
                 app.UseCookiePolicy();
+            }
+            else
+            {
+                app.UseExceptionHandler("/Error");
             }
 
             app.UseCoreLocalization();


### PR DESCRIPTION
## Overview
Previously the IdentityServer user interaction error path was populated for handling exceptions during the handling of the IdentityServer4 middleware, however that turns out to be only a small footprint and other handlers outside of IdentityServer4, including the underlying aspnet Core Identity and Security libraries also throw exceptions for various scenarios which are unhandled by IdentityServer and result in a blank, uninformative 500 error page in the browser.

This change adds a single catch-all exception handler for the entire pipeline so if any exception occurs the user can be notified with a friendly or at least more informative error message.

## Notes
* In HomeController.cs; we have to do our own protective filtering of exception messages coming from the underlying framework in the aspnet base AuthenticationService which appends as a footer message the entire array of names of all configured authentication schemes... this is most not desirable outside of a test/dev environment because it could potentially expose other Org IDs configured for SSO to any user.
**Example**
![image](https://user-images.githubusercontent.com/3904944/92531637-ae818d80-f1fc-11ea-91f6-a64bafd0fcc7.png)
_Turns into_
![image](https://user-images.githubusercontent.com/3904944/92531770-f0aacf00-f1fc-11ea-836b-01a4b7758cd5.png)

* Ensure the identityServer will not show PII unless it's Development or Self-Hosted environment.