### PR TITLE
started charging sales tax on seat/storage upgrades and auto renewals

### DIFF
--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -395,9 +395,9 @@ namespace Bit.Core.Services
             // Retain original collection method
             var collectionMethod = sub.CollectionMethod;
 
-            var subUpdateOptions = new SubscriptionUpdateOptions()
+            var subUpdateOptions = new SubscriptionUpdateOptions
             {
-                Items = new List<SubscriptionItemOptions>()
+                Items = new List<SubscriptionItemOptions>
                 {
                     new SubscriptionItemOptions
                     {
@@ -424,9 +424,9 @@ namespace Bit.Core.Services
             var taxRate = taxRates.FirstOrDefault();
             if (taxRate != null && !sub.DefaultTaxRates.Any(x => x.Equals(taxRate.Id)))
             {
-                subUpdateOptions.DefaultTaxRates = new List<string>() 
+                subUpdateOptions.DefaultTaxRates = new List<string>(1) 
                 { 
-                    taxRates.First().Id 
+                    taxRate.Id 
                 };
             }
 

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -38,6 +38,7 @@ namespace Bit.Core.Services
         private readonly ISsoUserRepository _ssoUserRepository;
         private readonly IReferenceEventService _referenceEventService;
         private readonly GlobalSettings _globalSettings;
+        private readonly ITaxRateRepository _taxRateRepository;
 
         public OrganizationService(
             IOrganizationRepository organizationRepository,
@@ -59,7 +60,8 @@ namespace Bit.Core.Services
             ISsoConfigRepository ssoConfigRepository,
             ISsoUserRepository ssoUserRepository,
             IReferenceEventService referenceEventService,
-            GlobalSettings globalSettings)
+            GlobalSettings globalSettings,
+            ITaxRateRepository taxRateRepository)
         {
             _organizationRepository = organizationRepository;
             _organizationUserRepository = organizationUserRepository;
@@ -81,6 +83,7 @@ namespace Bit.Core.Services
             _ssoUserRepository = ssoUserRepository;
             _referenceEventService = referenceEventService;
             _globalSettings = globalSettings;
+            _taxRateRepository = taxRateRepository;
         }
 
         public async Task ReplacePaymentMethodAsync(Guid organizationId, string paymentToken,
@@ -392,9 +395,9 @@ namespace Bit.Core.Services
             // Retain original collection method
             var collectionMethod = sub.CollectionMethod;
 
-            var subResponse = await subscriptionService.UpdateAsync(sub.Id, new SubscriptionUpdateOptions
+            var subUpdateOptions = new SubscriptionUpdateOptions()
             {
-                Items = new List<SubscriptionItemOptions>
+                Items = new List<SubscriptionItemOptions>()
                 {
                     new SubscriptionItemOptions
                     {
@@ -408,7 +411,26 @@ namespace Bit.Core.Services
                 DaysUntilDue = 1,
                 CollectionMethod = "send_invoice",
                 ProrationDate = prorationDate,
-            });
+            };
+
+            var customer = await new CustomerService().GetAsync(sub.CustomerId);
+            var taxRates = await _taxRateRepository.GetByLocationAsync(
+                new Bit.Core.Models.Table.TaxRate()
+                {
+                    Country = customer.Address.Country,
+                    PostalCode = customer.Address.PostalCode
+                }
+            );
+            var taxRate = taxRates.FirstOrDefault();
+            if (taxRate != null && !sub.DefaultTaxRates.Any(x => x.Equals(taxRate.Id)))
+            {
+                subUpdateOptions.DefaultTaxRates = new List<string>() 
+                { 
+                    taxRates.First().Id 
+                };
+            }
+
+            var subResponse = await subscriptionService.UpdateAsync(sub.Id, subUpdateOptions);
 
             string paymentIntentClientSecret = null;
             if (additionalSeats > 0)

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -684,7 +684,7 @@ namespace Bit.Core.Services
             // Retain original collection method
             var collectionMethod = sub.CollectionMethod;
 
-            var subUpdateOptions = new SubscriptionUpdateOptions()
+            var subUpdateOptions = new SubscriptionUpdateOptions
             {
                 Items = new List<SubscriptionItemOptions>
                 {
@@ -713,9 +713,9 @@ namespace Bit.Core.Services
             var taxRate = taxRates.FirstOrDefault();
             if (taxRate != null && !sub.DefaultTaxRates.Any(x => x.Equals(taxRate.Id)))
             {
-                subUpdateOptions.DefaultTaxRates = new List<string>() 
+                subUpdateOptions.DefaultTaxRates = new List<string>(1) 
                 { 
-                    taxRates.First().Id 
+                    taxRate.Id 
                 };
             }
 

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -684,7 +684,7 @@ namespace Bit.Core.Services
             // Retain original collection method
             var collectionMethod = sub.CollectionMethod;
 
-            var subResponse = await subscriptionService.UpdateAsync(sub.Id, new SubscriptionUpdateOptions
+            var subUpdateOptions = new SubscriptionUpdateOptions()
             {
                 Items = new List<SubscriptionItemOptions>
                 {
@@ -700,7 +700,26 @@ namespace Bit.Core.Services
                 DaysUntilDue = 1,
                 CollectionMethod = "send_invoice",
                 ProrationDate = prorationDate,
-            });
+            };
+
+            var customer = await new CustomerService().GetAsync(sub.CustomerId);
+            var taxRates = await _taxRateRepository.GetByLocationAsync(
+                new Bit.Core.Models.Table.TaxRate()
+                {
+                    Country = customer.Address.Country,
+                    PostalCode = customer.Address.PostalCode
+                }
+            );
+            var taxRate = taxRates.FirstOrDefault();
+            if (taxRate != null && !sub.DefaultTaxRates.Any(x => x.Equals(taxRate.Id)))
+            {
+                subUpdateOptions.DefaultTaxRates = new List<string>() 
+                { 
+                    taxRates.First().Id 
+                };
+            }
+
+            var subResponse = await subscriptionService.UpdateAsync(sub.Id, subUpdateOptions);
 
             string paymentIntentClientSecret = null;
             if (additionalStorage > 0)

--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -36,11 +36,12 @@ namespace Bit.Core.Test.Services
             var ssoUserRepo = Substitute.For<ISsoUserRepository>();
             var referenceEventService = Substitute.For<IReferenceEventService>();
             var globalSettings = Substitute.For<GlobalSettings>();
+            var taxRateRepository = Substitute.For<ITaxRateRepository>();
 
             var orgService = new OrganizationService(orgRepo, orgUserRepo, collectionRepo, userRepo,
                 groupRepo, dataProtector, mailService, pushNotService, pushRegService, deviceRepo,
                 licenseService, eventService, installationRepo, appCacheService, paymentService, policyRepo,
-                ssoConfigRepo, ssoUserRepo, referenceEventService, globalSettings);
+                ssoConfigRepo, ssoUserRepo, referenceEventService, globalSettings, taxRateRepository);
 
             var id = Guid.NewGuid();
             var userId = Guid.NewGuid();
@@ -97,11 +98,12 @@ namespace Bit.Core.Test.Services
             var ssoUserRepo = Substitute.For<ISsoUserRepository>();
             var referenceEventService = Substitute.For<IReferenceEventService>();
             var globalSettings = Substitute.For<GlobalSettings>();
+            var taxRateRepo = Substitute.For<ITaxRateRepository>();
 
             var orgService = new OrganizationService(orgRepo, orgUserRepo, collectionRepo, userRepo,
                 groupRepo, dataProtector, mailService, pushNotService, pushRegService, deviceRepo,
                 licenseService, eventService, installationRepo, appCacheService, paymentService, policyRepo,
-                ssoConfigRepo, ssoUserRepo, referenceEventService, globalSettings);
+                ssoConfigRepo, ssoUserRepo, referenceEventService, globalSettings, taxRateRepo);
 
             var id = Guid.NewGuid();
             var userId = Guid.NewGuid();

--- a/test/Core.Test/Services/StripePaymentServiceTests.cs
+++ b/test/Core.Test/Services/StripePaymentServiceTests.cs
@@ -25,6 +25,7 @@ namespace Bit.Core.Test.Services
             _appleIapService = Substitute.For<IAppleIapService>();
             _globalSettings = new GlobalSettings();
             _logger = Substitute.For<ILogger<StripePaymentService>>();
+            _taxRateRepository = Substitute.For<ITaxRateRepository>();
 
             _sut = new StripePaymentService(
                 _transactionRepository,


### PR DESCRIPTION
Some holes were left in the original sales tax implementation:

1. Charging sales tax on auto-renewals that for subscriptions created before the sales tax implementation
2. Charging sales tax on seat/storage upgrades that are performed before an subscription has an applied tax rate

Both of those are addressed in this PR. I also fixed a build warning where taxRateRepo never had an assigned value in a test class.