### PR TITLE
Update ACS path to embed Organization ID

### DIFF
--- a/bitwarden_license/src/Portal/Models/SsoConfigDataViewModel.cs
+++ b/bitwarden_license/src/Portal/Models/SsoConfigDataViewModel.cs
@@ -18,7 +18,8 @@ namespace Bit.Portal.Models
     {
         public SsoConfigDataViewModel() { }
 
-        public SsoConfigDataViewModel(SsoConfigurationData configurationData, GlobalSettings globalSettings)
+        public SsoConfigDataViewModel(SsoConfigurationData configurationData, GlobalSettings globalSettings,
+            Guid organizationId)
         {
             ConfigType = configurationData.ConfigType;
             Authority = configurationData.Authority;
@@ -30,7 +31,7 @@ namespace Bit.Portal.Models
             RedirectBehavior = configurationData.RedirectBehavior;
             GetClaimsFromUserInfoEndpoint = configurationData.GetClaimsFromUserInfoEndpoint;
             SpEntityId = configurationData.BuildSaml2ModulePath(globalSettings.BaseServiceUri.Sso);
-            SpAcsUrl = configurationData.BuildSaml2AcsUrl(globalSettings.BaseServiceUri.Sso);
+            SpAcsUrl = configurationData.BuildSaml2AcsUrl(globalSettings.BaseServiceUri.Sso, organizationId.ToString());
             IdpEntityId = configurationData.IdpEntityId;
             IdpBindingType = configurationData.IdpBindingType;
             IdpSingleSignOnServiceUrl = configurationData.IdpSingleSignOnServiceUrl;

--- a/bitwarden_license/src/Portal/Models/SsoConfigEditViewModel.cs
+++ b/bitwarden_license/src/Portal/Models/SsoConfigEditViewModel.cs
@@ -41,7 +41,7 @@ namespace Bit.Portal.Models
                 configurationData = new SsoConfigurationData();
             }
 
-            Data = new SsoConfigDataViewModel(configurationData, globalSettings);
+            Data = new SsoConfigDataViewModel(configurationData, globalSettings, ssoConfig.OrganizationId);
             BuildLists(i18nService);
         }
 

--- a/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
+++ b/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
@@ -340,7 +340,7 @@ namespace Bit.Core.Business.Sso
             var spOptions = new SPOptions
             {
                 EntityId = spEntityId,
-                ModulePath = config.BuildSaml2ModulePath(),
+                ModulePath = config.BuildSaml2ModulePath(null, name),
                 NameIdPolicy = new Saml2NameIdPolicy(allowCreate, GetNameIdFormat(config.SpNameIdFormat)),
                 WantAssertionsSigned = config.SpWantAssertionsSigned,
                 AuthenticateRequestSigningBehavior = GetSigningBehavior(config.SpSigningBehavior),

--- a/src/Core/Models/Data/SsoConfigurationData.cs
+++ b/src/Core/Models/Data/SsoConfigurationData.cs
@@ -50,14 +50,15 @@ namespace Bit.Core.Models.Data
             return BuildSsoUrl(_oidcSignedOutPath, ssoUri);
         }
 
-        public string BuildSaml2ModulePath(string ssoUri = null)
+        public string BuildSaml2ModulePath(string ssoUri = null, string scheme = null)
         {
-            return BuildSsoUrl(_saml2ModulePath, ssoUri);
+            return string.Concat(BuildSsoUrl(_saml2ModulePath, ssoUri),
+                string.IsNullOrWhiteSpace(scheme) ? string.Empty : $"/{scheme}");
         }
 
-        public string BuildSaml2AcsUrl(string ssoUri = null)
+        public string BuildSaml2AcsUrl(string ssoUri = null, string scheme = null)
         {
-            return string.Concat(BuildSaml2ModulePath(ssoUri), "/Acs");
+            return string.Concat(BuildSaml2ModulePath(ssoUri, scheme), "/Acs");
         }
 
         private string BuildSsoUrl(string relativePath, string ssoUri)


### PR DESCRIPTION
## Overview
We found an issue where certificate keys were not trusted while working with a customer setting up SAML, it turns out that some folks end up creating duplicate/colliding IdP Entity IDs, which for us causes issues matching an SSO request on the round-trip back to us with the correct Org configuration and when that happens while the signature provided validates, the key itself won't match the SSO configuration we're attempting to match it against and SSO login fails (a good and bad thing).

This change alters the ACS path to embed the Org ID in the URL, this guarantees we get the right Org back and then everyone can have duplicate Entity IDs, we wouldn’t care at that point.

### Considerations
If an org via their IdP have ACS validation turned on, and the `“AssertionConsumerServiceURL”` parameter we send in the AuthnRequest during SSO changes IdP validation may fail until they update their configuration with the new ACS URL from the business portal.

If they don’t have ACS validation turned on the IdP should redirect as expected back to the provided ACS URL from the AuthnRequest we send to them.

If they always use their own ACS URL regardless of what's sent, we will return a `404 - Not Found` because the handler for that request will not be able to be located until the SSO configuration admin updates the IdP configuration's ACS URL.

There was no way to make this accept either/or given the way SustainSys.Saml2 has implemented the base Saml2Handler and  validation around the underlying module path configured in the SP Options.