### PR TITLE
Add external amr to auth method claims accepted

### DIFF
--- a/src/Events/Startup.cs
+++ b/src/Events/Startup.cs
@@ -43,7 +43,7 @@ namespace Bit.Events
                 config.AddPolicy("Application", policy =>
                 {
                     policy.RequireAuthenticatedUser();
-                    policy.RequireClaim(JwtClaimTypes.AuthenticationMethod, "Application");
+                    policy.RequireClaim(JwtClaimTypes.AuthenticationMethod, "Application", "external");
                     policy.RequireClaim(JwtClaimTypes.Scope, "api");
                 });
             });

--- a/src/Notifications/Startup.cs
+++ b/src/Notifications/Startup.cs
@@ -39,7 +39,7 @@ namespace Bit.Notifications
                 config.AddPolicy("Application", policy =>
                 {
                     policy.RequireAuthenticatedUser();
-                    policy.RequireClaim(JwtClaimTypes.AuthenticationMethod, "Application");
+                    policy.RequireClaim(JwtClaimTypes.AuthenticationMethod, "Application", "external");
                     policy.RequireClaim(JwtClaimTypes.Scope, "api");
                 });
                 config.AddPolicy("Internal", policy =>


### PR DESCRIPTION
## Overview
Essentially there are 2 types of Application authentication types provided in the JWT token during Identity auth when the token is issued: `"Application"` and `"external"` depending on the IdP, either `"bitwarden"` or `"sso"`. In this instance, when the user is logged in via SSO, their JWT token issued has the Authentication Method claim (`"amr"`) set as `"external"` vs. `"Application"`. This is handled in the other services/APIs, except for Events and Notifications. Therefore, when the required claim, `"Application"` is not met in the `"amr"` portion of the user's auth token, authorization fails and the Events collection endpoint returns an HTTP 403,  causing the event logs `POST` to silently fail in the UI (but be retried over and over, only to fail continuously).

Example of a token that was working (password auth):
```json
{
   "nbf":1611760620,
   "exp":1611764220,
   "iss":"http://identity",
   "client_id":"web",
   "sub":"...",
   "auth_time":1611760620,
   "idp":"bitwarden",
   "premium":false,
   "email":"...",
   "email_verified":false,
   "sstamp":"...",
   "name":"...",
   "orgowner":[
      "..."
   ],
   "device":"...",
   "jti":"...",
   "iat":1611760620,
   "scope":[
      "api",
      "offline_access"
   ],
   "amr":[
      "Application"
   ]
}
```

Example of a token that was **not** working (SSO):
```json
{
   "nbf":1611699023,
   "exp":1611702623,
   "iss":"http://identity",
   "client_id":"web",
   "sub":"...",
   "auth_time":1611683683,
   "idp":"sso",
   "premium":false,
   "email":"...",
   "email_verified":false,
   "sstamp":"...",
   "name":"...",
   "orgowner":[
      "..."
   ],
   "device":"...",
   "jti":"...",
   "iat":"...",
   "scope":[
      "api",
      "offline_access"
   ],
   "amr":[
      "external"
   ]
}
```

The only difference is the `"idp"` and `"amr"` values; the only one checked as a required claim is the `"amr"`.

## Changes
This change carries forward the required claims extension to add the `"external"` type to the required `"amr"` list of acceptable and/or required types which mirror what `Api` is doing.