### PR TITLE
Expand Custom Field Values to 5000 characters

### DIFF
--- a/src/Core/Models/Api/CipherFieldModel.cs
+++ b/src/Core/Models/Api/CipherFieldModel.cs
@@ -19,7 +19,7 @@ namespace Bit.Core.Models.Api
         public FieldType Type { get; set; }
         [EncryptedStringLength(1000)]
         public string Name { get; set; }
-        [EncryptedStringLength(1000)]
+        [EncryptedStringLength(5000)]
         public string Value { get; set; }
     }
 }


### PR DESCRIPTION
# Overview 

Closes: https://app.asana.com/0/1153292148278596/1153357960682164/f

We want to be able to store SSH keys in custom fields. Testing showed 4096 keys with minimal comments resulted in 4680 characters. This was rounded to 5000 for a buffer.

Note, I didn't expand this to passwords for two reasons
  1. I think SSH keys make more sense in a secure note-type context
  2. We would need to expand other fields such as password history as well and that doesn't really make sense.

# Files Changed
* **CipherFieldModel**: Allow up to 5000 character long Custom Field Values.

# Testing
* Should be as simple as using a test SSH Key and putting it in a Custom field. No error should be observed, and the data should be preserved as normal.