### PR TITLE
Implement User-based API Keys

### DIFF
--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -756,5 +756,27 @@ namespace Bit.Api.Controllers
                 return response;
             }
         }
+
+        [HttpPost("rotate-api-key")]
+        public async Task<ApiKeyResponseModel> RotateApiKey([FromBody]ApiKeyRequestModel model)
+        {
+            var user = await _userService.GetUserByPrincipalAsync(User);
+            if (user == null)
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            if (!await _userService.CheckPasswordAsync(user, model.MasterPasswordHash))
+            {
+                await Task.Delay(2000);
+                throw new BadRequestException("MasterPasswordHash", "Invalid password.");
+            }
+            else
+            {
+                await _userService.RotateApiKeyAsync(user);
+                var response = new ApiKeyResponseModel(user);
+                return response;
+            }
+        }
     }
 }

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -734,5 +734,27 @@ namespace Bit.Api.Controllers
             var userIdentifier = $"{user.Id},{token}";
             return userIdentifier;
         }
+
+
+        [HttpPost("api-key")]
+        public async Task<ApiKeyResponseModel> ApiKey([FromBody]ApiKeyRequestModel model)
+        {
+            var user = await _userService.GetUserByPrincipalAsync(User);
+            if (user == null)
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            if (!await _userService.CheckPasswordAsync(user, model.MasterPasswordHash))
+            {
+                await Task.Delay(2000);
+                throw new BadRequestException("MasterPasswordHash", "Invalid password.");
+            }
+            else
+            {
+                var response = new ApiKeyResponseModel(user);
+                return response;
+            }
+        }
     }
 }

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -735,7 +735,6 @@ namespace Bit.Api.Controllers
             return userIdentifier;
         }
 
-
         [HttpPost("api-key")]
         public async Task<ApiKeyResponseModel> ApiKey([FromBody]ApiKeyRequestModel model)
         {

--- a/src/Core/IdentityServer/ApiClient.cs
+++ b/src/Core/IdentityServer/ApiClient.cs
@@ -14,7 +14,7 @@ namespace Bit.Core.IdentityServer
             string[] scopes = null)
         {
             ClientId = id;
-            AllowedGrantTypes = new[] { GrantType.ResourceOwnerPassword, GrantType.AuthorizationCode, GrantType.ClientCredentials };
+            AllowedGrantTypes = new[] { GrantType.ResourceOwnerPassword, GrantType.AuthorizationCode };
             RefreshTokenExpiration = TokenExpiration.Sliding;
             RefreshTokenUsage = TokenUsage.ReUse;
             SlidingRefreshTokenLifetime = 86400 * refreshTokenSlidingDays;

--- a/src/Core/IdentityServer/ApiClient.cs
+++ b/src/Core/IdentityServer/ApiClient.cs
@@ -11,11 +11,10 @@ namespace Bit.Core.IdentityServer
             string id,
             int refreshTokenSlidingDays,
             int accessTokenLifetimeHours,
-            string[] scopes = null,
-            ICollection<Secret> clientSecrets = null)
+            string[] scopes = null)
         {
             ClientId = id;
-            AllowedGrantTypes = new[] { GrantType.ResourceOwnerPassword, GrantType.AuthorizationCode };
+            AllowedGrantTypes = new[] { GrantType.ResourceOwnerPassword, GrantType.AuthorizationCode, GrantType.ClientCredentials };
             RefreshTokenExpiration = TokenExpiration.Sliding;
             RefreshTokenUsage = TokenUsage.ReUse;
             SlidingRefreshTokenLifetime = 86400 * refreshTokenSlidingDays;
@@ -54,7 +53,7 @@ namespace Bit.Core.IdentityServer
                 PostLogoutRedirectUris = new[] { globalSettings.BaseServiceUri.Vault };
                 AllowedCorsOrigins = new[] { globalSettings.BaseServiceUri.Vault };
             }
-            else if (id.StartsWith("cli"))
+            else if (id == "cli")
             {
                 var cliUris = new List<string>();
                 for (var port = 8065; port <= 8070; port++)
@@ -63,11 +62,6 @@ namespace Bit.Core.IdentityServer
                 }
                 RedirectUris = cliUris;
                 PostLogoutRedirectUris = cliUris;
-                
-                if (clientSecrets != null) 
-                {
-                  ClientSecrets = clientSecrets;
-                }
             }
             else if (id == "mobile")
             {

--- a/src/Core/IdentityServer/ApiClient.cs
+++ b/src/Core/IdentityServer/ApiClient.cs
@@ -11,7 +11,8 @@ namespace Bit.Core.IdentityServer
             string id,
             int refreshTokenSlidingDays,
             int accessTokenLifetimeHours,
-            string[] scopes = null)
+            string[] scopes = null,
+            ICollection<Secret> clientSecrets = null)
         {
             ClientId = id;
             AllowedGrantTypes = new[] { GrantType.ResourceOwnerPassword, GrantType.AuthorizationCode };
@@ -53,7 +54,7 @@ namespace Bit.Core.IdentityServer
                 PostLogoutRedirectUris = new[] { globalSettings.BaseServiceUri.Vault };
                 AllowedCorsOrigins = new[] { globalSettings.BaseServiceUri.Vault };
             }
-            else if (id == "cli")
+            else if (id.StartsWith("cli"))
             {
                 var cliUris = new List<string>();
                 for (var port = 8065; port <= 8070; port++)
@@ -62,6 +63,11 @@ namespace Bit.Core.IdentityServer
                 }
                 RedirectUris = cliUris;
                 PostLogoutRedirectUris = cliUris;
+                
+                if (clientSecrets != null) 
+                {
+                  ClientSecrets = clientSecrets;
+                }
             }
             else if (id == "mobile")
             {

--- a/src/Core/IdentityServer/ClientStore.cs
+++ b/src/Core/IdentityServer/ClientStore.cs
@@ -113,7 +113,7 @@ namespace Bit.Core.IdentityServer
             else if (clientId.StartsWith("user."))
             {
                 var idParts = clientId.Split('.');
-                if (idParts.Length > 2 && Guid.TryParse(idParts[2], out var id))
+                if (idParts.Length > 1 && Guid.TryParse(idParts[1], out var id))
                 {
                     var user = await _userRepository.GetByIdAsync(id);
                     if (user != null)

--- a/src/Core/IdentityServer/ClientStore.cs
+++ b/src/Core/IdentityServer/ClientStore.cs
@@ -124,7 +124,6 @@ namespace Bit.Core.IdentityServer
                             cliUris.Add(string.Format("http://localhost:{0}", port));
                         }
 
-                        Console.WriteLine(user.Id);
                         return new Client
                         {
                             ClientId = clientId,

--- a/src/Core/IdentityServer/ClientStore.cs
+++ b/src/Core/IdentityServer/ClientStore.cs
@@ -110,7 +110,7 @@ namespace Bit.Core.IdentityServer
                     }
                 }
             }
-            else if (clientId.Contains("user."))
+            else if (clientId.StartsWith("user."))
             {
                 var idParts = clientId.Split('.');
                 if (idParts.Length > 2 && Guid.TryParse(idParts[2], out var id))

--- a/src/Core/IdentityServer/ClientStore.cs
+++ b/src/Core/IdentityServer/ClientStore.cs
@@ -118,12 +118,6 @@ namespace Bit.Core.IdentityServer
                     var user = await _userRepository.GetByIdAsync(id);
                     if (user != null)
                     {
-                        var cliUris = new List<string>();
-                        for (var port = 8065; port <= 8070; port++)
-                        {
-                            cliUris.Add(string.Format("http://localhost:{0}", port));
-                        }
-
                         return new Client
                         {
                             ClientId = clientId,
@@ -132,8 +126,6 @@ namespace Bit.Core.IdentityServer
                             AllowedScopes = new string[] { "api" },
                             AllowedGrantTypes = GrantTypes.ClientCredentials,
                             AccessTokenLifetime = 3600 * 1,
-                            RedirectUris = cliUris,
-                            PostLogoutRedirectUris = cliUris,
                             Claims = new List<ClientClaim>
                             {
                                 new ClientClaim(JwtClaimTypes.Subject, user.Id.ToString()),

--- a/src/Core/IdentityServer/CustomTokenRequestValidator.cs
+++ b/src/Core/IdentityServer/CustomTokenRequestValidator.cs
@@ -43,7 +43,8 @@ namespace Bit.Core.IdentityServer
 
         public async Task ValidateAsync(CustomTokenRequestValidationContext context)
         {
-            if (context.Result.ValidatedRequest.GrantType != "authorization_code" && context.Result.ValidatedRequest.GrantType != "client_credentials")
+            string[] allowedGrantTypes = { "authorization_code", "client_credentials" };
+            if (!allowedGrantTypes.Contains(context.Result.ValidatedRequest.GrantType))
             {
                 return;
             }

--- a/src/Core/IdentityServer/CustomTokenRequestValidator.cs
+++ b/src/Core/IdentityServer/CustomTokenRequestValidator.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using Bit.Core.Identity;
 using Microsoft.Extensions.Logging;
 using IdentityServer4.Extensions;
+using IdentityModel;
 
 namespace Bit.Core.IdentityServer
 {
@@ -42,7 +43,7 @@ namespace Bit.Core.IdentityServer
 
         public async Task ValidateAsync(CustomTokenRequestValidationContext context)
         {
-            if (context.Result.ValidatedRequest.GrantType != "authorization_code")
+            if (context.Result.ValidatedRequest.GrantType != "authorization_code" && context.Result.ValidatedRequest.GrantType != "client_credentials")
             {
                 return;
             }
@@ -51,7 +52,9 @@ namespace Bit.Core.IdentityServer
 
         protected async override Task<(User, bool)> ValidateContextAsync(CustomTokenRequestValidationContext context)
         {
-            var user = await _userManager.FindByEmailAsync(context.Result.ValidatedRequest.Subject.GetDisplayName());
+            var email = context.Result.ValidatedRequest.Subject?.GetDisplayName() 
+                ?? context.Result.ValidatedRequest.ClientClaims.FirstOrDefault(claim => claim.Type == JwtClaimTypes.Email).Value;
+            var user = await _userManager.FindByEmailAsync(email);
             return (user, user != null);
         }
 

--- a/src/Core/IdentityServer/ProfileService.cs
+++ b/src/Core/IdentityServer/ProfileService.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System;
 using IdentityModel;
+using Bit.Core.Utilities;
 
 namespace Bit.Core.IdentityServer
 {
@@ -39,56 +40,15 @@ namespace Bit.Core.IdentityServer
             if (user != null)
             {
                 var isPremium = await _licensingService.ValidateUserPremiumAsync(user);
-                newClaims.AddRange(new List<Claim>
-                {
-                    new Claim("premium", isPremium ? "true" : "false", ClaimValueTypes.Boolean),
-                    new Claim(JwtClaimTypes.Email, user.Email),
-                    new Claim(JwtClaimTypes.EmailVerified, user.EmailVerified ? "true" : "false",
-                        ClaimValueTypes.Boolean),
-                    new Claim("sstamp", user.SecurityStamp)
-                });
-
-                if (!string.IsNullOrWhiteSpace(user.Name))
-                {
-                    newClaims.Add(new Claim(JwtClaimTypes.Name, user.Name));
-                }
-
-                // Orgs that this user belongs to
                 var orgs = await _currentContext.OrganizationMembershipAsync(_organizationUserRepository, user.Id);
-                if (orgs.Any())
+                foreach (var claim in CoreHelpers.BuildIdentityClaims(user, orgs, isPremium))
                 {
-                    foreach (var group in orgs.GroupBy(o => o.Type))
-                    {
-                        switch (group.Key)
-                        {
-                            case Enums.OrganizationUserType.Owner:
-                                foreach (var org in group)
-                                {
-                                    newClaims.Add(new Claim("orgowner", org.Id.ToString()));
-                                }
-                                break;
-                            case Enums.OrganizationUserType.Admin:
-                                foreach (var org in group)
-                                {
-                                    newClaims.Add(new Claim("orgadmin", org.Id.ToString()));
-                                }
-                                break;
-                            case Enums.OrganizationUserType.Manager:
-                                foreach (var org in group)
-                                {
-                                    newClaims.Add(new Claim("orgmanager", org.Id.ToString()));
-                                }
-                                break;
-                            case Enums.OrganizationUserType.User:
-                                foreach (var org in group)
-                                {
-                                    newClaims.Add(new Claim("orguser", org.Id.ToString()));
-                                }
-                                break;
-                            default:
-                                break;
-                        }
-                    }
+                    var upperValue = claim.Value.ToUpperInvariant();
+                    var isBool = upperValue == "TRUE" || upperValue == "FALSE";
+                    newClaims.Add(isBool ?
+                        new Claim(claim.Key, claim.Value, ClaimValueTypes.Boolean) :
+                        new Claim(claim.Key, claim.Value)
+                    );
                 }
             }
 

--- a/src/Core/Models/Api/Response/ApiKeyResponseModel.cs
+++ b/src/Core/Models/Api/Response/ApiKeyResponseModel.cs
@@ -15,6 +15,16 @@ namespace Bit.Core.Models.Api
             ApiKey = organization.ApiKey;
         }
 
+        public ApiKeyResponseModel(User user, string obj = "apiKey")
+            : base(obj)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+            ApiKey = user.ApiKey;
+        }
+
         public string ApiKey { get; set; }
     }
 }

--- a/src/Core/Models/Table/User.cs
+++ b/src/Core/Models/Table/User.cs
@@ -3,8 +3,6 @@ using Bit.Core.Enums;
 using Bit.Core.Utilities;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Bit.Core.Services;
-using Bit.Core.Exceptions;
 using Microsoft.AspNetCore.Identity;
 
 namespace Bit.Core.Models.Table
@@ -39,6 +37,7 @@ namespace Bit.Core.Models.Table
         public string GatewaySubscriptionId { get; set; }
         public string ReferenceData { get; set; }
         public string LicenseKey { get; set; }
+        public string ApiKey { get; set; }
         public KdfType Kdf { get; set; } = KdfType.PBKDF2_SHA256;
         public int KdfIterations { get; set; } = 5000;
         public DateTime CreationDate { get; internal set; } = DateTime.UtcNow;

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -69,5 +69,6 @@ namespace Bit.Core.Services
         Task<bool> TwoFactorProviderIsEnabledAsync(TwoFactorProviderType provider, ITwoFactorProvidersUser user);
         Task<string> GenerateEnterprisePortalSignInTokenAsync(User user);
         Task<string> GenerateSignInTokenAsync(User user, string purpose);
+        Task RotateApiKeyAsync(User user);
     }
 }

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -1204,5 +1204,12 @@ namespace Bit.Core.Services
             }
             return result;
         }
+
+        public async Task RotateApiKeyAsync(User user)
+        {
+            user.ApiKey = CoreHelpers.SecureRandomString(30);
+            user.RevisionDate = DateTime.UtcNow;
+            await _userRepository.ReplaceAsync(user);
+        }
     }
 }

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -292,6 +292,7 @@ namespace Bit.Core.Services
                 }
             }
 
+            user.ApiKey = CoreHelpers.SecureRandomString(30);
             var result = await base.CreateAsync(user, masterPassword);
             if (result == IdentityResult.Success)
             {

--- a/src/Sql/dbo/Stored Procedures/User_Create.sql
+++ b/src/Sql/dbo/Stored Procedures/User_Create.sql
@@ -28,7 +28,8 @@
     @Kdf TINYINT,
     @KdfIterations INT,
     @CreationDate DATETIME2(7),
-    @RevisionDate DATETIME2(7)
+    @RevisionDate DATETIME2(7),
+    @ApiKey VARCHAR(30)
 AS
 BEGIN
     SET NOCOUNT ON
@@ -64,7 +65,8 @@ BEGIN
         [Kdf],
         [KdfIterations],
         [CreationDate],
-        [RevisionDate]
+        [RevisionDate],
+        [ApiKey]
     )
     VALUES
     (
@@ -97,6 +99,7 @@ BEGIN
         @Kdf,
         @KdfIterations,
         @CreationDate,
-        @RevisionDate
+        @RevisionDate,
+        @ApiKey
     )
 END

--- a/src/Sql/dbo/Stored Procedures/User_Update.sql
+++ b/src/Sql/dbo/Stored Procedures/User_Update.sql
@@ -28,7 +28,8 @@
     @Kdf TINYINT,
     @KdfIterations INT,
     @CreationDate DATETIME2(7),
-    @RevisionDate DATETIME2(7)
+    @RevisionDate DATETIME2(7),
+    @ApiKey VARCHAR(30)
 AS
 BEGIN
     SET NOCOUNT ON
@@ -64,7 +65,8 @@ BEGIN
         [Kdf] = @Kdf,
         [KdfIterations] = @KdfIterations,
         [CreationDate] = @CreationDate,
-        [RevisionDate] = @RevisionDate
+        [RevisionDate] = @RevisionDate,
+        [ApiKey] = @ApiKey
     WHERE
         [Id] = @Id
 END

--- a/src/Sql/dbo/Tables/User.sql
+++ b/src/Sql/dbo/Tables/User.sql
@@ -29,6 +29,7 @@
     [KdfIterations]                   INT              NOT NULL,
     [CreationDate]                    DATETIME2 (7)    NOT NULL,
     [RevisionDate]                    DATETIME2 (7)    NOT NULL,
+    [ApiKey]                          VARCHAR (30)     NOT NULL,
     CONSTRAINT [PK_User] PRIMARY KEY CLUSTERED ([Id] ASC)
 );
 

--- a/test/Api.Test/Controllers/AccountsControllerTests.cs
+++ b/test/Api.Test/Controllers/AccountsControllerTests.cs
@@ -304,6 +304,66 @@ namespace Bit.Api.Test.Controllers
             );
         }
 
+        [Fact]
+        public async Task GetApiKey_ShouldReturnApiKeyResponse()
+        {
+            var user = GenerateExampleUser();
+            ConfigureUserServiceToReturnValidPrincipalFor(user);
+            ConfigureUserServiceToAcceptPasswordFor(user);
+            await _sut.ApiKey(new ApiKeyRequestModel());
+        }
+
+        [Fact]
+        public async Task GetApiKey_WhenUserDoesNotExist_ShouldThrowUnauthorizedAccessException()
+        {
+            ConfigureUserServiceToReturnNullPrincipal();
+
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(
+                () => _sut.ApiKey(new ApiKeyRequestModel())
+            );
+        }
+
+        [Fact]
+        public async Task GetApiKey_WhenPasswordCheckFails_ShouldThrowBadRequestException()
+        {
+            var user = GenerateExampleUser();
+            ConfigureUserServiceToReturnValidPrincipalFor(user);
+            ConfigureUserServiceToRejectPasswordFor(user);
+            await Assert.ThrowsAsync<BadRequestException>(
+                () => _sut.ApiKey(new ApiKeyRequestModel())
+            );
+        }
+
+        [Fact]
+        public async Task PostRotateApiKey_ShouldRotateApiKey()
+        {
+            var user = GenerateExampleUser();
+            ConfigureUserServiceToReturnValidPrincipalFor(user);
+            ConfigureUserServiceToAcceptPasswordFor(user);
+            await _sut.RotateApiKey(new ApiKeyRequestModel());
+        }
+
+        [Fact]
+        public async Task PostRotateApiKey_WhenUserDoesNotExist_ShouldThrowUnauthorizedAccessException()
+        {
+            ConfigureUserServiceToReturnNullPrincipal();
+
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(
+                () => _sut.ApiKey(new ApiKeyRequestModel())
+            );
+        }
+
+        [Fact]
+        public async Task PostRotateApiKey_WhenPasswordCheckFails_ShouldThrowBadRequestException()
+        {
+            var user = GenerateExampleUser();
+            ConfigureUserServiceToReturnValidPrincipalFor(user);
+            ConfigureUserServiceToRejectPasswordFor(user);
+            await Assert.ThrowsAsync<BadRequestException>(
+                () => _sut.ApiKey(new ApiKeyRequestModel())
+            );
+        }
+
         // Below are helper functions that currently belong to this
         // test class, but ultimately may need to be split out into
         // something greater in order to share common test steps with

--- a/util/Migrator/DbScripts/2020-10-28_00_UserApiKey.sql
+++ b/util/Migrator/DbScripts/2020-10-28_00_UserApiKey.sql
@@ -1,0 +1,263 @@
+-- Add ApiKey column to dbo.User, nullable for now but will be not null after backfilling
+IF COL_LENGTH('[dbo].[User]', 'ApiKey') IS NULL
+BEGIN
+    ALTER TABLE
+        [dbo].[User]
+    ADD
+        [ApiKey] VARCHAR (30) NULL
+END
+GO
+
+-- Setup for random string generation to backfill dbo.User.ApiKey
+CREATE VIEW [dbo].[SecureRandomBytes]
+AS
+SELECT [RandBytes] = CRYPT_GEN_RANDOM(2)
+GO
+
+CREATE FUNCTION [dbo].[SecureRandomString]()
+RETURNS varchar(30)
+AS
+BEGIN
+    declare @sLength tinyint
+    declare @randomString varchar(30)
+    declare @counter tinyint
+    declare @nextChar char(1)
+    declare @rnd as float
+    declare @bytes binary(2)
+
+
+    set @sLength = 30
+    set @counter = 1
+    set @randomString = ''
+
+
+    while @counter <= @sLength
+    begin
+        select @bytes = [RandBytes] from [dbo].[SecureRandomBytes]
+        select @rnd = cast(cast(cast(@bytes as int) as float) / 65535 as float)
+        select @nextChar = char(48 + convert(int, (122-48+1) * @rnd))
+        if ascii(@nextChar) not in (58,59,60,61,62,63,64,91,92,93,94,95,96)
+        begin
+            select @randomString = @randomString + @nextChar
+            set @counter = @counter + 1
+        end
+     end
+     return @randomString 
+END
+GO
+
+-- Backfill dbo.User.ApiKey
+UPDATE
+    [dbo].[User]
+SET
+    [ApiKey] = (SELECT [dbo].[SecureRandomString]())
+GO
+
+-- Change dbo.User.ApiKey to not null to enforece all future users to have one on create
+ALTER TABLE
+    [dbo].[User]
+ALTER COLUMN
+    [ApiKey] VARCHAR(30) NOT NULL
+GO
+
+
+-- Cleanup random string generation
+DROP VIEW [dbo].[SecureRandomBytes]
+GO
+DROP FUNCTION [dbo].[SecureRandomString]
+GO
+
+-- Update dbo.User_Create to account for ApiKey
+IF OBJECT_ID('[dbo].[User_Create]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[User_Create]
+END
+GO
+
+CREATE PROCEDURE [dbo].[User_Create]
+    @Id UNIQUEIDENTIFIER,
+    @Name NVARCHAR(50),
+    @Email NVARCHAR(50),
+    @EmailVerified BIT,
+    @MasterPassword NVARCHAR(300),
+    @MasterPasswordHint NVARCHAR(50),
+    @Culture NVARCHAR(10),
+    @SecurityStamp NVARCHAR(50),
+    @TwoFactorProviders NVARCHAR(MAX),
+    @TwoFactorRecoveryCode NVARCHAR(32),
+    @EquivalentDomains NVARCHAR(MAX),
+    @ExcludedGlobalEquivalentDomains NVARCHAR(MAX),
+    @AccountRevisionDate DATETIME2(7),
+    @Key NVARCHAR(MAX),
+    @PublicKey NVARCHAR(MAX),
+    @PrivateKey NVARCHAR(MAX),
+    @Premium BIT,
+    @PremiumExpirationDate DATETIME2(7),
+    @RenewalReminderDate DATETIME2(7),
+    @Storage BIGINT,
+    @MaxStorageGb SMALLINT,
+    @Gateway TINYINT,
+    @GatewayCustomerId VARCHAR(50),
+    @GatewaySubscriptionId VARCHAR(50),
+    @ReferenceData VARCHAR(MAX),
+    @LicenseKey VARCHAR(100),
+    @Kdf TINYINT,
+    @KdfIterations INT,
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @ApiKey VARCHAR(30)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    INSERT INTO [dbo].[User]
+    (
+        [Id],
+        [Name],
+        [Email],
+        [EmailVerified],
+        [MasterPassword],
+        [MasterPasswordHint],
+        [Culture],
+        [SecurityStamp],
+        [TwoFactorProviders],
+        [TwoFactorRecoveryCode],
+        [EquivalentDomains],
+        [ExcludedGlobalEquivalentDomains],
+        [AccountRevisionDate],
+        [Key],
+        [PublicKey],
+        [PrivateKey],
+        [Premium],
+        [PremiumExpirationDate],
+        [RenewalReminderDate],
+        [Storage],
+        [MaxStorageGb],
+        [Gateway],
+        [GatewayCustomerId],
+        [GatewaySubscriptionId],
+        [ReferenceData],
+        [LicenseKey],
+        [Kdf],
+        [KdfIterations],
+        [CreationDate],
+        [RevisionDate],
+        [ApiKey]
+    )
+    VALUES
+    (
+        @Id,
+        @Name,
+        @Email,
+        @EmailVerified,
+        @MasterPassword,
+        @MasterPasswordHint,
+        @Culture,
+        @SecurityStamp,
+        @TwoFactorProviders,
+        @TwoFactorRecoveryCode,
+        @EquivalentDomains,
+        @ExcludedGlobalEquivalentDomains,
+        @AccountRevisionDate,
+        @Key,
+        @PublicKey,
+        @PrivateKey,
+        @Premium,
+        @PremiumExpirationDate,
+        @RenewalReminderDate,
+        @Storage,
+        @MaxStorageGb,
+        @Gateway,
+        @GatewayCustomerId,
+        @GatewaySubscriptionId,
+        @ReferenceData,
+        @LicenseKey,
+        @Kdf,
+        @KdfIterations,
+        @CreationDate,
+        @RevisionDate,
+        @ApiKey
+    )
+END
+GO
+
+-- Update dbo.User_Update to account for ApiKey
+IF OBJECT_ID('[dbo].[User_Update]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[User_Update]
+END
+GO
+
+CREATE PROCEDURE [dbo].[User_Update]
+    @Id UNIQUEIDENTIFIER,
+    @Name NVARCHAR(50),
+    @Email NVARCHAR(50),
+    @EmailVerified BIT,
+    @MasterPassword NVARCHAR(300),
+    @MasterPasswordHint NVARCHAR(50),
+    @Culture NVARCHAR(10),
+    @SecurityStamp NVARCHAR(50),
+    @TwoFactorProviders NVARCHAR(MAX),
+    @TwoFactorRecoveryCode NVARCHAR(32),
+    @EquivalentDomains NVARCHAR(MAX),
+    @ExcludedGlobalEquivalentDomains NVARCHAR(MAX),
+    @AccountRevisionDate DATETIME2(7),
+    @Key NVARCHAR(MAX),
+    @PublicKey NVARCHAR(MAX),
+    @PrivateKey NVARCHAR(MAX),
+    @Premium BIT,
+    @PremiumExpirationDate DATETIME2(7),
+    @RenewalReminderDate DATETIME2(7),
+    @Storage BIGINT,
+    @MaxStorageGb SMALLINT,
+    @Gateway TINYINT,
+    @GatewayCustomerId VARCHAR(50),
+    @GatewaySubscriptionId VARCHAR(50),
+    @ReferenceData VARCHAR(MAX),
+    @LicenseKey VARCHAR(100),
+    @Kdf TINYINT,
+    @KdfIterations INT,
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @ApiKey VARCHAR(30)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    UPDATE
+        [dbo].[User]
+    SET
+        [Name] = @Name,
+        [Email] = @Email,
+        [EmailVerified] = @EmailVerified,
+        [MasterPassword] = @MasterPassword,
+        [MasterPasswordHint] = @MasterPasswordHint,
+        [Culture] = @Culture,
+        [SecurityStamp] = @SecurityStamp,
+        [TwoFactorProviders] = @TwoFactorProviders,
+        [TwoFactorRecoveryCode] = @TwoFactorRecoveryCode,
+        [EquivalentDomains] = @EquivalentDomains,
+        [ExcludedGlobalEquivalentDomains] = @ExcludedGlobalEquivalentDomains,
+        [AccountRevisionDate] = @AccountRevisionDate,
+        [Key] = @Key,
+        [PublicKey] = @PublicKey,
+        [PrivateKey] = @PrivateKey,
+        [Premium] = @Premium,
+        [PremiumExpirationDate] = @PremiumExpirationDate,
+        [RenewalReminderDate] = @RenewalReminderDate,
+        [Storage] = @Storage,
+        [MaxStorageGb] = @MaxStorageGb,
+        [Gateway] = @Gateway,
+        [GatewayCustomerId] = @GatewayCustomerId,
+        [GatewaySubscriptionId] = @GatewaySubscriptionId,
+        [ReferenceData] = @ReferenceData,
+        [LicenseKey] = @LicenseKey,
+        [Kdf] = @Kdf,
+        [KdfIterations] = @KdfIterations,
+        [CreationDate] = @CreationDate,
+        [RevisionDate] = @RevisionDate,
+        [ApiKey] = @ApiKey
+    WHERE
+        [Id] = @Id
+END
+GO

--- a/util/Migrator/DbScripts/2020-10-28_00_UserApiKey.sql
+++ b/util/Migrator/DbScripts/2020-10-28_00_UserApiKey.sql
@@ -261,3 +261,19 @@ BEGIN
         [Id] = @Id
 END
 GO
+
+-- Refresh dbo.UserView so it has access to ApiKey
+IF OBJECT_ID('[dbo].[UserView]') IS NOT NULL
+BEGIN
+    DROP VIEW [dbo].[UserView]
+END
+GO
+
+CREATE VIEW [dbo].[UserView]
+AS
+SELECT
+    *
+FROM
+    [dbo].[User]
+
+GO


### PR DESCRIPTION
# Description
In order to facilitate the new Force SSO policy enterprise users will need an alternative authentication method to use the Bitwarden CLI: user owned client keys.

https://app.asana.com/0/1195018406457675/1188892364010726/f

# Code Changes 
1. Created a new column: `dbo.User.ApiKey` with the same data type as the already existing `dbo.Organization.ApiKey`.
2. Populated existing users with a `dbo.User.ApiKey` using the same logic that was used to backfill `dbo.Organization.ApiKey`.
3. Updated `dbo.User_Create`, `dbo.User_Update`, and `dbo.UserView` to account for `dbo.User.ApiKey`.
4. Populated `dbo.User.ApiKey` as part of user registration.
5. Created new methods in `AccountsController.cs` for retrieving and regenerating `dbo.User.ApiKey` values for the currently logged in user.
6. Added a new conditional to `ClientStore.cs` to handle user API Keys.
7. Added `client_credentials` to the list of possible grant types that go through the custom token logic.
8. Added a new constructor to `ApiKeyResponseModel.cs` for working with the User model.
9. Wrote unit tests for new controller methods.

# Sibling PRs
https://github.com/bitwarden/jslib/pull/197
https://github.com/bitwarden/web/pull/688
https://github.com/bitwarden/cli/pull/178