### PR TITLE
Exempt owners and admins from single org and 2FA policy

### DIFF
--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -165,7 +165,8 @@ namespace Bit.Api.Controllers
             var policies = await _policyRepository.GetManyByUserIdAsync(user.Id);
             var orgUsers = await _organizationUserRepository.GetManyByUserAsync(user.Id);
 
-            var orgsWithSingleOrgPolicy = policies.Where(p => p.Enabled && p.Type == PolicyType.SingleOrg).Select(p => p.OrganizationId);
+            var orgsWithSingleOrgPolicy = policies.Where(p => p.Enabled && p.Type == PolicyType.SingleOrg)
+                .Select(p => p.OrganizationId);
             var blockedBySingleOrgPolicy = orgUsers.Any(ou => ou.Type != OrganizationUserType.Owner &&
                                                         ou.Type != OrganizationUserType.Admin &&
                                                         ou.Status != OrganizationUserStatusType.Invited &&
@@ -174,7 +175,7 @@ namespace Bit.Api.Controllers
             if (blockedBySingleOrgPolicy)
             {
                 throw new Exception("You may not create an organization. You belong to an organization " +
-                        "which has a policy that prohibits you from being a member of any other organization.");
+                    "which has a policy that prohibits you from being a member of any other organization.");
             }
 
             var organizationSignup = model.ToOrganizationSignup(user);

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1168,7 +1168,7 @@ namespace Bit.Core.Services
             if (thisSingleOrgPolicy != null &&
                 thisSingleOrgPolicy.Enabled &&
                 notExempt(orgUser) &&
-                allOrgUsers.Count(ou => ou.OrganizationId != orgUser.OrganizationId) > 0)
+                allOrgUsers.Any(ou => ou.OrganizationId != orgUser.OrganizationId))
             {
                 throw new BadRequestException("You may not join this organization until you leave or remove " +
                     "all other organizations.");
@@ -1177,7 +1177,8 @@ namespace Bit.Core.Services
             // Enforce Single Organization Policy of other organizations user is a member of
             var policies = await _policyRepository.GetManyByUserIdAsync(user.Id);
 
-            var orgsWithSingleOrgPolicy = policies.Where(p => p.Enabled && p.Type == PolicyType.SingleOrg).Select(p => p.OrganizationId);
+            var orgsWithSingleOrgPolicy = policies.Where(p => p.Enabled && p.Type == PolicyType.SingleOrg)
+                .Select(p => p.OrganizationId);
             var blockedBySingleOrgPolicy = allOrgUsers.Any(ou => notExempt(ou) &&
                 ou.Status != OrganizationUserStatusType.Invited &&
                 orgsWithSingleOrgPolicy.Contains(ou.OrganizationId));


### PR DESCRIPTION
## Objective

Single Organization Policies (SOP) are not properly exempting owners/admins. I found the following issues:

* owner/admin of an org with SOP enabled cannot create a new org (this was the original bug report)
* owner/admin of an org with SOP enabled is blocked from accepting invite into another org (blocked by first org's SOP)
* a member of an org is blocked from accepting an invite into another org with SOP enabled, where they are being invited as owner/admin (blocked by second org's SOP)

This is a little bit of scope creep, but 2FA is also checked when a user is being invited into an org, and was also not exempting owners/admins. I fixed it while I was here.

## Solution

I understand the business logic to be as follows.

**When user creates new org**
_(Enforce other orgs SOP) User cannot create new org if:_
* User is member of any other org, and
* User is not admin/owner of other org, and
* other org has SOP enabled

**When user accepts invite into a target org**
_(Enforce target org SOP) User cannot accept invite if:_
* target org has SOP, and
* user is not invited as admin/owner, and
* user is member of any other orgs

_(Enforce other orgs SOP) User cannot accept invite if:_
* User is member of any other org, and
* User is not admin/owner of other org, and
* other org has SOP enabled

_(Enforce target org 2FA policy) User cannot accept invite if:_
* target org has 2FA policy enabled
* user is not invited as admin/owner

**When target org turns on SOP** (this is already implemented correctly - no code changes)
_(Enforce target org SOP) Remove user from target org if:_
* User is not admin/owner of target org, and
* User is member of any other orgs

## Code changes
* `organizationController` - handles creating organization per the logic above
* `organizationService` - handles accepting an invite into an organization per the logic above

Related changes to the web vault: https://github.com/bitwarden/web/pull/855