### PR TITLE
enable default appsettings for self hosted installs

### DIFF
--- a/src/Admin/Program.cs
+++ b/src/Admin/Program.cs
@@ -11,6 +11,7 @@ namespace Bit.Admin
         {
             Host
                 .CreateDefaultBuilder(args)
+                .ConfigureCustomAppConfiguration(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.ConfigureKestrel(o =>

--- a/src/Admin/appsettings.SelfHosted.json
+++ b/src/Admin/appsettings.SelfHosted.json
@@ -1,0 +1,20 @@
+﻿{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": null,
+      "api": null,
+      "identity": null,
+      "admin": null,
+      "notifications": null,
+      "sso": null,
+      "portal": null,
+      "internalNotifications": null,
+      "internalAdmin": null,
+      "internalIdentity": null,
+      "internalApi": null,
+      "internalVault": null,
+      "internalSso": null,
+      "internalPortal": null
+    }
+  }
+}

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -13,6 +13,7 @@ namespace Bit.Api
         {
             Host
                 .CreateDefaultBuilder(args)
+                .ConfigureCustomAppConfiguration(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();

--- a/src/Api/appsettings.SelfHosted.json
+++ b/src/Api/appsettings.SelfHosted.json
@@ -1,0 +1,20 @@
+﻿{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": null,
+      "api": null,
+      "identity": null,
+      "admin": null,
+      "notifications": null,
+      "sso": null,
+      "portal": null,
+      "internalNotifications": null,
+      "internalAdmin": null,
+      "internalIdentity": null,
+      "internalApi": null,
+      "internalVault": null,
+      "internalSso": null,
+      "internalPortal": null
+    }
+  }
+}

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -23,13 +23,13 @@ namespace Bit.Core.Settings
         public virtual string LogDirectory
         {
             get => BuildDirectory(_logDirectory, "/logs");
-            set { _logDirectory = value; }
+            set => _logDirectory = value;
         }
         public virtual long? LogRollBySizeLimit { get; set; }
         public virtual string LicenseDirectory
         {
             get => BuildDirectory(_licenseDirectory, "/core/licenses");
-            set { _licenseDirectory = value; }
+            set => _licenseDirectory = value;
         }
         public string LicenseCertificatePassword { get; set; }
         public virtual string PushRelayBaseUri { get; set; }
@@ -133,68 +133,68 @@ namespace Bit.Core.Settings
             public string Api
             {
                 get => _globalSettings.BuildExternalUri(_api, "api");
-                set { _api = value; }
+                set => _api = value;
             }
             public string Identity
             {
                 get => _globalSettings.BuildExternalUri(_identity, "identity");
-                set { _identity = value; }
+                set => _identity = value;
             }
             public string Admin
             {
                 get => _globalSettings.BuildExternalUri(_admin, "admin");
-                set { _admin = value; }
+                set => _admin = value;
             }
             public string Notifications
             {
                 get => _globalSettings.BuildExternalUri(_notifications, "notifications");
-                set { _notifications = value; }
+                set => _notifications = value;
             }
             public string Sso
             {
                 get => _globalSettings.BuildExternalUri(_sso, "sso");
-                set { _sso = value; }
+                set => _sso = value;
             }
             public string Portal
             {
                 get => _globalSettings.BuildExternalUri(_portal, "portal");
-                set { _portal = value; }
+                set => _portal = value;
             }
 
             public string InternalNotifications
             {
                 get => _globalSettings.BuildInternalUri(_internalNotifications, "notifications");
-                set { _internalNotifications = value; }
+                set => _internalNotifications = value;
             }
             public string InternalAdmin
             {
                 get => _globalSettings.BuildInternalUri(_internalAdmin, "admin");
-                set { _internalAdmin = value; }
+                set => _internalAdmin = value;
             }
             public string InternalIdentity
             {
                 get => _globalSettings.BuildInternalUri(_internalIdentity, "identity");
-                set { _internalIdentity = value; }
+                set => _internalIdentity = value;
             }
             public string InternalApi
             {
                 get => _globalSettings.BuildInternalUri(_internalApi, "api");
-                set { _internalApi = value; }
+                set => _internalApi = value;
             }
             public string InternalVault
             {
                 get => _globalSettings.BuildInternalUri(_internalVault, "web");
-                set { _internalVault = value; }
+                set => _internalVault = value;
             }
             public string InternalSso
             {
                 get => _globalSettings.BuildInternalUri(_internalSso, "sso");
-                set { _internalSso = value; }
+                set => _internalSso = value;
             }
             public string InternalPortal
             {
                 get => _globalSettings.BuildInternalUri(_internalPortal, "portal");
-                set { _internalPortal = value; }
+                set => _internalPortal = value;
             }
         }
 
@@ -207,29 +207,20 @@ namespace Bit.Core.Settings
             public string ConnectionString
             {
                 get => _connectionString;
-                set
-                {
-                    _connectionString = value.Trim('"');
-                }
+                set => _connectionString = value.Trim('"');
             }
 
             public string ReadOnlyConnectionString
             {
                 get => string.IsNullOrWhiteSpace(_readOnlyConnectionString) ?
                     _connectionString : _readOnlyConnectionString;
-                set
-                {
-                    _readOnlyConnectionString = value.Trim('"');
-                }
+                set => _readOnlyConnectionString = value.Trim('"');
             }
 
             public string JobSchedulerConnectionString
             {
                 get => _jobSchedulerConnectionString;
-                set
-                {
-                    _jobSchedulerConnectionString = value.Trim('"');
-                }
+                set => _jobSchedulerConnectionString = value.Trim('"');
             }
         }
 
@@ -240,10 +231,7 @@ namespace Bit.Core.Settings
             public string ConnectionString
             {
                 get => _connectionString;
-                set
-                {
-                    _connectionString = value.Trim('"');
-                }
+                set => _connectionString = value.Trim('"');
             }
         }
 
@@ -266,22 +254,19 @@ namespace Bit.Core.Settings
             public string ConnectionString
             {
                 get => _connectionString;
-                set
-                {
-                    _connectionString = value.Trim('"');
-                }
+                set => _connectionString = value.Trim('"');
             }
 
             public string BaseDirectory
             {
                 get => _globalSettings.BuildDirectory(_baseDirectory, string.Concat("/core/", _directoryName));
-                set { _baseDirectory = value; }
+                set => _baseDirectory = value;
             }
 
             public string BaseUrl
             {
                 get => _globalSettings.BuildExternalUri(_baseUrl, _urlName);
-                set { _baseUrl = value; }
+                set => _baseUrl = value;
             }
         }
 
@@ -327,7 +312,7 @@ namespace Bit.Core.Settings
             public string Directory
             {
                 get => _globalSettings.BuildDirectory(_directory, "/core/aspnet-dataprotection");
-                set { _directory = value; }
+                set => _directory = value;
             }
         }
 
@@ -397,10 +382,7 @@ namespace Bit.Core.Settings
             public string ConnectionString
             {
                 get => _connectionString;
-                set
-                {
-                    _connectionString = value.Trim('"');
-                }
+                set => _connectionString = value.Trim('"');
             }
             public string HubName { get; set; }
         }
@@ -441,7 +423,7 @@ namespace Bit.Core.Settings
             public string IdentityUri
             {
                 get => string.IsNullOrWhiteSpace(_identityUri) ? "https://identity.bitwarden.com" : _identityUri;
-                set { _identityUri = value; }
+                set => _identityUri = value;
             }
         }
 

--- a/src/Core/Utilities/HostBuilderExtensions.cs
+++ b/src/Core/Utilities/HostBuilderExtensions.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace Bit.Core.Utilities
+{
+    public static class HostBuilderExtensions
+    {
+        public static IHostBuilder ConfigureCustomAppConfiguration(this IHostBuilder hostBuilder, string[] args)
+        {
+            // Reload app configuration with SelfHosted overrides.
+            return hostBuilder.ConfigureAppConfiguration((hostingContext, config) =>
+            {
+                if (Environment.GetEnvironmentVariable("globalSettings__selfHosted")?.ToLower() != "true")
+                {
+                    return;
+                }
+
+                var env = hostingContext.HostingEnvironment;
+
+                config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                    .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true)
+                    .AddJsonFile("appsettings.SelfHosted.json", optional: true, reloadOnChange: true);
+
+                if (env.IsDevelopment())
+                {
+                    var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
+                    if (appAssembly != null)
+                    {
+                        config.AddUserSecrets(appAssembly, optional: true);
+                    }
+                }
+
+                config.AddEnvironmentVariables();
+
+                if (args != null)
+                {
+                    config.AddCommandLine(args);
+                }
+            });
+        }
+    }
+}

--- a/src/Events/Program.cs
+++ b/src/Events/Program.cs
@@ -12,6 +12,7 @@ namespace Bit.Events
         {
             Host
                 .CreateDefaultBuilder(args)
+                .ConfigureCustomAppConfiguration(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();

--- a/src/Events/appsettings.SelfHosted.json
+++ b/src/Events/appsettings.SelfHosted.json
@@ -1,0 +1,20 @@
+﻿{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": null,
+      "api": null,
+      "identity": null,
+      "admin": null,
+      "notifications": null,
+      "sso": null,
+      "portal": null,
+      "internalNotifications": null,
+      "internalAdmin": null,
+      "internalIdentity": null,
+      "internalApi": null,
+      "internalVault": null,
+      "internalSso": null,
+      "internalPortal": null
+    }
+  }
+}

--- a/src/Identity/Program.cs
+++ b/src/Identity/Program.cs
@@ -12,6 +12,7 @@ namespace Bit.Identity
         {
             Host
                 .CreateDefaultBuilder(args)
+                .ConfigureCustomAppConfiguration(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();

--- a/src/Identity/appsettings.SelfHosted.json
+++ b/src/Identity/appsettings.SelfHosted.json
@@ -1,0 +1,20 @@
+﻿{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": null,
+      "api": null,
+      "identity": null,
+      "admin": null,
+      "notifications": null,
+      "sso": null,
+      "portal": null,
+      "internalNotifications": null,
+      "internalAdmin": null,
+      "internalIdentity": null,
+      "internalApi": null,
+      "internalVault": null,
+      "internalSso": null,
+      "internalPortal": null
+    }
+  }
+}

--- a/src/Notifications/Program.cs
+++ b/src/Notifications/Program.cs
@@ -11,6 +11,7 @@ namespace Bit.Notifications
         {
             Host
                 .CreateDefaultBuilder(args)
+                .ConfigureCustomAppConfiguration(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();

--- a/src/Notifications/appsettings.SelfHosted.json
+++ b/src/Notifications/appsettings.SelfHosted.json
@@ -1,0 +1,20 @@
+﻿{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": null,
+      "api": null,
+      "identity": null,
+      "admin": null,
+      "notifications": null,
+      "sso": null,
+      "portal": null,
+      "internalNotifications": null,
+      "internalAdmin": null,
+      "internalIdentity": null,
+      "internalApi": null,
+      "internalVault": null,
+      "internalSso": null,
+      "internalPortal": null
+    }
+  }
+}

--- a/test/Core.Test/AutoFixture/GlobalSettingsFixtures.cs
+++ b/test/Core.Test/AutoFixture/GlobalSettingsFixtures.cs
@@ -1,0 +1,16 @@
+﻿using AutoFixture;
+
+namespace Bit.Core.Test.AutoFixture
+{
+    internal class GlobalSettings : ICustomization
+    {
+        public void Customize(IFixture fixture)
+        {
+            fixture.Customize<Settings.GlobalSettings>(composer => composer
+                .Without(s => s.BaseServiceUri)
+                .Without(s => s.Attachment)
+                .Without(s => s.Send)
+                .Without(s => s.DataProtection));
+        }
+    }
+}

--- a/test/Core.Test/AutoFixture/SutProvider.cs
+++ b/test/Core.Test/AutoFixture/SutProvider.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using AutoFixture;
 using AutoFixture.Kernel;
@@ -21,7 +21,7 @@ namespace Bit.Core.Test.AutoFixture
         public SutProvider(IFixture fixture)
         {
             _dependencies = new Dictionary<Type, Dictionary<string, object>>();
-            _fixture = (fixture ?? new Fixture()).WithAutoNSubstitutions();
+            _fixture = (fixture ?? new Fixture()).WithAutoNSubstitutions().Customize(new GlobalSettings());
             _constructorParameterRelay = new ConstructorParameterRelay<TSut>(this, _fixture);
             _fixture.Customizations.Add(_constructorParameterRelay);
         }

--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -43,7 +43,7 @@ namespace Bit.Core.Test.Services
             var ssoConfigRepo = Substitute.For<ISsoConfigRepository>();
             var ssoUserRepo = Substitute.For<ISsoUserRepository>();
             var referenceEventService = Substitute.For<IReferenceEventService>();
-            var globalSettings = Substitute.For<GlobalSettings>();
+            var globalSettings = Substitute.For<Settings.GlobalSettings>();
             var taxRateRepository = Substitute.For<ITaxRateRepository>();
 
             var orgService = new OrganizationService(orgRepo, orgUserRepo, collectionRepo, userRepo,
@@ -105,7 +105,7 @@ namespace Bit.Core.Test.Services
             var ssoConfigRepo = Substitute.For<ISsoConfigRepository>();
             var ssoUserRepo = Substitute.For<ISsoUserRepository>();
             var referenceEventService = Substitute.For<IReferenceEventService>();
-            var globalSettings = Substitute.For<GlobalSettings>();
+            var globalSettings = Substitute.For<Settings.GlobalSettings>();
             var taxRateRepo = Substitute.For<ITaxRateRepository>();
 
             var orgService = new OrganizationService(orgRepo, orgUserRepo, collectionRepo, userRepo,

--- a/util/Setup/EnvironmentFileBuilder.cs
+++ b/util/Setup/EnvironmentFileBuilder.cs
@@ -23,21 +23,7 @@ namespace Bit.Setup
                 ["ASPNETCORE_ENVIRONMENT"] = "Production",
                 ["globalSettings__selfHosted"] = "true",
                 ["globalSettings__baseServiceUri__vault"] = "http://localhost",
-                ["globalSettings__baseServiceUri__api"] = "http://localhost/api",
-                ["globalSettings__baseServiceUri__identity"] = "http://localhost/identity",
-                ["globalSettings__baseServiceUri__admin"] = "http://localhost/admin",
-                ["globalSettings__baseServiceUri__sso"] = "http://localhost/sso",
-                ["globalSettings__baseServiceUri__portal"] = "http://localhost/portal",
-                ["globalSettings__baseServiceUri__notifications"] = "http://localhost/notifications",
-                ["globalSettings__baseServiceUri__internalNotifications"] = "http://notifications:5000",
-                ["globalSettings__baseServiceUri__internalAdmin"] = "http://admin:5000",
-                ["globalSettings__baseServiceUri__internalIdentity"] = "http://identity:5000",
-                ["globalSettings__baseServiceUri__internalApi"] = "http://api:5000",
-                ["globalSettings__baseServiceUri__internalVault"] = "http://web:5000",
-                ["globalSettings__baseServiceUri__internalSso"] = "http://sso:5000",
-                ["globalSettings__baseServiceUri__internalPortal"] = "http://portal:5000",
                 ["globalSettings__pushRelayBaseUri"] = "https://push.bitwarden.com",
-                ["globalSettings__installation__identityUri"] = "https://identity.bitwarden.com",
             };
             _mssqlValues = new Dictionary<string, string>
             {
@@ -89,23 +75,8 @@ namespace Bit.Setup
             _globalOverrideValues = new Dictionary<string, string>
             {
                 ["globalSettings__baseServiceUri__vault"] = _context.Config.Url,
-                ["globalSettings__baseServiceUri__api"] = $"{_context.Config.Url}/api",
-                ["globalSettings__baseServiceUri__identity"] = $"{_context.Config.Url}/identity",
-                ["globalSettings__baseServiceUri__admin"] = $"{_context.Config.Url}/admin",
-                ["globalSettings__baseServiceUri__notifications"] = $"{_context.Config.Url}/notifications",
-                ["globalSettings__baseServiceUri__sso"] = $"{_context.Config.Url}/sso",
-                ["globalSettings__baseServiceUri__portal"] = $"{_context.Config.Url}/portal",
                 ["globalSettings__sqlServer__connectionString"] = $"\"{dbConnectionString}\"",
                 ["globalSettings__identityServer__certificatePassword"] = _context.Install?.IdentityCertPassword,
-                ["globalSettings__attachment__baseDirectory"] = $"{_context.OutputDir}/core/attachments",
-                ["globalSettings__attachment__baseUrl"] = $"{_context.Config.Url}/attachments",
-                ["globalSettings__send__baseDirectory"] = $"{_context.OutputDir}/core/attachments/send",
-                ["globalSettings__send__baseUrl"] = $"{_context.Config.Url}/attachments/send",
-                ["globalSettings__dataProtection__directory"] = $"{_context.OutputDir}/core/aspnet-dataprotection",
-                ["globalSettings__logDirectory"] = $"{_context.OutputDir}/logs",
-                ["globalSettings__logRollBySizeLimit"] = string.Empty,
-                ["globalSettings__syslog__destination"] = string.Empty,
-                ["globalSettings__licenseDirectory"] = $"{_context.OutputDir}/core/licenses",
                 ["globalSettings__internalIdentityKey"] = _context.Stub ? "RANDOM_IDENTITY_KEY" :
                     Helpers.SecureRandomString(64, alpha: true, numeric: true),
                 ["globalSettings__oidcIdentityClientKey"] = _context.Stub ? "RANDOM_IDENTITY_KEY" :
@@ -134,8 +105,6 @@ namespace Bit.Setup
 
             _mssqlOverrideValues = new Dictionary<string, string>
             {
-                ["ACCEPT_EULA"] = "Y",
-                ["MSSQL_PID"] = "Express",
                 ["SA_PASSWORD"] = dbPassword,
             };
         }


### PR DESCRIPTION
Our self-hosted installs have a lot of app setting configurations that are boilerplate and don't really need to be configured by the user. This PR reduces the need for these settings to be set by the user (as env vars) and defaults them to sensible defaults. Users still have the ability to explicitly set them, if desired, and existing installs where they are already set will still continue to work in a backward-compatible way.