### PR TITLE
Fix column `NULL`ness for OrganizationUser table

### DIFF
--- a/util/Migrator/DbScripts/2021-03-04_03_OrganizationUser_Enlarge_Email_Column.sql
+++ b/util/Migrator/DbScripts/2021-03-04_03_OrganizationUser_Enlarge_Email_Column.sql
@@ -3,7 +3,7 @@ IF COL_LENGTH('[dbo].[OrganizationUser]', 'Email') = 100
 BEGIN
 	ALTER TABLE [dbo].[OrganizationUser] 
 	ALTER COLUMN 
-		Email NVARCHAR(256) NOT NULL
+		Email NVARCHAR(256) NULL
 END
 GO
 


### PR DESCRIPTION
Fix column `NULL`ness for OrganizationUser table in Upgrade script; prior PR I missed in the upgrade script submitted that the ALTER COLUMN statement incorrectly set the column to `NOT NULL` when the table definition had it correctly as `NULL`.

Since this has not yet been released, should be able to keep the file name the same.

Blame: https://github.com/bitwarden/server/pull/1191