### PR TITLE
Adding logout message when logging out of business portal

### DIFF
--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -638,4 +638,10 @@
     <value>Requested Authentication Context Class Reference values (acr_values)</value>
     <comment>'acr_values' is an explicit OIDC param, see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest. It should not be translated.</comment>
   </data>
+  <data name="LoggedOutMessage" xml:space="preserve">
+    <value>You have been logged out of the Bitwarden Business Portal.</value>
+  </data>
+  <data name="AccessDeniedError" xml:space="preserve">
+    <value>Access Denied to this resource.</value>
+  </data>
 </root>


### PR DESCRIPTION
This is a fix for [this issue](https://github.com/bitwarden/web/issues/897) raised in the web repository.

Also, I saw that AccessDeniedError also doesn't have a message. I have added a generic message for the same. Please let me know if you want me to change the message.

*Re-created PR #1247  to update author details of commit*