### PR TITLE
Resolved build issue introduced in #1267

### DIFF
--- a/test/Core.Test/AutoFixture/OrganizationFixtures.cs
+++ b/test/Core.Test/AutoFixture/OrganizationFixtures.cs
@@ -57,7 +57,7 @@ namespace Bit.Core.Test.AutoFixture.OrganizationFixtures
             fixture.Customize<OrganizationUpgrade>(composer => composer
                 .With(ou => ou.Plan, selectedPlan.Type)
                 .With(ou => ou.PremiumAccessAddon, selectedPlan.HasPremiumAccessOption));
-            fixture.Customize<Organization>(composer => composer
+            fixture.Customize<Models.Table.Organization>(composer => composer
                 .Without(o => o.GatewaySubscriptionId));
         }
     }


### PR DESCRIPTION
Build broke after merging #1267. The last "merge conflict" [commit](https://github.com/bitwarden/server/pull/1267/commits/e10f8a7db555ade4102e8d43a5257bbd2e8a69c9) seems to have accidentally changed `Models.Table.Organization` to `Organization`.