### PR TITLE
HTML encode sanitized inputs for email templates

### DIFF
--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -503,9 +503,10 @@ namespace Bit.Core.Utilities
 
         public static string SanitizeForEmail(string value)
         {
-            return value.Replace("@", "[at]")
+            var cleanedValue = value.Replace("@", "[at]")
                 .Replace("http://", string.Empty)
                 .Replace("https://", string.Empty);
+            return HttpUtility.HtmlEncode(cleanedValue);
         }
 
         public static string DateTimeToTableStorageKey(DateTime? date = null)
@@ -558,7 +559,7 @@ namespace Bit.Core.Utilities
         {
             return TokenIsValid("OrganizationUserInvite", protector, token, userEmail, orgUserId, globalSettings);
         }
-        
+
         public static bool TokenIsValid(string firstTokenPart, IDataProtector protector, string token, string userEmail,
             Guid id, GlobalSettings globalSettings)
         {


### PR DESCRIPTION
The Handlebars.NET library already HTML encodes model properties within our templates for us, however, in some cases we override this because we want to inject unencoded model content. For example, when printing a dynamic URL link within a template. That is usually ok, however, there are cases whenever our URL links have query string parameters that contain user-generated input. Since we escape the encoding to print the URL, this leaves an open a point of injection for HTML.

This PR manually adds HTML encoding to the existing `SanitizeForEmail` function, which all user-generated model properties flow through.

Note: This issue was reported through our HackerOne program.