### PR TITLE
SSO config revision date not updating fix

### DIFF
--- a/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
+++ b/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
@@ -75,7 +75,7 @@ namespace Bit.Core.Business.Sso
             _ssoConfigRepository = ssoConfigRepository;
             _logger = logger;
             _globalSettings = globalSettings;
-            _schemeCacheLifetime = TimeSpan.FromSeconds(_globalSettings.Sso?.CacheLifetimeInSeconds ?? 60);
+            _schemeCacheLifetime = TimeSpan.FromSeconds(_globalSettings.Sso?.CacheLifetimeInSeconds ?? 30);
             _samlEnvironment = samlEnvironment;
             _cachedSchemes = new Dictionary<string, DynamicAuthenticationScheme>();
             _cachedHandlerSchemes = new Dictionary<string, DynamicAuthenticationScheme>();

--- a/bitwarden_license/src/Sso/appsettings.json
+++ b/bitwarden_license/src/Sso/appsettings.json
@@ -59,7 +59,7 @@
       "region": "SECRET"
     },
     "sso": {
-      "cacheLifetimeInSeconds": 60
+      "cacheLifetimeInSeconds": 30
     }
   }
 }

--- a/src/Core/Repositories/SqlServer/SsoConfigRepository.cs
+++ b/src/Core/Repositories/SqlServer/SsoConfigRepository.cs
@@ -57,5 +57,17 @@ namespace Bit.Core.Repositories.SqlServer
                 return results.ToList();
             }
         }
+
+        public override async Task CreateAsync(SsoConfig obj)
+        {
+            obj.CreationDate = obj.RevisionDate = DateTime.UtcNow;
+            await base.CreateAsync(obj);
+        }
+
+        public override async Task ReplaceAsync(SsoConfig obj)
+        {
+            obj.RevisionDate = DateTime.UtcNow;
+            await base.ReplaceAsync(obj);
+        }
     }
 }


### PR DESCRIPTION
## Overview
Our entire caching scheme for SSO configurations stored in the database relies on `RevisionDate` stored in the `dbo.SsoConfig` table. This is how we know which configurations have changed or were created since X when we lazy-load or revise cache.

It turns out, because we don't have a wrapper service implementation for SSO configurations themselves, the controllers are calling `Replace()` and `Create()` directly against the repositories, which creates issues because `RevisionDate` has an internally protected property setter.

This fix overrides the Create and Replace methods to explicitly set the appropriate `CreationDate` and/or `RevisionDate` directly since the controller cannot and there's no core service like other table wrappers have.

Also, dropped the cache period to a default 30 seconds to aid in rapid integration, testing and turnarounds for our customers and CS team.