### PR TITLE
Update forgot password help URL

### DIFF
--- a/src/Core/MailTemplates/Handlebars/MasterPasswordHint.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/MasterPasswordHint.html.hbs
@@ -14,7 +14,7 @@
     <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
         <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;" valign="top">
             If you still cannot remember your master password, please refer to the following article for your options:<br style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;" />
-            {{{link 'https://help.bitwarden.com/article/forgot-master-password/'}}}
+            {{{link 'https://bitwarden.com/help/article/forgot-master-password/'}}}
         </td>
     </tr>
     <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">

--- a/src/Core/MailTemplates/Handlebars/MasterPasswordHint.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/MasterPasswordHint.text.hbs
@@ -5,7 +5,7 @@ Your hint is: "{{Hint}}"
 Log in: {{{WebVaultUrl}}}
 
 If you still cannot remember your master password, please refer to the following article for your options:
-https://help.bitwarden.com/article/forgot-master-password/
+https://bitwarden.com/help/article/forgot-master-password/
 
 If you did not request your master password hint you can safely ignore this email.
 {{/BasicTextLayout}}

--- a/src/Core/MailTemplates/Handlebars/NoMasterPasswordHint.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/NoMasterPasswordHint.html.hbs
@@ -3,7 +3,7 @@
     <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
         <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;" valign="top">
             You (or someone) recently requested your master password hint. Unfortunately, your account does not have a master password hint. If you cannot remember your master password, please refer to the following article for your options:<br style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;" />
-            {{{link 'https://help.bitwarden.com/article/forgot-master-password/'}}}
+            {{{link 'https://bitwarden.com/help/article/forgot-master-password/'}}}
         </td>
     </tr>
     <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">

--- a/src/Core/MailTemplates/Handlebars/NoMasterPasswordHint.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/NoMasterPasswordHint.text.hbs
@@ -1,6 +1,6 @@
 ﻿{{#>BasicTextLayout}}
 You (or someone) recently requested your master password hint. Unfortunately, your account does not have a master password hint. If you cannot remember your master password, please refer to the following article for your options:
-https://help.bitwarden.com/article/forgot-master-password/
+https://bitwarden.com/help/article/forgot-master-password/
 
 If you did not request your master password hint you can safely ignore this email.
 {{/BasicTextLayout}}


### PR DESCRIPTION
The automated email regarding master password hint contains an old link:
"If you still cannot remember your master password, please refer to the following article for your options:
https://help.bitwarden.com/article/forgot-master-password/"

The correct link is https://bitwarden.com/help/article/forgot-master-password/