### PR TITLE
Import Invite Error

### DIFF
--- a/src/Api/Public/Controllers/MembersController.cs
+++ b/src/Api/Public/Controllers/MembersController.cs
@@ -124,8 +124,8 @@ namespace Bit.Api.Public.Controllers
                 AccessAll = model.AccessAll.Value,
                 Collections = associations
             };
-            var userPromise = await _organizationService.InviteUserAsync(_currentContext.OrganizationId.Value, null, model.ExternalId, invite);
-            var user = userPromise.FirstOrDefault();
+            var user = await _organizationService.InviteUserAsync(_currentContext.OrganizationId.Value, null,
+                model.Email, model.Type.Value, model.AccessAll.Value, model.ExternalId, associations);
             var response = new MemberResponseModel(user, associations);
             return new JsonResult(response);
         }

--- a/src/Core/Services/IOrganizationService.cs
+++ b/src/Core/Services/IOrganizationService.cs
@@ -30,6 +30,8 @@ namespace Bit.Core.Services
         Task UpdateAsync(Organization organization, bool updateBilling = false);
         Task UpdateTwoFactorProviderAsync(Organization organization, TwoFactorProviderType type);
         Task DisableTwoFactorProviderAsync(Organization organization, TwoFactorProviderType type);
+        Task<OrganizationUser> InviteUserAsync(Guid organizationId, Guid? invitingUserId, string email,
+            OrganizationUserType type, bool accessAll, string externalId, IEnumerable<SelectionReadOnly> collections);
         Task<List<OrganizationUser>> InviteUserAsync(Guid organizationId, Guid? invitingUserId, string externalId, OrganizationUserInvite orgUserInvite);
         Task ResendInviteAsync(Guid organizationId, Guid? invitingUserId, Guid organizationUserId);
         Task<OrganizationUser> AcceptUserAsync(Guid organizationUserId, User user, string token,

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1388,6 +1388,25 @@ namespace Bit.Core.Services
             return new OrganizationLicense(organization, subInfo, installationId, _licensingService, version);
         }
 
+        public async Task<OrganizationUser> InviteUserAsync(Guid organizationId, Guid? invitingUserId, string email,
+            OrganizationUserType type, bool accessAll, string externalId, IEnumerable<SelectionReadOnly> collections)
+        {
+            var invite = new OrganizationUserInvite()
+            {
+                Emails = new List<string> { email },
+                Type = type,
+                AccessAll = accessAll,
+                Collections = collections,
+            };
+            var results = await InviteUserAsync(organizationId, invitingUserId, externalId, invite);
+            var result = results.FirstOrDefault();
+            if (result == null)
+            {
+                throw new BadRequestException("This user has already been invited.");
+            }
+            return result;
+        }
+
         public async Task ImportAsync(Guid organizationId,
             Guid? importingUserId,
             IEnumerable<ImportedGroup> groups,
@@ -1499,14 +1518,8 @@ namespace Bit.Core.Services
                                 AccessAll = false,
                                 Collections = new List<SelectionReadOnly>(),
                             };
-                            var newUserPromise = await InviteUserAsync(organizationId, importingUserId, user.ExternalId, invite);
-                            var newUser = newUserPromise.FirstOrDefault();
-
-                            if (newUser == null)
-                            {
-                                throw new BadRequestException("This user has already been invited.");
-                            }
-
+                            var newUser = await InviteUserAsync(organizationId, importingUserId, user.Email, 
+                                    OrganizationUserType.User, false, user.ExternalId, new List<SelectionReadOnly>());
                             existingExternalUsersIdDict.Add(newUser.ExternalId, newUser.Id);
                         }
                         catch (BadRequestException)

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1502,6 +1502,11 @@ namespace Bit.Core.Services
                             var newUserPromise = await InviteUserAsync(organizationId, importingUserId, user.ExternalId, invite);
                             var newUser = newUserPromise.FirstOrDefault();
 
+                            if (newUser == null)
+                            {
+                                throw new BadRequestException("This user has already been invited.");
+                            }
+
                             existingExternalUsersIdDict.Add(newUser.ExternalId, newUser.Id);
                         }
                         catch (BadRequestException)


### PR DESCRIPTION
https://github.com/bitwarden/server/commit/63fcdc14#diff-52f2ac8cf03d0a32342a14a25a25a25978a6bc3c56eb0c8e2b281c5b5083a789L983 removed an `InviteUser` method that threw an error if the main `InviteUser` method returned no data. Removing this has caused an issue with imports not working. This PR brings back that method, and reimplements it in the two places it was used.