### PR TITLE
[SSO] New user provision flow

### DIFF
--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -468,7 +468,7 @@ namespace Bit.Sso.Controllers
                         OrganizationId = orgId.Value,
                         UserId = user.Id,
                         Type = OrganizationUserType.User,
-                        Status = OrganizationUserStatusType.Accepted
+                        Status = OrganizationUserStatusType.Invited
                     };
                     await _organizationUserRepository.CreateAsync(orgUser);
                 }

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -17,7 +17,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using IdentityServer4.Extensions;
 
 namespace Bit.Api.Controllers
 {
@@ -214,13 +213,6 @@ namespace Bit.Api.Controllers
             var result = await _userService.SetPasswordAsync(model.ToUser(user), model.MasterPasswordHash, model.Key);
             if (result.Succeeded)
             {
-                if (!model.OrgIdentifier.IsNullOrEmpty())
-                {
-                    var acceptResult =
-                        await _organizationService.AcceptUserAsync(model.OrgIdentifier, model.ToUser(user),
-                            _userService);
-                }
-
                 return;
             }
 

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using IdentityServer4.Extensions;
 
 namespace Bit.Api.Controllers
 {
@@ -213,6 +214,13 @@ namespace Bit.Api.Controllers
             var result = await _userService.SetPasswordAsync(model.ToUser(user), model.MasterPasswordHash, model.Key);
             if (result.Succeeded)
             {
+                if (!model.OrgIdentifier.IsNullOrEmpty())
+                {
+                    var acceptResult =
+                        await _organizationService.AcceptUserAsync(model.OrgIdentifier, model.ToUser(user),
+                            _userService);
+                }
+
                 return;
             }
 

--- a/src/Core/Models/Api/Request/Accounts/SetPasswordRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/SetPasswordRequestModel.cs
@@ -19,6 +19,7 @@ namespace Bit.Core.Models.Api.Request.Accounts
         public KdfType Kdf { get; set; }
         [Required]
         public int KdfIterations { get; set; }
+        public string OrgIdentifier { get; set; }
 
         public User ToUser(User existingUser)
         {

--- a/src/Core/Services/IOrganizationService.cs
+++ b/src/Core/Services/IOrganizationService.cs
@@ -38,6 +38,7 @@ namespace Bit.Core.Services
         Task ResendInviteAsync(Guid organizationId, Guid? invitingUserId, Guid organizationUserId);
         Task<OrganizationUser> AcceptUserAsync(Guid organizationUserId, User user, string token,
             IUserService userService);
+        Task<OrganizationUser> AcceptUserAsync(string orgIdentifier, User user, IUserService userService);
         Task<OrganizationUser> ConfirmUserAsync(Guid organizationId, Guid organizationUserId, string key,
             Guid confirmingUserId, IUserService userService);
         Task SaveUserAsync(OrganizationUser user, Guid? savingUserId, IEnumerable<SelectionReadOnly> collections);

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -32,7 +32,7 @@ namespace Bit.Core.Services
         Task<IdentityResult> ChangeEmailAsync(User user, string masterPassword, string newEmail, string newMasterPassword,
             string token, string key);
         Task<IdentityResult> ChangePasswordAsync(User user, string masterPassword, string newMasterPassword, string key);
-        Task<IdentityResult> SetPasswordAsync(User user, string newMasterPassword, string key);
+        Task<IdentityResult> SetPasswordAsync(User user, string newMasterPassword, string key, string orgIdentifier = null);
         Task<IdentityResult> ChangeKdfAsync(User user, string masterPassword, string newMasterPassword, string key,
             KdfType kdf, int kdfIterations);
         Task<IdentityResult> UpdateKeyAsync(User user, string masterPassword, string key, string privateKey,

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1077,20 +1077,20 @@ namespace Bit.Core.Services
             {
                 throw new BadRequestException("Invalid token.");
             }
-            
+
             if (string.IsNullOrWhiteSpace(orgUser.Email) ||
                 !orgUser.Email.Equals(user.Email, StringComparison.InvariantCultureIgnoreCase))
             {
                 throw new BadRequestException("User email does not match invite.");
             }
-            
+
             var existingOrgUserCount = await _organizationUserRepository.GetCountByOrganizationAsync(
                 orgUser.OrganizationId, user.Email, true);
             if (existingOrgUserCount > 0)
             {
                 throw new BadRequestException("You are already part of this organization.");
             }
-            
+
             return await AcceptUserAsync(orgUser, user, userService);
         }
         
@@ -1101,14 +1101,14 @@ namespace Bit.Core.Services
             {
                 throw new BadRequestException("Organization invalid.");
             }
-            
+
             var usersOrgs = await _organizationUserRepository.GetManyByUserAsync(user.Id);
             var orgUser = usersOrgs.FirstOrDefault(u => u.OrganizationId == org.Id);
             if (orgUser == null)
             {
                 throw new BadRequestException("User not found within organization.");
             }
-            
+
             return await AcceptUserAsync(orgUser, user, userService);
         }
         
@@ -1143,13 +1143,13 @@ namespace Bit.Core.Services
                         "two-step login on your user account.");
                 }
             }
-            
+
             orgUser.Status = OrganizationUserStatusType.Accepted;
             orgUser.UserId = user.Id;
             orgUser.Email = null;
-            
+
             await _organizationUserRepository.ReplaceAsync(orgUser);
-            
+
             // TODO: send notification emails to org admins and accepting user?
             return orgUser;
         }

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1068,7 +1068,6 @@ namespace Bit.Core.Services
             IUserService userService)
         {
             var orgUser = await _organizationUserRepository.GetByIdAsync(organizationUserId);
-            
             if (orgUser == null)
             {
                 throw new BadRequestException("User invalid.");
@@ -1098,12 +1097,16 @@ namespace Bit.Core.Services
         public async Task<OrganizationUser> AcceptUserAsync(string orgIdentifier, User user, IUserService userService)
         {
             var org = await _organizationRepository.GetByIdentifierAsync(orgIdentifier);
+            if (org == null)
+            {
+                throw new BadRequestException("Organization invalid.");
+            }
+            
             var usersOrgs = await _organizationUserRepository.GetManyByUserAsync(user.Id);
             var orgUser = usersOrgs.FirstOrDefault(u => u.OrganizationId == org.Id);
-            
             if (orgUser == null)
             {
-                throw new BadRequestException("User invalid.");
+                throw new BadRequestException("User not found within organization.");
             }
             
             return await AcceptUserAsync(orgUser, user, userService);

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1085,6 +1085,13 @@ namespace Bit.Core.Services
                 throw new BadRequestException("User email does not match invite.");
             }
             
+            var existingOrgUserCount = await _organizationUserRepository.GetCountByOrganizationAsync(
+                orgUser.OrganizationId, user.Email, true);
+            if (existingOrgUserCount > 0)
+            {
+                throw new BadRequestException("You are already part of this organization.");
+            }
+            
             return await AcceptUserAsync(orgUser, user, userService);
         }
         
@@ -1123,14 +1130,7 @@ namespace Bit.Core.Services
                     }
                 }
             }
-            
-            var existingOrgUserCount = await _organizationUserRepository.GetCountByOrganizationAsync(
-                orgUser.OrganizationId, user.Email, true);
-            if (existingOrgUserCount > 0)
-            {
-                throw new BadRequestException("You are already part of this organization.");
-            }
-            
+
             if (!await userService.TwoFactorIsEnabledAsync(user))
             {
                 var policies = await _policyRepository.GetManyByOrganizationIdAsync(orgUser.OrganizationId);

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1093,7 +1093,7 @@ namespace Bit.Core.Services
 
             return await AcceptUserAsync(orgUser, user, userService);
         }
-        
+
         public async Task<OrganizationUser> AcceptUserAsync(string orgIdentifier, User user, IUserService userService)
         {
             var org = await _organizationRepository.GetByIdentifierAsync(orgIdentifier);
@@ -1111,7 +1111,7 @@ namespace Bit.Core.Services
 
             return await AcceptUserAsync(orgUser, user, userService);
         }
-        
+
         private async Task<OrganizationUser> AcceptUserAsync(OrganizationUser orgUser, User user, 
             IUserService userService)
         {

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1072,7 +1072,7 @@ namespace Bit.Core.Services
             {
                 throw new BadRequestException("User invalid.");
             }
-            
+
             if (!CoreHelpers.UserInviteTokenIsValid(_dataProtector, token, user.Email, orgUser.Id, _globalSettings))
             {
                 throw new BadRequestException("Invalid token.");

--- a/test/Core.Test/Services/UserServiceTests.cs
+++ b/test/Core.Test/Services/UserServiceTests.cs
@@ -41,6 +41,7 @@ namespace Bit.Core.Test.Services
         private readonly IReferenceEventService _referenceEventService;
         private readonly CurrentContext _currentContext;
         private readonly GlobalSettings _globalSettings;
+        private readonly IOrganizationService _organizationService;
 
         public UserServiceTests()
         {
@@ -69,6 +70,7 @@ namespace Bit.Core.Test.Services
             _referenceEventService = Substitute.For<IReferenceEventService>();
             _currentContext = new CurrentContext();
             _globalSettings = new GlobalSettings();
+            _organizationService = Substitute.For<IOrganizationService>();
 
             _sut = new UserService(
                 _userRepository,
@@ -95,7 +97,8 @@ namespace Bit.Core.Test.Services
                 _policyRepository,
                 _referenceEventService,
                 _currentContext,
-                _globalSettings
+                _globalSettings,
+                _organizationService
             );
         }
 


### PR DESCRIPTION
## Objective
> Currently, when a new bitwarden/org user is created, they are given a status of `accepted`.  This can create issues for organizations trying to `confirm` the same user (which can't happen until they've set their master password). To alleviate the issue, change new user's `orgUser` status to invited until after they've set a master password.

## Code Changes
- **Sso/Controllers/AccountController**: Changed new user/ new org user creation to apply the `invited` status
- **Api/Controllers/AccountsController**: Adjusted `PostSetPasswordAsync` to daisy chain call to newly created `AcceptUserAsync` function.
- **Core/.../SetPasswordRequestModel**: Added `orgIdentifier` string
- **Core/.../IOrganizationService (abstraction)**: Added new `AcceptUserAsync` function
- **Core/.../IUserService (abstraction)**: Added `null` by default `orgIdentifier` param
- **Core/.../OrganizationService**: Created two feeder functions used in different user acceptance scenarios. **NOTE: I had to add a few more checks than what was originally discussed for the token flow. `OrgUser` email will be null for those created JIT during SSO. The count check was also coming back true because we assign the `userId` to the `orgUser` during JIT.**
- **Core/.../UserService**: Added `OrganizatinoService` import/updated constructor. Moved business logic for handling accept user flow into `SetPasswordAsync`. Also added null by default `orgIdentifier` into the params.
- **UserServiceTests**: Added/Updated import and constructor for existing test
