### PR TITLE
Queue emails

### DIFF
--- a/src/Admin/HostedServices/AzureQueueMailHostedService.cs
+++ b/src/Admin/HostedServices/AzureQueueMailHostedService.cs
@@ -1,0 +1,107 @@
+using System;
+using Microsoft.Extensions.Hosting;
+using Azure.Storage.Queues;
+using Microsoft.Extensions.Logging;
+using Bit.Core.Settings;
+using System.Threading.Tasks;
+using System.Threading;
+using Bit.Core.Services;
+using Newtonsoft.Json;
+using Bit.Core.Models.Mail;
+using Azure.Storage.Queues.Models;
+using System.Linq;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace Bit.Admin.HostedServices
+{
+    public class AzureQueueMailHostedService : IHostedService
+    {
+        private readonly ILogger<AzureQueueMailHostedService> _logger;
+        private readonly GlobalSettings _globalSettings;
+        private readonly IMailService _mailService;
+        private CancellationTokenSource _cts;
+        private Task _executingTask;
+
+        private QueueClient _mailQueueClient;
+
+        public AzureQueueMailHostedService(
+            ILogger<AzureQueueMailHostedService> logger,
+            IMailService mailService,
+            GlobalSettings globalSettings)
+        { 
+            _logger = logger;
+            _mailService = mailService;
+            _globalSettings = globalSettings;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _executingTask = ExecuteAsync(_cts.Token);
+            return _executingTask.IsCompleted ? _executingTask : Task.CompletedTask;
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            if (_executingTask == null)
+            {
+                return;
+            }
+            _cts.Cancel();
+            await Task.WhenAny(_executingTask, Task.Delay(-1, cancellationToken));
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        private async Task ExecuteAsync(CancellationToken cancellationToken)
+        {
+            _mailQueueClient = new QueueClient(_globalSettings.Mail.ConnectionString, "mail");
+
+            QueueMessage[] mailMessages;
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                if (!(mailMessages = await RetrieveMessagesAsync()).Any())
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(15));
+                }
+
+                foreach (var message in mailMessages)
+                {
+                    try
+                    {
+                        var token = JToken.Parse(message.MessageText);
+                        if (token is JArray)
+                        {
+                            foreach (var mailQueueMessage in token.ToObject<List<MailQueueMessage>>())
+                            {
+                                await _mailService.SendEnqueuedMailMessageAsync(mailQueueMessage);
+                            }
+                        }
+                        else if (token is JObject)
+                        {
+                            var mailQueueMessage = token.ToObject<MailQueueMessage>();
+                            await _mailService.SendEnqueuedMailMessageAsync(mailQueueMessage);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError(e, "Failed to send email");
+                        // TODO: retries?
+                    }
+                    
+                    await _mailQueueClient.DeleteMessageAsync(message.MessageId, message.PopReceipt);
+
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+
+        private async Task<QueueMessage[]> RetrieveMessagesAsync()
+        {
+            return (await _mailQueueClient.ReceiveMessagesAsync(maxMessages: 32))?.Value ?? new QueueMessage[] { };
+        }
+    }
+}

--- a/src/Admin/Jobs/DeleteSendsJob.cs
+++ b/src/Admin/Jobs/DeleteSendsJob.cs
@@ -6,7 +6,6 @@ using Bit.Core.Context;
 using Bit.Core.Jobs;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Quartz;

--- a/src/Admin/Startup.cs
+++ b/src/Admin/Startup.cs
@@ -99,6 +99,10 @@ namespace Bit.Admin
                 {
                     services.AddHostedService<HostedServices.AmazonSqsBlockIpHostedService>();
                 }
+                if (CoreHelpers.SettingHasValue(globalSettings.Mail.ConnectionString))
+                {
+                    services.AddHostedService<HostedServices.AzureQueueMailHostedService>();
+                }
             }
         }
 

--- a/src/Core/Models/Mail/IMailQueueMessage.cs
+++ b/src/Core/Models/Mail/IMailQueueMessage.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Bit.Core.Models.Mail
+{
+    public interface IMailQueueMessage
+    {
+        string Subject { get; set; }
+        IEnumerable<string> ToEmails { get; set; }
+        IEnumerable<string> BccEmails { get; set; }
+        string Category {get; set;}
+        string TemplateName { get; set; }
+        object Model { get; set; }
+}
+}

--- a/src/Core/Models/Mail/MailQueueMessage.cs
+++ b/src/Core/Models/Mail/MailQueueMessage.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace Bit.Core.Models.Mail
+{
+    public class MailQueueMessage : IMailQueueMessage
+    {
+        public string Subject { get; set; }
+        public IEnumerable<string> ToEmails { get; set; }
+        public IEnumerable<string> BccEmails { get; set; }
+        public string Category { get; set; }
+        public string TemplateName { get; set; }
+        public object Model { get; set; }
+
+        public static MailQueueMessage FromMailMessage(MailMessage message, string templateName, object model)
+        {
+            return new MailQueueMessage
+            {
+                Subject = message.Subject,
+                ToEmails = message.ToEmails,
+                BccEmails = message.BccEmails,
+                Category = string.IsNullOrEmpty(message.Category) ? templateName : message.Category,
+                TemplateName = templateName,
+                Model = model
+            };
+        }
+    }
+}

--- a/src/Core/Models/Mail/MailQueueMessage.cs
+++ b/src/Core/Models/Mail/MailQueueMessage.cs
@@ -11,17 +11,16 @@ namespace Bit.Core.Models.Mail
         public string TemplateName { get; set; }
         public object Model { get; set; }
 
-        public static MailQueueMessage FromMailMessage(MailMessage message, string templateName, object model)
+        public MailQueueMessage() { }
+
+        public MailQueueMessage(MailMessage message, string templateName, object model)
         {
-            return new MailQueueMessage
-            {
-                Subject = message.Subject,
-                ToEmails = message.ToEmails,
-                BccEmails = message.BccEmails,
-                Category = string.IsNullOrEmpty(message.Category) ? templateName : message.Category,
-                TemplateName = templateName,
-                Model = model
-            };
+            Subject = message.Subject;
+            ToEmails = message.ToEmails;
+            BccEmails = message.BccEmails;
+            Category = string.IsNullOrEmpty(message.Category) ? templateName : message.Category;
+            TemplateName = templateName;
+            Model = model;
         }
     }
 }

--- a/src/Core/Repositories/IEventRepository.cs
+++ b/src/Core/Repositories/IEventRepository.cs
@@ -17,6 +17,6 @@ namespace Bit.Core.Repositories
         Task<PagedResult<IEvent>> GetManyByCipherAsync(Cipher cipher, DateTime startDate, DateTime endDate,
             PageOptions pageOptions);
         Task CreateAsync(IEvent e);
-        Task CreateManyAsync(IList<IEvent> e);
+        Task CreateManyAsync(IEnumerable<IEvent> e);
     }
 }

--- a/src/Core/Repositories/SqlServer/EventRepository.cs
+++ b/src/Core/Repositories/SqlServer/EventRepository.cs
@@ -74,14 +74,14 @@ namespace Bit.Core.Repositories.SqlServer
             await base.CreateAsync(ev);
         }
 
-        public async Task CreateManyAsync(IList<IEvent> entities)
+        public async Task CreateManyAsync(IEnumerable<IEvent> entities)
         {
             if (!entities?.Any() ?? true)
             {
                 return;
             }
 
-            if (entities.Count == 1)
+            if (!entities.Skip(1).Any())
             {
                 await CreateAsync(entities.First());
                 return;

--- a/src/Core/Repositories/TableStorage/EventRepository.cs
+++ b/src/Core/Repositories/TableStorage/EventRepository.cs
@@ -62,14 +62,14 @@ namespace Bit.Core.Repositories.TableStorage
             await CreateEntityAsync(entity);
         }
 
-        public async Task CreateManyAsync(IList<IEvent> e)
+        public async Task CreateManyAsync(IEnumerable<IEvent> e)
         {
             if (!e?.Any() ?? true)
             {
                 return;
             }
 
-            if (e.Count == 1)
+            if (!e.Skip(1).Any())
             {
                 await CreateAsync(e.First());
                 return;

--- a/src/Core/Services/IEventWriteService.cs
+++ b/src/Core/Services/IEventWriteService.cs
@@ -7,6 +7,6 @@ namespace Bit.Core.Services
     public interface IEventWriteService
     {
         Task CreateAsync(IEvent e);
-        Task CreateManyAsync(IList<IEvent> e);
+        Task CreateManyAsync(IEnumerable<IEvent> e);
     }
 }

--- a/src/Core/Services/IMailEnqueuingService.cs
+++ b/src/Core/Services/IMailEnqueuingService.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Bit.Core.Models.Mail;
+
+namespace Bit.Core.Services
+{
+    public interface IMailEnqueuingService
+    {
+        Task EnqueueAsync(IMailQueueMessage message, Func<IMailQueueMessage, Task> fallback);
+        Task EnqueueManyAsync(IEnumerable<IMailQueueMessage> messages, Func<IMailQueueMessage, Task> fallback);
+    }
+}

--- a/src/Core/Services/IMailService.cs
+++ b/src/Core/Services/IMailService.cs
@@ -2,6 +2,7 @@
 using Bit.Core.Models.Table;
 using System.Collections.Generic;
 using System;
+using Bit.Core.Models.Mail;
 
 namespace Bit.Core.Services
 {
@@ -16,6 +17,7 @@ namespace Bit.Core.Services
         Task SendNoMasterPasswordHintEmailAsync(string email);
         Task SendMasterPasswordHintEmailAsync(string email, string hint);
         Task SendOrganizationInviteEmailAsync(string organizationName, OrganizationUser orgUser, string token);
+        Task BulkSendOrganizationInviteEmailAsync(string organizationName, IEnumerable<(OrganizationUser orgUser, string token)> invites);
         Task SendOrganizationAcceptedEmailAsync(string organizationName, string userEmail,
             IEnumerable<string> adminEmails);
         Task SendOrganizationConfirmedEmailAsync(string organizationName, string email);
@@ -37,5 +39,6 @@ namespace Bit.Core.Services
         Task SendEmergencyAccessRecoveryRejected(EmergencyAccess emergencyAccess, string rejectingName, string email);
         Task SendEmergencyAccessRecoveryReminder(EmergencyAccess emergencyAccess, string initiatingName, string email);
         Task SendEmergencyAccessRecoveryTimedOut(EmergencyAccess ea, string initiatingName, string email);
+        Task SendEnqueuedMailMessageAsync(IMailQueueMessage queueMessage);
     }
 }

--- a/src/Core/Services/Implementations/AzureQueueEventWriteService.cs
+++ b/src/Core/Services/Implementations/AzureQueueEventWriteService.cs
@@ -9,11 +9,10 @@ using System.Text;
 
 namespace Bit.Core.Services
 {
-    public class AzureQueueEventWriteService : AzureQueueService, IEventWriteService
+    public class AzureQueueEventWriteService : AzureQueueService<IEvent>, IEventWriteService
     {
-        private readonly QueueClient _queueClient;
-
-        private JsonSerializerSettings _jsonSettings = new JsonSerializerSettings
+        protected override QueueClient QueueClient { get; }
+        protected override JsonSerializerSettings JsonSettings { get; } = new JsonSerializerSettings
         {
             NullValueHandling = NullValueHandling.Ignore
         };
@@ -21,32 +20,7 @@ namespace Bit.Core.Services
         public AzureQueueEventWriteService(
             GlobalSettings globalSettings)
         {
-            _queueClient = new QueueClient(globalSettings.Events.ConnectionString, "event");
-        }
-
-        public async Task CreateAsync(IEvent e)
-        {
-            var json = JsonConvert.SerializeObject(e, _jsonSettings);
-            await _queueClient.SendMessageAsync(json);
-        }
-
-        public async Task CreateManyAsync(IList<IEvent> e)
-        {
-            if (e?.Any() != true)
-            {
-                return;
-            }
-
-            if (e.Count == 1)
-            {
-                await CreateAsync(e.First());
-                return;
-            }
-
-            foreach (var json in SerializeMany(e, _jsonSettings))
-            {
-                await _queueClient.SendMessageAsync(json);
-            }
+            QueueClient = new QueueClient(globalSettings.Events.ConnectionString, "event");
         }
     }
 }

--- a/src/Core/Services/Implementations/AzureQueueMailService.cs
+++ b/src/Core/Services/Implementations/AzureQueueMailService.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Storage.Queues;
+using Bit.Core.Models.Mail;
+using Bit.Core.Settings;
+using Newtonsoft.Json;
+
+namespace Bit.Core.Services
+{
+    public class AzureQueueMailService : AzureQueueService<IMailQueueMessage>, IMailEnqueuingService
+    {
+        protected override QueueClient QueueClient { get; }
+        protected override JsonSerializerSettings JsonSettings { get; } = new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore
+        };
+
+        public AzureQueueMailService(
+            GlobalSettings globalSettings)
+        {
+            QueueClient = new QueueClient(globalSettings.Mail.ConnectionString, "mail");
+        }
+
+        public Task EnqueueAsync(IMailQueueMessage message, Func<IMailQueueMessage, Task> fallback) =>
+            CreateAsync(message);
+
+        public Task EnqueueManyAsync(IEnumerable<IMailQueueMessage> messages, Func<IMailQueueMessage, Task> fallback) =>
+            CreateManyAsync(messages);
+    }
+}

--- a/src/Core/Services/Implementations/AzureQueueService.cs
+++ b/src/Core/Services/Implementations/AzureQueueService.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace Bit.Core.Services
+{
+    public abstract class AzureQueueService
+    {
+        private const int _maxMessageBody = 64000; // 64 MB
+
+        protected IEnumerable<string> SerializeMany<T>(IEnumerable<T> messages, JsonSerializerSettings jsonSettings)
+        {
+            var messagesLists = new List<List<T>> { new List<T>() };
+            var strings = new List<string>();
+            var ListMessageLength = 2; // to account for json array brackets "[]"
+            foreach (var (message, jsonEvent) in messages.Select(e => (e, JsonConvert.SerializeObject(e, jsonSettings))))
+            {
+
+                var messageLength = jsonEvent.Length + 1; // To account for json array comma
+                if (ListMessageLength + messageLength > _maxMessageBody)
+                {
+                    messagesLists.Add(new List<T> { message });
+                    ListMessageLength = 2 + messageLength;
+                }
+                else
+                {
+                    messagesLists.Last().Add(message);
+                    ListMessageLength += messageLength;
+                }
+            }
+            return messagesLists.Select(l => JsonConvert.SerializeObject(l, jsonSettings));
+        }
+    }
+}

--- a/src/Core/Services/Implementations/AzureQueueService.cs
+++ b/src/Core/Services/Implementations/AzureQueueService.cs
@@ -1,14 +1,46 @@
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
+using System.Threading.Tasks;
+using Azure.Storage.Queues;
+using IdentityServer4.Extensions;
+using Microsoft.EntityFrameworkCore.Internal;
 using Newtonsoft.Json;
 
 namespace Bit.Core.Services
 {
-    public abstract class AzureQueueService
+    public abstract class AzureQueueService<T>
     {
-        private const int _maxMessageBody = 64000; // 64 MB
+        protected abstract QueueClient QueueClient { get; }
+        protected abstract JsonSerializerSettings JsonSettings { get; }
 
-        protected IEnumerable<string> SerializeMany<T>(IEnumerable<T> messages, JsonSerializerSettings jsonSettings)
+        public async Task CreateAsync(T message)
+        {
+            var json = JsonConvert.SerializeObject(message, JsonSettings);
+            await QueueClient.SendMessageAsync(json);
+        }
+
+        public async Task CreateManyAsync(IEnumerable<T> messages)
+        {
+            if (messages?.Any() != true)
+            {
+                return;
+            }
+
+            if (!messages.Skip(1).Any())
+            {
+                await CreateAsync(messages.First());
+                return;
+            }
+
+            foreach (var json in SerializeMany(messages, JsonSettings))
+            {
+                await QueueClient.SendMessageAsync(json);
+            }
+        }
+
+
+        protected IEnumerable<string> SerializeMany(IEnumerable<T> messages, JsonSerializerSettings jsonSettings)
         {
             var messagesLists = new List<List<T>> { new List<T>() };
             var strings = new List<string>();
@@ -17,7 +49,7 @@ namespace Bit.Core.Services
             {
 
                 var messageLength = jsonEvent.Length + 1; // To account for json array comma
-                if (ListMessageLength + messageLength > _maxMessageBody)
+                if (ListMessageLength + messageLength > QueueClient.MessageMaxBytes)
                 {
                     messagesLists.Add(new List<T> { message });
                     ListMessageLength = 2 + messageLength;

--- a/src/Core/Services/Implementations/BlockingMailQueueService.cs
+++ b/src/Core/Services/Implementations/BlockingMailQueueService.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Bit.Core.Models.Mail;
+
+namespace Bit.Core.Services
+{
+    public class BlockingMailEnqueuingService : IMailEnqueuingService
+    {
+        public async Task EnqueueAsync(IMailQueueMessage message, Func<IMailQueueMessage, Task> fallback)
+        {
+            await fallback(message);
+        }
+
+        public async Task EnqueueManyAsync(IEnumerable<IMailQueueMessage> messages, Func<IMailQueueMessage, Task> fallback)
+        {
+            foreach(var message in messages)
+            {
+                await fallback(message);
+            }
+        }
+    }
+}

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -179,7 +179,7 @@ namespace Bit.Core.Services
             MailQueueMessage CreateMessage(string email, object model)
             {
                 var message = CreateDefaultMessage($"Join {organizationName}", email);
-                return MailQueueMessage.FromMailMessage(message, "OrganizationUserInvited", model);
+                return new MailQueueMessage(message, "OrganizationUserInvited", model);
             }
 
             var messageModels = invites.Select(invite => CreateMessage(invite.orgUser.Email,

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -19,6 +19,7 @@ namespace Bit.Core.Services
 
         private readonly GlobalSettings _globalSettings;
         private readonly IMailDeliveryService _mailDeliveryService;
+        private readonly IMailEnqueuingService _mailEnqueuingService;
         private readonly Dictionary<string, Func<object, string>> _templateCache =
             new Dictionary<string, Func<object, string>>();
 
@@ -26,10 +27,12 @@ namespace Bit.Core.Services
 
         public HandlebarsMailService(
             GlobalSettings globalSettings,
-            IMailDeliveryService mailDeliveryService)
+            IMailDeliveryService mailDeliveryService,
+            IMailEnqueuingService mailEnqueuingService)
         {
             _globalSettings = globalSettings;
             _mailDeliveryService = mailDeliveryService;
+            _mailEnqueuingService = mailEnqueuingService;
         }
 
         public async Task SendVerifyEmailEmailAsync(string email, Guid userId, string token)
@@ -168,23 +171,32 @@ namespace Bit.Core.Services
             await _mailDeliveryService.SendEmailAsync(message);
         }
 
-        public async Task SendOrganizationInviteEmailAsync(string organizationName, OrganizationUser orgUser, string token)
+        public Task SendOrganizationInviteEmailAsync(string organizationName, OrganizationUser orgUser, string token) =>
+            BulkSendOrganizationInviteEmailAsync(organizationName, new[] { (orgUser, token) });
+
+        public async Task BulkSendOrganizationInviteEmailAsync(string organizationName, IEnumerable<(OrganizationUser orgUser, string token)> invites)
         {
-            var message = CreateDefaultMessage($"Join {organizationName}", orgUser.Email);
-            var model = new OrganizationUserInvitedViewModel
+            MailQueueMessage CreateMessage(string email, object model)
             {
-                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName),
-                Email = WebUtility.UrlEncode(orgUser.Email),
-                OrganizationId = orgUser.OrganizationId.ToString(),
-                OrganizationUserId = orgUser.Id.ToString(),
-                Token = WebUtility.UrlEncode(token),
-                OrganizationNameUrlEncoded = WebUtility.UrlEncode(organizationName),
-                WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
-                SiteName = _globalSettings.SiteName
-            };
-            await AddMessageContentAsync(message, "OrganizationUserInvited", model);
-            message.Category = "OrganizationUserInvited";
-            await _mailDeliveryService.SendEmailAsync(message);
+                var message = CreateDefaultMessage($"Join {organizationName}", email);
+                return MailQueueMessage.FromMailMessage(message, "OrganizationUserInvited", model);
+            }
+
+            var messageModels = invites.Select(invite => CreateMessage(invite.orgUser.Email,
+                new OrganizationUserInvitedViewModel
+                {
+                    OrganizationName = CoreHelpers.SanitizeForEmail(organizationName),
+                    Email = WebUtility.UrlEncode(invite.orgUser.Email),
+                    OrganizationId = invite.orgUser.OrganizationId.ToString(),
+                    OrganizationUserId = invite.orgUser.Id.ToString(),
+                    Token = WebUtility.UrlEncode(invite.token),
+                    OrganizationNameUrlEncoded = WebUtility.UrlEncode(organizationName),
+                    WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
+                    SiteName = _globalSettings.SiteName,
+                }
+            ));
+
+            await EnqueueMailAsync(messageModels);
         }
 
         public async Task SendOrganizationUserRemovedForPolicyTwoStepEmailAsync(string organizationName, string email)
@@ -340,6 +352,21 @@ namespace Bit.Core.Services
             message.Category = "OrganizationUserRemovedForPolicySingleOrg";
             await _mailDeliveryService.SendEmailAsync(message);
         }
+
+        public async Task SendEnqueuedMailMessageAsync(IMailQueueMessage queueMessage)
+        {
+            var message = CreateDefaultMessage(queueMessage.Subject, queueMessage.ToEmails);
+            message.BccEmails = queueMessage.BccEmails;
+            message.Category = queueMessage.Category;
+            await AddMessageContentAsync(message, queueMessage.TemplateName, queueMessage.Model);
+            await _mailDeliveryService.SendEmailAsync(message);
+        }
+
+        private Task EnqueueMailAsync(IMailQueueMessage queueMessage) =>
+            _mailEnqueuingService.EnqueueAsync(queueMessage, SendEnqueuedMailMessageAsync);
+
+        private Task EnqueueMailAsync(IEnumerable<IMailQueueMessage> queueMessages) =>
+            _mailEnqueuingService.EnqueueManyAsync(queueMessages, SendEnqueuedMailMessageAsync);
 
         private MailMessage CreateDefaultMessage(string subject, string toEmail)
         {

--- a/src/Core/Services/Implementations/RepositoryEventWriteService.cs
+++ b/src/Core/Services/Implementations/RepositoryEventWriteService.cs
@@ -20,7 +20,7 @@ namespace Bit.Core.Services
             await _eventRepository.CreateAsync(e);
         }
 
-        public async Task CreateManyAsync(IList<IEvent> e)
+        public async Task CreateManyAsync(IEnumerable<IEvent> e)
         {
             await _eventRepository.CreateManyAsync(e);
         }

--- a/src/Core/Services/NoopImplementations/NoopEventWriteService.cs
+++ b/src/Core/Services/NoopImplementations/NoopEventWriteService.cs
@@ -11,7 +11,7 @@ namespace Bit.Core.Services
             return Task.FromResult(0);
         }
 
-        public Task CreateManyAsync(IList<IEvent> e)
+        public Task CreateManyAsync(IEnumerable<IEvent> e)
         {
             return Task.FromResult(0);
         }

--- a/src/Core/Services/NoopImplementations/NoopMailService.cs
+++ b/src/Core/Services/NoopImplementations/NoopMailService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Bit.Core.Models.Mail;
 using Bit.Core.Models.Table;
 
 namespace Bit.Core.Services
@@ -43,6 +44,11 @@ namespace Bit.Core.Services
         }
 
         public Task SendOrganizationInviteEmailAsync(string organizationName, OrganizationUser orgUser, string token)
+        {
+            return Task.FromResult(0);
+        }
+
+        public Task BulkSendOrganizationInviteEmailAsync(string organizationName, IEnumerable<(OrganizationUser orgUser, string token)> invites)
         {
             return Task.FromResult(0);
         }
@@ -144,6 +150,11 @@ namespace Bit.Core.Services
         }
 
         public Task SendEmergencyAccessRecoveryTimedOut(EmergencyAccess ea, string initiatingName, string email)
+        {
+            return Task.FromResult(0);
+        }
+
+        public Task SendEnqueuedMailMessageAsync(IMailQueueMessage queueMessage)
         {
             return Task.FromResult(0);
         }

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -272,6 +272,18 @@ namespace Bit.Core.Settings
 
         public class MailSettings
         {
+            private ConnectionStringSettings _connectionStringSettings;
+            public string ConnectionString {
+                get => _connectionStringSettings?.ConnectionString;
+                set
+                {
+                    if (_connectionStringSettings == null)
+                    {
+                        _connectionStringSettings = new ConnectionStringSettings();
+                    }
+                    _connectionStringSettings.ConnectionString = value;
+                }
+            }
             public string ReplyToEmail { get; set; }
             public string AmazonConfigSetName { get; set; }
             public SmtpSettings Smtp { get; set; } = new SmtpSettings();

--- a/src/Core/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Core/Utilities/ServiceCollectionExtensions.cs
@@ -183,6 +183,15 @@ namespace Bit.Core.Utilities
                 services.AddSingleton<IBlockIpService, NoopBlockIpService>();
             }
 
+            if (!globalSettings.SelfHosted && CoreHelpers.SettingHasValue(globalSettings.Mail.ConnectionString))
+            {
+                services.AddSingleton<IMailEnqueuingService, AzureQueueMailService>();
+            }
+            else
+            {
+                services.AddSingleton<IMailEnqueuingService, BlockingMailEnqueuingService>();
+            }
+
             if (!globalSettings.SelfHosted && CoreHelpers.SettingHasValue(globalSettings.Events.ConnectionString))
             {
                 services.AddSingleton<IEventWriteService, AzureQueueEventWriteService>();

--- a/test/Core.Test/Services/HandlebarsMailServiceTests.cs
+++ b/test/Core.Test/Services/HandlebarsMailServiceTests.cs
@@ -12,15 +12,18 @@ namespace Bit.Core.Test.Services
 
         private readonly GlobalSettings _globalSettings;
         private readonly IMailDeliveryService _mailDeliveryService;
+        private readonly IMailEnqueuingService _mailEnqueuingService;
 
         public HandlebarsMailServiceTests()
         {
             _globalSettings = new GlobalSettings();
             _mailDeliveryService = Substitute.For<IMailDeliveryService>();
+            _mailEnqueuingService = Substitute.For<IMailEnqueuingService>();
 
             _sut = new HandlebarsMailService(
                 _globalSettings,
-                _mailDeliveryService
+                _mailDeliveryService,
+                _mailEnqueuingService
             );
         }
 


### PR DESCRIPTION
# Overview

**Merge into large organization sync feature branch** 

Alternative to #1276. This method uses Azure queues to enqueue emailing for later work. A `BlockingMailQueueService` is also provided for SelfHosted instances which simply blocks until the message is sent.

A Hosted Service is provided in the Admin project which processes and sends emails.

If we want, all emails should be able to be converted to this queued method without changes to the enqueue/dequeue/send methods.

# Files Changed
* **AzureQueueMailHostedService**: pulls down all enqueued messges and sends them prior to sleeping 15 seconds and checking again. Sends messages one at a time to avoid complications with Amazon SES templates.
* **DeleteSendsJobs**: Do not use internal EF namespace.
* **Admin/Startup**: Provide AzureQueueHostedService if appropriate
* **IMailQueueMessage/MailQueueMessage**: The model to encode mail information for enqueuing. Handlebars is run on this data after dequeue to reduce message size.
* **IEventRepository/EventRepository/IEventWriteService/RepositoryEventWriteService/NoopEventWriteService**: All of these `IList` types needed to be changed to `IEnumerable` to use the new `AzureQueueService` abstract type. Plus, they don't need to be IList.
* **IMailService**: Add interface methods for sending bulk org invites and for the Hosted Service to use while dequeuing messages.
* **AzureQueueEventWriteService**: Extracted to an abstract class for reuse.
* **AzureQueueMailService**: Write service for new mail queue. Note: Enqueue methods exist to avoid circular dependency with HandlebarsService to provide a fallback for `BlockingMailQueueService`.
* **AzureQueueService**: abstract azure enqueuing base class
* **BlockingMailQueueService**: The Self-Hosted implementation of AzureQueueMailService. This service just blocks until all messages are sent.

  The interface is pretty clunky in that it requires a fallback method to use for this class. This avoids a circular dependency from Handlebars service to actually process and send the email.

  If necessary, we can implement a sql-based queue for self-hosted, which would remove this weird interface.
* **HandlebarsMailService/NoopMailService**: Bulk org invite implementation and method to process `MailQueueMessage`s
* **GlobalSettings**: Add ConnectionString to mail settings to specify Azure connection string for enqueuing. This string must be present in `API` project to enqueue and `Admin` project to dequeue. `Admin` also requires all settings in order to successfully spin up smtp, just like `API`.
* **ServiceCollectionExtensions**: Provide IMailEnqueuingService