### PR TITLE
MultiplartSectionBody streams have 0 length until read.

### DIFF
--- a/src/Core/Services/Implementations/CipherService.cs
+++ b/src/Core/Services/Implementations/CipherService.cs
@@ -222,10 +222,11 @@ namespace Bit.Core.Services
                 AttachmentId = attachmentId,
                 FileName = fileName,
                 Key = key,
-                Size = stream.Length
             };
 
             await _attachmentStorageService.UploadNewAttachmentAsync(stream, cipher, data);
+            // Must read stream length after it has been saved, otherwise it's 0
+            data.Size = stream.Length;
 
             try
             {


### PR DESCRIPTION
# Overview

Fixes https://app.asana.com/0/1199659118818122/1200034924770277/f.
For external viewers or this PR: a bug where Cipher attachments were always shown as having 0 length

Introduced in #1153

# Files Changed

* **CipherService**: When saving the length of a body stream from a multipart form data, you must first read the body. Here, this is done by the storage service.