### PR TITLE
[Bug] Fix cipher clone yielding incorrect RevisionDate

### DIFF
--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -187,7 +187,7 @@ namespace Bit.Api.Controllers
             }
 
             // object cannot be a descendant of CipherDetails, so let's clone it.
-            var cipherClone = CoreHelpers.CloneObject(model.ToCipher(cipher));
+            var cipherClone = cipher.Clone();
             await _cipherService.SaveAsync(cipherClone, userId, model.LastKnownRevisionDate, null, true, false);
 
             var response = new CipherMiniResponseModel(cipherClone, _globalSettings, cipher.OrganizationUseTotp);
@@ -276,7 +276,7 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
-            var original = CoreHelpers.CloneObject(cipher);
+            var original = cipher.Clone();
             await _cipherService.ShareAsync(original, model.Cipher.ToCipher(cipher), new Guid(model.Cipher.OrganizationId),
                 model.CollectionIds.Select(c => new Guid(c)), userId, model.Cipher.LastKnownRevisionDate);
 

--- a/src/Core/Models/Table/Cipher.cs
+++ b/src/Core/Models/Table/Cipher.cs
@@ -92,5 +92,14 @@ namespace Bit.Core.Models.Table
             var attachments = GetAttachments();
             return attachments?.ContainsKey(id) ?? false;
         }
+
+        public Cipher Clone()
+        {
+            var clone = CoreHelpers.CloneObject(this);
+            clone.CreationDate = CreationDate;
+            clone.RevisionDate = RevisionDate;
+
+            return clone;
+        }
     }
 }

--- a/src/Core/Models/Table/Cipher.cs
+++ b/src/Core/Models/Table/Cipher.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Bit.Core.Models.Table
 {
-    public class Cipher : ITableObject<Guid>
+    public class Cipher : ITableObject<Guid>, ICloneable
     {
         private Dictionary<string, CipherAttachment.MetaData> _attachmentData;
 
@@ -93,6 +93,7 @@ namespace Bit.Core.Models.Table
             return attachments?.ContainsKey(id) ?? false;
         }
 
+        object ICloneable.Clone() => Clone();
         public Cipher Clone()
         {
             var clone = CoreHelpers.CloneObject(this);

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -359,6 +359,11 @@ namespace Bit.Core.Utilities
             return readable.ToString("0.## ") + suffix;
         }
 
+        /// <summary>
+        /// Creates a clone of the given object through serializing to json and deserializing.
+        /// This method is subject to the limitations of Newstonsoft. For example, properties with
+        /// inaccessible setters will not be set.
+        /// </summary>
         public static T CloneObject<T>(T obj)
         {
             return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(obj));

--- a/test/Core.Test/AutoFixture/CipherFixtures.cs
+++ b/test/Core.Test/AutoFixture/CipherFixtures.cs
@@ -61,9 +61,9 @@ namespace Bit.Core.Test.AutoFixture.CipherFixtures
         { }
     }
 
-    internal class InlineOrganizationCipherAuthoDataAttribute : InlineCustomAutoDataAttribute
+    internal class InlineOrganizationCipherAutoDataAttribute : InlineCustomAutoDataAttribute
     {
-        public InlineOrganizationCipherAuthoDataAttribute(params object[] values) : base(new[] { typeof(SutProviderCustomization),
+        public InlineOrganizationCipherAutoDataAttribute(params object[] values) : base(new[] { typeof(SutProviderCustomization),
             typeof(OrganizationCipher) }, values)
         { }
     }

--- a/test/Core.Test/AutoFixture/CipherFixtures.cs
+++ b/test/Core.Test/AutoFixture/CipherFixtures.cs
@@ -52,6 +52,19 @@ namespace Bit.Core.Test.AutoFixture.CipherFixtures
         public InlineKnownUserCipherAutoDataAttribute(string userId, params object[] values) : base(new ICustomization[]
             { new SutProviderCustomization(), new UserCipher { UserId = new Guid(userId) } }, values)
     { }
+    }
 
-}
+    internal class OrganizationCipherAutoDataAttribute : CustomAutoDataAttribute
+    {
+        public OrganizationCipherAutoDataAttribute(string organizationId = null) : base(new SutProviderCustomization(),
+            new OrganizationCipher { OrganizationId = organizationId == null ? (Guid?)null : new Guid(organizationId) })
+        { }
+    }
+
+    internal class InlineOrganizationCipherAuthoDataAttribute : InlineCustomAutoDataAttribute
+    {
+        public InlineOrganizationCipherAuthoDataAttribute(params object[] values) : base(new[] { typeof(SutProviderCustomization),
+            typeof(OrganizationCipher) }, values)
+        { }
+    }
 }

--- a/test/Core.Test/Models/CipherTests.cs
+++ b/test/Core.Test/Models/CipherTests.cs
@@ -9,7 +9,7 @@ namespace Core.Test.Models
     {
         [Theory]
         [InlineUserCipherAutoData]
-        [InlineOrganizationCipherAuthoData]
+        [InlineOrganizationCipherAutoData]
         public void Clone_CreatesExactCopy(Cipher cipher)
         {
             Assert.Equal(JsonConvert.SerializeObject(cipher), JsonConvert.SerializeObject(cipher.Clone()));

--- a/test/Core.Test/Models/CipherTests.cs
+++ b/test/Core.Test/Models/CipherTests.cs
@@ -1,0 +1,18 @@
+using Bit.Core.Models.Table;
+using Bit.Core.Test.AutoFixture.CipherFixtures;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Core.Test.Models
+{
+    public class CipherTests
+    {
+        [Theory]
+        [InlineUserCipherAutoData]
+        [InlineOrganizationCipherAuthoData]
+        public void Clone_CreatesExactCopy(Cipher cipher)
+        {
+            Assert.Equal(JsonConvert.SerializeObject(cipher), JsonConvert.SerializeObject(cipher.Clone()));
+        }
+    }
+}


### PR DESCRIPTION
# Objective

Fix out of sync issue with organization admin portal

## Description of bug

Cipher's are being cloned through Newtonsoft, but have inaccessible setters for CreationDate and RevisionDate and so these values are not being set on the clone. The fix for this is implementing a method to clone specifically Ciphers on the Model object.

# File changes

* **CiphersController.cs**: User new Clone method on Cipher object itself.
* **Cipher.cs**: Implement clone method. Simply uses the previous generic clone and then sets inaccessible properties.
* **CoreHelpers.cs**: Added xml comment warning of the issue. It's *possible* to write a test ensuring this doesn't happen, but it's not easy to do and does not provide much more benefit than this comment.
* **CipherFixtures.cs**: Implement organization cipher autoData attributes to test clone method
* **CipherTests.cs**: Test of clone.