### PR TITLE
Refuse upload renew if a file is validated

### DIFF
--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -609,7 +609,7 @@ namespace Bit.Api.Controllers
             var cipher = await _cipherRepository.GetByIdAsync(cipherId, userId);
             var attachments = cipher?.GetAttachments();
 
-            if (attachments == null || !attachments.ContainsKey(attachmentId))
+            if (attachments == null || !attachments.ContainsKey(attachmentId) || attachments[attachmentId].Validated)
             {
                 throw new NotFoundException();
             }

--- a/src/Core/Services/Implementations/CipherService.cs
+++ b/src/Core/Services/Implementations/CipherService.cs
@@ -365,7 +365,7 @@ namespace Bit.Core.Services
         {
             var attachments = cipher?.GetAttachments() ?? new Dictionary<string, CipherAttachment.MetaData>();
 
-            if (!attachments.ContainsKey(attachmentId) || attachments[attachmentId].Validated)
+            if (!attachments.ContainsKey(attachmentId))
             {
                 throw new NotFoundException();
             }


### PR DESCRIPTION
# Overview

Download should return regardless of file validation state. The validation check should be on the upload url renew request.

# Files Changed
* **CiphersController.cs**: refuse renew request if a blob has already been written and verified
* **CipherService.cs**: always provide a means to download data, regardless of whether the file is yet validated

# TODO:
push to `rc` branch