### PR TITLE
Add docker notary

### DIFF
--- a/.github/test/on-master-event.json
+++ b/.github/test/on-master-event.json
@@ -1,0 +1,7 @@
+{
+  "release": {
+    "head": {
+      "ref": "master"
+    }
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,13 @@ on:
     types:
       - published
 
+#######################################################
+# NOTE: DO NOT APPROVE IF IF THIS BLOCK IS STILL HERE #
+#       JOSEPH FORGOT TO REMOVE THE CI/CD TESTS...    #
+#######################################################
+env:
+  temp_test: True
+
 jobs:
 
   cloc:
@@ -54,14 +61,14 @@ jobs:
           GITHUB_EVENT: ${{ github.event_name }}
 
       - name: Log into docker
-        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || $temp_test == True
         run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Setup Docker Trust
-        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || $temp_test == True
         run: |
           echo "${{ secrets.DOCKER_DELEGATION_KEY }}" > ~/.docker/trust/private/$DOCKER_DELEGATION_KEY_ID.key
           echo "${{ secrets.DOCKER_REPO_API_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_API_ID.key
@@ -105,7 +112,7 @@ jobs:
           ./build.sh
 
       - name: Tag dev
-        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || $temp_test == True
         run: ./build.sh tag dev
 
       - name: Tag beta
@@ -124,7 +131,7 @@ jobs:
         run: docker images
 
       - name: Push dev images
-        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || $temp_test == True
         run: ./build.sh push dev
         env:
           DOCKER_CONTENT_TRUST: 1
@@ -188,7 +195,7 @@ jobs:
           path: ./swagger.json
 
       - name: Log out of docker
-        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || $temp_test == True
         run: docker logout
 
       - name: Upload release assets

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
     types:
       - published
 
+env:
+  DOCKER_CONTENT_TRUST: 1
+
 jobs:
 
   cloc:
@@ -60,6 +63,39 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Setup Docker Trust
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
+        run: |
+          echo "${{ secrets.DOCKER_DELEGATION_KEY }}" > ~/.docker/trust/private/$DOCKER_DELEGATION_KEY_ID.key
+          echo "${{ secrets.DOCKER_REPO_API_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_API_ID.key
+          echo "${{ secrets.DOCKER_REPO_IDENTITY_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_IDENTITY_ID.key
+          echo "${{ secrets.DOCKER_REPO_SERVER_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_SERVER_ID.key
+          echo "${{ secrets.DOCKER_REPO_ATTACHMENTS_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_ATTACHMENTS_ID.key
+          echo "${{ secrets.DOCKER_REPO_ICONS_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_ICONS_ID.key
+          echo "${{ secrets.DOCKER_REPO_NOTIFICATIONS_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_NOTIFICATIONS_ID.key
+          echo "${{ secrets.DOCKER_REPO_EVENTS_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_EVENTS_ID.key
+          echo "${{ secrets.DOCKER_REPO_ADMIN_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_ADMIN_ID.key
+          echo "${{ secrets.DOCKER_REPO_NGINX_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_NGINX_ID.key
+          echo "${{ secrets.DOCKER_REPO_SSO_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_SSO_ID.key
+          echo "${{ secrets.DOCKER_REPO_PORTAL_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_PORTAL_ID.key
+          echo "${{ secrets.DOCKER_REPO_MSSQL_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_MSSQL_ID.key
+          echo "${{ secrets.DOCKER_REPO_SETUP_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_SETUP_ID.key
+        env:
+          DOCKER_DELEGATION_KEY_ID: "5702b22123e058cbd96a7a43000cb981ae98ef3f2f4aa34138ab3dc1d011e446"
+          DOCKER_REPO_API_ID: "525fa3e70b84669c9fe489c5a3d0974898d14c0807b19447242c60ed8d4ca766"
+          DOCKER_REPO_IDENTITY_ID: "084da6ea47ba1c4f34c2870a78a17739cd5df50359d2c2c7616822632df726d3"
+          DOCKER_REPO_SERVER_ID: "ffbee21a1a71854a1c1310df4f5aded41726dd90d61050a6256168cd9268b1ee"
+          DOCKER_REPO_ATTACHMENTS_ID: "e40fbcb5b273ad601c00ea905ca326ab68b395f17a46a8530e0ddd7d12bd4240"
+          DOCKER_REPO_ICONS_ID: "0d3f5c6854610bd3d9b9c0a6851fe525b057976b46cb0f47de3942cf3b0be394"
+          DOCKER_REPO_NOTIFICATIONS_ID: "1bf8d22352ec65a6c9b9282c454462240e0a1eb78bff03b65b5a4b7887599ab2"
+          DOCKER_REPO_EVENTS_ID: "1020320052e6247f3c5fbfc2a3bfb0efc7e247f8a5a187dc03f60848359ac7c9"
+          DOCKER_REPO_ADMIN_ID: "c5d80db8745fcd7a1510c3fba5c65582cfc2453d2b1eeb292abe79eb1351cf5c"
+          DOCKER_REPO_NGINX_ID: "bf3d3247f5c2be73bbe830cddbae445c29e4fcc9e2fb4b4d39abf86a2740098b"
+          DOCKER_REPO_SSO_ID: "97a5f6d29b255ff709ec63faad27c2f76246f006563bf3ecbb71547325c05815"
+          DOCKER_REPO_PORTAL_ID: "4f358aa0a41c9a6650f5d2f907c2de418df34ddf3ee45e0994be7cc2dcd0b56e"
+          DOCKER_REPO_MSSQL_ID: "30a44d7efbe48d30ed06abef003d2d8990205dad6a034617cddc03548f8c084e"
+          DOCKER_REPO_SETUP_ID: "2932fb9c39b7eacf4418c7c9ee4c823f973c426412ddd64d7f9f0b6f940b8428"
+
       - name: Checkout repo
         uses: actions/checkout@v2
 
@@ -93,14 +129,20 @@ jobs:
       - name: Push dev images
         if: github.ref == 'refs/heads/master' || github.event_name == 'release'
         run: ./build.sh push dev
+        env:
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_DELEGATION_KEY_PASSPHRASE }}
 
       - name: Push beta images
         if: github.event_name == 'release'
         run: ./build.sh push beta
+        env:
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_DELEGATION_KEY_PASSPHRASE }}
 
       - name: Push latest images
         if: github.event_name == 'release'
         run: ./build.sh push latest
+        env:
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_DELEGATION_KEY_PASSPHRASE }}
 
       - name: Push version images
         if: github.event_name == 'release'
@@ -108,6 +150,7 @@ jobs:
         shell: pwsh
         env:
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_DELEGATION_KEY_PASSPHRASE }}
 
       - name: Make docker stub
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,8 @@
+#######################################################
+# NOTE: DO NOT APPROVE IF IF THIS BLOCK IS STILL HERE #
+#       JOSEPH FORGOT TO REMOVE THE CI/CD TESTS...    #
+#######################################################
+
 name: Build
 
 on:
@@ -8,13 +13,6 @@ on:
   release:
     types:
       - published
-
-#######################################################
-# NOTE: DO NOT APPROVE IF IF THIS BLOCK IS STILL HERE #
-#       JOSEPH FORGOT TO REMOVE THE CI/CD TESTS...    #
-#######################################################
-env:
-  temp_test: True
 
 jobs:
 
@@ -61,14 +59,14 @@ jobs:
           GITHUB_EVENT: ${{ github.event_name }}
 
       - name: Log into docker
-        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || $temp_test == True
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || github.ref == 'refs/heads/add-docker-notary'
         run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Setup Docker Trust
-        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || $temp_test == True
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || github.ref == 'refs/heads/add-docker-notary'
         run: |
           echo "${{ secrets.DOCKER_DELEGATION_KEY }}" > ~/.docker/trust/private/$DOCKER_DELEGATION_KEY_ID.key
           echo "${{ secrets.DOCKER_REPO_API_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_API_ID.key
@@ -112,7 +110,8 @@ jobs:
           ./build.sh
 
       - name: Tag dev
-        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || $temp_test == True
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || github.ref == 'refs/heads/add-docker-notary'
+
         run: ./build.sh tag dev
 
       - name: Tag beta
@@ -131,7 +130,7 @@ jobs:
         run: docker images
 
       - name: Push dev images
-        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || $temp_test == True
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || github.ref == 'refs/heads/add-docker-notary'
         run: ./build.sh push dev
         env:
           DOCKER_CONTENT_TRUST: 1
@@ -195,7 +194,7 @@ jobs:
           path: ./swagger.json
 
       - name: Log out of docker
-        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || $temp_test == True
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || github.ref == 'refs/heads/add-docker-notary'
         run: docker logout
 
       - name: Upload release assets

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
 
       - name: List docker images
-        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || github.ref == 'refs/heads/add-docker-notary'
         run: docker images
 
       - name: Push dev images
@@ -139,21 +139,21 @@ jobs:
         run: ./build.sh push dev
         env:
           DOCKER_CONTENT_TRUST: 1
-          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_DELEGATION_KEY_PASSPHRASE }}
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
 
       - name: Push beta images
         if: github.event_name == 'release'
         run: ./build.sh push beta
         env:
           DOCKER_CONTENT_TRUST: 1
-          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_DELEGATION_KEY_PASSPHRASE }}
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
 
       - name: Push latest images
         if: github.event_name == 'release'
         run: ./build.sh push latest
         env:
           DOCKER_CONTENT_TRUST: 1
-          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_DELEGATION_KEY_PASSPHRASE }}
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
 
       - name: Push version images
         if: github.event_name == 'release'
@@ -162,7 +162,7 @@ jobs:
         env:
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
           DOCKER_CONTENT_TRUST: 1
-          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_DELEGATION_KEY_PASSPHRASE }}
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
 
       - name: Make docker stub
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,3 @@
-#######################################################
-# NOTE: DO NOT APPROVE IF IF THIS BLOCK IS STILL HERE #
-#       JOSEPH FORGOT TO REMOVE THE CI/CD TESTS...    #
-#######################################################
-
 name: Build
 
 on:
@@ -59,17 +54,16 @@ jobs:
           GITHUB_EVENT: ${{ github.event_name }}
 
       - name: Log into docker
-        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || github.ref == 'refs/heads/add-docker-notary'
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
         run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Setup Docker Trust
-        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || github.ref == 'refs/heads/add-docker-notary'
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
         run: |
           mkdir -p ~/.docker/trust/private
-          ls -alht ~/.docker/trust/private
 
           echo "${{ secrets.DOCKER_DELEGATION_KEY }}" > ~/.docker/trust/private/$DOCKER_DELEGATION_KEY_ID.key
           echo "${{ secrets.DOCKER_REPO_API_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_API_ID.key
@@ -85,8 +79,6 @@ jobs:
           echo "${{ secrets.DOCKER_REPO_PORTAL_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_PORTAL_ID.key
           echo "${{ secrets.DOCKER_REPO_MSSQL_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_MSSQL_ID.key
           echo "${{ secrets.DOCKER_REPO_SETUP_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_SETUP_ID.key
-
-          ls -alht ~/.docker/trust/private
         env:
           DOCKER_DELEGATION_KEY_ID: "5702b22123e058cbd96a7a43000cb981ae98ef3f2f4aa34138ab3dc1d011e446"
           DOCKER_REPO_API_ID: "525fa3e70b84669c9fe489c5a3d0974898d14c0807b19447242c60ed8d4ca766"
@@ -115,7 +107,7 @@ jobs:
           ./build.sh
 
       - name: Tag dev
-        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || github.ref == 'refs/heads/add-docker-notary'
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
 
         run: ./build.sh tag dev
 
@@ -131,11 +123,11 @@ jobs:
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
 
       - name: List docker images
-        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || github.ref == 'refs/heads/add-docker-notary'
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
         run: docker images
 
       - name: Push dev images
-        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || github.ref == 'refs/heads/add-docker-notary'
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
         run: ./build.sh push dev
         env:
           DOCKER_CONTENT_TRUST: 1
@@ -199,7 +191,7 @@ jobs:
           path: ./swagger.json
 
       - name: Log out of docker
-        if: github.ref == 'refs/heads/master' || github.event_name == 'release' || github.ref == 'refs/heads/add-docker-notary'
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
         run: docker logout
 
       - name: Upload release assets

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,6 @@ on:
     types:
       - published
 
-env:
-  DOCKER_CONTENT_TRUST: 1
-
 jobs:
 
   cloc:
@@ -130,18 +127,21 @@ jobs:
         if: github.ref == 'refs/heads/master' || github.event_name == 'release'
         run: ./build.sh push dev
         env:
+          DOCKER_CONTENT_TRUST: 1
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_DELEGATION_KEY_PASSPHRASE }}
 
       - name: Push beta images
         if: github.event_name == 'release'
         run: ./build.sh push beta
         env:
+          DOCKER_CONTENT_TRUST: 1
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_DELEGATION_KEY_PASSPHRASE }}
 
       - name: Push latest images
         if: github.event_name == 'release'
         run: ./build.sh push latest
         env:
+          DOCKER_CONTENT_TRUST: 1
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_DELEGATION_KEY_PASSPHRASE }}
 
       - name: Push version images
@@ -150,6 +150,7 @@ jobs:
         shell: pwsh
         env:
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          DOCKER_CONTENT_TRUST: 1
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_DELEGATION_KEY_PASSPHRASE }}
 
       - name: Make docker stub

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,8 @@ jobs:
       - name: Setup Docker Trust
         if: github.ref == 'refs/heads/master' || github.event_name == 'release' || github.ref == 'refs/heads/add-docker-notary'
         run: |
+          ls -alht ~/.docker/trust/private
+
           echo "${{ secrets.DOCKER_DELEGATION_KEY }}" > ~/.docker/trust/private/$DOCKER_DELEGATION_KEY_ID.key
           echo "${{ secrets.DOCKER_REPO_API_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_API_ID.key
           echo "${{ secrets.DOCKER_REPO_IDENTITY_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_IDENTITY_ID.key
@@ -82,6 +84,8 @@ jobs:
           echo "${{ secrets.DOCKER_REPO_PORTAL_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_PORTAL_ID.key
           echo "${{ secrets.DOCKER_REPO_MSSQL_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_MSSQL_ID.key
           echo "${{ secrets.DOCKER_REPO_SETUP_KEY }}" > ~/.docker/trust/private/$DOCKER_REPO_SETUP_ID.key
+
+          ls -alht ~/.docker/trust/private
         env:
           DOCKER_DELEGATION_KEY_ID: "5702b22123e058cbd96a7a43000cb981ae98ef3f2f4aa34138ab3dc1d011e446"
           DOCKER_REPO_API_ID: "525fa3e70b84669c9fe489c5a3d0974898d14c0807b19447242c60ed8d4ca766"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Setup Docker Trust
         if: github.ref == 'refs/heads/master' || github.event_name == 'release' || github.ref == 'refs/heads/add-docker-notary'
         run: |
+          mkdir -p ~/.docker/trust/private
           ls -alht ~/.docker/trust/private
 
           echo "${{ secrets.DOCKER_DELEGATION_KEY }}" > ~/.docker/trust/private/$DOCKER_DELEGATION_KEY_ID.key

--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,4 @@ bitwarden_license/src/Portal/wwwroot/lib
 bitwarden_license/src/Portal/wwwroot/css
 bitwarden_license/src/Sso/wwwroot/lib
 bitwarden_license/src/Sso/wwwroot/css
+.github/test/build.secrets


### PR DESCRIPTION
## Changes
Updating the Build Github Action to sign the docker images when they are pushed to [Docker Hub](https://hub.docker.io).

## Files Changed
- **.github/workflows/build.yaml:** Updated with the signing keys for all of the docker repos
- **.github/test:** Adding test data to use in conjunction with  [act](https://github.com/nektos/act) for local testing
- **.gitignore:** Ignoring the local test secrets