### PR TITLE
Fix Organization put drops cipher updates

### DIFF
--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -187,7 +187,7 @@ namespace Bit.Api.Controllers
             }
 
             // object cannot be a descendant of CipherDetails, so let's clone it.
-            var cipherClone = cipher.Clone();
+            var cipherClone = model.ToCipher(cipher).Clone();
             await _cipherService.SaveAsync(cipherClone, userId, model.LastKnownRevisionDate, null, true, false);
 
             var response = new CipherMiniResponseModel(cipherClone, _globalSettings, cipher.OrganizationUseTotp);


### PR DESCRIPTION
# Overview

We are currently dropping any edits made on the Organization admin page due to cloning the cipher already stored in the db. We need to clone a cipher made of an amalgamation of the request and existing cipher.

# Files Changed

* **CiphersController.cs**: This was a bug introduced by me in fixing the clone issue. I should have cloned the Cipher object created by `model.ToCipher` rather than the existing cipher.