### PR TITLE
ensure fail isn't overwritten with success result

### DIFF
--- a/src/Core/IdentityServer/BaseRequestValidator.cs
+++ b/src/Core/IdentityServer/BaseRequestValidator.cs
@@ -124,6 +124,7 @@ namespace Bit.Core.IdentityServer
                 if (device == null)
                 {
                     await BuildErrorResultAsync("No device information provided.", false, context, user);
+                    return;
                 }
                 await BuildSuccessResultAsync(user, context, device, twoFactorRequest && twoFactorRemember);
             }


### PR DESCRIPTION
Logic fix from https://github.com/bitwarden/server/pull/1014 to ensure a failure result set into context isn't overwritten by a success result or getting into mixed contexts.