### PR TITLE
Fix empty grantee or grantor names in emergency access emails

### DIFF
--- a/src/Core/Models/Data/EmergencyAccessNotify.cs
+++ b/src/Core/Models/Data/EmergencyAccessNotify.cs
@@ -10,5 +10,6 @@ namespace Bit.Core.Models.Data
     {
         public string GrantorEmail { get; set; }
         public string GranteeName { get; set; }
+        public string GranteeEmail { get; set; }
     }
 }

--- a/src/Core/Services/Implementations/EmergencyAccessService.cs
+++ b/src/Core/Services/Implementations/EmergencyAccessService.cs
@@ -313,8 +313,10 @@ namespace Bit.Core.Services
                 var ea = notify.ToEmergencyAccess();
                 ea.LastNotificationDate = DateTime.UtcNow;
                 await _emergencyAccessRepository.ReplaceAsync(ea);
-                
-                await _mailService.SendEmergencyAccessRecoveryReminder(ea, notify.GranteeName, notify.GrantorEmail);
+
+                var granteeNameOrEmail = string.IsNullOrWhiteSpace(notify.GranteeName) ? notify.GranteeEmail : notify.GranteeName;
+
+                await _mailService.SendEmergencyAccessRecoveryReminder(ea, granteeNameOrEmail, notify.GrantorEmail);
             }
         }
 
@@ -327,9 +329,12 @@ namespace Bit.Core.Services
                 var ea = details.ToEmergencyAccess();
                 ea.Status = EmergencyAccessStatusType.RecoveryApproved;
                 await _emergencyAccessRepository.ReplaceAsync(ea);
-                
-                await _mailService.SendEmergencyAccessRecoveryApproved(ea, details.GrantorName, details.GranteeEmail);
-                await _mailService.SendEmergencyAccessRecoveryTimedOut(ea, details.GranteeName, details.GrantorEmail);
+
+                var grantorNameOrEmail = string.IsNullOrWhiteSpace(details.GrantorName) ? details.GrantorEmail : details.GrantorName;
+                var granteeNameOrEmail = string.IsNullOrWhiteSpace(details.GranteeName) ? details.GranteeEmail : details.GranteeName;
+
+                await _mailService.SendEmergencyAccessRecoveryApproved(ea, grantorNameOrEmail, details.GranteeEmail);
+                await _mailService.SendEmergencyAccessRecoveryTimedOut(ea, granteeNameOrEmail, details.GrantorEmail);
             }
         }
 

--- a/src/Sql/dbo/Stored Procedures/EmergencyAccess_ReadToNotify.sql
+++ b/src/Sql/dbo/Stored Procedures/EmergencyAccess_ReadToNotify.sql
@@ -6,6 +6,7 @@ BEGIN
     SELECT
         EA.*,
         Grantee.Name as GranteeName,
+        Grantee.Email as GranteeEmail,
         Grantor.Email as GrantorEmail
     FROM
         [dbo].[EmergencyAccess] EA

--- a/util/Migrator/DbScripts/2021_02_26_00_EmergencyAcess_ReadToNotify.sql
+++ b/util/Migrator/DbScripts/2021_02_26_00_EmergencyAcess_ReadToNotify.sql
@@ -1,0 +1,30 @@
+IF OBJECT_ID('[dbo].[EmergencyAccess_ReadToNotify]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[EmergencyAccess_ReadToNotify]
+END
+GO
+
+CREATE PROCEDURE [dbo].[EmergencyAccess_ReadToNotify]
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        EA.*,
+        Grantee.Name as GranteeName,
+        Grantee.Email as GranteeEmail,
+        Grantor.Email as GrantorEmail
+    FROM
+        [dbo].[EmergencyAccess] EA
+    LEFT JOIN
+        [dbo].[User] Grantor ON Grantor.[Id] = EA.[GrantorId]
+    LEFT JOIN
+        [dbo].[User] Grantee On Grantee.[Id] = EA.[GranteeId]
+    WHERE
+        EA.[Status] = 3
+    AND
+        DATEADD(DAY, EA.[WaitTimeDays] - 1, EA.[RecoveryInitiatedDate]) <= GETUTCDATE()
+    AND
+        DATEADD(DAY, 1, EA.[LastNotificationDate]) <= GETUTCDATE()
+END
+GO


### PR DESCRIPTION
## Objective

Fix the following emails, which were not handling blank/null user names properly:
* reminder email sent to grantor 1 day before EA is granted
* confirmation emails sent to grantee & grantor upon EA being granted

For example:

![Screen Shot 2021-02-25 at 11 10 38 am](https://user-images.githubusercontent.com/31796059/109089129-734c2a00-775c-11eb-88cb-e5bf1b1fd9a5.png)

## Code changes

* `EmergencyAccessService` - check if grantee/grantor name is null or blank, and if so, use email instead
* `EmergencyAccessNotify` and `EmergencyAccess_ReadToNotify.sql` - retrieve grantee email from database as well so that this can be used if required

**Do I need to update or add to any of the `util/migrator/DbScripts` to account for the change in the stored SQL procedure?**

## Screenshots

![Screen Shot 2021-02-25 at 11 33 09 am](https://user-images.githubusercontent.com/31796059/109089632-4b10fb00-775d-11eb-8eca-b757b1718f73.png)