### PR TITLE
Add cipher response to restore

### DIFF
--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -437,7 +437,7 @@ namespace Bit.Api.Controllers
         }
 
         [HttpPut("{id}/restore")]
-        public async Task PutRestore(string id)
+        public async Task<CipherResponseModel> PutRestore(string id)
         {
             var userId = _userService.GetProperUserId(User).Value;
             var cipher = await _cipherRepository.GetByIdAsync(new Guid(id), userId);
@@ -447,13 +447,14 @@ namespace Bit.Api.Controllers
             }
 
             await _cipherService.RestoreAsync(cipher, userId);
+            return new CipherResponseModel(cipher, _globalSettings);
         }
 
         [HttpPut("{id}/restore-admin")]
-        public async Task PutRestoreAdmin(string id)
+        public async Task<CipherMiniResponseModel> PutRestoreAdmin(string id)
         {
             var userId = _userService.GetProperUserId(User).Value;
-            var cipher = await _cipherRepository.GetByIdAsync(new Guid(id));
+            var cipher = await _cipherRepository.GetOrganizationDetailsByIdAsync(new Guid(id));
             if (cipher == null || !cipher.OrganizationId.HasValue ||
                 !_currentContext.OrganizationAdmin(cipher.OrganizationId.Value))
             {
@@ -461,10 +462,11 @@ namespace Bit.Api.Controllers
             }
 
             await _cipherService.RestoreAsync(cipher, userId, true);
+            return new CipherMiniResponseModel(cipher, _globalSettings, cipher.OrganizationUseTotp);
         }
 
         [HttpPut("restore")]
-        public async Task PutRestoreMany([FromBody]CipherBulkRestoreRequestModel model)
+        public async Task<ListResponseModel<CipherResponseModel>> PutRestoreMany([FromBody] CipherBulkRestoreRequestModel model)
         {
             if (!_globalSettings.SelfHosted && model.Ids.Count() > 500)
             {
@@ -472,7 +474,14 @@ namespace Bit.Api.Controllers
             }
 
             var userId = _userService.GetProperUserId(User).Value;
-            await _cipherService.RestoreManyAsync(model.Ids.Select(i => new Guid(i)), userId);
+            var cipherIdsToRestore = new HashSet<Guid>(model.Ids.Select(i => new Guid(i)));
+
+            var ciphers = await _cipherRepository.GetManyByUserIdAsync(userId);
+            var restoringCiphers = ciphers.Where(c => cipherIdsToRestore.Contains(c.Id) && c.Edit);
+
+            await _cipherService.RestoreManyAsync(restoringCiphers, userId);
+            var responses = restoringCiphers.Select(c => new CipherResponseModel(c, _globalSettings));
+            return new ListResponseModel<CipherResponseModel>(responses);
         }
 
         [HttpPut("move")]

--- a/src/Core/AssemblyInfo.cs
+++ b/src/Core/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Core.Test")]

--- a/src/Core/Repositories/ICipherRepository.cs
+++ b/src/Core/Repositories/ICipherRepository.cs
@@ -35,6 +35,6 @@ namespace Bit.Core.Repositories
             IEnumerable<CollectionCipher> collectionCiphers);
         Task SoftDeleteAsync(IEnumerable<Guid> ids, Guid userId);
         Task SoftDeleteByIdsOrganizationIdAsync(IEnumerable<Guid> ids, Guid organizationId);
-        Task RestoreAsync(IEnumerable<Guid> ids, Guid userId);
+        Task<DateTime> RestoreAsync(IEnumerable<Guid> ids, Guid userId);
     }
 }

--- a/src/Core/Repositories/SqlServer/CipherRepository.cs
+++ b/src/Core/Repositories/SqlServer/CipherRepository.cs
@@ -610,14 +610,16 @@ namespace Bit.Core.Repositories.SqlServer
             }
         }
 
-        public async Task RestoreAsync(IEnumerable<Guid> ids, Guid userId)
+        public async Task<DateTime> RestoreAsync(IEnumerable<Guid> ids, Guid userId)
         {
             using (var connection = new SqlConnection(ConnectionString))
             {
-                var results = await connection.ExecuteAsync(
+                var results = await connection.ExecuteScalarAsync<DateTime>(
                     $"[{Schema}].[Cipher_Restore]",
                     new { Ids = ids.ToGuidIdArrayTVP(), UserId = userId },
                     commandType: CommandType.StoredProcedure);
+
+                return results;
             }
         }
 

--- a/src/Core/Services/ICipherService.cs
+++ b/src/Core/Services/ICipherService.cs
@@ -36,6 +36,6 @@ namespace Bit.Core.Services
         Task SoftDeleteAsync(Cipher cipher, Guid deletingUserId, bool orgAdmin = false);
         Task SoftDeleteManyAsync(IEnumerable<Guid> cipherIds, Guid deletingUserId, Guid? organizationId = null, bool orgAdmin = false);
         Task RestoreAsync(Cipher cipher, Guid restoringUserId, bool orgAdmin = false);
-        Task RestoreManyAsync(IEnumerable<Guid> cipherIds, Guid restoringUserId);
+        Task RestoreManyAsync(IEnumerable<CipherDetails> ciphers, Guid restoringUserId);
     }
 }

--- a/src/Core/Services/Implementations/CipherService.cs
+++ b/src/Core/Services/Implementations/CipherService.cs
@@ -786,16 +786,15 @@ namespace Bit.Core.Services
             await _pushService.PushSyncCipherUpdateAsync(cipher, null);
         }
 
-        public async Task RestoreManyAsync(IEnumerable<Guid> cipherIds, Guid restoringUserId)
+        public async Task RestoreManyAsync(IEnumerable<CipherDetails> ciphers, Guid restoringUserId)
         {
-            var cipherIdsSet = new HashSet<Guid>(cipherIds);
-            var ciphers = await _cipherRepository.GetManyByUserIdAsync(restoringUserId);
-            var restoringCiphers = ciphers.Where(c => cipherIdsSet.Contains(c.Id) && c.Edit);
+            var revisionDate = await _cipherRepository.RestoreAsync(ciphers.Select(c => c.Id), restoringUserId);
 
-            await _cipherRepository.RestoreAsync(cipherIds, restoringUserId);
-
-            var events = restoringCiphers.Select(c =>
-                new Tuple<Cipher, EventType, DateTime?>(c, EventType.Cipher_Restored, null));
+            var events = ciphers.Select(c =>
+            {
+                c.RevisionDate = revisionDate;
+                return new Tuple<Cipher, EventType, DateTime?>(c, EventType.Cipher_Restored, null);
+            });
             foreach (var eventsBatch in events.Batch(100))
             {
                 await _eventService.LogCipherEventsAsync(eventsBatch);

--- a/src/Core/Services/Implementations/CipherService.cs
+++ b/src/Core/Services/Implementations/CipherService.cs
@@ -793,6 +793,7 @@ namespace Bit.Core.Services
             var events = ciphers.Select(c =>
             {
                 c.RevisionDate = revisionDate;
+                c.DeletedDate = null;
                 return new Tuple<Cipher, EventType, DateTime?>(c, EventType.Cipher_Restored, null);
             });
             foreach (var eventsBatch in events.Batch(100))

--- a/util/Migrator/DbScripts/2021-01-05_00_ReturnRevisionDateOnCipherRestore.sql
+++ b/util/Migrator/DbScripts/2021-01-05_00_ReturnRevisionDateOnCipherRestore.sql
@@ -65,5 +65,7 @@ BEGIN
     EXEC [dbo].[User_BumpAccountRevisionDate] @UserId
 
     DROP TABLE #Temp
+    
+    SELECT @UtcNow
 END
 GO


### PR DESCRIPTION
# Overview

Related to bitwarden/jslib#243 and bitwarden/web/issues/748.

Returns updated ciphers post restore to enable immediate edit without resync.

# Background

Ciphers that are soft deleted, then restored have their revision date updated on the server side. We recently implemented a data loss prevention technique which disallows edits for CipherRequests whose RevisionDate differs from that stored in the database.

Because restore updated RevisionDate, but did not respond with anything to alert the client to the new RevisionDate, edits without a forced resync result in an out-of-sync error. This issue is solved by returning the updated Ciphers for all restore requests.

# Files Changed
* **CiphersController.cs**: Add in the return values. RestoreMany required gathering together the ciphers in the Controller rather than the Service.
* **AssemblyInfo.cs**: This new file houses a compiler directive allowing internal access to the Core.Test project. It allows me to set `RevisionDate` and `DeletedDate` in the testing project.
* **ICipherRepository/CipherRepository.cs**: New method signature for sproc which now returns the revisionDate used on all ciphers edited.
* **ICipherService/CipherService**: RestoreManyAsync now accepts CipherDetails directly rather than gathering them itself. It also updates those ciphers appropriately to reflect the new database state post calling `_cipherRepository.RestoreAsync`.
* **Cipher_Restore.sql/migrator script**: Single line change to add return of RevisionDate to sproc.
* **CipherServiceTests.cs**: Test Restore methods to ensure ciphers are appropriately updated for return to the requestor.