### PR TITLE
Add API for bulk removal of org users

### DIFF
--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -283,5 +283,19 @@ namespace Bit.Api.Controllers
             var userId = _userService.GetProperUserId(User);
             await _organizationService.DeleteUserAsync(orgGuidId, new Guid(id), userId.Value);
         }
+
+        [HttpDelete("")]
+        [HttpPost("delete")]
+        public async Task BulkDelete(string orgId, [FromBody] OrganizationUserBulkRemoveRequestModel model)
+        {
+            var orgGuidId = new Guid(orgId);
+            if (!_currentContext.ManageUsers(orgGuidId))
+            {
+                throw new NotFoundException();
+            }
+
+            var userId = _userService.GetProperUserId(User);
+            await _organizationService.DeleteUsersAsync(orgGuidId, model.Ids, userId.Value);
+        }
     }
 }

--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -131,7 +131,7 @@ namespace Bit.Api.Controllers
         }
         
         [HttpPost("reinvite")]
-        public async Task BulkReinvite(string orgId, [FromBody]OrganizationUserBulkReinviteRequestModel model)
+        public async Task BulkReinvite(string orgId, [FromBody]OrganizationUserBulkRequestModel model)
         {
             var orgGuidId = new Guid(orgId);
             if (!_currentContext.ManageUsers(orgGuidId))
@@ -286,7 +286,7 @@ namespace Bit.Api.Controllers
 
         [HttpDelete("")]
         [HttpPost("delete")]
-        public async Task BulkDelete(string orgId, [FromBody] OrganizationUserBulkRemoveRequestModel model)
+        public async Task BulkDelete(string orgId, [FromBody] OrganizationUserBulkRequestModel model)
         {
             var orgGuidId = new Guid(orgId);
             if (!_currentContext.ManageUsers(orgGuidId))

--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -286,7 +286,7 @@ namespace Bit.Api.Controllers
 
         [HttpDelete("")]
         [HttpPost("delete")]
-        public async Task BulkDelete(string orgId, [FromBody] OrganizationUserBulkRequestModel model)
+        public async Task BulkDelete(string orgId, [FromBody]OrganizationUserBulkRequestModel model)
         {
             var orgGuidId = new Guid(orgId);
             if (!_currentContext.ManageUsers(orgGuidId))

--- a/src/Core/Models/Api/Request/Organizations/OrganizationUserRequestModels.cs
+++ b/src/Core/Models/Api/Request/Organizations/OrganizationUserRequestModels.cs
@@ -91,13 +91,7 @@ namespace Bit.Core.Models.Api
         public string ResetPasswordKey { get; set; }
     }
 
-    public class OrganizationUserBulkReinviteRequestModel
-    {
-        [Required]
-        public IEnumerable<Guid> Ids { get; set; }
-    }
-    
-    public class OrganizationUserBulkRemoveRequestModel
+    public class OrganizationUserBulkRequestModel
     {
         [Required]
         public IEnumerable<Guid> Ids { get; set; }

--- a/src/Core/Models/Api/Request/Organizations/OrganizationUserRequestModels.cs
+++ b/src/Core/Models/Api/Request/Organizations/OrganizationUserRequestModels.cs
@@ -96,4 +96,10 @@ namespace Bit.Core.Models.Api
         [Required]
         public IEnumerable<Guid> Ids { get; set; }
     }
+    
+    public class OrganizationUserBulkRemoveRequestModel
+    {
+        [Required]
+        public IEnumerable<Guid> Ids { get; set; }
+    }
 }

--- a/src/Core/Services/IOrganizationService.cs
+++ b/src/Core/Services/IOrganizationService.cs
@@ -43,6 +43,7 @@ namespace Bit.Core.Services
         Task SaveUserAsync(OrganizationUser user, Guid? savingUserId, IEnumerable<SelectionReadOnly> collections);
         Task DeleteUserAsync(Guid organizationId, Guid organizationUserId, Guid? deletingUserId);
         Task DeleteUserAsync(Guid organizationId, Guid userId);
+        Task DeleteUsersAsync(Guid organizationId, IEnumerable<Guid> organizationUserIds, Guid? deleteingUserId);
         Task UpdateUserGroupsAsync(OrganizationUser organizationUser, IEnumerable<Guid> groupIds, Guid? loggedInUserId);
         Task UpdateUserResetPasswordEnrollmentAsync(Guid organizationId, Guid organizationUserId, string resetPasswordKey, Guid? callingUserId);
         Task<OrganizationLicense> GenerateLicenseAsync(Guid organizationId, Guid installationId);

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1429,7 +1429,7 @@ namespace Bit.Core.Services
         {
             var confirmedOwners = await GetConfirmedOwnersAsync(organizationId);
             var confirmedOwnersIds = confirmedOwners.Select(u => u.Id);
-            return !confirmedOwnersIds.Except(organizationUsersId).Any();
+            return confirmedOwnersIds.Except(organizationUsersId).Any();
         }
 
         private async Task<bool> UserIsOwnerAsync(Guid organizationId, Guid deletingUserId)

--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -381,7 +381,7 @@ namespace Bit.Core.Test.Services
         }
         
         [Theory, CustomAutoData(typeof(SutProviderCustomization))]
-        public async Task DeleteUser_InvalidUser(OrganizationUser organizationUser,OrganizationUser deletingUser,
+        public async Task DeleteUser_InvalidUser(OrganizationUser organizationUser, OrganizationUser deletingUser,
             SutProvider<OrganizationService> sutProvider)
         {
             var organizationUserRepository = sutProvider.GetDependency<IOrganizationUserRepository>();

--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -373,7 +373,7 @@ namespace Bit.Core.Test.Services
             newUserData.OrganizationId = savingUser.OrganizationId = oldUserData.OrganizationId;
             savingUser.Type = OrganizationUserType.Owner;
             organizationUserRepository.GetByIdAsync(oldUserData.Id).Returns(oldUserData);
-            organizationUserRepository.GetManyByOrganizationAsync(newUserData.OrganizationId, OrganizationUserType.Owner)
+            organizationUserRepository.GetManyByOrganizationAsync(savingUser.OrganizationId, OrganizationUserType.Owner)
                 .Returns(new List<OrganizationUser> { savingUser });
             organizationUserRepository.GetManyByUserAsync(savingUser.UserId.Value).Returns(new List<OrganizationUser> { savingUser });
 


### PR DESCRIPTION
## Objective
Currently org administrators needs to manually remove user which requires multiple steps in the UI per user. To streamline this I've added a new bulk api which allows for removing multiple users at a time.

### Code Changes
- **src/Api/Controllers/OrganizationUsersController.cs**: Add new bulk `delete` endpoint.
- **src/Core/Models/Api/Request/Organizations/OrganizationUserRequestModels.cs**: Added the bulk remove request model.
- **src/Core/Services/Implementations/OrganizationService.cs**: Added new logic to handle removal of multiple users at a time.

### Testing Consideration
We should do regression testing on Delete APIs to verify everything behaves the same.

https://app.asana.com/0/1198901840263430/1200202229721743