### PR TITLE
Attempted fix for admin login redirect issue

### DIFF
--- a/bitwarden_license/src/Portal/Startup.cs
+++ b/bitwarden_license/src/Portal/Startup.cs
@@ -44,7 +44,7 @@ namespace Bit.Portal
                 serviceProvider.GetService<EnterprisePortalCurrentContext>());
 
             // Identity
-            services.AddEnterprisePortalTokenIdentityServices();
+            services.AddEnterprisePortalTokenIdentityServices(globalSettings.SelfHosted ? "/portal" : null);
             if (globalSettings.SelfHosted)
             {
                 services.ConfigureApplicationCookie(options =>

--- a/bitwarden_license/src/Portal/Utilities/EnterprisePortalServiceCollectionExtensions.cs
+++ b/bitwarden_license/src/Portal/Utilities/EnterprisePortalServiceCollectionExtensions.cs
@@ -10,7 +10,7 @@ namespace Bit.Portal.Utilities
     public static class EnterprisePortalServiceCollectionExtensions
     {
         public static (IdentityBuilder, IdentityBuilder) AddEnterprisePortalTokenIdentityServices(
-            this IServiceCollection services)
+            this IServiceCollection services, string basePath = null)
         {
             services.TryAddTransient<ILookupNormalizer, LowerInvariantLookupNormalizer>();
             var passwordlessIdentityBuilder = services.AddIdentity<User, Role>()
@@ -25,9 +25,9 @@ namespace Bit.Portal.Utilities
 
             services.ConfigureApplicationCookie(options =>
             {
-                options.LoginPath = "/login";
-                options.LogoutPath = "/logout";
-                options.AccessDeniedPath = "/access-denied";
+                options.LoginPath = $"{basePath}/login";
+                options.LogoutPath = $"{basePath}/logout";
+                options.AccessDeniedPath = $"{basePath}/access-denied";
                 options.Cookie.Name = $"Bitwarden_BusinessPortal";
                 options.Cookie.HttpOnly = true;
                 options.ExpireTimeSpan = TimeSpan.FromDays(2);

--- a/src/Admin/Startup.cs
+++ b/src/Admin/Startup.cs
@@ -48,7 +48,8 @@ namespace Bit.Admin
             services.AddScoped<CurrentContext>();
 
             // Identity
-            services.AddPasswordlessIdentityServices<ReadOnlyEnvIdentityUserStore>(globalSettings);
+            services.AddPasswordlessIdentityServices<ReadOnlyEnvIdentityUserStore>(globalSettings,
+                globalSettings.SelfHosted ? "/admin" : null);
             services.Configure<SecurityStampValidatorOptions>(options =>
             {
                 options.ValidationInterval = TimeSpan.FromMinutes(5);

--- a/src/Core/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Core/Utilities/ServiceCollectionExtensions.cs
@@ -278,7 +278,8 @@ namespace Bit.Core.Utilities
         }
 
         public static Tuple<IdentityBuilder, IdentityBuilder> AddPasswordlessIdentityServices<TUserStore>(
-            this IServiceCollection services, GlobalSettings globalSettings) where TUserStore : class
+            this IServiceCollection services, GlobalSettings globalSettings,
+            string basePath = null) where TUserStore : class
         {
             services.TryAddTransient<ILookupNormalizer, LowerInvariantLookupNormalizer>();
             services.Configure<DataProtectionTokenProviderOptions>(options =>
@@ -298,9 +299,9 @@ namespace Bit.Core.Utilities
 
             services.ConfigureApplicationCookie(options =>
             {
-                options.LoginPath = "/login";
-                options.LogoutPath = "/";
-                options.AccessDeniedPath = "/login?accessDenied=true";
+                options.LoginPath = $"{basePath}/login";
+                options.LogoutPath = $"{basePath}/";
+                options.AccessDeniedPath = $"{basePath}/login?accessDenied=true";
                 options.Cookie.Name = $"Bitwarden_{globalSettings.ProjectName}";
                 options.Cookie.HttpOnly = true;
                 options.ExpireTimeSpan = TimeSpan.FromDays(2);


### PR DESCRIPTION
## DRAFT 🚧 
This is still in testing/unit testing. Do not approve PR, do not merge.
Fixes and closes #546 

## Overview
It appears there are known issues with DotNet Core MVC (generally when using OWIN, however) where the Cookie Authentication Settings Login path will use the underlying request properties when forming the redirect URL and will ignore the base application path itself, i.e. a path in the application root, `/admin` will redirect to `/login` instead of `/admin/login` and even worse when behind a reverse proxy, etc. will ignore the request domain and instead using the underlying proxy domain.

## Fix
This essentially allows the application invoking the cookie authentication configuration to tell it what base path to set in the configuration options, i.e. `"/admin"` or `"/portal"` (which are the only 2 applications that use this method of auth).

String interpolation of the `$"{basePath}/..."` will simply inject an empty string and leave the value as it was before if `null` is passed in for the `basePath` parameter (for instance, if it's **not** self-hosted).