### PR TITLE
[Bug] SSO new user 2fa policy effects & status updates

### DIFF
--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -210,7 +210,8 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            var result = await _userService.SetPasswordAsync(model.ToUser(user), model.MasterPasswordHash, model.Key);
+            var result = await _userService.SetPasswordAsync(model.ToUser(user), model.MasterPasswordHash, model.Key, 
+                model.OrgIdentifier);
             if (result.Succeeded)
             {
                 return;


### PR DESCRIPTION
## Objective
> An organization that requires 2fa should default jit sso users with the `email` provider option. User's organization status should be changed to accepted during the `set-password` flow.

## Linked Issue
#996 

## Code Changes
- **Sso/AccountController**: Added logic to default jit sso users to `email` provider during sso auto provision flow.
- **Api/AccountsController**: Passed along the `OrgIdentifer` from the request model into the `UserService.SetPasswordAsync` method which will properly update the user's status.