### PR TITLE
Fix emergency access migration not working

### DIFF
--- a/util/Migrator/DbScripts/2021-03-04_04_EmergencyAccess_Enlarge_Email_Column.sql
+++ b/util/Migrator/DbScripts/2021-03-04_04_EmergencyAccess_Enlarge_Email_Column.sql
@@ -3,7 +3,7 @@ IF COL_LENGTH('[dbo].[EmergencyAccess]', 'Email') = 100
 BEGIN
 	ALTER TABLE [dbo].[EmergencyAccess] 
 	ALTER COLUMN 
-		Email NVARCHAR(256) NOT NULL
+		Email NVARCHAR(256) NULL
 END
 GO
 


### PR DESCRIPTION
## Overview
Migrations stopped working, after debugging it turned out that one of the new migrations incorrectly set the Email field to `NOT NULL` when it could be `NULL`.