### PR TITLE
Discourage user verification on WebAuthn enroll

### DIFF
--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -526,7 +526,13 @@ namespace Bit.Core.Services
                 .Select(k => new TwoFactorProvider.WebAuthnData((dynamic)k.Value).Descriptor)
                 .ToList();
 
-            var options = _fido2.RequestNewCredential(fidoUser, excludeCredentials, AuthenticatorSelection.Default, AttestationConveyancePreference.None);
+            var authenticatorSelection = new AuthenticatorSelection
+            {
+                AuthenticatorAttachment = null,
+                RequireResidentKey = false,
+                UserVerification = UserVerificationRequirement.Discouraged
+            };
+            var options = _fido2.RequestNewCredential(fidoUser, excludeCredentials, authenticatorSelection, AttestationConveyancePreference.None);
 
             provider.MetaData["pending"] = options.ToJson();
             providers[TwoFactorProviderType.WebAuthn] = provider;


### PR DESCRIPTION
## Objective
When adding a new WebAuthn key by default it preferes a key with `UserVerification` which on some keys will prompt for PIN. To avoid this I set the `UserVerificationRequirement` to `Discouraged`

Follow up of #1250 