### PR TITLE
Fixed storage issue when upgrading from a free plan

### DIFF
--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -253,8 +253,6 @@ namespace Bit.Core.Services
             organization.PlanType = newPlan.Type;
             organization.Seats = (short)(newPlan.BaseSeats + upgrade.AdditionalSeats);
             organization.MaxCollections = newPlan.MaxCollections;
-            organization.MaxStorageGb = !newPlan.BaseStorageGb.HasValue ?
-                (short?)null : (short)(newPlan.BaseStorageGb.Value + upgrade.AdditionalStorageGb);
             organization.UseGroups = newPlan.HasGroups;
             organization.UseDirectory = newPlan.HasDirectory;
             organization.UseEvents = newPlan.HasEvents;
@@ -263,8 +261,8 @@ namespace Bit.Core.Services
             organization.UseApi = newPlan.HasApi;
             organization.SelfHost = newPlan.HasSelfHost;
             organization.UsePolicies = newPlan.HasPolicies;
-            organization.MaxStorageGb = !newPlan.MaxAdditionalStorage.HasValue ?
-                (short?)null : (short)(newPlan.MaxAdditionalStorage.Value + upgrade.AdditionalStorageGb);
+            organization.MaxStorageGb = !newPlan.BaseStorageGb.HasValue ?
+                (short?)null : (short)(newPlan.BaseStorageGb.Value + upgrade.AdditionalStorageGb);
             organization.UseGroups = newPlan.HasGroups;
             organization.UseDirectory = newPlan.HasDirectory;
             organization.UseEvents = newPlan.HasEvents;


### PR DESCRIPTION
Max storage for an org was being set incorrectly when upgrading from a Free org to another type. This is causing upgraded organizations not to have any additional storage when they should.

Setting org.MaxStorage based on plan.BaseStorage + upgrade.AdditionalStorage fixes the issue.