### PR TITLE
Added OIDC scope management

### DIFF
--- a/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
+++ b/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
@@ -301,7 +301,7 @@ namespace Bit.Core.Business.Sso
                 Authority = config.Authority,
                 ClientId = config.ClientId,
                 ClientSecret = config.ClientSecret,
-                ResponseType = "code", // id_token
+                ResponseType = "code",
                 ResponseMode = "form_post",
                 SignInScheme = IdentityServerConstants.ExternalCookieAuthenticationScheme,
                 SignOutScheme = IdentityServerConstants.SignoutScheme,

--- a/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
+++ b/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
@@ -301,7 +301,7 @@ namespace Bit.Core.Business.Sso
                 Authority = config.Authority,
                 ClientId = config.ClientId,
                 ClientSecret = config.ClientSecret,
-                ResponseType = "code",
+                ResponseType = "code", // id_token
                 ResponseMode = "form_post",
                 SignInScheme = IdentityServerConstants.ExternalCookieAuthenticationScheme,
                 SignOutScheme = IdentityServerConstants.SignoutScheme,
@@ -318,6 +318,18 @@ namespace Bit.Core.Business.Sso
                 AuthenticationMethod = config.RedirectBehavior,
                 GetClaimsFromUserInfoEndpoint = config.GetClaimsFromUserInfoEndpoint,
             };
+            if (!oidcOptions.Scope.Contains(OpenIdConnectScopes.OpenId))
+            {
+                oidcOptions.Scope.Add(OpenIdConnectScopes.OpenId);
+            }
+            if (!oidcOptions.Scope.Contains(OpenIdConnectScopes.Email))
+            {
+                oidcOptions.Scope.Add(OpenIdConnectScopes.Email);
+            }
+            if (!oidcOptions.Scope.Contains(OpenIdConnectScopes.Profile))
+            {
+                oidcOptions.Scope.Add(OpenIdConnectScopes.Profile);
+            }
 
             return new DynamicAuthenticationScheme(name, name, typeof(OpenIdConnectHandler),
                 oidcOptions, SsoType.OpenIdConnect);

--- a/bitwarden_license/src/Sso/Utilities/OpenIdConnectScopes.cs
+++ b/bitwarden_license/src/Sso/Utilities/OpenIdConnectScopes.cs
@@ -1,0 +1,53 @@
+﻿namespace Bit.Sso.Utilities
+{
+    /// <summary>
+    /// OpenID Connect Clients use scope values as defined in 3.3 of OAuth 2.0
+    /// [RFC6749]. These values represent the standard scope values supported
+    /// by OAuth 2.0 and therefore OIDC.
+    /// </summary>
+    /// <remarks>
+    /// See: https://openid.net/specs/openid-connect-basic-1_0.html#Scopes
+    /// </remarks>
+    public static class OpenIdConnectScopes
+    {
+        /// <summary>
+        /// REQUIRED. Informs the Authorization Server that the Client is making
+        /// an OpenID Connect request. If the openid scope value is not present,
+        /// the behavior is entirely unspecified.
+        /// </summary>
+        public const string OpenId = "openid";
+
+        /// <summary>
+        /// OPTIONAL. This scope value requests access to the End-User's default
+        /// profile Claims, which are: name, family_name, given_name,
+        /// middle_name, nickname, preferred_username, profile, picture,
+        /// website, gender, birthdate, zoneinfo, locale, and updated_at.
+        /// </summary>
+        public const string Profile = "profile";
+
+        /// <summary>
+        /// OPTIONAL. This scope value requests access to the email and
+        /// email_verified Claims.
+        /// </summary>
+        public const string Email = "email";
+
+        /// <summary>
+        /// OPTIONAL. This scope value requests access to the address Claim.
+        /// </summary>
+        public const string Address = "address";
+
+        /// <summary>
+        /// OPTIONAL. This scope value requests access to the phone_number and
+        /// phone_number_verified Claims.
+        /// </summary>
+        public const string Phone = "phone";
+
+        /// <summary>
+        /// OPTIONAL. This scope value requests that an OAuth 2.0 Refresh Token
+        /// be issued that can be used to obtain an Access Token that grants
+        /// access to the End-User's UserInfo Endpoint even when the End-User is
+        /// not present (not logged in).
+        /// </summary>
+        public const string OfflineAccess = "offline_access";
+    }
+}


### PR DESCRIPTION
## Overview
Apparently some authentication providers/IdP's are pretty particular in the OIDC realm (as a superset of OAuth) in demanding scope be defined by the SP when initiating the request, before it will release any claims within those scopes. We expect some elements such as Email address to be sent back as an `email` claim, however we found providers like Auth0 did not release those claims (and no where to configure it otherwise) unless the `scope` explicitly requests it for the user to grant authorization to/for in the SSO handshake.

## Technical Stuff
This change ensures the OIDC provider/handler collection for the SP options in our dynamic binding adds the appropriate scope that we want or need (some cases want (display name for example), some cases need, like `email`) to the Scope list. This then in turn is sent to the IdP in the request via POST or Redirect depending on which protocol is being used.

i.e. `&scope=openid%20profile%20email` (the `openid` scope is required always and would be added by default by IdentityServer4 anyway), the `profile` scope which grants claims back for name, givenName, display name, etc. and `email` which, as you would probably guess, gives us back the email address for the user which is one of those things required by our user onboarding flow and Bitwarden in general.