### PR TITLE
Don't use dev licensing cert if self-hosted

### DIFF
--- a/src/Core/Services/Implementations/LicensingService.cs
+++ b/src/Core/Services/Implementations/LicensingService.cs
@@ -46,7 +46,8 @@ namespace Bit.Core.Services
             _logger = logger;
             _globalSettings = globalSettings;
 
-            var certThumbprint = environment.IsDevelopment() ? "207E64A231E8AA32AAF68A61037C075EBEBD553F" :
+            var certThumbprint = environment.IsDevelopment() && !_globalSettings.SelfHosted ?
+                "207E64A231E8AA32AAF68A61037C075EBEBD553F" :
                 "‎B34876439FCDA2846505B2EFBBA6C4A951313EBE";
             if (_globalSettings.SelfHosted)
             {


### PR DESCRIPTION
## Objective
Fix #1198: when a local dev environment is self-hosted, the `identity` project throws the following error:
```
      Starting IdentityServer4 version 4.0.4+1b36d1b414f4e0f965af97ab2a7e9dd1b5167bca
crit: Microsoft.AspNetCore.Hosting.Diagnostics[6]
      Application startup exception
System.Exception: Invalid licensing certificate.
```

## Code changes
The problem is that:
* the user is self-hosting, so `LicensingService` uses the `core/src/licensing.cer` certificate; but
* because the user is in a development environment, it is checked against the thumbprint for our internal development certificate (ending in `553F`)

Our development certificate is not publicly available, so its thumbprint should not be required if the user is developing in a self-hosted environment (which indicates a community member). I've changed the condition that sets the thumbprint accordingly.

I haven't done anything with licensing before, so happy to change if I've misunderstood something here.

Note to self: I need to remove the workaround in `contributing.md` once this is fixed.