### PR TITLE
[Reset Password] Update all existing tables/sprocs/view & create migrator script

### DIFF
--- a/src/Sql/dbo/Stored Procedures/OrganizationUser_Create.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationUser_Create.sql
@@ -10,7 +10,8 @@
     @ExternalId NVARCHAR(300),
     @CreationDate DATETIME2(7),
     @RevisionDate DATETIME2(7),
-    @Permissions NVARCHAR(MAX)
+    @Permissions NVARCHAR(MAX),
+    @ResetPasswordKey VARCHAR(MAX)
 AS
 BEGIN
     SET NOCOUNT ON
@@ -28,7 +29,8 @@ BEGIN
         [ExternalId],
         [CreationDate],
         [RevisionDate],
-        [Permissions]
+        [Permissions],
+        [ResetPasswordKey]
     )
     VALUES
     (
@@ -43,6 +45,7 @@ BEGIN
         @ExternalId,
         @CreationDate,
         @RevisionDate,
-        @Permissions
+        @Permissions,
+        @ResetPasswordKey
     )
 END

--- a/src/Sql/dbo/Stored Procedures/OrganizationUser_CreateWithCollections.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationUser_CreateWithCollections.sql
@@ -11,12 +11,13 @@
     @CreationDate DATETIME2(7),
     @RevisionDate DATETIME2(7),
     @Permissions NVARCHAR(MAX),
+    @ResetPasswordKey VARCHAR(MAX),
     @Collections AS [dbo].[SelectionReadOnlyArray] READONLY
 AS
 BEGIN
     SET NOCOUNT ON
 
-    EXEC [dbo].[OrganizationUser_Create] @Id, @OrganizationId, @UserId, @Email, @Key, @Status, @Type, @AccessAll, @ExternalId, @CreationDate, @RevisionDate, @Permissions
+    EXEC [dbo].[OrganizationUser_Create] @Id, @OrganizationId, @UserId, @Email, @Key, @Status, @Type, @AccessAll, @ExternalId, @CreationDate, @RevisionDate, @Permissions, @ResetPasswordKey
 
     ;WITH [AvailableCollectionsCTE] AS(
         SELECT

--- a/src/Sql/dbo/Stored Procedures/OrganizationUser_Update.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationUser_Update.sql
@@ -10,7 +10,8 @@
     @ExternalId NVARCHAR(300),
     @CreationDate DATETIME2(7),
     @RevisionDate DATETIME2(7),
-    @Permissions NVARCHAR(MAX)
+    @Permissions NVARCHAR(MAX),
+    @ResetPasswordKey VARCHAR(MAX)
 AS
 BEGIN
     SET NOCOUNT ON
@@ -28,7 +29,8 @@ BEGIN
         [ExternalId] = @ExternalId,
         [CreationDate] = @CreationDate,
         [RevisionDate] = @RevisionDate,
-        [Permissions] = @Permissions
+        [Permissions] = @Permissions,
+        [ResetPasswordKey] = @ResetPasswordKey
     WHERE
         [Id] = @Id
 

--- a/src/Sql/dbo/Stored Procedures/OrganizationUser_UpdateWithCollections.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationUser_UpdateWithCollections.sql
@@ -11,12 +11,13 @@
     @CreationDate DATETIME2(7),
     @RevisionDate DATETIME2(7),
     @Permissions NVARCHAR(MAX),
+    @ResetPasswordKey VARCHAR(MAX),
     @Collections AS [dbo].[SelectionReadOnlyArray] READONLY
 AS
 BEGIN
     SET NOCOUNT ON
 
-    EXEC [dbo].[OrganizationUser_Update] @Id, @OrganizationId, @UserId, @Email, @Key, @Status, @Type, @AccessAll, @ExternalId, @CreationDate, @RevisionDate, @Permissions
+    EXEC [dbo].[OrganizationUser_Update] @Id, @OrganizationId, @UserId, @Email, @Key, @Status, @Type, @AccessAll, @ExternalId, @CreationDate, @RevisionDate, @Permissions, @ResetPasswordKey
     -- Update
     UPDATE
         [Target]

--- a/src/Sql/dbo/Tables/OrganizationUser.sql
+++ b/src/Sql/dbo/Tables/OrganizationUser.sql
@@ -4,6 +4,7 @@
     [UserId]                        UNIQUEIDENTIFIER    NULL,
     [Email]                         NVARCHAR (256)      NULL,
     [Key]                           VARCHAR (MAX)       NULL,
+    [ResetPasswordKey]              VARCHAR (MAX)       NULL,
     [Status]                        TINYINT             NOT NULL,
     [Type]                          TINYINT             NOT NULL,
     [AccessAll]                     BIT                 NOT NULL,

--- a/src/Sql/dbo/Views/OrganizationUserOrganizationDetailsView.sql
+++ b/src/Sql/dbo/Views/OrganizationUserOrganizationDetailsView.sql
@@ -20,6 +20,7 @@ SELECT
     O.[MaxStorageGb],
     O.[Identifier],
     OU.[Key],
+    OU.[ResetPasswordKey],
     OU.[Status],
     OU.[Type],
     SU.[ExternalId] SsoExternalId,

--- a/src/Sql/dbo/Views/OrganizationUserUserDetailsView.sql
+++ b/src/Sql/dbo/Views/OrganizationUserUserDetailsView.sql
@@ -13,7 +13,8 @@ SELECT
     OU.[AccessAll],
     OU.[ExternalId],
     SU.[ExternalId] SsoExternalId,
-    OU.[Permissions]
+    OU.[Permissions],
+    OU.[ResetPasswordKey]
 FROM
     [dbo].[OrganizationUser] OU
 LEFT JOIN

--- a/util/Migrator/DbScripts/2021-03-23_00_AddResetPasswordKey.sql
+++ b/util/Migrator/DbScripts/2021-03-23_00_AddResetPasswordKey.sql
@@ -1,0 +1,350 @@
+-- Table: OrganizationUser
+IF COL_LENGTH('[dbo].[OrganizationUser]', 'ResetPasswordKey') IS NULL
+BEGIN
+ALTER TABLE
+    [dbo].[OrganizationUser]
+    ADD
+    [ResetPasswordKey] VARCHAR(MAX) NULL
+END
+GO
+
+-- View: OrganizationUser
+IF EXISTS(SELECT * FROM sys.views WHERE [Name] = 'OrganizationUserView')
+BEGIN
+    DROP VIEW [dbo].[OrganizationUserView];
+END
+GO
+
+CREATE VIEW [dbo].[OrganizationUserView]
+AS
+SELECT
+    *
+FROM
+    [dbo].[OrganizationUser]
+GO
+
+-- View: OrganizationUserOrganizationDetails
+IF EXISTS(SELECT * FROM sys.views WHERE [Name] = 'OrganizationUserOrganizationDetailsView')
+BEGIN
+    DROP VIEW [dbo].[OrganizationUserOrganizationDetailsView];
+END
+GO
+
+CREATE VIEW [dbo].[OrganizationUserOrganizationDetailsView]
+AS
+SELECT
+    OU.[UserId],
+    OU.[OrganizationId],
+    O.[Name],
+    O.[Enabled],
+    O.[UsePolicies],
+    O.[UseSso],
+    O.[UseGroups],
+    O.[UseDirectory],
+    O.[UseEvents],
+    O.[UseTotp],
+    O.[Use2fa],
+    O.[UseApi],
+    O.[SelfHost],
+    O.[UsersGetPremium],
+    O.[Seats],
+    O.[MaxCollections],
+    O.[MaxStorageGb],
+    O.[Identifier],
+    OU.[Key],
+    OU.[ResetPasswordKey],
+    OU.[Status],
+    OU.[Type],
+    SU.[ExternalId] SsoExternalId,
+    OU.[Permissions]
+FROM
+    [dbo].[OrganizationUser] OU
+INNER JOIN
+    [dbo].[Organization] O ON O.[Id] = OU.[OrganizationId]
+LEFT JOIN
+    [dbo].[SsoUser] SU ON SU.[UserId] = OU.[UserId] AND SU.[OrganizationId] = OU.[OrganizationId]
+GO
+
+-- View: OrganizationUserUserDetails
+IF EXISTS(SELECT * FROM sys.views WHERE [Name] = 'OrganizationUserUserDetailsView')
+BEGIN
+    DROP VIEW [dbo].[OrganizationUserUserDetailsView];
+END
+GO
+
+CREATE VIEW [dbo].[OrganizationUserUserDetailsView]
+AS
+SELECT
+    OU.[Id],
+    OU.[UserId],
+    OU.[OrganizationId],
+    U.[Name],
+    ISNULL(U.[Email], OU.[Email]) Email,
+    U.[TwoFactorProviders],
+    U.[Premium],
+    OU.[Status],
+    OU.[Type],
+    OU.[AccessAll],
+    OU.[ExternalId],
+    SU.[ExternalId] SsoExternalId,
+    OU.[Permissions],
+    OU.[ResetPasswordKey]
+FROM
+[dbo].[OrganizationUser] OU
+    LEFT JOIN
+[dbo].[User] U ON U.[Id] = OU.[UserId]
+    LEFT JOIN
+[dbo].[SsoUser] SU ON SU.[UserId] = OU.[UserId] AND SU.[OrganizationId] = OU.[OrganizationId]
+GO
+
+-- Stored Procedure: OrganizationUser_Create
+IF OBJECT_ID('[dbo].[OrganizationUser_Create]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationUser_Create]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationUser_Create]
+    @Id UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @Email NVARCHAR(256),
+    @Key VARCHAR(MAX),
+    @Status TINYINT,
+    @Type TINYINT,
+    @AccessAll BIT,
+    @ExternalId NVARCHAR(300),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @Permissions NVARCHAR(MAX),
+    @ResetPasswordKey VARCHAR(MAX)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    INSERT INTO [dbo].[OrganizationUser]
+    (
+        [Id],
+        [OrganizationId],
+        [UserId],
+        [Email],
+        [Key],
+        [Status],
+        [Type],
+        [AccessAll],
+        [ExternalId],
+        [CreationDate],
+        [RevisionDate],
+        [Permissions],
+        [ResetPasswordKey]
+    )
+    VALUES
+    (
+        @Id,
+        @OrganizationId,
+        @UserId,
+        @Email,
+        @Key,
+        @Status,
+        @Type,
+        @AccessAll,
+        @ExternalId,
+        @CreationDate,
+        @RevisionDate,
+        @Permissions,
+        @ResetPasswordKey
+    )
+END
+GO
+
+-- Stored Procedure: OrganizationUser_CreateWithCollections
+IF OBJECT_ID('[dbo].[OrganizationUser_CreateWithCollections]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationUser_CreateWithCollections]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationUser_CreateWithCollections]
+    @Id UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @Email NVARCHAR(256),
+    @Key VARCHAR(MAX),
+    @Status TINYINT,
+    @Type TINYINT,
+    @AccessAll BIT,
+    @ExternalId NVARCHAR(300),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @Permissions NVARCHAR(MAX),
+    @ResetPasswordKey VARCHAR(MAX),
+    @Collections AS [dbo].[SelectionReadOnlyArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    EXEC [dbo].[OrganizationUser_Create] @Id, @OrganizationId, @UserId, @Email, @Key, @Status, @Type, @AccessAll, @ExternalId, @CreationDate, @RevisionDate, @Permissions, @ResetPasswordKey
+
+    ;WITH [AvailableCollectionsCTE] AS(
+        SELECT
+            [Id]
+        FROM
+            [dbo].[Collection]
+        WHERE
+            [OrganizationId] = @OrganizationId
+    )
+    INSERT INTO [dbo].[CollectionUser]
+    (
+        [CollectionId],
+        [OrganizationUserId],
+        [ReadOnly],
+        [HidePasswords]
+    )
+    SELECT
+        [Id],
+        @Id,
+        [ReadOnly],
+        [HidePasswords]
+    FROM
+        @Collections
+    WHERE
+        [Id] IN (SELECT [Id] FROM [AvailableCollectionsCTE])
+END
+GO
+
+-- Stored Procedure: OrganizationUser_Update
+IF OBJECT_ID('[dbo].[OrganizationUser_Update]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationUser_Update]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationUser_Update]
+    @Id UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @Email NVARCHAR(256),
+    @Key VARCHAR(MAX),
+    @Status TINYINT,
+    @Type TINYINT,
+    @AccessAll BIT,
+    @ExternalId NVARCHAR(300),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @Permissions NVARCHAR(MAX),
+    @ResetPasswordKey VARCHAR(MAX)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    UPDATE
+        [dbo].[OrganizationUser]
+    SET
+        [OrganizationId] = @OrganizationId,
+        [UserId] = @UserId,
+        [Email] = @Email,
+        [Key] = @Key,
+        [Status] = @Status,
+        [Type] = @Type,
+        [AccessAll] = @AccessAll,
+        [ExternalId] = @ExternalId,
+        [CreationDate] = @CreationDate,
+        [RevisionDate] = @RevisionDate,
+        [Permissions] = @Permissions,
+        [ResetPasswordKey] = @ResetPasswordKey
+    WHERE
+        [Id] = @Id
+
+    EXEC [dbo].[User_BumpAccountRevisionDate] @UserId
+END
+GO
+
+-- Stored Procedure: OrganizationUser_UpdateWithCollections
+IF OBJECT_ID('[dbo].[OrganizationUser_UpdateWithCollections]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationUser_UpdateWithCollections]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationUser_UpdateWithCollections]
+    @Id UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @Email NVARCHAR(256),
+    @Key VARCHAR(MAX),
+    @Status TINYINT,
+    @Type TINYINT,
+    @AccessAll BIT,
+    @ExternalId NVARCHAR(300),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @Permissions NVARCHAR(MAX),
+    @ResetPasswordKey VARCHAR(MAX),
+    @Collections AS [dbo].[SelectionReadOnlyArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    EXEC [dbo].[OrganizationUser_Update] @Id, @OrganizationId, @UserId, @Email, @Key, @Status, @Type, @AccessAll, @ExternalId, @CreationDate, @RevisionDate, @Permissions, @ResetPasswordKey
+    
+    
+    -- Update
+    UPDATE
+        [Target]
+    SET
+        [Target].[ReadOnly] = [Source].[ReadOnly],
+        [Target].[HidePasswords] = [Source].[HidePasswords]
+    FROM
+        [dbo].[CollectionUser] AS [Target]
+    INNER JOIN
+        @Collections AS [Source] ON [Source].[Id] = [Target].[CollectionId]
+    WHERE
+        [Target].[OrganizationUserId] = @Id
+        AND (
+            [Target].[ReadOnly] != [Source].[ReadOnly]
+            OR [Target].[HidePasswords] != [Source].[HidePasswords]
+        )
+
+    -- Insert
+    INSERT INTO
+        [dbo].[CollectionUser]
+    SELECT
+        [Source].[Id],
+        @Id,
+        [Source].[ReadOnly],
+        [Source].[HidePasswords]
+    FROM
+        @Collections AS [Source]
+    INNER JOIN
+        [dbo].[Collection] C ON C.[Id] = [Source].[Id] AND C.[OrganizationId] = @OrganizationId
+    WHERE
+        NOT EXISTS (
+            SELECT
+                1
+            FROM
+                [dbo].[CollectionUser]
+            WHERE
+                [CollectionId] = [Source].[Id]
+                AND [OrganizationUserId] = @Id
+        )
+
+    -- Delete
+    DELETE
+        CU
+    FROM
+        [dbo].[CollectionUser] CU
+    WHERE
+        CU.[OrganizationUserId] = @Id
+        AND NOT EXISTS (
+            SELECT
+                1
+            FROM
+                @Collections
+            WHERE
+                [Id] = CU.[CollectionId]
+        )
+END
+GO
+
+
+


### PR DESCRIPTION
## Objective
> Start integration for Enterprise Master Password reset. Update all existing `OrganizationUser` DB tables/sprocs/views and create migrator script.

## Code Changes
- **Table/Stored Procedures/View**: Added `ResetPasswordKey` column/value
- **2021-03-23_00_AddResetPasswordKey**: Created migrator script that will adjust all existing tables/views/sprocs affected by the new column addition.