### PR TITLE
Outdated link

### DIFF
--- a/scripts/bitwarden.sh
+++ b/scripts/bitwarden.sh
@@ -96,7 +96,7 @@ renewcert
 rebuild
 help
 
-See more at https://bitwarden.com/help/article/install-on-premise/#script-commands
+See more at https://bitwarden.com/help/article/install-on-premise/#script-commands-reference
 
 EOT
 }


### PR DESCRIPTION
The anchor https://bitwarden.com/help/article/install-on-premise/#script-commands no longer exist, it should be https://bitwarden.com/help/article/install-on-premise/#script-commands-reference