### PR TITLE
SSO - Added custom scopes and claim types for OIDC

### DIFF
--- a/bitwarden_license/src/Portal/Models/SsoConfigDataViewModel.cs
+++ b/bitwarden_license/src/Portal/Models/SsoConfigDataViewModel.cs
@@ -49,6 +49,10 @@ namespace Bit.Portal.Models
             SpWantAssertionsSigned = configurationData.SpWantAssertionsSigned;
             SpValidateCertificates = configurationData.SpValidateCertificates;
             SpMinIncomingSigningAlgorithm = configurationData.SpMinIncomingSigningAlgorithm ?? SamlSigningAlgorithms.Sha256;
+            AdditionalScopes = configurationData.AdditionalScopes;
+            AdditionalUserIdClaimTypes = configurationData.AdditionalUserIdClaimTypes;
+            AdditionalEmailClaimTypes = configurationData.AdditionalEmailClaimTypes;
+            AdditionalNameClaimTypes = configurationData.AdditionalNameClaimTypes;
         }
 
         [Required]
@@ -72,6 +76,14 @@ namespace Bit.Portal.Models
         public OpenIdConnectRedirectBehavior RedirectBehavior { get; set; }
         [Display(Name = "GetClaimsFromUserInfoEndpoint")]
         public bool GetClaimsFromUserInfoEndpoint { get; set; }
+        [Display(Name = "AdditionalScopes")]
+        public string AdditionalScopes { get; set; }
+        [Display(Name = "AdditionalUserIdClaimTypes")]
+        public string AdditionalUserIdClaimTypes { get; set; }
+        [Display(Name = "AdditionalEmailClaimTypes")]
+        public string AdditionalEmailClaimTypes { get; set; }
+        [Display(Name = "AdditionalNameClaimTypes")]
+        public string AdditionalNameClaimTypes { get; set; }
 
         // SAML2 SP
         [Display(Name = "SpEntityId")]
@@ -218,6 +230,10 @@ namespace Bit.Portal.Models
                 SpWantAssertionsSigned = SpWantAssertionsSigned,
                 SpValidateCertificates = SpValidateCertificates,
                 SpMinIncomingSigningAlgorithm = SpMinIncomingSigningAlgorithm,
+                AdditionalScopes = AdditionalScopes,
+                AdditionalUserIdClaimTypes = AdditionalUserIdClaimTypes,
+                AdditionalEmailClaimTypes = AdditionalEmailClaimTypes,
+                AdditionalNameClaimTypes = AdditionalNameClaimTypes,
             };
         }
 

--- a/bitwarden_license/src/Portal/Models/SsoConfigDataViewModel.cs
+++ b/bitwarden_license/src/Portal/Models/SsoConfigDataViewModel.cs
@@ -53,6 +53,7 @@ namespace Bit.Portal.Models
             AdditionalUserIdClaimTypes = configurationData.AdditionalUserIdClaimTypes;
             AdditionalEmailClaimTypes = configurationData.AdditionalEmailClaimTypes;
             AdditionalNameClaimTypes = configurationData.AdditionalNameClaimTypes;
+            AcrValues = configurationData.AcrValues;
         }
 
         [Required]
@@ -84,6 +85,8 @@ namespace Bit.Portal.Models
         public string AdditionalEmailClaimTypes { get; set; }
         [Display(Name = "AdditionalNameClaimTypes")]
         public string AdditionalNameClaimTypes { get; set; }
+        [Display(Name = "AcrValues")]
+        public string AcrValues { get; set; }
 
         // SAML2 SP
         [Display(Name = "SpEntityId")]
@@ -234,6 +237,7 @@ namespace Bit.Portal.Models
                 AdditionalUserIdClaimTypes = AdditionalUserIdClaimTypes,
                 AdditionalEmailClaimTypes = AdditionalEmailClaimTypes,
                 AdditionalNameClaimTypes = AdditionalNameClaimTypes,
+                AcrValues = AcrValues,
             };
         }
 

--- a/bitwarden_license/src/Portal/Views/Sso/Index.cshtml
+++ b/bitwarden_license/src/Portal/Views/Sso/Index.cshtml
@@ -64,7 +64,7 @@
             <h2>@i18nService.T("OpenIdConnectConfig")</h2>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.CallbackPath">@i18nService.T("CallbackPath")</label>
+                    <label asp-for="Data.CallbackPath"></label>
                     <div class="input-group">
                         <input asp-for="Data.CallbackPath" class="form-control" readonly>
                         <div class="input-group-append">
@@ -79,7 +79,7 @@
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.SignedOutCallbackPath">@i18nService.T("SignedOutCallbackPath")</label>
+                    <label asp-for="Data.SignedOutCallbackPath"></label>
                     <div class="input-group">
                         <input asp-for="Data.SignedOutCallbackPath" class="form-control" readonly>
                         <div class="input-group-append">
@@ -94,34 +94,34 @@
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.Authority">@i18nService.T("Authority")</label>
+                    <label asp-for="Data.Authority"></label>
                     <input asp-for="Data.Authority" class="form-control">
                     <span asp-validation-for="Data.Authority" class="text-danger"></span>
                 </div>
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.ClientId">@i18nService.T("ClientId")</label>
+                    <label asp-for="Data.ClientId"></label>
                     <input asp-for="Data.ClientId" class="form-control">
                     <span asp-validation-for="Data.ClientId" class="text-danger"></span>
                 </div>
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.ClientSecret">@i18nService.T("ClientSecret")</label>
+                    <label asp-for="Data.ClientSecret"></label>
                     <input asp-for="Data.ClientSecret" class="form-control">
                     <span asp-validation-for="Data.ClientSecret" class="text-danger"></span>
                 </div>
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.MetadataAddress">@i18nService.T("MetadataAddress")</label>
+                    <label asp-for="Data.MetadataAddress"></label>
                     <input asp-for="Data.MetadataAddress" class="form-control">
                 </div>
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.RedirectBehavior">@i18nService.T("RedirectBehavior")</label>
+                    <label asp-for="Data.RedirectBehavior"></label>
                     <select asp-for="Data.RedirectBehavior" asp-items="Model.RedirectBehaviors"
                             class="form-control"></select>
                 </div>
@@ -136,25 +136,25 @@
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.AdditionalScopes">@i18nService.T("AdditionalScopes")</label>
+                    <label asp-for="Data.AdditionalScopes"></label>
                     <input asp-for="Data.AdditionalScopes" class="form-control">
                 </div>
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.AdditionalUserIdClaimTypes">@i18nService.T("AdditionalUserIdClaimTypes")</label>
+                    <label asp-for="Data.AdditionalUserIdClaimTypes"></label>
                     <input asp-for="Data.AdditionalUserIdClaimTypes" class="form-control">
                 </div>
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.AdditionalEmailClaimTypes">@i18nService.T("AdditionalEmailClaimTypes")</label>
+                    <label asp-for="Data.AdditionalEmailClaimTypes"></label>
                     <input asp-for="Data.AdditionalEmailClaimTypes" class="form-control">
                 </div>
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.AdditionalNameClaimTypes">@i18nService.T("AdditionalNameClaimTypes")</label>
+                    <label asp-for="Data.AdditionalNameClaimTypes"></label>
                     <input asp-for="Data.AdditionalNameClaimTypes" class="form-control">
                 </div>
             </div>
@@ -167,7 +167,7 @@
             <h2>@i18nService.T("SamlSpConfig")</h2>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.SpEntityId">@i18nService.T("SpEntityId")</label>
+                    <label asp-for="Data.SpEntityId"></label>
                     <div class="input-group">
                         <input asp-for="Data.SpEntityId" class="form-control" readonly>
                         <div class="input-group-append">
@@ -182,7 +182,7 @@
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.SpMetadataUrl">@i18nService.T("SpMetadataUrl")</label>
+                    <label asp-for="Data.SpMetadataUrl"></label>
                     <div class="input-group">
                         <input asp-for="Data.SpMetadataUrl" class="form-control" readonly>
                         <div class="input-group-append">
@@ -206,7 +206,7 @@
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.SpAcsUrl">@i18nService.T("SpAcsUrl")</label>
+                    <label asp-for="Data.SpAcsUrl"></label>
                     <div class="input-group">
                         <input asp-for="Data.SpAcsUrl" class="form-control" readonly>
                         <div class="input-group-append">
@@ -223,28 +223,28 @@
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.SpNameIdFormat">@i18nService.T("NameIdFormat")</label>
+                    <label asp-for="Data.SpNameIdFormat"></label>
                     <select asp-for="Data.SpNameIdFormat" asp-items="Model.SpNameIdFormats"
                             class="form-control"></select>
                 </div>
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.SpOutboundSigningAlgorithm">@i18nService.T("OutboundSigningAlgorithm")</label>
+                    <label asp-for="Data.SpOutboundSigningAlgorithm"></label>
                     <select asp-for="Data.SpOutboundSigningAlgorithm" asp-items="Model.SigningAlgorithms"
                             class="form-control"></select>
                 </div>
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.SpSigningBehavior">@i18nService.T("SigningBehavior")</label>
+                    <label asp-for="Data.SpSigningBehavior"></label>
                     <select asp-for="Data.SpSigningBehavior" asp-items="Model.SigningBehaviors"
                             class="form-control"></select>
                 </div>
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.SpMinIncomingSigningAlgorithm">@i18nService.T("MinIncomingSigningAlgorithm")</label>
+                    <label asp-for="Data.SpMinIncomingSigningAlgorithm"></label>
                     <select asp-for="Data.SpMinIncomingSigningAlgorithm" asp-items="Model.SigningAlgorithms"
                             class="form-control"></select>
                 </div>
@@ -269,7 +269,7 @@
 
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.IdpEntityId">@i18nService.T("EntityId")</label>
+                    <label asp-for="Data.IdpEntityId"></label>
                     <input asp-for="Data.IdpEntityId" class="form-control">
                     <span asp-validation-for="Data.IdpEntityId" class="text-danger"></span>
                 </div>
@@ -282,14 +282,14 @@
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.IdpSingleSignOnServiceUrl">@i18nService.T("SingleSignOnServiceUrl")</label>
+                    <label asp-for="Data.IdpSingleSignOnServiceUrl"></label>
                     <input asp-for="Data.IdpSingleSignOnServiceUrl" class="form-control">
                     <span asp-validation-for="Data.IdpSingleSignOnServiceUrl" class="text-danger"></span>
                 </div>
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.IdpSingleLogoutServiceUrl">@i18nService.T("SingleLogoutServiceUrl")</label>
+                    <label asp-for="Data.IdpSingleLogoutServiceUrl"></label>
                     <input asp-for="Data.IdpSingleLogoutServiceUrl" class="form-control">
                 </div>
             </div>
@@ -302,7 +302,7 @@
             </div>
             <div class="row">
                 <div class="col-7 form-group">
-                    <label asp-for="Data.IdpX509PublicCert">@i18nService.T("X509PublicCert")</label>
+                    <label asp-for="Data.IdpX509PublicCert"></label>
                     <textarea asp-for="Data.IdpX509PublicCert" class="form-control form-control-sm text-monospace" rows="6"></textarea>
                     <span asp-validation-for="Data.IdpX509PublicCert" class="text-danger"></span>
                 </div>

--- a/bitwarden_license/src/Portal/Views/Sso/Index.cshtml
+++ b/bitwarden_license/src/Portal/Views/Sso/Index.cshtml
@@ -134,6 +134,30 @@
                     </div>
                 </div>
             </div>
+            <div class="row">
+                <div class="col-7 form-group">
+                    <label asp-for="Data.AdditionalScopes">@i18nService.T("AdditionalScopes")</label>
+                    <input asp-for="Data.AdditionalScopes" class="form-control">
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-7 form-group">
+                    <label asp-for="Data.AdditionalUserIdClaimTypes">@i18nService.T("AdditionalUserIdClaimTypes")</label>
+                    <input asp-for="Data.AdditionalUserIdClaimTypes" class="form-control">
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-7 form-group">
+                    <label asp-for="Data.AdditionalEmailClaimTypes">@i18nService.T("AdditionalEmailClaimTypes")</label>
+                    <input asp-for="Data.AdditionalEmailClaimTypes" class="form-control">
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-7 form-group">
+                    <label asp-for="Data.AdditionalNameClaimTypes">@i18nService.T("AdditionalNameClaimTypes")</label>
+                    <input asp-for="Data.AdditionalNameClaimTypes" class="form-control">
+                </div>
+            </div>
         </div>
     </div>
 

--- a/bitwarden_license/src/Portal/Views/Sso/Index.cshtml
+++ b/bitwarden_license/src/Portal/Views/Sso/Index.cshtml
@@ -158,6 +158,12 @@
                     <input asp-for="Data.AdditionalNameClaimTypes" class="form-control">
                 </div>
             </div>
+            <div class="row">
+                <div class="col-7 form-group">
+                    <label asp-for="Data.AcrValues"></label>
+                    <input asp-for="Data.AcrValues" class="form-control">
+                </div>
+            </div>
         </div>
     </div>
 

--- a/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
+++ b/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
@@ -336,6 +336,19 @@ namespace Bit.Core.Business.Sso
 
             oidcOptions.StateDataFormat = new DistributedCacheStateDataFormatter(_httpContextAccessor, name);
 
+            // see: https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest (acr_values)
+            if (!string.IsNullOrWhiteSpace(config.AcrValues))
+            {
+                oidcOptions.Events = new OpenIdConnectEvents
+                {
+                    OnRedirectToIdentityProvider = ctx =>
+                    {
+                        ctx.ProtocolMessage.AcrValues = config.AcrValues;
+                        return Task.CompletedTask;
+                    }
+                };
+            }
+
             return new DynamicAuthenticationScheme(name, name, typeof(OpenIdConnectHandler),
                 oidcOptions, SsoType.OpenIdConnect);
         }

--- a/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
+++ b/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
@@ -10,6 +10,7 @@ using Bit.Core.Models.Data;
 using Bit.Core.Models.Table;
 using Bit.Core.Repositories;
 using Bit.Core.Sso;
+using Bit.Core.Utilities;
 using Bit.Sso.Models;
 using Bit.Sso.Utilities;
 using IdentityModel;
@@ -324,17 +325,13 @@ namespace Bit.Core.Business.Sso
                 AuthenticationMethod = config.RedirectBehavior,
                 GetClaimsFromUserInfoEndpoint = config.GetClaimsFromUserInfoEndpoint,
             };
-            if (!oidcOptions.Scope.Contains(OpenIdConnectScopes.OpenId))
+            oidcOptions.Scope
+                .AddIfNotExists(OpenIdConnectScopes.OpenId)
+                .AddIfNotExists(OpenIdConnectScopes.Email)
+                .AddIfNotExists(OpenIdConnectScopes.Profile);
+            foreach (var scope in config.GetAdditionalScopes())
             {
-                oidcOptions.Scope.Add(OpenIdConnectScopes.OpenId);
-            }
-            if (!oidcOptions.Scope.Contains(OpenIdConnectScopes.Email))
-            {
-                oidcOptions.Scope.Add(OpenIdConnectScopes.Email);
-            }
-            if (!oidcOptions.Scope.Contains(OpenIdConnectScopes.Profile))
-            {
-                oidcOptions.Scope.Add(OpenIdConnectScopes.Profile);
+                oidcOptions.Scope.AddIfNotExists(scope);
             }
 
             oidcOptions.StateDataFormat = new DistributedCacheStateDataFormatter(_httpContextAccessor, name);

--- a/src/Core/Models/Data/SsoConfigurationData.cs
+++ b/src/Core/Models/Data/SsoConfigurationData.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Bit.Core.Enums;
 using Bit.Core.Sso;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -20,6 +22,10 @@ namespace Bit.Core.Models.Data
         public string MetadataAddress { get; set; }
         public OpenIdConnectRedirectBehavior RedirectBehavior { get; set; } = OpenIdConnectRedirectBehavior.FormPost;
         public bool GetClaimsFromUserInfoEndpoint { get; set; }
+        public string AdditionalScopes { get; set; }
+        public string AdditionalUserIdClaimTypes { get; set; }
+        public string AdditionalEmailClaimTypes { get; set; }
+        public string AdditionalNameClaimTypes { get; set; }
 
         // SAML2 IDP
         public string IdpEntityId { get; set; }
@@ -66,6 +72,30 @@ namespace Bit.Core.Models.Data
         {
             return BuildSaml2ModulePath(ssoUri, scheme);
         }
+
+        public IEnumerable<string> GetAdditionalScopes() => AdditionalScopes?
+            .Split(',')?
+            .Where(c => !string.IsNullOrWhiteSpace(c))?
+            .Select(c => c.Trim()) ??
+            Array.Empty<string>();
+        
+        public IEnumerable<string> GetAdditionalUserIdClaimTypes() => AdditionalUserIdClaimTypes?
+            .Split(',')?
+            .Where(c => !string.IsNullOrWhiteSpace(c))?
+            .Select(c => c.Trim()) ??
+            Array.Empty<string>();
+        
+        public IEnumerable<string> GetAdditionalEmailClaimTypes() => AdditionalEmailClaimTypes?
+            .Split(',')?
+            .Where(c => !string.IsNullOrWhiteSpace(c))?
+            .Select(c => c.Trim()) ??
+            Array.Empty<string>();
+        
+        public IEnumerable<string> GetAdditionalNameClaimTypes() => AdditionalNameClaimTypes?
+            .Split(',')?
+            .Where(c => !string.IsNullOrWhiteSpace(c))?
+            .Select(c => c.Trim()) ??
+            Array.Empty<string>();
 
         private string BuildSsoUrl(string relativePath, string ssoUri)
         {

--- a/src/Core/Models/Data/SsoConfigurationData.cs
+++ b/src/Core/Models/Data/SsoConfigurationData.cs
@@ -26,6 +26,7 @@ namespace Bit.Core.Models.Data
         public string AdditionalUserIdClaimTypes { get; set; }
         public string AdditionalEmailClaimTypes { get; set; }
         public string AdditionalNameClaimTypes { get; set; }
+        public string AcrValues { get; set; }
 
         // SAML2 IDP
         public string IdpEntityId { get; set; }

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -616,4 +616,8 @@
   <data name="AdditionalNameClaimTypes" xml:space="preserve">
     <value>Additional/Custom Name Claim Types (comma delimited)</value>
   </data>
+  <data name="AcrValues" xml:space="preserve">
+    <value>Requested Authentication Context Class Reference values (acr_values)</value>
+    <comment>'acr_values' is an explicit OIDC param, see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest. It should not be translated.</comment>
+  </data>
 </root>

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -604,4 +604,16 @@
   <data name="PersonalOwnershipCheckboxDesc" xml:space="preserve">
     <value>Disable personal ownership for organization users</value>
   </data>
+  <data name="AdditionalScopes" xml:space="preserve">
+    <value>Additional/Custom Scopes (comma delimited)</value>
+  </data>
+  <data name="AdditionalUserIdClaimTypes" xml:space="preserve">
+    <value>Additional/Custom User ID Claim Types (comma delimited)</value>
+  </data>
+  <data name="AdditionalEmailClaimTypes" xml:space="preserve">
+    <value>Additional/Custom Email Claim Types (comma delimited)</value>
+  </data>
+  <data name="AdditionalNameClaimTypes" xml:space="preserve">
+    <value>Additional/Custom Name Claim Types (comma delimited)</value>
+  </data>
 </root>

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -810,5 +810,15 @@ namespace Bit.Core.Utilities
 
             return System.Text.Json.JsonSerializer.Deserialize<T>(jsonData, options);
         }
+
+        public static ICollection<T> AddIfNotExists<T>(this ICollection<T> list, T item)
+        {
+            if (list.Contains(item))
+            {
+                return list;
+            }
+            list.Add(item);
+            return list;
+        }
     }
 }


### PR DESCRIPTION
## Overview

We found the need, when using OIDC, for a customer to be able to configure one or more custom scopes to be added to the request going to the IdP from the Bitwarden SP so the correct or additional claims (or custom claims) could be released for proper attribute mapping and provisioning of users.

This change adds the following:

* **5** new settings on the OIDC section of the SSO config screen in the Business Portal (see screenshot)
* Custom Scopes - ability to define custom scopes to be added to the SSO request (comma-delimited, white-space okay)
* Custom User ID Claim Types - claim type names/keys for the user identifier of the user
* Custom Email Claim Types - claim type names/keys for the email address of the user
* Custom Name Claim Types - claim type names/keys for the full name/display name of the user
* ACR Values (acr_values) - see: https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest

When evaluating and performing discovery on provided claims during user authentication and auto-provisioning, each of the custom claim types will be searched for first, before falling back to the standard types. This allows for OIDC IdP administrators to pull in different groups, user populations and other scopes which may have missing data where a standard scope does not (i.e. external/partner users vs. internal users, etc.). Also, the ability to also pass the `acr_values` parameter with a space-delimited list by preference for optional `acr` claims is also provided for those IdP's that require or desire this.

## Code Changes

* SsoConfigDataViewModel.cs - new property mappings from the data model.
* Sso/Index.cshtml - new properties from view model mapped to simple text fields.
* AccountController.cs - need to deserialize and pass around the SSO configuration data a bit in order to get the custom claim types based on each bit of info we're trying to find (like user id, email, or name). Also update the order of operations a bit so we do that before we try to map claims.
* DynamicAuthenticationSchemeProvider.cs - add the additional scopes, if any, to the OIDC options for the organization specific provider. Also refactor to reduce repeated code (if not contains add); added the OIDC options events for handling setting the `AcrValues` property of the protocol message on redirect to the IdP.
* SsoConfigurationData.cs - Added new properties to handle additional scopes, claim types and acr_values based on target attribute.
* CoreHelpers.cs - DRY extension method to add fluid API for adding an item to a list/collection if not already in it (and doing so in a chained fashion if desired).

## Testing Considerations
The following are the scopes of testing necessary to ensure both regression and positive functional changes.
* Successful OIDC SSO (present-state) w/o any changes to custom scopes or claim types
* Successful SAML SSO
* OIDC SSO with Custom Scope(s)
   * This is "hard" to test well, using Okta you must grant an additional scope to the application, which only applies to API access (via token); you _should_ be able to use this for testing
   * Once setup, you can configure SSO in the business portal to add the additional scope
   * There won't be any additional claim types to use, but you can configure any that you want, they shouldn't negatively impact authentication
   * You can test collision by adding additional or duplicate claim types that mirror built-in types or even a list such as, `email, email, email, email, email, email,,,,,,,,,, *****, !` etc. (should still work)
* OIDC SSO with acr_values
   * Normal OIDC flow, watch the last `/ExternalChallenge` HTTP 302 for redirect with the configured `&acr_values=<configured_value>` come through the query string parameters

## Screenshots

![image](https://user-images.githubusercontent.com/3904944/107534301-c7b4ae80-6b8d-11eb-94b6-307fb72284df.png)

cc: @sevensixseven , @fschillingeriv 