### PR TITLE
[Reset Password] Admin reset actions

### DIFF
--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -97,7 +97,7 @@ namespace Bit.Api.Controllers
             var orgGuidId = new Guid(orgId);
             if (!_currentContext.ManageResetPassword(orgGuidId))
             {
-                throw new UnauthorizedAccessException();
+                throw new NotFoundException();
             }
             
             // Retrieve data necessary for response (KDF, KDF Iterations, ResetPasswordKey)
@@ -224,7 +224,7 @@ namespace Bit.Api.Controllers
             // Calling user must have Manage Reset Password permission
             if (!_currentContext.ManageResetPassword(orgGuidId))
             {
-                throw new UnauthorizedAccessException();
+                throw new NotFoundException();
             }
 
             var userGuidId = new Guid(userId);

--- a/src/Core/Models/Api/Request/Organizations/OrganizationUserResetPasswordRequestModel.cs
+++ b/src/Core/Models/Api/Request/Organizations/OrganizationUserResetPasswordRequestModel.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Bit.Core.Models.Api
+{
+    public class OrganizationUserResetPasswordRequestModel
+    {
+        [Required]
+        [StringLength(300)]
+        public string NewMasterPasswordHash { get; set; }
+        [Required]
+        public string Key { get; set; }
+    }
+}

--- a/src/Core/Models/Api/Response/OrganizationUserResponseModel.cs
+++ b/src/Core/Models/Api/Response/OrganizationUserResponseModel.cs
@@ -23,6 +23,7 @@ namespace Bit.Core.Models.Api
             Status = organizationUser.Status;
             AccessAll = organizationUser.AccessAll;
             Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(organizationUser.Permissions);
+            ResetPasswordEnrolled = !string.IsNullOrEmpty(organizationUser.ResetPasswordKey);
         }
 
         public OrganizationUserResponseModel(OrganizationUserUserDetails organizationUser, string obj = "organizationUser")
@@ -39,6 +40,7 @@ namespace Bit.Core.Models.Api
             Status = organizationUser.Status;
             AccessAll = organizationUser.AccessAll;
             Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(organizationUser.Permissions);
+            ResetPasswordEnrolled = !string.IsNullOrEmpty(organizationUser.ResetPasswordKey);
         }
 
         public string Id { get; set; }
@@ -47,6 +49,7 @@ namespace Bit.Core.Models.Api
         public OrganizationUserStatusType Status { get; set; }
         public bool AccessAll { get; set; }
         public Permissions Permissions { get; set; }
+        public bool ResetPasswordEnrolled { get; set; }
     }
 
     public class OrganizationUserDetailsResponseModel : OrganizationUserResponseModel
@@ -82,5 +85,25 @@ namespace Bit.Core.Models.Api
         public string Email { get; set; }
         public bool TwoFactorEnabled { get; set; }
         public bool SsoBound { get; set; }
+    }
+
+    public class OrganizationUserResetPasswordDetailsResponseModel : ResponseModel
+    {
+        public OrganizationUserResetPasswordDetailsResponseModel(OrganizationUserResetPasswordDetails orgUser,
+            string obj = "organizationUserResetPasswordDetails") : base(obj)
+        {
+            if (orgUser == null)
+            {
+                throw new ArgumentNullException(nameof(orgUser));
+            }
+
+            Kdf = orgUser.Kdf;
+            KdfIterations = orgUser.KdfIterations;
+            ResetPasswordKey = orgUser.ResetPasswordKey;
+        }
+        
+        public KdfType Kdf { get; set; }
+        public int KdfIterations { get; set; }
+        public string ResetPasswordKey { get; set; }
     }
 }

--- a/src/Core/Models/Api/Response/ProfileOrganizationResponseModel.cs
+++ b/src/Core/Models/Api/Response/ProfileOrganizationResponseModel.cs
@@ -30,7 +30,7 @@ namespace Bit.Core.Models.Api
             SsoBound = !string.IsNullOrWhiteSpace(organization.SsoExternalId);
             Identifier = organization.Identifier;
             Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(organization.Permissions);
-            ResetPasswordKey = organization.ResetPasswordKey;
+            ResetPasswordEnrolled = organization.ResetPasswordKey != null;
             UserId = organization.UserId?.ToString();
         }
 
@@ -57,7 +57,7 @@ namespace Bit.Core.Models.Api
         public bool SsoBound { get; set; }
         public string Identifier { get; set; }
         public Permissions Permissions { get; set; }
-        public string ResetPasswordKey { get; set; }
+        public bool ResetPasswordEnrolled { get; set; }
         public string UserId { get; set; }
     }
 }

--- a/src/Core/Models/Data/OrganizationUserResetPasswordDetails.cs
+++ b/src/Core/Models/Data/OrganizationUserResetPasswordDetails.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Bit.Core.Enums;
+using Bit.Core.Models.Table;
+
+namespace Bit.Core.Models.Data
+{
+    public class OrganizationUserResetPasswordDetails
+    {
+        public OrganizationUserResetPasswordDetails(OrganizationUser orgUser, User user)
+        {
+            if (orgUser == null)
+            {
+                throw new ArgumentNullException(nameof(orgUser));
+            }
+            
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            Kdf = user.Kdf;
+            KdfIterations = user.KdfIterations;
+            ResetPasswordKey = orgUser.ResetPasswordKey;
+        }
+        public KdfType Kdf { get; set; }
+        public int KdfIterations { get; set; }
+        public string ResetPasswordKey { get; set; }
+    }
+}

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -34,6 +34,7 @@ namespace Bit.Core.Services
             string token, string key);
         Task<IdentityResult> ChangePasswordAsync(User user, string masterPassword, string newMasterPassword, string key);
         Task<IdentityResult> SetPasswordAsync(User user, string newMasterPassword, string key, string orgIdentifier = null);
+        Task<IdentityResult> AdminResetPasswordAsync(User user, string newMasterPassword, string key);
         Task<IdentityResult> ChangeKdfAsync(User user, string masterPassword, string newMasterPassword, string key,
             KdfType kdf, int kdfIterations);
         Task<IdentityResult> UpdateKeyAsync(User user, string masterPassword, string key, string privateKey,


### PR DESCRIPTION
## Objective
> Enable Admins (owners, admins, custom permission holders) to perform the `Password Reset` action for users within the organization.

## Code Changes
- **Api/OrganizationUsersController**: Added two new API endpoints .`GET: reset-password-details` is responsible for returning information regarding the KDF settings and the `ResetPasswordKey`. Only organization Admins can make this call. `PUT: reset-password` is responsible for actually updating the selected user's hash and key. 
- **Core/OrganizationUserResetPasswordRequestModel**: Created request model that contains the `hash` and `key` to be updated for the user
- **Core/OrganizationUserResponseModel**: **Important**: Fixed response object to **only** return a boolean for if the user is enrolled. Created `OrganizationUserResetPasswordDetailsResponseModel` to handle passing back the gathered information
- **Core/ProfileOrganizationResponseModel**: **Important**: Fixed response object to **only** return a boolean for if the user is enrolled.
- **Core/OrganizationUserResetPasswordDetails**: Created Data layer object to house parameters retrieved from database tables
- **Core/IUserService**: Added `AdminResetPasswordAsync` stub
- **Core/UserService**: Added `AdminResetPasswordAsync` method that updates the user's hashed password and key. Similar to changing a password from settings, this will log the user out.