### PR TITLE
Use Any from Linq, not internal Entity Framework Any

### DIFF
--- a/src/Admin/Jobs/DeleteSendsJob.cs
+++ b/src/Admin/Jobs/DeleteSendsJob.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using System.Linq;
 using Bit.Core;
 using Bit.Core.Context;
 using Bit.Core.Jobs;


### PR DESCRIPTION
# Overview

Send Delete Job is currently using an internal Entity Framework API for an `IEnumberal<>.Any()` implementation. Change this to using Linq.

I doubt this is critical enough to delay release, but we shouldn't use this internal API when we don't need to.