### PR TITLE
Push syncs on Send Access

### DIFF
--- a/src/Core/Services/Implementations/SendService.cs
+++ b/src/Core/Services/Implementations/SendService.cs
@@ -212,7 +212,7 @@ namespace Bit.Core.Services
             }
 
             send.AccessCount++;
-            await SaveSendAsync(send);
+            await _sendRepository.ReplaceAsync(send);
             return (await _sendFileStorageService.GetSendFileDownloadUrlAsync(send, fileId), false, false);
         }
 
@@ -234,7 +234,7 @@ namespace Bit.Core.Services
                 send.AccessCount++;
             }
 
-            await SaveSendAsync(send);
+            await _sendRepository.ReplaceAsync(send);
             await RaiseReferenceEventAsync(send, ReferenceEventType.SendAccessed);
             return (send, false, false);
         }

--- a/src/Core/Services/Implementations/SendService.cs
+++ b/src/Core/Services/Implementations/SendService.cs
@@ -213,6 +213,7 @@ namespace Bit.Core.Services
 
             send.AccessCount++;
             await _sendRepository.ReplaceAsync(send);
+            await _pushService.PushSyncSendUpdateAsync(send);
             return (await _sendFileStorageService.GetSendFileDownloadUrlAsync(send, fileId), false, false);
         }
 
@@ -235,6 +236,7 @@ namespace Bit.Core.Services
             }
 
             await _sendRepository.ReplaceAsync(send);
+            await _pushService.PushSyncSendUpdateAsync(send);
             await RaiseReferenceEventAsync(send, ReferenceEventType.SendAccessed);
             return (send, false, false);
         }

--- a/src/Core/Services/Implementations/SendService.cs
+++ b/src/Core/Services/Implementations/SendService.cs
@@ -212,7 +212,7 @@ namespace Bit.Core.Services
             }
 
             send.AccessCount++;
-            await _sendRepository.ReplaceAsync(send);
+            await SaveSendAsync(send);
             return (await _sendFileStorageService.GetSendFileDownloadUrlAsync(send, fileId), false, false);
         }
 
@@ -234,7 +234,7 @@ namespace Bit.Core.Services
                 send.AccessCount++;
             }
 
-            await _sendRepository.ReplaceAsync(send);
+            await SaveSendAsync(send);
             await RaiseReferenceEventAsync(send, ReferenceEventType.SendAccessed);
             return (send, false, false);
         }


### PR DESCRIPTION
# Overview

Use the Service's Save method when accessing to speed up syncing of Access Count.

# Files Changed

* **SendService.cs**: We already have a helper method that saves the Send appropriately. Just use it when upserting into the repository.