### PR TITLE
Added ability to bulk-upload tax rates

### DIFF
--- a/src/Admin/Views/Tools/TaxRate.cshtml
+++ b/src/Admin/Views/Tools/TaxRate.cshtml
@@ -7,6 +7,39 @@
 
 <h1>Manage Tax Rates</h1>
 
+<h2>Bulk Upload Tax Rates</h2>
+<section>
+    <p>
+        Upload a CSV file containing multiple tax rates in bulk in order to update existing rates by country
+        and postal code OR to create new rates where a currently active rate is not found already.
+    </p>
+    <p>CSV Upload Format</p>
+    <ul>
+        <li><b>Postal Code</b> (required) - The postal code for the tax rate.</li>
+        <li><b>Rate</b> (required) - The effective tax rate for this postal code.</li>
+        <li><b>State</b> (<i>optional</i>) - The ISO-2 character code for the state. Optional but recommended.</li>
+        <li><b>Country</b> (<i>optional</i>) - The ISO-2 character country code, defaults to "US" if not provided.</li>
+    </ul>
+    <p>Example (white-space is ignored):</p>
+    <div class="card mb-2">
+        <div class="card-body">
+            <pre class="mb-0">87654,8.25,FL,US
+22334,8.5,CA
+11223,7</pre>
+        </div>
+    </div>
+    <form method="post" enctype="multipart/form-data" asp-action="TaxRateUpload">
+        <div class="form-group">
+            <input type="file" name="file" />
+        </div>
+        <div class="form-group">
+            <input type="submit" value="Upload" class="btn btn-primary mb-2" />
+        </div>
+    </form>
+</section>
+
+<hr/>
+<h2>View &amp; Manage Tax Rates</h2>
 <a class="btn btn-primary mb-2" asp-controller="Tools" asp-action="TaxRateAddEdit">Add a Rate</a>
 <div class="table-responsive">
     <table class="table table-striped table-hover">


### PR DESCRIPTION
## Overview
It turns out, nobody really wants to enter in tax rates for 5k+ individual postal codes 😁 , this PR wraps what's already there for "upsert" and allows a CSV file to be uploaded to do the same within the admin portal. Validation is done up-front against the entire list which consists of ensuring the CSV at least has the 2 fields we care about, but not much is possible to validate beyond that.

## Changes
* **ToolsController.cs** - Added a new action for handling a file upload, makes some assumptions here that the person uploading it has checked to ensure it's valid, it's a CSV, etc. given the user will already have trusted and technical privileges to upload to this page. Lines are parsed, whitespace is ignored, blank lines, etc. The final list of tax rates to add or update are saved to DB and Stripe
* **TaxRate.cshtml** - Very basic, Chad sucks at web UI, form to upload a file along with instructions, examples, etc. Could probably be improved, but it works/is functional and is on a page that will likely be looked at once or twice a year.

## Screenshots
The following contains fake postal codes and/or tax rates, they're for illustrative purposes only.

![image](https://user-images.githubusercontent.com/3904944/107698537-b00b2200-6c82-11eb-8901-cc1497c8ca9c.png)
