### PR TITLE
Fixed resource and err msg for user provisioning

### DIFF
--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -449,7 +449,7 @@ namespace Bit.Sso.Controllers
                 if (existingUser != null)
                 {
                     // TODO: send an email inviting this user to link SSO to their account?
-                    throw new Exception(_i18nService.T("NoDomainHintProvided"));
+                    throw new Exception(_i18nService.T("UserAlreadyExistsUseLinkViaSso"));
                 }
 
                 // Create user record

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -523,7 +523,7 @@
   <data name="UserAlreadyInvited" xml:space="preserve">
     <value>User, '{0}', has already been invited to this organization, '{1}'</value>
   </data>
-  <data name="NoDomainHintProvided" xml:space="preserve">
+  <data name="UserAlreadyExistsUseLinkViaSso" xml:space="preserve">
     <value>User already exists, please link account to SSO after logging in</value>
   </data>
 </root>


### PR DESCRIPTION
## Overview
There was a copy and paste error (duplicate key) with the resource strings around the error message that occurs when there's an existing user who SSO's in but is not associated with that organization but instead the error, "No domain_hint provided" was being thrown, which was confusing users trying to implement SSO configurations and test them.