### PR TITLE
Fix skip sso for apikey login

### DIFF
--- a/src/Core/IdentityServer/BaseRequestValidator.cs
+++ b/src/Core/IdentityServer/BaseRequestValidator.cs
@@ -87,7 +87,7 @@ namespace Bit.Core.IdentityServer
                 return;
             }
 
-            var twoFactorRequirement = await RequiresTwoFactorAsync(user);
+            var twoFactorRequirement = await RequiresTwoFactorAsync(user, request.GrantType);
             if (twoFactorRequirement.Item1)
             {
                 // Just defaulting it
@@ -260,8 +260,14 @@ namespace Bit.Core.IdentityServer
 
         protected abstract void SetErrorResult(T context, Dictionary<string, object> customResponse);
 
-        private async Task<Tuple<bool, Organization>> RequiresTwoFactorAsync(User user)
+        private async Task<Tuple<bool, Organization>> RequiresTwoFactorAsync(User user, string grantType)
         {
+            if (grantType == "client_credentials")
+            {
+                // Do not require MFA for api key logins
+                return new Tuple<bool, Organization>(false, null);
+            }
+
             var individualRequired = _userManager.SupportsUserTwoFactor &&
                 await _userManager.GetTwoFactorEnabledAsync(user) &&
                 (await _userManager.GetValidTwoFactorProvidersAsync(user)).Count > 0;

--- a/src/Core/IdentityServer/BaseRequestValidator.cs
+++ b/src/Core/IdentityServer/BaseRequestValidator.cs
@@ -286,9 +286,10 @@ namespace Bit.Core.IdentityServer
 
         private async Task<bool> IsValidAuthTypeAsync(User user, string grantType)
         {
-            if (grantType == "authorization_code")
+            if (grantType == "authorization_code" || grantType == "client_credentials")
             {
                 // Already using SSO to authorize, finish successfully
+                // Or login via api key, skip SSO requirement
                 return true;
             }
 

--- a/src/Core/IdentityServer/CustomTokenRequestValidator.cs
+++ b/src/Core/IdentityServer/CustomTokenRequestValidator.cs
@@ -87,7 +87,13 @@ namespace Bit.Core.IdentityServer
         }
 
         protected override void SetSsoResult(CustomTokenRequestValidationContext context, 
-            Dictionary<string, object> customResponse) => throw new System.NotImplementedException();
+            Dictionary<string, object> customResponse) 
+        {
+            context.Result.Error = "invalid_grant";
+            context.Result.ErrorDescription = "Single Sign on required.";
+            context.Result.IsError = true;
+            context.Result.CustomResponse = customResponse;
+        }
 
         protected override void SetErrorResult(CustomTokenRequestValidationContext context,
             Dictionary<string, object> customResponse)


### PR DESCRIPTION
# Overview

Fixes https://app.asana.com/0/1169444489336079/1200294152465325/f

It appears all api login requests are classified as `client_credentials` grantType logins (see here)[https://github.com/bitwarden/jslib/blob/master/src/models/request/tokenRequest.ts#L45]. Skip SSO required policy checks for these types of logins.

Also do not require MFA for api key authentication.

In addition to bypassing extra authentications, PR also improves the error message of our API Key validator to return a reasonable message:
```
SSO authentication is required.
```
rather than 
```json
{"response":null,"statusCode":500}
```

# Files Changed
* **BaseRequestValidator.cs**: ignore SSO required policy for `--apikey`-type requests. Ignore MFa for `--apikey`-type requests
* **CustomtokenRequestValidator**: Implement the standard error response for SSO required.

