### PR TITLE
Enable azure direct upload

### DIFF
--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.6" />
     <PackageReference Include="NewRelic.Agent" Version="8.30.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
+    <PackageReference Include="Microsoft.Azure.EventGrid" Version="3.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -157,7 +157,7 @@ namespace Bit.Api.Controllers
             var send = await _sendRepository.GetByIdAsync(new Guid(id));
             await Request.GetSendFileAsync(async (stream) =>
             {
-                await _sendFileStorageService.UploadNewFileAsync(stream, send, fileId);
+                await _sendService.UploadFileToExistingSendAsync(stream, send);
             });
         }
 

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -166,25 +166,28 @@ namespace Bit.Api.Controllers
         public async Task<OkObjectResult> AzureValidateFile()
         {
             return await ApiHelpers.HandleAzureEvents(Request, new Dictionary<string, Func<EventGridEvent, Task>>
+            {
                 {
-                  {"Microsoft.Storage.BlobCreated", async (eventGridEvent) => {
-                      try
-                      {
-                          var blobName = eventGridEvent.Subject.Split($"{AzureSendFileStorageService.FilesContainerName}/blobs/")[1];
-                          var sendId = AzureSendFileStorageService.SendIdFromBlobName(blobName);
-                          var send = await _sendRepository.GetByIdAsync(new Guid(sendId));
-                          if (send == null)
-                          {
-                              return;
-                          }
-                          await _sendService.ValidateSendFile(send);
-                      }
-                      catch
-                      {
-                          return;
-                      }
-                  }}
-                });
+                    "Microsoft.Storage.BlobCreated", async (eventGridEvent) =>
+                    {
+                        try
+                        {
+                            var blobName = eventGridEvent.Subject.Split($"{AzureSendFileStorageService.FilesContainerName}/blobs/")[1];
+                            var sendId = AzureSendFileStorageService.SendIdFromBlobName(blobName);
+                            var send = await _sendRepository.GetByIdAsync(new Guid(sendId));
+                            if (send == null)
+                            {
+                                return;
+                            }
+                            await _sendService.ValidateSendFile(send);
+                        }
+                        catch
+                        {
+                            return;
+                        }
+                    }
+                }
+            });
         }
 
         [HttpPut("{id}")]

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -66,10 +66,11 @@ namespace Bit.Api.Controllers
         }
 
         [AllowAnonymous]
-        [HttpGet("{sendId}/access/file/{fileId}")]
-        public async Task<SendFileDownloadDataResponseModel> GetSendFileDownloadData(string sendId, string fileId)
+        [HttpGet("{encodedSendId}/access/file/{fileId}")]
+        public async Task<SendFileDownloadDataResponseModel> GetSendFileDownloadData(string encodedSendId, string fileId)
         {
-            var send = await _sendRepository.GetByIdAsync(new Guid(sendId));
+            var sendId = new Guid(CoreHelpers.Base64UrlDecode(encodedSendId));
+            var send = await _sendRepository.GetByIdAsync(sendId);
 
             if (send == null)
             {

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -149,7 +149,7 @@ namespace Bit.Api.Controllers
                 throw new BadRequestException("Invalid content.");
             }
 
-            if (Request.ContentLength > 105906176) // 101 MB, give em' 1 extra MB for cushion
+            if (Request.ContentLength > 105906176 && !_globalSettings.SelfHosted) // 101 MB, give em' 1 extra MB for cushion
             {
                 throw new BadRequestException("Max file size for direct upload is 100 MB.");
             }

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -142,7 +142,6 @@ namespace Bit.Api.Controllers
 
         [AllowAnonymous]
         [HttpPost("file/validate/azure")]
-        [HttpGet("file/validate/azure")]
         public async Task<OkObjectResult> AzureValidateFile()
         {
             return await ApiHelpers.HandleAzureEvents(Request, new Dictionary<string, Func<EventGridEvent, Task>>

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -7,11 +7,13 @@ using Microsoft.AspNetCore.Authorization;
 using Bit.Core.Models.Api;
 using Bit.Core.Exceptions;
 using Bit.Core.Services;
-using Bit.Api.Utilities;
-using Bit.Core.Models.Table;
 using Bit.Core.Utilities;
 using Bit.Core.Settings;
 using Bit.Core.Models.Api.Response;
+using Bit.Core.Enums;
+using Microsoft.Azure.EventGrid.Models;
+using Bit.Api.Utilities;
+using System.Collections.Generic;
 
 namespace Bit.Api.Controllers
 {
@@ -64,13 +66,20 @@ namespace Bit.Api.Controllers
         }
 
         [AllowAnonymous]
-        [HttpGet("access/file/{id}")]
-        public async Task<SendFileDownloadDataResponseModel> GetSendFileDownloadData(string id)
+        [HttpGet("{sendId}/access/file/{fileId}")]
+        public async Task<SendFileDownloadDataResponseModel> GetSendFileDownloadData(string sendId, string fileId)
         {
+            var send = await _sendRepository.GetByIdAsync(new Guid(sendId));
+
+            if (send == null)
+            {
+                throw new BadRequestException("Could not locate send");
+            }
+
             return new SendFileDownloadDataResponseModel()
             {
-                Id = id,
-                Url = await _sendFileStorageService.GetSendFileDownloadUrlAsync(id),
+                Id = fileId,
+                Url = await _sendFileStorageService.GetSendFileDownloadUrlAsync(send, fileId),
             };
         }
 
@@ -107,31 +116,73 @@ namespace Bit.Api.Controllers
         }
 
         [HttpPost("file")]
-        [RequestSizeLimit(105_906_176)]
-        [DisableFormValueModelBinding]
-        public async Task<SendResponseModel> PostFile()
+        public async Task<SendFileUploadDataResponseModel> PostFile([FromBody] SendRequestModel model)
         {
-            if (!Request?.ContentType.Contains("multipart/") ?? true)
+            if (model.Type != SendType.File)
             {
                 throw new BadRequestException("Invalid content.");
             }
 
-            if (Request.ContentLength > 105906176) // 101 MB, give em' 1 extra MB for cushion
+            if (!model.FileLength.HasValue)
             {
-                throw new BadRequestException("Max file size is 100 MB.");
+                throw new BadRequestException("Invalid content. File size hint is required.");
             }
 
-            Send send = null;
-            await Request.GetSendFileAsync(async (stream, fileName, model) =>
+            var userId = _userService.GetProperUserId(User).Value;
+            var (send, data) = model.ToSend(userId, model.File.FileName, _sendService);
+            var uploadUrl = await _sendService.SaveFileSendAsync(send, data, model.FileLength.Value);
+            return new SendFileUploadDataResponseModel
             {
-                model.ValidateCreation();
-                var userId = _userService.GetProperUserId(User).Value;
-                var (madeSend, madeData) = model.ToSend(userId, fileName, _sendService);
-                send = madeSend;
-                await _sendService.CreateSendAsync(send, madeData, stream, Request.ContentLength.GetValueOrDefault(0));
-            });
+                Url = uploadUrl,
+                FileUploadType = _sendFileStorageService.FileUploadType,
+                SendResponse = new SendResponseModel(send, _globalSettings)
+            };
+        }
 
-            return new SendResponseModel(send, _globalSettings);
+        [AllowAnonymous]
+        [HttpPost("file/validate/azure")]
+        [HttpGet("file/validate/azure")]
+        public async Task<OkObjectResult> AzureValidateFile()
+        {
+            return await ApiHelpers.HandleAzureEvents(Request, new Dictionary<string, Func<EventGridEvent, Task>>
+                {
+                  {"Microsoft.Storage.BlobCreated", async (eventGridEvent) => {
+                      try
+                      {
+                          var blobName = eventGridEvent.Subject.Split($"{AzureSendFileStorageService.FilesContainerName}/blobs/")[1];
+                          var sendId = AzureSendFileStorageService.SendIdFromBlobName(blobName);
+                          var send = await _sendRepository.GetByIdAsync(new Guid(sendId));
+                          if (send == null)
+                          {
+                              return;
+                          }
+                          await _sendService.ValidateSendFile(send);
+                      }
+                      catch
+                      {
+                          return;
+                      }
+                  }}
+                });
+        }
+
+        [HttpPost("{id}/validate")]
+        public async Task PostValidateFile(string id)
+        {
+            var userId = _userService.GetProperUserId(User).Value;
+            var send = await _sendRepository.GetByIdAsync(new Guid(id));
+
+            if (send == null || send.UserId != userId)
+            {
+                throw new NotFoundException();
+            }
+
+            if (send.Type != SendType.File)
+            {
+                throw new BadRequestException("Invalid content.");
+            }
+
+            await _sendService.ValidateSendFile(send);
         }
 
         [HttpPut("{id}")]

--- a/src/Api/Utilities/ApiHelpers.cs
+++ b/src/Api/Utilities/ApiHelpers.cs
@@ -1,5 +1,10 @@
 ﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.EventGrid;
+using Microsoft.Azure.EventGrid.Models;
 using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -28,6 +33,43 @@ namespace Bit.Api.Utilities
             }
 
             return obj;
+        }
+
+        /// <summary>
+        /// Validates Azure event subscription and calls the appropriate event handler. Responds HttpOk.
+        /// </summary>
+        /// <param name="request">HttpRequest received from Azure</param>
+        /// <param name="eventTypeHandlers">Dictionary of eventType strings and their associated handlers.</param>
+        /// <returns>OkObjectResult</returns>
+        // Reference https://docs.microsoft.com/en-us/azure/event-grid/receive-events
+        public async static Task<OkObjectResult> HandleAzureEvents(HttpRequest request,
+            Dictionary<string, Func<EventGridEvent, Task>> eventTypeHandlers)
+        {
+            var response = string.Empty;
+            var requestContent = await new StreamReader(request.Body).ReadToEndAsync();
+            var eventGridSubscriber = new EventGridSubscriber();
+            var eventGridEvents = eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            foreach (var eventGridEvent in eventGridEvents)
+            {
+                if (eventGridEvent.Data is SubscriptionValidationEventData eventData)
+                {
+                    // Might want to enable additional validation: subject, topic etc.
+
+                    var responseData = new SubscriptionValidationResponse()
+                    {
+                        ValidationResponse = eventData.ValidationCode
+                    };
+
+                    return new OkObjectResult(responseData);
+                }
+                else if (eventTypeHandlers.ContainsKey(eventGridEvent.EventType))
+                {
+                    await eventTypeHandlers[eventGridEvent.EventType](eventGridEvent);
+                }
+            }
+
+            return new OkObjectResult(response);
         }
     }
 }

--- a/src/Api/Utilities/ApiHelpers.cs
+++ b/src/Api/Utilities/ApiHelpers.cs
@@ -47,6 +47,11 @@ namespace Bit.Api.Utilities
         {
             var response = string.Empty;
             var requestContent = await new StreamReader(request.Body).ReadToEndAsync();
+            if (string.IsNullOrWhiteSpace(requestContent))
+            {
+                return new OkObjectResult(response);
+            }
+
             var eventGridSubscriber = new EventGridSubscriber();
             var eventGridEvents = eventGridSubscriber.DeserializeEventGridEvents(requestContent);
 

--- a/src/Api/Utilities/ApiHelpers.cs
+++ b/src/Api/Utilities/ApiHelpers.cs
@@ -41,7 +41,7 @@ namespace Bit.Api.Utilities
         /// <param name="request">HttpRequest received from Azure</param>
         /// <param name="eventTypeHandlers">Dictionary of eventType strings and their associated handlers.</param>
         /// <returns>OkObjectResult</returns>
-        // Reference https://docs.microsoft.com/en-us/azure/event-grid/receive-events
+        /// <remarks>Reference https://docs.microsoft.com/en-us/azure/event-grid/receive-events</remarks>
         public async static Task<OkObjectResult> HandleAzureEvents(HttpRequest request,
             Dictionary<string, Func<EventGridEvent, Task>> eventTypeHandlers)
         {

--- a/src/Api/Utilities/MultipartFormDataHelper.cs
+++ b/src/Api/Utilities/MultipartFormDataHelper.cs
@@ -72,22 +72,19 @@ namespace Bit.Api.Utilities
                 _defaultFormOptions.MultipartBoundaryLengthLimit);
             var reader = new MultipartReader(boundary, request.Body);
 
-
             var dataSection = await reader.ReadNextSectionAsync();
             if (dataSection != null)
             {
-                if (ContentDispositionHeaderValue.TryParse(dataSection.ContentDisposition,
-                    out var thirdContent) && HasFileContentDisposition(thirdContent))
+                if (ContentDispositionHeaderValue.TryParse(dataSection.ContentDisposition, out var dataContent)
+                    && HasFileContentDisposition(dataContent))
                 {
                     using (dataSection.Body)
                     {
                         await callback(dataSection.Body);
                     }
                 }
-
+                dataSection = null;
             }
-
-            dataSection = null;
         }
 
 

--- a/src/Api/Utilities/MultipartFormDataHelper.cs
+++ b/src/Api/Utilities/MultipartFormDataHelper.cs
@@ -66,46 +66,28 @@ namespace Bit.Api.Utilities
             }
         }
 
-        public static async Task GetSendFileAsync(this HttpRequest request, Func<Stream, string,
-            SendRequestModel, Task> callback)
+        public static async Task GetSendFileAsync(this HttpRequest request, Func<Stream, Task> callback)
         {
             var boundary = GetBoundary(MediaTypeHeaderValue.Parse(request.ContentType),
                 _defaultFormOptions.MultipartBoundaryLengthLimit);
             var reader = new MultipartReader(boundary, request.Body);
 
-            var firstSection = await reader.ReadNextSectionAsync();
-            if (firstSection != null)
+
+            var dataSection = await reader.ReadNextSectionAsync();
+            if (dataSection != null)
             {
-                if (ContentDispositionHeaderValue.TryParse(firstSection.ContentDisposition, out _))
+                if (ContentDispositionHeaderValue.TryParse(dataSection.ContentDisposition,
+                    out var thirdContent) && HasFileContentDisposition(thirdContent))
                 {
-                    // Request model json, then data
-                    string requestModelJson = null;
-                    using (var sr = new StreamReader(firstSection.Body))
+                    using (dataSection.Body)
                     {
-                        requestModelJson = await sr.ReadToEndAsync();
+                        await callback(dataSection.Body);
                     }
-
-                    var secondSection = await reader.ReadNextSectionAsync();
-                    if (secondSection != null)
-                    {
-                        if (ContentDispositionHeaderValue.TryParse(secondSection.ContentDisposition,
-                            out var secondContent) && HasFileContentDisposition(secondContent))
-                        {
-                            var fileName = HeaderUtilities.RemoveQuotes(secondContent.FileName).ToString();
-                            using (secondSection.Body)
-                            {
-                                var model = JsonConvert.DeserializeObject<SendRequestModel>(requestModelJson);
-                                await callback(secondSection.Body, fileName, model);
-                            }
-                        }
-
-                        secondSection = null;
-                    }
-
                 }
 
-                firstSection = null;
             }
+
+            dataSection = null;
         }
 
 

--- a/src/Core/Enums/FileUploadType.cs
+++ b/src/Core/Enums/FileUploadType.cs
@@ -1,0 +1,8 @@
+namespace Bit.Core.Enums
+{
+    public enum FileUploadType
+    {
+        Direct = 0,
+        Azure = 1,
+    }
+}

--- a/src/Core/Models/Api/Request/SendRequestModel.cs
+++ b/src/Core/Models/Api/Request/SendRequestModel.cs
@@ -13,6 +13,7 @@ namespace Bit.Core.Models.Api
     public class SendRequestModel
     {
         public SendType Type { get; set; }
+        public long? FileLength { get; set; } = null;
         [EncryptedString]
         [EncryptedStringLength(1000)]
         public string Name { get; set; }

--- a/src/Core/Models/Api/Response/SendFileUploadDataResponseModel.cs
+++ b/src/Core/Models/Api/Response/SendFileUploadDataResponseModel.cs
@@ -1,0 +1,13 @@
+using Bit.Core.Enums;
+
+namespace Bit.Core.Models.Api.Response
+{
+    public class SendFileUploadDataResponseModel : ResponseModel
+    {
+        public string Url { get; set; }
+        public FileUploadType FileUploadType { get; set; }
+        public SendResponseModel SendResponse { get; set; }
+
+        public SendFileUploadDataResponseModel() : base("send-fileUpload") { }
+    }
+}

--- a/src/Core/Services/ISendService.cs
+++ b/src/Core/Services/ISendService.cs
@@ -10,8 +10,10 @@ namespace Bit.Core.Services
     {
         Task DeleteSendAsync(Send send);
         Task SaveSendAsync(Send send);
-        Task CreateSendAsync(Send send, SendFileData data, Stream stream, long requestLength);
+        Task<string> SaveFileSendAsync(Send send, SendFileData data, long fileLength);
         Task<(Send, bool, bool)> AccessAsync(Guid sendId, string password);
         string HashPassword(string password);
+        Task ValidateSendFile(Send send);
+
     }
 }

--- a/src/Core/Services/ISendService.cs
+++ b/src/Core/Services/ISendService.cs
@@ -11,6 +11,7 @@ namespace Bit.Core.Services
         Task DeleteSendAsync(Send send);
         Task SaveSendAsync(Send send);
         Task<string> SaveFileSendAsync(Send send, SendFileData data, long fileLength);
+        Task UploadFileToExistingSendAsync(Stream stream, Send send);
         Task<(Send, bool, bool)> AccessAsync(Guid sendId, string password);
         string HashPassword(string password);
         Task ValidateSendFile(Send send);

--- a/src/Core/Services/ISendService.cs
+++ b/src/Core/Services/ISendService.cs
@@ -14,7 +14,7 @@ namespace Bit.Core.Services
         Task UploadFileToExistingSendAsync(Stream stream, Send send);
         Task<(Send, bool, bool)> AccessAsync(Guid sendId, string password);
         string HashPassword(string password);
-        Task ValidateSendFile(Send send);
+        Task<bool> ValidateSendFile(Send send);
 
     }
 }

--- a/src/Core/Services/ISendService.cs
+++ b/src/Core/Services/ISendService.cs
@@ -15,6 +15,6 @@ namespace Bit.Core.Services
         Task<(Send, bool, bool)> AccessAsync(Guid sendId, string password);
         string HashPassword(string password);
         Task<bool> ValidateSendFile(Send send);
-
+        Task<(string, bool, bool)> GetSendFileDownloadUrlAsync(Send send, string fileId, string password);
     }
 }

--- a/src/Core/Services/ISendStorageService.cs
+++ b/src/Core/Services/ISendStorageService.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.Models.Table;
+﻿using Bit.Core.Enums;
+using Bit.Core.Models.Table;
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -7,10 +8,13 @@ namespace Bit.Core.Services
 {
     public interface ISendFileStorageService
     {
+        FileUploadType FileUploadType { get; }
         Task UploadNewFileAsync(Stream stream, Send send, string fileId);
-        Task DeleteFileAsync(string fileId);
+        Task DeleteFileAsync(Send send, string fileId);
         Task DeleteFilesForOrganizationAsync(Guid organizationId);
         Task DeleteFilesForUserAsync(Guid userId);
-        Task<string> GetSendFileDownloadUrlAsync(string fileId);
+        Task<string> GetSendFileDownloadUrlAsync(Send send, string fileId);
+        Task<string> GetSendFileUploadUrlAsync(Send send, string fileId);
+        Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize);
     }
 }

--- a/src/Core/Services/ISendStorageService.cs
+++ b/src/Core/Services/ISendStorageService.cs
@@ -15,6 +15,6 @@ namespace Bit.Core.Services
         Task DeleteFilesForUserAsync(Guid userId);
         Task<string> GetSendFileDownloadUrlAsync(Send send, string fileId);
         Task<string> GetSendFileUploadUrlAsync(Send send, string fileId);
-        Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize, long leeway);
+        Task<bool> ValidateFileAsync(Send send, string fileId, long expectedFileSize, long leeway);
     }
 }

--- a/src/Core/Services/ISendStorageService.cs
+++ b/src/Core/Services/ISendStorageService.cs
@@ -15,6 +15,6 @@ namespace Bit.Core.Services
         Task DeleteFilesForUserAsync(Guid userId);
         Task<string> GetSendFileDownloadUrlAsync(Send send, string fileId);
         Task<string> GetSendFileUploadUrlAsync(Send send, string fileId);
-        Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize);
+        Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize, long leeway);
     }
 }

--- a/src/Core/Services/Implementations/AzureSendFileStorageService.cs
+++ b/src/Core/Services/Implementations/AzureSendFileStorageService.cs
@@ -89,7 +89,7 @@ namespace Bit.Core.Services
             return blob.Uri + blob.GetSharedAccessSignature(accessPolicy);
         }
 
-        public async Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize, long leeway)
+        public async Task<bool> ValidateFileAsync(Send send, string fileId, long expectedFileSize, long leeway)
         {
             await InitAsync();
 

--- a/src/Core/Services/Implementations/AzureSendFileStorageService.cs
+++ b/src/Core/Services/Implementations/AzureSendFileStorageService.cs
@@ -5,16 +5,23 @@ using System.IO;
 using System;
 using Bit.Core.Models.Table;
 using Bit.Core.Settings;
+using Bit.Core.Enums;
 
 namespace Bit.Core.Services
 {
     public class AzureSendFileStorageService : ISendFileStorageService
     {
-        private const string FilesContainerName = "sendfiles";
+        public const string FilesContainerName = "sendfiles";
+        private const long FileSizeValidationGrace = 1024L;
 
         private static readonly TimeSpan _downloadLinkLiveTime = TimeSpan.FromMinutes(1);
         private readonly CloudBlobClient _blobClient;
         private CloudBlobContainer _sendFilesContainer;
+
+        public FileUploadType FileUploadType => FileUploadType.Azure;
+
+        public static string SendIdFromBlobName(string blobName) => blobName.Split('/')[0];
+        public static string BlobName(Send send, string fileId) => $"{send.Id}/{fileId}";
 
         public AzureSendFileStorageService(
             GlobalSettings globalSettings)
@@ -26,7 +33,7 @@ namespace Bit.Core.Services
         public async Task UploadNewFileAsync(Stream stream, Send send, string fileId)
         {
             await InitAsync();
-            var blob = _sendFilesContainer.GetBlockBlobReference(fileId);
+            var blob = _sendFilesContainer.GetBlockBlobReference(BlobName(send, fileId));
             if (send.UserId.HasValue)
             {
                 blob.Metadata.Add("userId", send.UserId.Value.ToString());
@@ -39,10 +46,10 @@ namespace Bit.Core.Services
             await blob.UploadFromStreamAsync(stream);
         }
 
-        public async Task DeleteFileAsync(string fileId)
+        public async Task DeleteFileAsync(Send send, string fileId)
         {
             await InitAsync();
-            var blob = _sendFilesContainer.GetBlockBlobReference(fileId);
+            var blob = _sendFilesContainer.GetBlockBlobReference(BlobName(send, fileId));
             await blob.DeleteIfExistsAsync();
         }
 
@@ -56,17 +63,65 @@ namespace Bit.Core.Services
             await InitAsync();
         }
 
-        public async Task<string> GetSendFileDownloadUrlAsync(string fileId)
+        public async Task<string> GetSendFileDownloadUrlAsync(Send send, string fileId)
         {
             await InitAsync();
-            var blob = _sendFilesContainer.GetBlockBlobReference(fileId);
+            var blob = _sendFilesContainer.GetBlockBlobReference(BlobName(send, fileId));
             var accessPolicy = new SharedAccessBlobPolicy()
             {
                 SharedAccessExpiryTime = DateTime.UtcNow.Add(_downloadLinkLiveTime),
-                Permissions = SharedAccessBlobPermissions.Read
+                Permissions = SharedAccessBlobPermissions.Read,
             };
 
             return blob.Uri + blob.GetSharedAccessSignature(accessPolicy);
+        }
+
+        public async Task<string> GetSendFileUploadUrlAsync(Send send, string fileId)
+        {
+            await InitAsync();
+            var blob = _sendFilesContainer.GetBlockBlobReference(BlobName(send, fileId));
+
+            var accessPolicy = new SharedAccessBlobPolicy()
+            {
+                SharedAccessExpiryTime = DateTime.UtcNow.Add(_downloadLinkLiveTime),
+                Permissions = SharedAccessBlobPermissions.Create,
+            };
+
+            return blob.Uri + blob.GetSharedAccessSignature(accessPolicy);
+        }
+
+        public async Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize)
+        {
+            await InitAsync();
+
+            var blob = _sendFilesContainer.GetBlockBlobReference(BlobName(send, fileId));
+
+            if (!blob.Exists())
+            {
+                return false;
+            }
+
+            blob.FetchAttributes();
+
+            if (send.UserId.HasValue)
+            {
+                blob.Metadata["userId"] = send.UserId.Value.ToString();
+            }
+            else
+            {
+                blob.Metadata["organizationId"] = send.OrganizationId.Value.ToString();
+            }
+            blob.Properties.ContentDisposition = $"attachment; filename=\"{fileId}\"";
+            blob.SetMetadata();
+            blob.SetProperties();
+
+            var length = blob.Properties.Length;
+            if (length < expectedFileSize - FileSizeValidationGrace || length > expectedFileSize + FileSizeValidationGrace)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private async Task InitAsync()

--- a/src/Core/Services/Implementations/AzureSendFileStorageService.cs
+++ b/src/Core/Services/Implementations/AzureSendFileStorageService.cs
@@ -12,7 +12,6 @@ namespace Bit.Core.Services
     public class AzureSendFileStorageService : ISendFileStorageService
     {
         public const string FilesContainerName = "sendfiles";
-        private const long FileSizeValidationGrace = 1024L;
 
         private static readonly TimeSpan _downloadLinkLiveTime = TimeSpan.FromMinutes(1);
         private readonly CloudBlobClient _blobClient;
@@ -90,7 +89,7 @@ namespace Bit.Core.Services
             return blob.Uri + blob.GetSharedAccessSignature(accessPolicy);
         }
 
-        public async Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize)
+        public async Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize, long leeway)
         {
             await InitAsync();
 
@@ -116,7 +115,7 @@ namespace Bit.Core.Services
             blob.SetProperties();
 
             var length = blob.Properties.Length;
-            if (length < expectedFileSize - FileSizeValidationGrace || length > expectedFileSize + FileSizeValidationGrace)
+            if (length < expectedFileSize - leeway || length > expectedFileSize + leeway)
             {
                 return false;
             }

--- a/src/Core/Services/Implementations/LocalSendStorageService.cs
+++ b/src/Core/Services/Implementations/LocalSendStorageService.cs
@@ -4,6 +4,7 @@ using System;
 using Bit.Core.Models.Table;
 using Bit.Core.Settings;
 using Bit.Core.Enums;
+using System.Linq;
 
 namespace Bit.Core.Services
 {
@@ -40,7 +41,7 @@ namespace Bit.Core.Services
             await InitAsync();
             var path = FilePath(send, fileId);
             DeleteFileIfExists(path);
-            DeleteDirectoryIfExists(Path.GetDirectoryName(path));
+            DeleteDirectoryIfExistsAndEmpty(Path.GetDirectoryName(path));
         }
 
         public async Task DeleteFilesForOrganizationAsync(Guid organizationId)
@@ -67,9 +68,9 @@ namespace Bit.Core.Services
             }
         }
 
-        private void DeleteDirectoryIfExists(string path)
+        private void DeleteDirectoryIfExistsAndEmpty(string path)
         {
-            if (Directory.Exists(path))
+            if (Directory.Exists(path) && !Directory.EnumerateFiles(path).Any())
             {
                 Directory.Delete(path);
             }

--- a/src/Core/Services/Implementations/LocalSendStorageService.cs
+++ b/src/Core/Services/Implementations/LocalSendStorageService.cs
@@ -71,8 +71,12 @@ namespace Bit.Core.Services
             return Task.FromResult(0);
         }
 
-        public Task<string> GetSendFileUploadUrlAsync(Send send, string fileId) => throw new NotImplementedException();
-        public Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize) => throw new NotImplementedException();
+        public Task<string> GetSendFileUploadUrlAsync(Send send, string fileId)
+            => Task.FromResult($"/sends/{send.Id}/file/{fileId}");
+
+        // Validation of local files is handled when they are direct uploaded
+        public Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize, long leeway) =>
+            Task.FromResult(true);
 
     }
 }

--- a/src/Core/Services/Implementations/LocalSendStorageService.cs
+++ b/src/Core/Services/Implementations/LocalSendStorageService.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System;
 using Bit.Core.Models.Table;
 using Bit.Core.Settings;
+using Bit.Core.Enums;
 
 namespace Bit.Core.Services
 {
@@ -10,6 +11,8 @@ namespace Bit.Core.Services
     {
         private readonly string _baseDirPath;
         private readonly string _baseSendUrl;
+
+        public FileUploadType FileUploadType => FileUploadType.Direct;
 
         public LocalSendStorageService(
             GlobalSettings globalSettings)
@@ -28,7 +31,7 @@ namespace Bit.Core.Services
             }
         }
 
-        public async Task DeleteFileAsync(string fileId)
+        public async Task DeleteFileAsync(Send send, string fileId)
         {
             await InitAsync();
             DeleteFileIfExists($"{_baseDirPath}/{fileId}");
@@ -44,7 +47,7 @@ namespace Bit.Core.Services
             await InitAsync();
         }
 
-        public async Task<string> GetSendFileDownloadUrlAsync(string fileId)
+        public async Task<string> GetSendFileDownloadUrlAsync(Send send, string fileId)
         {
             await InitAsync();
             return $"{_baseSendUrl}/{fileId}";
@@ -67,5 +70,9 @@ namespace Bit.Core.Services
 
             return Task.FromResult(0);
         }
+
+        public Task<string> GetSendFileUploadUrlAsync(Send send, string fileId) => throw new NotImplementedException();
+        public Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize) => throw new NotImplementedException();
+
     }
 }

--- a/src/Core/Services/Implementations/SendService.cs
+++ b/src/Core/Services/Implementations/SendService.cs
@@ -26,6 +26,7 @@ namespace Bit.Core.Services
         private readonly IPushNotificationService _pushService;
         private readonly GlobalSettings _globalSettings;
         private readonly ICurrentContext _currentContext;
+        private const long _fileSizeLeeway = 1024;
 
         public SendService(
             ISendRepository sendRepository,
@@ -107,11 +108,33 @@ namespace Bit.Core.Services
             }
         }
 
+        public async Task UploadFileToExistingSendAsync(Stream stream, Send send)
+        {
+            if (send?.Data == null)
+            {
+                throw new BadRequestException("Send does not have file data");
+            }
+
+            if (send.Type != SendType.File)
+            {
+                throw new BadRequestException("Not a File Type Send.");
+            }
+
+            var data = JsonConvert.DeserializeObject<SendFileData>(send.Data);
+
+            if (stream.Length < data.Size - _fileSizeLeeway || stream.Length > data.Size + _fileSizeLeeway)
+            {
+                throw new BadRequestException("Stream size does not match expected size.");
+            }
+
+            await _sendFileStorageService.UploadNewFileAsync(stream, send, data.Id);
+        }
+
         public async Task ValidateSendFile(Send send)
         {
             var fileData = JsonConvert.DeserializeObject<SendFileData>(send.Data);
 
-            var valid = await _sendFileStorageService.ValidateFile(send, fileData.Id, fileData.Size);
+            var valid = await _sendFileStorageService.ValidateFile(send, fileData.Id, fileData.Size, _fileSizeLeeway);
 
             if (!valid)
             {

--- a/src/Core/Services/Implementations/SendService.cs
+++ b/src/Core/Services/Implementations/SendService.cs
@@ -26,7 +26,7 @@ namespace Bit.Core.Services
         private readonly IPushNotificationService _pushService;
         private readonly GlobalSettings _globalSettings;
         private readonly ICurrentContext _currentContext;
-        private const long _fileSizeLeeway = 1024;
+        private const long _fileSizeLeeway = 1024L * 1024L; // 1MB
 
         public SendService(
             ISendRepository sendRepository,

--- a/src/Core/Services/Implementations/SendService.cs
+++ b/src/Core/Services/Implementations/SendService.cs
@@ -196,7 +196,7 @@ namespace Bit.Core.Services
         {
             if (send.Type != SendType.File)
             {
-                throw new BadRequestException("Can only get a download URL for file type a Send");
+                throw new BadRequestException("Can only get a download URL for a file type of Send");
             }
 
             var (grantAccess, passwordRequired, passwordInvalid) = SendCanBeAccessed(send, password);

--- a/src/Core/Services/NoopImplementations/NoopSendFileStorageService.cs
+++ b/src/Core/Services/NoopImplementations/NoopSendFileStorageService.cs
@@ -40,7 +40,7 @@ namespace Bit.Core.Services
             return Task.FromResult((string)null);
         }
 
-        public Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize)
+        public Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize, long leeway)
         {
             return Task.FromResult(false);
         }

--- a/src/Core/Services/NoopImplementations/NoopSendFileStorageService.cs
+++ b/src/Core/Services/NoopImplementations/NoopSendFileStorageService.cs
@@ -40,7 +40,7 @@ namespace Bit.Core.Services
             return Task.FromResult((string)null);
         }
 
-        public Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize, long leeway)
+        public Task<bool> ValidateFileAsync(Send send, string fileId, long expectedFileSize, long leeway)
         {
             return Task.FromResult(false);
         }

--- a/src/Core/Services/NoopImplementations/NoopSendFileStorageService.cs
+++ b/src/Core/Services/NoopImplementations/NoopSendFileStorageService.cs
@@ -2,17 +2,20 @@
 using System.IO;
 using System;
 using Bit.Core.Models.Table;
+using Bit.Core.Enums;
 
 namespace Bit.Core.Services
 {
     public class NoopSendFileStorageService : ISendFileStorageService
     {
+        public FileUploadType FileUploadType => FileUploadType.Direct;
+
         public Task UploadNewFileAsync(Stream stream, Send send, string attachmentId)
         {
             return Task.FromResult(0);
         }
 
-        public Task DeleteFileAsync(string fileId)
+        public Task DeleteFileAsync(Send send, string fileId)
         {
             return Task.FromResult(0);
         }
@@ -27,9 +30,19 @@ namespace Bit.Core.Services
             return Task.FromResult(0);
         }
 
-        public Task<string> GetSendFileDownloadUrlAsync(string fileId)
+        public Task<string> GetSendFileDownloadUrlAsync(Send send, string fileId)
         {
             return Task.FromResult((string)null);
+        }
+
+        public Task<string> GetSendFileUploadUrlAsync(Send send, string fileId)
+        {
+            return Task.FromResult((string)null);
+        }
+
+        public Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize)
+        {
+            return Task.FromResult(false);
         }
     }
 }


### PR DESCRIPTION
# Overview

This PR creates endpoints to allow direct upload to Azure blob storage and local storage.

# Files Changed
* **Api.csproj**: Add event grid nuget dependency. This package allows for easier integration with Azure Event Grid, which is used to verify Send file sizes.
* **SendsController.cs**: New endpoints:
  * **GetSendFileDownloadData**: Grabs a download URL. Response model object is for future-proof returning more information. For now, it's just a download URL.
  * **PostFile**: Creates a file type send and get a URL/SendResponse to upload the file to. FileUploadType is used to specify Azure vs Direct upload. This request makes and validates a send based on a promised file size. This is checked upon actual file upload.
  * **PostFileForExistingSend**: The API endpoint for localStorage deployments. This maintains the 100MB upload limit, uploads the file to local storage. SendService also validates the length of the received file stream is within a grace size.
  * **AzureValidateFile**: Azure event webhook endpoint. Accepts Azure Event Grid Event POSTs and handles blobCreate events, validating the final blob size. This method blocks the client's return from blob create writes.
* **ApiHelpers.cs**: Azure requires a response verification code to prove we own the webhook endpoint we specify. This helper automatically handles Verification events and accepts a Dictionary of event handlers to call for other Azure events.
* **MultipartFormDataHelper.cs**: GetSendFileAsync is a form containing only file data now since the URL has the send Id and file ID that have already been created.
* **FileUploadType.cs**: Specifies the method of uploading a file. Direct is direct to Bitwarden. Azure is an Azure Upload. This is used by the client to upload in the appropriate manner.
* **SendRequestModel.cs**: Optionally provide a hint of the File Size that will be uploaded for this Send. The FileLength is required for File Sends and ignored for Text sends.
* **SendFileUploadDataResponseModel**: Specifies the Send URL, UploadType, and Generated Send. This is the response to a request to make a new File Type Send.
* **ISendService/SendService.cs**: 
  * **SaveFileSendAsync**: Creates a File Send without file data and responds with a string to upload the file data to.
  * **UploadFileToExistingSend**: The local storage endpoint. Should not be used for Azure deployments. Validates existence of Send, stores the stream, and validates its size prior to returning. Throws in the event of a size mismatch since the client will correctly interpret that throw as a toast error.
  * **ValidateSendFile.cs**: Simply validates the specified file and deletes the send if it does not mesh within a reasonable leeway (set to 1MB).
* **AzureSendFileStorageService.cs**:
  * Blobs are stored under SendId. This is because Azure doesn't send metadata with Events. This way, we can grab Send objects in Controller, following the current pattern. It also allows us to eventually add multiple files to Sends if we want to.
  * **GetSendUploadUrl**: Uses SAS string to authorize a 1 min create permission to the specified blob. This requires a few Azure settings
    1. CORS for blob storage needs to be set to allow any orgin for GET and PUT methods (upload is PUT only, but GET is needed for the download portion).
    2. The `sendfiles` container should have permissions set to off
  * **ValidateFile**: Called from the Azure event webhook upon blob creation (which occurs after the file is finished uploading). Pulls the blob's size and sets some metadata/property attributes that could not be set prior to creation. We could offload this to the clients, but it makes sense to keep this file organization stuff in the server. If the size is not roughly equal to expected, returns false to indicate the Send should be removed due to unvalidated file size.
* **LocalSendFileStorageService**: Validates that file on disk equals expected file size. We need to write to disk first since HttpStreams have no known length until they're read and we don't want to risk storing a huge file in memory to figure out the size.
* **NoopSendFileStorageService**: Noop implementations. 

# Required Azure Changes
1. CORS for blob storage needs to be set to allow any orgin for GET and PUT methods (upload is PUT only, but GET is needed for the download portion).
2. The `sendfiles` container should have permissions set to off
3. Specify webhook event for blob creation with filters defined by @joseph-flinn. Endpoint is `<<apiUrl>>/sends/file/validate/azure`

# Testing requirements

Need to test upload and download to both local and Azure hosted environments.
I've tested lying about file size, but a second set of eyes on that is a good idea.

The above require access to bitwarden/web#853