### PR TITLE
Fix mssql healthcheck

### DIFF
--- a/util/MsSql/Dockerfile
+++ b/util/MsSql/Dockerfile
@@ -18,7 +18,7 @@ RUN chmod +x /entrypoint.sh \
 # Does not work unfortunately (https://github.com/bitwarden/server/issues/286)
 RUN /opt/mssql/bin/mssql-conf set telemetry.customerfeedback false
 
-HEALTHCHECK --start-period=60s --timeout=3s CMD /opt/mssql-tools/bin/sqlcmd \
+HEALTHCHECK --start-period=120s --timeout=3s CMD /opt/mssql-tools/bin/sqlcmd \
     -S localhost -U sa -P ${SA_PASSWORD} -Q "SELECT 1" || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Hi,

This follows #1030 where @danpoltawski reports that 60s are not enough to let the container properly start.
Let's then increase the healthcheck `--start-period`.

Perhaps that we could even go to a safer `300s` value.

Thx 👍