### PR TITLE
null checked Stripe.Customer.Address for org seat and storage upgrades

### DIFF
--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -415,20 +415,24 @@ namespace Bit.Core.Services
             };
 
             var customer = await new CustomerService().GetAsync(sub.CustomerId);
-            var taxRates = await _taxRateRepository.GetByLocationAsync(
-                new Bit.Core.Models.Table.TaxRate()
-                {
-                    Country = customer.Address.Country,
-                    PostalCode = customer.Address.PostalCode
-                }
-            );
-            var taxRate = taxRates.FirstOrDefault();
-            if (taxRate != null && !sub.DefaultTaxRates.Any(x => x.Equals(taxRate.Id)))
+            if (!string.IsNullOrWhiteSpace(customer?.Address?.Country)
+                    && !string.IsNullOrWhiteSpace(customer?.Address?.PostalCode))
             {
-                subUpdateOptions.DefaultTaxRates = new List<string>(1) 
-                { 
-                    taxRate.Id 
-                };
+                var taxRates = await _taxRateRepository.GetByLocationAsync(
+                    new Bit.Core.Models.Table.TaxRate()
+                    {
+                        Country = customer.Address.Country,
+                        PostalCode = customer.Address.PostalCode
+                    }
+                );
+                var taxRate = taxRates.FirstOrDefault();
+                if (taxRate != null && !sub.DefaultTaxRates.Any(x => x.Equals(taxRate.Id)))
+                {
+                    subUpdateOptions.DefaultTaxRates = new List<string>(1) 
+                    { 
+                        taxRate.Id 
+                    };
+                }
             }
 
             var subResponse = await subscriptionService.UpdateAsync(sub.Id, subUpdateOptions);

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -719,20 +719,24 @@ namespace Bit.Core.Services
             };
 
             var customer = await new CustomerService().GetAsync(sub.CustomerId);
-            var taxRates = await _taxRateRepository.GetByLocationAsync(
-                new Bit.Core.Models.Table.TaxRate()
-                {
-                    Country = customer.Address.Country,
-                    PostalCode = customer.Address.PostalCode
-                }
-            );
-            var taxRate = taxRates.FirstOrDefault();
-            if (taxRate != null && !sub.DefaultTaxRates.Any(x => x.Equals(taxRate.Id)))
+            if (!string.IsNullOrWhiteSpace(customer?.Address?.Country) 
+                    && !string.IsNullOrWhiteSpace(customer?.Address?.PostalCode))
             {
-                subUpdateOptions.DefaultTaxRates = new List<string>(1) 
-                { 
-                    taxRate.Id 
-                };
+                var taxRates = await _taxRateRepository.GetByLocationAsync(
+                    new Bit.Core.Models.Table.TaxRate()
+                    {
+                        Country = customer.Address.Country,
+                        PostalCode = customer.Address.PostalCode
+                    }
+                );
+                var taxRate = taxRates.FirstOrDefault();
+                if (taxRate != null && !sub.DefaultTaxRates.Any(x => x.Equals(taxRate.Id)))
+                {
+                    subUpdateOptions.DefaultTaxRates = new List<string>(1) 
+                    { 
+                        taxRate.Id 
+                    };
+                }
             }
 
             var subResponse = await subscriptionService.UpdateAsync(sub.Id, subUpdateOptions);


### PR DESCRIPTION
Resolves https://app.asana.com/0/1169444489336079/1199629746939252/f

When Stripe doesn't have billing information for a customer the tax rate check fails when upgrading seats or storage in an organization. Added some null checks to just skip that logic if relevant data doesn't exist.