### PR TITLE
Performed some null checks

### DIFF
--- a/src/Core/IdentityServer/CustomTokenRequestValidator.cs
+++ b/src/Core/IdentityServer/CustomTokenRequestValidator.cs
@@ -54,7 +54,7 @@ namespace Bit.Core.IdentityServer
         protected async override Task<(User, bool)> ValidateContextAsync(CustomTokenRequestValidationContext context)
         {
             var email = context.Result.ValidatedRequest.Subject?.GetDisplayName() 
-                ?? context.Result.ValidatedRequest.ClientClaims.FirstOrDefault(claim => claim.Type == JwtClaimTypes.Email).Value;
+                ?? context.Result.ValidatedRequest.ClientClaims?.FirstOrDefault(claim => claim.Type == JwtClaimTypes.Email)?.Value;
             var user = await _userManager.FindByEmailAsync(email);
             return (user, user != null);
         }


### PR DESCRIPTION
Resolves the likely culprit of the following stack trace:

`
Unhandled exception: "Object reference not set to an instance of an object."
Exception
Message:
Object reference not set to an instance of an object.
Stack Trace:
   at Bit.Core.IdentityServer.CustomTokenRequestValidator.ValidateContextAsync(CustomTokenRequestValidationContext context) in C:\Projects\bitwarden\server\src\Core\IdentityServer\CustomTokenRequestValidator.cs:line 56`