### PR TITLE
Amazon ses bulk organization invites

### DIFF
--- a/src/Core/MailTemplates/Handlebars/OrganizationUserInvited.subject.hbs
+++ b/src/Core/MailTemplates/Handlebars/OrganizationUserInvited.subject.hbs
@@ -1,0 +1,1 @@
+﻿Join {{OrganizationName}}

--- a/src/Core/Services/IMailService.cs
+++ b/src/Core/Services/IMailService.cs
@@ -16,6 +16,8 @@ namespace Bit.Core.Services
         Task SendNoMasterPasswordHintEmailAsync(string email);
         Task SendMasterPasswordHintEmailAsync(string email, string hint);
         Task SendOrganizationInviteEmailAsync(string organizationName, OrganizationUser orgUser, string token);
+        Task BulkSendOrganizationInviteEmailAsync(string organizationName, 
+            IEnumerable<(OrganizationUser orgUser, string token)> invites);
         Task SendOrganizationAcceptedEmailAsync(string organizationName, string userEmail,
             IEnumerable<string> adminEmails);
         Task SendOrganizationConfirmedEmailAsync(string organizationName, string email);

--- a/src/Core/Services/Implementations/AmazonSesMailDeliveryService.cs
+++ b/src/Core/Services/Implementations/AmazonSesMailDeliveryService.cs
@@ -147,14 +147,14 @@ namespace Bit.Core.Services
                 };
                 try
                 {
-                    await SendBulkEmails(request, false);
+                    await SendBulkEmailsAsync(request, false);
                 }
                 catch (Exception e)
                 {
                     try
                     {
                         _logger.LogWarning(e, "Failed to send emails. Re-retying...");
-                        await SendBulkEmails(request, true);
+                        await SendBulkEmailsAsync(request, true);
                     }
                     catch (Exception ex)
                     {
@@ -169,7 +169,7 @@ namespace Bit.Core.Services
             }
         }
 
-        public async Task UpsertTemplate(string templateName, string subjectPart, string textPart = null, string htmlPart = null)
+        public async Task UpsertTemplateAsync(string templateName, string subjectPart, string textPart = null, string htmlPart = null)
         {
             var template = new Template { TemplateName = templateName };
             if (subjectPart != null)
@@ -217,7 +217,7 @@ namespace Bit.Core.Services
             await _client.SendEmailAsync(request);
         }
 
-        private async Task SendBulkEmails(SendBulkTemplatedEmailRequest request, bool retry)
+        private async Task SendBulkEmailsAsync(SendBulkTemplatedEmailRequest request, bool retry)
         {
             if (retry)
             {

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -545,7 +545,7 @@ namespace Bit.Core.Services
                 var bulkTemplate = GenerateModelForBulkSend(messageModels.First().model.GetType(), unescapedModelProperties);
                 var (subjectPart, htmlPart, textPart) = await GetMessageContentAsync(templateName, bulkTemplate);
 
-                await sesService.UpsertTemplate(templateName, subjectPart, textPart, htmlPart);
+                await sesService.UpsertTemplateAsync(templateName, subjectPart, textPart, htmlPart);
 
                 await sesService.SendBulkTemplatedEmailAsync(templateName, bulkTemplate, messageModels);
             }

--- a/src/Core/Services/NoopImplementations/NoopMailService.cs
+++ b/src/Core/Services/NoopImplementations/NoopMailService.cs
@@ -147,5 +147,11 @@ namespace Bit.Core.Services
         {
             return Task.FromResult(0);
         }
+
+        public Task BulkSendOrganizationInviteEmailAsync(string organizationName,
+            IEnumerable<(OrganizationUser orgUser, string token)> invites)
+        {
+            return Task.FromResult(0);
+        }
     }
 }


### PR DESCRIPTION
# Overview

**Merge into large organization sync feature branch**

Amazon SES, the SMTP service backing Bitwarden cloud, offers a Handlebars-like email templating solution to batch email sends. Up to 50 email addresses can receive unique emails based off of a preexisting template design.

We don't really want to rely on Amazon's handlebars implementation, since there's no equivalent to Handlebars helpers or partials. So instead of using it to parse our templates, I'm creating new templates of fully compiled handlebars templates with each value just re-creating the `{{Key}}`.

# Files Changed
* **OrganizationUserInvited.subject.hbs**: SES templates expect the subject to be generated through the handlebars so we might as well implement this. Thus far, we are specifying the subject ourselves in the MailMessage.
* **IMailService.cs/NoopMailService.cs**: Add Bulk Send for OrganizationInviteEmails. This is the method we're looking to batch during directory-connector sync. The infrastructure here can be used for other emails as well
* **AmazonSesMailDeliveryService.cs**: This is where templated email is implemented. Note, there is a maximum of 50 recipients per bulk email. This is handled by the `BatchEmails` private method.
 * **SendBulkTemplatedEmailAsync**: Batches emails, generates SES models, and uploads all the necessary batch requests. Catches any failure and aggregates into a single message. **NOTE:** a bad email on any **one** email in a batch fails the entire batch. SES also requires a default model to insert values in case a recipient-specific value doesn't exist. This implementation requires a default model, but the Handlebars service is just giving in the model used to generate the Amazon template.
 * **UpsertTemplateAsync**: Ensures a template exists and have the given values. Handlebars updates these templates on every call to a bulk invite. This ensures amazon templates reflect those on the server at the time the invites are sent. We may need to be careful when adding new keys to templates that are batched. Templated requests that are in-flight may be impacted by this.
* **HandlebarsMailService**: There are a few key changes here
1. Handlebars now fills subjects
2. BulkSendAsync is available to send many emails. This method detects if the underlying email service is capable of templated batch sends and if so, uses it. If not, a fallback send `Func` is used.
3. `GenerateModelForBulkSend` Uses a fully compiled Handlebars template to generate another single-file Handlebars template for use in Amazon SES. This way, we can still use the helpers and partials we have built out while also utilizing batched emailing.