### PR TITLE
[Policy] Update Personal Ownership checkbox description

### DIFF
--- a/bitwarden_license/src/Portal/Models/PolicyEditModel.cs
+++ b/bitwarden_license/src/Portal/Models/PolicyEditModel.cs
@@ -16,7 +16,7 @@ namespace Bit.Portal.Models
             : base(type, false)
         {
             // Inject service and create static lists
-            BuildLists(i18nService);
+            TranslateStrings(i18nService);
         }
 
         public PolicyEditModel(Policy model, II18nService i18nService)
@@ -28,7 +28,7 @@ namespace Bit.Portal.Models
             }
 
             // Inject service and create static lists
-            BuildLists(i18nService);
+            TranslateStrings(i18nService);
 
             if (model.Data != null)
             {
@@ -55,6 +55,7 @@ namespace Bit.Portal.Models
         public PasswordGeneratorDataModel PasswordGeneratorDataModel { get; set; }
         public List<SelectListItem> Complexities { get; set; }
         public List<SelectListItem> DefaultTypes { get; set; }
+        public string EnabledCheckboxText { get; set; }
 
         public Policy ToPolicy(PolicyType type, Guid organizationId)
         {
@@ -93,7 +94,7 @@ namespace Bit.Portal.Models
             return existingPolicy;
         }
 
-        public void BuildLists(II18nService i18nService)
+        public void TranslateStrings(II18nService i18nService)
         {
             Complexities = new List<SelectListItem>
             {
@@ -110,6 +111,8 @@ namespace Bit.Portal.Models
                 new SelectListItem { Value = "password", Text = i18nService.T("Password") },
                 new SelectListItem { Value = "passphrase", Text = i18nService.T("Passphrase") },
             };
+            EnabledCheckboxText = PolicyType == PolicyType.PersonalOwnership
+                ? i18nService.T("PersonalOwnershipCheckboxDesc") : i18nService.T("Enabled");
         }
     }
 }

--- a/bitwarden_license/src/Portal/Models/PolicyEditModel.cs
+++ b/bitwarden_license/src/Portal/Models/PolicyEditModel.cs
@@ -55,7 +55,7 @@ namespace Bit.Portal.Models
         public PasswordGeneratorDataModel PasswordGeneratorDataModel { get; set; }
         public List<SelectListItem> Complexities { get; set; }
         public List<SelectListItem> DefaultTypes { get; set; }
-        public string EnabledCheckboxText { get; set; }
+        public string EnableCheckboxText { get; set; }
 
         public Policy ToPolicy(PolicyType type, Guid organizationId)
         {
@@ -111,7 +111,7 @@ namespace Bit.Portal.Models
                 new SelectListItem { Value = "password", Text = i18nService.T("Password") },
                 new SelectListItem { Value = "passphrase", Text = i18nService.T("Passphrase") },
             };
-            EnabledCheckboxText = PolicyType == PolicyType.PersonalOwnership
+            EnableCheckboxText = PolicyType == PolicyType.PersonalOwnership
                 ? i18nService.T("PersonalOwnershipCheckboxDesc") : i18nService.T("Enabled");
         }
     }

--- a/bitwarden_license/src/Portal/Models/PolicyModel.cs
+++ b/bitwarden_license/src/Portal/Models/PolicyModel.cs
@@ -58,7 +58,6 @@ namespace Bit.Portal.Models
         public string NameKey { get; set; }
         public string DescriptionKey { get; set; }
         public PolicyType PolicyType { get; set; }
-        [Display(Name = "Enabled")]
         public bool Enabled { get; set; }
     }
 }

--- a/bitwarden_license/src/Portal/Views/Policies/Edit.cshtml
+++ b/bitwarden_license/src/Portal/Views/Policies/Edit.cshtml
@@ -67,7 +67,7 @@
     <div class="form-group">
         <div class="form-check">
             <input class="form-check-input" type="checkbox" asp-for="Enabled">
-            <label class="form-check-label" asp-for="Enabled"></label>
+            <label class="form-check-label" asp-for="Enabled">@Model.EnabledCheckboxText</label>
         </div>
     </div>
 

--- a/bitwarden_license/src/Portal/Views/Policies/Edit.cshtml
+++ b/bitwarden_license/src/Portal/Views/Policies/Edit.cshtml
@@ -67,7 +67,7 @@
     <div class="form-group">
         <div class="form-check">
             <input class="form-check-input" type="checkbox" asp-for="Enabled">
-            <label class="form-check-label" asp-for="Enabled">@Model.EnabledCheckboxText</label>
+            <label class="form-check-label" asp-for="Enabled">@Model.EnableCheckboxText</label>
         </div>
     </div>
 

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -581,4 +581,7 @@
   <data name="DisableRequireSsoError" xml:space="preserve">
     <value>You must manually disable the Single Sign-On Authentication policy before this policy can be disabled.</value>
   </data>
+  <data name="PersonalOwnershipCheckboxDesc" xml:space="preserve">
+    <value>Disable personal ownership for organization users</value>
+  </data>
 </root>


### PR DESCRIPTION
## Objective
> Bring some clarity to what is happening when enabling the `Personal Ownership` policy.  Adjust the checkbox description to describe the action being taken.

## Code Changes
- **PolicyEditModel.cs**: Refactored `BuildLists` to `TranslateStrings` because this method is now doing more than just list building.  Added new `EnableCheckboxText` property. Set the `EnableCheckboxText` property within the `TranslateStrings` method that will set the proper string based on the `PolicyType` being edited.
- **PolicyModel.cs**: Removed the `Name` property since the string is now dynamically generated
- **Policies/Edit.cshtml**: Added reference to the newly created `EnableCheckboxText` property for the label used with the enable checkbox.
- **SharedResources.en.resx**: Added new string

## Screenshot
<img width="1003" alt="0-portal-enabled-checkbox" src="https://user-images.githubusercontent.com/26154748/103911488-b9c1c880-50cb-11eb-8f7a-543ad18a29a4.png">
