### PR TITLE
Add unit test for hiding emails on sends

### DIFF
--- a/test/Api.Test/Api.Test.csproj
+++ b/test/Api.Test/Api.Test.csproj
@@ -14,12 +14,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.14.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Api\Api.csproj" />
     <ProjectReference Include="..\..\src\Core\Core.csproj" />
-    <ProjectReference Include="..\Core.Test\Core.Test.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Api.Test/Api.Test.csproj
+++ b/test/Api.Test/Api.Test.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Api\Api.csproj" />
     <ProjectReference Include="..\..\src\Core\Core.csproj" />
+    <ProjectReference Include="..\Core.Test\Core.Test.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Api.Test/Controllers/SendsControllerTests.cs
+++ b/test/Api.Test/Controllers/SendsControllerTests.cs
@@ -1,0 +1,79 @@
+using AutoFixture.Xunit2;
+using Bit.Api.Controllers;
+using Bit.Core.Enums;
+using Bit.Core.Models.Api;
+using Bit.Core.Models.Table;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Bit.Core.Settings;
+using Bit.Core.Utilities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using NSubstitute;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System;
+using Xunit;
+
+namespace Bit.Api.Test.Controllers
+{
+    public class SendsControllerTests : IDisposable
+    {
+
+        private readonly SendsController _sut;
+        private readonly GlobalSettings _globalSettings;
+        private readonly IUserService _userService;
+        private readonly ISendRepository _sendRepository;
+        private readonly ISendService _sendService;
+        private readonly ISendFileStorageService _sendFileStorageService;
+        private readonly ILogger<SendsController> _logger;
+
+        public SendsControllerTests()
+        {
+            _userService = Substitute.For<IUserService>();
+            _sendRepository = Substitute.For<ISendRepository>();
+            _sendService = Substitute.For<ISendService>();
+            _sendFileStorageService = Substitute.For<ISendFileStorageService>();
+            _globalSettings = new GlobalSettings();
+            _logger = Substitute.For<ILogger<SendsController>>();
+
+            _sut = new SendsController(
+                _sendRepository,
+                _userService,
+                _sendService,
+                _sendFileStorageService,
+                _logger,
+                _globalSettings
+            );
+        }
+
+        public void Dispose()
+        {
+            _sut?.Dispose();
+        }
+
+        [Theory, AutoData]
+        public async Task SendsController_WhenSendHidesEmail_CreatorIdentifierShouldBeNull(
+            Guid id, Send send, User user)
+        {
+            var accessId = CoreHelpers.Base64UrlEncode(id.ToByteArray());
+
+            send.Id = default;
+            send.Type = SendType.Text;
+            send.Data = JsonConvert.SerializeObject(new Dictionary<string, string>());
+            send.HideEmail = true;
+
+            _sendService.AccessAsync(id, null).Returns((send, false, false));
+            _userService.GetUserByIdAsync(Arg.Any<Guid>()).Returns(user);
+
+            var request = new SendAccessRequestModel();
+            var actionResult = await _sut.Access(accessId, request);
+            var response = (actionResult as ObjectResult)?.Value as SendAccessResponseModel;
+
+            Assert.NotNull(response);
+            Assert.Null(response.CreatorIdentifier);
+        }
+    }
+}
+


### PR DESCRIPTION
## Objective
Add a new unit test for the changes in PR #1234.

This tests `SendsController.Access` to ensure that it respects the "Hide my email from recipients" option.

## Code changes
Added new unit test class for `SendsController`.

I haven't really dealt with our server testing framework before, so feedback is welcome.