### PR TITLE
Direct upload to Azure/Local

### DIFF
--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.6" />
     <PackageReference Include="NewRelic.Agent" Version="8.30.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
+    <PackageReference Include="Microsoft.Azure.EventGrid" Version="3.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -173,7 +173,7 @@ namespace Bit.Api.Controllers
                 throw new BadRequestException("Invalid content.");
             }
 
-            if (Request.ContentLength > 105906176) // 101 MB, give em' 1 extra MB for cushion
+            if (Request.ContentLength > 105906176 && !_globalSettings.SelfHosted) // 101 MB, give em' 1 extra MB for cushion
             {
                 throw new BadRequestException("Max file size for direct upload is 100 MB.");
             }

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using Bit.Core.Models.Table;
 using Newtonsoft.Json;
 using Bit.Core.Models.Data;
+using Microsoft.Extensions.Logging;
 
 namespace Bit.Api.Controllers
 {
@@ -28,6 +29,7 @@ namespace Bit.Api.Controllers
         private readonly IUserService _userService;
         private readonly ISendService _sendService;
         private readonly ISendFileStorageService _sendFileStorageService;
+        private readonly ILogger<SendsController> _logger;
         private readonly GlobalSettings _globalSettings;
 
         public SendsController(
@@ -35,12 +37,14 @@ namespace Bit.Api.Controllers
             IUserService userService,
             ISendService sendService,
             ISendFileStorageService sendFileStorageService,
+            ILogger<SendsController> logger,
             GlobalSettings globalSettings)
         {
             _sendRepository = sendRepository;
             _userService = userService;
             _sendService = sendService;
             _sendFileStorageService = sendFileStorageService;
+            _logger = logger;
             _globalSettings = globalSettings;
         }
 
@@ -262,8 +266,9 @@ namespace Bit.Api.Controllers
                             }
                             await _sendService.ValidateSendFile(send);
                         }
-                        catch
+                        catch (Exception e)
                         {
+                            _logger.LogError(e, $"Uncaught exception occurred while handling event grid event: {JsonConvert.SerializeObject(eventGridEvent)}");
                             return;
                         }
                     }

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -181,7 +181,7 @@ namespace Bit.Api.Controllers
             var send = await _sendRepository.GetByIdAsync(new Guid(id));
             await Request.GetSendFileAsync(async (stream) =>
             {
-                await _sendFileStorageService.UploadNewFileAsync(stream, send, fileId);
+                await _sendService.UploadFileToExistingSendAsync(stream, send);
             });
         }
 

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -164,6 +164,27 @@ namespace Bit.Api.Controllers
             };
         }
 
+        [HttpPost("{id}/file/{fileId}")]
+        [DisableFormValueModelBinding]
+        public async Task PostFileForExistingSend(string id, string fileId)
+        {
+            if (!Request?.ContentType.Contains("multipart/") ?? true)
+            {
+                throw new BadRequestException("Invalid content.");
+            }
+
+            if (Request.ContentLength > 105906176) // 101 MB, give em' 1 extra MB for cushion
+            {
+                throw new BadRequestException("Max file size for direct upload is 100 MB.");
+            }
+
+            var send = await _sendRepository.GetByIdAsync(new Guid(id));
+            await Request.GetSendFileAsync(async (stream) =>
+            {
+                await _sendFileStorageService.UploadNewFileAsync(stream, send, fileId);
+            });
+        }
+
         [AllowAnonymous]
         [HttpPost("file/validate/azure")]
         public async Task<OkObjectResult> AzureValidateFile()
@@ -188,25 +209,6 @@ namespace Bit.Api.Controllers
                       }
                   }}
                 });
-        }
-
-        [HttpPost("{id}/validate")]
-        public async Task PostValidateFile(string id)
-        {
-            var userId = _userService.GetProperUserId(User).Value;
-            var send = await _sendRepository.GetByIdAsync(new Guid(id));
-
-            if (send == null || send.UserId != userId)
-            {
-                throw new NotFoundException();
-            }
-
-            if (send.Type != SendType.File)
-            {
-                throw new BadRequestException("Invalid content.");
-            }
-
-            await _sendService.ValidateSendFile(send);
         }
 
         [HttpPut("{id}")]

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -166,7 +166,6 @@ namespace Bit.Api.Controllers
 
         [AllowAnonymous]
         [HttpPost("file/validate/azure")]
-        [HttpGet("file/validate/azure")]
         public async Task<OkObjectResult> AzureValidateFile()
         {
             return await ApiHelpers.HandleAzureEvents(Request, new Dictionary<string, Func<EventGridEvent, Task>>

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -190,25 +190,28 @@ namespace Bit.Api.Controllers
         public async Task<OkObjectResult> AzureValidateFile()
         {
             return await ApiHelpers.HandleAzureEvents(Request, new Dictionary<string, Func<EventGridEvent, Task>>
+            {
                 {
-                  {"Microsoft.Storage.BlobCreated", async (eventGridEvent) => {
-                      try
-                      {
-                          var blobName = eventGridEvent.Subject.Split($"{AzureSendFileStorageService.FilesContainerName}/blobs/")[1];
-                          var sendId = AzureSendFileStorageService.SendIdFromBlobName(blobName);
-                          var send = await _sendRepository.GetByIdAsync(new Guid(sendId));
-                          if (send == null)
-                          {
-                              return;
-                          }
-                          await _sendService.ValidateSendFile(send);
-                      }
-                      catch
-                      {
-                          return;
-                      }
-                  }}
-                });
+                    "Microsoft.Storage.BlobCreated", async (eventGridEvent) =>
+                    {
+                        try
+                        {
+                            var blobName = eventGridEvent.Subject.Split($"{AzureSendFileStorageService.FilesContainerName}/blobs/")[1];
+                            var sendId = AzureSendFileStorageService.SendIdFromBlobName(blobName);
+                            var send = await _sendRepository.GetByIdAsync(new Guid(sendId));
+                            if (send == null)
+                            {
+                                return;
+                            }
+                            await _sendService.ValidateSendFile(send);
+                        }
+                        catch
+                        {
+                            return;
+                        }
+                    }
+                }
+            });
         }
 
         [HttpPut("{id}")]

--- a/src/Api/Utilities/ApiHelpers.cs
+++ b/src/Api/Utilities/ApiHelpers.cs
@@ -1,5 +1,10 @@
 ﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.EventGrid;
+using Microsoft.Azure.EventGrid.Models;
 using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -28,6 +33,43 @@ namespace Bit.Api.Utilities
             }
 
             return obj;
+        }
+
+        /// <summary>
+        /// Validates Azure event subscription and calls the appropriate event handler. Responds HttpOk.
+        /// </summary>
+        /// <param name="request">HttpRequest received from Azure</param>
+        /// <param name="eventTypeHandlers">Dictionary of eventType strings and their associated handlers.</param>
+        /// <returns>OkObjectResult</returns>
+        // Reference https://docs.microsoft.com/en-us/azure/event-grid/receive-events
+        public async static Task<OkObjectResult> HandleAzureEvents(HttpRequest request,
+            Dictionary<string, Func<EventGridEvent, Task>> eventTypeHandlers)
+        {
+            var response = string.Empty;
+            var requestContent = await new StreamReader(request.Body).ReadToEndAsync();
+            var eventGridSubscriber = new EventGridSubscriber();
+            var eventGridEvents = eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            foreach (var eventGridEvent in eventGridEvents)
+            {
+                if (eventGridEvent.Data is SubscriptionValidationEventData eventData)
+                {
+                    // Might want to enable additional validation: subject, topic etc.
+
+                    var responseData = new SubscriptionValidationResponse()
+                    {
+                        ValidationResponse = eventData.ValidationCode
+                    };
+
+                    return new OkObjectResult(responseData);
+                }
+                else if (eventTypeHandlers.ContainsKey(eventGridEvent.EventType))
+                {
+                    await eventTypeHandlers[eventGridEvent.EventType](eventGridEvent);
+                }
+            }
+
+            return new OkObjectResult(response);
         }
     }
 }

--- a/src/Api/Utilities/ApiHelpers.cs
+++ b/src/Api/Utilities/ApiHelpers.cs
@@ -47,6 +47,11 @@ namespace Bit.Api.Utilities
         {
             var response = string.Empty;
             var requestContent = await new StreamReader(request.Body).ReadToEndAsync();
+            if (string.IsNullOrWhiteSpace(requestContent))
+            {
+                return new OkObjectResult(response);
+            }
+
             var eventGridSubscriber = new EventGridSubscriber();
             var eventGridEvents = eventGridSubscriber.DeserializeEventGridEvents(requestContent);
 

--- a/src/Api/Utilities/ApiHelpers.cs
+++ b/src/Api/Utilities/ApiHelpers.cs
@@ -41,7 +41,7 @@ namespace Bit.Api.Utilities
         /// <param name="request">HttpRequest received from Azure</param>
         /// <param name="eventTypeHandlers">Dictionary of eventType strings and their associated handlers.</param>
         /// <returns>OkObjectResult</returns>
-        // Reference https://docs.microsoft.com/en-us/azure/event-grid/receive-events
+        /// <remarks>Reference https://docs.microsoft.com/en-us/azure/event-grid/receive-events</remarks>
         public async static Task<OkObjectResult> HandleAzureEvents(HttpRequest request,
             Dictionary<string, Func<EventGridEvent, Task>> eventTypeHandlers)
         {

--- a/src/Api/Utilities/MultipartFormDataHelper.cs
+++ b/src/Api/Utilities/MultipartFormDataHelper.cs
@@ -72,22 +72,19 @@ namespace Bit.Api.Utilities
                 _defaultFormOptions.MultipartBoundaryLengthLimit);
             var reader = new MultipartReader(boundary, request.Body);
 
-
             var dataSection = await reader.ReadNextSectionAsync();
             if (dataSection != null)
             {
-                if (ContentDispositionHeaderValue.TryParse(dataSection.ContentDisposition,
-                    out var thirdContent) && HasFileContentDisposition(thirdContent))
+                if (ContentDispositionHeaderValue.TryParse(dataSection.ContentDisposition, out var dataContent)
+                    && HasFileContentDisposition(dataContent))
                 {
                     using (dataSection.Body)
                     {
                         await callback(dataSection.Body);
                     }
                 }
-
+                dataSection = null;
             }
-
-            dataSection = null;
         }
 
 

--- a/src/Api/Utilities/MultipartFormDataHelper.cs
+++ b/src/Api/Utilities/MultipartFormDataHelper.cs
@@ -66,46 +66,28 @@ namespace Bit.Api.Utilities
             }
         }
 
-        public static async Task GetSendFileAsync(this HttpRequest request, Func<Stream, string,
-            SendRequestModel, Task> callback)
+        public static async Task GetSendFileAsync(this HttpRequest request, Func<Stream, Task> callback)
         {
             var boundary = GetBoundary(MediaTypeHeaderValue.Parse(request.ContentType),
                 _defaultFormOptions.MultipartBoundaryLengthLimit);
             var reader = new MultipartReader(boundary, request.Body);
 
-            var firstSection = await reader.ReadNextSectionAsync();
-            if (firstSection != null)
+
+            var dataSection = await reader.ReadNextSectionAsync();
+            if (dataSection != null)
             {
-                if (ContentDispositionHeaderValue.TryParse(firstSection.ContentDisposition, out _))
+                if (ContentDispositionHeaderValue.TryParse(dataSection.ContentDisposition,
+                    out var thirdContent) && HasFileContentDisposition(thirdContent))
                 {
-                    // Request model json, then data
-                    string requestModelJson = null;
-                    using (var sr = new StreamReader(firstSection.Body))
+                    using (dataSection.Body)
                     {
-                        requestModelJson = await sr.ReadToEndAsync();
+                        await callback(dataSection.Body);
                     }
-
-                    var secondSection = await reader.ReadNextSectionAsync();
-                    if (secondSection != null)
-                    {
-                        if (ContentDispositionHeaderValue.TryParse(secondSection.ContentDisposition,
-                            out var secondContent) && HasFileContentDisposition(secondContent))
-                        {
-                            var fileName = HeaderUtilities.RemoveQuotes(secondContent.FileName).ToString();
-                            using (secondSection.Body)
-                            {
-                                var model = JsonConvert.DeserializeObject<SendRequestModel>(requestModelJson);
-                                await callback(secondSection.Body, fileName, model);
-                            }
-                        }
-
-                        secondSection = null;
-                    }
-
                 }
 
-                firstSection = null;
             }
+
+            dataSection = null;
         }
 
 

--- a/src/Core/Enums/FileUploadType.cs
+++ b/src/Core/Enums/FileUploadType.cs
@@ -1,0 +1,8 @@
+namespace Bit.Core.Enums
+{
+    public enum FileUploadType
+    {
+        Direct = 0,
+        Azure = 1,
+    }
+}

--- a/src/Core/Models/Api/Request/SendRequestModel.cs
+++ b/src/Core/Models/Api/Request/SendRequestModel.cs
@@ -13,7 +13,7 @@ namespace Bit.Core.Models.Api
     public class SendRequestModel
     {
         public SendType Type { get; set; }
-        public long? FileLength { get; set; }
+        public long? FileLength { get; set; } = null;
         [EncryptedString]
         [EncryptedStringLength(1000)]
         public string Name { get; set; }

--- a/src/Core/Models/Api/Response/SendFileUploadDataResponseModel.cs
+++ b/src/Core/Models/Api/Response/SendFileUploadDataResponseModel.cs
@@ -4,10 +4,11 @@ namespace Bit.Core.Models.Api.Response
 {
     public class SendFileUploadDataResponseModel : ResponseModel
     {
+        public SendFileUploadDataResponseModel() : base("send-fileUpload") { }
+        
         public string Url { get; set; }
         public FileUploadType FileUploadType { get; set; }
         public SendResponseModel SendResponse { get; set; }
 
-        public SendFileUploadDataResponseModel() : base("send-fileUpload") { }
     }
 }

--- a/src/Core/Models/Api/Response/SendFileUploadDataResponseModel.cs
+++ b/src/Core/Models/Api/Response/SendFileUploadDataResponseModel.cs
@@ -1,0 +1,13 @@
+using Bit.Core.Enums;
+
+namespace Bit.Core.Models.Api.Response
+{
+    public class SendFileUploadDataResponseModel : ResponseModel
+    {
+        public string Url { get; set; }
+        public FileUploadType FileUploadType { get; set; }
+        public SendResponseModel SendResponse { get; set; }
+
+        public SendFileUploadDataResponseModel() : base("send-fileUpload") { }
+    }
+}

--- a/src/Core/Models/Data/SendFileData.cs
+++ b/src/Core/Models/Data/SendFileData.cs
@@ -33,5 +33,6 @@ namespace Bit.Core.Models.Data
 
         public string Id { get; set; }
         public string FileName { get; set; }
+        public bool Validated { get; set; } = true;
     }
 }

--- a/src/Core/Services/ISendService.cs
+++ b/src/Core/Services/ISendService.cs
@@ -16,6 +16,6 @@ namespace Bit.Core.Services
         string HashPassword(string password);
         Task<(string, bool, bool)> GetSendFileDownloadUrlAsync(Send send, string fileId, string password);
         Task<bool> ValidateSendFile(Send send);
-
+        Task<(string, bool, bool)> GetSendFileDownloadUrlAsync(Send send, string fileId, string password);
     }
 }

--- a/src/Core/Services/ISendService.cs
+++ b/src/Core/Services/ISendService.cs
@@ -10,9 +10,11 @@ namespace Bit.Core.Services
     {
         Task DeleteSendAsync(Send send);
         Task SaveSendAsync(Send send);
-        Task CreateSendAsync(Send send, SendFileData data, Stream stream, long requestLength);
+        Task<string> SaveFileSendAsync(Send send, SendFileData data, long fileLength);
         Task<(Send, bool, bool)> AccessAsync(Guid sendId, string password);
         string HashPassword(string password);
         Task<(string, bool, bool)> GetSendFileDownloadUrlAsync(Send send, string fileId, string password);
+        Task ValidateSendFile(Send send);
+
     }
 }

--- a/src/Core/Services/ISendService.cs
+++ b/src/Core/Services/ISendService.cs
@@ -16,6 +16,5 @@ namespace Bit.Core.Services
         string HashPassword(string password);
         Task<(string, bool, bool)> GetSendFileDownloadUrlAsync(Send send, string fileId, string password);
         Task<bool> ValidateSendFile(Send send);
-        Task<(string, bool, bool)> GetSendFileDownloadUrlAsync(Send send, string fileId, string password);
     }
 }

--- a/src/Core/Services/ISendService.cs
+++ b/src/Core/Services/ISendService.cs
@@ -15,7 +15,7 @@ namespace Bit.Core.Services
         Task<(Send, bool, bool)> AccessAsync(Guid sendId, string password);
         string HashPassword(string password);
         Task<(string, bool, bool)> GetSendFileDownloadUrlAsync(Send send, string fileId, string password);
-        Task ValidateSendFile(Send send);
+        Task<bool> ValidateSendFile(Send send);
 
     }
 }

--- a/src/Core/Services/ISendService.cs
+++ b/src/Core/Services/ISendService.cs
@@ -11,6 +11,7 @@ namespace Bit.Core.Services
         Task DeleteSendAsync(Send send);
         Task SaveSendAsync(Send send);
         Task<string> SaveFileSendAsync(Send send, SendFileData data, long fileLength);
+        Task UploadFileToExistingSendAsync(Stream stream, Send send);
         Task<(Send, bool, bool)> AccessAsync(Guid sendId, string password);
         string HashPassword(string password);
         Task<(string, bool, bool)> GetSendFileDownloadUrlAsync(Send send, string fileId, string password);

--- a/src/Core/Services/ISendStorageService.cs
+++ b/src/Core/Services/ISendStorageService.cs
@@ -15,6 +15,6 @@ namespace Bit.Core.Services
         Task DeleteFilesForUserAsync(Guid userId);
         Task<string> GetSendFileDownloadUrlAsync(Send send, string fileId);
         Task<string> GetSendFileUploadUrlAsync(Send send, string fileId);
-        Task<bool> ValidateFileAsync(Send send, string fileId, long expectedFileSize, long leeway);
+        Task<(bool, long?)> ValidateFileAsync(Send send, string fileId, long expectedFileSize, long leeway);
     }
 }

--- a/src/Core/Services/ISendStorageService.cs
+++ b/src/Core/Services/ISendStorageService.cs
@@ -15,6 +15,6 @@ namespace Bit.Core.Services
         Task DeleteFilesForUserAsync(Guid userId);
         Task<string> GetSendFileDownloadUrlAsync(Send send, string fileId);
         Task<string> GetSendFileUploadUrlAsync(Send send, string fileId);
-        Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize, long leeway);
+        Task<bool> ValidateFileAsync(Send send, string fileId, long expectedFileSize, long leeway);
     }
 }

--- a/src/Core/Services/ISendStorageService.cs
+++ b/src/Core/Services/ISendStorageService.cs
@@ -15,6 +15,6 @@ namespace Bit.Core.Services
         Task DeleteFilesForUserAsync(Guid userId);
         Task<string> GetSendFileDownloadUrlAsync(Send send, string fileId);
         Task<string> GetSendFileUploadUrlAsync(Send send, string fileId);
-        Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize);
+        Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize, long leeway);
     }
 }

--- a/src/Core/Services/ISendStorageService.cs
+++ b/src/Core/Services/ISendStorageService.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.Models.Table;
+﻿using Bit.Core.Enums;
+using Bit.Core.Models.Table;
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -7,10 +8,13 @@ namespace Bit.Core.Services
 {
     public interface ISendFileStorageService
     {
+        FileUploadType FileUploadType { get; }
         Task UploadNewFileAsync(Stream stream, Send send, string fileId);
         Task DeleteFileAsync(Send send, string fileId);
         Task DeleteFilesForOrganizationAsync(Guid organizationId);
         Task DeleteFilesForUserAsync(Guid userId);
         Task<string> GetSendFileDownloadUrlAsync(Send send, string fileId);
+        Task<string> GetSendFileUploadUrlAsync(Send send, string fileId);
+        Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize);
     }
 }

--- a/src/Core/Services/Implementations/AzureSendFileStorageService.cs
+++ b/src/Core/Services/Implementations/AzureSendFileStorageService.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System;
 using Bit.Core.Models.Table;
 using Bit.Core.Settings;
+using Bit.Core.Enums;
 
 namespace Bit.Core.Services
 {
@@ -14,6 +15,8 @@ namespace Bit.Core.Services
         private static readonly TimeSpan _downloadLinkLiveTime = TimeSpan.FromMinutes(1);
         private readonly CloudBlobClient _blobClient;
         private CloudBlobContainer _sendFilesContainer;
+
+        public FileUploadType FileUploadType => FileUploadType.Azure;
 
         public static string SendIdFromBlobName(string blobName) => blobName.Split('/')[0];
         public static string BlobName(Send send, string fileId) => $"{send.Id}/{fileId}";
@@ -69,6 +72,54 @@ namespace Bit.Core.Services
             };
 
             return blob.Uri + blob.GetSharedAccessSignature(accessPolicy);
+        }
+
+        public async Task<string> GetSendFileUploadUrlAsync(Send send, string fileId)
+        {
+            await InitAsync();
+            var blob = _sendFilesContainer.GetBlockBlobReference(BlobName(send, fileId));
+
+            var accessPolicy = new SharedAccessBlobPolicy()
+            {
+                SharedAccessExpiryTime = DateTime.UtcNow.Add(_downloadLinkLiveTime),
+                Permissions = SharedAccessBlobPermissions.Create,
+            };
+
+            return blob.Uri + blob.GetSharedAccessSignature(accessPolicy);
+        }
+
+        public async Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize, long leeway)
+        {
+            await InitAsync();
+
+            var blob = _sendFilesContainer.GetBlockBlobReference(BlobName(send, fileId));
+
+            if (!blob.Exists())
+            {
+                return false;
+            }
+
+            blob.FetchAttributes();
+
+            if (send.UserId.HasValue)
+            {
+                blob.Metadata["userId"] = send.UserId.Value.ToString();
+            }
+            else
+            {
+                blob.Metadata["organizationId"] = send.OrganizationId.Value.ToString();
+            }
+            blob.Properties.ContentDisposition = $"attachment; filename=\"{fileId}\"";
+            blob.SetMetadata();
+            blob.SetProperties();
+
+            var length = blob.Properties.Length;
+            if (length < expectedFileSize - leeway || length > expectedFileSize + leeway)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private async Task InitAsync()

--- a/src/Core/Services/Implementations/AzureSendFileStorageService.cs
+++ b/src/Core/Services/Implementations/AzureSendFileStorageService.cs
@@ -88,7 +88,7 @@ namespace Bit.Core.Services
             return blob.Uri + blob.GetSharedAccessSignature(accessPolicy);
         }
 
-        public async Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize, long leeway)
+        public async Task<bool> ValidateFileAsync(Send send, string fileId, long expectedFileSize, long leeway)
         {
             await InitAsync();
 

--- a/src/Core/Services/Implementations/LocalSendStorageService.cs
+++ b/src/Core/Services/Implementations/LocalSendStorageService.cs
@@ -4,6 +4,7 @@ using System;
 using Bit.Core.Models.Table;
 using Bit.Core.Settings;
 using System.Linq;
+using Bit.Core.Enums;
 
 namespace Bit.Core.Services
 {
@@ -14,6 +15,7 @@ namespace Bit.Core.Services
 
         private string RelativeFilePath(Send send, string fileID) => $"{send.Id}/{fileID}";
         private string FilePath(Send send, string fileID) => $"{_baseDirPath}/{RelativeFilePath(send, fileID)}";
+        public FileUploadType FileUploadType => FileUploadType.Direct;
 
         public LocalSendStorageService(
             GlobalSettings globalSettings)
@@ -83,5 +85,9 @@ namespace Bit.Core.Services
 
             return Task.FromResult(0);
         }
+
+        public Task<string> GetSendFileUploadUrlAsync(Send send, string fileId) => throw new NotImplementedException();
+        public Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize) => throw new NotImplementedException();
+
     }
 }

--- a/src/Core/Services/Implementations/LocalSendStorageService.cs
+++ b/src/Core/Services/Implementations/LocalSendStorageService.cs
@@ -5,6 +5,7 @@ using Bit.Core.Models.Table;
 using Bit.Core.Settings;
 using System.Linq;
 using Bit.Core.Enums;
+using System.Linq;
 
 namespace Bit.Core.Services
 {

--- a/src/Core/Services/Implementations/LocalSendStorageService.cs
+++ b/src/Core/Services/Implementations/LocalSendStorageService.cs
@@ -5,7 +5,6 @@ using Bit.Core.Models.Table;
 using Bit.Core.Settings;
 using System.Linq;
 using Bit.Core.Enums;
-using System.Linq;
 
 namespace Bit.Core.Services
 {
@@ -17,8 +16,6 @@ namespace Bit.Core.Services
         private string RelativeFilePath(Send send, string fileID) => $"{send.Id}/{fileID}";
         private string FilePath(Send send, string fileID) => $"{_baseDirPath}/{RelativeFilePath(send, fileID)}";
         public FileUploadType FileUploadType => FileUploadType.Direct;
-        private string RelativeFilePath(Send send, string fileID) => $"{send.Id}/{fileID}";
-        private string FilePath(Send send, string fileID) => $"{_baseDirPath}/{RelativeFilePath(send, fileID)}";
 
         public LocalSendStorageService(
             GlobalSettings globalSettings)
@@ -92,21 +89,22 @@ namespace Bit.Core.Services
         public Task<string> GetSendFileUploadUrlAsync(Send send, string fileId)
             => Task.FromResult($"/sends/{send.Id}/file/{fileId}");
 
-        public Task<bool> ValidateFileAsync(Send send, string fileId, long expectedFileSize, long leeway)
+        public Task<(bool, long?)> ValidateFileAsync(Send send, string fileId, long expectedFileSize, long leeway)
         {
+            long? length = null;
             var path = FilePath(send, fileId);
             if (!File.Exists(path))
             {
-                return Task.FromResult(false);
+                return Task.FromResult((false, length));
             }
 
-            var fileInfo = new FileInfo(path);
-            if (expectedFileSize < fileInfo.Length - leeway || expectedFileSize > fileInfo.Length + leeway)
+            length = new FileInfo(path).Length;
+            if (expectedFileSize < length - leeway || expectedFileSize > length + leeway)
             {
-                return Task.FromResult(false);
+                return Task.FromResult((false, length));
             }
 
-            return Task.FromResult(true);
+            return Task.FromResult((true, length));
         }
     }
 }

--- a/src/Core/Services/Implementations/LocalSendStorageService.cs
+++ b/src/Core/Services/Implementations/LocalSendStorageService.cs
@@ -86,8 +86,12 @@ namespace Bit.Core.Services
             return Task.FromResult(0);
         }
 
-        public Task<string> GetSendFileUploadUrlAsync(Send send, string fileId) => throw new NotImplementedException();
-        public Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize) => throw new NotImplementedException();
+        public Task<string> GetSendFileUploadUrlAsync(Send send, string fileId)
+            => Task.FromResult($"/sends/{send.Id}/file/{fileId}");
+
+        // Validation of local files is handled when they are direct uploaded
+        public Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize, long leeway) =>
+            Task.FromResult(true);
 
     }
 }

--- a/src/Core/Services/Implementations/SendService.cs
+++ b/src/Core/Services/Implementations/SendService.cs
@@ -28,7 +28,7 @@ namespace Bit.Core.Services
         private readonly IReferenceEventService _referenceEventService;
         private readonly GlobalSettings _globalSettings;
         private readonly ICurrentContext _currentContext;
-        private const long _fileSizeLeeway = 1024;
+        private const long _fileSizeLeeway = 1024L * 1024L; // 1MB
 
         public SendService(
             ISendRepository sendRepository,

--- a/src/Core/Services/Implementations/SendService.cs
+++ b/src/Core/Services/Implementations/SendService.cs
@@ -140,25 +140,27 @@ namespace Bit.Core.Services
 
             var data = JsonConvert.DeserializeObject<SendFileData>(send.Data);
 
-            if (stream.Length < data.Size - _fileSizeLeeway || stream.Length > data.Size + _fileSizeLeeway)
-            {
-                throw new BadRequestException("Stream size does not match expected size.");
-            }
-
             await _sendFileStorageService.UploadNewFileAsync(stream, send, data.Id);
+
+            if (!await ValidateSendFile(send))
+            {
+                throw new BadRequestException("File received does not match expected file length.");
+            }
         }
 
-        public async Task ValidateSendFile(Send send)
+        public async Task<bool> ValidateSendFile(Send send)
         {
             var fileData = JsonConvert.DeserializeObject<SendFileData>(send.Data);
 
-            var valid = await _sendFileStorageService.ValidateFile(send, fileData.Id, fileData.Size, _fileSizeLeeway);
+            var valid = await _sendFileStorageService.ValidateFileAsync(send, fileData.Id, fileData.Size, _fileSizeLeeway);
 
             if (!valid)
             {
                 // File reported differs in size from that promised. Must be a rogue client. Delete Send
                 await DeleteSendAsync(send);
             }
+
+            return valid;
         }
 
         public async Task DeleteSendAsync(Send send)

--- a/src/Core/Services/Implementations/SendService.cs
+++ b/src/Core/Services/Implementations/SendService.cs
@@ -74,51 +74,21 @@ namespace Bit.Core.Services
             }
         }
 
-        public async Task CreateSendAsync(Send send, SendFileData data, Stream stream, long requestLength)
+        public async Task<string> SaveFileSendAsync(Send send, SendFileData data, long fileLength)
         {
             if (send.Type != SendType.File)
             {
                 throw new BadRequestException("Send is not of type \"file\".");
             }
 
-            if (requestLength < 1)
+            if (fileLength < 1)
             {
                 throw new BadRequestException("No file data.");
             }
 
-            var storageBytesRemaining = 0L;
-            if (send.UserId.HasValue)
-            {
-                var user = await _userRepository.GetByIdAsync(send.UserId.Value);
-                if (!(await _userService.CanAccessPremium(user)))
-                {
-                    throw new BadRequestException("You must have premium status to use file sends.");
-                }
+            var storageBytesRemaining = await StorageRemainingForSendAsync(send);
 
-                if (user.Premium)
-                {
-                    storageBytesRemaining = user.StorageBytesRemaining();
-                }
-                else
-                {
-                    // Users that get access to file storage/premium from their organization get the default
-                    // 1 GB max storage.
-                    storageBytesRemaining = user.StorageBytesRemaining(
-                        _globalSettings.SelfHosted ? (short)10240 : (short)1);
-                }
-            }
-            else if (send.OrganizationId.HasValue)
-            {
-                var org = await _organizationRepository.GetByIdAsync(send.OrganizationId.Value);
-                if (!org.MaxStorageGb.HasValue)
-                {
-                    throw new BadRequestException("This organization cannot use file sends.");
-                }
-
-                storageBytesRemaining = org.StorageBytesRemaining();
-            }
-
-            if (storageBytesRemaining < requestLength)
+            if (storageBytesRemaining < fileLength)
             {
                 throw new BadRequestException("Not enough storage available.");
             }
@@ -152,6 +122,19 @@ namespace Bit.Core.Services
                 // Clean up since this is not transactional
                 await _sendFileStorageService.DeleteFileAsync(send, fileId);
                 throw;
+            }
+        }
+
+        public async Task ValidateSendFile(Send send)
+        {
+            var fileData = JsonConvert.DeserializeObject<SendFileData>(send.Data);
+
+            var valid = await _sendFileStorageService.ValidateFile(send, fileData.Id, fileData.Size);
+
+            if (!valid)
+            {
+                // File reported differs in size from that promised. Must be a rogue client. Delete Send
+                await DeleteSendAsync(send);
             }
         }
 
@@ -278,6 +261,43 @@ namespace Bit.Core.Services
                     throw new BadRequestException("Due to an Enterprise Policy, you are only able to delete an existing Send.");
                 }
             }
+        }
+
+        private async Task<long> StorageRemainingForSendAsync(Send send)
+        {
+            var storageBytesRemaining = 0L;
+            if (send.UserId.HasValue)
+            {
+                var user = await _userRepository.GetByIdAsync(send.UserId.Value);
+                if (!await _userService.CanAccessPremium(user))
+                {
+                    throw new BadRequestException("You must have premium status to use file sends.");
+                }
+
+                if (user.Premium)
+                {
+                    storageBytesRemaining = user.StorageBytesRemaining();
+                }
+                else
+                {
+                    // Users that get access to file storage/premium from their organization get the default
+                    // 1 GB max storage.
+                    storageBytesRemaining = user.StorageBytesRemaining(
+                        _globalSettings.SelfHosted ? (short)10240 : (short)1);
+                }
+            }
+            else if (send.OrganizationId.HasValue)
+            {
+                var org = await _organizationRepository.GetByIdAsync(send.OrganizationId.Value);
+                if (!org.MaxStorageGb.HasValue)
+                {
+                    throw new BadRequestException("This organization cannot use file sends.");
+                }
+
+                storageBytesRemaining = org.StorageBytesRemaining();
+            }
+
+            return storageBytesRemaining;
         }
     }
 }

--- a/src/Core/Services/NoopImplementations/NoopSendFileStorageService.cs
+++ b/src/Core/Services/NoopImplementations/NoopSendFileStorageService.cs
@@ -40,7 +40,7 @@ namespace Bit.Core.Services
             return Task.FromResult((string)null);
         }
 
-        public Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize)
+        public Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize, long leeway)
         {
             return Task.FromResult(false);
         }

--- a/src/Core/Services/NoopImplementations/NoopSendFileStorageService.cs
+++ b/src/Core/Services/NoopImplementations/NoopSendFileStorageService.cs
@@ -2,11 +2,14 @@
 using System.IO;
 using System;
 using Bit.Core.Models.Table;
+using Bit.Core.Enums;
 
 namespace Bit.Core.Services
 {
     public class NoopSendFileStorageService : ISendFileStorageService
     {
+        public FileUploadType FileUploadType => FileUploadType.Direct;
+
         public Task UploadNewFileAsync(Stream stream, Send send, string attachmentId)
         {
             return Task.FromResult(0);
@@ -30,6 +33,16 @@ namespace Bit.Core.Services
         public Task<string> GetSendFileDownloadUrlAsync(Send send, string fileId)
         {
             return Task.FromResult((string)null);
+        }
+
+        public Task<string> GetSendFileUploadUrlAsync(Send send, string fileId)
+        {
+            return Task.FromResult((string)null);
+        }
+
+        public Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize)
+        {
+            return Task.FromResult(false);
         }
     }
 }

--- a/src/Core/Services/NoopImplementations/NoopSendFileStorageService.cs
+++ b/src/Core/Services/NoopImplementations/NoopSendFileStorageService.cs
@@ -40,9 +40,9 @@ namespace Bit.Core.Services
             return Task.FromResult((string)null);
         }
 
-        public Task<bool> ValidateFileAsync(Send send, string fileId, long expectedFileSize, long leeway)
+        public Task<(bool, long?)> ValidateFileAsync(Send send, string fileId, long expectedFileSize, long leeway)
         {
-            return Task.FromResult(false);
+            return Task.FromResult((false, default(long?)));
         }
     }
 }

--- a/src/Core/Services/NoopImplementations/NoopSendFileStorageService.cs
+++ b/src/Core/Services/NoopImplementations/NoopSendFileStorageService.cs
@@ -40,7 +40,7 @@ namespace Bit.Core.Services
             return Task.FromResult((string)null);
         }
 
-        public Task<bool> ValidateFile(Send send, string fileId, long expectedFileSize, long leeway)
+        public Task<bool> ValidateFileAsync(Send send, string fileId, long expectedFileSize, long leeway)
         {
             return Task.FromResult(false);
         }


### PR DESCRIPTION
# Overview

This PR is the second half of #1174. It creates endpoints to allow direct upload to Azure blob storage and local storage. It also provides renewed upload URLs if permissions expire, validates file upload sizes, and locks down Send writes once size is validated.

# Files Changed
* **Api.csproj**: Add event grid nuget dependency. This package allows for easier integration with Azure Event Grid, which is used to verify Send file sizes.
* **SendsController.cs**: New endpoints:
  * **PostFile (v2)**: Creates a file type send and get a URL/SendResponse to upload the file to. FileUploadType is used to specify Azure vs Direct upload. This request makes and validates a send based on a promised file size. This is checked upon actual file upload.
  * **RenewFileUploadUrl**: Verifies a Send exists, belongs to the user, and has not yet been written (`validated == false`), then provides a new upload URL to allow for extended file operations.
  * **PostFileForExistingSend**: The API endpoint for localStorage deployments. This maintains the 100MB upload limit, uploads the file to local storage. SendService also validates the length of the received file stream is within a grace size.
  * **AzureValidateFile**: Azure event webhook endpoint. Accepts Azure Event Grid Event POSTs and handles blobCreate events, validating the final blob size. This method blocks the client's return from blob create writes.
* **ApiHelpers.cs**: Azure requires a response verification code to prove we own the webhook endpoint we specify. This helper automatically handles Verification events and accepts a Dictionary of event handlers to call for other Azure events.
* **MultipartFormDataHelper.cs**: Add overload to GetSendFileAsync where formData contains only file data now since the URL has the send Id and file ID that have already been created. The old overload still exists to support old clients.
* **FileUploadType.cs**: Specifies the method of uploading a file. Direct is direct to Bitwarden. Azure is an Azure Upload. This is used by the client to upload in the appropriate manner.
* **SendRequestModel.cs**: Optionally provide a hint of the File Size that will be uploaded for this Send. The FileLength is required for File Sends and ignored for Text sends.
* **SendFileUploadDataResponseModel**: Specifies the Send URL, UploadType, and Generated Send. This is the response to a request to make a new File Type Send.
* **SendFileData**: Add Validated bool to data model. This defaults to `true` so existing sends cannot be updated by requesting an upload URL for them. Send Data Creations must, unfortunately, specify this value as false upon instantiating new SendFileData.
* **ISendService/SendService.cs**: 
  * **FileUploadType**: specify the file upload method to the client. Current options are `Direct` and `Azure`. 
  * **SaveFileSendAsync**: Creates a File Send without file data and responds with a string to upload the file data to.
  * **UploadFileToExistingSend**: The local storage endpoint. Should not be used for Azure deployments. Validates existence of Send, stores the stream, and validates its size prior to returning. Throws in the event of a size mismatch since the client will correctly interpret that throw as a toast error.
  * **ValidateSendFile.cs**: Simply validates the specified file and deletes the send if it does not mesh within a reasonable leeway (set to 1MB). Updates Send's data with size and sets validation to true.
* **AzureSendFileStorageService.cs**:
  * **GetSendUploadUrl**: Uses SAS string to authorize a 1 min create permission to the specified blob. This requires a few Azure settings
    1. CORS for blob storage needs to be set to allow any origin PUT
    2. The `sendfiles` container should have permissions set to off
  * **ValidateFile**: Called from the Azure event webhook upon blob creation (which occurs after the file is finished uploading). Pulls the blob's size and sets some metadata/property attributes that could not be set prior to creation. We could offload this to the clients, but it makes sense to keep this file organization stuff in the server. If the size is not roughly equal to expected, returns false to indicate the Send should be removed due to un-validated file size. Always returns size of the blob (null if not found). This allows SendService to do some additional work updating db 
* **LocalSendFileStorageService**: Validates that file on disk equals expected file size. We need to write to disk first since HttpStreams have no known length until they're read and we don't want to risk storing a huge file in memory to figure out the size.
* **NoopSendFileStorageService**: Noop implementations. 

# Required Azure Changes
1. CORS for blob storage needs to be set to allow any orgin for GET and PUT methods (upload is PUT only, but GET is needed for the download portion).
2. The `sendfiles` container should have permissions set to off
3. Specify webhook event for blob creation with filters defined by @joseph-flinn. Endpoint is `<<apiUrl>>/sends/file/validate/azure`

# Testing requirements

Need to test upload and download to both local and Azure hosted environments.

Need to test using both old and new client, to make sure original Send upload implementation is not broken.

I've tested lying about file size, but a second set of eyes on that is a good idea.

The above require access to bitwarden/web#875 for the new client implementation