### PR TITLE
Add SAML 2.0 metadata export for dynamic SPs

### DIFF
--- a/bitwarden_license/src/Portal/Models/SsoConfigDataViewModel.cs
+++ b/bitwarden_license/src/Portal/Models/SsoConfigDataViewModel.cs
@@ -31,6 +31,7 @@ namespace Bit.Portal.Models
             RedirectBehavior = configurationData.RedirectBehavior;
             GetClaimsFromUserInfoEndpoint = configurationData.GetClaimsFromUserInfoEndpoint;
             SpEntityId = configurationData.BuildSaml2ModulePath(globalSettings.BaseServiceUri.Sso);
+            SpMetadataUrl = configurationData.BuildSaml2MetadataUrl(globalSettings.BaseServiceUri.Sso, organizationId.ToString());
             SpAcsUrl = configurationData.BuildSaml2AcsUrl(globalSettings.BaseServiceUri.Sso, organizationId.ToString());
             IdpEntityId = configurationData.IdpEntityId;
             IdpBindingType = configurationData.IdpBindingType;
@@ -75,6 +76,8 @@ namespace Bit.Portal.Models
         // SAML2 SP
         [Display(Name = "SpEntityId")]
         public string SpEntityId { get; set; }
+        [Display(Name = "SpMetadataUrl")]
+        public string SpMetadataUrl { get; set; }
         [Display(Name = "SpAcsUrl")]
         public string SpAcsUrl { get; set; }
         [Display(Name = "NameIdFormat")]

--- a/bitwarden_license/src/Portal/Views/Sso/Index.cshtml
+++ b/bitwarden_license/src/Portal/Views/Sso/Index.cshtml
@@ -158,6 +158,30 @@
             </div>
             <div class="row">
                 <div class="col-7 form-group">
+                    <label asp-for="Data.SpMetadataUrl">@i18nService.T("SpMetadataUrl")</label>
+                    <div class="input-group">
+                        <input asp-for="Data.SpMetadataUrl" class="form-control" readonly>
+                        <div class="input-group-append">
+                            <a class="btn btn-outline-secondary launch-button"
+                               href="@Model.Data.SpMetadataUrl"
+                               target="_blank"
+                               aria-label="@i18nService.T("LaunchSpMetadataUrl")" title="@i18nService.T("LaunchSpMetadataUrl")"
+                               tabindex="-1">
+                                <i class="fa fa-lg fa-external-link" aria-hidden="true"></i>
+                            </a>
+                            <button type="button" class="btn btn-outline-secondary copy-button"
+                                    aria-label="@i18nService.T("CopySpMetadataUrl")" title="@i18nService.T("CopySpMetadataUrl")"
+                                    tabindex="-1">
+                                <i class="fa fa-lg fa-clone" aria-hidden="true"></i>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-1">
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-7 form-group">
                     <label asp-for="Data.SpAcsUrl">@i18nService.T("SpAcsUrl")</label>
                     <div class="input-group">
                         <input asp-for="Data.SpAcsUrl" class="form-control" readonly>

--- a/bitwarden_license/src/Sso/Controllers/MetadataController.cs
+++ b/bitwarden_license/src/Sso/Controllers/MetadataController.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Threading.Tasks;
+using Bit.Core.Enums;
+using Bit.Sso.Utilities;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc;
+using Sustainsys.Saml2.AspNetCore2;
+using Sustainsys.Saml2.WebSso;
+
+namespace Bit.Sso.Controllers
+{
+    public class MetadataController : Controller
+    {
+        private readonly IAuthenticationSchemeProvider _schemeProvider;
+
+        public MetadataController(
+            IAuthenticationSchemeProvider schemeProvider)
+        {
+            _schemeProvider = schemeProvider;
+        }
+
+        [HttpGet("saml2/{scheme}")]
+        public async Task<IActionResult> ViewAsync(string scheme)
+        {
+            if (string.IsNullOrWhiteSpace(scheme))
+            {
+                return NotFound();
+            }
+
+            var authScheme = await _schemeProvider.GetSchemeAsync(scheme);
+            if (authScheme == null ||
+                !(authScheme is DynamicAuthenticationScheme dynamicAuthScheme) ||
+                dynamicAuthScheme?.SsoType != SsoType.Saml2)
+            {
+                return NotFound();
+            }
+
+            if (!(dynamicAuthScheme.Options is Saml2Options options))
+            {
+                return NotFound();
+            }
+
+            var uri = new Uri(
+                Request.Scheme
+                + "://"
+                + Request.Host
+                + Request.Path
+                + Request.QueryString);
+
+            var pathBase = Request.PathBase.Value;
+            pathBase = string.IsNullOrEmpty(pathBase) ? "/" : pathBase;
+
+            var requestdata = new HttpRequestData(
+                Request.Method,
+                uri,
+                pathBase,
+                null,
+                Request.Cookies,
+                (data) => data);
+
+            var metadataResult = CommandFactory
+                .GetCommand(CommandFactory.MetadataCommand)
+                .Run(requestdata, options);
+            //Response.Headers.Add("Content-Disposition", $"filename= bitwarden-saml2-meta-{scheme}.xml");
+            return new ContentResult
+            {
+                Content = metadataResult.Content,
+                ContentType = "text/xml",
+            };
+        }
+    }
+}

--- a/src/Core/Models/Data/SsoConfigurationData.cs
+++ b/src/Core/Models/Data/SsoConfigurationData.cs
@@ -62,6 +62,11 @@ namespace Bit.Core.Models.Data
             return string.Concat(BuildSaml2ModulePath(ssoUri, scheme), "/Acs");
         }
 
+        public string BuildSaml2MetadataUrl(string ssoUri = null, string scheme = null)
+        {
+            return BuildSaml2ModulePath(ssoUri, scheme);
+        }
+
         private string BuildSsoUrl(string relativePath, string ssoUri)
         {
             if (string.IsNullOrWhiteSpace(ssoUri) ||

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -265,6 +265,9 @@
   <data name="SpEntityId" xml:space="preserve">
     <value>SP Entity ID</value>
   </data>
+  <data name="SpMetadataUrl" xml:space="preserve">
+    <value>SAML 2.0 Metadata URL</value>
+  </data>
   <data name="SpAcsUrl" xml:space="preserve">
     <value>Assertion Consumer Service (ACS) URL</value>
   </data>
@@ -474,6 +477,12 @@
   </data>
   <data name="CopySpEntityId">
     <value>Copy the SP Entity Id to your clipboard</value>
+  </data>
+  <data name="CopySpMetadataUrl">
+    <value>Copy the SAML 2.0 Metadata URL to your clipboard</value>
+  </data>
+  <data name="LaunchSpMetadataUrl">
+    <value>View the SAML 2.0 Metadata (opens in a new window)</value>
   </data>
   <data name="CopySpAcsUrl">
     <value>Copy the Assertion Consumer Service (ACS) URL to your clipboard</value>


### PR DESCRIPTION
## Overview

There are times when setting up SSO using SAML 2.0 that the Metadata protocol is useful for staging the Service Provider settings within the IdP (such as with Shibboleth) and loading an XML metadata file is much more simple than manual configuration.

This modification enhances Bitwarden to provide an export of the SAML 2.0 metadata that represents the organization's SSO configuration as the Service Provider from the SSO service. This is an additional endpoint and not part of the "live" SSO protocol itself (it simply provides the distributable SSO configuration to the IdP). This is 50% of the end-to-end metadata "exchange" process leaving only the IdP metadata import from being available from within Bitwarden (future).

## Screenshots

New field, **SAML 2.0 Metadata URL**
![image](https://user-images.githubusercontent.com/3904944/105084368-38bbe700-5a64-11eb-8f25-7a92ac876067.png)

Both launch (view) and copy buttons are available for this URL.

XML output snippet:
![image](https://user-images.githubusercontent.com/3904944/105084438-56894c00-5a64-11eb-8164-9e690139067b.png)
