### PR TITLE
Improved handling of grantor access to organizations after takeover

### DIFF
--- a/src/Api/Controllers/EmergencyAccessController.cs
+++ b/src/Api/Controllers/EmergencyAccessController.cs
@@ -136,8 +136,8 @@ namespace Bit.Api.Controllers
         public async Task<EmergencyAccessTakeoverResponseModel> Takeover(string id)
         {
             var user = await _userService.GetUserByPrincipalAsync(User);
-            var (result, grantor) = await _emergencyAccessService.TakeoverAsync(new Guid(id), user);
-            return new EmergencyAccessTakeoverResponseModel(result, grantor);
+            var (result, grantor, policy) = await _emergencyAccessService.TakeoverAsync(new Guid(id), user);
+            return new EmergencyAccessTakeoverResponseModel(result, grantor, policy);
         }
         
         [HttpPost("{id}/password")]

--- a/src/Core/Models/Api/Response/EmergencyAccessResponseModel.cs
+++ b/src/Core/Models/Api/Response/EmergencyAccessResponseModel.cs
@@ -84,7 +84,7 @@ namespace Bit.Core.Models.Api.Response
 
     public class EmergencyAccessTakeoverResponseModel : ResponseModel
     {
-        public EmergencyAccessTakeoverResponseModel(EmergencyAccess emergencyAccess, User grantor, string obj = "emergencyAccessTakeover") : base(obj)
+        public EmergencyAccessTakeoverResponseModel(EmergencyAccess emergencyAccess, User grantor, ICollection<Policy> policy, string obj = "emergencyAccessTakeover") : base(obj)
         {
             if (emergencyAccess == null)
             {
@@ -94,11 +94,13 @@ namespace Bit.Core.Models.Api.Response
             KeyEncrypted = emergencyAccess.KeyEncrypted;
             Kdf = grantor.Kdf;
             KdfIterations = grantor.KdfIterations;
+            Policy = policy.Select<Policy, PolicyResponseModel>(policy => new PolicyResponseModel(policy));
         }
 
         public int KdfIterations { get; private set; }
         public KdfType Kdf { get; private set; }
         public string KeyEncrypted { get; private set; }
+        public IEnumerable<PolicyResponseModel> Policy { get; private set; }
     }
 
     public class EmergencyAccessViewResponseModel : ResponseModel

--- a/src/Core/Models/Api/Response/EmergencyAccessResponseModel.cs
+++ b/src/Core/Models/Api/Response/EmergencyAccessResponseModel.cs
@@ -94,7 +94,7 @@ namespace Bit.Core.Models.Api.Response
             KeyEncrypted = emergencyAccess.KeyEncrypted;
             Kdf = grantor.Kdf;
             KdfIterations = grantor.KdfIterations;
-            Policy = policy.Select<Policy, PolicyResponseModel>(policy => new PolicyResponseModel(policy));
+            Policy = policy?.Select<Policy, PolicyResponseModel>(policy => new PolicyResponseModel(policy));
         }
 
         public int KdfIterations { get; private set; }

--- a/src/Core/Services/IEmergencyAccessService.cs
+++ b/src/Core/Services/IEmergencyAccessService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Bit.Core.Enums;
 using Bit.Core.Models.Api.Response;
@@ -19,7 +20,7 @@ namespace Bit.Core.Services
         Task InitiateAsync(Guid id, User initiatingUser);
         Task ApproveAsync(Guid id, User approvingUser);
         Task RejectAsync(Guid id, User rejectingUser);
-        Task<(EmergencyAccess, User)> TakeoverAsync(Guid id, User initiatingUser);
+        Task<(EmergencyAccess, User, ICollection<Policy>)> TakeoverAsync(Guid id, User initiatingUser);
         Task PasswordAsync(Guid id, User user, string newMasterPasswordHash, string key);
         Task SendNotificationsAsync();
         Task HandleTimedOutRequestsAsync();

--- a/src/Core/Services/Implementations/EmergencyAccessService.cs
+++ b/src/Core/Services/Implementations/EmergencyAccessService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
@@ -249,8 +250,11 @@ namespace Bit.Core.Services
             }
 
             var grantor = await _userRepository.GetByIdAsync(emergencyAccess.GrantorId);
-            var policy = await _policyRepository.GetManyByUserIdAsync(grantor.Id);
-            
+
+            var grantorOrganizations = await _organizationUserRepository.GetManyByUserAsync(grantor.Id);
+            var isOrganizationOwner = grantorOrganizations.Any<OrganizationUser>(organization => organization.Type == OrganizationUserType.Owner);
+            var policy = isOrganizationOwner ? await _policyRepository.GetManyByUserIdAsync(grantor.Id) : null;
+
             return (emergencyAccess, grantor, policy);
         }
 

--- a/src/Core/Services/Implementations/EmergencyAccessService.cs
+++ b/src/Core/Services/Implementations/EmergencyAccessService.cs
@@ -20,6 +20,7 @@ namespace Bit.Core.Services
         private readonly IOrganizationUserRepository _organizationUserRepository;
         private readonly IUserRepository _userRepository;
         private readonly ICipherRepository _cipherRepository;
+        private readonly IPolicyRepository _policyRepository;
         private readonly IMailService _mailService;
         private readonly IUserService _userService;
         private readonly IDataProtector _dataProtector;
@@ -32,6 +33,7 @@ namespace Bit.Core.Services
             IOrganizationUserRepository organizationUserRepository,
             IUserRepository userRepository,
             ICipherRepository cipherRepository,
+            IPolicyRepository policyRepository,
             IMailService mailService,
             IUserService userService,
             IPasswordHasher<User> passwordHasher,
@@ -43,6 +45,7 @@ namespace Bit.Core.Services
             _organizationUserRepository = organizationUserRepository;
             _userRepository = userRepository;
             _cipherRepository = cipherRepository;
+            _policyRepository = policyRepository;
             _mailService = mailService;
             _userService = userService;
             _passwordHasher = passwordHasher;
@@ -235,7 +238,7 @@ namespace Bit.Core.Services
             await _mailService.SendEmergencyAccessRecoveryRejected(emergencyAccess, NameOrEmail(rejectingUser), grantee.Email);
         }
 
-        public async Task<(EmergencyAccess, User)> TakeoverAsync(Guid id, User requestingUser)
+        public async Task<(EmergencyAccess, User, ICollection<Policy>)> TakeoverAsync(Guid id, User requestingUser)
         {
             var emergencyAccess = await _emergencyAccessRepository.GetByIdAsync(id);
 
@@ -246,8 +249,9 @@ namespace Bit.Core.Services
             }
 
             var grantor = await _userRepository.GetByIdAsync(emergencyAccess.GrantorId);
+            var policy = await _policyRepository.GetManyByUserIdAsync(grantor.Id);
             
-            return (emergencyAccess, grantor);
+            return (emergencyAccess, grantor, policy);
         }
 
         public async Task PasswordAsync(Guid id, User requestingUser, string newMasterPasswordHash, string key)


### PR DESCRIPTION
## Objective
Fix #1119, which raised the following issues:
* an organization's 2FA policy is not enforced when a grantor's master password is changed - 2FA is disabled on the grantor's account and is never required to be re-enabled
* an organization's password strength policy is not enforced when a grantor's master password is changed - the grantee can use a weak password that does not meet policy requirements
* more broadly, an organization member can give takeover emergency access to a non-organization member, and there is no way to control this or notify organization owners

At this stage, we are taking the following approach (per internal discussions):
* if the grantor is NOT an owner of an organization - the grantor will be removed from the organization after takeover. This way, the admins/owners of the organization must make an active decision to re-invite the user account, and any policies will be enforced per normal in the invite process.
* if the grantor IS an owner of the organization - the grantor will not be removed from the organization after takeover, and will retain all powers of owner. Owners already have the highest level of trust and are therefore trusted to nominate a suitable emergency contact. This is also intended to prevent owner-less (or effectively owner-less) zombie organizations.  Because the grantor remains in the organization, the password policy is enforced at the time of takeover. However, per normal practice, 2FA policy does not apply to owners.

## Code changes
This requires changes to:
* server - this PR
* web - https://github.com/bitwarden/web/pull/820
* jslib - https://github.com/bitwarden/jslib/pull/260

Broadly, the approach is:
* when an organization owner navigates to their Emergency Access page:
  * display a new warning to advise them that anyone with takeover access will retain all their permissions as owner
* when the `emergency-access-takeover.component` loads:
  * server-side: check whether the grantor is an owner of any organizations. If so, include all policies that apply to the grantor in the `EmergencyAccessTakeoverResponseModel` that is sent back to the client.
  * client-side: retrieve these policies from the response model and use the existing methods of the `ChangePasswordComponent` parent class to enforce the password policy (if any).
 * when the `emergency-access-takeover.component` submits the new password:
   * server-side: remove the grantor from any organizations unless they are the owner.