### PR TITLE
Send Sync Notifications

### DIFF
--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -84,7 +84,6 @@ namespace Bit.Api.Controllers
         [HttpPost("")]
         public async Task<SendResponseModel> Post([FromBody] SendRequestModel model)
         {
-            throw new NotFoundException();
             model.ValidateCreation();
             var userId = _userService.GetProperUserId(User).Value;
             var send = model.ToSend(userId, _sendService);
@@ -97,7 +96,6 @@ namespace Bit.Api.Controllers
         [DisableFormValueModelBinding]
         public async Task<SendResponseModel> PostFile()
         {
-            throw new NotFoundException();
             if (!Request?.ContentType.Contains("multipart/") ?? true)
             {
                 throw new BadRequestException("Invalid content.");

--- a/src/Core/Enums/PushType.cs
+++ b/src/Core/Enums/PushType.cs
@@ -16,5 +16,9 @@
         SyncSettings = 10,
 
         LogOut = 11,
+
+        SyncSendCreate = 12,
+        SyncSendUpdate = 13,
+        SyncSendDelete = 14,
     }
 }

--- a/src/Core/Models/PushNotification.cs
+++ b/src/Core/Models/PushNotification.cs
@@ -39,4 +39,11 @@ namespace Bit.Core.Models
         public Guid UserId { get; set; }
         public DateTime Date { get; set; }
     }
+
+    public class SyncSendPushNotification
+    {
+        public Guid Id { get; set; }
+        public Guid UserId { get; set; }
+        public DateTime RevisionDate { get; set; }
+    }
 }

--- a/src/Core/Services/IPushNotificationService.cs
+++ b/src/Core/Services/IPushNotificationService.cs
@@ -19,6 +19,9 @@ namespace Bit.Core.Services
         Task PushSyncOrgKeysAsync(Guid userId);
         Task PushSyncSettingsAsync(Guid userId);
         Task PushLogOutAsync(Guid userId);
+        Task PushSyncSendCreateAsync(Send send);
+        Task PushSyncSendUpdateAsync(Send send);
+        Task PushSyncSendDeleteAsync(Send send);
         Task SendPayloadToUserAsync(string userId, PushType type, object payload, string identifier, string deviceId = null);
         Task SendPayloadToOrganizationAsync(string orgId, PushType type, object payload, string identifier,
             string deviceId = null);

--- a/src/Core/Services/Implementations/AzureQueuePushNotificationService.cs
+++ b/src/Core/Services/Implementations/AzureQueuePushNotificationService.cs
@@ -135,6 +135,36 @@ namespace Bit.Core.Services
             await SendMessageAsync(type, message, false);
         }
 
+        public async Task PushSyncSendCreateAsync(Send send)
+        {
+            await PushSendAsync(send, PushType.SyncSendCreate);
+        }
+
+        public async Task PushSyncSendUpdateAsync(Send send)
+        {
+            await PushSendAsync(send, PushType.SyncSendUpdate);
+        }
+
+        public async Task PushSyncSendDeleteAsync(Send send)
+        {
+            await PushSendAsync(send, PushType.SyncSendDelete);
+        }
+
+        private async Task PushSendAsync(Send send, PushType type)
+        {
+            if (send.UserId.HasValue)
+            {
+                var message = new SyncSendPushNotification
+                {
+                    Id = send.Id,
+                    UserId = send.UserId.Value,
+                    RevisionDate = send.RevisionDate
+                };
+
+                await SendMessageAsync(type, message, true);
+            }
+        }
+
         private async Task SendMessageAsync<T>(PushType type, T payload, bool excludeCurrentContext)
         {
             var contextId = GetContextIdentifier(excludeCurrentContext);

--- a/src/Core/Services/Implementations/MultiServicePushNotificationService.cs
+++ b/src/Core/Services/Implementations/MultiServicePushNotificationService.cs
@@ -122,6 +122,24 @@ namespace Bit.Core.Services
             return Task.FromResult(0);
         }
 
+        public Task PushSyncSendCreateAsync(Send send)
+        {
+            PushToServices((s) => s.PushSyncSendCreateAsync(send));
+            return Task.FromResult(0);
+        }
+
+        public Task PushSyncSendUpdateAsync(Send send)
+        {
+            PushToServices((s) => s.PushSyncSendUpdateAsync(send));
+            return Task.FromResult(0);
+        }
+
+        public Task PushSyncSendDeleteAsync(Send send)
+        {
+            PushToServices((s) => s.PushSyncSendDeleteAsync(send));
+            return Task.FromResult(0);
+        }
+
         public Task SendPayloadToUserAsync(string userId, PushType type, object payload, string identifier,
             string deviceId = null)
         {

--- a/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
+++ b/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
@@ -136,6 +136,36 @@ namespace Bit.Core.Services
             await SendPayloadToUserAsync(userId, type, message, false);
         }
 
+        public async Task PushSyncSendCreateAsync(Send send)
+        {
+            await PushSendAsync(send, PushType.SyncSendCreate);
+        }
+
+        public async Task PushSyncSendUpdateAsync(Send send)
+        {
+            await PushSendAsync(send, PushType.SyncSendUpdate);
+        }
+
+        public async Task PushSyncSendDeleteAsync(Send send)
+        {
+            await PushSendAsync(send, PushType.SyncSendDelete);
+        }
+
+        private async Task PushSendAsync(Send send, PushType type)
+        {
+            if (send.UserId.HasValue)
+            {
+                var message = new SyncSendPushNotification
+                {
+                    Id = send.Id,
+                    UserId = send.UserId.Value,
+                    RevisionDate = send.RevisionDate
+                };
+
+                await SendPayloadToUserAsync(message.UserId, type, message, true);
+            }
+        }
+
         private async Task SendPayloadToUserAsync(Guid userId, PushType type, object payload, bool excludeCurrentContext)
         {
             await SendPayloadToUserAsync(userId.ToString(), type, payload, GetContextIdentifier(excludeCurrentContext));

--- a/src/Core/Services/Implementations/NotificationsApiPushNotificationService.cs
+++ b/src/Core/Services/Implementations/NotificationsApiPushNotificationService.cs
@@ -142,6 +142,36 @@ namespace Bit.Core.Services
             await SendMessageAsync(type, message, false);
         }
 
+        public async Task PushSyncSendCreateAsync(Send send)
+        {
+            await PushSendAsync(send, PushType.SyncSendCreate);
+        }
+
+        public async Task PushSyncSendUpdateAsync(Send send)
+        {
+            await PushSendAsync(send, PushType.SyncSendUpdate);
+        }
+
+        public async Task PushSyncSendDeleteAsync(Send send)
+        {
+            await PushSendAsync(send, PushType.SyncSendDelete);
+        }
+
+        private async Task PushSendAsync(Send send, PushType type)
+        {
+            if (send.UserId.HasValue)
+            {
+                var message = new SyncSendPushNotification
+                {
+                    Id = send.Id,
+                    UserId = send.UserId.Value,
+                    RevisionDate = send.RevisionDate
+                };
+
+                await SendMessageAsync(type, message, false);
+            }
+        }
+
         private async Task SendMessageAsync<T>(PushType type, T payload, bool excludeCurrentContext)
         {
             var contextId = GetContextIdentifier(excludeCurrentContext);

--- a/src/Core/Services/Implementations/RelayPushNotificationService.cs
+++ b/src/Core/Services/Implementations/RelayPushNotificationService.cs
@@ -139,6 +139,36 @@ namespace Bit.Core.Services
             await SendPayloadToUserAsync(userId, type, message, false);
         }
 
+        public async Task PushSyncSendCreateAsync(Send send)
+        {
+            await PushSendAsync(send, PushType.SyncSendCreate);
+        }
+
+        public async Task PushSyncSendUpdateAsync(Send send)
+        {
+            await PushSendAsync(send, PushType.SyncSendUpdate);
+        }
+
+        public async Task PushSyncSendDeleteAsync(Send send)
+        {
+            await PushSendAsync(send, PushType.SyncSendDelete);
+        }
+
+        private async Task PushSendAsync(Send send, PushType type)
+        {
+            if (send.UserId.HasValue)
+            {
+                var message = new SyncSendPushNotification
+                {
+                    Id = send.Id,
+                    UserId = send.UserId.Value,
+                    RevisionDate = send.RevisionDate
+                };
+
+                await SendPayloadToUserAsync(message.UserId, type, message, true);
+            }
+        }
+
         private async Task SendPayloadToUserAsync(Guid userId, PushType type, object payload, bool excludeCurrentContext)
         {
             var request = new PushSendRequestModel

--- a/src/Core/Services/NoopImplementations/NoopPushNotificationService.cs
+++ b/src/Core/Services/NoopImplementations/NoopPushNotificationService.cs
@@ -63,6 +63,21 @@ namespace Bit.Core.Services
             return Task.FromResult(0);
         }
 
+        public Task PushSyncSendCreateAsync(Send send)
+        {
+            return Task.FromResult(0);
+        }
+
+        public Task PushSyncSendDeleteAsync(Send send)
+        {
+            return Task.FromResult(0);
+        }
+
+        public Task PushSyncSendUpdateAsync(Send send)
+        {
+            return Task.FromResult(0);
+        }
+
         public Task SendPayloadToOrganizationAsync(string orgId, PushType type, object payload, string identifier,
             string deviceId = null)
         {

--- a/src/Notifications/HubHelpers.cs
+++ b/src/Notifications/HubHelpers.cs
@@ -54,6 +54,15 @@ namespace Bit.Notifications
                     await hubContext.Clients.User(userNotification.Payload.UserId.ToString())
                             .SendAsync("ReceiveMessage", userNotification, cancellationToken);
                     break;
+                case PushType.SyncSendCreate:
+                case PushType.SyncSendUpdate:
+                case PushType.SyncSendDelete:
+                    var sendNotification =
+                        JsonConvert.DeserializeObject<PushNotificationData<SyncSendPushNotification>>(
+                                notificationJson);
+                    await hubContext.Clients.User(sendNotification.Payload.UserId.ToString())
+                        .SendAsync("ReceiveMessage", sendNotification, cancellationToken);
+                    break;
                 default:
                     break;
             }


### PR DESCRIPTION
https://app.asana.com/0/1199659118818122/1199511462356833
https://github.com/bitwarden/jslib/pull/250
https://github.com/bitwarden/web/pull/799

### Narrative 
As a Bitwarden Send user I would like my local Send storage to stay in sync across concurrent sessions.

### Code Changes
1. Enabled Send API calls by removing the `NotFoundException()`s being thrown by default.
2. Added new PushType enums for relevant Send CRUD actions.
3. Added new methods to `IPushNotificationService` and its plethora of implementations for the new Send `PushType`s.
4. Added an `IPushNotificationService` instance to the `SendService` and called its Send methods in any relevant service logic.
5. Added new `case` statements to the Notification project's `HubHelper` for the new `PushType`s.