### PR TITLE
Fix send file length always zero

### DIFF
--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -160,7 +160,7 @@ namespace Bit.Api.Controllers
                 var userId = _userService.GetProperUserId(User).Value;
                 var (madeSend, madeData) = model.ToSend(userId, fileName, _sendService);
                 send = madeSend;
-                await _sendService.CreateSendAsync(send, madeData, stream, Request.ContentLength.GetValueOrDefault(0));
+                await _sendService.CreateSendAsync(send, madeData, stream, model.FileLength.GetValueOrDefault(0));
             });
 
             return new SendResponseModel(send, _globalSettings);

--- a/src/Core/Models/Api/Request/SendRequestModel.cs
+++ b/src/Core/Models/Api/Request/SendRequestModel.cs
@@ -13,6 +13,7 @@ namespace Bit.Core.Models.Api
     public class SendRequestModel
     {
         public SendType Type { get; set; }
+        public long? FileLength { get; set; }
         [EncryptedString]
         [EncryptedStringLength(1000)]
         public string Name { get; set; }

--- a/src/Core/Services/Implementations/SendService.cs
+++ b/src/Core/Services/Implementations/SendService.cs
@@ -133,7 +133,7 @@ namespace Bit.Core.Services
                 await SaveSendAsync(send);
                 await _sendFileStorageService.UploadNewFileAsync(stream, send, fileId);
                 // Need to save length of stream since that isn't available until it is read
-                if (data.Size <= requestLength)
+                if (stream.Length <= requestLength)
                 {
                     data.Size = stream.Length;
                     send.Data = JsonConvert.SerializeObject(data,


### PR DESCRIPTION
# Overview

Fixes issue introduced in #1174 

Moving Send file saving to after Send creation allowed for referencing the Send's Id in the storage location, but I forgot that the HttpStream's length is 0 until it is read out. This results in file length of 0 for all Send files.

This is a chicken-and-egg problem who's solution is to save the send twice. I'm saving the Send to get an Id, saving the file, **verifying** the file length, and updating the Send's file data to contain the proper length.

The verification step is a nice addition since there is no guarantee that a Content-Length header we're using as the request length to verify storage bytes is equal to the actual stream length uploaded.

If the actual stream's length is larger than that requested we throw back an error and delete the Send. This results in a failure in the client and a toast explaining the reason.

One potential issue: Do we want to provide a pad at all for slightly larger files? I haven't seen any examples where that can happen and the idea is that the requested length should be equal to the already encrypted data

# Files Changed
* **SendsController.cs/SendRequestModel.cs**: get request length from the model. To be populated by clients
* **SendService**: Validate stream length and update Send to proper length

# Testing Done
I've created files and verified their lengths, as well as intercepted save requests, monkeying with the promised file lengths. Files which are shorter than expected save file and register the proper length. Files which are actually longer fail to save.