### PR TITLE
return ProfileOrganizationResponseModel for /organizations

### DIFF
--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -136,12 +136,12 @@ namespace Bit.Api.Controllers
         }
 
         [HttpGet("")]
-        public async Task<ListResponseModel<OrganizationResponseModel>> GetUser()
+        public async Task<ListResponseModel<ProfileOrganizationResponseModel>> GetUser()
         {
             var userId = _userService.GetProperUserId(User).Value;
-            var organizations = await _organizationRepository.GetManyByUserIdAsync(userId);
-            var responses = organizations.Select(o => new OrganizationResponseModel(o));
-            return new ListResponseModel<OrganizationResponseModel>(responses);
+            var organizations = await _organizationUserRepository.GetManyDetailsByUserAsync(userId);
+            var responses = organizations.Select(o => new ProfileOrganizationResponseModel(o));
+            return new ListResponseModel<ProfileOrganizationResponseModel>(responses);
         }
 
         [HttpPost("")]


### PR DESCRIPTION
The `/organizations` API call for an authenticated user was returning an `OrganizationResponseModel`, which exposes potentially confidential organization properties to organization members of any user type. This PR changes the response to `ProfileOrganizationResponseModel`, which is suited for any user to view.

NOTE: This API is not used by any clients, but does exist to follow RESTful API design patterns. This change shouldn't affect any downstream clients.