### PR TITLE
Enforce SSO "Want assertions signed" option

### DIFF
--- a/bitwarden_license/src/Sso/Utilities/Saml2OptionsExtensions.cs
+++ b/bitwarden_license/src/Sso/Utilities/Saml2OptionsExtensions.cs
@@ -89,9 +89,9 @@ namespace Bit.Sso.Utilities
             if (options.SPOptions.WantAssertionsSigned)
             {
                 var assertion = envelope["Assertion", Saml2Namespaces.Saml2Name];
-                var IsAssertionSigned = assertion != null && XmlHelpers.IsSignedByAny(assertion, idp.SigningKeys,
+                var isAssertionSigned = assertion != null && XmlHelpers.IsSignedByAny(assertion, idp.SigningKeys,
                     options.SPOptions.ValidateCertificates, options.SPOptions.MinIncomingSigningAlgorithm);
-                if (!IsAssertionSigned)
+                if (!isAssertionSigned)
                 {
                     throw new Exception("Cannot verify SAML assertion signature.");
                 }

--- a/bitwarden_license/src/Sso/Utilities/Saml2OptionsExtensions.cs
+++ b/bitwarden_license/src/Sso/Utilities/Saml2OptionsExtensions.cs
@@ -86,6 +86,13 @@ namespace Bit.Sso.Utilities
                 return false;
             }
 
+            // Double check the entity Ids
+            var entityId = envelope["Issuer", Saml2Namespaces.Saml2Name]?.InnerText.Trim();
+            if (!string.Equals(entityId, idp.EntityId.Id, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return false;
+            }
+
             if (options.SPOptions.WantAssertionsSigned)
             {
                 var assertion = envelope["Assertion", Saml2Namespaces.Saml2Name];
@@ -97,9 +104,7 @@ namespace Bit.Sso.Utilities
                 }
             }
 
-            // Double check the entity Ids
-            var entityId = envelope["Issuer", Saml2Namespaces.Saml2Name]?.InnerText.Trim();
-            return string.Equals(entityId, idp.EntityId.Id, StringComparison.InvariantCultureIgnoreCase);
+            return true;
         }
     }
 }


### PR DESCRIPTION
## Objective

Currently, if you configure SSO to "Want Assertions Signed" (by the IdP), it will correctly issue the request to the IdP, but will not actually check that the IdP's response contains a properly signed assertion. (It will throw an error if neither the response nor the assertion is signed, but not otherwise.)

## Code changes

Add an extra check for this in `Saml2OptionsExtensions`, which is called as part of the SSO middleware. (Per @cscharf's helpful suggestion)