### PR TITLE
Fix server 500 error when enabling 2FA policy from Portal

### DIFF
--- a/src/Core/Services/Implementations/AmazonSesMailDeliveryService.cs
+++ b/src/Core/Services/Implementations/AmazonSesMailDeliveryService.cs
@@ -59,7 +59,7 @@ namespace Bit.Core.Services
             _logger = logger;
             _client = amazonSimpleEmailService;
             _source = $"\"{globalSettings.SiteName}\" <{globalSettings.Mail.ReplyToEmail}>";
-            _senderTag = $"Server_{globalSettings.ProjectName.Replace(' ', '_')}";
+            _senderTag = $"Server_{globalSettings.ProjectName?.Replace(' ', '_')}";
             if (!string.IsNullOrWhiteSpace(_globalSettings.Mail.AmazonConfigSetName))
             {
                 _configSetName = _globalSettings.Mail.AmazonConfigSetName;

--- a/src/Core/Services/Implementations/AmazonSesMailDeliveryService.cs
+++ b/src/Core/Services/Implementations/AmazonSesMailDeliveryService.cs
@@ -59,7 +59,7 @@ namespace Bit.Core.Services
             _logger = logger;
             _client = amazonSimpleEmailService;
             _source = $"\"{globalSettings.SiteName}\" <{globalSettings.Mail.ReplyToEmail}>";
-            _senderTag = $"Server_{globalSettings.ProjectName}";
+            _senderTag = $"Server_{globalSettings.ProjectName.Replace(' ', '_')}";
             if (!string.IsNullOrWhiteSpace(_globalSettings.Mail.AmazonConfigSetName))
             {
                 _configSetName = _globalSettings.Mail.AmazonConfigSetName;


### PR DESCRIPTION
## Objective

When an organization has users without 2FA enabled, and the organization enables the 2FA policy from the Bitwarden Portal, the following error is thrown:

`Amazon.SimpleEmail.AmazonSimpleEmailServiceException: Invalid tag value <Server_Business Portal>: only alphanumeric ASCII characters, '_', and '-' are allowed.`

Only one non-compliant user is removed. All other users remain members of the organization even if they don't have 2FA enabled.

## Code changes

Our `AmazonSesMailDeliveryService` uses the `ProjectName` in a `MessageTag`. In this case, the `ProjectName` is "Bitwarden Portal" - which contains an illegal whitespace char.

This is why the first non-compliant user is removed - it successfully removes the user, then tries to send them an email telling them they've been removed, and crashes.

Solved by replacing spaces with underscores in this particular case. I assume we otherwise want to leave the project name as is.