### PR TITLE
Null ref exception when saving config fix

### DIFF
--- a/bitwarden_license/src/Portal/Models/SsoConfigDataViewModel.cs
+++ b/bitwarden_license/src/Portal/Models/SsoConfigDataViewModel.cs
@@ -210,6 +210,10 @@ namespace Bit.Portal.Models
 
         private string StripPemCertificateElements(string certificateText)
         {
+            if (string.IsNullOrWhiteSpace(certificateText))
+            {
+                return null;
+            }
             return Regex.Replace(certificateText,
                 @"(((BEGIN|END) CERTIFICATE)|([\-\n\r\t\s\f]))",
                 string.Empty,


### PR DESCRIPTION
## Overview
I forgot to test this when there is no SSO certificate provided for the IdP's public key. Added `null` handler for that scenario.