### PR TITLE
Self hosted release - v1.39.0

### DIFF
--- a/scripts/bitwarden.ps1
+++ b/scripts/bitwarden.ps1
@@ -24,8 +24,8 @@ if ($output -eq "") {
 
 $scriptsDir = "${output}\scripts"
 $githubBaseUrl = "https://raw.githubusercontent.com/bitwarden/server/master"
-$coreVersion = "1.38.4"
-$webVersion = "2.17.1"
+$coreVersion = "1.39.0"
+$webVersion = "2.18.0"
 
 # Functions
 

--- a/scripts/bitwarden.sh
+++ b/scripts/bitwarden.sh
@@ -32,8 +32,8 @@ fi
 
 SCRIPTS_DIR="$OUTPUT/scripts"
 GITHUB_BASE_URL="https://raw.githubusercontent.com/bitwarden/server/master"
-COREVERSION="1.38.4"
-WEBVERSION="2.17.1"
+COREVERSION="1.39.0"
+WEBVERSION="2.18.0"
 
 echo "bitwarden.sh version $COREVERSION"
 docker --version


### PR DESCRIPTION
Point our self-hosted friends to the latest v1.39.0 release of the Bitwarden Server images and latest v1.18.0 version release of our web vault.