### PR TITLE
Add factory to IGlobalSettings DI singleton

### DIFF
--- a/src/Core/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Core/Utilities/ServiceCollectionExtensions.cs
@@ -423,7 +423,7 @@ namespace Bit.Core.Utilities
             var globalSettings = new GlobalSettings();
             ConfigurationBinder.Bind(configuration.GetSection("GlobalSettings"), globalSettings);
             services.AddSingleton(s => globalSettings);
-            services.AddSingleton<IGlobalSettings, GlobalSettings>();
+            services.AddSingleton<IGlobalSettings, GlobalSettings>(s => globalSettings);
             return globalSettings;
         }
 


### PR DESCRIPTION
It turns out Singleton DI of interfaces does not use the specified
instance's Singleton, but just creates its own. This fixes the bug
where classes expecting an IGlobalSettings were given an empty GlobaSettings
instance

# Overview

Fixes a bug instroduced in #1153. @cscharf, you called it. There was something stinky about the IGlobalSettings singleton implementation. I had thought that the Singleton instance would be the already existing GlobalSettings Singleton, instantiated just above this change. It turns out the Interface Singletons get their own instance so `LocalAttachmentStorageService` was getting a brand new (and empty) GlobalSettings instance.

This fixes to give a factory returning the one-and-only `GlobalSettings` instance.