### PR TITLE
Add amazon.{pl,se} to Amazon equivalent domains

### DIFF
--- a/src/Core/Utilities/StaticStore.cs
+++ b/src/Core/Utilities/StaticStore.cs
@@ -30,7 +30,7 @@ namespace Bit.Core.Utilities
             GlobalDomains.Add(GlobalEquivalentDomainsType.Avon, new List<string> { "avon.com", "youravon.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Diapers, new List<string> { "diapers.com", "soap.com", "wag.com", "yoyo.com", "beautybar.com", "casa.com", "afterschool.com", "vine.com", "bookworm.com", "look.com", "vinemarket.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Contacts, new List<string> { "1800contacts.com", "800contacts.com" });
-            GlobalDomains.Add(GlobalEquivalentDomainsType.Amazon, new List<string> { "amazon.com", "amazon.ae", "amazon.ca", "amazon.co.uk", "amazon.com.au", "amazon.com.br", "amazon.com.mx", "amazon.com.tr", "amazon.de", "amazon.es", "amazon.fr", "amazon.in", "amazon.it", "amazon.nl", "amazon.sa", "amazon.sg" });
+            GlobalDomains.Add(GlobalEquivalentDomainsType.Amazon, new List<string> { "amazon.com", "amazon.ae", "amazon.ca", "amazon.co.uk", "amazon.com.au", "amazon.com.br", "amazon.com.mx", "amazon.com.tr", "amazon.de", "amazon.es", "amazon.fr", "amazon.in", "amazon.it", "amazon.nl", "amazon.pl", "amazon.sa", "amazon.se", "amazon.sg" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Cox, new List<string> { "cox.com", "cox.net", "coxbusiness.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Norton, new List<string> { "mynortonaccount.com", "norton.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Verizon, new List<string> { "verizon.com", "verizon.net" });


### PR DESCRIPTION
# This PR:
&nbsp;
- adds the freshly launched `amazon.pl` — see [the press release](https://www.aboutamazon.eu/press-release/amazon-pl-launches-in-poland). :bulb:

![amazon.pl](https://user-images.githubusercontent.com/4764956/111343739-043b6480-867c-11eb-968b-a2a16da3849c.png)
:arrow_right_hook: _As you can see, I can log into it with an Amazon login created on `amazon.fr`._
&nbsp;
&nbsp;

- adds the recently launched `amazon.se` — see [the press release](https://www.aboutamazon.eu/press-release/amazon-se-launches-in-sweden). :bulb:

![amazon.se](https://user-images.githubusercontent.com/4764956/111343776-0d2c3600-867c-11eb-9cf0-8ef2f807511a.png)
:arrow_right_hook: _As you can see, I can log into it with an Amazon login created on `amazon.fr`._
&nbsp;
&nbsp;

<details>
<summary>Read more …</summary>
&nbsp;

# Credits
- Existence of the very recent `amazon.pl` discovered [here](https://github.com/apple/password-manager-resources/pull/434) (added by @maxromanovsky) and
- existence of the new `amazon.se` discovered [here](https://github.com/apple/password-manager-resources/pull/386) (added by @larstomas). :thumbsup:

:bulb: Official full list available [here](https://www.amazon.com/gp/navigation-country/select-country/).
_(Regarding the absence in the Bitwarden list of `amazon.cn` and `amazon.co.jp`, see https://github.com/bitwarden/server/pull/775 and https://github.com/bitwarden/server/pull/368 for the explanation.)_
&nbsp;

# Info
:apple: On the **Apple** side, [amazon.ae and amazon.sa](https://github.com/apple/password-manager-resources/pull/422) having been merged recently, as soon as [amazon.pl](https://github.com/apple/password-manager-resources/pull/434) is merged, their list will be up-to-date (as of March 2021).

:key: On the **Bitwarden** side, this will be the case once this one is merged.
</details>