### PR TITLE
Delete OrgUsers When Deleting An Org

### DIFF
--- a/src/Sql/dbo/Stored Procedures/Organization_DeleteById.sql
+++ b/src/Sql/dbo/Stored Procedures/Organization_DeleteById.sql
@@ -37,18 +37,19 @@ BEGIN
     WHERE
         [OrganizationId] = @Id
 
-    DELETE cu
+    DELETE CU
     FROM 
-        [dbo].[CollectionUser] cu
+        [dbo].[CollectionUser] CU
     INNER JOIN 
-        [dbo].[OrganizationUser] ou ON [cu].[OrganizationUserId] = [ou].[Id]
+        [dbo].[OrganizationUser] OU ON [CU].[OrganizationUserId] = [OU].[Id]
     WHERE 
-        [ou].[OrganizationId] = @Id
+        [OU].[OrganizationId] = @Id
 
     DELETE
     FROM 
         [dbo].[OrganizationUser]
-    WHERE [OrganizationId] = @Id
+    WHERE 
+        [OrganizationId] = @Id
 
     DELETE
     FROM

--- a/src/Sql/dbo/Stored Procedures/Organization_DeleteById.sql
+++ b/src/Sql/dbo/Stored Procedures/Organization_DeleteById.sql
@@ -37,6 +37,19 @@ BEGIN
     WHERE
         [OrganizationId] = @Id
 
+    DELETE cu
+    FROM 
+        [dbo].[CollectionUser] cu
+    INNER JOIN 
+        [dbo].[OrganizationUser] ou ON [cu].[OrganizationUserId] = [ou].[Id]
+    WHERE 
+        [ou].[OrganizationId] = @Id
+
+    DELETE
+    FROM 
+        [dbo].[OrganizationUser]
+    WHERE [OrganizationId] = @Id
+
     DELETE
     FROM
         [dbo].[Organization]

--- a/util/Migrator/DbScripts/2020-10-08_00_DeleteOrgUserWithOrg
+++ b/util/Migrator/DbScripts/2020-10-08_00_DeleteOrgUserWithOrg
@@ -1,0 +1,68 @@
+IF OBJECT_ID('[dbo].[Organization_DeleteById]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Organization_DeleteById]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Organization_DeleteById]
+    @Id UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    EXEC [dbo].[User_BumpAccountRevisionDateByOrganizationId] @Id
+
+    DECLARE @BatchSize INT = 100
+    WHILE @BatchSize > 0
+    BEGIN
+        BEGIN TRANSACTION Organization_DeleteById_Ciphers
+
+        DELETE TOP(@BatchSize)
+        FROM
+            [dbo].[Cipher]
+        WHERE
+            [UserId] IS NULL
+            AND [OrganizationId] = @Id
+
+        SET @BatchSize = @@ROWCOUNT
+
+        COMMIT TRANSACTION Organization_DeleteById_Ciphers
+    END
+
+    BEGIN TRANSACTION Organization_DeleteById
+
+    DELETE
+    FROM
+        [dbo].[SsoUser]
+    WHERE
+        [OrganizationId] = @Id
+
+    DELETE
+    FROM
+        [dbo].[SsoConfig]
+    WHERE
+        [OrganizationId] = @Id
+
+    DELETE cu
+    FROM 
+        [dbo].[CollectionUser] cu
+    INNER JOIN 
+        [dbo].[OrganizationUser] ou ON [cu].[OrganizationUserId] = [ou].[Id]
+    WHERE 
+        [ou].[OrganizationId] = @Id
+
+    DELETE
+    FROM 
+        [dbo].[OrganizationUser]
+    WHERE [OrganizationId] = @Id
+
+    DELETE
+    FROM
+        [dbo].[Organization]
+    WHERE
+        [Id] = @Id
+
+    COMMIT TRANSACTION Organization_DeleteById
+END
+
+GO

--- a/util/Migrator/DbScripts/2020-10-08_00_DeleteOrgUserWithOrg
+++ b/util/Migrator/DbScripts/2020-10-08_00_DeleteOrgUserWithOrg
@@ -43,18 +43,19 @@ BEGIN
     WHERE
         [OrganizationId] = @Id
 
-    DELETE cu
+    DELETE CU
     FROM 
-        [dbo].[CollectionUser] cu
+        [dbo].[CollectionUser] CU
     INNER JOIN 
-        [dbo].[OrganizationUser] ou ON [cu].[OrganizationUserId] = [ou].[Id]
+        [dbo].[OrganizationUser] OU ON [CU].[OrganizationUserId] = [OU].[Id]
     WHERE 
-        [ou].[OrganizationId] = @Id
+        [OU].[OrganizationId] = @Id
 
     DELETE
     FROM 
         [dbo].[OrganizationUser]
-    WHERE [OrganizationId] = @Id
+    WHERE 
+        [OrganizationId] = @Id
 
     DELETE
     FROM


### PR DESCRIPTION
## Bug 🕷
Currently deleting an organization leaves some orphaned data in CollectionUser and OrganizationUser records. 

This may have never been an issue before, but now it is causing problems with the [OnlyOrg policy](https://github.com/bitwarden/server/pull/962 ). If an organization has OnlyOrg enabled anyone that may have been left orphaned by a deleted organization can not join the org because an OrgUser record still exists for them from the deleted org.

## Fix 🔨
Delete OrgUser records and CollectionUser records when deleting an organization