### PR TITLE
Increase organization max seat size from 30k to 2b

### DIFF
--- a/src/Admin/Models/OrganizationEditModel.cs
+++ b/src/Admin/Models/OrganizationEditModel.cs
@@ -67,7 +67,7 @@ namespace Bit.Admin.Models
         [Display(Name = "Plan Name")]
         public string Plan { get; set; }
         [Display(Name = "Seats")]
-        public short? Seats { get; set; }
+        public int? Seats { get; set; }
         [Display(Name = "Max. Collections")]
         public short? MaxCollections { get; set; }
         [Display(Name = "Policies")]

--- a/src/Core/Models/Api/Response/OrganizationResponseModel.cs
+++ b/src/Core/Models/Api/Response/OrganizationResponseModel.cs
@@ -56,7 +56,7 @@ namespace Bit.Core.Models.Api
         public string BillingEmail { get; set; }
         public PlanResponseModel Plan { get; set; }
         public PlanType PlanType { get; set; }
-        public short? Seats { get; set; }
+        public int? Seats { get; set; }
         public short? MaxCollections { get; set; }
         public short? MaxStorageGb { get; set; }
         public bool UsePolicies { get; set; }

--- a/src/Core/Models/Business/OrganizationLicense.cs
+++ b/src/Core/Models/Business/OrganizationLicense.cs
@@ -99,7 +99,7 @@ namespace Bit.Core.Models.Business
         public bool Enabled { get; set; }
         public string Plan { get; set; }
         public PlanType PlanType { get; set; }
-        public short? Seats { get; set; }
+        public int? Seats { get; set; }
         public short? MaxCollections { get; set; }
         public bool UsePolicies { get; set; }
         public bool UseSso { get; set; }

--- a/src/Core/Models/Business/ReferenceEvent.cs
+++ b/src/Core/Models/Business/ReferenceEvent.cs
@@ -42,7 +42,7 @@ namespace Bit.Core.Models.Business
 
         public PlanType? PlanType { get; set; }
 
-        public short? Seats { get; set; }
+        public int? Seats { get; set; }
 
         public short? Storage { get; set; }
 

--- a/src/Core/Models/Table/Organization.cs
+++ b/src/Core/Models/Table/Organization.cs
@@ -23,7 +23,7 @@ namespace Bit.Core.Models.Table
         public string BillingEmail { get; set; }
         public string Plan { get; set; }
         public PlanType PlanType { get; set; }
-        public short? Seats { get; set; }
+        public int? Seats { get; set; }
         public short? MaxCollections { get; set; }
         public bool UsePolicies { get; set; }
         public bool UseSso { get; set; }

--- a/src/Sql/dbo/Stored Procedures/Organization_Create.sql
+++ b/src/Sql/dbo/Stored Procedures/Organization_Create.sql
@@ -11,7 +11,7 @@
     @BillingEmail NVARCHAR(256),
     @Plan NVARCHAR(50),
     @PlanType TINYINT,
-    @Seats SMALLINT,
+    @Seats INT,
     @MaxCollections SMALLINT,
     @UsePolicies BIT,
     @UseSso BIT,

--- a/src/Sql/dbo/Stored Procedures/Organization_Update.sql
+++ b/src/Sql/dbo/Stored Procedures/Organization_Update.sql
@@ -11,7 +11,7 @@
     @BillingEmail NVARCHAR(256),
     @Plan NVARCHAR(50),
     @PlanType TINYINT,
-    @Seats SMALLINT,
+    @Seats INT,
     @MaxCollections SMALLINT,
     @UsePolicies BIT,
     @UseSso BIT,

--- a/src/Sql/dbo/Tables/Organization.sql
+++ b/src/Sql/dbo/Tables/Organization.sql
@@ -11,7 +11,7 @@
     [BillingEmail]          NVARCHAR (256)   NOT NULL,
     [Plan]                  NVARCHAR (50)    NOT NULL,
     [PlanType]              TINYINT          NOT NULL,
-    [Seats]                 SMALLINT         NULL,
+    [Seats]                 INT              NULL,
     [MaxCollections]        SMALLINT         NULL,
     [UsePolicies]           BIT              NOT NULL,
     [UseSso]                BIT              NOT NULL,

--- a/util/Migrator/DbScripts/2021-04-07_00_IncreaseOrgSeatSize.sql
+++ b/util/Migrator/DbScripts/2021-04-07_00_IncreaseOrgSeatSize.sql
@@ -1,5 +1,14 @@
-ALTER TABLE [dbo].[Organization]
-ALTER COLUMN [Seats] INT; 
+IF EXISTS (
+    SELECT *
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE COLUMN_NAME = 'Seats' AND 
+        DATA_TYPE = 'smallint' AND
+        TABLE_NAME = 'Organization')
+BEGIN
+    ALTER TABLE [dbo].[Organization]
+    ALTER COLUMN [Seats] INT NULL
+END
+GO
 
 IF OBJECT_ID('[dbo].[Organization_Create]') IS NOT NULL
 BEGIN

--- a/util/Migrator/DbScripts/2021-04-07_00_IncreaseOrgSeatSize.sql
+++ b/util/Migrator/DbScripts/2021-04-07_00_IncreaseOrgSeatSize.sql
@@ -1,0 +1,226 @@
+ALTER TABLE [dbo].[Organization]
+ALTER COLUMN [Seats] INT; 
+
+IF OBJECT_ID('[dbo].[Organization_Create]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Organization_Create]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Organization_Create]
+    @Id UNIQUEIDENTIFIER,
+    @Identifier NVARCHAR(50),
+    @Name NVARCHAR(50),
+    @BusinessName NVARCHAR(50),
+    @BusinessAddress1 NVARCHAR(50),
+    @BusinessAddress2 NVARCHAR(50),
+    @BusinessAddress3 NVARCHAR(50),
+    @BusinessCountry VARCHAR(2),
+    @BusinessTaxNumber NVARCHAR(30),
+    @BillingEmail NVARCHAR(256),
+    @Plan NVARCHAR(50),
+    @PlanType TINYINT,
+    @Seats INT,
+    @MaxCollections SMALLINT,
+    @UsePolicies BIT,
+    @UseSso BIT,
+    @UseGroups BIT,
+    @UseDirectory BIT,
+    @UseEvents BIT,
+    @UseTotp BIT,
+    @Use2fa BIT,
+    @UseApi BIT,
+    @SelfHost BIT,
+    @UsersGetPremium BIT,
+    @Storage BIGINT,
+    @MaxStorageGb SMALLINT,
+    @Gateway TINYINT,
+    @GatewayCustomerId VARCHAR(50),
+    @GatewaySubscriptionId VARCHAR(50),
+    @ReferenceData VARCHAR(MAX),
+    @Enabled BIT,
+    @LicenseKey VARCHAR(100),
+    @ApiKey VARCHAR(30),
+    @TwoFactorProviders NVARCHAR(MAX),
+    @ExpirationDate DATETIME2(7),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    INSERT INTO [dbo].[Organization]
+        (
+        [Id],
+        [Identifier],
+        [Name],
+        [BusinessName],
+        [BusinessAddress1],
+        [BusinessAddress2],
+        [BusinessAddress3],
+        [BusinessCountry],
+        [BusinessTaxNumber],
+        [BillingEmail],
+        [Plan],
+        [PlanType],
+        [Seats],
+        [MaxCollections],
+        [UsePolicies],
+        [UseSso],
+        [UseGroups],
+        [UseDirectory],
+        [UseEvents],
+        [UseTotp],
+        [Use2fa],
+        [UseApi],
+        [SelfHost],
+        [UsersGetPremium],
+        [Storage],
+        [MaxStorageGb],
+        [Gateway],
+        [GatewayCustomerId],
+        [GatewaySubscriptionId],
+        [ReferenceData],
+        [Enabled],
+        [LicenseKey],
+        [ApiKey],
+        [TwoFactorProviders],
+        [ExpirationDate],
+        [CreationDate],
+        [RevisionDate]
+        )
+    VALUES
+        (
+            @Id,
+            @Identifier,
+            @Name,
+            @BusinessName,
+            @BusinessAddress1,
+            @BusinessAddress2,
+            @BusinessAddress3,
+            @BusinessCountry,
+            @BusinessTaxNumber,
+            @BillingEmail,
+            @Plan,
+            @PlanType,
+            @Seats,
+            @MaxCollections,
+            @UsePolicies,
+            @UseSso,
+            @UseGroups,
+            @UseDirectory,
+            @UseEvents,
+            @UseTotp,
+            @Use2fa,
+            @UseApi,
+            @SelfHost,
+            @UsersGetPremium,
+            @Storage,
+            @MaxStorageGb,
+            @Gateway,
+            @GatewayCustomerId,
+            @GatewaySubscriptionId,
+            @ReferenceData,
+            @Enabled,
+            @LicenseKey,
+            @ApiKey,
+            @TwoFactorProviders,
+            @ExpirationDate,
+            @CreationDate,
+            @RevisionDate
+    )
+END
+GO
+
+-- Recreate procedure Organization_Update
+IF OBJECT_ID('[dbo].[Organization_Update]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Organization_Update]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Organization_Update]
+    @Id UNIQUEIDENTIFIER,
+    @Identifier NVARCHAR(50),
+    @Name NVARCHAR(50),
+    @BusinessName NVARCHAR(50),
+    @BusinessAddress1 NVARCHAR(50),
+    @BusinessAddress2 NVARCHAR(50),
+    @BusinessAddress3 NVARCHAR(50),
+    @BusinessCountry VARCHAR(2),
+    @BusinessTaxNumber NVARCHAR(30),
+    @BillingEmail NVARCHAR(256),
+    @Plan NVARCHAR(50),
+    @PlanType TINYINT,
+    @Seats INT,
+    @MaxCollections SMALLINT,
+    @UsePolicies BIT,
+    @UseSso BIT,
+    @UseGroups BIT,
+    @UseDirectory BIT,
+    @UseEvents BIT,
+    @UseTotp BIT,
+    @Use2fa BIT,
+    @UseApi BIT,
+    @SelfHost BIT,
+    @UsersGetPremium BIT,
+    @Storage BIGINT,
+    @MaxStorageGb SMALLINT,
+    @Gateway TINYINT,
+    @GatewayCustomerId VARCHAR(50),
+    @GatewaySubscriptionId VARCHAR(50),
+    @ReferenceData VARCHAR(MAX),
+    @Enabled BIT,
+    @LicenseKey VARCHAR(100),
+    @ApiKey VARCHAR(30),
+    @TwoFactorProviders NVARCHAR(MAX),
+    @ExpirationDate DATETIME2(7),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    UPDATE
+        [dbo].[Organization]
+    SET
+        [Identifier] = @Identifier,
+        [Name] = @Name,
+        [BusinessName] = @BusinessName,
+        [BusinessAddress1] = @BusinessAddress1,
+        [BusinessAddress2] = @BusinessAddress2,
+        [BusinessAddress3] = @BusinessAddress3,
+        [BusinessCountry] = @BusinessCountry,
+        [BusinessTaxNumber] = @BusinessTaxNumber,
+        [BillingEmail] = @BillingEmail,
+        [Plan] = @Plan,
+        [PlanType] = @PlanType,
+        [Seats] = @Seats,
+        [MaxCollections] = @MaxCollections,
+        [UsePolicies] = @UsePolicies,
+        [UseSso] = @UseSso,
+        [UseGroups] = @UseGroups,
+        [UseDirectory] = @UseDirectory,
+        [UseEvents] = @UseEvents,
+        [UseTotp] = @UseTotp,
+        [Use2fa] = @Use2fa,
+        [UseApi] = @UseApi,
+        [SelfHost] = @SelfHost,
+        [UsersGetPremium] = @UsersGetPremium,
+        [Storage] = @Storage,
+        [MaxStorageGb] = @MaxStorageGb,
+        [Gateway] = @Gateway,
+        [GatewayCustomerId] = @GatewayCustomerId,
+        [GatewaySubscriptionId] = @GatewaySubscriptionId,
+        [ReferenceData] = @ReferenceData,
+        [Enabled] = @Enabled,
+        [LicenseKey] = @LicenseKey,
+        [ApiKey] = @ApiKey,
+        [TwoFactorProviders] = @TwoFactorProviders,
+        [ExpirationDate] = @ExpirationDate,
+        [CreationDate] = @CreationDate,
+        [RevisionDate] = @RevisionDate
+    WHERE
+        [Id] = @Id
+END
+GO


### PR DESCRIPTION
# Overview

**Merging into large org sync feature branch**

Storage of seat count limits currently max out at 32767. To support larger organizations for larger organization sync, increase this data type from smallint to int and the new limit will be >2 billion.

# Files Chaged
* **c# files**: These are all model updates to the new data type of `int`
* **Organization_Create.sql/Organization_Update.sql**: Update sprocs to new data type
* **Organization.table**: Update table to new data type
* **2021-04-07_00_IncreaseOrgSeatSize.sql**: Alters
  * table
  * Organization_Create sproc
  * Organization_Update sproc
to  new seats data type