### PR TITLE
Bulk re-invite of org users

### DIFF
--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -129,6 +129,19 @@ namespace Bit.Api.Controllers
             var userId = _userService.GetProperUserId(User);
             var result = await _organizationService.InviteUserAsync(orgGuidId, userId.Value, null, new OrganizationUserInvite(model));
         }
+        
+        [HttpPost("reinvite")]
+        public async Task BulkReinvite(string orgId, [FromBody]OrganizationUserBulkReinviteRequestModel model)
+        {
+            var orgGuidId = new Guid(orgId);
+            if (!_currentContext.ManageUsers(orgGuidId))
+            {
+                throw new NotFoundException();
+            }
+
+            var userId = _userService.GetProperUserId(User);
+            await _organizationService.ResendInvitesAsync(orgGuidId, userId.Value, model.Ids);
+        }
 
         [HttpPost("{id}/reinvite")]
         public async Task Reinvite(string orgId, string id)

--- a/src/Core/Models/Api/Request/Organizations/OrganizationUserRequestModels.cs
+++ b/src/Core/Models/Api/Request/Organizations/OrganizationUserRequestModels.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.Models.Data;
+﻿using System;
+using Bit.Core.Models.Data;
 using Bit.Core.Models.Table;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -88,5 +89,11 @@ namespace Bit.Core.Models.Api
     public class OrganizationUserResetPasswordEnrollmentRequestModel
     {
         public string ResetPasswordKey { get; set; }
+    }
+
+    public class OrganizationUserBulkReinviteRequestModel
+    {
+        [Required]
+        public IEnumerable<Guid> Ids { get; set; }
     }
 }

--- a/src/Core/Repositories/IOrganizationUserRepository.cs
+++ b/src/Core/Repositories/IOrganizationUserRepository.cs
@@ -29,6 +29,7 @@ namespace Bit.Core.Repositories
         Task CreateAsync(OrganizationUser obj, IEnumerable<SelectionReadOnly> collections);
         Task ReplaceAsync(OrganizationUser obj, IEnumerable<SelectionReadOnly> collections);
         Task<ICollection<OrganizationUser>> GetManyByManyUsersAsync(IEnumerable<Guid> userIds);
+        Task<ICollection<OrganizationUser>> GetManyAsync(IEnumerable<Guid> Ids);
         Task<OrganizationUser> GetByOrganizationEmailAsync(Guid organizationId, string email);
     }
 }

--- a/src/Core/Repositories/SqlServer/OrganizationUserRepository.cs
+++ b/src/Core/Repositories/SqlServer/OrganizationUserRepository.cs
@@ -260,6 +260,19 @@ namespace Bit.Core.Repositories.SqlServer
             }
         }
         
+        public async Task<ICollection<OrganizationUser>> GetManyAsync(IEnumerable<Guid> Ids)
+        {
+            using (var connection = new SqlConnection(ConnectionString))
+            {
+                var results = await connection.QueryAsync<OrganizationUser>(
+                    "[dbo].[OrganizationUser_ReadByIds]",
+                    new { Ids = Ids.ToGuidIdArrayTVP() },
+                    commandType: CommandType.StoredProcedure);
+
+                return results.ToList();
+            }
+        }
+        
         public async Task<OrganizationUser> GetByOrganizationEmailAsync(Guid organizationId, string email)
         {
             using (var connection = new SqlConnection(ConnectionString))

--- a/src/Core/Services/IOrganizationService.cs
+++ b/src/Core/Services/IOrganizationService.cs
@@ -33,6 +33,7 @@ namespace Bit.Core.Services
         Task<OrganizationUser> InviteUserAsync(Guid organizationId, Guid? invitingUserId, string email,
             OrganizationUserType type, bool accessAll, string externalId, IEnumerable<SelectionReadOnly> collections);
         Task<List<OrganizationUser>> InviteUserAsync(Guid organizationId, Guid? invitingUserId, string externalId, OrganizationUserInvite orgUserInvite);
+        Task ResendInvitesAsync(Guid organizationId, Guid? invitingUserId, IEnumerable<Guid> organizationUsersId);
         Task ResendInviteAsync(Guid organizationId, Guid? invitingUserId, Guid organizationUserId);
         Task<OrganizationUser> AcceptUserAsync(Guid organizationUserId, User user, string token,
             IUserService userService);

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -15,7 +15,6 @@ using Bit.Core.Settings;
 using System.IO;
 using Newtonsoft.Json;
 using System.Text.Json;
-using IdentityServer4.Extensions;
 
 namespace Bit.Core.Services
 {
@@ -1082,10 +1081,9 @@ namespace Bit.Core.Services
         {
             var orgUsers = await _organizationUserRepository.GetManyAsync(organizationUsersId);
             var filteredUsers = orgUsers
-                .Where(u => u.Status == OrganizationUserStatusType.Invited && u.OrganizationId == organizationId)
-                .ToList();
+                .Where(u => u.Status == OrganizationUserStatusType.Invited && u.OrganizationId == organizationId);
 
-            if (filteredUsers.Count == 0)
+            if (!filteredUsers.Any())
             {
                 throw new BadRequestException("Users invalid.");
             }

--- a/src/Sql/Sql.sqlproj
+++ b/src/Sql/Sql.sqlproj
@@ -112,6 +112,7 @@
     <Build Include="dbo\Stored Procedures\OrganizationUser_DeleteById.sql" />
     <Build Include="dbo\Stored Procedures\Grant_Delete.sql" />
     <Build Include="dbo\Stored Procedures\OrganizationUser_ReadById.sql" />
+    <Build Include="dbo\Stored Procedures\OrganizationUser_ReadByIds.sql" />
     <Build Include="dbo\Stored Procedures\OrganizationUser_ReadByOrganizationId.sql" />
     <Build Include="dbo\Stored Procedures\Grant_ReadByKey.sql" />
     <Build Include="dbo\Stored Procedures\Grant_Read.sql" />

--- a/src/Sql/dbo/Stored Procedures/OrganizationUser_ReadByIds.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationUser_ReadByIds.sql
@@ -1,0 +1,18 @@
+CREATE PROCEDURE [dbo].[OrganizationUser_ReadByIds]
+    @Ids AS [dbo].[GuidIdArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    IF (SELECT COUNT(1) FROM @Ids) < 1
+    BEGIN
+        RETURN(-1)
+    END
+
+    SELECT
+        *
+    FROM
+        [dbo].[OrganizationUserView]
+    WHERE
+        [Id] IN (SELECT [Id] FROM @Ids)
+END

--- a/util/Migrator/DbScripts/2021-05-11_00_BulkReinvite.sql
+++ b/util/Migrator/DbScripts/2021-05-11_00_BulkReinvite.sql
@@ -1,0 +1,24 @@
+﻿IF OBJECT_ID('[dbo].[OrganizationUser_ReadByIds]') IS NOT NULL
+BEGIN
+    DROP FUNCTION [dbo].[OrganizationUser_ReadByIds]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationUser_ReadByIds]
+    @Ids AS [dbo].[GuidIdArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    IF (SELECT COUNT(1) FROM @Ids) < 1
+    BEGIN
+        RETURN(-1)
+    END
+
+    SELECT
+        *
+    FROM
+        [dbo].[OrganizationUserView]
+    WHERE
+        [Id] IN (SELECT [Id] FROM @Ids)
+END


### PR DESCRIPTION
## Objective
Currently org administrators needs to manually re-invite each user which requires multiple steps in the UI per user. To streamline this I've added a new bulk api which allows for re-inviting multiple users at a time.

### Code Changes
- **src/Api/Controllers/OrganizationUsersController.cs**: Add new `reinvite` endpoint.
- **src/Core/Models/Api/Request/Organizations/OrganizationUserRequestModels.cs**: Added the bulk invite request model.
- **src/Core/Repositories/OrganizationUserRepository.cs**: Added a new method for getting multiple org users at a time.
- **src/Core/Services/Implementations/OrganizationService.cs**: Added new logic to handle multiple invites.
- **src/Sql/dbo/Stored Procedures/OrganizationUser_ReadByIds.sql**: Sproc for retrieving multiple org users at a time.

https://app.asana.com/0/1198901840263430/1200202229721743