### PR TITLE
Refactor WebAuthn IoC container

### DIFF
--- a/bitwarden_license/src/Portal/Startup.cs
+++ b/bitwarden_license/src/Portal/Startup.cs
@@ -57,7 +57,7 @@ namespace Bit.Portal
             }
 
             // Services
-            services.AddBaseServices(globalSettings);
+            services.AddBaseServices();
             services.AddDefaultServices(globalSettings);
             services.AddCoreLocalizationServices();
 

--- a/bitwarden_license/src/Portal/Startup.cs
+++ b/bitwarden_license/src/Portal/Startup.cs
@@ -57,18 +57,9 @@ namespace Bit.Portal
             }
 
             // Services
-            services.AddBaseServices();
+            services.AddBaseServices(globalSettings);
             services.AddDefaultServices(globalSettings);
             services.AddCoreLocalizationServices();
-
-            // Fido2
-            services.AddFido2(options =>
-            {
-                options.ServerDomain = new Uri(globalSettings.BaseServiceUri.Vault).Host;
-                options.ServerName = "Bitwarden";
-                options.Origin = globalSettings.BaseServiceUri.Vault;
-                options.TimestampDriftTolerance = 300000;
-            });
 
             // Mvc
             services.AddControllersWithViews()

--- a/bitwarden_license/src/Sso/Startup.cs
+++ b/bitwarden_license/src/Sso/Startup.cs
@@ -72,7 +72,7 @@ namespace Bit.Sso
             services.AddCustomIdentityServices(globalSettings);
 
             // Services
-            services.AddBaseServices(globalSettings);
+            services.AddBaseServices();
             services.AddDefaultServices(globalSettings);
             services.AddCoreLocalizationServices();
         }

--- a/bitwarden_license/src/Sso/Startup.cs
+++ b/bitwarden_license/src/Sso/Startup.cs
@@ -59,15 +59,6 @@ namespace Bit.Sso
                 });
             }
 
-            // Fido2
-            services.AddFido2(options =>
-            {
-                options.ServerDomain = new Uri(globalSettings.BaseServiceUri.Vault).Host;
-                options.ServerName = "Bitwarden";
-                options.Origin = globalSettings.BaseServiceUri.Vault;
-                options.TimestampDriftTolerance = 300000;
-            });
-
             // Authentication
             services.AddDistributedIdentityServices(globalSettings);
             services.AddAuthentication()
@@ -81,7 +72,7 @@ namespace Bit.Sso
             services.AddCustomIdentityServices(globalSettings);
 
             // Services
-            services.AddBaseServices();
+            services.AddBaseServices(globalSettings);
             services.AddDefaultServices(globalSettings);
             services.AddCoreLocalizationServices();
         }

--- a/src/Admin/Startup.cs
+++ b/src/Admin/Startup.cs
@@ -63,17 +63,8 @@ namespace Bit.Admin
             }
 
             // Services
-            services.AddBaseServices();
+            services.AddBaseServices(globalSettings);
             services.AddDefaultServices(globalSettings);
-
-            // Fido2
-            services.AddFido2(options =>
-            {
-                options.ServerDomain = new Uri(globalSettings.BaseServiceUri.Vault).Host;
-                options.ServerName = "Bitwarden";
-                options.Origin = globalSettings.BaseServiceUri.Vault;
-                options.TimestampDriftTolerance = 300000;
-            });
 
             // Mvc
             services.AddMvc(config =>

--- a/src/Admin/Startup.cs
+++ b/src/Admin/Startup.cs
@@ -63,7 +63,7 @@ namespace Bit.Admin
             }
 
             // Services
-            services.AddBaseServices(globalSettings);
+            services.AddBaseServices();
             services.AddDefaultServices(globalSettings);
 
             // Mvc

--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -115,18 +115,9 @@ namespace Bit.Api
             services.AddScoped<AuthenticatorTokenProvider>();
 
             // Services
-            services.AddBaseServices();
+            services.AddBaseServices(globalSettings);
             services.AddDefaultServices(globalSettings);
             services.AddCoreLocalizationServices();
-
-            // Fido2
-            services.AddFido2(options =>
-            {
-                options.ServerDomain = new Uri(globalSettings.BaseServiceUri.Vault).Host;
-                options.ServerName = "Bitwarden";
-                options.Origin = globalSettings.BaseServiceUri.Vault;
-                options.TimestampDriftTolerance = 300000;
-            });
 
             // MVC
             services.AddMvc(config =>

--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -115,7 +115,7 @@ namespace Bit.Api
             services.AddScoped<AuthenticatorTokenProvider>();
 
             // Services
-            services.AddBaseServices(globalSettings);
+            services.AddBaseServices();
             services.AddDefaultServices(globalSettings);
             services.AddCoreLocalizationServices();
 

--- a/src/Billing/Startup.cs
+++ b/src/Billing/Startup.cs
@@ -54,7 +54,7 @@ namespace Bit.Billing
             //services.AddPasswordlessIdentityServices<ReadOnlyDatabaseIdentityUserStore>(globalSettings);
 
             // Services
-            services.AddBaseServices(globalSettings);
+            services.AddBaseServices();
             services.AddDefaultServices(globalSettings);
 
             services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();

--- a/src/Billing/Startup.cs
+++ b/src/Billing/Startup.cs
@@ -49,21 +49,12 @@ namespace Bit.Billing
             // Context
             services.AddScoped<ICurrentContext, CurrentContext>();
 
-            // Fido2
-            services.AddFido2(options =>
-            {
-                options.ServerDomain = new Uri(globalSettings.BaseServiceUri.Vault).Host;
-                options.ServerName = "Bitwarden";
-                options.Origin = globalSettings.BaseServiceUri.Vault;
-                options.TimestampDriftTolerance = 300000;
-            });
-
             // Identity
             services.AddCustomIdentityServices(globalSettings);
             //services.AddPasswordlessIdentityServices<ReadOnlyDatabaseIdentityUserStore>(globalSettings);
 
             // Services
-            services.AddBaseServices();
+            services.AddBaseServices(globalSettings);
             services.AddDefaultServices(globalSettings);
 
             services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();

--- a/src/Core/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Core/Utilities/ServiceCollectionExtensions.cs
@@ -108,11 +108,8 @@ namespace Bit.Core.Utilities
             }
         }
 
-        public static void AddBaseServices(this IServiceCollection services, GlobalSettings globalSettings)
+        public static void AddBaseServices(this IServiceCollection services)
         {
-            // Required for UserService
-            services.AddWebAuthn(globalSettings);
-
             services.AddScoped<ICipherService, CipherService>();
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<IOrganizationService, OrganizationService>();
@@ -129,6 +126,9 @@ namespace Bit.Core.Utilities
 
         public static void AddDefaultServices(this IServiceCollection services, GlobalSettings globalSettings)
         {
+            // Required for UserService
+            services.AddWebAuthn(globalSettings);
+
             services.AddSingleton<IPaymentService, StripePaymentService>();
             services.AddSingleton<IMailService, HandlebarsMailService>();
             services.AddSingleton<ILicensingService, LicensingService>();

--- a/src/Core/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Core/Utilities/ServiceCollectionExtensions.cs
@@ -108,8 +108,11 @@ namespace Bit.Core.Utilities
             }
         }
 
-        public static void AddBaseServices(this IServiceCollection services)
+        public static void AddBaseServices(this IServiceCollection services, GlobalSettings globalSettings)
         {
+            // Required for UserService
+            services.AddWebAuthn(globalSettings);
+
             services.AddScoped<ICipherService, CipherService>();
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<IOrganizationService, OrganizationService>();
@@ -534,6 +537,17 @@ namespace Bit.Core.Utilities
             );
 
             return services;
+        }
+
+        public static void AddWebAuthn(this IServiceCollection services, GlobalSettings globalSettings)
+        {
+            services.AddFido2(options =>
+            {
+                options.ServerDomain = new Uri(globalSettings.BaseServiceUri.Vault).Host;
+                options.ServerName = "Bitwarden";
+                options.Origin = globalSettings.BaseServiceUri.Vault;
+                options.TimestampDriftTolerance = 300000;
+            });
         }
     }
 }

--- a/src/Identity/Startup.cs
+++ b/src/Identity/Startup.cs
@@ -122,7 +122,7 @@ namespace Bit.Identity
             services.AddCustomIdentityServices(globalSettings);
 
             // Services
-            services.AddBaseServices(globalSettings);
+            services.AddBaseServices();
             services.AddDefaultServices(globalSettings);
             services.AddCoreLocalizationServices();
 

--- a/src/Identity/Startup.cs
+++ b/src/Identity/Startup.cs
@@ -56,15 +56,6 @@ namespace Bit.Identity
             // Caching
             services.AddMemoryCache();
 
-            // Fido2
-            services.AddFido2(options =>
-            {
-                options.ServerDomain = new Uri(globalSettings.BaseServiceUri.Vault).Host;
-                options.ServerName = "Bitwarden";
-                options.Origin = globalSettings.BaseServiceUri.Vault;
-                options.TimestampDriftTolerance = 300000;
-            });
-
             // Mvc
             services.AddMvc();
 
@@ -131,7 +122,7 @@ namespace Bit.Identity
             services.AddCustomIdentityServices(globalSettings);
 
             // Services
-            services.AddBaseServices();
+            services.AddBaseServices(globalSettings);
             services.AddDefaultServices(globalSettings);
             services.AddCoreLocalizationServices();
 


### PR DESCRIPTION
## Objective
Initializing WebAuthn was a bit fragile and #1299 caught some services not initializing it properly when using `UserService`. In an effort to avoid this happening in the future and also streamline possible changes to the WebAuthn settings I extracted the setup part to our `ServiceCollectionExtension`, and also added it to `AddBaseServices`, which should ensure it always gets initialized.

### Code Changes
- **src/*/Startup.cs**: Removed Fido2 initialization since it happens in `AddBaseServices`.
- **src/Core/Utilities/ServiceCollectionExtensions.cs**: Extracted Fido2 setup to `AddWebAuthn`, and added initialization of it to `AddBaseServices`.