### PR TITLE
Ensure that users are confirmed status

### DIFF
--- a/bitwarden_license/src/Portal/EnterprisePortalCurrentContext.cs
+++ b/bitwarden_license/src/Portal/EnterprisePortalCurrentContext.cs
@@ -52,7 +52,8 @@ namespace Bit.Portal
 
             // TODO: maybe make loading orgs Lazy<T> somehow?
             var orgUserRepo = _serviceProvider.GetRequiredService<IOrganizationUserRepository>();
-            var userOrgs = await orgUserRepo.GetManyDetailsByUserAsync(UserId.Value);
+            var userOrgs = await orgUserRepo.GetManyDetailsByUserAsync(UserId.Value,
+                Core.Enums.OrganizationUserStatusType.Confirmed);
             OrganizationsDetails = userOrgs.ToList();
             Organizations = userOrgs.Select(ou => new CurrentContentOrganization
             {

--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -139,7 +139,8 @@ namespace Bit.Api.Controllers
         public async Task<ListResponseModel<ProfileOrganizationResponseModel>> GetUser()
         {
             var userId = _userService.GetProperUserId(User).Value;
-            var organizations = await _organizationUserRepository.GetManyDetailsByUserAsync(userId);
+            var organizations = await _organizationUserRepository.GetManyDetailsByUserAsync(userId,
+                OrganizationUserStatusType.Confirmed);
             var responses = organizations.Select(o => new ProfileOrganizationResponseModel(o));
             return new ListResponseModel<ProfileOrganizationResponseModel>(responses);
         }

--- a/src/Core/IdentityServer/BaseRequestValidator.cs
+++ b/src/Core/IdentityServer/BaseRequestValidator.cs
@@ -301,7 +301,8 @@ namespace Bit.Core.IdentityServer
                 if (ssoOrgs.Any())
                 {
                     // Parse users orgs and determine if require sso policy is enabled
-                    var userOrgs = await _organizationUserRepository.GetManyDetailsByUserAsync(user.Id);
+                    var userOrgs = await _organizationUserRepository.GetManyDetailsByUserAsync(user.Id,
+                        OrganizationUserStatusType.Confirmed);
                     foreach (var userOrg in userOrgs.Where(o => o.Enabled && o.UseSso))
                     {
                         var orgPolicy = await _policyRepository.GetByOrganizationIdTypeAsync(userOrg.OrganizationId,


### PR DESCRIPTION
This PR fixes a few areas where pulling a listing of user organizations did not filter to ensure that the user's membership was in a finalized confirmed status.

This could allow non-confirmed users to have access to things they should not yet (for example, biusiness portal), or be subject to policies like SSO login.