### PR TITLE
Added New Fields to the Send Access Response Model

### DIFF
--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -60,7 +60,12 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
-            return new ObjectResult(new SendAccessResponseModel(send, _globalSettings));
+            var sendResponse = new SendAccessResponseModel(send, _globalSettings);
+            if (send.UserId.HasValue) {
+                var creator = await _userService.GetUserByIdAsync(send.UserId.Value);
+                sendResponse.CreatorIdentifier = creator.Email;
+            }
+            return new ObjectResult(sendResponse);
         }
 
         [AllowAnonymous]

--- a/src/Core/Models/Api/Response/SendAccessResponseModel.cs
+++ b/src/Core/Models/Api/Response/SendAccessResponseModel.cs
@@ -4,6 +4,7 @@ using Bit.Core.Models.Data;
 using Bit.Core.Models.Table;
 using Bit.Core.Utilities;
 using Bit.Core.Settings;
+using Bit.Core.Services;
 using Newtonsoft.Json;
 
 namespace Bit.Core.Models.Api
@@ -39,6 +40,7 @@ namespace Bit.Core.Models.Api
             }
 
             Name = sendData.Name;
+            ExpirationDate = send.ExpirationDate;
         }
 
         public string Id { get; set; }
@@ -46,5 +48,7 @@ namespace Bit.Core.Models.Api
         public string Name { get; set; }
         public SendFileModel File { get; set; }
         public SendTextModel Text { get; set; }
+        public DateTime? ExpirationDate { get; set; }
+        public string CreatorIdentifier { get; set; }
     }
 }


### PR DESCRIPTION
To support the UI changes on the access page a Send's expiration date and an identifier for their creator needs to be passed through the AccessResponseModel. 

Note: `CreatorIdentifier` is an odd prop, as its not *directly* related to any saved Send data, making it inaccessible in the service layer without adding it to a bunch of models that don't run that way. It is being found and added to the response model in the Send controller for right now.