### PR TITLE
[Require SSO] Bugfix - Dependent policy check

### DIFF
--- a/bitwarden_license/src/Portal/Controllers/PoliciesController.cs
+++ b/bitwarden_license/src/Portal/Controllers/PoliciesController.cs
@@ -143,7 +143,7 @@ namespace Bit.Portal.Controllers
                     {
                         break;
                     }
-                    var singleOrg = await _policyRepository.GetByOrganizationIdTypeAsync(orgId.Value, type);
+                    var singleOrg = await _policyRepository.GetByOrganizationIdTypeAsync(orgId.Value, PolicyType.SingleOrg);
                     if (singleOrg?.Enabled != true)
                     {
                         ModelState.AddModelError(string.Empty, _i18nService.T("RequireSsoPolicyReqError"));


### PR DESCRIPTION
## Objective
> Fix the Business Portal bug in which the `Require SSO` policy incorrectly states the `Single Org` policy is not enabled.

## Code Changes
- **PoliciesController**: Passed in the correct `PolicyType` for retrieving the `SingleOrg` policy.