### PR TITLE
Delete sends belonging to user on user delete

### DIFF
--- a/src/Sql/dbo/Stored Procedures/User_DeleteById.sql
+++ b/src/Sql/dbo/Stored Procedures/User_DeleteById.sql
@@ -87,6 +87,15 @@ BEGIN
         [GrantorId] = @Id
     OR
         [GranteeId] = @Id
+
+
+-- Delete Sends
+DELETE
+
+FROM
+        [dbo].[Send]
+    WHERE 
+        [UserId] = @Id
     
     -- Finally, delete the user
     DELETE

--- a/src/Sql/dbo/Stored Procedures/User_DeleteById.sql
+++ b/src/Sql/dbo/Stored Procedures/User_DeleteById.sql
@@ -88,11 +88,9 @@ BEGIN
     OR
         [GranteeId] = @Id
 
-
--- Delete Sends
-DELETE
-
-FROM
+    -- Delete Sends
+    DELETE
+    FROM
         [dbo].[Send]
     WHERE 
         [UserId] = @Id

--- a/util/Migrator/DbScripts/2021-01-28_00_AddDeleteSendsToUserDeleteById.sql
+++ b/util/Migrator/DbScripts/2021-01-28_00_AddDeleteSendsToUserDeleteById.sql
@@ -1,0 +1,132 @@
+IF OBJECT_ID('[dbo].[User_DeleteById]') IS NOT NULL
+BEGIN
+
+DROP PROCEDURE [dbo].[User_DeleteById]
+END
+GO
+
+CREATE PROCEDURE [dbo].[User_DeleteById]
+    @Id UNIQUEIDENTIFIER
+WITH
+    RECOMPILE
+AS
+BEGIN
+    SET NOCOUNT ON
+
+DECLARE @BatchSize INT = 100
+
+
+-- Delete ciphers
+WHILE @BatchSize > 0
+    BEGIN
+    BEGIN TRANSACTION User_DeleteById_Ciphers
+
+    DELETE TOP(@BatchSize)
+        FROM
+            [dbo].[Cipher]
+        WHERE
+            [UserId] = @Id
+
+    SET @BatchSize = @@ROWCOUNT
+
+    COMMIT TRANSACTION User_DeleteById_Ciphers
+END
+
+BEGIN TRANSACTION User_DeleteById
+
+-- Delete folders
+DELETE
+    FROM
+        [dbo].[Folder]
+    WHERE
+        [UserId] = @Id
+
+-- Delete devices
+DELETE
+    FROM
+        [dbo].[Device]
+    WHERE
+        [UserId] = @Id
+
+-- Delete collection users
+DELETE
+        CU
+    FROM
+    [dbo].[CollectionUser] CU
+    INNER JOIN
+    [dbo].[OrganizationUser] OU ON OU.[Id] = CU.[OrganizationUserId]
+    WHERE
+        OU.[UserId] = @Id
+
+-- Delete group users
+DELETE
+        GU
+    FROM
+    [dbo].[GroupUser] GU
+    INNER JOIN
+    [dbo].[OrganizationUser] OU ON OU.[Id] = GU.[OrganizationUserId]
+    WHERE
+        OU.[UserId] = @Id
+
+-- Delete organization users
+DELETE
+    FROM
+        [dbo].[OrganizationUser]
+    WHERE
+        [UserId] = @Id
+
+
+-- Delete U2F logins
+DELETE
+    FROM
+
+[dbo].[U2f]
+    WHERE
+
+[UserId]
+= @Id
+
+
+-- Delete SSO Users
+DELETE
+    FROM
+        [dbo].[SsoUser]
+    WHERE
+
+[UserId]
+= @Id
+
+
+-- Delete Emergency Accesses
+DELETE
+    FROM
+
+[dbo].[EmergencyAccess]
+    WHERE
+
+[GrantorId]
+= @Id
+        OR
+        [GranteeId] = @Id
+
+
+
+-- Delete Sends
+DELETE
+
+FROM
+        [dbo].[Send]
+    WHERE 
+        [UserId] = @Id
+
+
+-- Finally, delete the user
+DELETE
+    FROM
+        [dbo].[User]
+    WHERE
+        [Id] = @Id
+
+
+COMMIT TRANSACTION User_DeleteById
+END

--- a/util/Migrator/DbScripts/2021-01-28_00_AddDeleteSendsToUserDeleteById.sql
+++ b/util/Migrator/DbScripts/2021-01-28_00_AddDeleteSendsToUserDeleteById.sql
@@ -1,7 +1,6 @@
 IF OBJECT_ID('[dbo].[User_DeleteById]') IS NOT NULL
 BEGIN
-
-DROP PROCEDURE [dbo].[User_DeleteById]
+    DROP PROCEDURE [dbo].[User_DeleteById]
 END
 GO
 
@@ -14,18 +13,16 @@ BEGIN
     SET NOCOUNT ON
 
 DECLARE @BatchSize INT = 100
-
-
 -- Delete ciphers
 WHILE @BatchSize > 0
-    BEGIN
+BEGIN
     BEGIN TRANSACTION User_DeleteById_Ciphers
 
     DELETE TOP(@BatchSize)
-        FROM
-            [dbo].[Cipher]
-        WHERE
-            [UserId] = @Id
+    FROM
+        [dbo].[Cipher]
+     WHERE
+         [UserId] = @Id
 
     SET @BatchSize = @@ROWCOUNT
 
@@ -36,97 +33,74 @@ BEGIN TRANSACTION User_DeleteById
 
 -- Delete folders
 DELETE
-    FROM
-        [dbo].[Folder]
-    WHERE
-        [UserId] = @Id
+FROM
+    [dbo].[Folder]
+WHERE
+    [UserId] = @Id
 
 -- Delete devices
 DELETE
-    FROM
-        [dbo].[Device]
-    WHERE
-        [UserId] = @Id
+FROM
+    [dbo].[Device]
+WHERE
+    [UserId] = @Id
 
 -- Delete collection users
 DELETE
-        CU
-    FROM
+    CU
+FROM
     [dbo].[CollectionUser] CU
-    INNER JOIN
+INNER JOIN
     [dbo].[OrganizationUser] OU ON OU.[Id] = CU.[OrganizationUserId]
-    WHERE
-        OU.[UserId] = @Id
+WHERE
+    OU.[UserId] = @Id
 
 -- Delete group users
 DELETE
-        GU
-    FROM
+    GU
+FROM
     [dbo].[GroupUser] GU
-    INNER JOIN
+INNER JOIN
     [dbo].[OrganizationUser] OU ON OU.[Id] = GU.[OrganizationUserId]
-    WHERE
-        OU.[UserId] = @Id
+WHERE
+    OU.[UserId] = @Id
 
 -- Delete organization users
 DELETE
-    FROM
-        [dbo].[OrganizationUser]
-    WHERE
-        [UserId] = @Id
-
-
+FROM
+    [dbo].[OrganizationUser]
+WHERE
+    [UserId] = @Id
 -- Delete U2F logins
 DELETE
-    FROM
-
-[dbo].[U2f]
-    WHERE
-
-[UserId]
-= @Id
-
-
+FROM
+    [dbo].[U2f]
+WHERE
+    [UserId] = @Id
 -- Delete SSO Users
 DELETE
-    FROM
-        [dbo].[SsoUser]
-    WHERE
-
-[UserId]
-= @Id
-
-
+FROM
+    [dbo].[SsoUser]
+WHERE
+    [UserId] = @Id
 -- Delete Emergency Accesses
 DELETE
-    FROM
-
-[dbo].[EmergencyAccess]
-    WHERE
-
-[GrantorId]
-= @Id
-        OR
-        [GranteeId] = @Id
-
-
-
+FROM
+    [dbo].[EmergencyAccess]
+WHERE
+    [GrantorId] = @Id 
+    OR [GranteeId] = @Id
 -- Delete Sends
 DELETE
-
 FROM
-        [dbo].[Send]
-    WHERE 
-        [UserId] = @Id
-
-
+    [dbo].[Send]
+WHERE 
+    [UserId] = @Id
 -- Finally, delete the user
 DELETE
-    FROM
-        [dbo].[User]
-    WHERE
-        [Id] = @Id
-
-
+FROM
+    [dbo].[User]
+WHERE
+    [Id] = @Id
 COMMIT TRANSACTION User_DeleteById
 END


### PR DESCRIPTION
# Overview

The admin page barfs on user delete when that user has sends in the database due to foreign key dependence.

Adds send deletes prior to user delete.

# Files Changed
* **User_DeleteById.sql**: Add send deletes to sproc
* **2021-01-28_00_AddDeleteSendsToUserDeleteById.sql**: migration script to delete old version and add the new.

# Testing Concerns

This can be verified by deleting a user that has sends. An exception will throw without these changes. After the updates, it should work and all sends belonging to the user will be purged