### PR TITLE
[Bug] Improve SSO user provision flow

### DIFF
--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -413,7 +413,7 @@ namespace Bit.Sso.Controllers
             orgUser = orgUsersByOrgId.SingleOrDefault(ou =>
                 (existingUser != null && ou.UserId != null && existingUser.Id == ou.UserId.Value) ||
                 (!string.IsNullOrEmpty(ou.Email) &&
-                !ou.Email.Equals(email, StringComparison.InvariantCultureIgnoreCase)));
+                ou.Email.Equals(email, StringComparison.InvariantCultureIgnoreCase)));
 
             if (existingUser != null)
             {

--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -357,13 +357,8 @@ namespace Bit.Sso.Controllers
             {
                 email = providerUserId;
             }
-
-            Guid? orgId = null;
-            if (Guid.TryParse(provider, out var oId))
-            {
-                orgId = oId;
-            }
-            else
+            
+            if (!Guid.TryParse(provider, out var orgId))
             {
                 // TODO: support non-org (server-wide) SSO in the future?
                 throw new Exception(_i18nService.T("SSOProviderIsNotAnOrgId", provider));
@@ -407,106 +402,97 @@ namespace Bit.Sso.Controllers
             }
 
             OrganizationUser orgUser = null;
-            if (orgId.HasValue)
+            var organization = await _organizationRepository.GetByIdAsync(orgId);
+            if (organization == null)
             {
-                var organization = await _organizationRepository.GetByIdAsync(orgId.Value);
-                if (organization == null)
-                {
-                    throw new Exception(_i18nService.T("CouldNotFindOrganization", orgId));
-                }
+                throw new Exception(_i18nService.T("CouldNotFindOrganization", orgId));
+            }
+            
+            // Try to find OrgUser via existing User Id (accepted/confirmed user) or Email + OrgId (invited user)
+            var orgUsersByOrgId = await _organizationUserRepository.GetManyByOrganizationAsync(orgId, null);
+            orgUser = orgUsersByOrgId.SingleOrDefault(ou =>
+                (existingUser != null && ou.UserId != null && existingUser.Id == ou.UserId.Value) ||
+                (!string.IsNullOrEmpty(ou.Email) &&
+                !ou.Email.Equals(email, StringComparison.InvariantCultureIgnoreCase)));
 
-                if (existingUser != null)
-                {
-                    var orgUsers = await _organizationUserRepository.GetManyByUserAsync(existingUser.Id);
-                    orgUser = orgUsers.SingleOrDefault(u => u.OrganizationId == orgId.Value &&
-                        u.Status != OrganizationUserStatusType.Invited);
-                }
-
+            if (existingUser != null)
+            {
                 if (orgUser == null)
                 {
-                    if (organization.Seats.HasValue)
-                    {
-                        var userCount = await _organizationUserRepository.GetCountByOrganizationIdAsync(orgId.Value);
-                        var availableSeats = organization.Seats.Value - userCount;
-                        if (availableSeats < 1)
-                        {
-                            // No seats are available
-                            throw new Exception(_i18nService.T("NoSeatsAvailable", organization.Name));
-                        }
-                    }
+                    // Org User is not created - no invite has been sent
+                    // In order to join this organization, contact an admin to send you an invite.
+                    throw new Exception(_i18nService.T("UserAlreadyExistsUseLinkViaSso"));
+                }
+                
+                if (orgUser.Status == OrganizationUserStatusType.Invited)
+                {
+                    // Org User is invited - they must manually accept the invite via email and authenticate with MP
+                    throw new Exception(_i18nService.T("UserAlreadyInvited", email, organization.Name)); 
+                }
+                
+                // Accepted or Confirmed - create SSO link and return;
+                await _ssoUserRepository.CreateAsync(
+                    CreateSsoUserObject(providerUserId, existingUser.Id, orgId));
+                return existingUser;
+            }
 
-                    // Make sure user is not already invited to this org
-                    var existingOrgUserCount = await _organizationUserRepository.GetCountByOrganizationAsync(
-                        orgId.Value, email, false);
-                    if (existingOrgUserCount > 0)
-                    {
-                        throw new Exception(_i18nService.T("UserAlreadyInvited", email, organization.Name));
-                    }
+            // Before any user creation - if Org User doesn't exist at this point - make sure there are enough seats to add one
+            if (orgUser == null && organization.Seats.HasValue)
+            {
+                var userCount = await _organizationUserRepository.GetCountByOrganizationIdAsync(orgId);
+                var availableSeats = organization.Seats.Value - userCount;
+                if (availableSeats < 1)
+                {
+                    throw new Exception(_i18nService.T("NoSeatsAvailable", organization.Name));
                 }
             }
 
-            User user = null;
+            // Create user record - all existing user flows are handled above
+            var user = new User
+            {
+                Name = name,
+                Email = email,
+                ApiKey = CoreHelpers.SecureRandomString(30)
+            };
+            await _userService.RegisterUserAsync(user);
+            
+            // If the organization has 2fa policy enabled, make sure to default jit user 2fa to email
+            var twoFactorPolicy =
+                await _policyRepository.GetByOrganizationIdTypeAsync(orgId, PolicyType.TwoFactorAuthentication);
+            if (twoFactorPolicy != null && twoFactorPolicy.Enabled)
+            {
+                user.SetTwoFactorProviders(new Dictionary<TwoFactorProviderType, TwoFactorProvider>
+                {
+                    [TwoFactorProviderType.Email] = new TwoFactorProvider
+                        {
+                            MetaData = new Dictionary<string, object> { ["Email"] = user.Email.ToLowerInvariant() },
+                            Enabled = true
+                        }
+                });
+                await _userService.UpdateTwoFactorProviderAsync(user, TwoFactorProviderType.Email);
+            }
+            
+            // Create Org User if null or else update existing Org User
             if (orgUser == null)
             {
-                if (existingUser != null)
+                orgUser = new OrganizationUser
                 {
-                    // TODO: send an email inviting this user to link SSO to their account?
-                    throw new Exception(_i18nService.T("UserAlreadyExistsUseLinkViaSso"));
-                }
-
-                // Create user record
-                user = new User
-                {
-                    Name = name,
-                    Email = email,
-                    ApiKey = CoreHelpers.SecureRandomString(30)
+                    OrganizationId = orgId,
+                    UserId = user.Id,
+                    Type = OrganizationUserType.User,
+                    Status = OrganizationUserStatusType.Invited
                 };
-                await _userService.RegisterUserAsync(user);
-
-                if (orgId.HasValue)
-                {
-                    // If the organization has 2fa policy enabled, make sure to default jit user 2fa to email
-                    var twoFactorPolicy =
-                        await _policyRepository.GetByOrganizationIdTypeAsync(orgId.Value, PolicyType.TwoFactorAuthentication);
-                    if (twoFactorPolicy != null && twoFactorPolicy.Enabled)
-                    {
-                        user.SetTwoFactorProviders(new Dictionary<TwoFactorProviderType, TwoFactorProvider>
-                        {
-
-                            [TwoFactorProviderType.Email] = new TwoFactorProvider
-                            {
-                                MetaData = new Dictionary<string, object> { ["Email"] = user.Email.ToLowerInvariant() },
-                                Enabled = true
-                            }
-                        });
-                        await _userService.UpdateTwoFactorProviderAsync(user, TwoFactorProviderType.Email);
-                    }
-                    // Create organization user record
-                    orgUser = new OrganizationUser
-                    {
-                        OrganizationId = orgId.Value,
-                        UserId = user.Id,
-                        Type = OrganizationUserType.User,
-                        Status = OrganizationUserStatusType.Invited
-                    };
-                    await _organizationUserRepository.CreateAsync(orgUser);
-                }
+                await _organizationUserRepository.CreateAsync(orgUser);
             }
             else
             {
-                // Since the user is already a member of this organization, let's link their existing user account
-                user = existingUser;
+                orgUser.UserId = user.Id;
+                await _organizationUserRepository.ReplaceAsync(orgUser);
             }
-
+            
             // Create sso user record
-            var ssoUser = new SsoUser
-            {
-                ExternalId = providerUserId,
-                UserId = user.Id,
-                OrganizationId = orgId
-            };
-            await _ssoUserRepository.CreateAsync(ssoUser);
-
+            await _ssoUserRepository.CreateAsync(CreateSsoUserObject(providerUserId, user.Id, orgId));
+            
             return user;
         }
 
@@ -552,6 +538,17 @@ namespace Bit.Sso.Controllers
             }
 
             return null;
+        }
+
+        private SsoUser CreateSsoUserObject(string providerUserId, Guid userId, Guid orgId)
+        {
+            var ssoUser = new SsoUser
+            {
+                ExternalId = providerUserId,
+                UserId = userId,
+                OrganizationId = orgId
+            };
+            return ssoUser;
         }
 
         private void ProcessLoginCallback(AuthenticateResult externalResult,

--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -420,8 +420,7 @@ namespace Bit.Sso.Controllers
                 if (orgUser == null)
                 {
                     // Org User is not created - no invite has been sent
-                    // In order to join this organization, contact an admin to send you an invite.
-                    throw new Exception(_i18nService.T("UserAlreadyExistsUseLinkViaSso"));
+                    throw new Exception(_i18nService.T("UserAlreadyExistsInviteProcess"));
                 }
                 
                 if (orgUser.Status == OrganizationUserStatusType.Invited)

--- a/src/Core/Repositories/IOrganizationUserRepository.cs
+++ b/src/Core/Repositories/IOrganizationUserRepository.cs
@@ -27,5 +27,6 @@ namespace Bit.Core.Repositories
         Task CreateAsync(OrganizationUser obj, IEnumerable<SelectionReadOnly> collections);
         Task ReplaceAsync(OrganizationUser obj, IEnumerable<SelectionReadOnly> collections);
         Task<ICollection<OrganizationUser>> GetManyByManyUsersAsync(IEnumerable<Guid> userIds);
+        Task<OrganizationUser> GetByOrganizationEmailAsync(Guid organizationId, string email);
     }
 }

--- a/src/Core/Repositories/SqlServer/OrganizationUserRepository.cs
+++ b/src/Core/Repositories/SqlServer/OrganizationUserRepository.cs
@@ -244,5 +244,18 @@ namespace Bit.Core.Repositories.SqlServer
                 return results.ToList();
             }
         }
+        
+        public async Task<OrganizationUser> GetByOrganizationEmailAsync(Guid organizationId, string email)
+        {
+            using (var connection = new SqlConnection(ConnectionString))
+            {
+                var results = await connection.QueryAsync<OrganizationUser>(
+                    "[dbo].[OrganizationUser_ReadByOrganizationIdEmail]",
+                    new { OrganizationId = organizationId, Email = email },
+                    commandType: CommandType.StoredProcedure);
+
+                return results.SingleOrDefault();
+            }
+        }
     }
 }

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -521,10 +521,10 @@
     <value>No seats available for organization, '{0}'</value>
   </data>
   <data name="UserAlreadyInvited" xml:space="preserve">
-    <value>User, '{0}', has already been invited to this organization, '{1}'</value>
+    <value>User, '{0}', has already been invited to this organization, '{1}'. Accept the invite in order to log in with SSO.</value>
   </data>
-  <data name="UserAlreadyExistsUseLinkViaSso" xml:space="preserve">
-    <value>User already exists, please link account to SSO after logging in</value>
+  <data name="UserAlreadyExistsInviteProcess" xml:space="preserve">
+    <value>In order to join this organization, contact an admin to send you an invite and follow the instructions within to accept.</value>
   </data>
   <data name="RedirectGet" xml:space="preserve">
     <value>Redirect GET</value>

--- a/src/Sql/Sql.sqlproj
+++ b/src/Sql/Sql.sqlproj
@@ -288,4 +288,7 @@
     <Build Include="dbo\Stored Procedures\OrganizationUser_ReadByUserIds.sql" />
     <Build Include="dbo\Stored Procedures\Send_ReadByDeletionDateBefore.sql" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="dbo\Stored Procedures\OrganizationUser_ReadByOrganizationIdEmail.sql" />
+  </ItemGroup>
 </Project>

--- a/src/Sql/dbo/Stored Procedures/OrganizationUser_ReadByOrganizationIdEmail.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationUser_ReadByOrganizationIdEmail.sql
@@ -1,0 +1,17 @@
+CREATE PROCEDURE [dbo].[OrganizationUser_ReadByOrganizationIdEmail]
+    @OrganizationId UNIQUEIDENTIFIER,
+    @Email NVARCHAR(50)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        *
+    FROM
+        [dbo].[OrganizationUserView]
+    WHERE
+        [OrganizationId] = @OrganizationId
+        AND [Email] IS NOT NULL
+        AND @Email IS NOT NULL
+        AND [Email] = @Email
+END

--- a/util/Migrator/DbScripts/2020_12_04_00_OrgUserReadByOrgEmail.sql
+++ b/util/Migrator/DbScripts/2020_12_04_00_OrgUserReadByOrgEmail.sql
@@ -1,0 +1,24 @@
+IF OBJECT_ID('[dbo].[OrganizationUser_ReadByOrganizationEmail]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationUser_ReadByOrganizationEmail]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationUser_ReadByOrganizationIdEmail]
+    @OrganizationId UNIQUEIDENTIFIER,
+    @Email NVARCHAR(50)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        *
+    FROM
+        [dbo].[OrganizationUserView]
+    WHERE
+        [OrganizationId] = @OrganizationId
+        AND [Email] IS NOT NULL
+        AND @Email IS NOT NULL
+        AND [Email] = @Email
+END
+GO


### PR DESCRIPTION
## Objective
> Update SSO provisioning flow to handle all possible combinations of existing user and related organization user.  Improve error responses for these scenarios as well.

## Code Changes
**Sso/AccountController**
- Adjusted `guid` to not be nullable - removed downstream checks. 
- Added more robust `orgUser` checking. Will look by `user.Id` if available or will try to search by `email` via new stored procedure.
- Clarified the `existingUser` flow: adjusted error messages and added comments for all situations
- Removed user count check and isolated seat count check before any user creation
- Updated `orgUser` creation by adding conditional for an update if the `orgUser` already exists (adds `user.id` to `orgUser`)
- Created helper method for creation of SSO object

**IOrganizationUserRepository**
- Added `GetByOrganizationEmailAsync` method reference

**OrganizationUserRepository**
- Added `GetByOrganizationEmailAsync` method that will call a new stored procedure and return an `orgUser` within the given `orgId` and has a matching `email`

**OrganizationUser_ReadByOrganizationIdEmail**
- Created stored procedure to return a user within the given organization and has a matching email

**2020_12_04_00_OrgUserReadByOrgEmail**
- Created migrator script

**SharedResources**
- Updated `UserAlreadyInvited` string.  Added some follow-up steps if the user runs into this error.
- Added `UserAlreadyExistsInviteProcess`. This occurs when the user exists but there is **no** `orgUser` found.