### PR TITLE
Correct localhost port number in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ dotnet build
 dotnet run
 ```
 
-visit http://localhost:5000/alive
+visit http://localhost:4000/alive
 
 ### Identity
 


### PR DESCRIPTION
### Closes:
https://github.com/bitwarden/server/issues/1037

### Additional Info:
As reported by @mvakili, the README seems to have a typo. Correcting localhost to match [appsettings.json](https://github.com/bitwarden/server/blob/master/src/Api/appsettings.json) and the [CONTRIBUTING](https://github.com/bitwarden/server/blob/52d29aef947d58ddb4d010d1458ea76bbf27140f/CONTRIBUTING.md#testing-your-deployment) markdown file