### PR TITLE
Emergency Access handle null

### DIFF
--- a/src/Api/Controllers/EmergencyAccessController.cs
+++ b/src/Api/Controllers/EmergencyAccessController.cs
@@ -87,14 +87,14 @@ namespace Bit.Api.Controllers
         public async Task Invite([FromBody] EmergencyAccessInviteRequestModel model)
         {
             var user = await _userService.GetUserByPrincipalAsync(User);
-            await _emergencyAccessService.InviteAsync(user, user.Name, model.Email, model.Type.Value, model.WaitTimeDays);
+            await _emergencyAccessService.InviteAsync(user, model.Email, model.Type.Value, model.WaitTimeDays);
         }
 
         [HttpPost("{id}/reinvite")]
         public async Task Reinvite(string id)
         {
             var user = await _userService.GetUserByPrincipalAsync(User);
-            await _emergencyAccessService.ResendInviteAsync(user.Id, new Guid(id), user.Name);
+            await _emergencyAccessService.ResendInviteAsync(user, new Guid(id));
         }
 
         [HttpPost("{id}/accept")]

--- a/src/Core/Services/IEmergencyAccessService.cs
+++ b/src/Core/Services/IEmergencyAccessService.cs
@@ -9,8 +9,8 @@ namespace Bit.Core.Services
 {
     public interface IEmergencyAccessService
     {
-        Task<EmergencyAccess> InviteAsync(User invitingUser, string invitingUsersName, string email, EmergencyAccessType type, int waitTime);
-        Task ResendInviteAsync(Guid invitingUserId, Guid emergencyAccessId, string invitingUsersName);
+        Task<EmergencyAccess> InviteAsync(User invitingUser, string email, EmergencyAccessType type, int waitTime);
+        Task ResendInviteAsync(User invitingUser, Guid emergencyAccessId);
         Task<EmergencyAccess> AcceptUserAsync(Guid emergencyAccessId, User user, string token, IUserService userService);
         Task DeleteAsync(Guid emergencyAccessId, Guid grantorId);
         Task<EmergencyAccess> ConfirmUserAsync(Guid emergencyAccessId, string key, Guid grantorId);


### PR DESCRIPTION
It's possible for `user.Name` to be null. Which causes issues since the emails assumes it to always exist. Updated the logic to fallback to the email if name is null or whitespace.

Resolves https://github.com/bitwarden/web/issues/791