### PR TITLE
Add identifiers to Triggers and Jobs

### DIFF
--- a/src/Admin/Jobs/JobsHostedService.cs
+++ b/src/Admin/Jobs/JobsHostedService.cs
@@ -31,22 +31,27 @@ namespace Bit.Admin.Jobs
             }
 
             var everyTopOfTheHourTrigger = TriggerBuilder.Create()
+                .WithIdentity("EveryTopOfTheHourTrigger")
                 .StartNow()
                 .WithCronSchedule("0 0 * * * ?")
                 .Build();
             var everyFiveMinutesTrigger = TriggerBuilder.Create()
+                .WithIdentity("EveryFiveMinutesTrigger")
                 .StartNow()
                 .WithCronSchedule("0 */5 * * * ?")
                 .Build();
             var everyFridayAt10pmTrigger = TriggerBuilder.Create()
+                .WithIdentity("EveryFridayAt10pmTrigger")
                 .StartNow()
                 .WithCronSchedule("0 0 22 ? * FRI", x => x.InTimeZone(timeZone))
                 .Build();
             var everySaturdayAtMidnightTrigger = TriggerBuilder.Create()
+                .WithIdentity("EverySaturdayAtMidnightTrigger")
                 .StartNow()
                 .WithCronSchedule("0 0 0 ? * SAT", x => x.InTimeZone(timeZone))
                 .Build();
             var everySundayAtMidnightTrigger = TriggerBuilder.Create()
+                .WithIdentity("EverySundayAtMidnightTrigger")
                 .StartNow()
                 .WithCronSchedule("0 0 0 ? * SUN", x => x.InTimeZone(timeZone))
                 .Build();

--- a/src/Api/Jobs/JobsHostedService.cs
+++ b/src/Api/Jobs/JobsHostedService.cs
@@ -22,22 +22,27 @@ namespace Bit.Api.Jobs
         public override async Task StartAsync(CancellationToken cancellationToken)
         {
             var everyTopOfTheHourTrigger = TriggerBuilder.Create()
+                .WithIdentity("EveryTopOfTheHourTrigger")
                 .StartNow()
                 .WithCronSchedule("0 0 * * * ?")
                 .Build();
             var emergencyAccessNotificationTrigger = TriggerBuilder.Create()
+                .WithIdentity("EmergencyAccessNotificationTrigger")
                 .StartNow()
                 .WithCronSchedule("0 0 * * * ?")
                 .Build();
             var emergencyAccessTimeoutTrigger  = TriggerBuilder.Create()
+                .WithIdentity("EmergencyAccessTimeoutTrigger")
                 .StartNow()
                 .WithCronSchedule("0 0 * * * ?")
                 .Build();
             var everyTopOfTheSixthHourTrigger = TriggerBuilder.Create()
+                .WithIdentity("EveryTopOfTheSixthHourTrigger")
                 .StartNow()
                 .WithCronSchedule("0 0 */6 * * ?")
                 .Build();
             var everyTwelfthHourAndThirtyMinutesTrigger = TriggerBuilder.Create()
+                .WithIdentity("EveryTwelfthHourAndThirtyMinutesTrigger")
                 .StartNow()
                 .WithCronSchedule("0 30 */12 * * ?")
                 .Build();

--- a/src/Billing/Jobs/JobsHostedService.cs
+++ b/src/Billing/Jobs/JobsHostedService.cs
@@ -31,6 +31,7 @@ namespace Bit.Billing.Jobs
             }
 
             var everyDayAtNinePmTrigger = TriggerBuilder.Create()
+                .WithIdentity("EveryDayAtNinePmTrigger")
                 .StartNow()
                 .WithCronSchedule("0 0 21 * * ?", x => x.InTimeZone(timeZone))
                 .Build();

--- a/src/Core/Jobs/BaseJobsHostedService.cs
+++ b/src/Core/Jobs/BaseJobsHostedService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
@@ -85,6 +86,41 @@ namespace Bit.Core.Jobs
 
                     await _scheduler.ScheduleJob(jobDetail, trigger);
                 }
+            }
+
+            // Delete old Jobs and Triggers
+            var existingJobKeys = await _scheduler.GetJobKeys(GroupMatcher<JobKey>.AnyGroup());
+            var jobKeys = Jobs.Select(j =>
+            {
+                var job = j.Item1;
+                return JobBuilder.Create(job)
+                    .WithIdentity(job.FullName)
+                    .Build().Key;
+            });
+
+            foreach (var key in existingJobKeys)
+            {
+                if (jobKeys.Contains(key))
+                {
+                    continue;
+                }
+
+                _logger.LogInformation($"Deleting old job with key {key}");
+                await _scheduler.DeleteJob(key);
+            }
+
+            var existingTriggerKeys = await _scheduler.GetTriggerKeys(GroupMatcher<TriggerKey>.AnyGroup());
+            var triggerKeys = Jobs.Select(j => j.Item2.Key);
+
+            foreach (var key in existingTriggerKeys)
+            {
+                if (triggerKeys.Contains(key))
+                {
+                    continue;
+                }
+
+                _logger.LogInformation($"Unscheduling old trigger with key {key}");
+                await _scheduler.UnscheduleJob(key);
             }
         }
 

--- a/src/Notifications/Jobs/JobsHostedService.cs
+++ b/src/Notifications/Jobs/JobsHostedService.cs
@@ -22,6 +22,7 @@ namespace Bit.Notifications.Jobs
         public override async Task StartAsync(CancellationToken cancellationToken)
         {
             var everyFiveMinutesTrigger = TriggerBuilder.Create()
+                .WithIdentity("EveryFiveMinutesTrigger")
                 .StartNow()
                 .WithCronSchedule("0 */30 * * * ?")
                 .Build();


### PR DESCRIPTION
## Overview
Quartz still runs duplicate jobs which should have been fixed by #1123. After digging through the documentation it seems we need assign identifiers to our jobs.

Additionally now that we have stable identifiers for jobs we get an error when creating already existing jobs and triggers. To avoid this I added some logic to either update triggers or re-create jobs.