### PR TITLE
Fix no licence expiration date on self-hosted

### DIFF
--- a/src/Core/Models/Business/UserLicense.cs
+++ b/src/Core/Models/Business/UserLicense.cs
@@ -27,7 +27,7 @@ namespace Bit.Core.Models.Business
             MaxStorageGb = user.MaxStorageGb;
             Issued = DateTime.UtcNow;
             Expires = subscriptionInfo?.UpcomingInvoice?.Date != null ?
-                subscriptionInfo?.UpcomingInvoice?.Date?.AddDays(7) :
+                subscriptionInfo.UpcomingInvoice.Date?.AddDays(7) :
                 user.PremiumExpirationDate?.AddDays(7);
             Refresh = subscriptionInfo?.UpcomingInvoice?.Date;
             Trial = (subscriptionInfo?.Subscription?.TrialEndDate.HasValue ?? false) &&

--- a/src/Core/Models/Business/UserLicense.cs
+++ b/src/Core/Models/Business/UserLicense.cs
@@ -26,7 +26,9 @@ namespace Bit.Core.Models.Business
             Premium = user.Premium;
             MaxStorageGb = user.MaxStorageGb;
             Issued = DateTime.UtcNow;
-            Expires = subscriptionInfo?.UpcomingInvoice?.Date?.AddDays(7);
+            Expires = subscriptionInfo?.UpcomingInvoice?.Date != null ?
+                subscriptionInfo?.UpcomingInvoice?.Date?.AddDays(7) :
+                user.PremiumExpirationDate?.AddDays(7);
             Refresh = subscriptionInfo?.UpcomingInvoice?.Date;
             Trial = (subscriptionInfo?.Subscription?.TrialEndDate.HasValue ?? false) &&
                 subscriptionInfo.Subscription.TrialEndDate.Value > DateTime.UtcNow;

--- a/src/Core/Models/Business/UserLicense.cs
+++ b/src/Core/Models/Business/UserLicense.cs
@@ -27,7 +27,7 @@ namespace Bit.Core.Models.Business
             MaxStorageGb = user.MaxStorageGb;
             Issued = DateTime.UtcNow;
             Expires = subscriptionInfo?.UpcomingInvoice?.Date != null ?
-                subscriptionInfo.UpcomingInvoice.Date?.AddDays(7) :
+                subscriptionInfo.UpcomingInvoice.Date.Value.AddDays(7) :
                 user.PremiumExpirationDate?.AddDays(7);
             Refresh = subscriptionInfo?.UpcomingInvoice?.Date;
             Trial = (subscriptionInfo?.Subscription?.TrialEndDate.HasValue ?? false) &&


### PR DESCRIPTION
## Objective
Fix: https://app.asana.com/0/1169444489336079/1200022338203644/

## Code changes
The problem is that the exported license expiration date (and therefore the premium expiration date in the self-hosted instance) comes from the next billing date (plus 7 days). Therefore, if the subscription has been cancelled, there is no next billing date, and the expiration date is set to `null`.

I have fixed this by using `user.PremiumExpirationDate` (plus 7 days) as the expiration date if the next billing date is null. `user.PremiumExpirationDate` is set and updated separately and is not wiped when the billing cycle is cancelled.

Note that this is what the constructor does if no `SubscriptionInfo` is supplied, so I presume this is fine, just not preferable to using the `subscriptionInfo` if available.

## Testing considerations
Refer to the steps to reproduce in Asana.