### PR TITLE
Test 1: add acr_values return validation value

### DIFF
--- a/bitwarden_license/src/Portal/Models/SsoConfigDataViewModel.cs
+++ b/bitwarden_license/src/Portal/Models/SsoConfigDataViewModel.cs
@@ -54,6 +54,7 @@ namespace Bit.Portal.Models
             AdditionalEmailClaimTypes = configurationData.AdditionalEmailClaimTypes;
             AdditionalNameClaimTypes = configurationData.AdditionalNameClaimTypes;
             AcrValues = configurationData.AcrValues;
+            ExpectedReturnAcrValue = configurationData.ExpectedReturnAcrValue;
         }
 
         [Required]
@@ -87,6 +88,8 @@ namespace Bit.Portal.Models
         public string AdditionalNameClaimTypes { get; set; }
         [Display(Name = "AcrValues")]
         public string AcrValues { get; set; }
+        [Display(Name = "ExpectedReturnAcrValue")]
+        public string ExpectedReturnAcrValue { get; set; }
 
         // SAML2 SP
         [Display(Name = "SpEntityId")]
@@ -238,6 +241,7 @@ namespace Bit.Portal.Models
                 AdditionalEmailClaimTypes = AdditionalEmailClaimTypes,
                 AdditionalNameClaimTypes = AdditionalNameClaimTypes,
                 AcrValues = AcrValues,
+                ExpectedReturnAcrValue = ExpectedReturnAcrValue,
             };
         }
 

--- a/bitwarden_license/src/Portal/Views/Sso/Index.cshtml
+++ b/bitwarden_license/src/Portal/Views/Sso/Index.cshtml
@@ -164,6 +164,12 @@
                     <input asp-for="Data.AcrValues" class="form-control">
                 </div>
             </div>
+            <div class="row">
+                <div class="col-7 form-group">
+                    <label asp-for="Data.ExpectedReturnAcrValue"></label>
+                    <input asp-for="Data.ExpectedReturnAcrValue" class="form-control">
+                </div>
+            </div>
         </div>
     </div>
 

--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -326,6 +326,16 @@ namespace Bit.Sso.Controllers
 
             var externalUser = result.Principal;
 
+            // Validate acr claim against expectation before going further
+            if (!string.IsNullOrWhiteSpace(ssoConfigData.ExpectedReturnAcrValue))
+            {
+                var acrClaim = externalUser.FindFirst(JwtClaimTypes.AuthenticationContextClassReference);
+                if (acrClaim?.Value != ssoConfigData.ExpectedReturnAcrValue)
+                {
+                    throw new Exception(_i18nService.T("AcrMissingOrInvalid"));
+                }
+            }
+
             // Ensure the NameIdentifier used is not a transient name ID, if so, we need a different attribute
             //  for the user identifier.
             static bool nameIdIsNotTransient(Claim c) => c.Type == ClaimTypes.NameIdentifier

--- a/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
+++ b/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
@@ -333,6 +333,10 @@ namespace Bit.Core.Business.Sso
             {
                 oidcOptions.Scope.AddIfNotExists(scope);
             }
+            if (!string.IsNullOrWhiteSpace(config.ExpectedReturnAcrValue))
+            {
+                oidcOptions.Scope.AddIfNotExists(OpenIdConnectScopes.Acr);
+            }
 
             oidcOptions.StateDataFormat = new DistributedCacheStateDataFormatter(_httpContextAccessor, name);
 
@@ -343,24 +347,6 @@ namespace Bit.Core.Business.Sso
                 oidcOptions.Events.OnRedirectToIdentityProvider = ctx =>
                 {
                     ctx.ProtocolMessage.AcrValues = config.AcrValues;
-                    return Task.CompletedTask;
-                };
-            }
-            if (!string.IsNullOrWhiteSpace(config.ExpectedReturnAcrValue))
-            {
-                oidcOptions.Events ??= new OpenIdConnectEvents();
-                oidcOptions.Events.OnMessageReceived = ctx =>
-                {
-                    // TODO: Determine if this is correct or if there's a different format or parameter to expect this back
-                    if (ctx.ProtocolMessage.AcrValues != config.ExpectedReturnAcrValue)
-                    {
-                        ctx.Fail("Expected acr_values was not returned with the authentication response.");
-                    }
-                    return Task.CompletedTask;
-                };
-                oidcOptions.Events.OnTokenResponseReceived = ctx =>
-                {
-                    // TODO: Figure out token validation for return acr_values, if possible
                     return Task.CompletedTask;
                 };
             }

--- a/bitwarden_license/src/Sso/Utilities/OpenIdConnectScopes.cs
+++ b/bitwarden_license/src/Sso/Utilities/OpenIdConnectScopes.cs
@@ -49,5 +49,16 @@
         /// not present (not logged in).
         /// </summary>
         public const string OfflineAccess = "offline_access";
+
+        /// <summary>
+        /// OPTIONAL. Authentication Context Class Reference. String specifying
+        /// an Authentication Context Class Reference value that identifies the
+        /// Authentication Context Class that the authentication performed
+        /// satisfied.
+        /// </summary>
+        /// <remarks>
+        /// See: https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.2
+        /// </remarks>
+        public const string Acr = "acr";
     }
 }

--- a/src/Core/Models/Data/SsoConfigurationData.cs
+++ b/src/Core/Models/Data/SsoConfigurationData.cs
@@ -27,6 +27,7 @@ namespace Bit.Core.Models.Data
         public string AdditionalEmailClaimTypes { get; set; }
         public string AdditionalNameClaimTypes { get; set; }
         public string AcrValues { get; set; }
+        public string ExpectedReturnAcrValue { get; set; }
 
         // SAML2 IDP
         public string IdpEntityId { get; set; }

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -648,4 +648,8 @@
   <data name="AccessDeniedError" xml:space="preserve">
     <value>Access Denied to this resource.</value>
   </data>
+  <data name="AcrMissingOrInvalid" xml:space="preserve">
+    <value>Expected authentication context class reference (acr) was not returned with the authentication response or is invalid.</value>
+    <comment>'acr' is an explicit OIDC claim type, see https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.2 (acr). It should not be translated.</comment>
+  </data>
 </root>

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -639,8 +639,8 @@
     <comment>'acr_values' is an explicit OIDC param, see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest. It should not be translated.</comment>
   </data>
   <data name="ExpectedReturnAcrValue" xml:space="preserve">
-    <value>Expected acr_values In Authentication Response (validation)</value>
-    <comment>'acr_values' is an explicit OIDC param, see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest. It should not be translated.</comment>
+    <value>Expected "acr" Claim Value In Response (acr validation)</value>
+    <comment>'acr' is an explicit OIDC claim type, see https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.2 (acr). It should not be translated.</comment>
   </data>
   <data name="LoggedOutMessage" xml:space="preserve">
     <value>You have been logged out of the Bitwarden Business Portal.</value>

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -638,6 +638,10 @@
     <value>Requested Authentication Context Class Reference values (acr_values)</value>
     <comment>'acr_values' is an explicit OIDC param, see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest. It should not be translated.</comment>
   </data>
+  <data name="ExpectedReturnAcrValue" xml:space="preserve">
+    <value>Expected acr_values In Authentication Response (validation)</value>
+    <comment>'acr_values' is an explicit OIDC param, see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest. It should not be translated.</comment>
+  </data>
   <data name="LoggedOutMessage" xml:space="preserve">
     <value>You have been logged out of the Bitwarden Business Portal.</value>
   </data>


### PR DESCRIPTION
## Overview

As part of a security review, one of our customers found that they need to not only send `acr_values` with the OIDC authentication request to the IdP, but also to validate the `acr` claim in the response, as to prevent out-of-context actors using the same IdP from authenticating to Bitwarden w/o going through the appropriate channel. This request was that Bitwarden enforce, through configuration, the return `acr` claim to a configured value pre-set in the SSO settings for that organization within Bitwarden. This value may, or may _not_, match the `acr_values` passed in the original request, necessitating a new field.

This check has been implemented as case-sensitive, per specifications, The `acr` value is a case sensitive string; see https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.2. Also this check will send the `acr` scope with the request if there's an expected `acr` claim to be evaluated in the response, where the `acr_values` for the request may or may not be configured. There is no documented expectation of behavior for this type of configuration, however the hope is where needed, this configuration setup can be facilitated explicitly by the IdP for the desired behavior.

## Changes

1. **SsoConfigDataViewModel.cs** - Added the expected `acr` return value property to the model for configuration UI
2. **Portal/Views/Sso/Index.cshtml ** - Added the expected `acr` return value property to the edit screen
3. **AccountController.cs** - Simple validation of the `acr` claim with expectations, throw exception if not a match (or missing)
4. **DynamicAuthenticationSchemeProvider.cs** - OIDC claims request if there's an expected `acr` claim, to add that to the list of scopes; also updated the OIDC provider events pattern as there may need to be (as I had started going down that road initially) additional events added outside of the constructor. This wasn't necessary to _leave_ per-se, but I left it there as IMHO a better pattern for repeatability and extension later on.
5. **OpenIdConnectScopes.cs** - Continuation of the `const` pattern for these "magic" strings (per spec) for the `acr` scope
6. **SsoConfigurationData.cs** - Data model updates to mirror the view model updates (or vice-versa)
7. **SharedResources.en.resx** - Configuration screen label for new field, and exception message resources for the new setting and validation

## Screen Shots

![image](https://user-images.githubusercontent.com/3904944/116291870-13293280-a763-11eb-9ff1-975f8eed1284.png)

## Testing Considerations

Since we do not actually have an OIDC SSO configuration that supports the relevant scopes/acr_values, this will necessarily be only a **regression** test that existing and new OIDC SSO configurations continue to work as expected. The customer requesting this change will be requested to also test in this context to ensure it meets their needs from the `dev` tag in Docker Hub.