### PR TITLE
Do not overwrite existing kdf iteration settings

### DIFF
--- a/util/Migrator/DbScripts/2018-08-14_00_UserKdf.sql
+++ b/util/Migrator/DbScripts/2018-08-14_00_UserKdf.sql
@@ -13,6 +13,8 @@ UPDATE
 SET
     [Kdf] = 0,
     [KdfIterations] = 5000
+WHERE
+    [Kdf] IS NULL
 GO
 
 ALTER TABLE


### PR DESCRIPTION
# Overview

This migration method overwrites existing kdf iteration settings, which causes hash values to be out-of-sync with client supplied hashes on login.

This out-of-sync state results in users locked out of their accounts. If the user happens to remember their kdf iteration count, recovery is possible with db access.

This fix sets kdf/kdfiterations _only_ if kdf is already null. I believe this migration script was to create the columns necessary for users to configure their own kdf iteration count. If that's the case I believe this to be sufficient to make this migration script idempotent. @kspearrin do you remember this change and the original intent here? Pretty far back at this point.

## Monkeying with migration risk

The risk of this change is misinterpreting this code and not setting these values when they are necessary, which would lock out all users on a _very_ old server. However, we know that the correct values for kdf/kdfiterations are 0/5000.

The risk of **not** implementing this change is a self-hosted server runs migration scripts and loses all user-defined kdf/kdfiteration values. In that case, the fix would be to ask each user individually what they specified their kdf/kdfiteration to be and fallback to 100000 or 5000 if they can't remember.

In my mind the later is scarier, hence the PR.