### PR TITLE
Fix error message if already accepted EA invite

### DIFF
--- a/src/Core/Services/Implementations/EmergencyAccessService.cs
+++ b/src/Core/Services/Implementations/EmergencyAccessService.cs
@@ -116,15 +116,15 @@ namespace Bit.Core.Services
                 throw new BadRequestException("Invalid token.");
             }
 
+            if (emergencyAccess.Status != EmergencyAccessStatusType.Invited)
+            {
+                throw new BadRequestException("Invitation already accepted. You will receive an email when the grantor confirms you as an emergency access contact.");
+            }
+
             if (string.IsNullOrWhiteSpace(emergencyAccess.Email) ||
                 !emergencyAccess.Email.Equals(user.Email, StringComparison.InvariantCultureIgnoreCase))
             {
                 throw new BadRequestException("User email does not match invite.");
-            }
-
-            if (emergencyAccess.Status != EmergencyAccessStatusType.Invited)
-            {
-                throw new BadRequestException("Already accepted.");
             }
 
             var granteeEmail = emergencyAccess.Email;

--- a/src/Core/Services/Implementations/EmergencyAccessService.cs
+++ b/src/Core/Services/Implementations/EmergencyAccessService.cs
@@ -116,9 +116,13 @@ namespace Bit.Core.Services
                 throw new BadRequestException("Invalid token.");
             }
 
-            if (emergencyAccess.Status != EmergencyAccessStatusType.Invited)
+            if (emergencyAccess.Status == EmergencyAccessStatusType.Accepted)
             {
                 throw new BadRequestException("Invitation already accepted. You will receive an email when the grantor confirms you as an emergency access contact.");
+            }
+            else if (emergencyAccess.Status != EmergencyAccessStatusType.Invited)
+            {
+                throw new BadRequestException("Invitation already accepted.");
             }
 
             if (string.IsNullOrWhiteSpace(emergencyAccess.Email) ||


### PR DESCRIPTION
## Objective

I already fixed a confusing error message when a user tries to accepts an org invite more than once: see #1140 

This issue also occurs when a user accepts an emergency access invite more than once.

## Code changes

This is basically the same fix as #1140:
* Fix order of error checking
* More descriptive error message if accepted but not confirmed, used similar wording as the other issue.