### PR TITLE
Bwsh surpress warnings

### DIFF
--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -83,7 +83,9 @@ function Docker-Compose-Up {
 
 function Docker-Compose-Down {
     Docker-Compose-Files
-    Invoke-Expression ("docker-compose down{0}" -f "") #TODO: qFlag
+    if ((Invoke-Expression ("docker-compose ps{0}" -f "") | Measure-Object -Line).lines -gt 2 ) {
+        Invoke-Expression ("docker-compose down{0}" -f "") #TODO: qFlag
+    }
 }
 
 function Docker-Compose-Pull {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -91,7 +91,9 @@ function dockerComposeUp() {
 
 function dockerComposeDown() {
     dockerComposeFiles
-    docker-compose down
+    if [ $(docker-compose ps | wc -l) -gt 2 ]; then
+        docker-compose down
+    fi
 }
 
 function dockerComposePull() {


### PR DESCRIPTION
## Summary
The self-host bitwarden scripts assume that the docker-compose app is up. If it is run without being up, there are warnings when we force `docker-compose down`. These changes suppress those warnings.

## Files Changed
- scripts/run.ps1
- scripts/run.sh

## Notes
run.sh has been tested on Linux. run.ps1 has been tested on both Linux and Windows.