### PR TITLE
[Policy] Single Org dependency chain

### DIFF
--- a/bitwarden_license/src/Portal/Controllers/PoliciesController.cs
+++ b/bitwarden_license/src/Portal/Controllers/PoliciesController.cs
@@ -135,7 +135,20 @@ namespace Bit.Portal.Controllers
                 case PolicyType.MasterPassword:
                 case PolicyType.PasswordGenerator:
                 case PolicyType.TwoFactorAuthentication:
+                    break;
+                
                 case PolicyType.SingleOrg:
+                    if (enabled)
+                    {
+                        break;
+                    }
+
+                    var requireSso =
+                        await _policyRepository.GetByOrganizationIdTypeAsync(orgId.Value, PolicyType.RequireSso);
+                    if (requireSso?.Enabled == true)
+                    {
+                        ModelState.AddModelError(string.Empty, _i18nService.T("DisableRequireSsoError"));
+                    }
                     break;
                 
                 case PolicyType.RequireSso:
@@ -143,6 +156,7 @@ namespace Bit.Portal.Controllers
                     {
                         break;
                     }
+                    
                     var singleOrg = await _policyRepository.GetByOrganizationIdTypeAsync(orgId.Value, PolicyType.SingleOrg);
                     if (singleOrg?.Enabled != true)
                     {

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -575,4 +575,7 @@
   <data name="PersonalOwnershipExemption" xml:space="preserve">
     <value>Organization Owners and Administrators are exempt from this policy's enforcement.</value>
   </data>
+  <data name="DisableRequireSsoError" xml:space="preserve">
+    <value>You must manually disable the Single Sign-On Authentication policy before this policy can be disabled.</value>
+  </data>
 </root>

--- a/src/Core/Services/Implementations/PolicyService.cs
+++ b/src/Core/Services/Implementations/PolicyService.cs
@@ -48,6 +48,18 @@ namespace Bit.Core.Services
             // Handle dependent policy checks
             switch(policy.Type)
             {
+                case PolicyType.SingleOrg:
+                    if (!policy.Enabled)
+                    {
+                        var requireSso =
+                            await _policyRepository.GetByOrganizationIdTypeAsync(org.Id, PolicyType.RequireSso);
+                        if (requireSso?.Enabled == true)
+                        {
+                            throw new BadRequestException("Single Sign-On Authentication policy is enabled.");
+                        }
+                    }
+                    break;
+                
                case PolicyType.RequireSso:
                    if (policy.Enabled)
                    {
@@ -58,9 +70,6 @@ namespace Bit.Core.Services
                        }
                    }
                    break;
-                   
-                default:
-                    break;
             }
 
             var now = DateTime.UtcNow;


### PR DESCRIPTION
## Objective
> Do not allow users to **disable** the `SingleOrg` policy when the `RequireSso` policy is **enabled**.

## Code Changes
- **PoliciesController**: Added explicit `SingleOrg` check during the `ValidateDependentPolicies` method. 
- **SharedResources**: Added error string
- **PolicyService**: Added explicit error check to the API flow.

## Screenshots
<img width="1142" alt="1-portal-error" src="https://user-images.githubusercontent.com/26154748/102282081-a9b43000-3ef5-11eb-869d-15f8cb7629b9.png">
