### PR TITLE
Add install-id, install-key, and skip-ssl flags to Setup Project

### DIFF
--- a/util/Setup/CertBuilder.cs
+++ b/util/Setup/CertBuilder.cs
@@ -28,7 +28,7 @@ namespace Bit.Setup
 
             if (!_context.Config.Ssl)
             {
-                var skipSSL = false;
+                var skipSSL = _context.Parameters.ContainsKey("skip-ssl") && (_context.Parameters["skip-ssl"] == "true" || _context.Parameters["skip-ssl"] == "1");
                 if (_context.Parameters.ContainsKey("skip-ssl"))
                 {
                     skipSSL = _context.Parameters["skip-ssl"] == "true" ||

--- a/util/Setup/CertBuilder.cs
+++ b/util/Setup/CertBuilder.cs
@@ -29,11 +29,6 @@ namespace Bit.Setup
             if (!_context.Config.Ssl)
             {
                 var skipSSL = _context.Parameters.ContainsKey("skip-ssl") && (_context.Parameters["skip-ssl"] == "true" || _context.Parameters["skip-ssl"] == "1");
-                if (_context.Parameters.ContainsKey("skip-ssl"))
-                {
-                    skipSSL = _context.Parameters["skip-ssl"] == "true" ||
-                                          _context.Parameters["skip-ssl"] == "1";
-                }
 
                 if (!skipSSL)
                 {

--- a/util/Setup/CertBuilder.cs
+++ b/util/Setup/CertBuilder.cs
@@ -28,27 +28,37 @@ namespace Bit.Setup
 
             if (!_context.Config.Ssl)
             {
-                _context.Config.Ssl = Helpers.ReadQuestion("Do you have a SSL certificate to use?");
-                if (_context.Config.Ssl)
+                var skipSSL = false;
+                if (_context.Parameters.ContainsKey("skip-ssl"))
                 {
-                    Directory.CreateDirectory($"/bitwarden/ssl/{_context.Install.Domain}/");
-                    var message = "Make sure 'certificate.crt' and 'private.key' are provided in the \n" +
-                                  "appropriate directory before running 'start' (see docs for info).";
-                    Helpers.ShowBanner(_context, "NOTE", message);
+                    skipSSL = _context.Parameters["skip-ssl"] == "true" ||
+                                          _context.Parameters["skip-ssl"] == "1";
                 }
-                else if (Helpers.ReadQuestion("Do you want to generate a self-signed SSL certificate?"))
+
+                if (!skipSSL)
                 {
-                    Directory.CreateDirectory($"/bitwarden/ssl/self/{_context.Install.Domain}/");
-                    Helpers.WriteLine(_context, "Generating self signed SSL certificate.");
-                    _context.Config.Ssl = true;
-                    _context.Install.Trusted = false;
-                    _context.Install.SelfSignedCert = true;
-                    Helpers.Exec("openssl req -x509 -newkey rsa:4096 -sha256 -nodes -days 36500 " +
-                        $"-keyout /bitwarden/ssl/self/{_context.Install.Domain}/private.key " +
-                        $"-out /bitwarden/ssl/self/{_context.Install.Domain}/certificate.crt " +
-                        $"-reqexts SAN -extensions SAN " +
-                        $"-config <(cat /usr/lib/ssl/openssl.cnf <(printf '[SAN]\nsubjectAltName=DNS:{_context.Install.Domain}\nbasicConstraints=CA:true')) " +
-                        $"-subj \"/C=US/ST=California/L=Santa Barbara/O=Bitwarden Inc./OU=Bitwarden/CN={_context.Install.Domain}\"");
+                    _context.Config.Ssl = Helpers.ReadQuestion("Do you have a SSL certificate to use?");
+                    if (_context.Config.Ssl)
+                    {
+                        Directory.CreateDirectory($"/bitwarden/ssl/{_context.Install.Domain}/");
+                        var message = "Make sure 'certificate.crt' and 'private.key' are provided in the \n" +
+                                      "appropriate directory before running 'start' (see docs for info).";
+                        Helpers.ShowBanner(_context, "NOTE", message);
+                    }
+                    else if (Helpers.ReadQuestion("Do you want to generate a self-signed SSL certificate?"))
+                    {
+                        Directory.CreateDirectory($"/bitwarden/ssl/self/{_context.Install.Domain}/");
+                        Helpers.WriteLine(_context, "Generating self signed SSL certificate.");
+                        _context.Config.Ssl = true;
+                        _context.Install.Trusted = false;
+                        _context.Install.SelfSignedCert = true;
+                        Helpers.Exec("openssl req -x509 -newkey rsa:4096 -sha256 -nodes -days 36500 " +
+                                     $"-keyout /bitwarden/ssl/self/{_context.Install.Domain}/private.key " +
+                                     $"-out /bitwarden/ssl/self/{_context.Install.Domain}/certificate.crt " +
+                                     $"-reqexts SAN -extensions SAN " +
+                                     $"-config <(cat /usr/lib/ssl/openssl.cnf <(printf '[SAN]\nsubjectAltName=DNS:{_context.Install.Domain}\nbasicConstraints=CA:true')) " +
+                                     $"-subj \"/C=US/ST=California/L=Santa Barbara/O=Bitwarden Inc./OU=Bitwarden/CN={_context.Install.Domain}\"");
+                    }
                 }
             }
 

--- a/util/Setup/Program.cs
+++ b/util/Setup/Program.cs
@@ -196,15 +196,35 @@ namespace Bit.Setup
 
         private static bool ValidateInstallation()
         {
-            var installationId = Helpers.ReadInput("Enter your installation id (get at https://bitwarden.com/host)");
+            var installationId = "";
+            var installationKey = "";
+            
+            if (_context.Parameters.ContainsKey("install-id"))
+            {
+                installationId = _context.Parameters["install-id"].ToLowerInvariant();
+            }
+            else
+            {
+                installationId = Helpers.ReadInput("Enter your installation id (get at https://bitwarden.com/host)");                
+            }
+            
             if (!Guid.TryParse(installationId.Trim(), out var installationidGuid))
             {
                 Console.WriteLine("Invalid installation id.");
                 return false;
             }
 
+            if (_context.Parameters.ContainsKey("install-key"))
+            {
+                installationKey = _context.Parameters["install-key"];
+            }
+            else
+            {
+                installationKey = Helpers.ReadInput("Enter your installation key");
+            }
+            
             _context.Install.InstallationId = installationidGuid;
-            _context.Install.InstallationKey = Helpers.ReadInput("Enter your installation key");
+            _context.Install.InstallationKey = installationKey;
 
             try
             {

--- a/util/Setup/Program.cs
+++ b/util/Setup/Program.cs
@@ -196,8 +196,8 @@ namespace Bit.Setup
 
         private static bool ValidateInstallation()
         {
-            var installationId = "";
-            var installationKey = "";
+            var installationId = string.Empty;
+            var installationKey = string.Empty;
             
             if (_context.Parameters.ContainsKey("install-id"))
             {


### PR DESCRIPTION
Added three flags for the command-line execution of the Setup Project.
* install-id - The Installation ID of the Bitwarden Installation.
* install-key - The Installation Key of the Bitwarden Installation.
* skip-ssl - Skip SSL questions.  Used if you plan on using a HTTPS proxy in front of the Bitwarden Installation.