### PR TITLE
[Reset Password] Enrollment API, Service, and Model updates

### DIFF
--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -184,7 +184,8 @@ namespace Bit.Api.Controllers
         [HttpPut("{userId}/reset-password-enrollment")]
         public async Task PutResetPasswordEnrollment(string orgId, string userId, [FromBody]OrganizationUserResetPasswordEnrollmentRequestModel model)
         {
-            await _organizationService.UpdateUserResetPasswordEnrollmentAsync(new Guid(orgId), new Guid(userId), model.ResetPasswordKey);
+            var callingUserId = _userService.GetProperUserId(User);
+            await _organizationService.UpdateUserResetPasswordEnrollmentAsync(new Guid(orgId), new Guid(userId), model.ResetPasswordKey, callingUserId);
         }
 
         [HttpDelete("{id}")]

--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -180,6 +180,12 @@ namespace Bit.Api.Controllers
             var loggedInUserId = _userService.GetProperUserId(User);
             await _organizationService.UpdateUserGroupsAsync(organizationUser, model.GroupIds.Select(g => new Guid(g)), loggedInUserId);
         }
+        
+        [HttpPut("{userId}/reset-password-enrollment")]
+        public async Task PutResetPasswordEnrollment(string orgId, string userId, [FromBody]OrganizationUserResetPasswordEnrollmentRequestModel model)
+        {
+            await _organizationService.UpdateUserResetPasswordEnrollmentAsync(new Guid(orgId), new Guid(userId), model.ResetPasswordKey);
+        }
 
         [HttpDelete("{id}")]
         [HttpPost("{id}/delete")]

--- a/src/Core/Enums/EventType.cs
+++ b/src/Core/Enums/EventType.cs
@@ -43,6 +43,8 @@
         OrganizationUser_Removed = 1503,
         OrganizationUser_UpdatedGroups = 1504,
         OrganizationUser_UnlinkedSso = 1505,
+        OrganizationUser_ResetPassword_Enroll = 1506,
+        OrganizationUser_ResetPassword_Withdraw = 1507,
 
         Organization_Updated = 1600,
         Organization_PurgedVault = 1601,

--- a/src/Core/Models/Api/Request/Organizations/OrganizationUserRequestModels.cs
+++ b/src/Core/Models/Api/Request/Organizations/OrganizationUserRequestModels.cs
@@ -84,4 +84,9 @@ namespace Bit.Core.Models.Api
         [Required]
         public IEnumerable<string> GroupIds { get; set; }
     }
+    
+    public class OrganizationUserResetPasswordEnrollmentRequestModel
+    {
+        public string ResetPasswordKey { get; set; }
+    }
 }

--- a/src/Core/Models/Api/Response/ProfileOrganizationResponseModel.cs
+++ b/src/Core/Models/Api/Response/ProfileOrganizationResponseModel.cs
@@ -30,6 +30,8 @@ namespace Bit.Core.Models.Api
             SsoBound = !string.IsNullOrWhiteSpace(organization.SsoExternalId);
             Identifier = organization.Identifier;
             Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(organization.Permissions);
+            ResetPasswordKey = organization.ResetPasswordKey;
+            UserId = organization.UserId?.ToString();
         }
 
         public string Id { get; set; }
@@ -55,5 +57,7 @@ namespace Bit.Core.Models.Api
         public bool SsoBound { get; set; }
         public string Identifier { get; set; }
         public Permissions Permissions { get; set; }
+        public string ResetPasswordKey { get; set; }
+        public string UserId { get; set; }
     }
 }

--- a/src/Core/Models/Data/OrganizationUserOrganizationDetails.cs
+++ b/src/Core/Models/Data/OrganizationUserOrganizationDetails.cs
@@ -28,5 +28,6 @@ namespace Bit.Core.Models.Data
         public string SsoExternalId { get; set; }
         public string Identifier { get; set; }
         public string Permissions { get; set; }
+        public string ResetPasswordKey { get; set; }
     }
 }

--- a/src/Core/Models/Data/OrganizationUserUserDetails.cs
+++ b/src/Core/Models/Data/OrganizationUserUserDetails.cs
@@ -22,6 +22,7 @@ namespace Bit.Core.Models.Data
         public string ExternalId { get; set; }
         public string SsoExternalId { get; set; }
         public string Permissions { get; set; }
+        public string ResetPasswordKey { get; set; }
 
         public Dictionary<TwoFactorProviderType, TwoFactorProvider> GetTwoFactorProviders()
         {

--- a/src/Core/Models/Table/OrganizationUser.cs
+++ b/src/Core/Models/Table/OrganizationUser.cs
@@ -11,6 +11,7 @@ namespace Bit.Core.Models.Table
         public Guid? UserId { get; set; }
         public string Email { get; set; }
         public string Key { get; set; }
+        public string ResetPasswordKey { get; set; }
         public OrganizationUserStatusType Status { get; set; }
         public OrganizationUserType Type { get; set; }
         public bool AccessAll { get; set; }

--- a/src/Core/Services/IOrganizationService.cs
+++ b/src/Core/Services/IOrganizationService.cs
@@ -43,7 +43,7 @@ namespace Bit.Core.Services
         Task DeleteUserAsync(Guid organizationId, Guid organizationUserId, Guid? deletingUserId);
         Task DeleteUserAsync(Guid organizationId, Guid userId);
         Task UpdateUserGroupsAsync(OrganizationUser organizationUser, IEnumerable<Guid> groupIds, Guid? loggedInUserId);
-        Task UpdateUserResetPasswordEnrollmentAsync(Guid organizationId, Guid organizationUserId, string resetPasswordKey);
+        Task UpdateUserResetPasswordEnrollmentAsync(Guid organizationId, Guid organizationUserId, string resetPasswordKey, Guid? callingUserId);
         Task<OrganizationLicense> GenerateLicenseAsync(Guid organizationId, Guid installationId);
         Task<OrganizationLicense> GenerateLicenseAsync(Organization organization, Guid installationId,
             int? version = null);

--- a/src/Core/Services/IOrganizationService.cs
+++ b/src/Core/Services/IOrganizationService.cs
@@ -43,6 +43,7 @@ namespace Bit.Core.Services
         Task DeleteUserAsync(Guid organizationId, Guid organizationUserId, Guid? deletingUserId);
         Task DeleteUserAsync(Guid organizationId, Guid userId);
         Task UpdateUserGroupsAsync(OrganizationUser organizationUser, IEnumerable<Guid> groupIds, Guid? loggedInUserId);
+        Task UpdateUserResetPasswordEnrollmentAsync(Guid organizationId, Guid organizationUserId, string resetPasswordKey);
         Task<OrganizationLicense> GenerateLicenseAsync(Guid organizationId, Guid installationId);
         Task<OrganizationLicense> GenerateLicenseAsync(Organization organization, Guid installationId,
             int? version = null);

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1378,6 +1378,23 @@ namespace Bit.Core.Services
             await _eventService.LogOrganizationUserEventAsync(organizationUser,
                 EventType.OrganizationUser_UpdatedGroups);
         }
+        
+        public async Task UpdateUserResetPasswordEnrollmentAsync(Guid organizationId, Guid organizationUserId, string resetPasswordKey)
+        {
+            var orgUser = await _organizationUserRepository.GetByOrganizationAsync(organizationId, organizationUserId);
+            if (orgUser == null || orgUser.Status != OrganizationUserStatusType.Confirmed ||
+                orgUser.OrganizationId != organizationId)
+            {
+                throw new BadRequestException("User not valid.");
+            }
+            
+            // TODO - Block certain org types from using this feature?
+
+            orgUser.ResetPasswordKey = resetPasswordKey;
+            await _organizationUserRepository.ReplaceAsync(orgUser);
+            await _eventService.LogOrganizationUserEventAsync(orgUser, resetPasswordKey != null ? 
+                EventType.OrganizationUser_ResetPassword_Enroll : EventType.OrganizationUser_ResetPassword_Withdraw);
+        }
 
         public async Task<OrganizationLicense> GenerateLicenseAsync(Guid organizationId, Guid installationId)
         {

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1379,10 +1379,11 @@ namespace Bit.Core.Services
                 EventType.OrganizationUser_UpdatedGroups);
         }
         
-        public async Task UpdateUserResetPasswordEnrollmentAsync(Guid organizationId, Guid organizationUserId, string resetPasswordKey)
+        public async Task UpdateUserResetPasswordEnrollmentAsync(Guid organizationId, Guid organizationUserId, string resetPasswordKey, Guid? callingUserId)
         {
             var orgUser = await _organizationUserRepository.GetByOrganizationAsync(organizationId, organizationUserId);
-            if (orgUser == null || orgUser.Status != OrganizationUserStatusType.Confirmed ||
+            if (!callingUserId.HasValue || orgUser == null || orgUser.UserId != callingUserId.Value ||
+                orgUser.Status != OrganizationUserStatusType.Confirmed ||
                 orgUser.OrganizationId != organizationId)
             {
                 throw new BadRequestException("User not valid.");


### PR DESCRIPTION
## Objective
> Create the `ResetPasswordEnrollment` API that will set an Organization User's `ResetPasswordKey`.  

## Code Changes
- **OrganizationUsersController**: Created `PUT` API -> `PutResetPasswordEnrollment`
- **EventType**: Added `Enroll` and `Withdraw` event type enums
- **OrganizationUserRequestModel**: Created `OrganizationUserResetPasswordEnrollmentRequestModel` that will contain the `ResetPasswordKey`
- **ProfileOrganizationResponseModel**: Added `ResetPasswordKey` and `UserId`. **NOTE:** `UserId` isn't necessary but when creating this model, the data includes the `UserId` already and we can use it in the clients without making another storage call, so I thought it would be useful to add.
- **OrganizationUserOrganizationDetails**: Added `ResetPasswordKey`
- **OrganizationUserUserDetails**: Added `ResetPasswordKey`
- **OrganizationUser**: Added `ResetPasswordKey`
- **IOrganizaitonService**: Added `UpdateUserResetPasswordEnrollmentAsync` method
- **OrganizationService**: Added `UpdateUserResetPasswordEnrollmentAsync` method and left a TODO for potential organization type restrictions.