### PR TITLE
Add Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+﻿<Project>
+
+	<PropertyGroup>
+		<Version>1.41.2</Version>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<RootNamespace>Bit.$(MSBuildProjectName)</RootNamespace>
+	</PropertyGroup>
+
+</Project>

--- a/bitwarden-server.sln
+++ b/bitwarden-server.sln
@@ -22,6 +22,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		NuGet.Config = NuGet.Config
 		README.md = README.md
 		SECURITY.md = SECURITY.md
+		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core", "src\Core\Core.csproj", "{3973D21B-A692-4B60-9B70-3631C057423A}"

--- a/src/Admin/Admin.csproj
+++ b/src/Admin/Admin.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>1.41.2</Version>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RootNamespace>Bit.Admin</RootNamespace>
     <UserSecretsId>bitwarden-Admin</UserSecretsId>
   </PropertyGroup>
   

--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>1.41.2</Version>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RootNamespace>Bit.Api</RootNamespace>
     <UserSecretsId>bitwarden-Api</UserSecretsId>
     <MvcRazorCompileOnPublish>false</MvcRazorCompileOnPublish>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/src/Billing/Billing.csproj
+++ b/src/Billing/Billing.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>1.41.2</Version>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RootNamespace>Bit.Billing</RootNamespace>
     <UserSecretsId>bitwarden-Billing</UserSecretsId>
     <MvcRazorCompileOnPublish>false</MvcRazorCompileOnPublish>
   </PropertyGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RootNamespace>Bit.Core</RootNamespace>
     <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>

--- a/src/Events/Events.csproj
+++ b/src/Events/Events.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>1.41.2</Version>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RootNamespace>Bit.Events</RootNamespace>
     <UserSecretsId>bitwarden-Events</UserSecretsId>
     <MvcRazorCompileOnPublish>false</MvcRazorCompileOnPublish>
   </PropertyGroup>

--- a/src/EventsProcessor/EventsProcessor.csproj
+++ b/src/EventsProcessor/EventsProcessor.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>1.41.2</Version>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RootNamespace>Bit.EventsProcessor</RootNamespace>
     <UserSecretsId>bitwarden-EventsProcessor</UserSecretsId>
   </PropertyGroup>
 

--- a/src/Icons/Icons.csproj
+++ b/src/Icons/Icons.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>1.41.2</Version>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RootNamespace>Bit.Icons</RootNamespace>
     <UserSecretsId>bitwarden-Icons</UserSecretsId>
     <MvcRazorCompileOnPublish>false</MvcRazorCompileOnPublish>
   </PropertyGroup>

--- a/src/Identity/Identity.csproj
+++ b/src/Identity/Identity.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>1.41.2</Version>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RootNamespace>Bit.Identity</RootNamespace>
     <UserSecretsId>bitwarden-Identity</UserSecretsId>
     <MvcRazorCompileOnPublish>false</MvcRazorCompileOnPublish>
   </PropertyGroup>

--- a/src/Notifications/Notifications.csproj
+++ b/src/Notifications/Notifications.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>1.41.2</Version>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RootNamespace>Bit.Notifications</RootNamespace>
     <UserSecretsId>bitwarden-Notifications</UserSecretsId>
   </PropertyGroup>
 

--- a/test/Api.Test/Api.Test.csproj
+++ b/test/Api.Test/Api.Test.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Core.Test/Core.Test.csproj
+++ b/test/Core.Test/Core.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Bit.Core.Test</RootNamespace>
   </PropertyGroup>

--- a/util/Migrator/Migrator.csproj
+++ b/util/Migrator/Migrator.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RootNamespace>Bit.Migrator</RootNamespace>
-  </PropertyGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="DbScripts\**\*.sql" />
   </ItemGroup>

--- a/util/Server/Server.csproj
+++ b/util/Server/Server.csproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
     <MvcRazorCompileOnPublish>false</MvcRazorCompileOnPublish>
-    <RootNamespace>Bit.Server</RootNamespace>
   </PropertyGroup>
 
 </Project>

--- a/util/Setup/Setup.csproj
+++ b/util/Setup/Setup.csproj
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
     <NoWarn>1701;1702;1705;NU1701</NoWarn>
-    <RootNamespace>Bit.Setup</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As discussed with @cscharf in #1305. This will make it so the version number only needs to be bumped in a single file and the version number will cascade down to all other projects that do not have an override for the `Version` property in their own `csproj` file. 

One thing to note is that the `Core` project did not have a `Version` property set and this will give it one. I don't think this should have any effect but I can override it to the default of `1.0.0` if need be. 