### PR TITLE
Implemented new OIDC redirect behavior

### DIFF
--- a/bitwarden_license/src/Portal/Models/SsoConfigDataViewModel.cs
+++ b/bitwarden_license/src/Portal/Models/SsoConfigDataViewModel.cs
@@ -10,6 +10,7 @@ using U2F.Core.Utils;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 
 namespace Bit.Portal.Models
 {
@@ -26,6 +27,7 @@ namespace Bit.Portal.Models
             CallbackPath = configurationData.BuildCallbackPath(globalSettings.BaseServiceUri.Sso);
             SignedOutCallbackPath = configurationData.BuildSignedOutCallbackPath(globalSettings.BaseServiceUri.Sso);
             MetadataAddress = configurationData.MetadataAddress;
+            RedirectBehavior = configurationData.RedirectBehavior;
             GetClaimsFromUserInfoEndpoint = configurationData.GetClaimsFromUserInfoEndpoint;
             SpEntityId = configurationData.BuildSaml2ModulePath(globalSettings.BaseServiceUri.Sso);
             SpAcsUrl = configurationData.BuildSaml2AcsUrl(globalSettings.BaseServiceUri.Sso);
@@ -63,6 +65,8 @@ namespace Bit.Portal.Models
         public string SignedOutCallbackPath { get; set; }
         [Display(Name = "MetadataAddress")]
         public string MetadataAddress { get; set; }
+        [Display(Name = "RedirectBehavior")]
+        public OpenIdConnectRedirectBehavior RedirectBehavior { get; set; }
         [Display(Name = "GetClaimsFromUserInfoEndpoint")]
         public bool GetClaimsFromUserInfoEndpoint { get; set; }
 
@@ -190,6 +194,7 @@ namespace Bit.Portal.Models
                 ClientSecret = ClientSecret,
                 MetadataAddress = MetadataAddress,
                 GetClaimsFromUserInfoEndpoint = GetClaimsFromUserInfoEndpoint,
+                RedirectBehavior = RedirectBehavior,
                 IdpEntityId = IdpEntityId,
                 IdpBindingType = IdpBindingType,
                 IdpSingleSignOnServiceUrl = IdpSingleSignOnServiceUrl,

--- a/bitwarden_license/src/Portal/Models/SsoConfigEditViewModel.cs
+++ b/bitwarden_license/src/Portal/Models/SsoConfigEditViewModel.cs
@@ -9,6 +9,7 @@ using Bit.Core.Models.Data;
 using Bit.Core.Models.Table;
 using Bit.Core.Services;
 using Bit.Core.Sso;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace Bit.Portal.Models
@@ -54,6 +55,7 @@ namespace Bit.Portal.Models
         public List<SelectListItem> BindingTypes { get; set; }
         public List<SelectListItem> SigningBehaviors { get; set; }
         public List<SelectListItem> SigningAlgorithms { get; set; }
+        public List<SelectListItem> RedirectBehaviors { get; set; }
 
         public SsoConfig ToSsoConfig(Guid organizationId)
         {
@@ -103,6 +105,13 @@ namespace Bit.Portal.Models
 
             SigningAlgorithms = SamlSigningAlgorithms.GetEnumerable().Select(a =>
                 new SelectListItem(a, a)).ToList();
+
+            RedirectBehaviors = Enum.GetNames(typeof(OpenIdConnectRedirectBehavior))
+                .Select(behavior => new SelectListItem
+                {
+                    Value = behavior,
+                    Text = i18nService.T(behavior),
+                }).ToList();
         }
     }
 }

--- a/bitwarden_license/src/Portal/Views/Sso/Index.cshtml
+++ b/bitwarden_license/src/Portal/Views/Sso/Index.cshtml
@@ -121,6 +121,13 @@
             </div>
             <div class="row">
                 <div class="col-7 form-group">
+                    <label asp-for="Data.RedirectBehavior">@i18nService.T("RedirectBehavior")</label>
+                    <select asp-for="Data.RedirectBehavior" asp-items="Model.RedirectBehaviors"
+                            class="form-control"></select>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-7 form-group">
                     <div class="form-check">
                         <input asp-for="Data.GetClaimsFromUserInfoEndpoint" type="checkbox" class="form-check-input">
                         <label asp-for="Data.GetClaimsFromUserInfoEndpoint" class="form-check-label"></label>

--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -21,9 +21,6 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Bit.Core.Models.Api;
-using Microsoft.AspNetCore.WebUtilities;
-using Microsoft.Extensions.Primitives;
-using System.Net;
 
 namespace Bit.Sso.Controllers
 {

--- a/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
+++ b/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
@@ -315,6 +315,7 @@ namespace Bit.Core.Business.Sso
                 SignedOutCallbackPath = config.BuildSignedOutCallbackPath(),
                 MetadataAddress = config.MetadataAddress,
                 // Prevents URLs that go beyond 1024 characters which may break for some servers
+                AuthenticationMethod = config.RedirectBehavior,
                 GetClaimsFromUserInfoEndpoint = config.GetClaimsFromUserInfoEndpoint,
             };
 

--- a/src/Core/Models/Data/SsoConfigurationData.cs
+++ b/src/Core/Models/Data/SsoConfigurationData.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Bit.Core.Enums;
 using Bit.Core.Sso;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 
 namespace Bit.Core.Models.Data
 {
@@ -17,6 +18,7 @@ namespace Bit.Core.Models.Data
         public string ClientId { get; set; }
         public string ClientSecret { get; set; }
         public string MetadataAddress { get; set; }
+        public OpenIdConnectRedirectBehavior RedirectBehavior { get; set; } = OpenIdConnectRedirectBehavior.FormPost;
         public bool GetClaimsFromUserInfoEndpoint { get; set; }
 
         // SAML2 IDP

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -526,4 +526,17 @@
   <data name="UserAlreadyExistsUseLinkViaSso" xml:space="preserve">
     <value>User already exists, please link account to SSO after logging in</value>
   </data>
+  <data name="RedirectGet" xml:space="preserve">
+    <value>Redirect GET</value>
+    <comment>An OIDC Connect Redirect Behavior, Redirect; Emits a 302 response 
+    to redirect the user agent to the OpenID Connect provider using a GET request.</comment>
+  </data>
+  <data name="FormPost" xml:space="preserve">
+    <value>Form POST</value>
+    <comment>An OIDC Connect Redirect Behavior, Form POST; Emits an HTML form to
+      redirect the user agent to the OpenID Connect provider using a POST request.</comment>
+  </data>
+  <data name="RedirectBehavior" xml:space="preserve">
+    <value>OIDC Redirect Behavior</value>
+  </data>
 </root>


### PR DESCRIPTION
Resolves and closes #953 

## Overview
OIDC passes claims by default via a state parameter, along with all of our other state, via query-string in the URL performing a GET request. We had started seeing issues in Okta and Azure when implementing OIDC with query-string or URL too long exceptions coming from those Identity Providers when we would send the authorization request.

Turns out, while we had our hard-coded response method set to POST, we missed the authentication method (redirect behavior) of how we actually send the initial request. So while the response was POST back to us, our request should have also been set to POST.

I've made this a configuration option (just in case an IdP doesn't support POST for OIDC) and made it the default going forward.

**OIDC Redirect Behavior** is one of:
* Form POST (default), or
* Redirect GET

## Screenshots
![image](https://user-images.githubusercontent.com/3904944/94614657-840f7700-0274-11eb-9ccf-178a2c99fb35.png)

## Testing
Tested against Okta using OIDC locally to verify the request method leaving our SSO service respects the configuration accordingly and the POST body is encoded correctly and contains the necessary state and claims.

cc: @sevensixseven , @tgreer-bw 