### PR TITLE
Remove referer header match from middleware

### DIFF
--- a/bitwarden_license/src/Sso/Utilities/OpenIdConnectOptionsExtensions.cs
+++ b/bitwarden_license/src/Sso/Utilities/OpenIdConnectOptionsExtensions.cs
@@ -25,16 +25,6 @@ namespace Bit.Sso.Utilities
                 return true;
             }
 
-            // Determine if the Authority matches the Referrer (short-cut)
-            var referrer = context.Request.Headers["Referer"].FirstOrDefault();
-            if (!string.IsNullOrWhiteSpace(referrer) &&
-                Uri.TryCreate(options.Authority, UriKind.Absolute, out var authorityUri) &&
-                Uri.TryCreate(referrer, UriKind.Absolute, out var referrerUri) &&
-                (referrerUri.IsBaseOf(authorityUri) || authorityUri.IsBaseOf(referrerUri)))
-            {
-                return true;
-            }
-
             try
             {
                 // Parse out the message

--- a/bitwarden_license/src/Sso/Utilities/Saml2OptionsExtensions.cs
+++ b/bitwarden_license/src/Sso/Utilities/Saml2OptionsExtensions.cs
@@ -32,20 +32,6 @@ namespace Bit.Sso.Utilities
                 return true;
             }
 
-            // Determine if the Authority matches the Referrer (short-cut)
-            var referrer = context.Request.Headers["Referer"].FirstOrDefault();
-            if (!string.IsNullOrWhiteSpace(referrer) &&
-                Uri.TryCreate(referrer, UriKind.Absolute, out var referrerUri) &&
-                (referrerUri.IsBaseOf(idp.SingleSignOnServiceUrl) ||
-                idp.SingleSignOnServiceUrl.IsBaseOf(referrerUri) ||
-                referrerUri.IsBaseOf(idp.SingleLogoutServiceUrl) ||
-                idp.SingleLogoutServiceUrl.IsBaseOf(referrerUri) ||
-                referrerUri.IsBaseOf(idp.SingleLogoutServiceResponseUrl) ||
-                idp.SingleLogoutServiceResponseUrl.IsBaseOf(referrerUri)))
-            {
-                return true;
-            }
-
             // We need to pull out and parse the response or request SAML envelope
             XmlElement assertion = null;
             try


### PR DESCRIPTION
## Overview
As a possible "match" for SSO response handlers in our middleware we were using the `referer` header, if available, against the scheme's login service URL, for each scheme to determine which, if any, could or should handle the response. This is a problem is multiple schemes are configured for the same IdP provider and therefore the same referring site, for instance, Azure AD, which universally redirects from `login.microsoft.com`, and therefore breaks when the first handler is selected but the IdP in the SAML assertion, or OIDC state doesn't match what's configured on the handler itself.

Removed this faulty match logic.