### PR TITLE
SetIdentityServerOrigin for all non-dev

### DIFF
--- a/bitwarden_license/src/Sso/Startup.cs
+++ b/bitwarden_license/src/Sso/Startup.cs
@@ -87,7 +87,7 @@ namespace Bit.Sso
 
             app.UseSerilog(env, appLifetime, globalSettings);
 
-            if (globalSettings.SelfHosted)
+            if (!env.IsDevelopment())
             {
                 var uri = new Uri(globalSettings.BaseServiceUri.Sso);
                 app.Use(async (ctx, next) =>
@@ -95,6 +95,10 @@ namespace Bit.Sso
                     ctx.SetIdentityServerOrigin($"{uri.Scheme}://{uri.Host}");
                     await next();
                 });
+            }
+
+            if (globalSettings.SelfHosted)
+            {
                 app.UsePathBase("/sso");
                 app.UseForwardedHeaders(globalSettings);
             }

--- a/src/Identity/Startup.cs
+++ b/src/Identity/Startup.cs
@@ -144,7 +144,7 @@ namespace Bit.Identity
 
             app.UseSerilog(env, appLifetime, globalSettings);
 
-            if (globalSettings.SelfHosted)
+            if (!env.IsDevelopment())
             {
                 var uri = new Uri(globalSettings.BaseServiceUri.Identity);
                 app.Use(async (ctx, next) =>
@@ -152,6 +152,10 @@ namespace Bit.Identity
                     ctx.SetIdentityServerOrigin($"{uri.Scheme}://{uri.Host}");
                     await next();
                 });
+            }
+
+            if (globalSettings.SelfHosted)
+            {
                 app.UsePathBase("/identity");
                 app.UseForwardedHeaders(globalSettings);
             }


### PR DESCRIPTION
We need to call SetIdentityServerOrigin for all non-dev deployments so that identity will use the proper URLs for redirects. This is mainly an issue whenever the server is served behind a proxy.