### PR TITLE
Fix password re-prompt not working in org view

### DIFF
--- a/src/Core/Models/Api/Request/CipherRequestModel.cs
+++ b/src/Core/Models/Api/Request/CipherRequestModel.cs
@@ -60,7 +60,6 @@ namespace Bit.Core.Models.Api
         {
             existingCipher.FolderId = string.IsNullOrWhiteSpace(FolderId) ? null : (Guid?)new Guid(FolderId);
             existingCipher.Favorite = Favorite;
-            existingCipher.Reprompt = Reprompt;
             ToCipher(existingCipher);
             return existingCipher;
         }
@@ -90,6 +89,8 @@ namespace Bit.Core.Models.Api
                 default:
                     throw new ArgumentException("Unsupported type: " + nameof(Type) + ".");
             }
+
+            existingCipher.Reprompt = Reprompt;
 
             var hasAttachments2 = (Attachments2?.Count ?? 0) > 0;
             var hasAttachments = (Attachments?.Count ?? 0) > 0;

--- a/src/Core/Models/Api/Response/CipherResponseModel.cs
+++ b/src/Core/Models/Api/Response/CipherResponseModel.cs
@@ -63,6 +63,7 @@ namespace Bit.Core.Models.Api
             Attachments = AttachmentResponseModel.FromCipher(cipher, globalSettings);
             OrganizationUseTotp = orgUseTotp;
             DeletedDate = cipher.DeletedDate;
+            Reprompt = cipher.Reprompt.GetValueOrDefault(CipherRepromptType.None);
         }
 
         public string Id { get; set; }
@@ -81,6 +82,7 @@ namespace Bit.Core.Models.Api
         public bool OrganizationUseTotp { get; set; }
         public DateTime RevisionDate { get; set; }
         public DateTime? DeletedDate { get; set; }
+        public CipherRepromptType Reprompt { get; set; }
     }
 
     public class CipherResponseModel : CipherMiniResponseModel
@@ -92,14 +94,12 @@ namespace Bit.Core.Models.Api
             Favorite = cipher.Favorite;
             Edit = cipher.Edit;
             ViewPassword = cipher.ViewPassword;
-            Reprompt = cipher.Reprompt.GetValueOrDefault(CipherRepromptType.None);
         }
 
         public string FolderId { get; set; }
         public bool Favorite { get; set; }
         public bool Edit { get; set; }
         public bool ViewPassword { get; set; }
-        public CipherRepromptType Reprompt { get; set; }
     }
 
     public class CipherDetailsResponseModel : CipherResponseModel

--- a/src/Core/Repositories/SqlServer/CipherRepository.cs
+++ b/src/Core/Repositories/SqlServer/CipherRepository.cs
@@ -668,6 +668,8 @@ namespace Bit.Core.Repositories.SqlServer
             ciphersTable.Columns.Add(revisionDateColumn);
             var deletedDateColumn = new DataColumn(nameof(c.DeletedDate), typeof(DateTime));
             ciphersTable.Columns.Add(deletedDateColumn);
+            var repromptColumn = new DataColumn(nameof(c.Reprompt), typeof(short));
+            ciphersTable.Columns.Add(repromptColumn);
 
             foreach (DataColumn col in ciphersTable.Columns)
             {
@@ -693,6 +695,7 @@ namespace Bit.Core.Repositories.SqlServer
                 row[creationDateColumn] = cipher.CreationDate;
                 row[revisionDateColumn] = cipher.RevisionDate;
                 row[deletedDateColumn] = cipher.DeletedDate.HasValue ? (object)cipher.DeletedDate : DBNull.Value;
+                row[repromptColumn] = cipher.Reprompt;
 
                 ciphersTable.Rows.Add(row);
             }

--- a/src/Sql/dbo/Stored Procedures/CipherDetails_CreateWithCollections.sql
+++ b/src/Sql/dbo/Stored Procedures/CipherDetails_CreateWithCollections.sql
@@ -15,6 +15,7 @@
     @ViewPassword BIT, -- not used
     @OrganizationUseTotp BIT, -- not used
     @DeletedDate DATETIME2(7),
+    @Reprompt TINYINT,
     @CollectionIds AS [dbo].[GuidIdArray] READONLY
 AS
 BEGIN
@@ -22,7 +23,7 @@ BEGIN
 
     EXEC [dbo].[CipherDetails_Create] @Id, @UserId, @OrganizationId, @Type, @Data, @Favorites, @Folders,
         @Attachments, @CreationDate, @RevisionDate, @FolderId, @Favorite, @Edit, @ViewPassword,
-        @OrganizationUseTotp, @DeletedDate
+        @OrganizationUseTotp, @DeletedDate, @Reprompt
 
     DECLARE @UpdateCollectionsSuccess INT
     EXEC @UpdateCollectionsSuccess = [dbo].[Cipher_UpdateCollections] @Id, @UserId, @OrganizationId, @CollectionIds

--- a/src/Sql/dbo/Stored Procedures/Cipher_Create.sql
+++ b/src/Sql/dbo/Stored Procedures/Cipher_Create.sql
@@ -9,7 +9,8 @@
     @Attachments NVARCHAR(MAX),
     @CreationDate DATETIME2(7),
     @RevisionDate DATETIME2(7),
-    @DeletedDate DATETIME2(7)
+    @DeletedDate DATETIME2(7),
+    @Reprompt TINYINT
 AS
 BEGIN
     SET NOCOUNT ON
@@ -26,7 +27,8 @@ BEGIN
         [Attachments],
         [CreationDate],
         [RevisionDate],
-        [DeletedDate]
+        [DeletedDate],
+        [Reprompt]
     )
     VALUES
     (
@@ -40,7 +42,8 @@ BEGIN
         @Attachments,
         @CreationDate,
         @RevisionDate,
-        @DeletedDate
+        @DeletedDate,
+        @Reprompt
     )
 
     IF @OrganizationId IS NOT NULL

--- a/src/Sql/dbo/Stored Procedures/Cipher_CreateWithCollections.sql
+++ b/src/Sql/dbo/Stored Procedures/Cipher_CreateWithCollections.sql
@@ -10,13 +10,14 @@
     @CreationDate DATETIME2(7),
     @RevisionDate DATETIME2(7),
     @DeletedDate DATETIME2(7),
+    @Reprompt TINYINT,
     @CollectionIds AS [dbo].[GuidIdArray] READONLY
 AS
 BEGIN
     SET NOCOUNT ON
 
     EXEC [dbo].[Cipher_Create] @Id, @UserId, @OrganizationId, @Type, @Data, @Favorites, @Folders,
-        @Attachments, @CreationDate, @RevisionDate, @DeletedDate
+        @Attachments, @CreationDate, @RevisionDate, @DeletedDate, @Reprompt
 
     DECLARE @UpdateCollectionsSuccess INT
     EXEC @UpdateCollectionsSuccess = [dbo].[Cipher_UpdateCollections] @Id, @UserId, @OrganizationId, @CollectionIds

--- a/src/Sql/dbo/Stored Procedures/Cipher_Update.sql
+++ b/src/Sql/dbo/Stored Procedures/Cipher_Update.sql
@@ -9,7 +9,8 @@
     @Attachments NVARCHAR(MAX),
     @CreationDate DATETIME2(7),
     @RevisionDate DATETIME2(7),
-    @DeletedDate DATETIME2(7)
+    @DeletedDate DATETIME2(7),
+    @Reprompt TINYINT
 AS
 BEGIN
     SET NOCOUNT ON
@@ -26,7 +27,8 @@ BEGIN
         [Attachments] = @Attachments,
         [CreationDate] = @CreationDate,
         [RevisionDate] = @RevisionDate,
-        [DeletedDate] = @DeletedDate
+        [DeletedDate] = @DeletedDate,
+        [Reprompt] = @Reprompt
     WHERE
         [Id] = @Id
 

--- a/src/Sql/dbo/Stored Procedures/Cipher_UpdateWithCollections.sql
+++ b/src/Sql/dbo/Stored Procedures/Cipher_UpdateWithCollections.sql
@@ -10,6 +10,7 @@
     @CreationDate DATETIME2(7),
     @RevisionDate DATETIME2(7),
     @DeletedDate DATETIME2(7),
+    @Reprompt TINYINT,
     @CollectionIds AS [dbo].[GuidIdArray] READONLY
 AS
 BEGIN

--- a/util/Migrator/DbScripts/2021-04-13_00_CipherPasswordPrompt.sql
+++ b/util/Migrator/DbScripts/2021-04-13_00_CipherPasswordPrompt.sql
@@ -50,6 +50,12 @@ BEGIN
 END
 GO
 
+IF OBJECT_ID('[dbo].[CipherView]') IS NOT NULL
+BEGIN
+    EXECUTE sp_refreshsqlmodule N'[dbo].[CipherView]';
+END
+GO
+
 IF OBJECT_ID('[dbo].[CipherDetails_Create]') IS NOT NULL
 BEGIN
     DROP PROCEDURE [dbo].[CipherDetails_Create]
@@ -192,5 +198,153 @@ BEGIN
     BEGIN
         EXEC [dbo].[User_BumpAccountRevisionDate] @UserId
     END
+END
+GO
+
+IF OBJECT_ID('[dbo].[Cipher_Update]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Cipher_Update]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Cipher_Update]
+    @Id UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @Type TINYINT,
+    @Data NVARCHAR(MAX),
+    @Favorites NVARCHAR(MAX),
+    @Folders NVARCHAR(MAX),
+    @Attachments NVARCHAR(MAX),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @DeletedDate DATETIME2(7),
+    @Reprompt TINYINT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    UPDATE
+        [dbo].[Cipher]
+    SET
+        [UserId] = CASE WHEN @OrganizationId IS NULL THEN @UserId ELSE NULL END,
+        [OrganizationId] = @OrganizationId,
+        [Type] = @Type,
+        [Data] = @Data,
+        [Favorites] = @Favorites,
+        [Folders] = @Folders,
+        [Attachments] = @Attachments,
+        [CreationDate] = @CreationDate,
+        [RevisionDate] = @RevisionDate,
+        [DeletedDate] = @DeletedDate,
+        [Reprompt] = @Reprompt
+    WHERE
+        [Id] = @Id
+
+    IF @OrganizationId IS NOT NULL
+    BEGIN
+        EXEC [dbo].[User_BumpAccountRevisionDateByCipherId] @Id, @OrganizationId
+    END
+    ELSE IF @UserId IS NOT NULL
+    BEGIN
+        EXEC [dbo].[User_BumpAccountRevisionDate] @UserId
+    END
+END
+GO
+
+IF OBJECT_ID('[dbo].[Cipher_Create]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Cipher_Create]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Cipher_Create]
+    @Id UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @Type TINYINT,
+    @Data NVARCHAR(MAX),
+    @Favorites NVARCHAR(MAX),
+    @Folders NVARCHAR(MAX),
+    @Attachments NVARCHAR(MAX),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @DeletedDate DATETIME2(7),
+    @Reprompt TINYINT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    INSERT INTO [dbo].[Cipher]
+    (
+        [Id],
+        [UserId],
+        [OrganizationId],
+        [Type],
+        [Data],
+        [Favorites],
+        [Folders],
+        [Attachments],
+        [CreationDate],
+        [RevisionDate],
+        [DeletedDate],
+        [Reprompt]
+    )
+    VALUES
+    (
+        @Id,
+        CASE WHEN @OrganizationId IS NULL THEN @UserId ELSE NULL END,
+        @OrganizationId,
+        @Type,
+        @Data,
+        @Favorites,
+        @Folders,
+        @Attachments,
+        @CreationDate,
+        @RevisionDate,
+        @DeletedDate,
+        @Reprompt
+    )
+
+    IF @OrganizationId IS NOT NULL
+    BEGIN
+        EXEC [dbo].[User_BumpAccountRevisionDateByCipherId] @Id, @OrganizationId
+    END
+    ELSE IF @UserId IS NOT NULL
+    BEGIN
+        EXEC [dbo].[User_BumpAccountRevisionDate] @UserId
+    END
+END
+GO
+
+IF OBJECT_ID('[dbo].[Cipher_CreateWithCollections]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Cipher_CreateWithCollections]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Cipher_CreateWithCollections]
+    @Id UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @Type TINYINT,
+    @Data NVARCHAR(MAX),
+    @Favorites NVARCHAR(MAX),
+    @Folders NVARCHAR(MAX),
+    @Attachments NVARCHAR(MAX),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @DeletedDate DATETIME2(7),
+    @Reprompt TINYINT,
+    @CollectionIds AS [dbo].[GuidIdArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    EXEC [dbo].[Cipher_Create] @Id, @UserId, @OrganizationId, @Type, @Data, @Favorites, @Folders,
+        @Attachments, @CreationDate, @RevisionDate, @DeletedDate, @Reprompt
+
+    DECLARE @UpdateCollectionsSuccess INT
+    EXEC @UpdateCollectionsSuccess = [dbo].[Cipher_UpdateCollections] @Id, @UserId, @OrganizationId, @CollectionIds
 END
 GO

--- a/util/Migrator/DbScripts/2021-05-04_00_CipherPasswordPromptFixed.sql
+++ b/util/Migrator/DbScripts/2021-05-04_00_CipherPasswordPromptFixed.sql
@@ -348,3 +348,103 @@ BEGIN
     EXEC @UpdateCollectionsSuccess = [dbo].[Cipher_UpdateCollections] @Id, @UserId, @OrganizationId, @CollectionIds
 END
 GO
+
+IF OBJECT_ID('[dbo].[Cipher_UpdateWithCollections]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Cipher_UpdateWithCollections]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Cipher_UpdateWithCollections]
+    @Id UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @Type TINYINT,
+    @Data NVARCHAR(MAX),
+    @Favorites NVARCHAR(MAX),
+    @Folders NVARCHAR(MAX),
+    @Attachments NVARCHAR(MAX),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @DeletedDate DATETIME2(7),
+    @Reprompt TINYINT,
+    @CollectionIds AS [dbo].[GuidIdArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    BEGIN TRANSACTION Cipher_UpdateWithCollections
+
+    DECLARE @UpdateCollectionsSuccess INT
+    EXEC @UpdateCollectionsSuccess = [dbo].[Cipher_UpdateCollections] @Id, @UserId, @OrganizationId, @CollectionIds
+
+    IF @UpdateCollectionsSuccess < 0
+    BEGIN
+        COMMIT TRANSACTION Cipher_UpdateWithCollections
+        SELECT -1 -- -1 = Failure
+        RETURN
+    END
+
+    UPDATE
+        [dbo].[Cipher]
+    SET
+        [UserId] = NULL,
+        [OrganizationId] = @OrganizationId,
+        [Data] = @Data,
+        [Attachments] = @Attachments,
+        [RevisionDate] = @RevisionDate,
+        [DeletedDate] = @DeletedDate
+        -- No need to update CreationDate, Favorites, Folders, or Type since that data will not change
+    WHERE
+        [Id] = @Id
+
+    COMMIT TRANSACTION Cipher_UpdateWithCollections
+
+    IF @Attachments IS NOT NULL
+    BEGIN
+        EXEC [dbo].[Organization_UpdateStorage] @OrganizationId
+        EXEC [dbo].[User_UpdateStorage] @UserId
+    END
+
+    EXEC [dbo].[User_BumpAccountRevisionDateByCipherId] @Id, @OrganizationId
+
+    SELECT 0 -- 0 = Success
+END
+GO
+
+IF OBJECT_ID('[dbo].[CipherDetails_CreateWithCollections]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[CipherDetails_CreateWithCollections]
+END
+GO
+
+CREATE PROCEDURE [dbo].[CipherDetails_CreateWithCollections]
+    @Id UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @Type TINYINT,
+    @Data NVARCHAR(MAX),
+    @Favorites NVARCHAR(MAX), -- not used
+    @Folders NVARCHAR(MAX), -- not used
+    @Attachments NVARCHAR(MAX), -- not used
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @FolderId UNIQUEIDENTIFIER,
+    @Favorite BIT,
+    @Edit BIT, -- not used
+    @ViewPassword BIT, -- not used
+    @OrganizationUseTotp BIT, -- not used
+    @DeletedDate DATETIME2(7),
+    @Reprompt TINYINT,
+    @CollectionIds AS [dbo].[GuidIdArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    EXEC [dbo].[CipherDetails_Create] @Id, @UserId, @OrganizationId, @Type, @Data, @Favorites, @Folders,
+        @Attachments, @CreationDate, @RevisionDate, @FolderId, @Favorite, @Edit, @ViewPassword,
+        @OrganizationUseTotp, @DeletedDate, @Reprompt
+
+    DECLARE @UpdateCollectionsSuccess INT
+    EXEC @UpdateCollectionsSuccess = [dbo].[Cipher_UpdateCollections] @Id, @UserId, @OrganizationId, @CollectionIds
+END

--- a/util/Migrator/Migrator.csproj
+++ b/util/Migrator/Migrator.csproj
@@ -10,10 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="DbScripts\2021-04-13_00_CipherPasswordPrompt.sql" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="dbup-sqlserver" Version="4.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
   </ItemGroup>


### PR DESCRIPTION
## Objective
I incorrectly put all logic for password reprompt into `CipherDetails` when it should be applied to `Cipher`. Which resulted in editing ciphers in organizations not working correctly. Also added support for handling reprompt in imports.

### Code Changes
- **src/Core/Models/Api/Request/CipherRequestModel.cs**:  Move reprompt logic from `CipherDetails` to `Cipher`.
- **src/Core/Models/Api/Response/CipherResponseModel.cs**: Move reprompt logic to `CipherMiniResponseModel`.
- **src/Core/Repositories/SqlServer/CipherRepository.cs**: Support reprompt in cipher import.
- **src/Sql/dbo/Stored Procedures/*.sql**: Add reprompt logic to necessary sprocs.
