### PR TITLE
Adding core version number in output for CS

### DIFF
--- a/scripts/bitwarden.ps1
+++ b/scripts/bitwarden.ps1
@@ -100,6 +100,7 @@ https://bitwarden.com, https://github.com/bitwarden
 "
 
 if($env:BITWARDEN_QUIET -ne "true") {
+    Write-Line "bitwarden.ps1 version ${coreVersion}"
     docker --version
     docker-compose --version
 }

--- a/scripts/bitwarden.sh
+++ b/scripts/bitwarden.sh
@@ -19,11 +19,6 @@ https://bitwarden.com, https://github.com/bitwarden
 
 EOF
 
-docker --version
-docker-compose --version
-
-echo ""
-
 # Setup
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -39,6 +34,12 @@ SCRIPTS_DIR="$OUTPUT/scripts"
 GITHUB_BASE_URL="https://raw.githubusercontent.com/bitwarden/server/master"
 COREVERSION="1.38.2"
 WEBVERSION="2.17.1"
+
+echo "bitwarden.sh version $COREVERSION"
+docker --version
+docker-compose --version
+
+echo ""
 
 # Functions
 


### PR DESCRIPTION
## Change Summary
Adding in the CS requested versioning output for the self-hosted scripts to help troubleshoot customer issues.

## Files Changed
- `scripts/bitwarden.ps1`
- `scripts/bitwarden.sh`

## Manual Testing
- Ran `./bitwarden.sh` in a bash environment and got version output
- Ran `.\bitwarden.ps1` in powershell environment and got version output