### PR TITLE
Fixes #1101: Extend email column length to 256 characters (Postgres)

### DIFF
--- a/src/Sql/PostgreSQL/Functions/user_search.sql
+++ b/src/Sql/PostgreSQL/Functions/user_search.sql
@@ -11,7 +11,7 @@ LANGUAGE 'plpgsql'
 AS
 $BODY$
 DECLARE 
-    email_like_search VARCHAR(55) = _email || '%';
+    email_like_search VARCHAR(261) = _email || '%';
 
 BEGIN
     RETURN QUERY

--- a/src/Sql/PostgreSQL/Tables/installation.sql
+++ b/src/Sql/PostgreSQL/Tables/installation.sql
@@ -3,7 +3,7 @@
 
 CREATE TABLE IF NOT EXISTS installation (
     id            UUID             NOT NULL,
-    email         VARCHAR (50)     NOT NULL,
+    email         VARCHAR (256)    NOT NULL,
     key           VARCHAR (150)    NOT NULL,
     enabled       BIT              NOT NULL,
     creation_date TIMESTAMPTZ     NOT NULL,

--- a/src/Sql/PostgreSQL/Tables/organization.sql
+++ b/src/Sql/PostgreSQL/Tables/organization.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS organization (
     business_address_3      VARCHAR (50)  NULL,
     business_country        VARCHAR (2)   NULL,
     business_tax_number     VARCHAR (30)  NULL,
-    billing_email           VARCHAR (50)  NOT NULL,
+    billing_email           VARCHAR (256) NOT NULL,
     plan                    VARCHAR (50)  NOT NULL,
     plan_type               SMALLINT      NOT NULL,
     seats                   SMALLINT      NULL,

--- a/src/Sql/PostgreSQL/Tables/organization_user.sql
+++ b/src/Sql/PostgreSQL/Tables/organization_user.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS organization_user (
     id              UUID          NOT NULL,
     organization_id UUID          NOT NULL,
     user_id         UUID          NULL,
-    email           VARCHAR (50)  NULL,
+    email           VARCHAR (256) NULL,
     key             TEXT          NULL,
     status          SMALLINT      NOT NULL,
     type            SMALLINT      NOT NULL,

--- a/src/Sql/PostgreSQL/Tables/user.sql
+++ b/src/Sql/PostgreSQL/Tables/user.sql
@@ -3,7 +3,7 @@
 CREATE TABLE "user" (
     id                                 UUID          NOT NULL,
     name                               VARCHAR (50)  NULL,
-    email                              VARCHAR (50)  NOT NULL,
+    email                              VARCHAR (256) NOT NULL,
     email_verified                     BOOLEAN       NOT NULL,
     master_password                    VARCHAR (300) NOT NULL,
     master_password_hint               VARCHAR (50)  NULL,


### PR DESCRIPTION
Fixes #1101

Due to the limitations in the database schema no email address longer than 50 characters could be saved. This PR fixes this and extends it to 256 characters.