### PR TITLE
Email length in IdSv4 config needed to be 256

### DIFF
--- a/bitwarden_license/src/Sso/Utilities/ServiceCollectionExtensions.cs
+++ b/bitwarden_license/src/Sso/Utilities/ServiceCollectionExtensions.cs
@@ -62,6 +62,7 @@ namespace Bit.Sso.Utilities
                         options.UserInteraction.ErrorUrl = "/Error";
                         options.UserInteraction.ErrorIdParameter = "errorId";
                     }
+                    options.InputLengthRestrictions.UserName = 256;
                 })
                 .AddInMemoryCaching()
                 .AddInMemoryClients(new List<Client>

--- a/src/Identity/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Identity/Utilities/ServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ namespace Bit.Identity.Utilities
                     {
                         options.Authentication.CookieSameSiteMode = Microsoft.AspNetCore.Http.SameSiteMode.Unspecified;
                     }
+                    options.InputLengthRestrictions.UserName = 256;
                 })
                 .AddInMemoryCaching()
                 .AddInMemoryApiResources(ApiResources.GetApiResources())


### PR DESCRIPTION
Fixes #1101 ; there was a missed requirement found during testing where [IdentityServer4's configuration's default length for `UserName` ](https://github.com/IdentityServer/IdentityServer4/blob/997a6cdd643e46cd5762b710c4ddc43574cbec2e/src/IdentityServer4/src/Configuration/DependencyInjection/Options/InputLengthRestrictions.cs#L62) was set to the `Default = 100` and this needed to be updated to `256` to match our database and model validation.

## Overview
Update the IdentityServer extension methods' options to set `InputLengthRestrictions.UserName = 256`.