### PR TITLE
Set user API key on account creation through SSO auto provision

### DIFF
--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Bit.Core.Models.Api;
+using Bit.Core.Utilities;
 
 namespace Bit.Sso.Controllers
 {
@@ -453,7 +454,8 @@ namespace Bit.Sso.Controllers
                 user = new User
                 {
                     Name = name,
-                    Email = email
+                    Email = email,
+                    ApiKey = CoreHelpers.SecureRandomString(30)
                 };
                 await _userService.RegisterUserAsync(user);
 


### PR DESCRIPTION
Currently creating an account through SSO doesn't create an API Key, which is a non-null value in the database. This is causing errors when trying to create user accounts through SSO.