### PR TITLE
check that SingleOrg policy is enabled before saying users cant create new orgs

### DIFF
--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -162,7 +162,7 @@ namespace Bit.Api.Controllers
             }
 
             var policies = await _policyRepository.GetManyByUserIdAsync(user.Id);
-            if (policies.Where(policy => policy.Enabled).Any(policy => policy.Type == PolicyType.SingleOrg))
+            if (policies.Any(policy => policy.Enabled && policy.Type == PolicyType.SingleOrg))
             {
                 throw new Exception("You may not create an organization. You belong to an organization " +
                      "which has a policy that prohibits you from being a member of any other organization.");
@@ -190,7 +190,7 @@ namespace Bit.Api.Controllers
             }
 
             var policies = await _policyRepository.GetManyByUserIdAsync(user.Id);
-            if (policies.Where(policy => policy.Enabled).Any(policy => policy.Type == PolicyType.SingleOrg))
+            if (policies.Any(policy => policy.Enabled && policy.Type == PolicyType.SingleOrg))
             {
                 throw new Exception("You may not create an organization. You belong to an organization " +
                      "which has a policy that prohibits you from being a member of any other organization.");

--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -162,7 +162,7 @@ namespace Bit.Api.Controllers
             }
 
             var policies = await _policyRepository.GetManyByUserIdAsync(user.Id);
-            if (policies.Any(policy => policy.Type == PolicyType.SingleOrg))
+            if (policies.Where(policy => policy.Enabled).Any(policy => policy.Type == PolicyType.SingleOrg))
             {
                 throw new Exception("You may not create an organization. You belong to an organization " +
                      "which has a policy that prohibits you from being a member of any other organization.");
@@ -190,7 +190,7 @@ namespace Bit.Api.Controllers
             }
 
             var policies = await _policyRepository.GetManyByUserIdAsync(user.Id);
-            if (policies.Any(policy => policy.Type == PolicyType.SingleOrg))
+            if (policies.Where(policy => policy.Enabled).Any(policy => policy.Type == PolicyType.SingleOrg))
             {
                 throw new Exception("You may not create an organization. You belong to an organization " +
                      "which has a policy that prohibits you from being a member of any other organization.");

--- a/src/Core/Services/Implementations/PolicyService.cs
+++ b/src/Core/Services/Implementations/PolicyService.cs
@@ -107,11 +107,13 @@ namespace Bit.Core.Services
                         case Enums.PolicyType.SingleOrg:
                             var userOrgs = await _organizationUserRepository.GetManyByManyUsersAsync(
                                     removableOrgUsers.Select(ou => ou.UserId.Value));
+                            organization = organization ?? await _organizationRepository.GetByIdAsync(policy.OrganizationId);
                             foreach (var orgUser in removableOrgUsers)
                             {
-                                if (userOrgs.Any(ou => ou.UserId == orgUser.UserId && ou.Status != OrganizationUserStatusType.Invited))
+                                if (userOrgs.Any(ou => ou.UserId == orgUser.UserId 
+                                            && ou.OrganizationId != organization.Id 
+                                            && ou.Status != OrganizationUserStatusType.Invited))
                                 {
-                                    organization = organization ?? await _organizationRepository.GetByIdAsync(policy.OrganizationId);
                                     await organizationService.DeleteUserAsync(policy.OrganizationId, orgUser.Id,
                                         savingUserId);
                                     await _mailService.SendOrganizationUserRemovedForPolicySingleOrgEmailAsync(


### PR DESCRIPTION
This addresses the bugs brought up this morning around the SingleOrg policy.

**1. Enabling single organization policy will kick all members even though they only have 1 org.** 
Fixed by verifying `.Any(alreadyExistingOrgUserRecords)` excludes the orgUser record for the org applying the policy

**2. And also, when we are in enterprise org, we can't create a free org even though single org policy is disabled.**
Checked to make sure the SingleOrg policy is Enabled for the users orgs, instead of just existing at all