### PR TITLE
Validate cipher updates with revision date

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
           nuget-version: 'latest'
 
       - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v1.0.0
+        uses: microsoft/setup-msbuild@v1.0.2
 
       - name: Set up Node
         uses: actions/setup-node@v1

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -503,7 +503,7 @@ namespace Bit.Api.Controllers
             var ciphers = await _cipherRepository.GetManyByUserIdAsync(userId, false);
             var ciphersDict = ciphers.ToDictionary(c => c.Id);
 
-            var shareCiphers = new List<Cipher>();
+            var shareCiphers = new List<(Cipher, DateTime?)>();
             foreach (var cipher in model.Ciphers)
             {
                 if (!ciphersDict.ContainsKey(cipher.Id.Value))
@@ -511,7 +511,7 @@ namespace Bit.Api.Controllers
                     throw new BadRequestException("Trying to share ciphers that you do not own.");
                 }
 
-                shareCiphers.Add(cipher.ToCipher(ciphersDict[cipher.Id.Value]));
+                shareCiphers.Add((cipher.ToCipher(ciphersDict[cipher.Id.Value]), cipher.LastKnownRevisionDate));
             }
 
             await _cipherService.ShareManyAsync(shareCiphers, organizationId,

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -113,7 +113,7 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
-            await _cipherService.SaveDetailsAsync(cipher, userId, null, cipher.OrganizationId.HasValue);
+            await _cipherService.SaveDetailsAsync(cipher, userId, model.LastKnownRevisionDate, null, cipher.OrganizationId.HasValue);
             var response = new CipherResponseModel(cipher, _globalSettings);
             return response;
         }
@@ -128,7 +128,7 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
-            await _cipherService.SaveDetailsAsync(cipher, userId, model.CollectionIds, cipher.OrganizationId.HasValue);
+            await _cipherService.SaveDetailsAsync(cipher, userId, model.Cipher.LastKnownRevisionDate, model.CollectionIds, cipher.OrganizationId.HasValue);
             var response = new CipherResponseModel(cipher, _globalSettings);
             return response;
         }
@@ -143,7 +143,7 @@ namespace Bit.Api.Controllers
             }
 
             var userId = _userService.GetProperUserId(User).Value;
-            await _cipherService.SaveAsync(cipher, userId, model.CollectionIds, true, false);
+            await _cipherService.SaveAsync(cipher, userId, model.Cipher.LastKnownRevisionDate, model.CollectionIds, true, false);
 
             var response = new CipherMiniResponseModel(cipher, _globalSettings, false);
             return response;
@@ -168,7 +168,7 @@ namespace Bit.Api.Controllers
                     "then try again.");
             }
 
-            await _cipherService.SaveDetailsAsync(model.ToCipherDetails(cipher), userId);
+            await _cipherService.SaveDetailsAsync(model.ToCipherDetails(cipher), userId, model.LastKnownRevisionDate);
 
             var response = new CipherResponseModel(cipher, _globalSettings);
             return response;
@@ -188,7 +188,7 @@ namespace Bit.Api.Controllers
 
             // object cannot be a descendant of CipherDetails, so let's clone it.
             var cipherClone = CoreHelpers.CloneObject(model.ToCipher(cipher));
-            await _cipherService.SaveAsync(cipherClone, userId, null, true, false);
+            await _cipherService.SaveAsync(cipherClone, userId, model.LastKnownRevisionDate, null, true, false);
 
             var response = new CipherMiniResponseModel(cipherClone, _globalSettings, cipher.OrganizationUseTotp);
             return response;
@@ -277,8 +277,8 @@ namespace Bit.Api.Controllers
             }
 
             var original = CoreHelpers.CloneObject(cipher);
-            await _cipherService.ShareAsync(original, model.Cipher.ToCipher(cipher), 
-                new Guid(model.Cipher.OrganizationId), model.CollectionIds.Select(c => new Guid(c)), userId);
+            await _cipherService.ShareAsync(original, model.Cipher.ToCipher(cipher), new Guid(model.Cipher.OrganizationId),
+                model.CollectionIds.Select(c => new Guid(c)), userId, model.Cipher.LastKnownRevisionDate);
 
             var sharedCipher = await _cipherRepository.GetByIdAsync(cipherId, userId);
             var response = new CipherResponseModel(sharedCipher, _globalSettings);

--- a/src/Core/Models/Api/Request/CipherRequestModel.cs
+++ b/src/Core/Models/Api/Request/CipherRequestModel.cs
@@ -38,6 +38,7 @@ namespace Bit.Core.Models.Api
         public CipherCardModel Card { get; set; }
         public CipherIdentityModel Identity { get; set; }
         public CipherSecureNoteModel SecureNote { get; set; }
+        public DateTime? LastKnownRevisionDate { get; set; } = null;
 
         public CipherDetails ToCipherDetails(Guid userId, bool allowOrgIdSet = true)
         {

--- a/src/Core/Services/ICipherService.cs
+++ b/src/Core/Services/ICipherService.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Bit.Core.Models.Table;
 using Core.Models.Data;
@@ -26,8 +26,8 @@ namespace Bit.Core.Services
         Task DeleteFolderAsync(Folder folder);
         Task ShareAsync(Cipher originalCipher, Cipher cipher, Guid organizationId, IEnumerable<Guid> collectionIds,
             Guid userId, DateTime? lastKnownRevisionDate);
-        Task ShareManyAsync(IEnumerable<Cipher> ciphers, Guid organizationId, IEnumerable<Guid> collectionIds,
-            Guid sharingUserId);
+        Task ShareManyAsync(IEnumerable<(Cipher cipher, DateTime? lastKnownRevisionDate)> ciphers, Guid organizationId,
+            IEnumerable<Guid> collectionIds, Guid sharingUserId);
         Task SaveCollectionsAsync(Cipher cipher, IEnumerable<Guid> collectionIds, Guid savingUserId, bool orgAdmin);
         Task ImportCiphersAsync(List<Folder> folders, List<CipherDetails> ciphers,
             IEnumerable<KeyValuePair<int, int>> folderRelationships);

--- a/src/Core/Services/ICipherService.cs
+++ b/src/Core/Services/ICipherService.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Bit.Core.Models.Table;
 using Core.Models.Data;
@@ -9,10 +9,10 @@ namespace Bit.Core.Services
 {
     public interface ICipherService
     {
-        Task SaveAsync(Cipher cipher, Guid savingUserId, IEnumerable<Guid> collectionIds = null,
+        Task SaveAsync(Cipher cipher, Guid savingUserId, DateTime? lastKnownRevisionDate, IEnumerable<Guid> collectionIds = null,
             bool skipPermissionCheck = false, bool limitCollectionScope = true);
-        Task SaveDetailsAsync(CipherDetails cipher, Guid savingUserId, IEnumerable<Guid> collectionIds = null,
-            bool skipPermissionCheck = false);
+        Task SaveDetailsAsync(CipherDetails cipher, Guid savingUserId, DateTime? lastKnownRevisionDate,
+            IEnumerable<Guid> collectionIds = null, bool skipPermissionCheck = false);
         Task CreateAttachmentAsync(Cipher cipher, Stream stream, string fileName, string key,
             long requestLength, Guid savingUserId, bool orgAdmin = false);
         Task CreateAttachmentShareAsync(Cipher cipher, Stream stream, long requestLength, string attachmentId,
@@ -25,7 +25,7 @@ namespace Bit.Core.Services
         Task SaveFolderAsync(Folder folder);
         Task DeleteFolderAsync(Folder folder);
         Task ShareAsync(Cipher originalCipher, Cipher cipher, Guid organizationId, IEnumerable<Guid> collectionIds,
-            Guid userId);
+            Guid userId, DateTime? lastKnownRevisionDate);
         Task ShareManyAsync(IEnumerable<Cipher> ciphers, Guid organizationId, IEnumerable<Guid> collectionIds,
             Guid sharingUserId);
         Task SaveCollectionsAsync(Cipher cipher, IEnumerable<Guid> collectionIds, Guid savingUserId, bool orgAdmin);

--- a/test/Core.Test/AutoFixture/Attributes/CustomAutoDataAttribute.cs
+++ b/test/Core.Test/AutoFixture/Attributes/CustomAutoDataAttribute.cs
@@ -6,8 +6,7 @@ namespace Bit.Core.Test.AutoFixture.Attributes
 {
     internal class CustomAutoDataAttribute : AutoDataAttribute
     {
-        public CustomAutoDataAttribute(params Type[] iCustomizationTypes)
-        : base(() =>
+        public CustomAutoDataAttribute(params Type[] iCustomizationTypes) : base(() =>
         {
             var fixture = new Fixture();
             foreach (Type iCustomizationType in iCustomizationTypes)

--- a/test/Core.Test/AutoFixture/Attributes/CustomAutoDataAttribute.cs
+++ b/test/Core.Test/AutoFixture/Attributes/CustomAutoDataAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using AutoFixture;
 using AutoFixture.Xunit2;
 
@@ -6,12 +7,16 @@ namespace Bit.Core.Test.AutoFixture.Attributes
 {
     internal class CustomAutoDataAttribute : AutoDataAttribute
     {
-        public CustomAutoDataAttribute(params Type[] iCustomizationTypes) : base(() =>
+        public CustomAutoDataAttribute(params Type[] iCustomizationTypes) : this(iCustomizationTypes
+            .Select(t => (ICustomization)Activator.CreateInstance(t)).ToArray())
+        { }
+
+        public CustomAutoDataAttribute(params ICustomization[] customizations) : base(() =>
         {
             var fixture = new Fixture();
-            foreach (Type iCustomizationType in iCustomizationTypes)
+            foreach (var customization in customizations)
             {
-                fixture.Customize((ICustomization)Activator.CreateInstance(iCustomizationType));
+                fixture.Customize(customization);
             }
             return fixture;
         })

--- a/test/Core.Test/AutoFixture/Attributes/CustomAutoDataAttribute.cs
+++ b/test/Core.Test/AutoFixture/Attributes/CustomAutoDataAttribute.cs
@@ -1,0 +1,21 @@
+using System;
+using AutoFixture;
+using AutoFixture.Xunit2;
+
+namespace Bit.Core.Test.AutoFixture.Attributes
+{
+    internal class CustomAutoDataAttribute : AutoDataAttribute
+    {
+        public CustomAutoDataAttribute(params Type[] iCustomizationTypes)
+        : base(() =>
+        {
+            var fixture = new Fixture();
+            foreach (Type iCustomizationType in iCustomizationTypes)
+            {
+                fixture.Customize((ICustomization)Activator.CreateInstance(iCustomizationType));
+            }
+            return fixture;
+        })
+        { }
+    }
+}

--- a/test/Core.Test/AutoFixture/Attributes/InlineCustomAutoDataAttribute.cs
+++ b/test/Core.Test/AutoFixture/Attributes/InlineCustomAutoDataAttribute.cs
@@ -2,6 +2,7 @@ using System;
 using Xunit;
 using Xunit.Sdk;
 using AutoFixture.Xunit2;
+using AutoFixture;
 
 namespace Bit.Core.Test.AutoFixture.Attributes
 {
@@ -10,6 +11,12 @@ namespace Bit.Core.Test.AutoFixture.Attributes
         public InlineCustomAutoDataAttribute(Type[] iCustomizationTypes, params object[] values) : base(new DataAttribute[] {
             new InlineDataAttribute(values),
             new CustomAutoDataAttribute(iCustomizationTypes)
+        })
+        { }
+
+        public InlineCustomAutoDataAttribute(ICustomization[] customizations, params object[] values) : base(new DataAttribute[] {
+            new InlineDataAttribute(values),
+            new CustomAutoDataAttribute(customizations)
         })
         { }
     }

--- a/test/Core.Test/AutoFixture/Attributes/InlineCustomAutoDataAttribute.cs
+++ b/test/Core.Test/AutoFixture/Attributes/InlineCustomAutoDataAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+using Xunit;
+using Xunit.Sdk;
+using AutoFixture.Xunit2;
+
+namespace Bit.Core.Test.AutoFixture.Attributes
+{
+    internal class InlineCustomAutoDataAttribute : CompositeDataAttribute
+    {
+        public InlineCustomAutoDataAttribute(Type[] iCustomizationTypes, params object[] values)
+        : base(new DataAttribute[] {
+            new InlineDataAttribute(values),
+            new CustomAutoDataAttribute(iCustomizationTypes)
+        })
+        { }
+    }
+}

--- a/test/Core.Test/AutoFixture/Attributes/InlineCustomAutoDataAttribute.cs
+++ b/test/Core.Test/AutoFixture/Attributes/InlineCustomAutoDataAttribute.cs
@@ -7,8 +7,7 @@ namespace Bit.Core.Test.AutoFixture.Attributes
 {
     internal class InlineCustomAutoDataAttribute : CompositeDataAttribute
     {
-        public InlineCustomAutoDataAttribute(Type[] iCustomizationTypes, params object[] values)
-        : base(new DataAttribute[] {
+        public InlineCustomAutoDataAttribute(Type[] iCustomizationTypes, params object[] values) : base(new DataAttribute[] {
             new InlineDataAttribute(values),
             new CustomAutoDataAttribute(iCustomizationTypes)
         })

--- a/test/Core.Test/AutoFixture/CipherFixtures.cs
+++ b/test/Core.Test/AutoFixture/CipherFixtures.cs
@@ -34,12 +34,12 @@ namespace Bit.Core.Test.AutoFixture.CipherFixtures
 
     internal class UserCipherAutoDataAttribute : CustomAutoDataAttribute
     {
-        public UserCipherAutoDataAttribute() : base(typeof(UserCipher))
+        public UserCipherAutoDataAttribute() : base(typeof(SutProviderCustomization), typeof(UserCipher))
         { }
     }
     internal class InlineUserCipherAutoData : InlineCustomAutoDataAttribute
     {
-        public InlineUserCipherAutoData(params object[] values) : base(new[] { typeof(UserCipher) }, values)
+        public InlineUserCipherAutoData(params object[] values) : base(new[] { typeof(SutProviderCustomization), typeof(UserCipher) }, values)
         { }
     }
 }

--- a/test/Core.Test/AutoFixture/CipherFixtures.cs
+++ b/test/Core.Test/AutoFixture/CipherFixtures.cs
@@ -8,10 +8,11 @@ namespace Bit.Core.Test.AutoFixture.CipherFixtures
 {
     internal class OrganizationCipher : ICustomization
     {
+        public Guid? OrganizationId { get; set; }
         public void Customize(IFixture fixture)
         {
             fixture.Customize<Cipher>(composer => composer
-                .With(c => c.OrganizationId, Guid.NewGuid())
+                .With(c => c.OrganizationId, OrganizationId ?? Guid.NewGuid())
                 .Without(c => c.UserId));
             fixture.Customize<CipherDetails>(composer => composer
                 .With(c => c.OrganizationId, Guid.NewGuid())
@@ -21,10 +22,11 @@ namespace Bit.Core.Test.AutoFixture.CipherFixtures
 
     internal class UserCipher : ICustomization
     {
+        public Guid? UserId { get; set; }
         public void Customize(IFixture fixture)
         {
             fixture.Customize<Cipher>(composer => composer
-                .With(c => c.UserId, Guid.NewGuid())
+                .With(c => c.UserId, UserId ?? Guid.NewGuid())
                 .Without(c => c.OrganizationId));
             fixture.Customize<CipherDetails>(composer => composer
                 .With(c => c.UserId, Guid.NewGuid())
@@ -34,12 +36,22 @@ namespace Bit.Core.Test.AutoFixture.CipherFixtures
 
     internal class UserCipherAutoDataAttribute : CustomAutoDataAttribute
     {
-        public UserCipherAutoDataAttribute() : base(typeof(SutProviderCustomization), typeof(UserCipher))
+        public UserCipherAutoDataAttribute(string userId = null) : base(new SutProviderCustomization(),
+            new UserCipher { UserId = userId == null ? (Guid?)null : new Guid(userId) })
         { }
     }
-    internal class InlineUserCipherAutoData : InlineCustomAutoDataAttribute
+    internal class InlineUserCipherAutoDataAttribute : InlineCustomAutoDataAttribute
     {
-        public InlineUserCipherAutoData(params object[] values) : base(new[] { typeof(SutProviderCustomization), typeof(UserCipher) }, values)
+        public InlineUserCipherAutoDataAttribute(params object[] values) : base(new[] { typeof(SutProviderCustomization),
+            typeof(UserCipher) }, values)
         { }
     }
+
+    internal class InlineKnownUserCipherAutoDataAttribute : InlineCustomAutoDataAttribute
+    {
+        public InlineKnownUserCipherAutoDataAttribute(string userId, params object[] values) : base(new ICustomization[]
+            { new SutProviderCustomization(), new UserCipher { UserId = new Guid(userId) } }, values)
+    { }
+
+}
 }

--- a/test/Core.Test/AutoFixture/CipherFixtures.cs
+++ b/test/Core.Test/AutoFixture/CipherFixtures.cs
@@ -1,0 +1,45 @@
+using System;
+using AutoFixture;
+using Bit.Core.Models.Table;
+using Bit.Core.Test.AutoFixture.Attributes;
+using Core.Models.Data;
+
+namespace Bit.Core.Test.AutoFixture.CipherFixtures
+{
+    internal class OrganizationCipher : ICustomization
+    {
+        public void Customize(IFixture fixture)
+        {
+            fixture.Customize<Cipher>(composer => composer
+                .With(c => c.OrganizationId, Guid.NewGuid())
+                .Without(c => c.UserId));
+            fixture.Customize<CipherDetails>(composer => composer
+                .With(c => c.OrganizationId, Guid.NewGuid())
+                .Without(c => c.UserId));
+        }
+    }
+
+    internal class UserCipher : ICustomization
+    {
+        public void Customize(IFixture fixture)
+        {
+            fixture.Customize<Cipher>(composer => composer
+                .With(c => c.UserId, Guid.NewGuid())
+                .Without(c => c.OrganizationId));
+            fixture.Customize<CipherDetails>(composer => composer
+                .With(c => c.UserId, Guid.NewGuid())
+                .Without(c => c.OrganizationId));
+        }
+    }
+
+    internal class UserCipherAutoDataAttribute : CustomAutoDataAttribute
+    {
+        public UserCipherAutoDataAttribute() : base(typeof(UserCipher))
+        { }
+    }
+    internal class InlineUserCipherAutoData : InlineCustomAutoDataAttribute
+    {
+        public InlineUserCipherAutoData(params object[] values) : base(new[] { typeof(UserCipher) }, values)
+        { }
+    }
+}

--- a/test/Core.Test/AutoFixture/FixtureExtensions.cs
+++ b/test/Core.Test/AutoFixture/FixtureExtensions.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Reflection;
+using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using AutoFixture.Kernel;
+
+namespace Bit.Core.Test.AutoFixture
+{
+    public static class FixtureExtensions
+    {
+        // Based on https://stackoverflow.com/a/58170719
+        public static FreezeCreateProvider<TTypeToConstruct> For<TTypeToConstruct>(this IFixture fixture)
+        {
+            return new FreezeCreateProvider<TTypeToConstruct>(fixture);
+        }
+
+        public static IFixture WithAutoNSubstitutions(this IFixture fixture)
+            => fixture.Customize(new AutoNSubstituteCustomization());
+    }
+
+    #region ConstructorParameter fluent classes
+    public class FreezeCreateProvider<TTypeToConstruct>
+    {
+        private readonly IFixture _fixture;
+
+        public FreezeCreateProvider(IFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        public FreezeCreateProvider<TTypeToConstruct> Freeze<TTypeOfParam>(out TTypeOfParam parameterValue, string parameterName = null)
+        {
+            parameterValue = _fixture.Create<TTypeOfParam>();
+            AddConstructorParameter(parameterName, parameterValue);
+            return this;
+        }
+
+        public TTypeToConstruct Create()
+        {
+            var instance = _fixture.Create<TTypeToConstruct>();
+            return instance;
+        }
+
+        internal void AddConstructorParameter<TTypeOfParam>(string parameterName, TTypeOfParam parameterValue)
+        {
+            _fixture.Customizations.Add(new ConstructorParameterRelay<TTypeToConstruct, TTypeOfParam>(parameterName, parameterValue));
+        }
+    }
+
+    public class ConstructorParameterRelay<TTypeToConstruct, TValueType> : ISpecimenBuilder
+    {
+        private readonly string _paramName;
+        private readonly TValueType _paramValue;
+
+        public ConstructorParameterRelay(string paramName, TValueType paramValue)
+        {
+            _paramName = paramName;
+            _paramValue = paramValue;
+        }
+
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
+            if (!(request is ParameterInfo parameterInfo))
+                return new NoSpecimen();
+            if (parameterInfo.Member.DeclaringType != typeof(TTypeToConstruct) ||
+                parameterInfo.Member.MemberType != MemberTypes.Constructor ||
+                parameterInfo.ParameterType != typeof(TValueType) ||
+                (_paramName != null && parameterInfo.Name != _paramName))
+                return new NoSpecimen();
+            return _paramValue;
+        }
+    }
+    #endregion
+}

--- a/test/Core.Test/AutoFixture/FixtureExtensions.cs
+++ b/test/Core.Test/AutoFixture/FixtureExtensions.cs
@@ -1,76 +1,11 @@
-using System;
-using System.Reflection;
 using AutoFixture;
 using AutoFixture.AutoNSubstitute;
-using AutoFixture.Kernel;
 
 namespace Bit.Core.Test.AutoFixture
 {
     public static class FixtureExtensions
     {
-        // Based on https://stackoverflow.com/a/58170719
-        public static FreezeCreateProvider<TTypeToConstruct> For<TTypeToConstruct>(this IFixture fixture)
-        {
-            return new FreezeCreateProvider<TTypeToConstruct>(fixture);
-        }
-
         public static IFixture WithAutoNSubstitutions(this IFixture fixture)
             => fixture.Customize(new AutoNSubstituteCustomization());
     }
-
-    #region ConstructorParameter fluent classes
-    public class FreezeCreateProvider<TTypeToConstruct>
-    {
-        private readonly IFixture _fixture;
-
-        public FreezeCreateProvider(IFixture fixture)
-        {
-            _fixture = fixture;
-        }
-
-        public FreezeCreateProvider<TTypeToConstruct> Freeze<TTypeOfParam>(out TTypeOfParam parameterValue, string parameterName = null)
-        {
-            parameterValue = _fixture.Create<TTypeOfParam>();
-            AddConstructorParameter(parameterName, parameterValue);
-            return this;
-        }
-
-        public TTypeToConstruct Create()
-        {
-            var instance = _fixture.Create<TTypeToConstruct>();
-            return instance;
-        }
-
-        internal void AddConstructorParameter<TTypeOfParam>(string parameterName, TTypeOfParam parameterValue)
-        {
-            _fixture.Customizations.Add(new ConstructorParameterRelay<TTypeToConstruct, TTypeOfParam>(parameterName, parameterValue));
-        }
-    }
-
-    public class ConstructorParameterRelay<TTypeToConstruct, TValueType> : ISpecimenBuilder
-    {
-        private readonly string _paramName;
-        private readonly TValueType _paramValue;
-
-        public ConstructorParameterRelay(string paramName, TValueType paramValue)
-        {
-            _paramName = paramName;
-            _paramValue = paramValue;
-        }
-
-        public object Create(object request, ISpecimenContext context)
-        {
-            if (context == null)
-                throw new ArgumentNullException(nameof(context));
-            if (!(request is ParameterInfo parameterInfo))
-                return new NoSpecimen();
-            if (parameterInfo.Member.DeclaringType != typeof(TTypeToConstruct) ||
-                parameterInfo.Member.MemberType != MemberTypes.Constructor ||
-                parameterInfo.ParameterType != typeof(TValueType) ||
-                (_paramName != null && parameterInfo.Name != _paramName))
-                return new NoSpecimen();
-            return _paramValue;
-        }
-    }
-    #endregion
 }

--- a/test/Core.Test/AutoFixture/ISutProvider.cs
+++ b/test/Core.Test/AutoFixture/ISutProvider.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Bit.Core.Test.AutoFixture
+{
+    public interface ISutProvider
+    {
+        Type SutType { get; }
+        ISutProvider Create();
+    }
+}

--- a/test/Core.Test/AutoFixture/SutProvider.cs
+++ b/test/Core.Test/AutoFixture/SutProvider.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using AutoFixture;
+using AutoFixture.Kernel;
+using System.Reflection;
+using System.Linq;
+
+namespace Bit.Core.Test.AutoFixture
+{
+    public class SutProvider<TSut> : ISutProvider
+    {
+        private Dictionary<Type, Dictionary<string, object>> _dependencies;
+        private readonly IFixture _fixture;
+        private readonly ConstructorParameterRelay<TSut> _constructorParameterRelay;
+
+        public TSut Sut { get; private set; }
+        public Type SutType => typeof(TSut);
+
+        public SutProvider()
+        {
+            _dependencies = new Dictionary<Type, Dictionary<string, object>>();
+            _fixture = new Fixture().WithAutoNSubstitutions();
+            _constructorParameterRelay = new ConstructorParameterRelay<TSut>(this, _fixture);
+            _fixture.Customizations.Add(_constructorParameterRelay);
+        }
+
+        public SutProvider<TSut> SetDependency<T>(T dependency, string parameterName = "")
+            => SetDependency(typeof(T), dependency, parameterName);
+        public SutProvider<TSut> SetDependency(Type dependencyType, object dependency, string parameterName = "")
+        {
+            if (_dependencies.ContainsKey(dependencyType))
+            {
+                _dependencies[dependencyType][parameterName] = dependency;
+            }
+            else
+            {
+                _dependencies[dependencyType] = new Dictionary<string, object> { { parameterName, dependency } };
+            }
+
+            return this;
+        }
+
+        public T GetDependency<T>(string parameterName = "") => (T)GetDependency(typeof(T), parameterName);
+        public object GetDependency(Type dependencyType, string parameterName = "")
+        {
+            if (DependencyIsSet(dependencyType, parameterName))
+            {
+                return _dependencies[dependencyType][parameterName];
+            }
+            else if (_dependencies.ContainsKey(dependencyType))
+            {
+                var knownDependencies = _dependencies[dependencyType];
+                if (knownDependencies.Values.Count == 1)
+                {
+                    return _dependencies[dependencyType].Values.Single();
+                }
+                else
+                {
+                    throw new ArgumentException(string.Concat($"Dependency of type {dependencyType.Name} and name ",
+                        $"{parameterName} does not exist. Available dependency names are: ",
+                        string.Join(", ", knownDependencies.Keys)));
+                }
+            }
+            else
+            {
+                throw new ArgumentException($"Dependency of type {dependencyType.Name} and name {parameterName} has not been set.");
+            }
+        }
+
+        public void Reset()
+        {
+            _dependencies = new Dictionary<Type, Dictionary<string, object>>();
+            Sut = default;
+        }
+
+        ISutProvider ISutProvider.Create() => Create();
+        public SutProvider<TSut> Create()
+        {
+            Sut = _fixture.Create<TSut>();
+            return this;
+        }
+
+        private bool DependencyIsSet(Type dependencyType, string parameterName = "")
+            => _dependencies.ContainsKey(dependencyType) && _dependencies[dependencyType].ContainsKey(parameterName);
+
+        private object GetDefault(Type type) => type.IsValueType ? Activator.CreateInstance(type) : null;
+
+        private class ConstructorParameterRelay<T> : ISpecimenBuilder
+        {
+            private readonly SutProvider<T> _sutProvider;
+            private readonly IFixture _fixture;
+
+            public ConstructorParameterRelay(SutProvider<T> sutProvider, IFixture fixture)
+            {
+                _sutProvider = sutProvider;
+                _fixture = fixture;
+            }
+
+            public object Create(object request, ISpecimenContext context)
+            {
+                if (context == null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+                if (!(request is ParameterInfo parameterInfo))
+                {
+                    return new NoSpecimen();
+                }
+                if (parameterInfo.Member.DeclaringType != typeof(T) ||
+                    parameterInfo.Member.MemberType != MemberTypes.Constructor)
+                {
+                    return new NoSpecimen();
+                }
+
+                if (_sutProvider.DependencyIsSet(parameterInfo.ParameterType, parameterInfo.Name))
+                {
+                    return _sutProvider.GetDependency(parameterInfo.ParameterType, parameterInfo.Name);
+                }
+
+
+                // This is the equivalent of _fixture.Create<parameterInfo.ParameterType>, but no overload for
+                // Create(Type type) exists.
+                var dependency = new SpecimenContext(_fixture).Resolve(new SeededRequest(parameterInfo.ParameterType,
+                    _sutProvider.GetDefault(parameterInfo.ParameterType)));
+                _sutProvider.SetDependency(parameterInfo.ParameterType, dependency, parameterInfo.Name);
+                return dependency;
+            }
+        }
+    }
+}

--- a/test/Core.Test/AutoFixture/SutProviderCustomization.cs
+++ b/test/Core.Test/AutoFixture/SutProviderCustomization.cs
@@ -1,0 +1,32 @@
+using System;
+using AutoFixture;
+using AutoFixture.Kernel;
+
+namespace Bit.Core.Test.AutoFixture
+{
+    public class SutProviderCustomization : ICustomization, ISpecimenBuilder
+    {
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            if (!(request is Type typeRequest))
+            {
+                return new NoSpecimen();
+            }
+            if (!typeof(ISutProvider).IsAssignableFrom(typeRequest))
+            {
+                return new NoSpecimen();
+            }
+
+            return ((ISutProvider)Activator.CreateInstance(typeRequest)).Create();
+        }
+
+        public void Customize(IFixture fixture)
+        {
+            fixture.Customizations.Add(this);
+        }
+    }
+}

--- a/test/Core.Test/Core.Test.csproj
+++ b/test/Core.Test/Core.Test.csproj
@@ -7,14 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.14.0"/>
-    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.14.0"/>
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.14.0" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Core.Test/Core.Test.csproj
+++ b/test/Core.Test/Core.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -7,13 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.14.0"/>
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.14.0"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Core.Test/Services/CipherServiceTests.cs
+++ b/test/Core.Test/Services/CipherServiceTests.cs
@@ -10,6 +10,8 @@ using Core.Models.Data;
 using Bit.Core.Test.AutoFixture.CipherFixtures;
 using System.Collections.Generic;
 using Bit.Core.Test.AutoFixture;
+using System.Linq;
+using Castle.Core.Internal;
 
 namespace Bit.Core.Test.Services
 {
@@ -19,7 +21,6 @@ namespace Bit.Core.Test.Services
         public async Task SaveAsync_WrongRevisionDate_Throws(SutProvider<CipherService> sutProvider, Cipher cipher)
         {
             var lastKnownRevisionDate = cipher.RevisionDate.AddDays(-1);
-            sutProvider.GetDependency<ICipherRepository>().GetByIdAsync(cipher.Id).Returns(cipher);
 
             var exception = await Assert.ThrowsAsync<BadRequestException>(
                 () => sutProvider.Sut.SaveAsync(cipher, cipher.UserId.Value, lastKnownRevisionDate));
@@ -31,7 +32,6 @@ namespace Bit.Core.Test.Services
             CipherDetails cipherDetails)
         {
             var lastKnownRevisionDate = cipherDetails.RevisionDate.AddDays(-1);
-            sutProvider.GetDependency<ICipherRepository>().GetByIdAsync(cipherDetails.Id).Returns(cipherDetails);
 
             var exception = await Assert.ThrowsAsync<BadRequestException>(
                 () => sutProvider.Sut.SaveDetailsAsync(cipherDetails, cipherDetails.UserId.Value, lastKnownRevisionDate));
@@ -42,13 +42,23 @@ namespace Bit.Core.Test.Services
         public async Task ShareAsync_WrongRevisionDate_Throws(SutProvider<CipherService> sutProvider, Cipher cipher,
             Organization organization, List<Guid> collectionIds)
         {
-            sutProvider.GetDependency<ICipherRepository>().GetByIdAsync(cipher.Id).Returns(cipher);
             sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
             var lastKnownRevisionDate = cipher.RevisionDate.AddDays(-1);
 
             var exception = await Assert.ThrowsAsync<BadRequestException>(
                 () => sutProvider.Sut.ShareAsync(cipher, cipher, organization.Id, collectionIds, cipher.UserId.Value,
                 lastKnownRevisionDate));
+            Assert.Contains("out of date", exception.Message);
+        }
+
+        [Theory, UserCipherAutoData("99ab4f6c-44f8-4ff5-be7a-75c37c33c69e")]
+        public async Task ShareManyAsync_WrongRevisionDate_Throws(SutProvider<CipherService> sutProvider,
+            IEnumerable<Cipher> ciphers, Guid organizationId, List<Guid> collectionIds)
+        {
+            var cipherInfos = ciphers.Select(c => (c, (DateTime?)c.RevisionDate.AddDays(-1)));
+
+            var exception = await Assert.ThrowsAsync<BadRequestException>(
+                () => sutProvider.Sut.ShareManyAsync(cipherInfos, organizationId, collectionIds, ciphers.First().UserId.Value));
             Assert.Contains("out of date", exception.Message);
         }
 
@@ -59,7 +69,6 @@ namespace Bit.Core.Test.Services
             SutProvider<CipherService> sutProvider, Cipher cipher)
         {
             var lastKnownRevisionDate = string.IsNullOrEmpty(revisionDateString) ? (DateTime?)null : cipher.RevisionDate;
-            sutProvider.GetDependency<ICipherRepository>().GetByIdAsync(cipher.Id).Returns(cipher);
 
             await sutProvider.Sut.SaveAsync(cipher, cipher.UserId.Value, lastKnownRevisionDate);
             await sutProvider.GetDependency<ICipherRepository>().Received(1).ReplaceAsync(cipher);
@@ -72,7 +81,6 @@ namespace Bit.Core.Test.Services
             SutProvider<CipherService> sutProvider, CipherDetails cipherDetails)
         {
             var lastKnownRevisionDate = string.IsNullOrEmpty(revisionDateString) ? (DateTime?)null : cipherDetails.RevisionDate;
-            sutProvider.GetDependency<ICipherRepository>().GetByIdAsync(cipherDetails.Id).Returns(cipherDetails);
 
             await sutProvider.Sut.SaveDetailsAsync(cipherDetails, cipherDetails.UserId.Value, lastKnownRevisionDate);
             await sutProvider.GetDependency<ICipherRepository>().Received(1).ReplaceAsync(cipherDetails);
@@ -86,13 +94,27 @@ namespace Bit.Core.Test.Services
         {
             var lastKnownRevisionDate = string.IsNullOrEmpty(revisionDateString) ? (DateTime?)null : cipher.RevisionDate;
             var cipherRepository = sutProvider.GetDependency<ICipherRepository>();
-            cipherRepository.GetByIdAsync(cipher.Id).Returns(cipher);
             cipherRepository.ReplaceAsync(cipher, collectionIds).Returns(true);
             sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
 
             await sutProvider.Sut.ShareAsync(cipher, cipher, organization.Id, collectionIds, cipher.UserId.Value,
                 lastKnownRevisionDate);
             await cipherRepository.Received(1).ReplaceAsync(cipher, collectionIds);
+        }
+
+        [Theory]
+        [InlineKnownUserCipherAutoData(userId: "99ab4f6c-44f8-4ff5-be7a-75c37c33c69e", "")]
+        [InlineKnownUserCipherAutoData(userId: "99ab4f6c-44f8-4ff5-be7a-75c37c33c69e", "CorrectTime")]
+        public async Task ShareManyAsync_CorrectRevisionDate_Passes(string revisionDateString,
+            SutProvider<CipherService> sutProvider, IEnumerable<Cipher> ciphers, Organization organization, List<Guid> collectionIds)
+        {
+            var cipherInfos = ciphers.Select(c => (c,
+                string.IsNullOrEmpty(revisionDateString) ? null : (DateTime?)c.RevisionDate));
+            var sharingUserId = ciphers.First().UserId.Value;
+
+            await sutProvider.Sut.ShareManyAsync(cipherInfos, organization.Id, collectionIds, sharingUserId);
+            await sutProvider.GetDependency<ICipherRepository>().Received(1).UpdateCiphersAsync(sharingUserId,
+                Arg.Is<IEnumerable<Cipher>>(arg => arg.Except(ciphers).IsNullOrEmpty()));
         }
     }
 }

--- a/test/Core.Test/Services/CipherServiceTests.cs
+++ b/test/Core.Test/Services/CipherServiceTests.cs
@@ -9,7 +9,6 @@ using Bit.Core.Models.Table;
 using Core.Models.Data;
 using Bit.Core.Test.AutoFixture.CipherFixtures;
 using System.Collections.Generic;
-using AutoFixture;
 using Bit.Core.Test.AutoFixture;
 
 namespace Bit.Core.Test.Services
@@ -17,105 +16,82 @@ namespace Bit.Core.Test.Services
     public class CipherServiceTests
     {
         [Theory, UserCipherAutoData]
-        public async Task SaveAsync_WrongRevisionDate_Throws(Cipher cipher)
+        public async Task SaveAsync_WrongRevisionDate_Throws(SutProvider<CipherService> sutProvider, Cipher cipher)
         {
             var lastKnownRevisionDate = cipher.RevisionDate.AddDays(-1);
-            var sut = new Fixture().WithAutoNSubstitutions()
-                                   .For<CipherService>()
-                                   .Freeze(out ICipherRepository cipherRepository)
-                                   .Create();
-            cipherRepository.GetByIdAsync(cipher.Id).Returns(cipher);
+            sutProvider.GetDependency<ICipherRepository>().GetByIdAsync(cipher.Id).Returns(cipher);
 
             var exception = await Assert.ThrowsAsync<BadRequestException>(
-                () => sut.SaveAsync(cipher, cipher.UserId.Value, lastKnownRevisionDate));
+                () => sutProvider.Sut.SaveAsync(cipher, cipher.UserId.Value, lastKnownRevisionDate));
             Assert.Contains("out of date", exception.Message);
         }
 
         [Theory, UserCipherAutoData]
-        public async Task SaveDetailsAsync_WrongRevisionDate_Throws(CipherDetails cipherDetails)
+        public async Task SaveDetailsAsync_WrongRevisionDate_Throws(SutProvider<CipherService> sutProvider,
+            CipherDetails cipherDetails)
         {
             var lastKnownRevisionDate = cipherDetails.RevisionDate.AddDays(-1);
-            var sut = new Fixture().WithAutoNSubstitutions()
-                                   .For<CipherService>()
-                                   .Freeze(out ICipherRepository cipherRepository)
-                                   .Create();
-            cipherRepository.GetByIdAsync(cipherDetails.Id).Returns(cipherDetails);
+            sutProvider.GetDependency<ICipherRepository>().GetByIdAsync(cipherDetails.Id).Returns(cipherDetails);
 
             var exception = await Assert.ThrowsAsync<BadRequestException>(
-                () => sut.SaveDetailsAsync(cipherDetails, cipherDetails.UserId.Value, lastKnownRevisionDate));
+                () => sutProvider.Sut.SaveDetailsAsync(cipherDetails, cipherDetails.UserId.Value, lastKnownRevisionDate));
             Assert.Contains("out of date", exception.Message);
         }
 
         [Theory, UserCipherAutoData]
-        public async Task ShareAsync_WrongRevisionDate_Throws(Cipher cipher, Organization organization,
-            List<Guid> collectionIds)
+        public async Task ShareAsync_WrongRevisionDate_Throws(SutProvider<CipherService> sutProvider, Cipher cipher,
+            Organization organization, List<Guid> collectionIds)
         {
-            var sut = new Fixture().WithAutoNSubstitutions()
-                                   .For<CipherService>()
-                                   .Freeze(out ICipherRepository cipherRepository)
-                                   .Freeze(out IOrganizationRepository organizationRepository)
-                                   .Create();
-            cipherRepository.GetByIdAsync(cipher.Id).Returns(cipher);
-            organizationRepository.GetByIdAsync(organization.Id).Returns(organization);
-
+            sutProvider.GetDependency<ICipherRepository>().GetByIdAsync(cipher.Id).Returns(cipher);
+            sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
             var lastKnownRevisionDate = cipher.RevisionDate.AddDays(-1);
+
             var exception = await Assert.ThrowsAsync<BadRequestException>(
-                () => sut.ShareAsync(cipher, cipher, organization.Id, collectionIds, cipher.UserId.Value,
-                    lastKnownRevisionDate));
+                () => sutProvider.Sut.ShareAsync(cipher, cipher, organization.Id, collectionIds, cipher.UserId.Value,
+                lastKnownRevisionDate));
             Assert.Contains("out of date", exception.Message);
         }
 
         [Theory]
         [InlineUserCipherAutoData("")]
         [InlineUserCipherAutoData("Correct Time")]
-        public async Task SaveAsync_CorrectRevisionDate_Passes(string revisionDateString, Cipher cipher)
+        public async Task SaveAsync_CorrectRevisionDate_Passes(string revisionDateString,
+            SutProvider<CipherService> sutProvider, Cipher cipher)
         {
             var lastKnownRevisionDate = string.IsNullOrEmpty(revisionDateString) ? (DateTime?)null : cipher.RevisionDate;
-            var sut = new Fixture().WithAutoNSubstitutions()
-                                   .For<CipherService>()
-                                   .Freeze(out ICipherRepository cipherRepository)
-                                   .Create();
-            cipherRepository.GetByIdAsync(cipher.Id).Returns(cipher);
+            sutProvider.GetDependency<ICipherRepository>().GetByIdAsync(cipher.Id).Returns(cipher);
 
-            await sut.SaveAsync(cipher, cipher.UserId.Value, lastKnownRevisionDate);
-            await cipherRepository.Received(1).ReplaceAsync(cipher);
+            await sutProvider.Sut.SaveAsync(cipher, cipher.UserId.Value, lastKnownRevisionDate);
+            await sutProvider.GetDependency<ICipherRepository>().Received(1).ReplaceAsync(cipher);
         }
 
         [Theory]
         [InlineUserCipherAutoData("")]
         [InlineUserCipherAutoData("Correct Time")]
-        public async Task SaveDetailsAsync_CorrectRevisionDate_Passes(string revisionDateString, CipherDetails cipherDetails)
+        public async Task SaveDetailsAsync_CorrectRevisionDate_Passes(string revisionDateString,
+            SutProvider<CipherService> sutProvider, CipherDetails cipherDetails)
         {
             var lastKnownRevisionDate = string.IsNullOrEmpty(revisionDateString) ? (DateTime?)null : cipherDetails.RevisionDate;
-            var sut = new Fixture().WithAutoNSubstitutions()
-                                   .For<CipherService>()
-                                   .Freeze(out ICipherRepository cipherRepository)
-                                   .Create();
-            cipherRepository.GetByIdAsync(cipherDetails.Id).Returns(cipherDetails);
+            sutProvider.GetDependency<ICipherRepository>().GetByIdAsync(cipherDetails.Id).Returns(cipherDetails);
 
-            await sut.SaveDetailsAsync(cipherDetails, cipherDetails.UserId.Value, lastKnownRevisionDate);
-            await cipherRepository.Received(1).ReplaceAsync(cipherDetails);
+            await sutProvider.Sut.SaveDetailsAsync(cipherDetails, cipherDetails.UserId.Value, lastKnownRevisionDate);
+            await sutProvider.GetDependency<ICipherRepository>().Received(1).ReplaceAsync(cipherDetails);
         }
 
         [Theory]
         [InlineUserCipherAutoData("")]
         [InlineUserCipherAutoData("Correct Time")]
-        public async Task ShareAsync_CorrectRevisionDate_Passes(string revisionDateString, Cipher cipher,
-            Organization organization, List<Guid> collectionIds)
+        public async Task ShareAsync_CorrectRevisionDate_Passes(string revisionDateString,
+            SutProvider<CipherService> sutProvider, Cipher cipher, Organization organization, List<Guid> collectionIds)
         {
             var lastKnownRevisionDate = string.IsNullOrEmpty(revisionDateString) ? (DateTime?)null : cipher.RevisionDate;
-            var sut = new Fixture().WithAutoNSubstitutions()
-                                   .For<CipherService>()
-                                   .Freeze(out ICipherRepository cipherRepository)
-                                   .Freeze(out IOrganizationRepository organizationRepository)
-                                   .Create();
+            var cipherRepository = sutProvider.GetDependency<ICipherRepository>();
             cipherRepository.GetByIdAsync(cipher.Id).Returns(cipher);
-            organizationRepository.GetByIdAsync(organization.Id).Returns(organization);
             cipherRepository.ReplaceAsync(cipher, collectionIds).Returns(true);
+            sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
 
-
-            await sut.ShareAsync(cipher, cipher, organization.Id, collectionIds, cipher.UserId.Value,
-                    lastKnownRevisionDate);
+            await sutProvider.Sut.ShareAsync(cipher, cipher, organization.Id, collectionIds, cipher.UserId.Value,
+                lastKnownRevisionDate);
             await cipherRepository.Received(1).ReplaceAsync(cipher, collectionIds);
         }
     }


### PR DESCRIPTION
# Objective

Syncs between clients which are out-of-date can cause data loss by updating records with stale data. Clients already receive a RevisionDate with all Cipher models, this changes the API to expect a `lastKnownRevisionDate` validation parameter for calls which, when successful, overwrite Ciphers.

A comensurate change in jslib will be required to use this validation, but for backwards compatibility, the default null passes all checks.

Secondarily, this PR demonstrates testing of the Cipher Service changes through Xunit, AutoFixture, and NSubstitute. There are two avenues the addition of AutoFixture helps on. First, is generation of test data. Examples of generating test data with constraints can be seen in **CipherFixtures.cs**, where the mutually exclusive UserId and OrganizationId are defined. Attributes in that file can be used to automatically provide test data to Xunit Theories. The Second avenue is in SUT creation. For this I've included a fluent implementation of parameter-based dependency injection, found in **FixtureExtensions.cs**

# Code Changes

* **CipherService.cs**: Business logic to throw upon detecting an out-of-date cipher update request.
* **ICipherService.cs**: method signature changes for above.
* **CipherRequestModel.cs**: Request API changes so the clients send back the RevisionDate they already have.
* **CiphersController.cs**: Plumbing of above items.
* **Core.Test.csproj**: Inclusion of Autofixture and Autofixture.AutoNSubstitute.
* **FixtureExtensions.cs**: AutoFixture extension methods to ease generation of SUT
* **CustomAutoDataAttribute.cs**: Attribute to enable use of custom autogeneration classes for XUnit Theories. [See this cheat sheet](https://github.com/AutoFixture/AutoFixture/wiki/Cheat-Sheet#autodata-theories)
* **InlineCustomAutoDataAttribute.cs**: Attribute to enable specification of some parameters in a Theory. [See this cheat sheet](https://github.com/AutoFixture/AutoFixture/wiki/Cheat-Sheet#inline-autodata-theories)
* **CipherServiceTests.cs**: Actual use of above test infrastructure to test CipherService changes.