### PR TITLE
Allow SHA1 inbound sigs from Idp

### DIFF
--- a/bitwarden_license/src/Portal/Models/SsoConfigDataViewModel.cs
+++ b/bitwarden_license/src/Portal/Models/SsoConfigDataViewModel.cs
@@ -47,6 +47,7 @@ namespace Bit.Portal.Models
             SpSigningBehavior = configurationData.SpSigningBehavior;
             SpWantAssertionsSigned = configurationData.SpWantAssertionsSigned;
             SpValidateCertificates = configurationData.SpValidateCertificates;
+            SpMinIncomingSigningAlgorithm = configurationData.SpMinIncomingSigningAlgorithm ?? SamlSigningAlgorithms.Sha256;
         }
 
         [Required]
@@ -86,6 +87,8 @@ namespace Bit.Portal.Models
         public bool SpWantAssertionsSigned { get; set; }
         [Display(Name = "SpValidateCertificates")]
         public bool SpValidateCertificates { get; set; }
+        [Display(Name = "MinIncomingSigningAlgorithm")]
+        public string SpMinIncomingSigningAlgorithm { get; set; }
 
         // SAML2 IDP
         [Display(Name = "EntityId")]
@@ -211,6 +214,7 @@ namespace Bit.Portal.Models
                 SpSigningBehavior = SpSigningBehavior,
                 SpWantAssertionsSigned = SpWantAssertionsSigned,
                 SpValidateCertificates = SpValidateCertificates,
+                SpMinIncomingSigningAlgorithm = SpMinIncomingSigningAlgorithm,
             };
         }
 

--- a/bitwarden_license/src/Portal/Views/Sso/Index.cshtml
+++ b/bitwarden_license/src/Portal/Views/Sso/Index.cshtml
@@ -194,6 +194,13 @@
                             class="form-control"></select>
                 </div>
             </div>
+            <div class="row">
+                <div class="col-7 form-group">
+                    <label asp-for="Data.SpMinIncomingSigningAlgorithm">@i18nService.T("MinIncomingSigningAlgorithm")</label>
+                    <select asp-for="Data.SpMinIncomingSigningAlgorithm" asp-items="Model.SigningAlgorithms"
+                            class="form-control"></select>
+                </div>
+            </div>
             <div class="form-group">
                 <div class="form-check">
                     <input asp-for="Data.SpWantAssertionsSigned" type="checkbox" class="form-check-input">

--- a/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
+++ b/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
@@ -9,6 +9,7 @@ using Bit.Core.Enums;
 using Bit.Core.Models.Data;
 using Bit.Core.Models.Table;
 using Bit.Core.Repositories;
+using Bit.Core.Sso;
 using Bit.Sso.Models;
 using Bit.Sso.Utilities;
 using IdentityModel;
@@ -346,6 +347,10 @@ namespace Bit.Core.Business.Sso
                 AuthenticateRequestSigningBehavior = GetSigningBehavior(config.SpSigningBehavior),
                 ValidateCertificates = config.SpValidateCertificates,
             };
+            if (!string.IsNullOrWhiteSpace(config.SpMinIncomingSigningAlgorithm))
+            {
+                spOptions.MinIncomingSigningAlgorithm = config.SpMinIncomingSigningAlgorithm;
+            }
             if (!string.IsNullOrWhiteSpace(config.SpOutboundSigningAlgorithm))
             {
                 spOptions.OutboundSigningAlgorithm = config.SpOutboundSigningAlgorithm;

--- a/src/Core/Models/Data/SsoConfigurationData.cs
+++ b/src/Core/Models/Data/SsoConfigurationData.cs
@@ -39,6 +39,7 @@ namespace Bit.Core.Models.Data
         public Saml2SigningBehavior SpSigningBehavior { get; set; } = Saml2SigningBehavior.IfIdpWantAuthnRequestsSigned;
         public bool SpWantAssertionsSigned { get; set; }
         public bool SpValidateCertificates { get; set; }
+        public string SpMinIncomingSigningAlgorithm { get; set; } = SamlSigningAlgorithms.Sha256;
 
         public string BuildCallbackPath(string ssoUri = null)
         {

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -331,6 +331,9 @@
   <data name="SigningBehavior" xml:space="preserve">
     <value>Signing Behavior</value>
   </data>
+  <data name="MinIncomingSigningAlgorithm" xml:space="preserve">
+    <value>Minimum Incoming Signing Algorithm</value>
+  </data>
   <data name="BindingType" xml:space="preserve">
     <value>Binding Type</value>
   </data>


### PR DESCRIPTION
## Overview
Apparently some SAML providers like Auth0 get stuck on using SHA-1 as their signing algorithm OR make it incredibly difficult to change. With that, and an eye towards potentially other legacy systems which may require this, this change introduces a new configuration point to the SAML SSO configuration in the Business Portal that allows an Organization Administrator with SSO enabled, to set the Minimum Incoming Signing Algorithm. This value defaults to SHA-256, and any existing configurations will not be changed (will still use the system default). New configurations or edits will persist whatever is selected here:

![image](https://user-images.githubusercontent.com/3904944/102547335-0dba2e00-4087-11eb-8d5f-d9c5788cef7e.png)

Testing this against OneLogin SAML with success by setting the OneLogin test account signing algorithm to SHA-1 and the callback through the SSO service was successful.