### PR TITLE
Fix null ref exception for new org SSO

### DIFF
--- a/bitwarden_license/src/Portal/Controllers/SsoController.cs
+++ b/bitwarden_license/src/Portal/Controllers/SsoController.cs
@@ -47,7 +47,7 @@ namespace Bit.Portal.Controllers
             }
 
             var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(orgId.Value);
-            var model = new SsoConfigEditViewModel(ssoConfig, _i18nService, _globalSettings);
+            var model = new SsoConfigEditViewModel(ssoConfig, orgId.Value, _i18nService, _globalSettings);
 
             return View(model);
         }

--- a/bitwarden_license/src/Portal/Models/SsoConfigEditViewModel.cs
+++ b/bitwarden_license/src/Portal/Models/SsoConfigEditViewModel.cs
@@ -18,8 +18,8 @@ namespace Bit.Portal.Models
     {
         public SsoConfigEditViewModel() { }
 
-        public SsoConfigEditViewModel(SsoConfig ssoConfig, II18nService i18nService,
-            GlobalSettings globalSettings)
+        public SsoConfigEditViewModel(SsoConfig ssoConfig, Guid organizationId,
+            II18nService i18nService, GlobalSettings globalSettings)
         {
             if (ssoConfig != null)
             {
@@ -41,7 +41,7 @@ namespace Bit.Portal.Models
                 configurationData = new SsoConfigurationData();
             }
 
-            Data = new SsoConfigDataViewModel(configurationData, globalSettings, ssoConfig.OrganizationId);
+            Data = new SsoConfigDataViewModel(configurationData, globalSettings, organizationId);
             BuildLists(i18nService);
         }
 


### PR DESCRIPTION
## Overview
Apparently C# doesn't like it when you try to access a property of an object instance that also happens to be `null` (who knew 🤷🏻 ). When I had implemented the ACS update and ran through testing, it was always with existing SSO configurations to measure impact, but I missed the scenario where a new org, configuring SSO for the first time, would not have any config data, and therefore we couldn't reliably pull out the org ID from that `null` config data (and should instead pass it through directly each time).

## Changes
Pass the organization ID directly through the `SsoConfigEditViewModel` constructor from the Controller so it doesn't try to pull it out of the data instance (which it turns out can legitimately be `null`)