### PR TITLE
Move renew endpoint to fix overlapping endpoint issue

### DIFF
--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -601,7 +601,7 @@ namespace Bit.Api.Controllers
             };
         }
 
-        [HttpGet("{id}/attachment/{attachmentId}")]
+        [HttpGet("{id}/attachment/{attachmentId}/renew")]
         public async Task<AttachmentUploadDataResponseModel> RenewFileUploadUrl(string id, string attachmentId)
         {
             var userId = _userService.GetProperUserId(User).Value;


### PR DESCRIPTION
# Overview

Fix https://app.asana.com/0/0/1200170130625742/f, which reports an issue introduced late in the development cycle of direct azure uploads for cipher attachments.

I reverted the renew upload url endpoint to overlap with the `GetAttachmentDownloadData` one. This fixes that error.

# TODO:
 - [ ] jslib
 - [ ] web jslib reference
 - [ ] cli jslib reference
 - [ ] browser jslib reference
 - [ ] desktop jslib reference
 - [ ] mobile