### PR TITLE
Handle nameID as email w/o email attribute

### DIFF
--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -351,6 +351,10 @@ namespace Bit.Sso.Controllers
         {
             var name = GetName(claims);
             var email = GetEmailAddress(claims);
+            if (string.IsNullOrWhiteSpace(email) && providerUserId.Contains("@"))
+            {
+                email = providerUserId;
+            }
 
             Guid? orgId = null;
             if (Guid.TryParse(provider, out var oId))


### PR DESCRIPTION
## Overview
If using Email for the NameID which is passed in the Subject claim, it gets removed from the claims list finally passed down to auto provision the user account, and then it can't find an email address if it is not _also_ passed as a SAML attribute in the assertion from the IdP. This fix basically adds a last-ditch check to see if the provider's user identifier _is also_ the user's email address if no other email address if found in the assertion (we can't just assume this up-front because it may be a netID or another non-deliverable identifier only formatted as an email address but there is a separate email address provided in the attributes for deliverability for that user).

cc: @sevensixseven 