### PR TITLE
Make nginx Content-Security-Policy configurable

### DIFF
--- a/util/Setup/Configuration.cs
+++ b/util/Setup/Configuration.cs
@@ -74,9 +74,9 @@ namespace Bit.Setup
 
         [Description("Nginx Header Content-Security-Policy parameter\n" +
             "WARNING: Reconfiguring this parameter may break features. By changing this parameter\n" +
-	    "you become responsible for maintaining this value.")]
-        public string NginxHeaderContentSecurityPolicy { get; set; } = "default-src 'self'; style-src 'self' " + 
-	    "'unsafe-inline'; img-src 'self' data: https://haveibeenpwned.com https://www.gravatar.com; " +
+            "you become responsible for maintaining this value.")]
+        public string NginxHeaderContentSecurityPolicy { get; set; } = "default-src 'self'; style-src 'self' " 
+            "'unsafe-inline'; img-src 'self' data: https://haveibeenpwned.com https://www.gravatar.com; " +
             "child-src 'self' https://*.duosecurity.com; frame-src 'self' https://*.duosecurity.com; " +
             "connect-src 'self' wss://{0} https://api.pwnedpasswords.com " +
             "https://twofactorauth.org; object-src 'self' blob:;";

--- a/util/Setup/Configuration.cs
+++ b/util/Setup/Configuration.cs
@@ -75,8 +75,8 @@ namespace Bit.Setup
         [Description("Nginx Header Content-Security-Policy parameter\n" +
             "WARNING: Reconfiguring this parameter may break features. By changing this parameter\n" +
             "you become responsible for maintaining this value.")]
-        public string NginxHeaderContentSecurityPolicy { get; set; } = "default-src 'self'; style-src 'self' " 
-            "'unsafe-inline'; img-src 'self' data: https://haveibeenpwned.com https://www.gravatar.com; " +
+        public string NginxHeaderContentSecurityPolicy { get; set; } = "default-src 'self'; style-src 'self' " +
+            "'unsafe-inline'; img-src 'self' data: https://haveibeenpwned.com https://www.gravatar.com; " + 
             "child-src 'self' https://*.duosecurity.com; frame-src 'self' https://*.duosecurity.com; " +
             "connect-src 'self' wss://{0} https://api.pwnedpasswords.com " +
             "https://twofactorauth.org; object-src 'self' blob:;";

--- a/util/Setup/Configuration.cs
+++ b/util/Setup/Configuration.cs
@@ -72,6 +72,15 @@ namespace Bit.Setup
             "`/etc/ssl` within the container.")]
         public string SslDiffieHellmanPath { get; set; }
 
+        [Description("Nginx Header Content-Security-Policy parameter\n" +
+            "WARNING: Reconfiguring this parameter may break features. By changing this parameter\n" +
+	    "you become responsible for maintaining this value.")]
+        public string NginxHeaderContentSecurityPolicy { get; set; } = "default-src 'self'; style-src 'self' " + 
+	    "'unsafe-inline'; img-src 'self' data: https://haveibeenpwned.com https://www.gravatar.com; " +
+            "child-src 'self' https://*.duosecurity.com; frame-src 'self' https://*.duosecurity.com; " +
+            "connect-src 'self' wss://{0} https://api.pwnedpasswords.com " +
+            "https://twofactorauth.org; object-src 'self' blob:;";
+
         [Description("Communicate with the Bitwarden push relay service (push.bitwarden.com) for mobile\n" +
             "app live sync.")]
         public bool PushNotifications { get; set; } = true;

--- a/util/Setup/NginxConfigBuilder.cs
+++ b/util/Setup/NginxConfigBuilder.cs
@@ -72,7 +72,7 @@ namespace Bit.Setup
                 Domain = context.Config.Domain;
                 Url = context.Config.Url;
                 RealIps = context.Config.RealIps;
-		ContentSecurityPolicy = string.Format(context.Config.NginxHeaderContentSecurityPolicy, Domain);
+                ContentSecurityPolicy = string.Format(context.Config.NginxHeaderContentSecurityPolicy, Domain);
 
                 if (Ssl)
                 {

--- a/util/Setup/NginxConfigBuilder.cs
+++ b/util/Setup/NginxConfigBuilder.cs
@@ -6,13 +6,6 @@ namespace Bit.Setup
     public class NginxConfigBuilder
     {
         private const string ConfFile = "/bitwarden/nginx/default.conf";
-        private const string ContentSecurityPolicy =
-            "default-src 'self'; style-src 'self' 'unsafe-inline'; " +
-            "img-src 'self' data: https://haveibeenpwned.com https://www.gravatar.com; " +
-            "child-src 'self' https://*.duosecurity.com; frame-src 'self' https://*.duosecurity.com; " +
-            "connect-src 'self' wss://{0} https://api.pwnedpasswords.com " +
-            "https://twofactorauth.org; " +
-            "object-src 'self' blob:;";
 
         private readonly Context _context;
 
@@ -79,6 +72,7 @@ namespace Bit.Setup
                 Domain = context.Config.Domain;
                 Url = context.Config.Url;
                 RealIps = context.Config.RealIps;
+		ContentSecurityPolicy = string.Format(context.Config.NginxHeaderContentSecurityPolicy, Domain);
 
                 if (Ssl)
                 {
@@ -129,7 +123,7 @@ namespace Bit.Setup
             public string DiffieHellmanPath { get; set; }
             public string SslCiphers { get; set; }
             public string SslProtocols { get; set; }
-            public string ContentSecurityPolicy => string.Format(NginxConfigBuilder.ContentSecurityPolicy, Domain);
+            public string ContentSecurityPolicy { get; set; }
             public List<string> RealIps { get; set; }
         }
     }


### PR DESCRIPTION
## Change Summary
Making the Content-Security-Policy configurable through the `config.yaml` for self-hosted instances. 

The default value has been moved into Configuration class so that it is available to the user for configuration. A warning is supplied to hopefully ward off non-advanced users from changing the value.


## Files Changed:
- util/Setup/Configuration.cs
- util/Setup/NginxConfig/Builder.cs


## Manual Tests Run
Using a slightly modified `bitwarden.sh` that uses a locally built `bitwarden/setup:latest`:
- install
- rebuild