### PR TITLE
Organization sync simultaneous event reporting

### DIFF
--- a/src/Core/Services/IEventService.cs
+++ b/src/Core/Services/IEventService.cs
@@ -15,6 +15,7 @@ namespace Bit.Core.Services
         Task LogGroupEventAsync(Group group, EventType type, DateTime? date = null);
         Task LogPolicyEventAsync(Policy policy, EventType type, DateTime? date = null);
         Task LogOrganizationUserEventAsync(OrganizationUser organizationUser, EventType type, DateTime? date = null);
+        Task LogOrganizationUserEventsAsync(IEnumerable<(OrganizationUser, EventType, DateTime?)> events);
         Task LogOrganizationEventAsync(Organization organization, EventType type, DateTime? date = null);
     }
 }

--- a/src/Core/Services/Implementations/AzureQueueEventWriteService.cs
+++ b/src/Core/Services/Implementations/AzureQueueEventWriteService.cs
@@ -33,6 +33,17 @@ namespace Bit.Core.Services
 
         public async Task CreateManyAsync(IList<IEvent> e)
         {
+            if (!e?.Any() ?? true)
+            {
+                return;
+            }
+
+            if (e.Count == 1)
+            {
+                await CreateAsync(e.First());
+                return;
+            }
+
             foreach(var json in SerializeMany(e))
             {
                 await _queueClient.SendMessageAsync(json);

--- a/src/Core/Services/Implementations/AzureQueueEventWriteService.cs
+++ b/src/Core/Services/Implementations/AzureQueueEventWriteService.cs
@@ -4,12 +4,15 @@ using Azure.Storage.Queues;
 using Newtonsoft.Json;
 using Bit.Core.Models.Data;
 using Bit.Core.Settings;
+using System.Linq;
+using System.Text;
 
 namespace Bit.Core.Services
 {
     public class AzureQueueEventWriteService : IEventWriteService
     {
         private readonly QueueClient _queueClient;
+        private const int MAX_MESSAGE_BODY = 128000;
 
         private JsonSerializerSettings _jsonSettings = new JsonSerializerSettings
         {
@@ -30,8 +33,33 @@ namespace Bit.Core.Services
 
         public async Task CreateManyAsync(IList<IEvent> e)
         {
-            var json = JsonConvert.SerializeObject(e, _jsonSettings);
-            await _queueClient.SendMessageAsync(json);
+            foreach(var json in SerializeMany(e))
+            {
+                await _queueClient.SendMessageAsync(json);
+            }
+        }
+
+        private IEnumerable<string> SerializeMany(IList<IEvent> events)
+        {
+            var strings = new List<string>();
+            var jsonEvents = events.Select(e => JsonConvert.SerializeObject(e, _jsonSettings));
+            var stringBuilder = new StringBuilder("[");
+            foreach(var jsonEvent in jsonEvents)
+            {
+                if (stringBuilder.Length + jsonEvent.Length + 2 < MAX_MESSAGE_BODY)
+                {
+                    stringBuilder.Append($",{jsonEvent}");
+                }
+                else
+                {
+                    stringBuilder.Append("]");
+                    strings.Append(stringBuilder.ToString());
+                    stringBuilder = new StringBuilder("[");
+                }
+            }
+            stringBuilder.Append("]");
+            strings.Append(stringBuilder.ToString());
+            return strings;
         }
     }
 }

--- a/src/Core/Services/Implementations/AzureQueueEventWriteService.cs
+++ b/src/Core/Services/Implementations/AzureQueueEventWriteService.cs
@@ -33,7 +33,7 @@ namespace Bit.Core.Services
 
         public async Task CreateManyAsync(IList<IEvent> e)
         {
-            if (!e?.Any() ?? true)
+            if (e?.Any() != true)
             {
                 return;
             }

--- a/src/Core/Services/Implementations/EventService.cs
+++ b/src/Core/Services/Implementations/EventService.cs
@@ -179,15 +179,15 @@ namespace Bit.Core.Services
 
         public async Task LogOrganizationUserEventAsync(OrganizationUser organizationUser, EventType type,
             DateTime? date = null) =>
-            await LogOrganizationUserEventsAsync(new[] {(organizationUser, type, date)});
+            await LogOrganizationUserEventsAsync(new[] { (organizationUser, type, date) });
 
         public async Task LogOrganizationUserEventsAsync(IEnumerable<(OrganizationUser, EventType, DateTime?)> events)
         {
             var orgAbilities = await _applicationCacheService.GetOrganizationAbilitiesAsync();
             var eventMessages = new List<IEvent>();
-            foreach(var (organizationUser, type, date) in events)
+            foreach (var (organizationUser, type, date) in events)
             {
-                if(!CanUseEvents(orgAbilities, organizationUser.OrganizationId))
+                if (!CanUseEvents(orgAbilities, organizationUser.OrganizationId))
                 {
                     continue;
                 }

--- a/src/Core/Services/NoopImplementations/NoopEventService.cs
+++ b/src/Core/Services/NoopImplementations/NoopEventService.cs
@@ -44,6 +44,11 @@ namespace Bit.Core.Services
             return Task.FromResult(0);
         }
 
+        public Task LogOrganizationUserEventsAsync(IEnumerable<(OrganizationUser, EventType, DateTime?)> events)
+        {
+            return Task.FromResult(0);
+        }
+
         public Task LogUserEventAsync(Guid userId, EventType type, DateTime? date = null)
         {
             return Task.FromResult(0);


### PR DESCRIPTION
# Overview

**Merge into large organization sync feature branch**

Implements a bulk OrganizationUser event method and fixes an issue with `AzureQueueEventWriteService` implementation.

The bulk event will be used for OrganizationUser syncs to reduce wire-time and speed up sync times.

These bulk events have so many events associated with them that we were maxing out Azure QueueClient's max message size. The improvement generates JSON messages until the next would overfill the queue message, As many queue messages as necessary are sent to cover all events requested.

# Files Changed
* **IEventService.cs/EventService.cs/NoopEventService.cs**: added batched OrganizationUserEvent method. Rerouted the single event to the batched events as special cases.
* **AzureQueueEventWriteService.cs**: Create messages limited in size to the maximum event queue message size. Send as many messages as necessary to log all events. **NOTE: googling reports max size as 64KB, but the error message for an over-size message says 138000**. I settled on 128000, but perhaps we should limit message size to the published guarantee?