### PR TITLE
Use sas token for send downloads

### DIFF
--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -70,7 +70,7 @@ namespace Bit.Api.Controllers
             return new SendFileDownloadDataResponseModel()
             {
                 Id = id,
-                Url = await _sendFileStorageService.GetSendFileDownloadUrlAsync(id)
+                Url = await _sendFileStorageService.GetSendFileDownloadUrlAsync(id),
             };
         }
 

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -11,6 +11,7 @@ using Bit.Api.Utilities;
 using Bit.Core.Models.Table;
 using Bit.Core.Utilities;
 using Bit.Core.Settings;
+using Bit.Core.Models.Api.Response;
 
 namespace Bit.Api.Controllers
 {
@@ -21,17 +22,20 @@ namespace Bit.Api.Controllers
         private readonly ISendRepository _sendRepository;
         private readonly IUserService _userService;
         private readonly ISendService _sendService;
+        private readonly ISendFileStorageService _sendFileStorageService;
         private readonly GlobalSettings _globalSettings;
 
         public SendsController(
             ISendRepository sendRepository,
             IUserService userService,
             ISendService sendService,
+            ISendFileStorageService sendFileStorageService,
             GlobalSettings globalSettings)
         {
             _sendRepository = sendRepository;
             _userService = userService;
             _sendService = sendService;
+            _sendFileStorageService = sendFileStorageService;
             _globalSettings = globalSettings;
         }
 
@@ -57,6 +61,17 @@ namespace Bit.Api.Controllers
             }
 
             return new ObjectResult(new SendAccessResponseModel(send, _globalSettings));
+        }
+
+        [AllowAnonymous]
+        [HttpGet("access/file/{id}")]
+        public async Task<SendFileDownloadDataResponseModel> GetSendFileDownloadData(string id)
+        {
+            return new SendFileDownloadDataResponseModel()
+            {
+                Id = id,
+                Url = await _sendFileStorageService.GetSendFileDownloadUrlAsync(id)
+            };
         }
 
         [HttpGet("{id}")]

--- a/src/Core/Models/Api/Response/SendFileDownloadDataResponseModel.cs
+++ b/src/Core/Models/Api/Response/SendFileDownloadDataResponseModel.cs
@@ -1,0 +1,10 @@
+namespace Bit.Core.Models.Api.Response
+{
+    public class SendFileDownloadDataResponseModel : ResponseModel
+    {
+        public string Id { get; set; }
+        public string Url { get; set; }
+
+        public SendFileDownloadDataResponseModel() : base("send-fileDownload") { }
+    }
+}

--- a/src/Core/Models/Api/SendFileModel.cs
+++ b/src/Core/Models/Api/SendFileModel.cs
@@ -11,14 +11,12 @@ namespace Bit.Core.Models.Api
         public SendFileModel(SendFileData data, GlobalSettings globalSettings)
         {
             Id = data.Id;
-            Url = $"{globalSettings.Send.BaseUrl}/{data.Id}";
             FileName = data.FileName;
             Size = data.SizeString;
             SizeName = CoreHelpers.ReadableBytesSize(data.Size);
         }
 
         public string Id { get; set; }
-        public string Url { get; set; }
         [EncryptedString]
         [EncryptedStringLength(1000)]
         public string FileName { get; set; }

--- a/src/Core/Services/ISendStorageService.cs
+++ b/src/Core/Services/ISendStorageService.cs
@@ -11,5 +11,6 @@ namespace Bit.Core.Services
         Task DeleteFileAsync(string fileId);
         Task DeleteFilesForOrganizationAsync(Guid organizationId);
         Task DeleteFilesForUserAsync(Guid userId);
+        Task<string> GetSendFileDownloadUrlAsync(string fileId);
     }
 }

--- a/src/Core/Services/Implementations/LocalSendStorageService.cs
+++ b/src/Core/Services/Implementations/LocalSendStorageService.cs
@@ -9,11 +9,13 @@ namespace Bit.Core.Services
     public class LocalSendStorageService : ISendFileStorageService
     {
         private readonly string _baseDirPath;
+        private readonly string _baseSendUrl;
 
         public LocalSendStorageService(
             GlobalSettings globalSettings)
         {
             _baseDirPath = globalSettings.Send.BaseDirectory;
+            _baseSendUrl = globalSettings.Send.BaseUrl;
         }
 
         public async Task UploadNewFileAsync(Stream stream, Send send, string fileId)
@@ -40,6 +42,12 @@ namespace Bit.Core.Services
         public async Task DeleteFilesForUserAsync(Guid userId)
         {
             await InitAsync();
+        }
+
+        public async Task<string> GetSendFileDownloadUrlAsync(string fileId)
+        {
+            await InitAsync();
+            return $"{_baseSendUrl}/{fileId}";
         }
 
         private void DeleteFileIfExists(string path)

--- a/src/Core/Services/NoopImplementations/NoopSendFileStorageService.cs
+++ b/src/Core/Services/NoopImplementations/NoopSendFileStorageService.cs
@@ -26,5 +26,10 @@ namespace Bit.Core.Services
         {
             return Task.FromResult(0);
         }
+
+        public Task<string> GetSendFileDownloadUrlAsync(string fileId)
+        {
+            return Task.FromResult((string)null);
+        }
     }
 }


### PR DESCRIPTION
# Overview

Related to #1153. This work similarly restricts Send download files to a 1 minute lifespan. In contrast to Cipher Attachments, we don't have any other Send files existing so we can be more direct about changes.

Remove the from the basic Send Response and require all clients to download a download url and then directly use that url to download.

# Files changed
* **SendsController**: add the API endpoint to download a File Send download URL. This is implemented as a full response object for adding additional information in the future, if needed.
* **SendFileDownloadDataResponseModel**: A big name for a simple object. Just holds the download URL calculated by the various SendFileStorageServices.
* **SendFileModel**: Do not assume a download URL. We don't need to support old client versions here so this can be excised safely.
* **ISendFileStorageService**: Add method to calculate a limited-life download URL.
* **LocalSendStorageService/NoopSendStorageService**: Straightforward implements of either existing behavior (link to baseurl/fileId) or noop (return null)
* **AzureSendStorageService**:
  * Create Send containers without public access
  * Create read-only, 1 min life url for downloads. These short lifetimes should be fine given that they are intended to be created upon clicking download file, not upon accessing the send.

# Test concerns

* Testing needs to wait until I get a client in that uses these changes. Likely that will be Web.
* The Standard test environment should be tested to confirm working, but that is an on-prem deployment and **does not use Azure**. This needs to be tested in a local environment hooked up to and Azure cloud storage system.