### PR TITLE
Attachment blob upload

### DIFF
--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -772,6 +772,11 @@ namespace Bit.Api.Controllers
 
                             if (cipher == null || !attachments.ContainsKey(attachmentId) || attachments[attachmentId].Validated)
                             {
+                                if (_attachmentStorageService is AzureSendFileStorageService azureFileStorageService)
+                                {
+                                    await azureFileStorageService.DeleteBlobAsync(blobName);
+                                }
+
                                 return;
                             }
 

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -584,6 +584,12 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
+            if (request.FileSize > CipherService.MAX_FILE_SIZE && !_globalSettings.SelfHosted)
+            {
+                throw new BadRequestException($"Max file size is {CipherService.MAX_FILE_SIZE_READABLE}.");
+            }
+
+
             var (attachmentId, uploadUrl) = await _cipherService.CreateAttachmentForDelayedUploadAsync(cipher, request, userId);
             return new AttachmentUploadDataResponseModel
             {

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -601,7 +601,7 @@ namespace Bit.Api.Controllers
             };
         }
 
-        [HttpGet("{id}/attachment/{attachmentId}/renew")]
+        [HttpGet("{id}/attachment/{attachmentId}")]
         public async Task<AttachmentUploadDataResponseModel> RenewFileUploadUrl(string id, string attachmentId)
         {
             var userId = _userService.GetProperUserId(User).Value;

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -12,7 +12,9 @@ using Bit.Api.Utilities;
 using System.Collections.Generic;
 using Bit.Core.Models.Table;
 using Bit.Core.Settings;
-
+using Core.Models.Data;
+using Microsoft.Azure.EventGrid.Models;
+using Bit.Core.Models.Data;
 
 namespace Bit.Api.Controllers
 {
@@ -562,6 +564,76 @@ namespace Bit.Api.Controllers
             }
         }
 
+        [HttpPost("{id}/attachment/v2")]
+        public async Task<AttachmentUploadDataResponseModel> PostAttachment(string id, [FromBody] AttachmentRequestModel request)
+        {
+            var idGuid = new Guid(id);
+            var userId = _userService.GetProperUserId(User).Value;
+            var cipher = request.AdminRequest ?
+                await _cipherRepository.GetOrganizationDetailsByIdAsync(idGuid) :
+                await _cipherRepository.GetByIdAsync(idGuid, userId);
+
+            if (cipher == null || (request.AdminRequest && (!cipher.OrganizationId.HasValue ||
+                !_currentContext.ManageAllCollections(cipher.OrganizationId.Value))))
+            {
+                throw new NotFoundException();
+            }
+
+            var (attachmentId, uploadUrl) = await _cipherService.CreateAttachmentForDelayedUploadAsync(cipher, request, userId);
+            return new AttachmentUploadDataResponseModel
+            {
+                AttachmentId = attachmentId,
+                Url = uploadUrl,
+                FileUploadType = _attachmentStorageService.FileUploadType,
+                CipherResponse = request.AdminRequest ? null : new CipherResponseModel((CipherDetails)cipher, _globalSettings),
+                CipherMiniResponse = request.AdminRequest ? new CipherMiniResponseModel(cipher, _globalSettings, cipher.OrganizationUseTotp) : null,
+            };
+        }
+
+        [HttpGet("{id}/attachment/{attachmentId}/renew")]
+        public async Task<AttachmentUploadDataResponseModel> RenewFileUploadUrl(string id, string attachmentId)
+        {
+            var userId = _userService.GetProperUserId(User).Value;
+            var cipherId = new Guid(id);
+            var cipher = await _cipherRepository.GetByIdAsync(cipherId, userId);
+            var attachments = cipher?.GetAttachments();
+
+            if (attachments == null || !attachments.ContainsKey(attachmentId))
+            {
+                throw new NotFoundException();
+            }
+
+            return new AttachmentUploadDataResponseModel
+            {
+                Url = await _attachmentStorageService.GetAttachmentUploadUrlAsync(cipher, attachments[attachmentId]),
+                FileUploadType = _attachmentStorageService.FileUploadType,
+            };
+        }
+
+        [HttpPost("{id}/attachment/{attachmentId}")]
+        [DisableFormValueModelBinding]
+        public async Task PostFileForExistingAttachment(string id, string attachmentId)
+        {
+            if (!Request?.ContentType.Contains("multipart/") ?? true)
+            {
+                throw new BadRequestException("Invalid content.");
+            }
+
+            var userId = _userService.GetProperUserId(User).Value;
+            var cipher = await _cipherRepository.GetByIdAsync(new Guid(id), userId);
+            var attachments = cipher?.GetAttachments();
+            if (attachments == null || !attachments.ContainsKey(attachmentId))
+            {
+                throw new NotFoundException();
+            }
+            var attachmentData = attachments[attachmentId];
+
+            await Request.GetFileAsync(async (stream) =>
+            {
+                await _cipherService.UploadFileForExistingAttachmentAsync(stream, cipher, attachmentData);
+            });
+        }
+
         [HttpPost("{id}/attachment")]
         [RequestSizeLimit(105_906_176)]
         [DisableFormValueModelBinding]
@@ -616,20 +688,7 @@ namespace Bit.Api.Controllers
         {
             var userId = _userService.GetProperUserId(User).Value;
             var cipher = await _cipherRepository.GetByIdAsync(new Guid(id), userId);
-            var attachments = cipher.GetAttachments();
-
-            if (!attachments.ContainsKey(attachmentId))
-            {
-                throw new NotFoundException();
-            }
-
-            var data = attachments[attachmentId];
-            var response = new AttachmentResponseModel(attachmentId, data, cipher, _globalSettings)
-            {
-                Url = await _attachmentStorageService.GetAttachmentDownloadUrlAsync(cipher, data)
-            };
-
-            return response;
+            return await _cipherService.GetAttachmentDownloadDataAsync(cipher, attachmentId);
         }
 
         [HttpPost("{id}/attachment/{attachmentId}/share")]
@@ -682,6 +741,38 @@ namespace Bit.Api.Controllers
             }
 
             await _cipherService.DeleteAttachmentAsync(cipher, attachmentId, userId, true);
+        }
+
+        [AllowAnonymous]
+        [HttpPost("attachment/validate/azure")]
+        public async Task<OkObjectResult> AzureValidateFile()
+        {
+            return await ApiHelpers.HandleAzureEvents(Request, new Dictionary<string, Func<EventGridEvent, Task>>
+            {
+                {
+                    "Microsoft.Storage.BlobCreated", async (eventGridEvent) =>
+                    {
+                        try
+                        {
+                            var blobName = eventGridEvent.Subject.Split($"{AzureAttachmentStorageService.EventGridEnabledContainerName}/blobs/")[1];
+                            var (cipherId, organizationId, attachmentId) = AzureAttachmentStorageService.IdentifiersFromBlobName(blobName);
+                            var cipher = await _cipherRepository.GetByIdAsync(new Guid(cipherId));
+                            var attachments = cipher?.GetAttachments() ?? new Dictionary<string, CipherAttachment.MetaData>();
+
+                            if (cipher == null || !attachments.ContainsKey(attachmentId) || attachments[attachmentId].Validated)
+                            {
+                                return;
+                            }
+
+                            await _cipherService.ValidateCipherAttachmentFile(cipher, attachments[attachmentId]);
+                        }
+                        catch
+                        {
+                            return;
+                        }
+                    }
+                }
+            });
         }
 
         private void ValidateAttachment()

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -756,9 +756,9 @@ namespace Bit.Api.Controllers
 
         [AllowAnonymous]
         [HttpPost("attachment/validate/azure")]
-        public async Task<OkObjectResult> AzureValidateFile()
+        public async Task<ObjectResult> AzureValidateFile()
         {
-            return await ApiHelpers.HandleAzureEvents(Request, new Dictionary<string, Func<EventGridEvent, Task>>
+            return await ApiHelpers.HandleAzureEvents(Request, _globalSettings.EventGridSecret, new Dictionary<string, Func<EventGridEvent, Task>>
             {
                 {
                     "Microsoft.Storage.BlobCreated", async (eventGridEvent) =>

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -15,6 +15,8 @@ using Bit.Core.Settings;
 using Core.Models.Data;
 using Microsoft.Azure.EventGrid.Models;
 using Bit.Core.Models.Data;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 
 namespace Bit.Api.Controllers
 {
@@ -28,6 +30,7 @@ namespace Bit.Api.Controllers
         private readonly IUserService _userService;
         private readonly IAttachmentStorageService _attachmentStorageService;
         private readonly ICurrentContext _currentContext;
+        private readonly ILogger<CiphersController> _logger;
         private readonly GlobalSettings _globalSettings;
 
         public CiphersController(
@@ -37,6 +40,7 @@ namespace Bit.Api.Controllers
             IUserService userService,
             IAttachmentStorageService attachmentStorageService,
             ICurrentContext currentContext,
+            ILogger<CiphersController> logger,
             GlobalSettings globalSettings)
         {
             _cipherRepository = cipherRepository;
@@ -45,6 +49,7 @@ namespace Bit.Api.Controllers
             _userService = userService;
             _attachmentStorageService = attachmentStorageService;
             _currentContext = currentContext;
+            _logger = logger;
             _globalSettings = globalSettings;
         }
 
@@ -766,8 +771,9 @@ namespace Bit.Api.Controllers
 
                             await _cipherService.ValidateCipherAttachmentFile(cipher, attachments[attachmentId]);
                         }
-                        catch
+                        catch (Exception e)
                         {
+                            _logger.LogError(e, $"Uncaught exception occurred while handling event grid event: {JsonConvert.SerializeObject(eventGridEvent)}");
                             return;
                         }
                     }

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -758,7 +758,7 @@ namespace Bit.Api.Controllers
         [HttpPost("attachment/validate/azure")]
         public async Task<ObjectResult> AzureValidateFile()
         {
-            return await ApiHelpers.HandleAzureEvents(Request, _globalSettings.EventGridSecret, new Dictionary<string, Func<EventGridEvent, Task>>
+            return await ApiHelpers.HandleAzureEvents(Request, new Dictionary<string, Func<EventGridEvent, Task>>
             {
                 {
                     "Microsoft.Storage.BlobCreated", async (eventGridEvent) =>

--- a/src/Api/Controllers/EmergencyAccessController.cs
+++ b/src/Api/Controllers/EmergencyAccessController.cs
@@ -163,5 +163,12 @@ namespace Bit.Api.Controllers
             var user = await _userService.GetUserByPrincipalAsync(User);
             return await _emergencyAccessService.ViewAsync(new Guid(id), user);
         }
+
+        [HttpGet("{id}/{cipherId}/attachment/{attachmentId}")]
+        public async Task<AttachmentResponseModel> GetAttachmentData(string id, string cipherId, string attachmentId)
+        {
+            var user = await _userService.GetUserByPrincipalAsync(User);
+            return await _emergencyAccessService.GetAttachmentDownloadAsync(new Guid(id), cipherId, attachmentId, user);
+        }
     }
 }

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -240,7 +240,7 @@ namespace Bit.Api.Controllers
             }
 
             var send = await _sendRepository.GetByIdAsync(new Guid(id));
-            await Request.GetSendFileAsync(async (stream) =>
+            await Request.GetFileAsync(async (stream) =>
             {
                 await _sendService.UploadFileToExistingSendAsync(stream, send);
             });

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -253,9 +253,9 @@ namespace Bit.Api.Controllers
 
         [AllowAnonymous]
         [HttpPost("file/validate/azure")]
-        public async Task<OkObjectResult> AzureValidateFile()
+        public async Task<ObjectResult> AzureValidateFile()
         {
-            return await ApiHelpers.HandleAzureEvents(Request, new Dictionary<string, Func<EventGridEvent, Task>>
+            return await ApiHelpers.HandleAzureEvents(Request, _globalSettings.EventGridSecret, new Dictionary<string, Func<EventGridEvent, Task>>
             {
                 {
                     "Microsoft.Storage.BlobCreated", async (eventGridEvent) =>

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -255,7 +255,7 @@ namespace Bit.Api.Controllers
         [HttpPost("file/validate/azure")]
         public async Task<ObjectResult> AzureValidateFile()
         {
-            return await ApiHelpers.HandleAzureEvents(Request, _globalSettings.EventGridSecret, new Dictionary<string, Func<EventGridEvent, Task>>
+            return await ApiHelpers.HandleAzureEvents(Request, new Dictionary<string, Func<EventGridEvent, Task>>
             {
                 {
                     "Microsoft.Storage.BlobCreated", async (eventGridEvent) =>

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -267,6 +267,10 @@ namespace Bit.Api.Controllers
                             var send = await _sendRepository.GetByIdAsync(new Guid(sendId));
                             if (send == null)
                             {
+                                if (_sendFileStorageService is AzureSendFileStorageService azureSendFileStorageService)
+                                {
+                                    await azureSendFileStorageService.DeleteBlobAsync(blobName);
+                                }
                                 return;
                             }
                             await _sendService.ValidateSendFile(send);

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -190,6 +190,11 @@ namespace Bit.Api.Controllers
                 throw new BadRequestException("Invalid content. File size hint is required.");
             }
 
+            if (model.FileLength.Value > SendService.MAX_FILE_SIZE)
+            {
+                throw new BadRequestException($"Max file size is {SendService.MAX_FILE_SIZE_READABLE}.");
+            }
+
             var userId = _userService.GetProperUserId(User).Value;
             var (send, data) = model.ToSend(userId, model.File.FileName, _sendService);
             var uploadUrl = await _sendService.SaveFileSendAsync(send, data, model.FileLength.Value);

--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -49,6 +49,12 @@ namespace Bit.Api
             // Data Protection
             services.AddCustomDataProtectionServices(Environment, globalSettings);
 
+            // Event Grid
+            if (!string.IsNullOrWhiteSpace(globalSettings.EventGridKey))
+            {
+                ApiHelpers.EventGridKey = globalSettings.EventGridKey;
+            }
+
             // Stripe Billing
             StripeConfiguration.ApiKey = globalSettings.StripeApiKey;
 

--- a/src/Api/Utilities/ApiHelpers.cs
+++ b/src/Api/Utilities/ApiHelpers.cs
@@ -12,6 +12,7 @@ namespace Bit.Api.Utilities
 {
     public static class ApiHelpers
     {
+        public static string EventGridKey { get; set; }
         public async static Task<T> ReadJsonFileFromBody<T>(HttpContext httpContext, IFormFile file, long maxSize = 51200)
         {
             T obj = default(T);
@@ -42,16 +43,16 @@ namespace Bit.Api.Utilities
         /// <param name="eventTypeHandlers">Dictionary of eventType strings and their associated handlers.</param>
         /// <returns>OkObjectResult</returns>
         /// <remarks>Reference https://docs.microsoft.com/en-us/azure/event-grid/receive-events</remarks>
-        public async static Task<ObjectResult> HandleAzureEvents(HttpRequest request, string key,
+        public async static Task<ObjectResult> HandleAzureEvents(HttpRequest request,
             Dictionary<string, Func<EventGridEvent, Task>> eventTypeHandlers)
         {
             var queryKey = request.Query["key"];
 
-            if (queryKey != key)
+            if (queryKey != EventGridKey)
             {
                 return new UnauthorizedObjectResult("Authentication failed. Please use a valid key.");
             }
-            
+
             var response = string.Empty;
             var requestContent = await new StreamReader(request.Body).ReadToEndAsync();
             if (string.IsNullOrWhiteSpace(requestContent))

--- a/src/Api/Utilities/ApiHelpers.cs
+++ b/src/Api/Utilities/ApiHelpers.cs
@@ -42,9 +42,16 @@ namespace Bit.Api.Utilities
         /// <param name="eventTypeHandlers">Dictionary of eventType strings and their associated handlers.</param>
         /// <returns>OkObjectResult</returns>
         /// <remarks>Reference https://docs.microsoft.com/en-us/azure/event-grid/receive-events</remarks>
-        public async static Task<OkObjectResult> HandleAzureEvents(HttpRequest request,
+        public async static Task<ObjectResult> HandleAzureEvents(HttpRequest request, string key,
             Dictionary<string, Func<EventGridEvent, Task>> eventTypeHandlers)
         {
+            var queryKey = request.Query["key"];
+
+            if (queryKey != key)
+            {
+                return new UnauthorizedObjectResult("Authentication failed. Please use a valid key.");
+            }
+            
             var response = string.Empty;
             var requestContent = await new StreamReader(request.Body).ReadToEndAsync();
             if (string.IsNullOrWhiteSpace(requestContent))

--- a/src/Api/Utilities/MultipartFormDataHelper.cs
+++ b/src/Api/Utilities/MultipartFormDataHelper.cs
@@ -108,7 +108,7 @@ namespace Bit.Api.Utilities
             }
         }
 
-        public static async Task GetSendFileAsync(this HttpRequest request, Func<Stream, Task> callback)
+        public static async Task GetFileAsync(this HttpRequest request, Func<Stream, Task> callback)
         {
             var boundary = GetBoundary(MediaTypeHeaderValue.Parse(request.ContentType),
                 _defaultFormOptions.MultipartBoundaryLengthLimit);

--- a/src/Core/Models/Api/Request/AttachmentRequestModel.cs
+++ b/src/Core/Models/Api/Request/AttachmentRequestModel.cs
@@ -2,7 +2,7 @@ namespace Bit.Core.Models.Api
 {
     public class AttachmentRequestModel
     {
-        public string key { get; set; }
+        public string Key { get; set; }
         public string FileName { get; set; }
         public long FileSize { get; set; }
         public bool AdminRequest { get; set; } = false;

--- a/src/Core/Models/Api/Request/AttachmentRequestModel.cs
+++ b/src/Core/Models/Api/Request/AttachmentRequestModel.cs
@@ -1,0 +1,10 @@
+namespace Bit.Core.Models.Api
+{
+    public class AttachmentRequestModel
+    {
+        public string key { get; set; }
+        public string FileName { get; set; }
+        public long FileSize { get; set; }
+        public bool AdminRequest { get; set; } = false;
+    }
+}

--- a/src/Core/Models/Api/Response/AttachmentUploadDataResponseModel.cs
+++ b/src/Core/Models/Api/Response/AttachmentUploadDataResponseModel.cs
@@ -1,0 +1,15 @@
+using Bit.Core.Enums;
+
+namespace Bit.Core.Models.Api
+{
+    public class AttachmentUploadDataResponseModel : ResponseModel
+    {
+        public string AttachmentId { get; set; }
+        public string Url { get; set; }
+        public FileUploadType FileUploadType { get; set; }
+        public CipherResponseModel CipherResponse { get; set; }
+        public CipherMiniResponseModel CipherMiniResponse { get; set; }
+
+        public AttachmentUploadDataResponseModel() : base("attachment-fileUpload") { }
+    }
+}

--- a/src/Core/Models/Data/CipherAttachment.cs
+++ b/src/Core/Models/Data/CipherAttachment.cs
@@ -34,6 +34,7 @@ namespace Bit.Core.Models.Data
             public string Key { get; set; }
 
             public string ContainerName { get; set; } = "attachments";
+            public bool Validated { get; set; } = true;
 
             // This is stored alongside metadata as an identifier. It does not need repeating in serialization
             [JsonIgnore]

--- a/src/Core/Services/IAttachmentStorageService.cs
+++ b/src/Core/Services/IAttachmentStorageService.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Core.Models.Data;
 using Bit.Core.Models.Table;
+using Bit.Core.Enums;
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -8,15 +9,18 @@ namespace Bit.Core.Services
 {
     public interface IAttachmentStorageService
     {
-        Task UploadNewAttachmentAsync(Stream stream, Cipher cipher, CipherAttachment.MetaData attachment);
-        Task UploadShareAttachmentAsync(Stream stream, Guid cipherId, Guid organizationId, CipherAttachment.MetaData attachment);
+        FileUploadType FileUploadType { get; }
+        Task UploadNewAttachmentAsync(Stream stream, Cipher cipher, CipherAttachment.MetaData attachmentData);
+        Task UploadShareAttachmentAsync(Stream stream, Guid cipherId, Guid organizationId, CipherAttachment.MetaData attachmentData);
         Task StartShareAttachmentAsync(Guid cipherId, Guid organizationId, CipherAttachment.MetaData attachmentData);
         Task RollbackShareAttachmentAsync(Guid cipherId, Guid organizationId, CipherAttachment.MetaData attachmentData, string originalContainer);
         Task CleanupAsync(Guid cipherId);
-        Task DeleteAttachmentAsync(Guid cipherId, CipherAttachment.MetaData attachment);
+        Task DeleteAttachmentAsync(Guid cipherId, CipherAttachment.MetaData attachmentData);
         Task DeleteAttachmentsForCipherAsync(Guid cipherId);
         Task DeleteAttachmentsForOrganizationAsync(Guid organizationId);
         Task DeleteAttachmentsForUserAsync(Guid userId);
+        Task<string> GetAttachmentUploadUrlAsync(Cipher cipher, CipherAttachment.MetaData attachmentData);
         Task<string> GetAttachmentDownloadUrlAsync(Cipher cipher, CipherAttachment.MetaData attachmentData);
+        Task<(bool, long?)> ValidateFileAsync(Cipher cipher, CipherAttachment.MetaData attachmentData, long leeway);
     }
 }

--- a/src/Core/Services/ICipherService.cs
+++ b/src/Core/Services/ICipherService.cs
@@ -4,6 +4,8 @@ using Bit.Core.Models.Table;
 using Core.Models.Data;
 using System;
 using System.IO;
+using Bit.Core.Models.Api;
+using Bit.Core.Models.Data;
 
 namespace Bit.Core.Services
 {
@@ -13,6 +15,8 @@ namespace Bit.Core.Services
             bool skipPermissionCheck = false, bool limitCollectionScope = true);
         Task SaveDetailsAsync(CipherDetails cipher, Guid savingUserId, DateTime? lastKnownRevisionDate,
             IEnumerable<Guid> collectionIds = null, bool skipPermissionCheck = false);
+        Task<(string attachmentId, string uploadUrl)> CreateAttachmentForDelayedUploadAsync(Cipher cipher,
+            AttachmentRequestModel request, Guid savingUserId);
         Task CreateAttachmentAsync(Cipher cipher, Stream stream, string fileName, string key,
             long requestLength, Guid savingUserId, bool orgAdmin = false);
         Task CreateAttachmentShareAsync(Cipher cipher, Stream stream, long requestLength, string attachmentId,
@@ -37,5 +41,8 @@ namespace Bit.Core.Services
         Task SoftDeleteManyAsync(IEnumerable<Guid> cipherIds, Guid deletingUserId, Guid? organizationId = null, bool orgAdmin = false);
         Task RestoreAsync(Cipher cipher, Guid restoringUserId, bool orgAdmin = false);
         Task RestoreManyAsync(IEnumerable<CipherDetails> ciphers, Guid restoringUserId);
+        Task UploadFileForExistingAttachmentAsync(Stream stream, Cipher cipher, CipherAttachment.MetaData attachmentId);
+        Task<AttachmentResponseModel> GetAttachmentDownloadDataAsync(Cipher cipher, string attachmentId);
+        Task<bool> ValidateCipherAttachmentFile(Cipher cipher, CipherAttachment.MetaData attachmentData);
     }
 }

--- a/src/Core/Services/IEmergencyAccessService.cs
+++ b/src/Core/Services/IEmergencyAccessService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Bit.Core.Enums;
+using Bit.Core.Models.Api;
 using Bit.Core.Models.Api.Response;
 using Bit.Core.Models.Data;
 using Bit.Core.Models.Table;
@@ -26,5 +27,6 @@ namespace Bit.Core.Services
         Task SendNotificationsAsync();
         Task HandleTimedOutRequestsAsync();
         Task<EmergencyAccessViewResponseModel> ViewAsync(Guid id, User user);
+        Task<AttachmentResponseModel> GetAttachmentDownloadAsync(Guid id, string cipherId, string attachmentId, User user);
     }
 }

--- a/src/Core/Services/Implementations/AzureSendFileStorageService.cs
+++ b/src/Core/Services/Implementations/AzureSendFileStorageService.cs
@@ -44,10 +44,12 @@ namespace Bit.Core.Services
             await blob.UploadFromStreamAsync(stream);
         }
 
-        public async Task DeleteFileAsync(Send send, string fileId)
+        public async Task DeleteFileAsync(Send send, string fileId) => await DeleteBlobAsync(BlobName(send, fileId));
+
+        public async Task DeleteBlobAsync(string blobName)
         {
             await InitAsync();
-            var blob = _sendFilesContainer.GetBlockBlobReference(BlobName(send, fileId));
+            var blob = _sendFilesContainer.GetBlockBlobReference(blobName);
             await blob.DeleteIfExistsAsync();
         }
 

--- a/src/Core/Services/Implementations/CipherService.cs
+++ b/src/Core/Services/Implementations/CipherService.cs
@@ -195,7 +195,7 @@ namespace Bit.Core.Services
             {
                 AttachmentId = attachmentId,
                 FileName = request.FileName,
-                Key = request.key,
+                Key = request.Key,
                 Size = request.FileSize,
                 Validated = false,
            };

--- a/src/Core/Services/Implementations/SendService.cs
+++ b/src/Core/Services/Implementations/SendService.cs
@@ -17,6 +17,8 @@ namespace Bit.Core.Services
 {
     public class SendService : ISendService
     {
+        public const long MAX_FILE_SIZE = 500L * 1024L * 1024L; // 500MB
+        public const string MAX_FILE_SIZE_READABLE = "500 MB";
         private readonly ISendRepository _sendRepository;
         private readonly IUserRepository _userRepository;
         private readonly IPolicyRepository _policyRepository;
@@ -142,10 +144,11 @@ namespace Bit.Core.Services
 
             var (valid, realSize) = await _sendFileStorageService.ValidateFileAsync(send, fileData.Id, fileData.Size, _fileSizeLeeway);
 
-            if (!valid)
+            if (!valid || realSize > MAX_FILE_SIZE)
             {
                 // File reported differs in size from that promised. Must be a rogue client. Delete Send
                 await DeleteSendAsync(send);
+                return false;
             }
 
             // Update Send data if necessary

--- a/src/Core/Services/NoopImplementations/NoopAttachmentStorageService.cs
+++ b/src/Core/Services/NoopImplementations/NoopAttachmentStorageService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
+using Bit.Core.Enums;
 using Bit.Core.Models.Data;
 using Bit.Core.Models.Table;
 
@@ -8,6 +9,8 @@ namespace Bit.Core.Services
 {
     public class NoopAttachmentStorageService : IAttachmentStorageService
     {
+        public FileUploadType FileUploadType => FileUploadType.Direct;
+
         public Task CleanupAsync(Guid cipherId)
         {
             return Task.FromResult(0);
@@ -58,5 +61,13 @@ namespace Bit.Core.Services
             return Task.FromResult((string)null);
         }
 
+        public Task<string> GetAttachmentUploadUrlAsync(Cipher cipher, CipherAttachment.MetaData attachmentData)
+        {
+            return Task.FromResult(default(string));
+        }
+        public Task<(bool, long?)> ValidateFileAsync(Cipher cipher, CipherAttachment.MetaData attachmentData, long leeway)
+        {
+            return Task.FromResult((false, (long?)null));
+        }
     }
 }

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -21,6 +21,7 @@ namespace Bit.Core.Settings
         public virtual bool DisableUserRegistration { get; set; }
         public virtual bool DisableEmailNewDevice { get; set; }
         public virtual int OrganizationInviteExpirationHours { get; set; } = 120; // 5 days
+        public virtual string EventGridSecret { get; set; }
         public virtual InstallationSettings Installation { get; set; } = new InstallationSettings();
         public virtual BaseServiceUriSettings BaseServiceUri { get; set; } = new BaseServiceUriSettings();
         public virtual SqlSettings SqlServer { get; set; } = new SqlSettings();

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -21,7 +21,7 @@ namespace Bit.Core.Settings
         public virtual bool DisableUserRegistration { get; set; }
         public virtual bool DisableEmailNewDevice { get; set; }
         public virtual int OrganizationInviteExpirationHours { get; set; } = 120; // 5 days
-        public virtual string EventGridSecret { get; set; }
+        public virtual string EventGridKey { get; set; }
         public virtual InstallationSettings Installation { get; set; } = new InstallationSettings();
         public virtual BaseServiceUriSettings BaseServiceUri { get; set; } = new BaseServiceUriSettings();
         public virtual SqlSettings SqlServer { get; set; } = new SqlSettings();


### PR DESCRIPTION
# Overview

Server-side changes to support direct upload for cipher attachments. Similar changes to #1188.

Special care must be taken handling attachments which were uploaded prior to these changes. There are a few concerns here. Chief is that the `attachments` container is publicly available on the blob level. We can't give direct links to those attachments without either breaking old clients or allowing unfettered access to our storage accounts.

Therefore, a second `attachments-v2` storage container is necessary. The container an attachment is stored in is saved along its other metadata, assuming `attachments` if not present.

Also Limits Send and Attachment size to 500MB per discussion this morning. Further evaluation on legitimate use cases may push this limit further, so it's defined as a couple of constants for Send and Cipher Attachments separately.

# Files Changed
* **CiphersController**: New endpoints for attachment upload and download
  * PostAttachment (v2): Notification to create an attachment of a certain size with associated with a cipher item. This is just the request part of the v1 PostAttachment endpoint. A URL to upload the file to is included in the response
  * RenewFileUploadUrl: Uploads are limited to 1 min. This endpoint allows renewal of the upload link if needed for large uploads as long as the blob has not yet been created
  * PostFileForExistingAttachment: Used for local attachment storage solutions. Allows upload of files direct to Bitwarden.
  * AzureValidateFile: Event Grid webhook endpoint to process Event Grid Events and validate files uploaded are of the size promised upon attachment creation.
* **EmergencyAccessController.cs**: Emergency accesses with view permission need to be able to download attachments through emergency access.
* **SendsController/MultipartFormDataHelper**: Rename method for code reuse
* **AttachmentRequestModel**: Model specifying attachment data including whether or not the attachment is for an organization (adminRequest)
* **AttachmentUploadDataResponseModel**: split attachment create response. Contains the created Cipher response (mini response for AdminRequests), a URL to upload data to, and the upload type (Azure vs Direct for self-hosted)
* **CipherAttachment**: Validated property holds whether we have validated the Requested file size or not. Validated attachments will not renew upload URLs and have passed file size matching to within a specified limit (currently 1MB)
* **IAttachmentStorageService/NoopAttachmentStorageService**: Interface and noop for direct attachment upload and validation.
* **CipherService**:
  * CreateAttachmentForDelayedUploadAsync: Creates attachment and applies it to a Cipher. Stores the expected file size at creation time.
  * UploadFileForExistingAttachmentAsync: Uploads a file to the storage service. Exists for backwards compatibility with clients and local storage solutions
  * GetAttachmentDownloadDataAsync: Returns model specifying download information for an attachment. Used by CiphersController and EmergencyAccessController to allow for download of Cipher attachments.
  * ValidateCipherAttachmentFile: Handles validating actual file size on disk to the promised file size in the attachment request. If the size is not within a specified limit (Currently 1MB), the attachment is deleted.
* **EmergencyAccessService**: GetAttachmentDownloadAsync returns model to allow client to directly download an attachment.
*  **AzureAttachmentStorageService**: Updates to allow for multiple containers storing attachments. The container used is specified in CipherAttachment.MetaData. `attachments` (the old container) is used everywhere unless using the new separate upload scheme by accessing `GetAttachmentUploadUrlAsync`, which only exists in new clients capable of uploading/downloading from Azure directly. Validate needs to set metadata since the blob is actually created by the client and we don't want to leave that job to trusting the client.
* **LocalAttachmentStorageService**: Provide Upload URL and validate file sizes on disk.