### PR TITLE
changed the address data used to pull sales tax for premium subscriptions

### DIFF
--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -447,8 +447,8 @@ namespace Bit.Core.Services
             var taxRates = await _taxRateRepository.GetByLocationAsync(
                 new Bit.Core.Models.Table.TaxRate()
                 {
-                    Country = customer.Address.Country,
-                    PostalCode = customer.Address.PostalCode
+                    Country = taxInfo.BillingAddressCountry,
+                    PostalCode = taxInfo.BillingAddressPostalCode
                 }
             );
             var taxRate = taxRates.FirstOrDefault();

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -444,8 +444,8 @@ namespace Bit.Core.Services
                 Quantity = 1,
             });
 
-            if (string.IsNullOrWhiteSpace(taxInfo?.BillingAddressCountry) 
-                    && string.IsNullOrWhiteSpace(taxInfo?.BillingAddressPostalCode)) 
+            if (!string.IsNullOrWhiteSpace(taxInfo?.BillingAddressCountry) 
+                    && !string.IsNullOrWhiteSpace(taxInfo?.BillingAddressPostalCode)) 
             {
                 var taxRates = await _taxRateRepository.GetByLocationAsync(
                     new Bit.Core.Models.Table.TaxRate()

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -444,20 +444,24 @@ namespace Bit.Core.Services
                 Quantity = 1,
             });
 
-            var taxRates = await _taxRateRepository.GetByLocationAsync(
-                new Bit.Core.Models.Table.TaxRate()
-                {
-                    Country = taxInfo.BillingAddressCountry,
-                    PostalCode = taxInfo.BillingAddressPostalCode
-                }
-            );
-            var taxRate = taxRates.FirstOrDefault();
-            if (taxRate != null)
+            if (string.IsNullOrWhiteSpace(taxInfo?.BillingAddressCountry) 
+                    && string.IsNullOrWhiteSpace(taxInfo?.BillingAddressPostalCode)) 
             {
-                subCreateOptions.DefaultTaxRates = new List<string>(1) 
-                { 
-                    taxRate.Id 
-                };
+                var taxRates = await _taxRateRepository.GetByLocationAsync(
+                    new Bit.Core.Models.Table.TaxRate()
+                    {
+                        Country = taxInfo.BillingAddressCountry,
+                        PostalCode = taxInfo.BillingAddressPostalCode
+                    }
+                );
+                var taxRate = taxRates.FirstOrDefault();
+                if (taxRate != null)
+                {
+                    subCreateOptions.DefaultTaxRates = new List<string>(1) 
+                    { 
+                        taxRate.Id 
+                    };
+                }
             }
 
             if (additionalStorageGb > 0)


### PR DESCRIPTION
This resolves the bug where using account credit to pay an invoice isn't working.

When signing up for Premium I originally set up logic to search for a relevant tax rate based on the Stripe-stored customer billing address. This isn't the best place to check for this data, as we collect it on checkout and Stripe doesn't always have it. This PR changes that logic to use the form collected tax info, and checks to make sure that exists. 