### PR TITLE
Fix sproc name mismatch in migration sql

### DIFF
--- a/util/Migrator/DbScripts/2020-12-04_00_OrgUserReadByOrgEmail.sql
+++ b/util/Migrator/DbScripts/2020-12-04_00_OrgUserReadByOrgEmail.sql
@@ -1,6 +1,6 @@
-IF OBJECT_ID('[dbo].[OrganizationUser_ReadByOrganizationEmail]') IS NOT NULL
+IF OBJECT_ID('[dbo].[OrganizationUser_ReadByOrganizationIdEmail]') IS NOT NULL
 BEGIN
-    DROP PROCEDURE [dbo].[OrganizationUser_ReadByOrganizationEmail]
+    DROP PROCEDURE [dbo].[OrganizationUser_ReadByOrganizationIdEmail]
 END
 GO
 


### PR DESCRIPTION
Migration script had a if exists/drop wrong sproc name (missing the `Id` in the name) compared to the sproc it was creating. This was causing failures in deployment where the script is re-run a 2nd time.