### PR TITLE
[Exemption] Updated policy messages

### DIFF
--- a/bitwarden_license/src/Portal/Views/Policies/Edit.cshtml
+++ b/bitwarden_license/src/Portal/Views/Policies/Edit.cshtml
@@ -42,6 +42,13 @@
             </h3>
             @i18nService.T("RequireSsoPolicyReq")
         </div>
+        <div class="callout callout-warning" role="alert">
+            <h3 class="callout-heading">
+                <i class="fa fa-warning" *ngIf="icon" aria-hidden="true"></i>
+                @i18nService.T("Warning")
+            </h3>
+            @i18nService.T("RequireSsoExemption")
+        </div>
     }
     
     <div asp-validation-summary="ModelOnly" class="alert alert-danger"></div>

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -149,7 +149,7 @@
     <value>Edit Policy - {0}</value>
   </data>
   <data name="EditPolicyTwoStepLoginWarning" xml:space="preserve">
-    <value>Organization Users and Managers who do not have two-step login enabled for their personal account will be removed from the organization and will receive an email notifying them about the change.</value>
+    <value>Organization members who are not Owners or Administrators and do not have two-step login enabled for their personal account will be removed from the organization and will receive an email notifying them about the change.</value>
   </data>
   <data name="Save" xml:space="preserve">
     <value>Save</value>
@@ -546,7 +546,7 @@
     <value>Restrict users from being able to join any other organizations.</value>
   </data>
   <data name="SingleOrganizationPolicyWarning" xml:space="preserve">
-    <value>Organization Users and Managers who are already a part of another organization will be removed from this organization and will receive an email notifying them about the change.</value>
+    <value>Organization members who are not Owners or Administrators and are already a part of another organization will be removed from this organization and will receive an email notifying them about the change.</value>
   </data>
   <data name="RequireSso" xml:space="preserve">
     <value>Single Sign-On Authentication</value>
@@ -564,6 +564,6 @@
     <value>Single Organization policy not enabled.</value>
   </data>
   <data name="RequireSsoExemption" xml:space="preserve">
-    <value>Organization Owners and Admins are exempt from this policy's enforcement.</value>
+    <value>Organization Owners and Administrators are exempt from this policy's enforcement.</value>
   </data>
 </root>

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -149,7 +149,7 @@
     <value>Edit Policy - {0}</value>
   </data>
   <data name="EditPolicyTwoStepLoginWarning" xml:space="preserve">
-    <value>Organization members who do not have two-step login enabled for their personal account will be removed from the organization and will receive an email notifying them about the change.</value>
+    <value>Organization Users and Managers who do not have two-step login enabled for their personal account will be removed from the organization and will receive an email notifying them about the change.</value>
   </data>
   <data name="Save" xml:space="preserve">
     <value>Save</value>
@@ -546,7 +546,7 @@
     <value>Restrict users from being able to join any other organizations.</value>
   </data>
   <data name="SingleOrganizationPolicyWarning" xml:space="preserve">
-    <value>Organization members who are already a part of another organization will be removed from this organization and will receive an email notifying them about the change.</value>
+    <value>Organization Users and Managers who are already a part of another organization will be removed from this organization and will receive an email notifying them about the change.</value>
   </data>
   <data name="RequireSso" xml:space="preserve">
     <value>Single Sign-On Authentication</value>
@@ -562,5 +562,8 @@
   </data>
   <data name="RequireSsoPolicyReqError" xml:space="preserve">
     <value>Single Organization policy not enabled.</value>
+  </data>
+  <data name="RequireSsoExemption" xml:space="preserve">
+    <value>Organization Owners and Admins are exempt from this policy's enforcement.</value>
   </data>
 </root>

--- a/src/Core/Services/Implementations/PolicyService.cs
+++ b/src/Core/Services/Implementations/PolicyService.cs
@@ -78,7 +78,8 @@ namespace Bit.Core.Services
                         policy.OrganizationId);
                     var removableOrgUsers = orgUsers.Where(ou =>
                         ou.Status != Enums.OrganizationUserStatusType.Invited &&
-                        ou.Type != Enums.OrganizationUserType.Owner && ou.UserId != savingUserId);
+                        ou.Type != Enums.OrganizationUserType.Owner && ou.Type != Enums.OrganizationUserType.Admin && 
+                        ou.UserId != savingUserId);
                     switch (currentPolicy.Type)
                     {
                         case Enums.PolicyType.TwoFactorAuthentication:


### PR DESCRIPTION
## Objective
> UI Updates: Owners and admins are exempt from organization removal during policy saving for the following policies: **2fa, Single Org**. Owners and Admins are exempt from policy enforcement for **Require SSO** policy. Add **Admins** to exemption logic when saving policy.

## Code Changes
- **Policies/Edit.cshtml**: Added `warning` callout for **RequireSso** describing exemption rules.
- **SharedResources**: Updated messages to include exemption rules.
- **PolicyService**: Added `admin` to exemption rules logic when determining removable users

## Screenshots
<img width="1011" alt="bp-0-2fa" src="https://user-images.githubusercontent.com/26154748/98690869-09d21800-2333-11eb-8738-1bdc54a5f5b2.png">
<img width="1011" alt="bp-1-single-org" src="https://user-images.githubusercontent.com/26154748/98690873-0b034500-2333-11eb-8da0-373a5ecd3cd9.png">
<img width="1010" alt="bp-2-require-sso" src="https://user-images.githubusercontent.com/26154748/98690877-0b9bdb80-2333-11eb-9a70-fc539160ed6b.png">


