### PR TITLE
fixed faulty conditional logic for showing enabled policy labels

### DIFF
--- a/bitwarden_license/src/Portal/Models/PoliciesModel.cs
+++ b/bitwarden_license/src/Portal/Models/PoliciesModel.cs
@@ -20,7 +20,7 @@ namespace Bit.Portal.Models
 
             foreach (var type in Enum.GetValues(typeof(PolicyType)).Cast<PolicyType>())
             {
-                var enabled = policyDict?.ContainsKey(type) ?? false && policyDict[type].Enabled;
+                var enabled = policyDict.ContainsKey(type) ? policyDict[type].Enabled : false;
                 Policies.Add(new PolicyModel(type, enabled));
             }
         }


### PR DESCRIPTION
Fixes https://github.com/bitwarden/server/issues/951

### Issue
The "Policy Enabled" badge is showing next to any policy that has even been enabled instead of policies that are currently enabled.

<img width="496" alt="Screen Shot 2020-09-24 at 11 45 33 AM" src="https://user-images.githubusercontent.com/15897251/94168282-76fd1d00-fe5b-11ea-9ecd-78d3293a3b61.png">

### Solution
The original logic here was stopping at the `true` returned by `ContainsKey()` if a policy existed. This means that if a policy had ever been enabled, even if it is currently not enabled, we flagged it as enabled in the logic below.

- Removed null conditional operator from policyDict because it is declared above with a minimum value of an empty dict, and having the null conditional operator was blocking using ContainsKey() as a true boolean condition.

- Checked `policy.Enabled` when `ContainsKey()` is true 