### PR TITLE
enabled SSO when needed when upgrading from a free plan

### DIFF
--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -269,6 +269,7 @@ namespace Bit.Core.Services
             organization.UseTotp = newPlan.HasTotp;
             organization.Use2fa = newPlan.Has2fa;
             organization.UseApi = newPlan.HasApi;
+            organization.UseSso = newPlan.HasSso;
             organization.SelfHost = newPlan.HasSelfHost;
             organization.UsersGetPremium = newPlan.UsersGetPremium || upgrade.PremiumAccessAddon;
             organization.Plan = newPlan.Name;


### PR DESCRIPTION
### Bug 🪲
When upgrading from a free plan to an enterprise plan SSO is not being turned on

### Fix 🌈
Enable SSO when upgrading from a free plan to an enterprise plan

[Relevant Asana ticket with more info](https://app.asana.com/0/1195018406457675/1196087783601361)