### PR TITLE
[SSO] Bug - Set password session expired

### DIFF
--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -592,7 +592,7 @@ namespace Bit.Core.Services
                 return IdentityResult.Failed(_identityErrorDescriber.UserAlreadyHasPassword());
             }
 
-            var result = await UpdatePasswordHash(user, masterPassword);
+            var result = await UpdatePasswordHash(user, masterPassword, true, false);
             if (!result.Succeeded)
             {
                 return result;


### PR DESCRIPTION
## Objective
> Fix bug [found here](https://app.asana.com/0/1188746734054362/1192745697764264) 

## Code Changes
- **UserService**: Remove security stamp rotation during the `set-password` SSO flow. This will allow a new user to set a password and immediately advance to their vault.