### PR TITLE
Fix error message if user already accepted invite

### DIFF
--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1094,17 +1094,21 @@ namespace Bit.Core.Services
                 throw new BadRequestException("Invalid token.");
             }
 
-            if (string.IsNullOrWhiteSpace(orgUser.Email) ||
-                !orgUser.Email.Equals(user.Email, StringComparison.InvariantCultureIgnoreCase))
-            {
-                throw new BadRequestException("User email does not match invite.");
-            }
-
             var existingOrgUserCount = await _organizationUserRepository.GetCountByOrganizationAsync(
                 orgUser.OrganizationId, user.Email, true);
             if (existingOrgUserCount > 0)
             {
+                if (orgUser.Status == OrganizationUserStatusType.Accepted)
+                {
+                    throw new BadRequestException("You must wait for an administrator to confirm your membership to this organization.");
+                }
                 throw new BadRequestException("You are already part of this organization.");
+            }
+
+            if (string.IsNullOrWhiteSpace(orgUser.Email) ||
+                !orgUser.Email.Equals(user.Email, StringComparison.InvariantCultureIgnoreCase))
+            {
+                throw new BadRequestException("User email does not match invite.");
             }
 
             return await AcceptUserAsync(orgUser, user, userService);

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1100,7 +1100,7 @@ namespace Bit.Core.Services
             {
                 if (orgUser.Status == OrganizationUserStatusType.Accepted)
                 {
-                    throw new BadRequestException("Invitation already accepted. You will receive an email when your Organization membership is confirmed.");
+                    throw new BadRequestException("Invitation already accepted. You will receive an email when your organization membership is confirmed.");
                 }
                 throw new BadRequestException("You are already part of this organization.");
             }

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1100,7 +1100,7 @@ namespace Bit.Core.Services
             {
                 if (orgUser.Status == OrganizationUserStatusType.Accepted)
                 {
-                    throw new BadRequestException("You must wait for an administrator to confirm your membership to this organization.");
+                    throw new BadRequestException("Invitation already accepted. You will receive an email when your Organization membership is confirmed.");
                 }
                 throw new BadRequestException("You are already part of this organization.");
             }


### PR DESCRIPTION
## Objective
Fix the following issue reported via freshdesk:
>Right now if an invitation it's accepted for a second time (without a confirmation in the middle), the error message that appear is: "Unable to accept invitation. User email does not match invite"
>
>This is quite misleading and confuses both the customers and the CS team.

## Code changes
* Change order of error checking in `OrganizationService.AcceptUserAsync`
* Add new error message to tell the user that they are awaiting confirmation (so they understand why they have already accepted the invite but can't access org items)

## Screenshots

![Screen Shot 2021-02-12 at 9 43 45 am](https://user-images.githubusercontent.com/31796059/107713733-9cf66180-6d17-11eb-8a00-ec975c644a15.png)
