### PR TITLE
Let "Manage Users" permission see group membership

### DIFF
--- a/src/Api/Controllers/GroupsController.cs
+++ b/src/Api/Controllers/GroupsController.cs
@@ -60,7 +60,8 @@ namespace Bit.Api.Controllers
             var orgIdGuid = new Guid(orgId);
             var canAccess = _currentContext.ManageGroups(orgIdGuid) ||
                 _currentContext.ManageAssignedCollections(orgIdGuid) ||
-                _currentContext.ManageAllCollections(orgIdGuid);
+                _currentContext.ManageAllCollections(orgIdGuid) ||
+                _currentContext.ManageUsers(orgIdGuid);
 
             if (!canAccess)
             {

--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -59,7 +59,9 @@ namespace Bit.Api.Controllers
         public async Task<ListResponseModel<OrganizationUserUserDetailsResponseModel>> Get(string orgId)
         {
             var orgGuidId = new Guid(orgId);
-            if (!_currentContext.ManageAssignedCollections(orgGuidId) && !_currentContext.ManageGroups(orgGuidId))
+            if (!_currentContext.ManageAssignedCollections(orgGuidId) &&
+                !_currentContext.ManageGroups(orgGuidId) &&
+                !_currentContext.ManageUsers(orgGuidId))
             {
                 throw new NotFoundException();
             }
@@ -75,7 +77,8 @@ namespace Bit.Api.Controllers
         public async Task<IEnumerable<string>> GetGroups(string orgId, string id)
         {
             var organizationUser = await _organizationUserRepository.GetByIdAsync(new Guid(id));
-            if (organizationUser == null || !_currentContext.ManageGroups(organizationUser.OrganizationId))
+            if (organizationUser == null || (!_currentContext.ManageGroups(organizationUser.OrganizationId) &&
+                                             !_currentContext.ManageUsers(organizationUser.OrganizationId)))
             {
                 throw new NotFoundException();
             }


### PR DESCRIPTION
## Objective

Fix #1118. Currently, a user with the "Manage Users" permission (and no other) can add or remove users from groups via the People page. However, they do not have permission to see the target user's group membership, so the checkboxes are not pre-filled based on existing data. This can also cause data loss if they Save the group modal without making any changes (because it may unintentionally remove users from their existing groups).

I wanted to focus on fixing the immediate risk of data loss. I assume we'll look at the separate "invite users" permission suggested by @slavdok when we revisit custom permissions generally.

## Code changes

Change the controllers to allow the required api calls from users with the Manage Users permission. The client-side code is already in place, the server was just blocking the responses.

These api calls only return data about the user, groups generally, and the user's group membership, which (as I understand it) is all permitted for someone with the Manage Users permission. However, this would be good to check in code review to make sure we're not exposing anything else unintentionally.

## Testing considerations

Refer to Chad's description of the intended functionality in the issue report:

> As a user with only Manage Users  permission:
>   * I should be able to see membership of, add and remove membership of a user within a group from the User Edit page.
>   * I should not be able to see or modify any association with a Collection for that user from the User Edit page.
>   * Saving the user, w/o manage collections permissions should not modify any collections that user is a party to

