### PR TITLE
Permissions bugs

### DIFF
--- a/src/Core/Models/Business/OrganizationUserInvite.cs
+++ b/src/Core/Models/Business/OrganizationUserInvite.cs
@@ -20,8 +20,12 @@ namespace Bit.Core.Models.Business
             Emails = requestModel.Emails;
             Type = requestModel.Type.Value;
             AccessAll = requestModel.AccessAll;
-            Collections = requestModel.Collections.Select(c => c.ToSelectionReadOnly());
             Permissions = requestModel.Permissions;
+
+            if (requestModel.Collections != null && requestModel.Collections.Any())
+            {
+                Collections = requestModel.Collections.Select(c => c.ToSelectionReadOnly());
+            }
         }
     }
 }

--- a/src/Core/Models/Business/OrganizationUserInvite.cs
+++ b/src/Core/Models/Business/OrganizationUserInvite.cs
@@ -20,12 +20,8 @@ namespace Bit.Core.Models.Business
             Emails = requestModel.Emails;
             Type = requestModel.Type.Value;
             AccessAll = requestModel.AccessAll;
+            Collections = requestModel.Collections?.Select(c => c.ToSelectionReadOnly());
             Permissions = requestModel.Permissions;
-
-            if (requestModel.Collections != null && requestModel.Collections.Any())
-            {
-                Collections = requestModel.Collections.Select(c => c.ToSelectionReadOnly());
-            }
         }
     }
 }

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1022,11 +1022,15 @@ namespace Bit.Core.Services
                     ExternalId = externalId,
                     CreationDate = DateTime.UtcNow,
                     RevisionDate = DateTime.UtcNow,
-                    Permissions = System.Text.Json.JsonSerializer.Serialize(invite.Permissions, new JsonSerializerOptions
+                };
+
+                if (invite.Permissions != null)
+                {
+                    orgUser.Permissions = System.Text.Json.JsonSerializer.Serialize(invite.Permissions, new JsonSerializerOptions
                     {
                         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                    }),
-                };
+                    });
+                }
 
                 if (!orgUser.AccessAll && invite.Collections.Any())
                 {

--- a/test/Core.Test/AutoFixture/OrganizationFixtures.cs
+++ b/test/Core.Test/AutoFixture/OrganizationFixtures.cs
@@ -56,7 +56,8 @@ namespace Bit.Core.Test.AutoFixture.OrganizationFixtures
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             });
             fixture.Customize<Organization>(composer => composer
-                .With(o => o.Id, organizationId));
+                .With(o => o.Id, organizationId)
+                .With(o => o.Seats, (short)100));
             fixture.Customize<OrganizationUser>(composer => composer
                 .With(ou => ou.OrganizationId, organizationId)
                 .With(ou => ou.Type, InvitorUserType)

--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -299,6 +299,25 @@ namespace Bit.Core.Test.Services
         [Theory] 
         [OrganizationInviteAutoData(
             inviteeUserType: (int)OrganizationUserType.User, 
+            invitorUserType: (int)OrganizationUserType.Owner
+        )]
+        public async Task InviteUser_NoPermissionsObject_Passes(Organization organization, OrganizationUserInvite invite, 
+            OrganizationUser invitor, SutProvider<OrganizationService> sutProvider)
+        {
+            invite.Permissions = null;
+            var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
+            var organizationUserRepository = sutProvider.GetDependency<IOrganizationUserRepository>();
+            var eventService = sutProvider.GetDependency<IEventService>();
+
+            organizationRepository.GetByIdAsync(organization.Id).Returns(organization);
+            organizationUserRepository.GetManyByUserAsync(invitor.UserId.Value).Returns(new List<OrganizationUser> { invitor });
+
+            await sutProvider.Sut.InviteUserAsync(organization.Id, invitor.UserId, null, invite);
+        }
+
+        [Theory] 
+        [OrganizationInviteAutoData(
+            inviteeUserType: (int)OrganizationUserType.User, 
             invitorUserType: (int)OrganizationUserType.Custom
         )]
         public async Task InviteUser_Passes(Organization organization, OrganizationUserInvite invite, 


### PR DESCRIPTION
Fixed a couple of things I noticed doing final dev testing of Permissions.

1. Null checked the Collections prop of the new OrgInvite object. This was throwing an error when "Access All" was selected on invite.
2. Null checked the Permissions object on invite & added a test to verify this case would still work. This should never happen, and didn't happen to me, but I wanted to cover the bases.
3. Gave a static org seat count to the invite fixture to prevent errors over seat count