### PR TITLE
[Reset Password] Manage Reset Password permission

### DIFF
--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -252,6 +252,12 @@ namespace Bit.Core.Context
             return OrganizationAdmin(orgId) || (Organizations?.Any(o => o.Id == orgId 
                         && (o.Permissions?.ManageUsers ?? false)) ?? false);
         }
+        
+        public bool ManageResetPassword(Guid orgId)
+        {
+            return OrganizationAdmin(orgId) || (Organizations?.Any(o => o.Id == orgId 
+                        && (o.Permissions?.ManageResetPassword ?? false)) ?? false);
+        }
 
         public async Task<ICollection<CurrentContentOrganization>> OrganizationMembershipAsync(
             IOrganizationUserRepository organizationUserRepository, Guid userId)
@@ -294,7 +300,8 @@ namespace Bit.Core.Context
                 ManageGroups = hasClaim("managegroups"),
                 ManagePolicies = hasClaim("managepolicies"),
                 ManageSso = hasClaim("managesso"),
-                ManageUsers = hasClaim("manageusers")
+                ManageUsers = hasClaim("manageusers"),
+                ManageResetPassword = hasClaim("manageresetpassword")
             };
         }
     }

--- a/src/Core/Context/ICurrentContext.cs
+++ b/src/Core/Context/ICurrentContext.cs
@@ -43,6 +43,7 @@ namespace Bit.Core.Context
         bool ManagePolicies(Guid orgId);
         bool ManageSso(Guid orgId);
         bool ManageUsers(Guid orgId);
+        bool ManageResetPassword(Guid orgId);
 
         Task<ICollection<CurrentContentOrganization>> OrganizationMembershipAsync(
             IOrganizationUserRepository organizationUserRepository, Guid userId);

--- a/src/Core/Models/Data/Permissions.cs
+++ b/src/Core/Models/Data/Permissions.cs
@@ -12,5 +12,6 @@ namespace Bit.Core.Models.Data
         public bool ManagePolicies { get; set; }
         public bool ManageSso { get; set; }
         public bool ManageUsers { get; set; }
+        public bool ManageResetPassword { get; set; }
     }
 }

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -788,6 +788,11 @@ namespace Bit.Core.Utilities
                                 {
                                     claims.Add(new KeyValuePair<string, string>("manageusers", org.Id.ToString()));
                                 }
+                                
+                                if (org.Permissions.ManageResetPassword)
+                                {
+                                    claims.Add(new KeyValuePair<string, string>("manageresetpassword", org.Id.ToString()));
+                                }
                             }
                             break;
                         default:


### PR DESCRIPTION
## Objective
> Allow users with the `custom` user type to be able to manage password resets (along with owners and administrators)

## Code Changes
- **CurrentContext**: Added helper method `ManageResetPassword` that will determine if the current user has permission to handle password resets.
- **ICurrentContext**: Added interface method `ManageResetPassword`
- **Permissions**: Added `ManageResetPassword` boolean field
- **CoreHelpers**: Added conditional to support setting the current context from claims for `manageresetpassword` functionality