### PR TITLE
Throw error if not enough seats available for a sync

### DIFF
--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1542,6 +1542,7 @@ namespace Bit.Core.Services
                     }
                     catch (BadRequestException)
                     {
+                        // Thrown when the user is already invited to the organization
                         continue;
                     }
                 }


### PR DESCRIPTION
# Overview

Fixes: https://app.asana.com/0/1169444489336079/1200094108924557/f

We are currently silently failing to update any seats if an organization request a sync through directory-connector, but too few seats are available. BWDC thinks it's successfully syncing, but the server makes no user changes.

# Files Changed
* **OrganizationService.cs**: Inverted the if and throw if not `enoughSeatsAvailable` with a reasonable error message. The rest of the changes is an indentation change due to getting rid of the surrounding `if`.