### PR TITLE
Add disable send policy

### DIFF
--- a/bitwarden_license/src/Portal/Controllers/PoliciesController.cs
+++ b/bitwarden_license/src/Portal/Controllers/PoliciesController.cs
@@ -136,6 +136,7 @@ namespace Bit.Portal.Controllers
                 case PolicyType.PasswordGenerator:
                 case PolicyType.TwoFactorAuthentication:
                 case PolicyType.PersonalOwnership:
+                case PolicyType.DisableSend:
                     break;
                 
                 case PolicyType.SingleOrg:

--- a/bitwarden_license/src/Portal/EnterprisePortalCurrentContext.cs
+++ b/bitwarden_license/src/Portal/EnterprisePortalCurrentContext.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Bit.Core;
+using Bit.Core.Context;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;

--- a/bitwarden_license/src/Portal/Models/PolicyEditModel.cs
+++ b/bitwarden_license/src/Portal/Models/PolicyEditModel.cs
@@ -86,6 +86,7 @@ namespace Bit.Portal.Models
                 case PolicyType.TwoFactorAuthentication:
                 case PolicyType.RequireSso:
                 case PolicyType.PersonalOwnership:
+                case PolicyType.DisableSend:
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();

--- a/bitwarden_license/src/Portal/Models/PolicyModel.cs
+++ b/bitwarden_license/src/Portal/Models/PolicyModel.cs
@@ -47,6 +47,11 @@ namespace Bit.Portal.Models
                     DescriptionKey = "PersonalOwnershipDescription";
                     break;
 
+                case PolicyType.DisableSend:
+                    NameKey = "DisableSend";
+                    DescriptionKey = "DisableSendDescription";
+                    break;
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/bitwarden_license/src/Portal/Startup.cs
+++ b/bitwarden_license/src/Portal/Startup.cs
@@ -41,7 +41,7 @@ namespace Bit.Portal
 
             // Context
             services.AddScoped<EnterprisePortalCurrentContext>();
-            services.AddScoped<CurrentContext>((serviceProvider) =>
+            services.AddScoped<ICurrentContext, CurrentContext>((serviceProvider) =>
                 serviceProvider.GetService<EnterprisePortalCurrentContext>());
 
             // Identity

--- a/bitwarden_license/src/Portal/Startup.cs
+++ b/bitwarden_license/src/Portal/Startup.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Utilities;
 using Bit.Portal.Utilities;
 using Microsoft.AspNetCore.Builder;

--- a/bitwarden_license/src/Portal/Views/Policies/Edit.cshtml
+++ b/bitwarden_license/src/Portal/Views/Policies/Edit.cshtml
@@ -61,6 +61,17 @@
             @i18nService.T("PersonalOwnershipExemption")
         </div>
     }
+
+    @if (Model.PolicyType == PolicyType.DisableSend)
+    {
+        <div class="callout callout-warning" role="alert">
+            <h3 class="callout-heading">
+                <i class="fa fa-warning" *ngIf="icon" aria-hidden="true"></i>
+                @i18nService.T("Warning")
+            </h3>
+            @i18nService.T("DisableSendExemption")
+        </div>
+    }
     
     <div asp-validation-summary="ModelOnly" class="alert alert-danger"></div>
 

--- a/bitwarden_license/src/Sso/Startup.cs
+++ b/bitwarden_license/src/Sso/Startup.cs
@@ -40,7 +40,7 @@ namespace Bit.Sso
             services.AddSqlServerRepositories(globalSettings);
 
             // Context
-            services.AddScoped<CurrentContext>();
+            services.AddScoped<ICurrentContext, CurrentContext>();
 
             // Mvc
             services.AddControllersWithViews();

--- a/bitwarden_license/src/Sso/Startup.cs
+++ b/bitwarden_license/src/Sso/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Utilities;
 using Bit.Sso.Utilities;
 using IdentityServer4.Extensions;

--- a/src/Admin/Jobs/DeleteSendsJob.cs
+++ b/src/Admin/Jobs/DeleteSendsJob.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Jobs;
 using Bit.Core.Repositories;
 using Bit.Core.Services;

--- a/src/Admin/Startup.cs
+++ b/src/Admin/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Identity;
 using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Builder;

--- a/src/Admin/Startup.cs
+++ b/src/Admin/Startup.cs
@@ -46,7 +46,7 @@ namespace Bit.Admin
             services.AddSqlServerRepositories(globalSettings);
 
             // Context
-            services.AddScoped<CurrentContext>();
+            services.AddScoped<ICurrentContext, CurrentContext>();
 
             // Identity
             services.AddPasswordlessIdentityServices<ReadOnlyEnvIdentityUserStore>(globalSettings);

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -24,7 +24,7 @@ namespace Bit.Api.Controllers
         private readonly ICollectionCipherRepository _collectionCipherRepository;
         private readonly ICipherService _cipherService;
         private readonly IUserService _userService;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
         private readonly GlobalSettings _globalSettings;
 
         public CiphersController(
@@ -32,7 +32,7 @@ namespace Bit.Api.Controllers
             ICollectionCipherRepository collectionCipherRepository,
             ICipherService cipherService,
             IUserService userService,
-            CurrentContext currentContext,
+            ICurrentContext currentContext,
             GlobalSettings globalSettings)
         {
             _cipherRepository = cipherRepository;

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -8,6 +8,7 @@ using Bit.Core.Models.Api;
 using Bit.Core.Exceptions;
 using Bit.Core.Services;
 using Bit.Core;
+using Bit.Core.Context;
 using Bit.Api.Utilities;
 using Bit.Core.Utilities;
 using System.Collections.Generic;

--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -20,13 +20,13 @@ namespace Bit.Api.Controllers
         private readonly ICollectionRepository _collectionRepository;
         private readonly ICollectionService _collectionService;
         private readonly IUserService _userService;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
 
         public CollectionsController(
             ICollectionRepository collectionRepository,
             ICollectionService collectionService,
             IUserService userService,
-            CurrentContext currentContext)
+            ICurrentContext currentContext)
         {
             _collectionRepository = collectionRepository;
             _collectionService = collectionService;

--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using Bit.Core.Models.Api;
 using Bit.Core.Exceptions;
 using Bit.Core.Services;
-using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Models.Table;
 using System.Collections.Generic;
 

--- a/src/Api/Controllers/EventsController.cs
+++ b/src/Api/Controllers/EventsController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Api;
 using Bit.Core.Services;
-using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Models.Data;
 
 namespace Bit.Api.Controllers

--- a/src/Api/Controllers/EventsController.cs
+++ b/src/Api/Controllers/EventsController.cs
@@ -20,14 +20,14 @@ namespace Bit.Api.Controllers
         private readonly ICipherRepository _cipherRepository;
         private readonly IOrganizationUserRepository _organizationUserRepository;
         private readonly IEventRepository _eventRepository;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
 
         public EventsController(
             IUserService userService,
             ICipherRepository cipherRepository,
             IOrganizationUserRepository organizationUserRepository,
             IEventRepository eventRepository,
-            CurrentContext currentContext)
+            ICurrentContext currentContext)
         {
             _userService = userService;
             _cipherRepository = cipherRepository;

--- a/src/Api/Controllers/GroupsController.cs
+++ b/src/Api/Controllers/GroupsController.cs
@@ -18,12 +18,12 @@ namespace Bit.Api.Controllers
     {
         private readonly IGroupRepository _groupRepository;
         private readonly IGroupService _groupService;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
 
         public GroupsController(
             IGroupRepository groupRepository,
             IGroupService groupService,
-            CurrentContext currentContext)
+            ICurrentContext currentContext)
         {
             _groupRepository = groupRepository;
             _groupService = groupService;

--- a/src/Api/Controllers/GroupsController.cs
+++ b/src/Api/Controllers/GroupsController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using Bit.Core.Models.Api;
 using Bit.Core.Exceptions;
 using Bit.Core.Services;
-using Bit.Core;
+using Bit.Core.Context;
 using System.Collections.Generic;
 
 namespace Bit.Api.Controllers

--- a/src/Api/Controllers/HibpController.cs
+++ b/src/Api/Controllers/HibpController.cs
@@ -23,7 +23,7 @@ namespace Bit.Api.Controllers
         private static HttpClient _httpClient;
 
         private readonly IUserService _userService;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
         private readonly GlobalSettings _globalSettings;
         private readonly string _userAgent;
 
@@ -34,7 +34,7 @@ namespace Bit.Api.Controllers
 
         public HibpController(
             IUserService userService,
-            CurrentContext currentContext,
+            ICurrentContext currentContext,
             GlobalSettings globalSettings)
         {
             _userService = userService;

--- a/src/Api/Controllers/HibpController.cs
+++ b/src/Api/Controllers/HibpController.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Security.Cryptography;
 using Bit.Core.Services;
 using Bit.Core;
+using Bit.Core.Context;
 using System.Net;
 using Bit.Core.Exceptions;
 using System.Linq;

--- a/src/Api/Controllers/LicensesController.cs
+++ b/src/Api/Controllers/LicensesController.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Bit.Core.Services;
 using Microsoft.AspNetCore.Authorization;
-using Bit.Core;
+using Bit.Core.Context;
 using System.Threading.Tasks;
 using Bit.Core.Models.Business;
 using Bit.Core.Exceptions;

--- a/src/Api/Controllers/LicensesController.cs
+++ b/src/Api/Controllers/LicensesController.cs
@@ -21,7 +21,7 @@ namespace Bit.Api.Controllers
         private readonly IUserService _userService;
         private readonly IOrganizationRepository _organizationRepository;
         private readonly IOrganizationService _organizationService;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
 
         public LicensesController(
             ILicensingService licensingService,
@@ -29,7 +29,7 @@ namespace Bit.Api.Controllers
             IUserService userService,
             IOrganizationRepository organizationRepository,
             IOrganizationService organizationService,
-            CurrentContext currentContext)
+            ICurrentContext currentContext)
         {
             _licensingService = licensingService;
             _userRepository = userRepository;

--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -23,7 +23,7 @@ namespace Bit.Api.Controllers
         private readonly ICollectionRepository _collectionRepository;
         private readonly IGroupRepository _groupRepository;
         private readonly IUserService _userService;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
 
         public OrganizationUsersController(
             IOrganizationRepository organizationRepository,
@@ -32,7 +32,7 @@ namespace Bit.Api.Controllers
             ICollectionRepository collectionRepository,
             IGroupRepository groupRepository,
             IUserService userService,
-            CurrentContext currentContext)
+            ICurrentContext currentContext)
         {
             _organizationRepository = organizationRepository;
             _organizationUserRepository = organizationUserRepository;

--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using Bit.Core.Models.Api;
 using Bit.Core.Exceptions;
 using Bit.Core.Services;
-using Bit.Core;
+using Bit.Core.Context;
 using System.Collections.Generic;
 using Bit.Core.Models.Business;
 

--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -9,6 +9,7 @@ using Bit.Core.Models.Api;
 using Bit.Core.Exceptions;
 using Bit.Core.Services;
 using Bit.Core;
+using Bit.Core.Context;
 using Bit.Api.Utilities;
 using Bit.Core.Models.Business;
 using Bit.Core.Utilities;

--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -25,7 +25,7 @@ namespace Bit.Api.Controllers
         private readonly IOrganizationService _organizationService;
         private readonly IUserService _userService;
         private readonly IPaymentService _paymentService;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
         private readonly GlobalSettings _globalSettings;
         private readonly IPolicyRepository _policyRepository;
 
@@ -35,7 +35,7 @@ namespace Bit.Api.Controllers
             IOrganizationService organizationService,
             IUserService userService,
             IPaymentService paymentService,
-            CurrentContext currentContext,
+            ICurrentContext currentContext,
             GlobalSettings globalSettings,
             IPolicyRepository policyRepository)
         {

--- a/src/Api/Controllers/PoliciesController.cs
+++ b/src/Api/Controllers/PoliciesController.cs
@@ -8,6 +8,7 @@ using Bit.Core.Models.Api;
 using Bit.Core.Exceptions;
 using Bit.Core.Services;
 using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Enums;
 using Bit.Core.Utilities;
 using Microsoft.AspNetCore.DataProtection;

--- a/src/Api/Controllers/PoliciesController.cs
+++ b/src/Api/Controllers/PoliciesController.cs
@@ -24,7 +24,7 @@ namespace Bit.Api.Controllers
         private readonly IOrganizationService _organizationService;
         private readonly IOrganizationUserRepository _organizationUserRepository;
         private readonly IUserService _userService;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
         private readonly GlobalSettings _globalSettings;
         private readonly IDataProtector _organizationServiceDataProtector;
 
@@ -34,7 +34,7 @@ namespace Bit.Api.Controllers
             IOrganizationService organizationService,
             IOrganizationUserRepository organizationUserRepository,
             IUserService userService,
-            CurrentContext currentContext,
+            ICurrentContext currentContext,
             GlobalSettings globalSettings,
             IDataProtectionProvider dataProtectionProvider)
         {

--- a/src/Api/Controllers/PushController.cs
+++ b/src/Api/Controllers/PushController.cs
@@ -2,6 +2,7 @@
 using Bit.Core.Services;
 using Microsoft.AspNetCore.Authorization;
 using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Api;
 using System.Threading.Tasks;

--- a/src/Api/Controllers/PushController.cs
+++ b/src/Api/Controllers/PushController.cs
@@ -22,14 +22,14 @@ namespace Bit.Api.Controllers
         private readonly IPushRegistrationService _pushRegistrationService;
         private readonly IPushNotificationService _pushNotificationService;
         private readonly IWebHostEnvironment _environment;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
         private readonly GlobalSettings _globalSettings;
 
         public PushController(
             IPushRegistrationService pushRegistrationService,
             IPushNotificationService pushNotificationService,
             IWebHostEnvironment environment,
-            CurrentContext currentContext,
+            ICurrentContext currentContext,
             GlobalSettings globalSettings)
         {
             _currentContext = currentContext;

--- a/src/Api/Controllers/TwoFactorController.cs
+++ b/src/Api/Controllers/TwoFactorController.cs
@@ -26,7 +26,7 @@ namespace Bit.Api.Controllers
         private readonly IOrganizationService _organizationService;
         private readonly GlobalSettings _globalSettings;
         private readonly UserManager<User> _userManager;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
 
         public TwoFactorController(
             IUserService userService,
@@ -34,7 +34,7 @@ namespace Bit.Api.Controllers
             IOrganizationService organizationService,
             GlobalSettings globalSettings,
             UserManager<User> userManager,
-            CurrentContext currentContext)
+            ICurrentContext currentContext)
         {
             _userService = userService;
             _organizationRepository = organizationRepository;

--- a/src/Api/Controllers/TwoFactorController.cs
+++ b/src/Api/Controllers/TwoFactorController.cs
@@ -10,6 +10,7 @@ using Bit.Core.Models.Table;
 using Bit.Core.Enums;
 using System.Linq;
 using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Repositories;
 using Bit.Core.Utilities;
 using Bit.Core.Utilities.Duo;

--- a/src/Api/Public/Controllers/CollectionsController.cs
+++ b/src/Api/Public/Controllers/CollectionsController.cs
@@ -17,12 +17,12 @@ namespace Bit.Api.Public.Controllers
     {
         private readonly ICollectionRepository _collectionRepository;
         private readonly ICollectionService _collectionService;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
 
         public CollectionsController(
             ICollectionRepository collectionRepository,
             ICollectionService collectionService,
-            CurrentContext currentContext)
+            ICurrentContext currentContext)
         {
             _collectionRepository = collectionRepository;
             _collectionService = collectionService;

--- a/src/Api/Public/Controllers/CollectionsController.cs
+++ b/src/Api/Public/Controllers/CollectionsController.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Models.Api.Public;
 using Bit.Core.Repositories;
 using Bit.Core.Services;

--- a/src/Api/Public/Controllers/EventsController.cs
+++ b/src/Api/Public/Controllers/EventsController.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Models.Api.Public;
 using Bit.Core.Models.Data;
 using Bit.Core.Repositories;

--- a/src/Api/Public/Controllers/EventsController.cs
+++ b/src/Api/Public/Controllers/EventsController.cs
@@ -17,12 +17,12 @@ namespace Bit.Api.Public.Controllers
     {
         private readonly IEventRepository _eventRepository;
         private readonly ICipherRepository _cipherRepository;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
 
         public EventsController(
             IEventRepository eventRepository,
             ICipherRepository cipherRepository,
-            CurrentContext currentContext)
+            ICurrentContext currentContext)
         {
             _eventRepository = eventRepository;
             _cipherRepository = cipherRepository;

--- a/src/Api/Public/Controllers/GroupsController.cs
+++ b/src/Api/Public/Controllers/GroupsController.cs
@@ -18,12 +18,12 @@ namespace Bit.Api.Public.Controllers
     {
         private readonly IGroupRepository _groupRepository;
         private readonly IGroupService _groupService;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
 
         public GroupsController(
             IGroupRepository groupRepository,
             IGroupService groupService,
-            CurrentContext currentContext)
+            ICurrentContext currentContext)
         {
             _groupRepository = groupRepository;
             _groupService = groupService;

--- a/src/Api/Public/Controllers/GroupsController.cs
+++ b/src/Api/Public/Controllers/GroupsController.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Models.Api.Public;
 using Bit.Core.Repositories;
 using Bit.Core.Services;

--- a/src/Api/Public/Controllers/MembersController.cs
+++ b/src/Api/Public/Controllers/MembersController.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Models.Api.Public;
 using Bit.Core.Models.Business;
 using Bit.Core.Repositories;

--- a/src/Api/Public/Controllers/MembersController.cs
+++ b/src/Api/Public/Controllers/MembersController.cs
@@ -21,14 +21,14 @@ namespace Bit.Api.Public.Controllers
         private readonly IGroupRepository _groupRepository;
         private readonly IOrganizationService _organizationService;
         private readonly IUserService _userService;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
 
         public MembersController(
             IOrganizationUserRepository organizationUserRepository,
             IGroupRepository groupRepository,
             IOrganizationService organizationService,
             IUserService userService,
-            CurrentContext currentContext)
+            ICurrentContext currentContext)
         {
             _organizationUserRepository = organizationUserRepository;
             _groupRepository = groupRepository;

--- a/src/Api/Public/Controllers/OrganizationController.cs
+++ b/src/Api/Public/Controllers/OrganizationController.cs
@@ -16,12 +16,12 @@ namespace Bit.Api.Public.Controllers
     public class OrganizationController : Controller
     {
         private readonly IOrganizationService _organizationService;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
         private readonly GlobalSettings _globalSettings;
 
         public OrganizationController(
             IOrganizationService organizationService,
-            CurrentContext currentContext,
+            ICurrentContext currentContext,
             GlobalSettings globalSettings)
         {
             _organizationService = organizationService;

--- a/src/Api/Public/Controllers/OrganizationController.cs
+++ b/src/Api/Public/Controllers/OrganizationController.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Threading.Tasks;
 using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Api.Public;
 using Bit.Core.Services;

--- a/src/Api/Public/Controllers/PoliciesController.cs
+++ b/src/Api/Public/Controllers/PoliciesController.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Enums;
 using Bit.Core.Models.Api.Public;
 using Bit.Core.Repositories;

--- a/src/Api/Public/Controllers/PoliciesController.cs
+++ b/src/Api/Public/Controllers/PoliciesController.cs
@@ -20,14 +20,14 @@ namespace Bit.Api.Public.Controllers
         private readonly IPolicyService _policyService;
         private readonly IUserService _userService;
         private readonly IOrganizationService _organizationService;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
 
         public PoliciesController(
             IPolicyRepository policyRepository,
             IPolicyService policyService,
             IUserService userService,
             IOrganizationService organizationService,
-            CurrentContext currentContext)
+            ICurrentContext currentContext)
         {
             _policyRepository = policyRepository;
             _policyService = policyService;

--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Bit.Api.Utilities;
 using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Identity;
 using Newtonsoft.Json.Serialization;
 using AspNetCoreRateLimit;

--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -55,7 +55,7 @@ namespace Bit.Api
             services.AddSqlServerRepositories(globalSettings);
 
             // Context
-            services.AddScoped<CurrentContext>();
+            services.AddScoped<ICurrentContext, CurrentContext>();
 
             // Caching
             services.AddMemoryCache();

--- a/src/Billing/Startup.cs
+++ b/src/Billing/Startup.cs
@@ -47,7 +47,7 @@ namespace Bit.Billing
             services.AddSingleton<BitPayClient>();
 
             // Context
-            services.AddScoped<CurrentContext>();
+            services.AddScoped<ICurrentContext, CurrentContext>();
 
             // Identity
             services.AddCustomIdentityServices(globalSettings);

--- a/src/Billing/Startup.cs
+++ b/src/Billing/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Bit.Core;
+using Bit.Core.Context;
 using Stripe;
 using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Http;

--- a/src/Core/Context/CurrentContentOrganization.cs
+++ b/src/Core/Context/CurrentContentOrganization.cs
@@ -1,0 +1,24 @@
+using System;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data;
+using Bit.Core.Models.Table;
+using Bit.Core.Utilities;
+
+namespace Bit.Core.Context
+{
+    public class CurrentContentOrganization
+    {
+        public CurrentContentOrganization() { }
+
+        public CurrentContentOrganization(OrganizationUser orgUser)
+        {
+            Id = orgUser.OrganizationId;
+            Type = orgUser.Type;
+            Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(orgUser.Permissions);
+        }
+
+        public Guid Id { get; set; }
+        public OrganizationUserType Type { get; set; }
+        public Permissions Permissions { get; set; }
+    }
+}

--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -10,9 +10,9 @@ using System.Security.Claims;
 using Bit.Core.Utilities;
 using Bit.Core.Models.Data;
 
-namespace Bit.Core
+namespace Bit.Core.Context
 {
-    public class CurrentContext
+    public class CurrentContext : ICurrentContext
     {
         private bool _builtHttpContext;
         private bool _builtClaimsPrincipal;
@@ -295,22 +295,6 @@ namespace Bit.Core
                 ManageSso = hasClaim("managesso"),
                 ManageUsers = hasClaim("manageusers")
             };
-        }
-
-        public class CurrentContentOrganization
-        {
-            public CurrentContentOrganization() { }
-
-            public CurrentContentOrganization(OrganizationUser orgUser)
-            {
-                Id = orgUser.OrganizationId;
-                Type = orgUser.Type;
-                Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(orgUser.Permissions);
-            }
-
-            public Guid Id { get; set; }
-            public OrganizationUserType Type { get; set; }
-            public Permissions Permissions { get; set; }
         }
     }
 }

--- a/src/Core/Context/ICurrentContext.cs
+++ b/src/Core/Context/ICurrentContext.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+namespace Bit.Core.Context
+{
+    public interface ICurrentContext
+    {
+        List<CurrentContentOrganization> Organizations { get; set; }
+
+        bool ManagePolicies(Guid orgId);
+    }
+}

--- a/src/Core/Context/ICurrentContext.cs
+++ b/src/Core/Context/ICurrentContext.cs
@@ -1,12 +1,49 @@
 using System;
 using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Bit.Core.Enums;
+using Bit.Core.Models.Table;
+using Bit.Core.Repositories;
+using Microsoft.AspNetCore.Http;
 
 namespace Bit.Core.Context
 {
     public interface ICurrentContext
     {
+        HttpContext HttpContext { get; set; }
+        Guid? UserId { get; set; }
+        User User { get; set; }
+        string DeviceIdentifier { get; set; }
+        DeviceType? DeviceType { get; set; }
+        string IpAddress { get; set; }
         List<CurrentContentOrganization> Organizations { get; set; }
+        Guid? InstallationId { get; set; }
+        Guid? OrganizationId { get; set; }
 
+        Task BuildAsync(HttpContext httpContext, GlobalSettings globalSettings);
+        Task BuildAsync(ClaimsPrincipal user, GlobalSettings globalSettings);
+
+        Task SetContextAsync(ClaimsPrincipal user);
+
+
+        bool OrganizationUser(Guid orgId);
+        bool OrganizationManager(Guid orgId);
+        bool OrganizationAdmin(Guid orgId);
+        bool OrganizationOwner(Guid orgId);
+        bool OrganizationCustom(Guid orgId);
+        bool AccessBusinessPortal(Guid orgId);
+        bool AccessEventLogs(Guid orgId);
+        bool AccessImportExport(Guid orgId);
+        bool AccessReports(Guid orgId);
+        bool ManageAllCollections(Guid orgId);
+        bool ManageAssignedCollections(Guid orgId);
+        bool ManageGroups(Guid orgId);
         bool ManagePolicies(Guid orgId);
+        bool ManageSso(Guid orgId);
+        bool ManageUsers(Guid orgId);
+
+        Task<ICollection<CurrentContentOrganization>> OrganizationMembershipAsync(
+            IOrganizationUserRepository organizationUserRepository, Guid userId);
     }
 }

--- a/src/Core/Enums/PolicyType.cs
+++ b/src/Core/Enums/PolicyType.cs
@@ -8,5 +8,6 @@
         SingleOrg = 3,
         RequireSso = 4,
         PersonalOwnership = 5,
+        DisableSend = 6,
     }
 }

--- a/src/Core/Identity/UserStore.cs
+++ b/src/Core/Identity/UserStore.cs
@@ -19,12 +19,12 @@ namespace Bit.Core.Identity
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly IUserRepository _userRepository;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
 
         public UserStore(
             IServiceProvider serviceProvider,
             IUserRepository userRepository,
-            CurrentContext currentContext)
+            ICurrentContext currentContext)
         {
             _serviceProvider = serviceProvider;
             _userRepository = userRepository;

--- a/src/Core/Identity/UserStore.cs
+++ b/src/Core/Identity/UserStore.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Identity;
 using Bit.Core.Models.Table;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
+using Bit.Core.Context;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Bit.Core.Identity

--- a/src/Core/IdentityServer/BaseRequestValidator.cs
+++ b/src/Core/IdentityServer/BaseRequestValidator.cs
@@ -17,6 +17,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using Bit.Core.Models.Api;
+using Bit.Core.Context;
 
 namespace Bit.Core.IdentityServer
 {

--- a/src/Core/IdentityServer/BaseRequestValidator.cs
+++ b/src/Core/IdentityServer/BaseRequestValidator.cs
@@ -34,7 +34,7 @@ namespace Bit.Core.IdentityServer
         private readonly IApplicationCacheService _applicationCacheService;
         private readonly IMailService _mailService;
         private readonly ILogger<ResourceOwnerPasswordValidator> _logger;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
         private readonly GlobalSettings _globalSettings;
         private readonly IPolicyRepository _policyRepository;
 
@@ -50,7 +50,7 @@ namespace Bit.Core.IdentityServer
             IApplicationCacheService applicationCacheService,
             IMailService mailService,
             ILogger<ResourceOwnerPasswordValidator> logger,
-            CurrentContext currentContext,
+            ICurrentContext currentContext,
             GlobalSettings globalSettings,
             IPolicyRepository policyRepository)
         {

--- a/src/Core/IdentityServer/ClientStore.cs
+++ b/src/Core/IdentityServer/ClientStore.cs
@@ -9,6 +9,7 @@ using IdentityModel;
 using Bit.Core.Utilities;
 using System.Security.Claims;
 using Bit.Core.Services;
+using Bit.Core.Context;
 using System.Collections.ObjectModel;
 
 namespace Bit.Core.IdentityServer

--- a/src/Core/IdentityServer/ClientStore.cs
+++ b/src/Core/IdentityServer/ClientStore.cs
@@ -22,7 +22,7 @@ namespace Bit.Core.IdentityServer
         private readonly GlobalSettings _globalSettings;
         private readonly StaticClientStore _staticClientStore;
         private readonly ILicensingService _licensingService;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
         private readonly IOrganizationUserRepository _organizationUserRepository;
 
         public ClientStore(
@@ -32,7 +32,7 @@ namespace Bit.Core.IdentityServer
             GlobalSettings globalSettings,
             StaticClientStore staticClientStore,
             ILicensingService licensingService,
-            CurrentContext currentContext,
+            ICurrentContext currentContext,
             IOrganizationUserRepository organizationUserRepository)
         {
             _installationRepository = installationRepository;

--- a/src/Core/IdentityServer/CustomTokenRequestValidator.cs
+++ b/src/Core/IdentityServer/CustomTokenRequestValidator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Bit.Core.Services;
+using Bit.Core.Context;
 using System.Linq;
 using Bit.Core.Identity;
 using Microsoft.Extensions.Logging;

--- a/src/Core/IdentityServer/CustomTokenRequestValidator.cs
+++ b/src/Core/IdentityServer/CustomTokenRequestValidator.cs
@@ -32,7 +32,7 @@ namespace Bit.Core.IdentityServer
             IApplicationCacheService applicationCacheService,
             IMailService mailService,
             ILogger<ResourceOwnerPasswordValidator> logger,
-            CurrentContext currentContext,
+            ICurrentContext currentContext,
             GlobalSettings globalSettings,
             IPolicyRepository policyRepository)
             : base(userManager, deviceRepository, deviceService, userService, eventService,

--- a/src/Core/IdentityServer/ProfileService.cs
+++ b/src/Core/IdentityServer/ProfileService.cs
@@ -18,13 +18,13 @@ namespace Bit.Core.IdentityServer
         private readonly IUserService _userService;
         private readonly IOrganizationUserRepository _organizationUserRepository;
         private readonly ILicensingService _licensingService;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
 
         public ProfileService(
             IUserService userService,
             IOrganizationUserRepository organizationUserRepository,
             ILicensingService licensingService,
-            CurrentContext currentContext)
+            ICurrentContext currentContext)
         {
             _userService = userService;
             _organizationUserRepository = organizationUserRepository;

--- a/src/Core/IdentityServer/ProfileService.cs
+++ b/src/Core/IdentityServer/ProfileService.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System;
 using IdentityModel;
 using Bit.Core.Utilities;
+using Bit.Core.Context;
 
 namespace Bit.Core.IdentityServer
 {

--- a/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
+++ b/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
@@ -8,6 +8,7 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Bit.Core.Services;
 using Bit.Core.Identity;
+using Bit.Core.Context;
 using Microsoft.Extensions.Logging;
 
 namespace Bit.Core.IdentityServer

--- a/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
+++ b/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
@@ -31,7 +31,7 @@ namespace Bit.Core.IdentityServer
             IApplicationCacheService applicationCacheService,
             IMailService mailService,
             ILogger<ResourceOwnerPasswordValidator> logger,
-            CurrentContext currentContext,
+            ICurrentContext currentContext,
             GlobalSettings globalSettings,
             IPolicyRepository policyRepository)
             : base(userManager, deviceRepository, deviceService, userService, eventService,

--- a/src/Core/Models/Data/EventMessage.cs
+++ b/src/Core/Models/Data/EventMessage.cs
@@ -8,7 +8,7 @@ namespace Bit.Core.Models.Data
     {
         public EventMessage() { }
 
-        public EventMessage(CurrentContext currentContext)
+        public EventMessage(ICurrentContext currentContext)
             : base()
         {
             IpAddress = currentContext.IpAddress;

--- a/src/Core/Models/Data/EventMessage.cs
+++ b/src/Core/Models/Data/EventMessage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Bit.Core.Enums;
+using Bit.Core.Context;
 
 namespace Bit.Core.Models.Data
 {

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -589,9 +589,11 @@
   </data>
   <data name="DisableSend" xml:space="preserve">
     <value>Disable Send</value>
+    <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
   <data name="DisableSendDescription" xml:space="preserve">
-    <value>Do not allow users to create or edit Bitwarden Sends. Deleting existing Sends is still allowed.</value>
+    <value>Do not allow users to create or edit a Bitwarden Send. Deleting an existing Send is still allowed.</value>
+    <comment>'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated.</comment>
   </data>
   <data name="DisableSendExemption" xml:space="preserve">
     <value>Organization Owners and Administrators are exempt from this policy's enforcement.</value>

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -587,6 +587,15 @@
   <data name="PersonalOwnershipExemption" xml:space="preserve">
     <value>Organization Owners and Administrators are exempt from this policy's enforcement.</value>
   </data>
+  <data name="DisableSend" xml:space="preserve">
+    <value>Disable Send</value>
+  </data>
+  <data name="DisableSendDescription" xml:space="preserve">
+    <value>Do not allow users to create or edit Bitwarden Sends. Deleting existing Sends is still allowed</value>
+  </data>
+  <data name="DisableSendExemption" xml:space="preserve">
+    <value>Organization Owners and Administrators are exempt from this policy's enforcement.</value>
+  </data>
   <data name="DisableRequireSsoError" xml:space="preserve">
     <value>You must manually disable the Single Sign-On Authentication policy before this policy can be disabled.</value>
   </data>

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -585,13 +585,13 @@
     <value>Require users to save vault items to an organization by removing the personal ownership option.</value>
   </data>
   <data name="PersonalOwnershipExemption" xml:space="preserve">
-    <value>Organization Owners and Administrators are exempt from this policy's enforcement.</value>
+    <value>Organization members that can manage policies are exempt from this policy's enforcement.</value>
   </data>
   <data name="DisableSend" xml:space="preserve">
     <value>Disable Send</value>
   </data>
   <data name="DisableSendDescription" xml:space="preserve">
-    <value>Do not allow users to create or edit Bitwarden Sends. Deleting existing Sends is still allowed</value>
+    <value>Do not allow users to create or edit Bitwarden Sends. Deleting existing Sends is still allowed.</value>
   </data>
   <data name="DisableSendExemption" xml:space="preserve">
     <value>Organization Owners and Administrators are exempt from this policy's enforcement.</value>

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -585,7 +585,7 @@
     <value>Require users to save vault items to an organization by removing the personal ownership option.</value>
   </data>
   <data name="PersonalOwnershipExemption" xml:space="preserve">
-    <value>Organization members that can manage policies are exempt from this policy's enforcement.</value>
+    <value>Organization users that can manage the organization's policies are exempt from this policy's enforcement.</value>
   </data>
   <data name="DisableSend" xml:space="preserve">
     <value>Disable Send</value>

--- a/src/Core/Services/Implementations/AzureQueuePushNotificationService.cs
+++ b/src/Core/Services/Implementations/AzureQueuePushNotificationService.cs
@@ -182,7 +182,7 @@ namespace Bit.Core.Services
             }
 
             var currentContext = _httpContextAccessor?.HttpContext?.
-                RequestServices.GetService(typeof(CurrentContext)) as CurrentContext;
+                RequestServices.GetService(typeof(ICurrentContext)) as ICurrentContext;
             return currentContext?.DeviceIdentifier;
         }
 

--- a/src/Core/Services/Implementations/AzureQueuePushNotificationService.cs
+++ b/src/Core/Services/Implementations/AzureQueuePushNotificationService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Bit.Core.Context;
 using Bit.Core.Models.Table;
 using Bit.Core.Enums;
 using Newtonsoft.Json;

--- a/src/Core/Services/Implementations/EventService.cs
+++ b/src/Core/Services/Implementations/EventService.cs
@@ -15,14 +15,14 @@ namespace Bit.Core.Services
         private readonly IEventWriteService _eventWriteService;
         private readonly IOrganizationUserRepository _organizationUserRepository;
         private readonly IApplicationCacheService _applicationCacheService;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
         private readonly GlobalSettings _globalSettings;
 
         public EventService(
             IEventWriteService eventWriteService,
             IOrganizationUserRepository organizationUserRepository,
             IApplicationCacheService applicationCacheService,
-            CurrentContext currentContext,
+            ICurrentContext currentContext,
             GlobalSettings globalSettings)
         {
             _eventWriteService = eventWriteService;

--- a/src/Core/Services/Implementations/EventService.cs
+++ b/src/Core/Services/Implementations/EventService.cs
@@ -6,6 +6,7 @@ using Bit.Core.Models.Data;
 using System.Linq;
 using System.Collections.Generic;
 using Bit.Core.Models.Table;
+using Bit.Core.Context;
 
 namespace Bit.Core.Services
 {

--- a/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
+++ b/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Bit.Core.Models.Table;
 using Microsoft.Azure.NotificationHubs;
+using Bit.Core.Context;
 using Bit.Core.Enums;
 using Newtonsoft.Json;
 using System.Collections.Generic;

--- a/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
+++ b/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
@@ -207,7 +207,7 @@ namespace Bit.Core.Services
             }
 
             var currentContext = _httpContextAccessor?.HttpContext?.
-                RequestServices.GetService(typeof(CurrentContext)) as CurrentContext;
+                RequestServices.GetService(typeof(ICurrentContext)) as ICurrentContext;
             return currentContext?.DeviceIdentifier;
         }
 

--- a/src/Core/Services/Implementations/NotificationsApiPushNotificationService.cs
+++ b/src/Core/Services/Implementations/NotificationsApiPushNotificationService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Bit.Core.Context;
 using Bit.Core.Models.Table;
 using Bit.Core.Enums;
 using Newtonsoft.Json;

--- a/src/Core/Services/Implementations/NotificationsApiPushNotificationService.cs
+++ b/src/Core/Services/Implementations/NotificationsApiPushNotificationService.cs
@@ -188,7 +188,7 @@ namespace Bit.Core.Services
             }
 
             var currentContext = _httpContextAccessor?.HttpContext?.
-                RequestServices.GetService(typeof(CurrentContext)) as CurrentContext;
+                RequestServices.GetService(typeof(ICurrentContext)) as ICurrentContext;
             return currentContext?.DeviceIdentifier;
         }
 

--- a/src/Core/Services/Implementations/RelayPushNotificationService.cs
+++ b/src/Core/Services/Implementations/RelayPushNotificationService.cs
@@ -199,7 +199,7 @@ namespace Bit.Core.Services
         private async Task AddCurrentContextAsync(PushSendRequestModel request, bool addIdentifier)
         {
             var currentContext = _httpContextAccessor?.HttpContext?.
-                RequestServices.GetService(typeof(CurrentContext)) as CurrentContext;
+                RequestServices.GetService(typeof(ICurrentContext)) as ICurrentContext;
             if (!string.IsNullOrWhiteSpace(currentContext?.DeviceIdentifier))
             {
                 var device = await _deviceRepository.GetByIdentifierAsync(currentContext.DeviceIdentifier);

--- a/src/Core/Services/Implementations/RelayPushNotificationService.cs
+++ b/src/Core/Services/Implementations/RelayPushNotificationService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Bit.Core.Context;
 using Bit.Core.Models.Table;
 using Bit.Core.Enums;
 using Microsoft.AspNetCore.Http;

--- a/src/Core/Services/Implementations/SendService.cs
+++ b/src/Core/Services/Implementations/SendService.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Bit.Core.Context;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Data;
@@ -23,7 +24,7 @@ namespace Bit.Core.Services
         private readonly IPasswordHasher<User> _passwordHasher;
         private readonly IPushNotificationService _pushService;
         private readonly GlobalSettings _globalSettings;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
 
         public SendService(
             ISendRepository sendRepository,
@@ -35,7 +36,7 @@ namespace Bit.Core.Services
             IPushNotificationService pushService,
             GlobalSettings globalSettings,
             IPolicyRepository policyRepository,
-            CurrentContext currentContext)
+            ICurrentContext currentContext)
         {
             _sendRepository = sendRepository;
             _userRepository = userRepository;
@@ -188,7 +189,7 @@ namespace Bit.Core.Services
 
         private async Task ValidateUserCanSaveAsync(Guid? userId)
         {
-            if (!userId.HasValue || _currentContext.Organizations.FirstOrDefault() == default)
+            if (!userId.HasValue || _currentContext.Organizations?.FirstOrDefault() == null)
             {
                 return;
             }

--- a/src/Core/Services/Implementations/SendService.cs
+++ b/src/Core/Services/Implementations/SendService.cs
@@ -189,7 +189,7 @@ namespace Bit.Core.Services
 
         private async Task ValidateUserCanSaveAsync(Guid? userId)
         {
-            if (!userId.HasValue || _currentContext.Organizations?.FirstOrDefault() == null)
+            if (!userId.HasValue || (!_currentContext.Organizations?.Any() ?? true))
             {
                 return;
             }
@@ -205,7 +205,7 @@ namespace Bit.Core.Services
             {
                 if (!_currentContext.ManagePolicies(policy.OrganizationId))
                 {
-                    throw new BadRequestException("Due to an Enterprise Policy, you are restricted to only Deleting Sends.");
+                    throw new BadRequestException("Due to an Enterprise Policy, you are only able to delete an existing Send.");
                 }
             }
         }

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -47,7 +47,7 @@ namespace Bit.Core.Services
         private readonly IPolicyRepository _policyRepository;
         private readonly IDataProtector _organizationServiceDataProtector;
         private readonly IReferenceEventService _referenceEventService;
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
         private readonly GlobalSettings _globalSettings;
         private readonly IOrganizationService _organizationService;
 
@@ -75,7 +75,7 @@ namespace Bit.Core.Services
             IPaymentService paymentService,
             IPolicyRepository policyRepository,
             IReferenceEventService referenceEventService,
-            CurrentContext currentContext,
+            ICurrentContext currentContext,
             GlobalSettings globalSettings,
             IOrganizationService organizationService)
             : base(

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -14,6 +14,7 @@ using Bit.Core.Models.Business;
 using U2fLib = U2F.Core.Crypto.U2F;
 using U2F.Core.Models;
 using U2F.Core.Utils;
+using Bit.Core.Context;
 using Bit.Core.Exceptions;
 using Bit.Core.Utilities;
 using System.IO;

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -15,6 +15,7 @@ using System.Globalization;
 using System.Web;
 using Microsoft.AspNetCore.DataProtection;
 using Bit.Core.Enums;
+using Bit.Core.Context;
 using System.Threading.Tasks;
 using Microsoft.Azure.Storage;
 using Microsoft.Azure.Storage.Blob;
@@ -685,7 +686,7 @@ namespace Bit.Core.Utilities
             return configDict;
         }
 
-        public static List<KeyValuePair<string, string>> BuildIdentityClaims(User user, ICollection<CurrentContext.CurrentContentOrganization> orgs, bool isPremium) 
+        public static List<KeyValuePair<string, string>> BuildIdentityClaims(User user, ICollection<CurrentContentOrganization> orgs, bool isPremium)
         {
             var claims = new List<KeyValuePair<string, string>>()
             {

--- a/src/Core/Utilities/CurrentContextMiddleware.cs
+++ b/src/Core/Utilities/CurrentContextMiddleware.cs
@@ -13,7 +13,7 @@ namespace Bit.Core.Utilities
             _next = next;
         }
 
-        public async Task Invoke(HttpContext httpContext, CurrentContext currentContext, GlobalSettings globalSettings)
+        public async Task Invoke(HttpContext httpContext, ICurrentContext currentContext, GlobalSettings globalSettings)
         {
             await currentContext.BuildAsync(httpContext, globalSettings);
             await _next.Invoke(httpContext);

--- a/src/Core/Utilities/CurrentContextMiddleware.cs
+++ b/src/Core/Utilities/CurrentContextMiddleware.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using System.Threading.Tasks;
+using Bit.Core.Context;
 
 namespace Bit.Core.Utilities
 {

--- a/src/Events/Controllers/CollectController.cs
+++ b/src/Events/Controllers/CollectController.cs
@@ -18,12 +18,12 @@ namespace Bit.Events.Controllers
     [Authorize("Application")]
     public class CollectController : Controller
     {
-        private readonly CurrentContext _currentContext;
+        private readonly ICurrentContext _currentContext;
         private readonly IEventService _eventService;
         private readonly ICipherRepository _cipherRepository;
 
         public CollectController(
-            CurrentContext currentContext,
+            ICurrentContext currentContext,
             IEventService eventService,
             ICipherRepository cipherRepository)
         {

--- a/src/Events/Controllers/CollectController.cs
+++ b/src/Events/Controllers/CollectController.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Enums;
 using Bit.Core.Models.Table;
 using Bit.Core.Repositories;

--- a/src/Events/Startup.cs
+++ b/src/Events/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Services;
 using Bit.Core.Utilities;
 using IdentityModel;

--- a/src/Events/Startup.cs
+++ b/src/Events/Startup.cs
@@ -36,7 +36,7 @@ namespace Bit.Events
             services.AddSqlServerRepositories(globalSettings);
 
             // Context
-            services.AddScoped<CurrentContext>();
+            services.AddScoped<ICurrentContext, CurrentContext>();
 
             // Identity
             services.AddIdentityAuthenticationServices(globalSettings, Environment, config =>

--- a/src/Identity/Startup.cs
+++ b/src/Identity/Startup.cs
@@ -50,7 +50,7 @@ namespace Bit.Identity
             services.AddSqlServerRepositories(globalSettings);
 
             // Context
-            services.AddScoped<CurrentContext>();
+            services.AddScoped<ICurrentContext, CurrentContext>();
 
             // Caching
             services.AddMemoryCache();

--- a/src/Identity/Startup.cs
+++ b/src/Identity/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Bit.Core;
+using Bit.Core.Context;
 using Bit.Core.Utilities;
 using AspNetCoreRateLimit;
 using System.Globalization;

--- a/src/Notifications/NotificationsHub.cs
+++ b/src/Notifications/NotificationsHub.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Bit.Core;
+using Bit.Core.Context;
 using Microsoft.AspNetCore.Authorization;
 
 namespace Bit.Notifications

--- a/test/Core.Test/AutoFixture/CurrentContextFixtures.cs
+++ b/test/Core.Test/AutoFixture/CurrentContextFixtures.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using AutoFixture;
+using AutoFixture.Kernel;
+using Bit.Core.Context;
+
+namespace Bit.Core.Test.AutoFixture.CurrentContextFixtures
+{
+    internal class CurrentContext : ICustomization
+    {
+        public void Customize(IFixture fixture)
+        {
+            fixture.Customizations.Add(new CurrentContextBuilder());
+        }
+    }
+
+    internal class CurrentContextBuilder : ISpecimenBuilder
+    {
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            if (!(request is Type typeRequest))
+            {
+                return new NoSpecimen();
+            }
+            if (typeof(ICurrentContext) != typeRequest)
+            {
+                return new NoSpecimen();
+            }
+
+            var obj = new Fixture().WithAutoNSubstitutions().Create<ICurrentContext>();
+            obj.Organizations = context.Create<List<CurrentContentOrganization>>();
+            return obj;
+        }
+    }
+}

--- a/test/Core.Test/AutoFixture/SendFixtures.cs
+++ b/test/Core.Test/AutoFixture/SendFixtures.cs
@@ -35,29 +35,31 @@ namespace Bit.Core.Test.AutoFixture.SendFixtures
     }
     internal class InlineUserSendAutoDataAttribute : InlineCustomAutoDataAttribute
     {
-        public InlineUserSendAutoDataAttribute(params object[] values) : base(new[] { typeof(SutProviderCustomization),
-            typeof(UserSend) }, values)
+        public InlineUserSendAutoDataAttribute(params object[] values) : base(new[] { typeof(CurrentContextFixtures.CurrentContext),
+            typeof(SutProviderCustomization), typeof(UserSend) }, values)
         { }
     }
 
     internal class InlineKnownUserSendAutoDataAttribute : InlineCustomAutoDataAttribute
     {
         public InlineKnownUserSendAutoDataAttribute(string userId, params object[] values) : base(new ICustomization[]
-            { new SutProviderCustomization(), new UserSend { UserId = new Guid(userId) } }, values)
+            { new CurrentContextFixtures.CurrentContext(), new SutProviderCustomization(),
+            new UserSend { UserId = new Guid(userId) } }, values)
         { }
     }
 
     internal class OrganizationSendAutoDataAttribute : CustomAutoDataAttribute
     {
-        public OrganizationSendAutoDataAttribute(string organizationId = null) : base(new SutProviderCustomization(),
+        public OrganizationSendAutoDataAttribute(string organizationId = null) : base(new CurrentContextFixtures.CurrentContext(),
+            new SutProviderCustomization(),
             new OrganizationSend { OrganizationId = organizationId == null ? (Guid?)null : new Guid(organizationId) })
         { }
     }
 
     internal class InlineOrganizationSendAutoDataAttribute : InlineCustomAutoDataAttribute
     {
-        public InlineOrganizationSendAutoDataAttribute(params object[] values) : base(new[] { typeof(SutProviderCustomization),
-            typeof(OrganizationSend) }, values)
+        public InlineOrganizationSendAutoDataAttribute(params object[] values) : base(new[] { typeof(CurrentContextFixtures.CurrentContext),
+            typeof(SutProviderCustomization), typeof(OrganizationSend) }, values)
         { }
     }
 }

--- a/test/Core.Test/AutoFixture/SendFixtures.cs
+++ b/test/Core.Test/AutoFixture/SendFixtures.cs
@@ -1,0 +1,63 @@
+using System;
+using AutoFixture;
+using Bit.Core.Models.Table;
+using Bit.Core.Test.AutoFixture.Attributes;
+
+namespace Bit.Core.Test.AutoFixture.SendFixtures
+{
+    internal class OrganizationSend : ICustomization
+    {
+        public Guid? OrganizationId { get; set; }
+        public void Customize(IFixture fixture)
+        {
+            fixture.Customize<Send>(composer => composer
+                .With(s => s.OrganizationId, OrganizationId ?? Guid.NewGuid())
+                .Without(s => s.UserId));
+        }
+    }
+
+    internal class UserSend : ICustomization
+    {
+        public Guid? UserId { get; set; }
+        public void Customize(IFixture fixture)
+        {
+            fixture.Customize<Send>(composer => composer
+                .With(s => s.UserId, UserId ?? Guid.NewGuid())
+                .Without(s => s.OrganizationId));
+        }
+    }
+
+    internal class UserSendAutoDataAttribute : CustomAutoDataAttribute
+    {
+        public UserSendAutoDataAttribute(string userId = null) : base(new SutProviderCustomization(),
+            new UserSend { UserId = userId == null ? (Guid?)null : new Guid(userId) })
+        { }
+    }
+    internal class InlineUserSendAutoDataAttribute : InlineCustomAutoDataAttribute
+    {
+        public InlineUserSendAutoDataAttribute(params object[] values) : base(new[] { typeof(SutProviderCustomization),
+            typeof(UserSend) }, values)
+        { }
+    }
+
+    internal class InlineKnownUserSendAutoDataAttribute : InlineCustomAutoDataAttribute
+    {
+        public InlineKnownUserSendAutoDataAttribute(string userId, params object[] values) : base(new ICustomization[]
+            { new SutProviderCustomization(), new UserSend { UserId = new Guid(userId) } }, values)
+        { }
+    }
+
+    internal class OrganizationSendAutoDataAttribute : CustomAutoDataAttribute
+    {
+        public OrganizationSendAutoDataAttribute(string organizationId = null) : base(new SutProviderCustomization(),
+            new OrganizationSend { OrganizationId = organizationId == null ? (Guid?)null : new Guid(organizationId) })
+        { }
+    }
+
+    internal class InlineOrganizationSendAutoDataAttribute : InlineCustomAutoDataAttribute
+    {
+        public InlineOrganizationSendAutoDataAttribute(params object[] values) : base(new[] { typeof(SutProviderCustomization),
+            typeof(OrganizationSend) }, values)
+        { }
+    }
+}

--- a/test/Core.Test/AutoFixture/SutProvider.cs
+++ b/test/Core.Test/AutoFixture/SutProvider.cs
@@ -16,10 +16,12 @@ namespace Bit.Core.Test.AutoFixture
         public TSut Sut { get; private set; }
         public Type SutType => typeof(TSut);
 
-        public SutProvider()
+        public SutProvider() : this(new Fixture()) { }
+
+        public SutProvider(IFixture fixture)
         {
             _dependencies = new Dictionary<Type, Dictionary<string, object>>();
-            _fixture = new Fixture().WithAutoNSubstitutions();
+            _fixture = (fixture ?? new Fixture()).WithAutoNSubstitutions();
             _constructorParameterRelay = new ConstructorParameterRelay<TSut>(this, _fixture);
             _fixture.Customizations.Add(_constructorParameterRelay);
         }

--- a/test/Core.Test/AutoFixture/SutProviderCustomization.cs
+++ b/test/Core.Test/AutoFixture/SutProviderCustomization.cs
@@ -6,6 +6,8 @@ namespace Bit.Core.Test.AutoFixture
 {
     public class SutProviderCustomization : ICustomization, ISpecimenBuilder
     {
+        private IFixture _fixture = null;
+
         public object Create(object request, ISpecimenContext context)
         {
             if (context == null)
@@ -21,11 +23,12 @@ namespace Bit.Core.Test.AutoFixture
                 return new NoSpecimen();
             }
 
-            return ((ISutProvider)Activator.CreateInstance(typeRequest)).Create();
+            return ((ISutProvider)Activator.CreateInstance(typeRequest, _fixture)).Create();
         }
 
         public void Customize(IFixture fixture)
         {
+            _fixture = fixture;
             fixture.Customizations.Add(this);
         }
     }

--- a/test/Core.Test/Services/EventServiceTests.cs
+++ b/test/Core.Test/Services/EventServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Bit.Core.Context;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using NSubstitute;

--- a/test/Core.Test/Services/SendServiceTests.cs
+++ b/test/Core.Test/Services/SendServiceTests.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Linq;
+using Bit.Core.Enums;
+using Bit.Core.Exceptions;
+using Bit.Core.Models.Data;
+using Bit.Core.Models.Table;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Bit.Core.Test.AutoFixture;
+using Bit.Core.Test.AutoFixture.SendFixtures;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class SendServiceTests
+    {
+        private void SaveSendAsync_Setup(SendType sendType, OrganizationUserType userType,
+            SutProvider<SendService> sutProvider, Send send, List<Policy> policies,
+            OrganizationUserOrganizationDetails organizationDetails)
+        {
+            send.Id = default;
+            send.Type = sendType;
+
+            organizationDetails.Enabled = true;
+            organizationDetails.UsePolicies = true;
+            organizationDetails.Type = userType;
+
+            policies.First().Type = PolicyType.DisableSend;
+            policies.First().Enabled = true;
+
+            sutProvider.GetDependency<IPolicyRepository>().GetManyByUserIdAsync(send.UserId.Value).Returns(policies);
+            sutProvider.GetDependency<IOrganizationUserRepository>().GetDetailsByUserAsync(send.UserId.Value,
+                policies.First().OrganizationId, OrganizationUserStatusType.Confirmed).Returns(organizationDetails);
+        }
+
+        [Theory]
+        [InlineUserSendAutoData(SendType.File, OrganizationUserType.User)]
+        [InlineUserSendAutoData(SendType.File, OrganizationUserType.Manager)]
+        [InlineUserSendAutoData(SendType.File, OrganizationUserType.Custom)]
+        [InlineUserSendAutoData(SendType.Text, OrganizationUserType.User)]
+        [InlineUserSendAutoData(SendType.Text, OrganizationUserType.Manager)]
+        [InlineUserSendAutoData(SendType.Text, OrganizationUserType.Custom)]
+        public async void SaveSendAsync_DisableSend_NonAdmin_throws(SendType sendType, OrganizationUserType userType,
+            SutProvider<SendService> sutProvider, Send send, List<Policy> policies,
+            OrganizationUserOrganizationDetails organizationDetails)
+        {
+            SaveSendAsync_Setup(sendType, userType, sutProvider, send, policies, organizationDetails);
+
+            await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.SaveSendAsync(send));
+        }
+
+        [Theory]
+        [InlineUserSendAutoData(SendType.File, OrganizationUserType.User)]
+        [InlineUserSendAutoData(SendType.File, OrganizationUserType.Manager)]
+        [InlineUserSendAutoData(SendType.File, OrganizationUserType.Custom)]
+        [InlineUserSendAutoData(SendType.Text, OrganizationUserType.User)]
+        [InlineUserSendAutoData(SendType.Text, OrganizationUserType.Manager)]
+        [InlineUserSendAutoData(SendType.Text, OrganizationUserType.Custom)]
+        public async void SaveSendAsync_DisableSend_DisabledPolicy_NonAdmin_success(SendType sendType, OrganizationUserType userType,
+            SutProvider<SendService> sutProvider, Send send, List<Policy> policies,
+            OrganizationUserOrganizationDetails organizationDetails)
+        {
+            SaveSendAsync_Setup(sendType, userType, sutProvider, send, policies, organizationDetails);
+            foreach (var policy in policies.Where(p => p.Type == PolicyType.DisableSend))
+            {
+                policy.Enabled = false;
+            }
+
+            await sutProvider.Sut.SaveSendAsync(send);
+
+            await sutProvider.GetDependency<ISendRepository>().Received(1).CreateAsync(send);
+        }
+
+        [Theory]
+        [InlineUserSendAutoData(SendType.File, OrganizationUserType.Admin)]
+        [InlineUserSendAutoData(SendType.File, OrganizationUserType.Owner)]
+        [InlineUserSendAutoData(SendType.Text, OrganizationUserType.Admin)]
+        [InlineUserSendAutoData(SendType.Text, OrganizationUserType.Owner)]
+        public async void SaveSendAsync_DisableSend_Admin_success(SendType sendType, OrganizationUserType userType,
+            SutProvider<SendService> sutProvider, Send send, List<Policy> policies,
+            OrganizationUserOrganizationDetails organizationDetails)
+        {
+            SaveSendAsync_Setup(sendType, userType, sutProvider, send, policies, organizationDetails);
+
+            await sutProvider.Sut.SaveSendAsync(send);
+
+            await sutProvider.GetDependency<ISendRepository>().Received(1).CreateAsync(send);
+        }
+    }
+}

--- a/test/Core.Test/Services/SendServiceTests.cs
+++ b/test/Core.Test/Services/SendServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Bit.Core.Context;
@@ -26,7 +27,7 @@ namespace Bit.Core.Test.Services
             policies.First().Enabled = true;
 
             sutProvider.GetDependency<IPolicyRepository>().GetManyByUserIdAsync(send.UserId.Value).Returns(policies);
-            sutProvider.GetDependency<ICurrentContext>().ManagePolicies(policies.First().Id).Returns(canManagePolicies);
+            sutProvider.GetDependency<ICurrentContext>().ManagePolicies(Arg.Any<Guid>()).Returns(canManagePolicies);
         }
 
         [Theory]

--- a/test/Core.Test/Services/UserServiceTests.cs
+++ b/test/Core.Test/Services/UserServiceTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
+using Bit.Core.Context;
 
 namespace Bit.Core.Test.Services
 {


### PR DESCRIPTION
# Overview

# Files Changed

* **PoliciesController**: Add DisableSend to pass-through in dependent policies switch
* **PolicyEditModel**: Add DisableSend to model to policy switch. No data required for this policy
* **PolicyModel**: Add DisableSend to policy model definitions.
* **Policies/Edit.cshtml**: Show DisableSend in policies edit page
* **PolicyType**: Add DisableSend type
* **SharedResources.en.resx**: DisableSend description strings
* **SendService**: Block saving, create or upsert, of Sends if the user is blocked by an organization they belong to.

### Testing Files Changed

* **SendFixtures**: Add user and organization type fixtures for testing. Organization types are currently unused.
* **SendServiceTests**: Tests bad request error thrown (or not) when the Disable Send policy is in play

# Testing Concerns

Basic automated unit tests are in place to ensure the policy is enforced for non Admin/Owners if the rule is enabled.

Web tests validating toast message returned is appropriate would be a good idea.