### PR TITLE
Sales Tax for Premium signups

### DIFF
--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -444,6 +444,21 @@ namespace Bit.Core.Services
                 Quantity = 1,
             });
 
+            var taxRates = await _taxRateRepository.GetByLocationAsync(
+                new Bit.Core.Models.Table.TaxRate()
+                {
+                    Country = customer.Address.Country,
+                    PostalCode = customer.Address.PostalCode
+                }
+            );
+            var taxRate = taxRates.FirstOrDefault();
+            if (taxRate != null)
+            {
+                subCreateOptions.DefaultTaxRates = new List<string>(1) 
+                { 
+                    taxRate.Id 
+                };
+            }
             if (additionalStorageGb > 0)
             {
                 subCreateOptions.Items.Add(new SubscriptionItemOptions

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -459,6 +459,7 @@ namespace Bit.Core.Services
                     taxRate.Id 
                 };
             }
+
             if (additionalStorageGb > 0)
             {
                 subCreateOptions.Items.Add(new SubscriptionItemOptions


### PR DESCRIPTION
https://github.com/bitwarden/web/pull/774

@thekazian discovered during testing that sales tax isn't being charged on Premium signups

### Code Changes
1. Added `TaxRate` lookup & application logic to `PurchasePremiumAsync()`