### PR TITLE
Fixed badge link to open workflows on master

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://github.com/bitwarden/brand/blob/master/screenshots/apps-combo-logo.png" alt="Bitwarden" />
 </p>
 <p align="center">
-  <a href="https://https://github.com/bitwarden/server/actions/workflows/build.yml?query=branch%3Amaster" target="_blank">
+  <a href="https://github.com/bitwarden/server/actions/workflows/build.yml?query=branch:master" target="_blank">
     <img src="https://github.com/bitwarden/server/actions/workflows/build.yml/badge.svg?branch=master" alt="Github Workflow build on master" />
   </a>
   <a href="https://hub.docker.com/u/bitwarden/" target="_blank">


### PR DESCRIPTION
Fixes the badge link in the `README.md` to open workflows on `master`. Unfortunately introduced by myself through #1231 