### PR TITLE
Ef database support implementation examples

### DIFF
--- a/src/Core/Enums/SupportedDatabaseProviders.cs
+++ b/src/Core/Enums/SupportedDatabaseProviders.cs
@@ -1,0 +1,10 @@
+namespace Bit.Core.Enums
+{
+    public enum SupportedDatabaseProviders 
+    {
+        MsSql,
+        MySql,
+        Postgres
+    }
+}
+

--- a/src/Core/Models/EntityFramework/Organization.cs
+++ b/src/Core/Models/EntityFramework/Organization.cs
@@ -1,25 +1,12 @@
 ﻿using System.Collections.Generic;
-using System.Text.Json;
 using AutoMapper;
 
 namespace Bit.Core.Models.EntityFramework
 {
     public class Organization : Table.Organization
     {
-        private JsonDocument _twoFactorProvidersJson;
-
         public ICollection<Cipher> Ciphers { get; set; }
-        
-        [IgnoreMap]
-        public JsonDocument TwoFactorProvidersJson
-        {
-            get => _twoFactorProvidersJson;
-            set
-            {
-                TwoFactorProviders = value?.ToString();
-                _twoFactorProvidersJson = value;
-            }
-        }
+        public ICollection<OrganizationUser> OrganizationUsers { get; set; }
     }
 
     public class OrganizationMapperProfile : Profile

--- a/src/Core/Models/EntityFramework/OrganizationUser.cs
+++ b/src/Core/Models/EntityFramework/OrganizationUser.cs
@@ -6,6 +6,8 @@ namespace Bit.Core.Models.EntityFramework
 {
     public class OrganizationUser : Table.OrganizationUser
     {
+        public Organization Organization { get; set; }
+        public User User { get; set; }
     }
 
     public class OrganizationUserMapperProfile : Profile

--- a/src/Core/Models/EntityFramework/SsoConfig.cs
+++ b/src/Core/Models/EntityFramework/SsoConfig.cs
@@ -6,6 +6,7 @@ namespace Bit.Core.Models.EntityFramework
 {
     public class SsoConfig : Table.SsoConfig
     {
+        public Organization Organization { get; set; }
     }
 
     public class SsoConfigMapperProfile : Profile

--- a/src/Core/Models/EntityFramework/User.cs
+++ b/src/Core/Models/EntityFramework/User.cs
@@ -6,7 +6,7 @@ namespace Bit.Core.Models.EntityFramework
 {
     public class User : Table.User
     {
-
+        public ICollection<OrganizationUser> OrganizationUsers { get; set; }
     }
 
     public class UserMapperProfile : Profile

--- a/src/Core/Models/EntityFramework/User.cs
+++ b/src/Core/Models/EntityFramework/User.cs
@@ -6,27 +6,14 @@ namespace Bit.Core.Models.EntityFramework
 {
     public class User : Table.User
     {
-        private JsonDocument _twoFactorProvidersJson;
 
-        public ICollection<Cipher> Ciphers { get; set; }
-
-        [IgnoreMap]
-        public JsonDocument TwoFactorProvidersJson
-        {
-            get => _twoFactorProvidersJson;
-            set
-            {
-                TwoFactorProviders = value?.ToString();
-                _twoFactorProvidersJson = value;
-            }
-        }
     }
 
     public class UserMapperProfile : Profile
     {
         public UserMapperProfile()
         {
-            CreateMap<Table.User, User>().ReverseMap();
+           CreateMap<Table.User, User>().ReverseMap();
         }
     }
 }

--- a/src/Core/Models/Table/Organization.cs
+++ b/src/Core/Models/Table/Organization.cs
@@ -4,6 +4,7 @@ using Bit.Core.Enums;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using System.Linq;
+using System.ComponentModel.DataAnnotations;
 
 namespace Bit.Core.Models.Table
 {
@@ -12,15 +13,25 @@ namespace Bit.Core.Models.Table
         private Dictionary<TwoFactorProviderType, TwoFactorProvider> _twoFactorProviders;
 
         public Guid Id { get; set; }
+        [MaxLength(50)]
         public string Identifier { get; set; }
+        [MaxLength(50)]
         public string Name { get; set; }
+        [MaxLength(50)]
         public string BusinessName { get; set; }
+        [MaxLength(50)]
         public string BusinessAddress1 { get; set; }
+        [MaxLength(50)]
         public string BusinessAddress2 { get; set; }
+        [MaxLength(50)]
         public string BusinessAddress3 { get; set; }
+        [MaxLength(2)]
         public string BusinessCountry { get; set; }
+        [MaxLength(30)]
         public string BusinessTaxNumber { get; set; }
+        [MaxLength(256)]
         public string BillingEmail { get; set; }
+        [MaxLength(50)]
         public string Plan { get; set; }
         public PlanType PlanType { get; set; }
         public short? Seats { get; set; }
@@ -38,11 +49,15 @@ namespace Bit.Core.Models.Table
         public long? Storage { get; set; }
         public short? MaxStorageGb { get; set; }
         public GatewayType? Gateway { get; set; }
+        [MaxLength(50)]
         public string GatewayCustomerId { get; set; }
+        [MaxLength(50)]
         public string GatewaySubscriptionId { get; set; }
         public string ReferenceData { get; set; }
         public bool Enabled { get; set; } = true;
+        [MaxLength(100)]
         public string LicenseKey { get; set; }
+        [MaxLength(30)]
         public string ApiKey { get; set; }
         public string TwoFactorProviders { get; set; }
         public DateTime? ExpirationDate { get; set; }

--- a/src/Core/Models/Table/SsoConfig.cs
+++ b/src/Core/Models/Table/SsoConfig.cs
@@ -13,7 +13,8 @@ namespace Bit.Core.Models.Table
         
         public void SetNewId()
         {
-            // nothing - int will be auto-populated
+            // int will be auto-populated
+            Id = 0;
         }
     }
 }

--- a/src/Core/Models/Table/SsoUser.cs
+++ b/src/Core/Models/Table/SsoUser.cs
@@ -12,7 +12,8 @@ namespace Bit.Core.Models.Table
 
         public void SetNewId()
         {
-            // nothing - int will be auto-populated
+            // int will be auto-populated
+            Id = 0;
         }
     }
 }

--- a/src/Core/Models/Table/User.cs
+++ b/src/Core/Models/Table/User.cs
@@ -4,6 +4,7 @@ using Bit.Core.Utilities;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Microsoft.AspNetCore.Identity;
+using System.ComponentModel.DataAnnotations;
 
 namespace Bit.Core.Models.Table
 {
@@ -12,14 +13,23 @@ namespace Bit.Core.Models.Table
         private Dictionary<TwoFactorProviderType, TwoFactorProvider> _twoFactorProviders;
 
         public Guid Id { get; set; }
+        [MaxLength(50)]
         public string Name { get; set; }
+        [Required]
+        [MaxLength(50)]
         public string Email { get; set; }
         public bool EmailVerified { get; set; }
+        [MaxLength(300)]
         public string MasterPassword { get; set; }
+        [MaxLength(50)]
         public string MasterPasswordHint { get; set; }
+        [MaxLength(10)]
         public string Culture { get; set; } = "en-US";
+        [Required]
+        [MaxLength(50)]
         public string SecurityStamp { get; set; }
         public string TwoFactorProviders { get; set; }
+        [MaxLength(32)]
         public string TwoFactorRecoveryCode { get; set; }
         public string EquivalentDomains { get; set; }
         public string ExcludedGlobalEquivalentDomains { get; set; }
@@ -33,10 +43,15 @@ namespace Bit.Core.Models.Table
         public long? Storage { get; set; }
         public short? MaxStorageGb { get; set; }
         public GatewayType? Gateway { get; set; }
+        [MaxLength(50)]
         public string GatewayCustomerId { get; set; }
+        [MaxLength(50)]
         public string GatewaySubscriptionId { get; set; }
         public string ReferenceData { get; set; }
+        [MaxLength(100)]
         public string LicenseKey { get; set; }
+        [Required]
+        [MaxLength(30)]
         public string ApiKey { get; set; }
         public KdfType Kdf { get; set; } = KdfType.PBKDF2_SHA256;
         public int KdfIterations { get; set; } = 5000;

--- a/src/Core/Repositories/EntityFramework/DatabaseContext.cs
+++ b/src/Core/Repositories/EntityFramework/DatabaseContext.cs
@@ -76,11 +76,9 @@ namespace Bit.Core.Repositories.EntityFramework
 
             eGroupUser.HasNoKey();
 
-            eOrganization.Ignore(e => e.TwoFactorProviders);
-            eOrganization.Property(e => e.TwoFactorProvidersJson).HasColumnName("TwoFactorProviders");
-
             if (Database.IsNpgsql()) 
             {
+                eOrganization.Property(e => e.TwoFactorProviders).HasColumnType("jsonb");
                 eUser.Property(e => e.TwoFactorProviders).HasColumnType("jsonb");
             }
 

--- a/src/Core/Repositories/EntityFramework/DatabaseContext.cs
+++ b/src/Core/Repositories/EntityFramework/DatabaseContext.cs
@@ -6,12 +6,9 @@ namespace Bit.Core.Repositories.EntityFramework
 {
     public class DatabaseContext : DbContext
     {
-        private DbContextOptions<DatabaseContext> _options { get; set; }
         public DatabaseContext(DbContextOptions<DatabaseContext> options)
             : base(options)
-        { 
-            _options = options;
-        }
+        { }
 
         public DbSet<Cipher> Ciphers { get; set; }
         public DbSet<Collection> Collections { get; set; }

--- a/src/Core/Repositories/EntityFramework/DatabaseContext.cs
+++ b/src/Core/Repositories/EntityFramework/DatabaseContext.cs
@@ -6,9 +6,12 @@ namespace Bit.Core.Repositories.EntityFramework
 {
     public class DatabaseContext : DbContext
     {
+        private DbContextOptions<DatabaseContext> _options { get; set; }
         public DatabaseContext(DbContextOptions<DatabaseContext> options)
             : base(options)
-        { }
+        { 
+            _options = options;
+        }
 
         public DbSet<Cipher> Ciphers { get; set; }
         public DbSet<Collection> Collections { get; set; }
@@ -24,7 +27,6 @@ namespace Bit.Core.Repositories.EntityFramework
         public DbSet<Organization> Organizations { get; set; }
         public DbSet<OrganizationUser> OrganizationUsers { get; set; }
         public DbSet<Policy> Policies { get; set; }
-        public DbSet<Role> Roles { get; set; }
         public DbSet<Send> Sends { get; set; }
         public DbSet<SsoConfig> SsoConfigs { get; set; }
         public DbSet<SsoUser> SsoUsers { get; set; }
@@ -35,42 +37,74 @@ namespace Bit.Core.Repositories.EntityFramework
         
         protected override void OnModelCreating(ModelBuilder builder)
         {
-            builder.Entity<Cipher>().Ignore(e => e.Data);
-            builder.Entity<Cipher>().Property(e => e.DataJson).HasColumnName("Data");
-            builder.Entity<Cipher>().Ignore(e => e.Attachments);
-            builder.Entity<Cipher>().Property(e => e.AttachmentsJson).HasColumnName("Attachments");
-            builder.Entity<Cipher>().Ignore(e => e.Favorites);
-            builder.Entity<Cipher>().Property(e => e.FavoritesJson).HasColumnName("Favorites");
-            builder.Entity<Cipher>().Ignore(e => e.Folders);
-            builder.Entity<Cipher>().Property(e => e.FoldersJson).HasColumnName("Folders");
+            var eCipher = builder.Entity<Cipher>();
+            var eCollection = builder.Entity<Collection>();
+            var eCollectionCipher = builder.Entity<CollectionCipher>();
+            var eDevice = builder.Entity<Device>();
+            var eEmergencyAccess = builder.Entity<EmergencyAccess>();
+            var eEvent = builder.Entity<Event>();
+            var eFolder = builder.Entity<Folder>();
+            var eGrant = builder.Entity<Grant>();
+            var eGroup = builder.Entity<Group>();
+            var eGroupUser = builder.Entity<GroupUser>();
+            var eInstallation = builder.Entity<Installation>();
+            var eOrganization = builder.Entity<Organization>();
+            var eOrganizationUser = builder.Entity<OrganizationUser>();
+            var ePolicy = builder.Entity<Policy>();
+            var eSend = builder.Entity<Send>();
+            var eSsoConfig = builder.Entity<SsoConfig>();
+            var eSsoUser = builder.Entity<SsoUser>();
+            var eTaxRate = builder.Entity<TaxRate>();
+            var eTransaction = builder.Entity<Transaction>();
+            var eU2f = builder.Entity<U2f>();
+            var eUser = builder.Entity<User>();
 
-            builder.Entity<User>().Ignore(e => e.TwoFactorProviders);
-            builder.Entity<User>().Property(e => e.TwoFactorProvidersJson).HasColumnName("TwoFactorProviders");
+            eCipher.Property(e => e.AttachmentsJson).HasColumnName("Attachments");
+            eCipher.Ignore(e => e.Attachments);
+            eCipher.Property(e => e.DataJson).HasColumnName("Data");
+            eCipher.Ignore(e => e.Data);
+            eCipher.Property(e => e.FavoritesJson).HasColumnName("Favorites");
+            eCipher.Ignore(e => e.Favorites);
+            eCipher.Ignore(e => e.Folders);
+            eCipher.Property(e => e.FoldersJson).HasColumnName("Folders");
 
-            builder.Entity<Organization>().Ignore(e => e.TwoFactorProviders);
-            builder.Entity<Organization>().Property(e => e.TwoFactorProvidersJson).HasColumnName("TwoFactorProviders");
+            eCollectionCipher.HasNoKey();
 
-            builder.Entity<Cipher>().ToTable(nameof(Cipher));
-            builder.Entity<Collection>().ToTable(nameof(Collection));
-            builder.Entity<CollectionCipher>().ToTable(nameof(CollectionCipher));
-            builder.Entity<Device>().ToTable(nameof(Device));
-            builder.Entity<EmergencyAccess>().ToTable(nameof(EmergencyAccess));
-            builder.Entity<Event>().ToTable(nameof(Event));
-            builder.Entity<Folder>().ToTable(nameof(Folder));
-            builder.Entity<Grant>().ToTable(nameof(Grant));
-            builder.Entity<Group>().ToTable(nameof(Group));
-            builder.Entity<GroupUser>().ToTable(nameof(GroupUser));
-            builder.Entity<Installation>().ToTable(nameof(Installation));
-            builder.Entity<Organization>().ToTable(nameof(Organization));
-            builder.Entity<OrganizationUser>().ToTable(nameof(OrganizationUser));
-            builder.Entity<Policy>().ToTable(nameof(Policy));
-            builder.Entity<Send>().ToTable(nameof(Send));
-            builder.Entity<SsoConfig>().ToTable(nameof(SsoConfig));
-            builder.Entity<SsoUser>().ToTable(nameof(SsoUser));
-            builder.Entity<TaxRate>().ToTable(nameof(TaxRate));
-            builder.Entity<Transaction>().ToTable(nameof(Transaction));
-            builder.Entity<U2f>().ToTable(nameof(U2f));
-            builder.Entity<User>().ToTable(nameof(User));
+            eGrant.HasNoKey();
+            eCipher.Property(e => e.DataJson).HasColumnName("Data");
+            eCipher.Ignore(e => e.Data);
+
+            eGroupUser.HasNoKey();
+
+            eOrganization.Ignore(e => e.TwoFactorProviders);
+            eOrganization.Property(e => e.TwoFactorProvidersJson).HasColumnName("TwoFactorProviders");
+
+            if (Database.IsNpgsql()) 
+            {
+                eUser.Property(e => e.TwoFactorProviders).HasColumnType("jsonb");
+            }
+
+            eCipher.ToTable(nameof(Cipher));
+            eCollection.ToTable(nameof(Collection));
+            eCollectionCipher.ToTable(nameof(CollectionCipher));
+            eDevice.ToTable(nameof(Device));
+            eEmergencyAccess.ToTable(nameof(EmergencyAccess));
+            eEvent.ToTable(nameof(Event));
+            eFolder.ToTable(nameof(Folder));
+            eGrant.ToTable(nameof(Grant));
+            eGroup.ToTable(nameof(Group));
+            eGroupUser.ToTable(nameof(GroupUser));
+            eInstallation.ToTable(nameof(Installation));
+            eOrganization.ToTable(nameof(Organization));
+            eOrganizationUser.ToTable(nameof(OrganizationUser));
+            ePolicy.ToTable(nameof(Policy));
+            eSend.ToTable(nameof(Send));
+            eSsoConfig.ToTable(nameof(SsoConfig));
+            eSsoUser.ToTable(nameof(SsoUser));
+            eTaxRate.ToTable(nameof(TaxRate));
+            eTransaction.ToTable(nameof(Transaction));
+            eU2f.ToTable(nameof(U2f));
+            eUser.ToTable(nameof(User));
         }
     }
 }

--- a/src/Core/Repositories/EntityFramework/OrganizationRepository.cs
+++ b/src/Core/Repositories/EntityFramework/OrganizationRepository.cs
@@ -23,10 +23,15 @@ namespace Bit.Core.Repositories.EntityFramework
             using (var scope = ServiceScopeFactory.CreateScope())
             {
                 var dbContext = GetDatabaseContext(scope);
-                var organization = await GetDbSet(dbContext).Where(e => e.Identifier == identifier)
-                    .FirstOrDefaultAsync();
-                return organization;
+                return await GetByIdentifierAsync(dbContext, identifier);
             }
+        }
+
+        internal async Task<Organization> GetByIdentifierAsync(DatabaseContext dbContext, string identifier)
+        {
+            var organization = await GetDbSet(dbContext).Where(e => e.Identifier == identifier)
+                .FirstOrDefaultAsync();
+            return organization;
         }
 
         public async Task<ICollection<TableModel.Organization>> GetManyByEnabledAsync()
@@ -34,31 +39,58 @@ namespace Bit.Core.Repositories.EntityFramework
             using (var scope = ServiceScopeFactory.CreateScope())
             {
                 var dbContext = GetDatabaseContext(scope);
-                var organizations = await GetDbSet(dbContext).Where(e => e.Enabled).ToListAsync();
-                return Mapper.Map<List<TableModel.Organization>>(organizations);
+                return await GetManyByEnabledAsync(dbContext);
             }
+        }
+
+        internal async Task<ICollection<TableModel.Organization>> GetManyByEnabledAsync(DatabaseContext dbContext)
+        {
+            var organizations = await GetDbSet(dbContext).Where(e => e.Enabled).ToListAsync();
+            return Mapper.Map<List<TableModel.Organization>>(organizations);
         }
 
         public async Task<ICollection<TableModel.Organization>> GetManyByUserIdAsync(Guid userId)
         {
-            // TODO
-            return await Task.FromResult(null as ICollection<TableModel.Organization>);
+            using (var scope = ServiceScopeFactory.CreateScope())
+            {
+                var dbContext = GetDatabaseContext(scope);
+                return await GetManyByUserIdAsync(dbContext, userId);
+            }
         }
 
-        public async Task<ICollection<TableModel.Organization>> SearchAsync(string name, string userEmail, bool? paid,
-            int skip, int take)
+        internal async Task<ICollection<TableModel.Organization>> GetManyByUserIdAsync(DatabaseContext dbContext, Guid userId)
+        {
+            var organizations = await GetDbSet(dbContext)
+                .Select(e => e.OrganizationUsers
+                    .Where(ou => ou.UserId == userId)
+                    .Select(ou => ou.Organization))
+                .ToListAsync();
+            return Mapper.Map<List<TableModel.Organization>>(organizations);
+        }
+
+        public async Task<ICollection<TableModel.Organization>> SearchAsync(string name, string userEmail,
+                bool? paid, int skip, int take)
         {
             using (var scope = ServiceScopeFactory.CreateScope())
             {
                 var dbContext = GetDatabaseContext(scope);
-                // TODO: more filters
-                var organizations = await GetDbSet(dbContext)
-                .Where(e => name == null || e.Name.StartsWith(name))
-                .OrderBy(e => e.Name)
+                return await SearchAsync(dbContext, name, userEmail, paid, skip, take);
+            }
+        }
+
+        internal async Task<ICollection<TableModel.Organization>> SearchAsync(DatabaseContext dbContext, string name,
+                string userEmail, bool? paid, int skip, int take)
+        {
+            var organizations = await GetDbSet(dbContext)
+                .Where(e => name == null || e.Name.Contains(name))
+                .Where(e => userEmail == null || e.OrganizationUsers.Any(u => u.Email == userEmail))
+                .Where(e => paid == null || 
+                        (paid == true && !string.IsNullOrWhiteSpace(e.GatewaySubscriptionId)) ||
+                        (paid == false && e.GatewaySubscriptionId == null))
+                .OrderBy(e => e.CreationDate)
                 .Skip(skip).Take(take)
                 .ToListAsync();
-                return Mapper.Map<List<TableModel.Organization>>(organizations);
-            }
+            return Mapper.Map<List<TableModel.Organization>>(organizations);
         }
 
         public async Task UpdateStorageAsync(Guid id)
@@ -66,6 +98,12 @@ namespace Bit.Core.Repositories.EntityFramework
             using (var scope = ServiceScopeFactory.CreateScope())
             {
                 var dbContext = GetDatabaseContext(scope);
+                await UpdateStorageAsync(dbContext, id);
+            }
+        }
+
+        internal async Task UpdateStorageAsync(DatabaseContext dbContext, Guid id)
+        {
                 var ciphers = await dbContext.Ciphers
                     .Where(e => e.UserId == null && e.OrganizationId == id).ToListAsync();
                 var storage = ciphers.Sum(e => e.AttachmentsJson?.RootElement.EnumerateArray()
@@ -82,7 +120,6 @@ namespace Bit.Core.Repositories.EntityFramework
                 entry.Property(e => e.RevisionDate).IsModified = true;
                 entry.Property(e => e.Storage).IsModified = true;
                 await dbContext.SaveChangesAsync();
-            }
         }
 
         public async Task<ICollection<DataModel.OrganizationAbility>> GetManyAbilitiesAsync()
@@ -90,18 +127,23 @@ namespace Bit.Core.Repositories.EntityFramework
             using (var scope = ServiceScopeFactory.CreateScope())
             {
                 var dbContext = GetDatabaseContext(scope);
-                return await GetDbSet(dbContext)
-                .Select(e => new DataModel.OrganizationAbility
-                {
-                    Enabled = e.Enabled,
-                    Id = e.Id,
-                    Use2fa = e.Use2fa,
-                    UseEvents = e.UseEvents,
-                    UsersGetPremium = e.UsersGetPremium,
-                    Using2fa = e.Use2fa && e.TwoFactorProviders != null,
-                    UseSso = e.UseSso,
-                }).ToListAsync();
+                return await GetManyAbilitiesAsync(dbContext);
             }
+        }
+
+        internal async Task<ICollection<DataModel.OrganizationAbility>> GetManyAbilitiesAsync(DatabaseContext dbContext)
+        {
+            return await GetDbSet(dbContext)
+            .Select(e => new DataModel.OrganizationAbility
+            {
+                Enabled = e.Enabled,
+                Id = e.Id,
+                Use2fa = e.Use2fa,
+                UseEvents = e.UseEvents,
+                UsersGetPremium = e.UsersGetPremium,
+                Using2fa = e.Use2fa && e.TwoFactorProviders != null,
+                UseSso = e.UseSso,
+            }).ToListAsync();
         }
     }
 }

--- a/src/Core/Repositories/EntityFramework/Repository.cs
+++ b/src/Core/Repositories/EntityFramework/Repository.cs
@@ -46,6 +46,7 @@ namespace Bit.Core.Repositories.EntityFramework
 
         internal async Task<T> CreateAsync(DatabaseContext dbContext, T obj)
         {
+            obj.SetNewId();
             var entity = Mapper.Map<TEntity>(obj);
             dbContext.Add(entity);
             await dbContext.SaveChangesAsync();

--- a/src/Core/Repositories/EntityFramework/SsoUserRepository.cs
+++ b/src/Core/Repositories/EntityFramework/SsoUserRepository.cs
@@ -18,9 +18,20 @@ namespace Bit.Core.Repositories.EntityFramework
             : base(serviceScopeFactory, mapper, (DatabaseContext context) => context.SsoUsers)
         { }
 
-        public Task DeleteAsync(Guid userId, Guid? organizationId)
+        public async Task DeleteAsync(Guid userId, Guid? organizationId)
         {
-            throw new NotImplementedException();
+            using (var scope = ServiceScopeFactory.CreateScope())
+            {
+                var dbContext = GetDatabaseContext(scope);
+                await DeleteAsync(dbContext, userId, organizationId);
+            }
+        }
+
+        internal async Task DeleteAsync(DatabaseContext dbContext, Guid userId, Guid? organizationId)
+        {
+            var entity = await GetDbSet(dbContext).SingleOrDefaultAsync(su => su.UserId == userId && su.OrganizationId == organizationId);
+            dbContext.Entry(entity).State = EntityState.Deleted;
+            await dbContext.SaveChangesAsync();
         }
     }
 }

--- a/src/Core/Repositories/EntityFramework/UserRepository.cs
+++ b/src/Core/Repositories/EntityFramework/UserRepository.cs
@@ -165,9 +165,20 @@ namespace Bit.Core.Repositories.EntityFramework
             await dbContext.SaveChangesAsync();
         }
 
-        public Task<User> GetBySsoUserAsync(string externalId, Guid? organizationId)
+        public async Task<User> GetBySsoUserAsync(string externalId, Guid? organizationId)
         {
-            throw new NotImplementedException();
+            using (var scope = ServiceScopeFactory.CreateScope())
+            {
+                var dbContext = GetDatabaseContext(scope);
+                return await GetBySsoUserAsync(dbContext, externalId, organizationId);
+            }
+        }
+
+        internal async Task<User> GetBySsoUserAsync(DatabaseContext dbContext, string externalId, Guid? organizationId)
+        {
+            var ssoUser = await dbContext.SsoUsers.SingleOrDefaultAsync(e =>
+                    e.OrganizationId == organizationId && e.ExternalId == externalId);
+            return await dbContext.Users.SingleOrDefaultAsync(e => e.Id == ssoUser.UserId);
         }
     }
 }

--- a/src/Core/Repositories/IRepository.cs
+++ b/src/Core/Repositories/IRepository.cs
@@ -7,7 +7,7 @@ namespace Bit.Core.Repositories
     public interface IRepository<T, TId> where TId : IEquatable<TId> where T : class, ITableObject<TId>
     {
         Task<T> GetByIdAsync(TId id);
-        Task CreateAsync(T obj);
+        Task<T> CreateAsync(T obj);
         Task ReplaceAsync(T obj);
         Task UpsertAsync(T obj);
         Task DeleteAsync(T obj);

--- a/src/Core/Repositories/SqlServer/Repository.cs
+++ b/src/Core/Repositories/SqlServer/Repository.cs
@@ -48,10 +48,14 @@ namespace Bit.Core.Repositories.SqlServer
             obj.SetNewId();
             using (var connection = new SqlConnection(ConnectionString))
             {
+                var parameters = new DynamicParameters();
+                parameters.AddDynamicParams(obj);
+                parameters.Add("Id", obj.Id, direction: ParameterDirection.InputOutput);
                 var results = await connection.ExecuteAsync(
                     $"[{Schema}].[{Table}_Create]",
-                    obj,
+                    parameters,
                     commandType: CommandType.StoredProcedure);
+                obj.Id = parameters.Get<TId>(nameof(obj.Id));
             }
             return obj;
         }

--- a/src/Core/Repositories/SqlServer/Repository.cs
+++ b/src/Core/Repositories/SqlServer/Repository.cs
@@ -43,7 +43,7 @@ namespace Bit.Core.Repositories.SqlServer
             }
         }
 
-        public virtual async Task CreateAsync(T obj)
+        public virtual async Task<T> CreateAsync(T obj)
         {
             obj.SetNewId();
             using (var connection = new SqlConnection(ConnectionString))
@@ -53,6 +53,7 @@ namespace Bit.Core.Repositories.SqlServer
                     obj,
                     commandType: CommandType.StoredProcedure);
             }
+            return obj;
         }
 
         public virtual async Task ReplaceAsync(T obj)

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -23,6 +23,7 @@ namespace Bit.Core.Settings
         public virtual int OrganizationInviteExpirationHours { get; set; } = 120; // 5 days
         public virtual InstallationSettings Installation { get; set; } = new InstallationSettings();
         public virtual BaseServiceUriSettings BaseServiceUri { get; set; } = new BaseServiceUriSettings();
+        public virtual string DatabaseProvider { get; set; }
         public virtual SqlSettings SqlServer { get; set; } = new SqlSettings();
         public virtual SqlSettings PostgreSql { get; set; } = new SqlSettings();
         public virtual SqlSettings MySql { get; set; } = new SqlSettings();

--- a/src/Core/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Core/Utilities/ServiceCollectionExtensions.cs
@@ -46,20 +46,37 @@ namespace Bit.Core.Utilities
     {
         public static void AddSqlServerRepositories(this IServiceCollection services, GlobalSettings globalSettings)
         {
-            var usePostgreSql = CoreHelpers.SettingHasValue(globalSettings.PostgreSql?.ConnectionString);
-            var useMySql = CoreHelpers.SettingHasValue(globalSettings.MySql?.ConnectionString);
-            var useEf = usePostgreSql || useMySql;
+            var selectedDatabaseProvider = globalSettings.DatabaseProvider;
+            var provider = SupportedDatabaseProviders.MsSql;
+            if (!string.IsNullOrWhiteSpace(selectedDatabaseProvider))
+            {
+                switch (selectedDatabaseProvider.ToLowerInvariant())
+                {
+                    case "postgres":
+                    case "postgresql":
+                        provider = SupportedDatabaseProviders.Postgres;
+                        break;
+                    case "mysql":
+                    case "mariadb":
+                        provider = SupportedDatabaseProviders.MySql;
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            var useEf = (provider != SupportedDatabaseProviders.MsSql);
 
             if (useEf)
             {
                 services.AddAutoMapper(typeof(EntityFrameworkRepos.UserRepository));
                 services.AddDbContext<EntityFrameworkRepos.DatabaseContext>(options =>
                 {
-                    if (usePostgreSql)
+                    if (provider == SupportedDatabaseProviders.Postgres)
                     {
                         options.UseNpgsql(globalSettings.PostgreSql.ConnectionString);
                     } 
-                    else if (useMySql)
+                    else if (provider == SupportedDatabaseProviders.MySql)
                     {
                         options.UseMySql(globalSettings.MySql.ConnectionString);
                     }

--- a/src/Sql/dbo/Stored Procedures/Organization_Create.sql
+++ b/src/Sql/dbo/Stored Procedures/Organization_Create.sql
@@ -1,5 +1,5 @@
 ﻿CREATE PROCEDURE [dbo].[Organization_Create]
-    @Id UNIQUEIDENTIFIER,
+    @Id UNIQUEIDENTIFIER OUTPUT,
     @Identifier NVARCHAR(50),
     @Name NVARCHAR(50),
     @BusinessName NVARCHAR(50),

--- a/src/Sql/dbo/Stored Procedures/SsoConfig_DeleteById.sql
+++ b/src/Sql/dbo/Stored Procedures/SsoConfig_DeleteById.sql
@@ -1,0 +1,12 @@
+﻿CREATE PROCEDURE [dbo].[SsoConfig_DeleteById]
+    @Id BIGINT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    DELETE
+    FROM
+        [dbo].[SsoConfig]
+    WHERE
+        [Id] = @Id
+END

--- a/src/Sql/dbo/Stored Procedures/SsoConfig_ReadById.sql
+++ b/src/Sql/dbo/Stored Procedures/SsoConfig_ReadById.sql
@@ -1,4 +1,4 @@
-﻿CREATE PROCEDURE [dbo].[SsoConfig_ReadById]
+﻿CREATE PROCEDURE [dbo].[SsoUser_ReadById]
     @Id BIGINT
 AS
 BEGIN
@@ -7,7 +7,7 @@ BEGIN
     SELECT
         *
     FROM
-        [dbo].[SsoConfigView]
+        [dbo].[SsoUserView]
     WHERE
         [Id] = @Id
 END

--- a/src/Sql/dbo/Stored Procedures/SsoUser_DeleteById.sql
+++ b/src/Sql/dbo/Stored Procedures/SsoUser_DeleteById.sql
@@ -1,0 +1,12 @@
+﻿CREATE PROCEDURE [dbo].[SsoUser_DeleteById]
+    @Id BIGINT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    DELETE
+    FROM
+        [dbo].[SsoUser]
+    WHERE
+        [Id] = @Id
+END

--- a/src/Sql/dbo/Stored Procedures/User_Create.sql
+++ b/src/Sql/dbo/Stored Procedures/User_Create.sql
@@ -1,5 +1,5 @@
 ﻿CREATE PROCEDURE [dbo].[User_Create]
-    @Id UNIQUEIDENTIFIER,
+    @Id UNIQUEIDENTIFIER OUTPUT,
     @Name NVARCHAR(50),
     @Email NVARCHAR(256),
     @EmailVerified BIT,

--- a/src/Sql/dbo/Views/SsoUserView.sql
+++ b/src/Sql/dbo/Views/SsoUserView.sql
@@ -1,0 +1,6 @@
+CREATE VIEW [dbo].[SsoUserView]
+AS
+SELECT
+    *
+FROM
+    [dbo].[SsoUser]

--- a/test/Core.Test/AutoFixture/GlobalSettingsFixtures.cs
+++ b/test/Core.Test/AutoFixture/GlobalSettingsFixtures.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using AutoFixture;
+using AutoFixture.Kernel;
+using AutoMapper;
+using Bit.Core.Enums;
+using Bit.Core.Models;
+using Bit.Core.Models.Table;
+using Bit.Core.Settings;
+using Bit.Core.Test.Helpers.Factories;
+
+namespace Bit.Core.Test.AutoFixture.GlobalSettingsFixtures
+{
+    internal class GlobalSettingsBuilder: ISpecimenBuilder
+    {
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var pi = request as ParameterInfo;
+            if (pi == null || pi.ParameterType != typeof(GlobalSettings))
+                return new NoSpecimen();
+
+            return GlobalSettingsFactory.GlobalSettings;
+        }
+    }
+}

--- a/test/Core.Test/AutoFixture/SsoConfigFixtures.cs
+++ b/test/Core.Test/AutoFixture/SsoConfigFixtures.cs
@@ -1,0 +1,69 @@
+using System;
+using AutoFixture;
+using AutoFixture.Kernel;
+using AutoMapper;
+using TableModel = Bit.Core.Models.Table;
+using Bit.Core.Models.EntityFramework;
+using Bit.Core.Test.AutoFixture.Attributes;
+using Bit.Core.Test.AutoFixture.GlobalSettingsFixtures;
+using Bit.Core.Test.AutoFixture.OrganizationFixtures;
+using Bit.Core.Models.Data;
+using System.Text.Json;
+
+namespace Bit.Core.Test.AutoFixture.SsoConfigFixtures
+{
+    internal class SsoConfigBuilder: ISpecimenBuilder
+    {
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null) 
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var type = request as Type;
+            if (type == null || type != typeof(TableModel.SsoConfig))
+            {
+                return new NoSpecimen();
+            }
+
+            var fixture = new Fixture();
+            var ssoConfig = fixture.WithAutoNSubstitutions().Create<TableModel.SsoConfig>();
+            var ssoConfigData = fixture.WithAutoNSubstitutions().Create<SsoConfigurationData>();
+            ssoConfig.Data = JsonSerializer.Serialize(ssoConfigData, new JsonSerializerOptions(){
+               PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            });
+            return ssoConfig;
+        }
+    }
+
+   internal class EfSsoConfig: ICustomization 
+   {
+      public void Customize(IFixture fixture)
+      {
+         fixture.Customizations.Add(new GlobalSettingsBuilder());
+         fixture.Customize<IMapper>(x => x.FromFactory(() => 
+            new MapperConfiguration(cfg => cfg.AddProfile<SsoConfigMapperProfile>()).CreateMapper()));
+        fixture.Customize<IMapper>(x => x.FromFactory(() => 
+            new MapperConfiguration(cfg => {
+            cfg.AddProfile<SsoConfigMapperProfile>();
+            cfg.AddProfile<OrganizationMapperProfile>();
+        }).CreateMapper()));
+         fixture.Customizations.Add(new OrganizationBuilder());
+         fixture.Customizations.Add(new SsoConfigBuilder());
+      }
+   }
+
+    internal class EfSsoConfigAutoDataAttribute : CustomAutoDataAttribute
+    {
+        public EfSsoConfigAutoDataAttribute() : base(new SutProviderCustomization(), new EfSsoConfig())
+        { }
+    }
+
+    internal class InlineEfSsoConfigAutoDataAttribute : InlineCustomAutoDataAttribute
+    {
+        public InlineEfSsoConfigAutoDataAttribute(params object[] values) : base(new[] { typeof(SutProviderCustomization),
+            typeof(EfSsoConfig) }, values)
+        { }
+    }
+}

--- a/test/Core.Test/AutoFixture/SsoUserFixtures.cs
+++ b/test/Core.Test/AutoFixture/SsoUserFixtures.cs
@@ -1,0 +1,41 @@
+using AutoFixture;
+using AutoMapper;
+using Bit.Core.Models.EntityFramework;
+using Bit.Core.Test.AutoFixture.Attributes;
+using Bit.Core.Test.AutoFixture.GlobalSettingsFixtures;
+using Bit.Core.Test.AutoFixture.OrganizationFixtures;
+using Bit.Core.Test.AutoFixture.UserFixtures;
+using TableModel = Bit.Core.Models.Table;
+
+namespace Bit.Core.Test.AutoFixture.SsoUserFixtures
+{
+   internal class EfSsoUser: ICustomization 
+   {
+      public void Customize(IFixture fixture)
+      {
+         fixture.Customizations.Add(new GlobalSettingsBuilder());
+         fixture.Customize<IMapper>(x => x.FromFactory(() => 
+            new MapperConfiguration(cfg => {
+                cfg.AddProfile<SsoUserMapperProfile>();
+                cfg.AddProfile<UserMapperProfile>();
+                cfg.AddProfile<OrganizationMapperProfile>();
+            }).CreateMapper()));
+         fixture.Customizations.Add(new UserBuilder());
+         fixture.Customizations.Add(new OrganizationBuilder());
+         fixture.Customize<TableModel.SsoUser>(composer => composer.Without(ou => ou.Id));
+      }
+   }
+
+    internal class EfSsoUserAutoDataAttribute : CustomAutoDataAttribute
+    {
+        public EfSsoUserAutoDataAttribute() : base(new SutProviderCustomization(), new EfSsoUser())
+        { }
+    }
+
+    internal class InlineEfSsoUserAutoDataAttribute : InlineCustomAutoDataAttribute
+    {
+        public InlineEfSsoUserAutoDataAttribute(params object[] values) : base(new[] { typeof(SutProviderCustomization),
+            typeof(EfSsoUser) }, values)
+        { }
+    }
+}

--- a/test/Core.Test/AutoFixture/UserFixtures.cs
+++ b/test/Core.Test/AutoFixture/UserFixtures.cs
@@ -10,6 +10,10 @@ using System.Collections.Generic;
 using Bit.Core.Enums;
 using AutoFixture.Kernel;
 using System;
+using Bit.Core.Repositories;
+using Bit.Core.Test.Helpers.Factories;
+using Bit.Core.Repositories.EntityFramework;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Bit.Core.Test.AutoFixture.UserFixtures
 {

--- a/test/Core.Test/AutoFixture/UserFixtures.cs
+++ b/test/Core.Test/AutoFixture/UserFixtures.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using AutoFixture;
 using TableModel = Bit.Core.Models.Table;
 using Bit.Core.Test.AutoFixture.Attributes;
@@ -10,10 +9,7 @@ using System.Collections.Generic;
 using Bit.Core.Enums;
 using AutoFixture.Kernel;
 using System;
-using Bit.Core.Repositories;
-using Bit.Core.Test.Helpers.Factories;
-using Bit.Core.Repositories.EntityFramework;
-using Microsoft.Extensions.DependencyInjection;
+using Bit.Core.Test.AutoFixture.OrganizationFixtures;
 
 namespace Bit.Core.Test.AutoFixture.UserFixtures
 {
@@ -45,10 +41,15 @@ namespace Bit.Core.Test.AutoFixture.UserFixtures
       public void Customize(IFixture fixture)
       {
 
-         fixture.Customizations.Add(new UserBuilder());
          fixture.Customizations.Add(new GlobalSettingsBuilder());
+         fixture.Customizations.Add(new UserBuilder());
+         fixture.Customizations.Add(new OrganizationBuilder());
          fixture.Customize<IMapper>(x => x.FromFactory(() => 
-            new MapperConfiguration(cfg => cfg.AddProfile<UserMapperProfile>()).CreateMapper()));
+            new MapperConfiguration(cfg => {
+                cfg.AddProfile<UserMapperProfile>();
+                cfg.AddProfile<OrganizationMapperProfile>();
+                cfg.AddProfile<SsoUserMapperProfile>();
+            }).CreateMapper()));
       }
    }
 

--- a/test/Core.Test/AutoFixture/UserFixtures.cs
+++ b/test/Core.Test/AutoFixture/UserFixtures.cs
@@ -1,0 +1,63 @@
+using System.Linq;
+using AutoFixture;
+using TableModel = Bit.Core.Models.Table;
+using Bit.Core.Test.AutoFixture.Attributes;
+using Bit.Core.Test.AutoFixture.GlobalSettingsFixtures;
+using AutoMapper;
+using Bit.Core.Models.EntityFramework;
+using Bit.Core.Models;
+using System.Collections.Generic;
+using Bit.Core.Enums;
+using AutoFixture.Kernel;
+using System;
+
+namespace Bit.Core.Test.AutoFixture.UserFixtures
+{
+    internal class UserBuilder: ISpecimenBuilder
+    {
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null) 
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var type = request as Type;
+            if (type == null || type != typeof(TableModel.User))
+            {
+                return new NoSpecimen();
+            }
+
+            var fixture = new Fixture();
+            var providers = fixture.Create<Dictionary<TwoFactorProviderType, TwoFactorProvider>>();
+            var user = new Fixture().WithAutoNSubstitutions().Create<TableModel.User>();
+            user.SetTwoFactorProviders(providers);
+            return user;
+        }
+    }
+
+   internal class EfUser: ICustomization 
+   {
+      public void Customize(IFixture fixture)
+      {
+
+         fixture.Customizations.Add(new UserBuilder());
+         fixture.Customizations.Add(new GlobalSettingsBuilder());
+         fixture.Customize<IMapper>(x => x.FromFactory(() => 
+            new MapperConfiguration(cfg => cfg.AddProfile<UserMapperProfile>()).CreateMapper()));
+      }
+   }
+
+    internal class EfUserAutoDataAttribute : CustomAutoDataAttribute
+    {
+        public EfUserAutoDataAttribute() : base(new SutProviderCustomization(), new EfUser())
+        { }
+    }
+
+    internal class InlineEfUserAutoDataAttribute : InlineCustomAutoDataAttribute
+    {
+        public InlineEfUserAutoDataAttribute(params object[] values) : base(new[] { typeof(SutProviderCustomization),
+            typeof(EfUser) }, values)
+        { }
+    }
+}

--- a/test/Core.Test/Core.Test.csproj
+++ b/test/Core.Test/Core.Test.csproj
@@ -1,12 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Bit.Core.Test</RootNamespace>
+    <UserSecretsId>bitwarden-Core-Test</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -20,6 +22,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Core\Core.csproj" />
+    <ProjectReference Include="..\..\src\Api\Api.csproj" />
   </ItemGroup>
-
 </Project>

--- a/test/Core.Test/Helpers/Factories.cs
+++ b/test/Core.Test/Helpers/Factories.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using Bit.Core.Repositories.EntityFramework;
+using Bit.Core.Settings;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+
+namespace Bit.Core.Test.Helpers.Factories
+{
+    public static class GlobalSettingsFactory
+    {
+        public static GlobalSettings GlobalSettings { get; } = new GlobalSettings();
+        static GlobalSettingsFactory()
+        {
+            var configBuilder = new ConfigurationBuilder().AddUserSecrets<Bit.Api.Startup>();
+            var Configuration = configBuilder.Build();
+            ConfigurationBinder.Bind(Configuration.GetSection("GlobalSettings"), GlobalSettings);
+        }
+    }
+
+    public static class DatabaseOptionsFactory
+    {
+        public static List<DbContextOptions<DatabaseContext>> Options { get; } = new List<DbContextOptions<DatabaseContext>>();
+
+        static DatabaseOptionsFactory()
+        {
+            Options.Add(new DbContextOptionsBuilder<DatabaseContext>().UseNpgsql(GlobalSettingsFactory.GlobalSettings.PostgreSql.ConnectionString).Options);
+        }
+    }
+}

--- a/test/Core.Test/Repositories/EntityFramework/EqualityComparers/OrganizationCompare.cs
+++ b/test/Core.Test/Repositories/EntityFramework/EqualityComparers/OrganizationCompare.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Bit.Core.Models.Table;
+
+namespace Bit.Core.Test.Repositories.EntityFramework.EqualityComparers
+{
+    public class OrganizationCompare: IEqualityComparer<Organization>
+    {
+        public bool Equals(Organization x, Organization y)
+        {
+            var a = x.ExpirationDate.ToString();
+            var b = y.ExpirationDate.ToString();
+            return x.Identifier.Equals(y.Identifier) &&
+                   x.Name.Equals(y.Name) &&
+                   x.BusinessName.Equals(y.BusinessName) &&
+                   x.BusinessAddress1.Equals(y.BusinessAddress1) &&
+                   x.BusinessAddress2.Equals(y.BusinessAddress2) &&
+                   x.BusinessAddress3.Equals(y.BusinessAddress3) &&
+                   x.BusinessCountry.Equals(y.BusinessCountry) &&
+                   x.BusinessTaxNumber.Equals(y.BusinessTaxNumber) &&
+                   x.BillingEmail.Equals(y.BillingEmail) &&
+                   x.Plan.Equals(y.Plan) &&
+                   x.PlanType.Equals(y.PlanType) &&
+                   x.Seats.Equals(y.Seats) &&
+                   x.MaxCollections.Equals(y.MaxCollections) &&
+                   x.UsePolicies.Equals(y.UsePolicies) &&
+                   x.UseSso.Equals(y.UseSso) &&
+                   x.UseGroups.Equals(y.UseGroups) &&
+                   x.UseDirectory.Equals(y.UseDirectory) &&
+                   x.UseEvents.Equals(y.UseEvents) &&
+                   x.UseTotp.Equals(y.UseTotp) &&
+                   x.Use2fa.Equals(y.Use2fa) &&
+                   x.UseApi.Equals(y.UseApi) &&
+                   x.SelfHost.Equals(y.SelfHost) &&
+                   x.UsersGetPremium.Equals(y.UsersGetPremium) &&
+                   x.Storage.Equals(y.Storage) &&
+                   x.MaxStorageGb.Equals(y.MaxStorageGb) &&
+                   x.Gateway.Equals(y.Gateway) &&
+                   x.GatewayCustomerId.Equals(y.GatewayCustomerId) &&
+                   x.GatewaySubscriptionId.Equals(y.GatewaySubscriptionId) &&
+                   x.ReferenceData.Equals(y.ReferenceData) &&
+                   x.Enabled.Equals(y.Enabled) &&
+                   x.LicenseKey.Equals(y.LicenseKey) &&
+                   x.ApiKey.Equals(y.ApiKey) &&
+                   x.TwoFactorProviders.Equals(y.TwoFactorProviders) &&
+                   x.ExpirationDate.ToString().Equals(y.ExpirationDate.ToString());
+        }
+
+        public int GetHashCode([DisallowNull] Organization obj)
+        {
+            return base.GetHashCode();
+        }
+    }
+}

--- a/test/Core.Test/Repositories/EntityFramework/EqualityComparers/SsoConfigCompare.cs
+++ b/test/Core.Test/Repositories/EntityFramework/EqualityComparers/SsoConfigCompare.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Bit.Core.Models.Table;
+
+namespace Bit.Core.Test.Repositories.EntityFramework.EqualityComparers
+{
+    public class SsoConfigCompare: IEqualityComparer<SsoConfig>
+    {
+        public bool Equals(SsoConfig x, SsoConfig y)
+        {
+            return x.Enabled == y.Enabled &&
+                   x.OrganizationId == y.OrganizationId &&
+                   x.Data == y.Data;
+        }
+
+        public int GetHashCode([DisallowNull] SsoConfig obj)
+        {
+            return base.GetHashCode();
+        }
+    }
+}

--- a/test/Core.Test/Repositories/EntityFramework/EqualityComparers/SsoUserCompare.cs
+++ b/test/Core.Test/Repositories/EntityFramework/EqualityComparers/SsoUserCompare.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Bit.Core.Models.Table;
+
+namespace Bit.Core.Test.Repositories.EntityFramework.EqualityComparers
+{
+    public class SsoUserCompare: IEqualityComparer<SsoUser>
+    {
+        public bool Equals(SsoUser x, SsoUser y)
+        {
+            return x.ExternalId == y.ExternalId;
+        }
+
+        public int GetHashCode([DisallowNull] SsoUser obj)
+        {
+            return base.GetHashCode();
+        }
+    }
+}

--- a/test/Core.Test/Repositories/EntityFramework/EqualityComparers/UserCompare.cs
+++ b/test/Core.Test/Repositories/EntityFramework/EqualityComparers/UserCompare.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Bit.Core.Models.Table;
+
+namespace Bit.Core.Test.Repositories.EntityFramework.EqualityComparers
+{
+    public class UserCompare: IEqualityComparer<User>
+    {
+        public bool Equals(User x, User y)
+        {
+            return  x.Name == y.Name &&
+                    x.Email == y.Email &&
+                    x.EmailVerified == y.EmailVerified &&
+                    x.MasterPassword == y.MasterPassword &&
+                    x.MasterPasswordHint == y.MasterPasswordHint &&
+                    x.Culture == y.Culture &&
+                    x.SecurityStamp == y.SecurityStamp &&
+                    x.TwoFactorProviders == y.TwoFactorProviders &&
+                    x.TwoFactorRecoveryCode == y.TwoFactorRecoveryCode &&
+                    x.EquivalentDomains == y.EquivalentDomains &&
+                    x.Key == y.Key &&
+                    x.PublicKey == y.PublicKey &&
+                    x.PrivateKey == y.PrivateKey &&
+                    x.Premium == y.Premium &&
+                    x.Storage == y.Storage &&
+                    x.MaxStorageGb == y.MaxStorageGb &&
+                    x.Gateway == y.Gateway &&
+                    x.GatewayCustomerId == y.GatewayCustomerId &&
+                    x.ReferenceData == y.ReferenceData &&
+                    x.LicenseKey == y.LicenseKey &&
+                    x.ApiKey == y.ApiKey &&
+                    x.Kdf == y.Kdf &&
+                    x.KdfIterations == y.KdfIterations;
+        }
+
+        public int GetHashCode([DisallowNull] User obj)
+        {
+            return base.GetHashCode();
+        }
+    }
+}

--- a/test/Core.Test/Repositories/EntityFramework/EqualityComparers/UserKdfInformation.cs
+++ b/test/Core.Test/Repositories/EntityFramework/EqualityComparers/UserKdfInformation.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Bit.Core.Models.Data;
+
+namespace Bit.Core.Test.Repositories.EntityFramework.EqualityComparers
+{
+    public class UserKdfInformationCompare: IEqualityComparer<UserKdfInformation>
+    {
+        public bool Equals(UserKdfInformation x, UserKdfInformation y)
+        {
+            return  x.Kdf == y.Kdf &&
+                    x.KdfIterations == y.KdfIterations;
+        }
+
+        public int GetHashCode([DisallowNull] UserKdfInformation obj)
+        {
+            return base.GetHashCode();
+        }
+    }
+}

--- a/test/Core.Test/Repositories/EntityFramework/OrganizationRepositoryTests.cs
+++ b/test/Core.Test/Repositories/EntityFramework/OrganizationRepositoryTests.cs
@@ -1,0 +1,191 @@
+using Bit.Core.Test.AutoFixture;
+using Bit.Core.Test.Helpers.Factories;
+using EfRepo = Bit.Core.Repositories.EntityFramework;
+using SqlRepo = Bit.Core.Repositories.SqlServer;
+using System.Collections.Generic;
+using System.Linq;
+using TableModel = Bit.Core.Models.Table;
+using DataModel = Bit.Core.Models.Data;
+using Xunit;
+using Bit.Core.Test.Repositories.EntityFramework.EqualityComparers;
+using Bit.Core.Test.AutoFixture.OrganizationFixtures;
+
+namespace Bit.Core.Test.Repositories.EntityFramework
+{
+    public class OrganizationRepositoryTests
+    {
+        [Theory, EfOrganizationAutoData]
+        public async void CreateAsync_Works_DataMatches(TableModel.Organization organization,
+                SqlRepo.OrganizationRepository sqlOrganizationRepo, OrganizationCompare equalityComparer,
+                SutProvider<EfRepo.OrganizationRepository> sutProvider)
+        {
+            var savedOrganizations = new List<TableModel.Organization>();
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    context.Database.EnsureDeleted();
+                    context.Database.EnsureCreated();
+                    var postEfOrganization = await sutProvider.Sut.CreateAsync(context, organization);
+                    var savedOrganization = await sutProvider.Sut.GetByIdAsync(context, organization.Id);
+                    savedOrganizations.Add(savedOrganization);
+                }
+            }
+
+            var sqlUser = await sqlOrganizationRepo.CreateAsync(organization);
+            savedOrganizations.Add(await sqlOrganizationRepo.GetByIdAsync(sqlUser.Id));
+
+            var distinctItems = savedOrganizations.Distinct(equalityComparer);
+            Assert.True(!distinctItems.Skip(1).Any());
+        }
+
+        [Theory, EfOrganizationAutoData]
+        public async void ReplaceAsync_Works_DataMatches(TableModel.Organization postOrganization,
+                TableModel.Organization replaceOrganization, SqlRepo.OrganizationRepository sqlOrganizationRepo,
+                OrganizationCompare equalityComparer, SutProvider<EfRepo.OrganizationRepository> sutProvider)
+        {
+            var savedOrganizations = new List<TableModel.Organization>();
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var postEfOrganization = await sutProvider.Sut.CreateAsync(context, postOrganization);
+                    replaceOrganization.Id = postEfOrganization.Id;
+                    await sutProvider.Sut.ReplaceAsync(context, replaceOrganization);
+                    var replacedOrganization = await sutProvider.Sut.GetByIdAsync(context, replaceOrganization.Id);
+                    savedOrganizations.Add(replacedOrganization);
+                }
+            }
+
+            var postSqlOrganization = await sqlOrganizationRepo.CreateAsync(postOrganization);
+            replaceOrganization.Id = postSqlOrganization.Id;
+            await sqlOrganizationRepo.ReplaceAsync(replaceOrganization);
+            savedOrganizations.Add(await sqlOrganizationRepo.GetByIdAsync(replaceOrganization.Id));
+
+            var distinctItems = savedOrganizations.Distinct(equalityComparer);
+            Assert.True(!distinctItems.Skip(1).Any());
+        }
+
+        [Theory, EfOrganizationAutoData]
+        public async void DeleteAsync_Works_DataMatches(TableModel.Organization organization,
+                SqlRepo.OrganizationRepository sqlOrganizationRepo, OrganizationCompare equalityComparer, 
+                SutProvider<EfRepo.OrganizationRepository> sutProvider)
+        {
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                TableModel.Organization savedEfOrganization = null;
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var postEfOrganization = await sutProvider.Sut.CreateAsync(context, organization);
+                    savedEfOrganization = await sutProvider.Sut.GetByIdAsync(context, postEfOrganization.Id);
+                    Assert.True(savedEfOrganization != null);
+                }
+
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    await sutProvider.Sut.DeleteAsync(context, savedEfOrganization);
+                    savedEfOrganization = await sutProvider.Sut.GetByIdAsync(context, savedEfOrganization.Id);
+                    Assert.True(savedEfOrganization == null);
+                }
+            }
+
+            var postSqlOrganization = await sqlOrganizationRepo.CreateAsync(organization);
+            var savedSqlOrganization = await sqlOrganizationRepo.GetByIdAsync(postSqlOrganization.Id);
+            Assert.True(savedSqlOrganization != null);
+
+            await sqlOrganizationRepo.DeleteAsync(postSqlOrganization);
+            savedSqlOrganization = await sqlOrganizationRepo.GetByIdAsync(postSqlOrganization.Id);
+            Assert.True(savedSqlOrganization == null);
+        }
+
+        [Theory, EfOrganizationAutoData]
+        public async void GetByIdentifierAsync_Works_DataMatches(TableModel.Organization organization,
+                SqlRepo.OrganizationRepository sqlOrganizationRepo, OrganizationCompare equalityComparer, 
+                SutProvider<EfRepo.OrganizationRepository> sutProvider)
+        {
+            var returnedOrgs = new List<TableModel.Organization>();
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var postEfOrg = await sutProvider.Sut.CreateAsync(context, organization);
+                    var returnedOrg = await sutProvider.Sut.GetByIdentifierAsync(context, postEfOrg.Identifier);
+                    returnedOrgs.Add(returnedOrg);
+                }
+            }
+
+            var postSqlOrg = await sqlOrganizationRepo.CreateAsync(organization);
+            returnedOrgs.Add(await sqlOrganizationRepo.GetByIdentifierAsync(postSqlOrg.Identifier));
+
+            var distinctItems = returnedOrgs.Distinct(equalityComparer);
+            Assert.True(!distinctItems.Skip(1).Any());
+        }
+
+        [Theory, EfOrganizationAutoData]
+        public async void GetManyByEnabledAsync_Works_DataMatches(TableModel.Organization organization,
+                SqlRepo.OrganizationRepository sqlOrganizationRepo, OrganizationCompare equalityCompare, 
+                SutProvider<EfRepo.OrganizationRepository> sutProvider)
+        {
+            var returnedOrgs = new List<TableModel.Organization>();
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var postEfOrg = await sutProvider.Sut.CreateAsync(context, organization);
+                    var efReturnedOrgs = await sutProvider.Sut.GetManyByEnabledAsync(context);
+                    returnedOrgs.Concat(efReturnedOrgs);
+                }
+            }
+
+            var postSqlOrg = await sqlOrganizationRepo.CreateAsync(organization);
+            returnedOrgs.Concat(await sqlOrganizationRepo.GetManyByEnabledAsync());
+
+            Assert.True(returnedOrgs.All(o => o.Enabled));
+        }
+
+        [Theory, EfOrganizationAutoData]
+        public async void GetManyByUserIdAsync_Works_DataMatches(TableModel.Organization organization,
+                SqlRepo.OrganizationRepository sqlOrganizationRepo, OrganizationCompare equalityComparer, 
+                SutProvider<EfRepo.OrganizationRepository> sutProvider)
+        {
+            // TODO: OrgUser repo needed
+            Assert.True(true);
+        }
+
+        [Theory, EfOrganizationAutoData]
+        public async void SearchAsync_Works_DataMatches(TableModel.Organization organization,
+                SqlRepo.OrganizationRepository sqlOrganizationRepo, OrganizationCompare equalityCompare, 
+                SutProvider<EfRepo.OrganizationRepository> sutProvider)
+        {
+            // TODO: OrgUser repo needed
+            Assert.True(true);
+        }
+
+        [Theory, EfOrganizationAutoData]
+        public async void UpdateStorageAsync_Works_DataMatches(TableModel.Organization organization,
+                SqlRepo.OrganizationRepository sqlOrganizationRepo, OrganizationCompare equalityComparer, 
+                SutProvider<EfRepo.OrganizationRepository> sutProvider)
+        {
+            // TODO: Cipher repo needed
+            Assert.True(true);
+        }
+
+        [Theory, EfOrganizationAutoData]
+        public async void GetManyAbilitiesAsync_Works_DataMatches(TableModel.Organization organization,
+                SqlRepo.OrganizationRepository sqlOrganizationRepo, OrganizationCompare equalityComparer, 
+                SutProvider<EfRepo.OrganizationRepository> sutProvider)
+        {
+            var list = new List<DataModel.OrganizationAbility>();
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    list.Concat(await sutProvider.Sut.GetManyAbilitiesAsync(context));
+                }
+            }
+
+            list.Concat(await sqlOrganizationRepo.GetManyAbilitiesAsync());
+            Assert.True(list.All(x => x.GetType() == typeof(DataModel.OrganizationAbility)));
+        }
+    }
+}

--- a/test/Core.Test/Repositories/EntityFramework/SsoConfigRepositoryTests.cs
+++ b/test/Core.Test/Repositories/EntityFramework/SsoConfigRepositoryTests.cs
@@ -1,0 +1,288 @@
+using Bit.Core.Test.AutoFixture;
+using Bit.Core.Test.Helpers.Factories;
+using EfRepo = Bit.Core.Repositories.EntityFramework;
+using SqlRepo = Bit.Core.Repositories.SqlServer;
+using System.Collections.Generic;
+using System.Linq;
+using TableModel = Bit.Core.Models.Table;
+using Xunit;
+using Bit.Core.Test.Repositories.EntityFramework.EqualityComparers;
+using Bit.Core.Test.AutoFixture.SsoConfigFixtures;
+using System;
+
+namespace Bit.Core.Test.Repositories.EntityFramework
+{
+    public class SsoConfigRepositoryTests
+    {
+        [Theory, EfSsoConfigAutoData]
+        public async void CreateAsync_Works_DataMatches(TableModel.SsoConfig ssoConfig, SqlRepo.SsoConfigRepository sqlSsoConfigRepo,
+                SsoConfigCompare equalityComparer, SutProvider<EfRepo.SsoConfigRepository> sutProvider, SutProvider<EfRepo.OrganizationRepository> orgRepoSut,
+                TableModel.Organization org, SqlRepo.OrganizationRepository sqlOrganizationRepo)
+        {
+            // init list to hold one instance of the tested object from each database provider
+            var savedSsoConfigs = new List<TableModel.SsoConfig>();
+
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                // satisfy any foreign key constraints for the tested object
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var savedEfOrg = await orgRepoSut.Sut.CreateAsync(context, org);
+                    ssoConfig.OrganizationId = savedEfOrg.Id;
+                }
+
+                // save the tested object & assert its existance
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var postEfSsoConfig = await sutProvider.Sut.CreateAsync(context, ssoConfig);
+                    var savedEfSsoConfig = await sutProvider.Sut.GetByIdAsync(context, ssoConfig.Id);
+                    Assert.True(savedEfSsoConfig != null);
+                    savedSsoConfigs.Add(savedEfSsoConfig);
+                }
+            }
+
+            //satisfy any foreign key constraints for the tested object
+            var sqlOrganization = await sqlOrganizationRepo.CreateAsync(org);
+            ssoConfig.OrganizationId = sqlOrganization.Id;
+
+            // save the tested object and assert its existance
+            var sqlSsoConfig = await sqlSsoConfigRepo.CreateAsync(ssoConfig);
+            var savedSqlSsoConfig = await sqlSsoConfigRepo.GetByIdAsync(sqlSsoConfig.Id);
+            Assert.True(savedSqlSsoConfig != null);
+            savedSsoConfigs.Add(savedSqlSsoConfig);
+
+            // assert all saved objects contain the same user relevant data
+            var distinctItems = savedSsoConfigs.Distinct(equalityComparer);
+            Assert.True(!distinctItems.Skip(1).Any());
+        }
+
+        [Theory, EfSsoConfigAutoData]
+        public async void ReplaceAsync_Works_DataMatches(TableModel.SsoConfig postSsoConfig, TableModel.SsoConfig replaceSsoConfig, 
+                SqlRepo.SsoConfigRepository sqlSsoConfigRepo, SsoConfigCompare equalityComparer, SutProvider<EfRepo.SsoConfigRepository> sutProvider,
+                SutProvider<EfRepo.OrganizationRepository> orgRepoSut, TableModel.Organization org, SqlRepo.OrganizationRepository sqlOrganizationRepo)
+        {
+            // init list to hold an instance of the tested object from each database provider
+            var savedSsoConfigs = new List<TableModel.SsoConfig>();
+
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                // satisfy any foreign key constraints for the tested object
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var savedEfOrg = await orgRepoSut.Sut.CreateAsync(context, org);
+                    postSsoConfig.OrganizationId = replaceSsoConfig.OrganizationId = savedEfOrg.Id;
+                }
+
+                // save the tested object
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var postEfSsoConfig = await sutProvider.Sut.CreateAsync(context, postSsoConfig);
+                    replaceSsoConfig.Id = postEfSsoConfig.Id;
+                    savedSsoConfigs.Add(postEfSsoConfig);
+                }
+
+                // replace the tested object & assert its existance 
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    await sutProvider.Sut.ReplaceAsync(context, replaceSsoConfig);
+                    var replacedSsoConfig = await sutProvider.Sut.GetByIdAsync(context, replaceSsoConfig.Id);
+                    Assert.True(replacedSsoConfig != null);
+                    savedSsoConfigs.Add(replacedSsoConfig);
+                }
+            }
+
+            // satisfy any foreign key constraints for the tested object
+            var sqlOrganization = await sqlOrganizationRepo.CreateAsync(org);
+            postSsoConfig.OrganizationId = sqlOrganization.Id;
+
+            // save the tested object
+            var postSqlSsoConfig = await sqlSsoConfigRepo.CreateAsync(postSsoConfig);
+            replaceSsoConfig.Id = postSqlSsoConfig.Id;
+            savedSsoConfigs.Add(postSqlSsoConfig);
+
+            // replace the tested object & assert its existance
+            await sqlSsoConfigRepo.ReplaceAsync(replaceSsoConfig);
+            var replacedSqlSsoConfig = await sqlSsoConfigRepo.GetByIdAsync(replaceSsoConfig.Id);
+            Assert.True(replacedSqlSsoConfig != null);
+            savedSsoConfigs.Add(replacedSqlSsoConfig);
+
+            // assert that the stored post models and replace models are different, but that user-relevant data matches across database providers
+            var distinctItems = savedSsoConfigs.Distinct(equalityComparer);
+            Assert.True(!distinctItems.Skip(2).Any());
+        }
+
+        [Theory, EfSsoConfigAutoData]
+        public async void DeleteAsync_Works_DataMatches(TableModel.SsoConfig ssoConfig, SqlRepo.SsoConfigRepository sqlSsoConfigRepo, SsoConfigCompare equalityComparer,
+                SutProvider<EfRepo.SsoConfigRepository> ssoConfigRepoSut, SutProvider<EfRepo.OrganizationRepository> orgRepoSut,
+                TableModel.Organization org, SqlRepo.OrganizationRepository sqlOrganizationRepo)
+        {
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                // satisfy any foreign key constraints for the tested object
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var savedEfOrg = await orgRepoSut.Sut.CreateAsync(context, org);
+                    ssoConfig.OrganizationId = savedEfOrg.Id;
+                }
+
+                // save the tested object & assert its existance
+                TableModel.SsoConfig savedEfSsoConfig;
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var postEfSsoConfig = await ssoConfigRepoSut.Sut.CreateAsync(context, ssoConfig);
+                    savedEfSsoConfig = await ssoConfigRepoSut.Sut.GetByIdAsync(context, postEfSsoConfig.Id);
+                    Assert.True(savedEfSsoConfig != null);
+                }
+
+                // delete the tested object & assert its nonexistance
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    await ssoConfigRepoSut.Sut.DeleteAsync(context, savedEfSsoConfig);
+                    var deletedEfSsoConfig= await ssoConfigRepoSut.Sut.GetByIdAsync(context, savedEfSsoConfig.Id);
+                    Assert.True(deletedEfSsoConfig == null);
+                }
+            }
+
+            //init any objects that will be written to the database
+            var sqlOrganization = await sqlOrganizationRepo.CreateAsync(org);
+            ssoConfig.OrganizationId = sqlOrganization.Id;
+
+            // save the tested object and assert its existance
+            var postSqlSsoConfig = await sqlSsoConfigRepo.CreateAsync(ssoConfig);
+            var savedSqlSsoConfig = await sqlSsoConfigRepo.GetByIdAsync(postSqlSsoConfig.Id);
+            Assert.True(savedSqlSsoConfig != null);
+
+            // delete the tested object and assert its nonexistance
+            await sqlSsoConfigRepo.DeleteAsync(savedSqlSsoConfig);
+            savedSqlSsoConfig = await sqlSsoConfigRepo.GetByIdAsync(postSqlSsoConfig.Id);
+            Assert.True(savedSqlSsoConfig == null);
+        }
+
+        [Theory, EfSsoConfigAutoData]
+        public async void GetByOrganizationIdAsync_Works_DataMatches(TableModel.SsoConfig ssoConfig, SqlRepo.SsoConfigRepository sqlSsoConfigRepo, SsoConfigCompare equalityComparer,
+                SutProvider<EfRepo.SsoConfigRepository> sutProvider, SutProvider<EfRepo.OrganizationRepository> orgRepoSut, TableModel.Organization org, SqlRepo.OrganizationRepository sqlOrgRepo)
+        {
+            // init list to hold one instance of the tested object from each database provider
+            var returnedList = new List<TableModel.SsoConfig>();
+
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                // satisfy any foreign key constraints for the tested object
+                TableModel.Organization savedEfOrg;
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    savedEfOrg = await orgRepoSut.Sut.CreateAsync(context, org);
+                    ssoConfig.OrganizationId = savedEfOrg.Id;
+                }
+
+                // save an instance of the tested object
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    await sutProvider.Sut.CreateAsync(context, ssoConfig);
+                }
+
+                // retreive the previously saved instance and assert its existence
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var savedEfUser = await sutProvider.Sut.GetByOrganizationIdAsync(context, savedEfOrg.Id);
+                    Assert.True(savedEfUser != null);
+                    returnedList.Add(savedEfUser);
+                }
+            }
+
+            // satisfy any foreign key constraints for the tested object
+            var savedSqlOrg = await sqlOrgRepo.CreateAsync(org);
+            ssoConfig.OrganizationId = savedSqlOrg.Id;
+
+            // save an instance of the tested object
+            var postSqlSsoConfig = await sqlSsoConfigRepo.CreateAsync(ssoConfig);
+
+            // retrieve the previously saved instance and assert its existence
+            var savedSqlSsoConfig = await sqlSsoConfigRepo.GetByOrganizationIdAsync(ssoConfig.OrganizationId);
+            Assert.True(savedSqlSsoConfig != null);
+            returnedList.Add(savedSqlSsoConfig);
+
+            // assert all retrieved objects contain the same user relevant data
+            var distinctItems = returnedList.Distinct(equalityComparer);
+            Assert.True(!distinctItems.Skip(1).Any());
+        }
+
+        [Theory, EfSsoConfigAutoData]
+        public async void GetByIdentifierAsync_Works_DataMatches(TableModel.SsoConfig ssoConfig, SqlRepo.SsoConfigRepository sqlSsoConfigRepo, SsoConfigCompare equalityComparer,
+                SutProvider<EfRepo.SsoConfigRepository> ssoConfigRepoSut, SutProvider<EfRepo.OrganizationRepository> orgRepoSut, TableModel.Organization org,
+                SqlRepo.OrganizationRepository sqlOrgRepo)
+        {
+            // init list to hold one instance of the tested object from each database provider
+            var returnedList = new List<TableModel.SsoConfig>();
+
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                // satisfy any foreign key constraints for the tested object
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var savedEfOrg = await orgRepoSut.Sut.CreateAsync(context, org);
+                    ssoConfig.OrganizationId = savedEfOrg.Id;
+                }
+
+                // save an instance of the tested object
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    await ssoConfigRepoSut.Sut.CreateAsync(context, ssoConfig);
+                }
+
+                // retrieve the previously saved instance and assert its existance
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var savedEfSsoConfig = await ssoConfigRepoSut.Sut.GetByIdentifierAsync(context, org.Identifier);
+                    Assert.True(savedEfSsoConfig != null);
+                    returnedList.Add(savedEfSsoConfig);
+                }
+            }
+
+            // satisfy any foreign key constraints for the tested object
+            var savedSqlOrg = await sqlOrgRepo.CreateAsync(org);
+            ssoConfig.OrganizationId = savedSqlOrg.Id;
+
+            // save an instance of the tested object
+            var postSqlSsoConfig = await sqlSsoConfigRepo.CreateAsync(ssoConfig);
+
+            // retrieve the previously saved instance and assert its existence
+            var savedSqlSsoConfig = await sqlSsoConfigRepo.GetByIdentifierAsync(org.Identifier);
+            Assert.True(savedSqlSsoConfig != null);
+            returnedList.Add(savedSqlSsoConfig);
+
+            // assert all retrieved objects contain the same user relevant data
+            var distinctItems = returnedList.Distinct(equalityComparer);
+            Assert.True(!distinctItems.Skip(1).Any());
+        }
+
+        [Theory, EfSsoConfigAutoData]
+        public async void GetManyByRevisionNotBeforeDate_Works(TableModel.SsoConfig ssoConfig, SqlRepo.SsoConfigRepository sqlSsoConfigRepo, SsoConfigCompare equalityComparer,
+                SutProvider<EfRepo.SsoConfigRepository> ssoConfigRepoSut, DateTime notBeforeDate, SutProvider<EfRepo.OrganizationRepository> orgRepoSut, TableModel.Organization org)
+        {
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                // satisfy any foreign key constraints for the tested object
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var savedEfOrg = await orgRepoSut.Sut.CreateAsync(context, org);
+                    ssoConfig.OrganizationId = savedEfOrg.Id;
+                }
+
+                // save an instance of the tested object
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    await ssoConfigRepoSut.Sut.CreateAsync(context, ssoConfig);
+                }
+
+                // retrieve data from repo and assert they all match the condition logic
+                // we can't compare directly with SQL here without modifying data for the entire table
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var returnedEfSsoConfigs = await ssoConfigRepoSut.Sut.GetManyByRevisionNotBeforeDate(context, notBeforeDate);
+                    Assert.True(returnedEfSsoConfigs.All(sc => sc.RevisionDate >= notBeforeDate));
+                }
+            }
+        }
+    }
+}

--- a/test/Core.Test/Repositories/EntityFramework/SsoUserRepositoryTests.cs
+++ b/test/Core.Test/Repositories/EntityFramework/SsoUserRepositoryTests.cs
@@ -1,0 +1,209 @@
+using Bit.Core.Test.AutoFixture;
+using Bit.Core.Test.Helpers.Factories;
+using EfRepo = Bit.Core.Repositories.EntityFramework;
+using SqlRepo = Bit.Core.Repositories.SqlServer;
+using System.Collections.Generic;
+using System.Linq;
+using TableModel = Bit.Core.Models.Table;
+using Xunit;
+using Bit.Core.Test.Repositories.EntityFramework.EqualityComparers;
+using Bit.Core.Test.AutoFixture.SsoUserFixtures;
+
+namespace Bit.Core.Test.Repositories.EntityFramework
+{
+    public class SsoUserRepositoryTests
+    {
+        [Theory, EfSsoUserAutoData]
+        public async void CreateAsync_Works_DataMatches(TableModel.SsoUser ssoUser, SqlRepo.SsoUserRepository sqlSsoUserRepo,
+                SsoUserCompare equalityComparer, SutProvider<EfRepo.SsoUserRepository> ssoUserRepoSut,
+                SutProvider<EfRepo.UserRepository> userRepoSut, SutProvider<EfRepo.OrganizationRepository> orgRepoSut,
+                TableModel.User user, TableModel.Organization org, SqlRepo.UserRepository sqlUserRepo, SqlRepo.OrganizationRepository sqlOrgRepo)
+        {
+            // init list to hold an instance of the tested object from each database provider
+            var createdSsoUsers = new List<TableModel.SsoUser>();
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                // satisfy any foreign key constraints for the tested object
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var efUser = await userRepoSut.Sut.CreateAsync(context, user);
+                    var efOrg = await orgRepoSut.Sut.CreateAsync(context, org);
+                    ssoUser.UserId = efUser.Id;
+                    ssoUser.OrganizationId = efOrg.Id;
+                }
+
+                // save the tested object & assert its existance
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var postEfSsoUser = await ssoUserRepoSut.Sut.CreateAsync(context, ssoUser);
+                    var savedSsoUser = await ssoUserRepoSut.Sut.GetByIdAsync(context, ssoUser.Id);
+                    createdSsoUsers.Add(savedSsoUser);
+                }
+            }
+
+            //satisfy any foreign key constraints for the tested object
+            var sqlUser = await sqlUserRepo.CreateAsync(user);
+            var sqlOrganization = await sqlOrgRepo.CreateAsync(org);
+            ssoUser.UserId = sqlUser.Id;
+            ssoUser.OrganizationId = sqlOrganization.Id;
+
+            // save the tested object and assert its existance
+            var sqlSsoUser = await sqlSsoUserRepo.CreateAsync(ssoUser);
+            createdSsoUsers.Add(await sqlSsoUserRepo.GetByIdAsync(sqlSsoUser.Id));
+
+            // assert all saved objects contain the same user relevant data
+            var distinctSsoUsers = createdSsoUsers.Distinct(equalityComparer);
+            Assert.True(!distinctSsoUsers.Skip(1).Any());
+        }
+
+        [Theory, EfSsoUserAutoData]
+        public async void ReplaceAsync_Works_DataMatches(TableModel.SsoUser postSsoUser, TableModel.SsoUser replaceSsoUser, 
+                SqlRepo.SsoUserRepository sqlSsoUserRepo, SsoUserCompare equalityComparer, SutProvider<EfRepo.SsoUserRepository> sutProvider,
+                SutProvider<EfRepo.UserRepository> userRepoSut, SutProvider<EfRepo.OrganizationRepository> orgRepoSut,
+                TableModel.Organization org, TableModel.User user, SqlRepo.OrganizationRepository sqlOrgRepo, SqlRepo.UserRepository sqlUserRepo)
+        {
+            // 
+            var savedSsoUsers = new List<TableModel.SsoUser>();
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var efUser = await userRepoSut.Sut.CreateAsync(context, user);
+                    var efOrg = await orgRepoSut.Sut.CreateAsync(context, org);
+                    postSsoUser.UserId = efUser.Id;
+                    postSsoUser.OrganizationId = efOrg.Id;
+                }
+
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var postEfSsoUser = await sutProvider.Sut.CreateAsync(context, postSsoUser);
+                    replaceSsoUser.Id = postEfSsoUser.Id;
+                    replaceSsoUser.UserId = postEfSsoUser.UserId;
+                    replaceSsoUser.OrganizationId = postEfSsoUser.OrganizationId;
+                    await sutProvider.Sut.ReplaceAsync(context, replaceSsoUser);
+                    var replacedSsoUser = await sutProvider.Sut.GetByIdAsync(context, replaceSsoUser.Id);
+                    savedSsoUsers.Add(replacedSsoUser);
+                }
+            }
+
+            var sqlUser = await sqlUserRepo.CreateAsync(user);
+            var sqlOrganization = await sqlOrgRepo.CreateAsync(org);
+            postSsoUser.Id = 0;
+            postSsoUser.UserId = sqlUser.Id;
+            postSsoUser.OrganizationId = sqlOrganization.Id;
+            var postSqlSsoUser = await sqlSsoUserRepo.CreateAsync(postSsoUser);
+
+            replaceSsoUser.Id = postSqlSsoUser.Id;
+            replaceSsoUser.UserId = postSqlSsoUser.UserId;
+            replaceSsoUser.OrganizationId = postSqlSsoUser.OrganizationId;
+            await sqlSsoUserRepo.ReplaceAsync(replaceSsoUser);
+
+            savedSsoUsers.Add(await sqlSsoUserRepo.GetByIdAsync(replaceSsoUser.Id));
+
+            var distinctItems = savedSsoUsers.Distinct(equalityComparer);
+            Assert.True(!distinctItems.Skip(1).Any());
+        }
+
+        [Theory, EfSsoUserAutoData]
+        public async void DeleteAsync_Works_DataMatches(TableModel.SsoUser ssoUser, SqlRepo.SsoUserRepository sqlSsoUserRepo, SsoUserCompare equalityComparer,
+                SutProvider<EfRepo.SsoUserRepository> ssoUserRepoSut, SutProvider<EfRepo.UserRepository> userRepoSut, SutProvider<EfRepo.OrganizationRepository> orgRepoSut,
+                TableModel.User user, TableModel.Organization org, SqlRepo.UserRepository sqlUserRepo, SqlRepo.OrganizationRepository sqlOrganizationRepo)
+        {
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                // satisfy any foreign key constraints for the tested object
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var savedEfUser = await userRepoSut.Sut.CreateAsync(context, user);
+                    var savedEfOrg = await orgRepoSut.Sut.CreateAsync(context, org);
+                    ssoUser.UserId = savedEfUser.Id;
+                    ssoUser.OrganizationId = savedEfOrg.Id;
+                }
+
+                // save the tested object & assert its existance
+                TableModel.SsoUser savedEfSsoUser = null;
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var postEfSsoUser = await ssoUserRepoSut.Sut.CreateAsync(context, ssoUser);
+                    savedEfSsoUser = await ssoUserRepoSut.Sut.GetByIdAsync(context, postEfSsoUser.Id);
+                    Assert.True(savedEfSsoUser != null);
+                }
+
+                // delete the tested object & assert its nonexistance
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    await ssoUserRepoSut.Sut.DeleteAsync(context, savedEfSsoUser);
+                    savedEfSsoUser = await ssoUserRepoSut.Sut.GetByIdAsync(context, savedEfSsoUser.Id);
+                    Assert.True(savedEfSsoUser == null);
+                }
+            }
+
+            //init any objects that will be written to the database
+            var sqlUser = await sqlUserRepo.CreateAsync(user);
+            var sqlOrganization = await sqlOrganizationRepo.CreateAsync(org);
+            ssoUser.UserId = sqlUser.Id;
+            ssoUser.OrganizationId = sqlOrganization.Id;
+
+            // save the tested object and assert its existance
+            var postSqlSsoUser = await sqlSsoUserRepo.CreateAsync(ssoUser);
+            var savedSqlSsoUser = await sqlSsoUserRepo.GetByIdAsync(postSqlSsoUser.Id);
+            Assert.True(savedSqlSsoUser != null);
+
+            // delete the tested object and assert its nonexistance
+            await sqlSsoUserRepo.DeleteAsync(savedSqlSsoUser);
+            savedSqlSsoUser = await sqlSsoUserRepo.GetByIdAsync(postSqlSsoUser.Id);
+            Assert.True(savedSqlSsoUser == null);
+        }
+
+        [Theory, EfSsoUserAutoData]
+        public async void DeleteAsync_UserIdOrganizationId_Works_DataMatches(TableModel.SsoUser ssoUser, SqlRepo.SsoUserRepository sqlSsoUserRepo, SsoUserCompare equalityComparer,
+                SutProvider<EfRepo.SsoUserRepository> ssoUserRepoSut, SutProvider<EfRepo.UserRepository> userRepoSut, SutProvider<EfRepo.OrganizationRepository> orgRepoSut,
+                TableModel.User user, TableModel.Organization org, SqlRepo.UserRepository sqlUserRepo, SqlRepo.OrganizationRepository sqlOrganizationRepo)
+        {
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                // satisfy any foreign key constraints for the tested object
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var savedEfUser = await userRepoSut.Sut.CreateAsync(context, user);
+                    var savedEfOrg = await orgRepoSut.Sut.CreateAsync(context, org);
+                    ssoUser.UserId = savedEfUser.Id;
+                    ssoUser.OrganizationId = savedEfOrg.Id;
+                }
+
+                // save the tested object & assert its existance
+                TableModel.SsoUser savedEfSsoUser = null;
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var postEfSsoUser = await ssoUserRepoSut.Sut.CreateAsync(context, ssoUser);
+                    savedEfSsoUser = await ssoUserRepoSut.Sut.GetByIdAsync(context, postEfSsoUser.Id);
+                    Assert.True(savedEfSsoUser != null);
+                }
+
+                // delete the tested object & assert its nonexistance
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    await ssoUserRepoSut.Sut.DeleteAsync(context, savedEfSsoUser.UserId, savedEfSsoUser.OrganizationId);
+                    savedEfSsoUser = await ssoUserRepoSut.Sut.GetByIdAsync(context, savedEfSsoUser.Id);
+                    Assert.True(savedEfSsoUser == null);
+                }
+            }
+
+            //init any objects that will be written to the database
+            var sqlUser = await sqlUserRepo.CreateAsync(user);
+            var sqlOrganization = await sqlOrganizationRepo.CreateAsync(org);
+            ssoUser.UserId = sqlUser.Id;
+            ssoUser.OrganizationId = sqlOrganization.Id;
+
+            // save the tested object and assert its existance
+            var postSqlSsoUser = await sqlSsoUserRepo.CreateAsync(ssoUser);
+            var savedSqlSsoUser = await sqlSsoUserRepo.GetByIdAsync(postSqlSsoUser.Id);
+            Assert.True(savedSqlSsoUser != null);
+
+            // delete the tested object and assert its nonexistance
+            await sqlSsoUserRepo.DeleteAsync(savedSqlSsoUser.UserId, savedSqlSsoUser.OrganizationId);
+            savedSqlSsoUser = await sqlSsoUserRepo.GetByIdAsync(postSqlSsoUser.Id);
+            Assert.True(savedSqlSsoUser == null);
+        }
+    }
+}

--- a/test/Core.Test/Repositories/EntityFramework/UserRepositoryTests.cs
+++ b/test/Core.Test/Repositories/EntityFramework/UserRepositoryTests.cs
@@ -1,0 +1,143 @@
+using AutoMapper;
+using Bit.Core.Test.AutoFixture.UserFixtures;
+using Bit.Core.Test.AutoFixture;
+using Bit.Core.Test.Helpers.Factories;
+using EfRepo = Bit.Core.Repositories.EntityFramework;
+using SqlRepo = Bit.Core.Repositories.SqlServer;
+using System.Collections.Generic;
+using System.Linq;
+using TableModel = Bit.Core.Models.Table;
+using Xunit;
+using Bit.Core.Test.Repositories.EntityFramework.EqualityComparers;
+using Bit.Core.Models.Data;
+
+namespace Bit.Core.Test.Repositories.EntityFramework
+{
+    public class UserRepositoryTests
+    {
+        [Theory, EfUserAutoData]
+        public async void CreateAsync_Works_DataMatches(TableModel.User user, SqlRepo.UserRepository sqlUserRepo,
+                IMapper mapper, UserCompare equalityComparer, SutProvider<EfRepo.UserRepository> sutProvider)
+        {
+            var savedUsers = new List<TableModel.User>();
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var postEfUser = await sutProvider.Sut.CreateAsync(context, user);
+                    var savedUser = await sutProvider.Sut.GetByIdAsync(context, postEfUser.Id);
+                    savedUsers.Add(savedUser);
+                }
+            }
+
+            var sqlUser = await sqlUserRepo.CreateAsync(user);
+            savedUsers.Add(await sqlUserRepo.GetByIdAsync(sqlUser.Id));
+
+            var distinctItems = savedUsers.Distinct(equalityComparer);
+            Assert.True(!distinctItems.Skip(1).Any());
+        }
+
+        [Theory, EfUserAutoData]
+        public async void ReplaceAsync_Works_DataMatches(TableModel.User postUser, TableModel.User replaceUser, 
+                SqlRepo.UserRepository sqlUserRepo, UserCompare equalityComparer, SutProvider<EfRepo.UserRepository> sutProvider)
+        {
+            var savedUsers = new List<TableModel.User>();
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var postEfUser = await sutProvider.Sut.CreateAsync(context, postUser);
+                    replaceUser.Id = postEfUser.Id;
+                    await sutProvider.Sut.ReplaceAsync(context, replaceUser);
+                    var replacedUser = await sutProvider.Sut.GetByIdAsync(context, replaceUser.Id);
+                    savedUsers.Add(replacedUser);
+                }
+            }
+
+            var postSqlUser = await sqlUserRepo.CreateAsync(postUser);
+            replaceUser.Id = postSqlUser.Id;
+            await sqlUserRepo.ReplaceAsync(replaceUser);
+            savedUsers.Add(await sqlUserRepo.GetByIdAsync(replaceUser.Id));
+
+            var distinctItems = savedUsers.Distinct(equalityComparer);
+            Assert.True(!distinctItems.Skip(1).Any());
+        }
+
+        [Theory, EfUserAutoData]
+        public async void DeleteAsync_Works_DataMatches(TableModel.User user, SqlRepo.UserRepository sqlUserRepo, UserCompare equalityComparer,
+                SutProvider<EfRepo.UserRepository> sutProvider)
+        {
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                TableModel.User savedEfUser = null;
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var postEfUser = await sutProvider.Sut.CreateAsync(context, user);
+                    savedEfUser = await sutProvider.Sut.GetByIdAsync(context, postEfUser.Id);
+                    Assert.True(savedEfUser != null);
+                }
+
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    await sutProvider.Sut.DeleteAsync(context, savedEfUser);
+                    savedEfUser = await sutProvider.Sut.GetByIdAsync(context, savedEfUser.Id);
+                    Assert.True(savedEfUser == null);
+                }
+            }
+
+            var postSqlUser = await sqlUserRepo.CreateAsync(user);
+            var savedSqlUser = await sqlUserRepo.GetByIdAsync(postSqlUser.Id);
+            Assert.True(savedSqlUser != null);
+
+            await sqlUserRepo.DeleteAsync(postSqlUser);
+            savedSqlUser = await sqlUserRepo.GetByIdAsync(postSqlUser.Id);
+            Assert.True(savedSqlUser == null);
+        }
+
+        [Theory, EfUserAutoData]
+        public async void GetByEmailAsync_Works_DataMatches(TableModel.User user, SqlRepo.UserRepository sqlUserRepo,
+                UserCompare equalityComparer, SutProvider<EfRepo.UserRepository> sutProvider)
+        {
+            var savedUsers = new List<TableModel.User>();
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var postEfUser = await sutProvider.Sut.CreateAsync(context, user);
+                    var savedUser = await sutProvider.Sut.GetByEmailAsync(context, postEfUser.Email);
+                    savedUsers.Add(savedUser);
+                }
+            }
+
+            var postSqlUser = await sqlUserRepo.CreateAsync(user);
+            savedUsers.Add(await sqlUserRepo.GetByEmailAsync(postSqlUser.Email));
+
+            var distinctItems = savedUsers.Distinct(equalityComparer);
+            Assert.True(!distinctItems.Skip(1).Any());
+        }
+
+        [Theory, EfUserAutoData]
+        public async void GetKdfInformationByEmailAsync_Works_DataMatches(TableModel.User user, SqlRepo.UserRepository sqlUserRepo,
+                UserKdfInformationCompare equalityComparer, SutProvider<EfRepo.UserRepository> sutProvider)
+        {
+            
+            var savedKdfInformation = new List<UserKdfInformation>();
+            foreach(var option in DatabaseOptionsFactory.Options)
+            {
+                using (var context = new EfRepo.DatabaseContext(option))
+                {
+                    var postEfUser = await sutProvider.Sut.CreateAsync(context, user);
+                    var kdfInformation = await sutProvider.Sut.GetKdfInformationByEmailAsync(context, postEfUser.Email);
+                    savedKdfInformation.Add(kdfInformation);
+                }
+            }
+
+            var postSqlUser = await sqlUserRepo.CreateAsync(user);
+            var sqlKdfInformation = await sqlUserRepo.GetKdfInformationByEmailAsync(postSqlUser.Email);
+            savedKdfInformation.Add(sqlKdfInformation);
+
+            var distinctItems = savedKdfInformation.Distinct(equalityComparer);
+            Assert.True(!distinctItems.Skip(1).Any());
+        }
+    }
+}

--- a/util/Migrator/DbScripts/2021-04-08_00_SsoUserView.sql
+++ b/util/Migrator/DbScripts/2021-04-08_00_SsoUserView.sql
@@ -1,0 +1,315 @@
+IF EXISTS(SELECT * FROM sys.views WHERE [Name] = 'SsoUserView')
+BEGIN
+    DROP VIEW [dbo].[SsoUserView];
+END
+GO
+
+CREATE VIEW [dbo].[SsoUserView]
+AS
+SELECT
+    *
+FROM
+    [dbo].[SsoUser]
+GO
+
+IF OBJECT_ID('[dbo].[Organization_Create]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Organization_Create]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Organization_Create]
+    @Id UNIQUEIDENTIFIER OUTPUT,
+    @Identifier NVARCHAR(50),
+    @Name NVARCHAR(50),
+    @BusinessName NVARCHAR(50),
+    @BusinessAddress1 NVARCHAR(50),
+    @BusinessAddress2 NVARCHAR(50),
+    @BusinessAddress3 NVARCHAR(50),
+    @BusinessCountry VARCHAR(2),
+    @BusinessTaxNumber NVARCHAR(30),
+    @BillingEmail NVARCHAR(256),
+    @Plan NVARCHAR(50),
+    @PlanType TINYINT,
+    @Seats SMALLINT,
+    @MaxCollections SMALLINT,
+    @UsePolicies BIT,
+    @UseSso BIT,
+    @UseGroups BIT,
+    @UseDirectory BIT,
+    @UseEvents BIT,
+    @UseTotp BIT,
+    @Use2fa BIT,
+    @UseApi BIT,
+    @SelfHost BIT,
+    @UsersGetPremium BIT,
+    @Storage BIGINT,
+    @MaxStorageGb SMALLINT,
+    @Gateway TINYINT,
+    @GatewayCustomerId VARCHAR(50),
+    @GatewaySubscriptionId VARCHAR(50),
+    @ReferenceData VARCHAR(MAX),
+    @Enabled BIT,
+    @LicenseKey VARCHAR(100),
+    @ApiKey VARCHAR(30),
+    @TwoFactorProviders NVARCHAR(MAX),
+    @ExpirationDate DATETIME2(7),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    INSERT INTO [dbo].[Organization]
+    (
+        [Id],
+        [Identifier],
+        [Name],
+        [BusinessName],
+        [BusinessAddress1],
+        [BusinessAddress2],
+        [BusinessAddress3],
+        [BusinessCountry],
+        [BusinessTaxNumber],
+        [BillingEmail],
+        [Plan],
+        [PlanType],
+        [Seats],
+        [MaxCollections],
+        [UsePolicies],
+        [UseSso],
+        [UseGroups],
+        [UseDirectory],
+        [UseEvents],
+        [UseTotp],
+        [Use2fa],
+        [UseApi],
+        [SelfHost],
+        [UsersGetPremium],
+        [Storage],
+        [MaxStorageGb],
+        [Gateway],
+        [GatewayCustomerId],
+        [GatewaySubscriptionId],
+        [ReferenceData],
+        [Enabled],
+        [LicenseKey],
+        [ApiKey],
+        [TwoFactorProviders],
+        [ExpirationDate],
+        [CreationDate],
+        [RevisionDate]
+    )
+    VALUES
+    (
+        @Id,
+        @Identifier,
+        @Name,
+        @BusinessName,
+        @BusinessAddress1,
+        @BusinessAddress2,
+        @BusinessAddress3,
+        @BusinessCountry,
+        @BusinessTaxNumber,
+        @BillingEmail,
+        @Plan,
+        @PlanType,
+        @Seats,
+        @MaxCollections,
+        @UsePolicies,
+        @UseSso,
+        @UseGroups,
+        @UseDirectory,
+        @UseEvents,
+        @UseTotp,
+        @Use2fa,
+        @UseApi,
+        @SelfHost,
+        @UsersGetPremium,
+        @Storage,
+        @MaxStorageGb,
+        @Gateway,
+        @GatewayCustomerId,
+        @GatewaySubscriptionId,
+        @ReferenceData,
+        @Enabled,
+        @LicenseKey,
+        @ApiKey,
+        @TwoFactorProviders,
+        @ExpirationDate,
+        @CreationDate,
+        @RevisionDate
+    )
+END
+GO
+
+IF OBJECT_ID('[dbo].[User_Create]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[User_Create]
+END
+GO
+
+CREATE PROCEDURE [dbo].[User_Create]
+    @Id UNIQUEIDENTIFIER OUTPUT,
+    @Name NVARCHAR(50),
+    @Email NVARCHAR(256),
+    @EmailVerified BIT,
+    @MasterPassword NVARCHAR(300),
+    @MasterPasswordHint NVARCHAR(50),
+    @Culture NVARCHAR(10),
+    @SecurityStamp NVARCHAR(50),
+    @TwoFactorProviders NVARCHAR(MAX),
+    @TwoFactorRecoveryCode NVARCHAR(32),
+    @EquivalentDomains NVARCHAR(MAX),
+    @ExcludedGlobalEquivalentDomains NVARCHAR(MAX),
+    @AccountRevisionDate DATETIME2(7),
+    @Key NVARCHAR(MAX),
+    @PublicKey NVARCHAR(MAX),
+    @PrivateKey NVARCHAR(MAX),
+    @Premium BIT,
+    @PremiumExpirationDate DATETIME2(7),
+    @RenewalReminderDate DATETIME2(7),
+    @Storage BIGINT,
+    @MaxStorageGb SMALLINT,
+    @Gateway TINYINT,
+    @GatewayCustomerId VARCHAR(50),
+    @GatewaySubscriptionId VARCHAR(50),
+    @ReferenceData VARCHAR(MAX),
+    @LicenseKey VARCHAR(100),
+    @Kdf TINYINT,
+    @KdfIterations INT,
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @ApiKey VARCHAR(30)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    INSERT INTO [dbo].[User]
+    (
+        [Id],
+        [Name],
+        [Email],
+        [EmailVerified],
+        [MasterPassword],
+        [MasterPasswordHint],
+        [Culture],
+        [SecurityStamp],
+        [TwoFactorProviders],
+        [TwoFactorRecoveryCode],
+        [EquivalentDomains],
+        [ExcludedGlobalEquivalentDomains],
+        [AccountRevisionDate],
+        [Key],
+        [PublicKey],
+        [PrivateKey],
+        [Premium],
+        [PremiumExpirationDate],
+        [RenewalReminderDate],
+        [Storage],
+        [MaxStorageGb],
+        [Gateway],
+        [GatewayCustomerId],
+        [GatewaySubscriptionId],
+        [ReferenceData],
+        [LicenseKey],
+        [Kdf],
+        [KdfIterations],
+        [CreationDate],
+        [RevisionDate],
+        [ApiKey]
+    )
+    VALUES
+    (
+        @Id,
+        @Name,
+        @Email,
+        @EmailVerified,
+        @MasterPassword,
+        @MasterPasswordHint,
+        @Culture,
+        @SecurityStamp,
+        @TwoFactorProviders,
+        @TwoFactorRecoveryCode,
+        @EquivalentDomains,
+        @ExcludedGlobalEquivalentDomains,
+        @AccountRevisionDate,
+        @Key,
+        @PublicKey,
+        @PrivateKey,
+        @Premium,
+        @PremiumExpirationDate,
+        @RenewalReminderDate,
+        @Storage,
+        @MaxStorageGb,
+        @Gateway,
+        @GatewayCustomerId,
+        @GatewaySubscriptionId,
+        @ReferenceData,
+        @LicenseKey,
+        @Kdf,
+        @KdfIterations,
+        @CreationDate,
+        @RevisionDate,
+        @ApiKey
+    )
+END
+GO
+
+IF OBJECT_ID('[dbo].[SsoConfig_ReadById]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[SsoConfig_ReadById]
+END
+GO
+CREATE PROCEDURE [dbo].[SsoConfig_ReadById]
+    @Id BIGINT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        *
+    FROM
+        [dbo].[SsoConfigView]
+    WHERE
+        [Id] = @Id
+END
+
+IF OBJECT_ID('[dbo].[SsoUser_DeleteById]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[SsoUser_DeleteById]
+END
+GO
+
+CREATE PROCEDURE [dbo].[SsoUser_DeleteById]
+    @Id BIGINT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    DELETE
+    FROM
+        [dbo].[SsoUser]
+    WHERE
+        [Id] = @Id
+END
+GO
+
+IF OBJECT_ID('[dbo].[SsoConfig_DeleteById]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[SsoConfig_DeleteById]
+END
+GO
+CREATE PROCEDURE [dbo].[SsoConfig_DeleteById]
+    @Id BIGINT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    DELETE
+    FROM
+        [dbo].[SsoConfig]
+    WHERE
+        [Id] = @Id
+END
+GO


### PR DESCRIPTION
Working implementations and tests for the EF implementations of the User, Organization, SsoConfig, and SsoUser repos.

PR is in a draft state w/no marked reviewers while I try and address a few design bits that could be better:
1. The separating of each interface method implementation in an EF Repo into two parts. Currently this is being done to inject the test dbContext configs into the repo.
2. Building foreign key relationships (ssoConfig.OrgID = org.Id) in each test. I think this could be done on fixture creation.
3. Equality compares being useless unless updated each time a new prop is added to the model they represent.
4. I haven't merged from master in a while

But this is all working, so I wanted it out there in case anybody wanted to see it.