### PR TITLE
Change UserVerificationRequirement to Discouraged

### DIFF
--- a/src/Core/Identity/WebAuthnTokenProvider.cs
+++ b/src/Core/Identity/WebAuthnTokenProvider.cs
@@ -70,7 +70,7 @@ namespace Bit.Core.Identity
                 AppID = CoreHelpers.U2fAppIdUrl(_globalSettings),
             };
 
-            var options = _fido2.GetAssertionOptions(existingCredentials, UserVerificationRequirement.Preferred, exts);
+            var options = _fido2.GetAssertionOptions(existingCredentials, UserVerificationRequirement.Discouraged, exts);
 
             provider.MetaData["login"] = options;
 


### PR DESCRIPTION
## Overview
When using the new WebAuthn 2FA some security keys prompts for a PIN. Since we only use it for 2FA we can safely change UserVerification to Discouraged which should remove the pin prompt.

https://developers.yubico.com/WebAuthn/WebAuthn_Developer_Guide/User_Presence_vs_User_Verification.html