### PR TITLE
Add Fido2 to Portal services

### DIFF
--- a/bitwarden_license/src/Portal/Startup.cs
+++ b/bitwarden_license/src/Portal/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using System;
 
 namespace Bit.Portal
 {
@@ -59,6 +60,15 @@ namespace Bit.Portal
             services.AddBaseServices();
             services.AddDefaultServices(globalSettings);
             services.AddCoreLocalizationServices();
+
+            // Fido2
+            services.AddFido2(options =>
+            {
+                options.ServerDomain = new Uri(globalSettings.BaseServiceUri.Vault).Host;
+                options.ServerName = "Bitwarden";
+                options.Origin = globalSettings.BaseServiceUri.Vault;
+                options.TimestampDriftTolerance = 300000;
+            });
 
             // Mvc
             services.AddControllersWithViews()

--- a/bitwarden_license/src/Sso/Startup.cs
+++ b/bitwarden_license/src/Sso/Startup.cs
@@ -59,6 +59,15 @@ namespace Bit.Sso
                 });
             }
 
+            // Fido2
+            services.AddFido2(options =>
+            {
+                options.ServerDomain = new Uri(globalSettings.BaseServiceUri.Vault).Host;
+                options.ServerName = "Bitwarden";
+                options.Origin = globalSettings.BaseServiceUri.Vault;
+                options.TimestampDriftTolerance = 300000;
+            });
+
             // Authentication
             services.AddDistributedIdentityServices(globalSettings);
             services.AddAuthentication()


### PR DESCRIPTION
## Objective

Fix the following error when executing `dotnet run --project bitwarden_license/src/Portal`:

>Unhandled exception. System.AggregateException: Some services are not able to be constructed (Error while validating the service descriptor 'ServiceType: Bit.Core.Services.ICipherService Lifetime: Scoped ImplementationType: Bit.Core.Services.CipherService': Unable to resolve service for type 'Fido2NetLib.IFido2' while attempting to activate 'Bit.Core.Services.UserService'.) (Error while validating the service descriptor 'ServiceType: Bit.Core.Services.IUserService Lifetime: Scoped ImplementationType: Bit.Core.Services.UserService': Unable to resolve service for type 'Fido2NetLib.IFido2' while attempting to activate 'Bit.Core.Services.UserService'.) (Error while validating the service descriptor 'ServiceType: Bit.Core.Services.IEmergencyAccessService Lifetime: Scoped ImplementationType: Bit.Core.Services.EmergencyAccessService': Unable to resolve service for type 'Fido2NetLib.IFido2' while attempting to activate 'Bit.Core.Services.UserService'.) (Error while validating the service descriptor 'ServiceType: Bit.Core.Services.ISendService Lifetime: Scoped ImplementationType: Bit.Core.Services.SendService': Unable to resolve service for type 'Fido2NetLib.IFido2' while attempting to activate 'Bit.Core.Services.UserService'.)

## Code changes

I think this was caused by PR #903. Adding Fido2 to `Portal/Startup.cs` seems to fix it. I copied this code block from similar changes made to `Identity/Startup.cs` and `Api/Startup.cs` in #903. Happy to be corrected if there is a better way of fixing the issue.

EDIT: also made the same change to `Sso`.