### PR TITLE
[Reset Password] Get/Post Org Keys and API updates

### DIFF
--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -251,8 +251,15 @@ namespace Bit.Api.Controllers
             {
                 throw new NotFoundException();
             }
+            
+            // Get the calling user's Type for this organization and pass it along
+            var orgType = _currentContext.Organizations?.FirstOrDefault(o => o.Id == orgGuidId)?.Type;
+            if (orgType == null)
+            {
+                throw new NotFoundException();
+            }
 
-            var result = await _userService.AdminResetPasswordAsync(orgGuidId, new Guid(id), model.NewMasterPasswordHash, model.Key);
+            var result = await _userService.AdminResetPasswordAsync(orgType.Value, orgGuidId, new Guid(id), model.NewMasterPasswordHash, model.Key);
             if (result.Succeeded)
             {
                 return;

--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -26,7 +26,6 @@ namespace Bit.Api.Controllers
         private readonly IGroupRepository _groupRepository;
         private readonly IUserService _userService;
         private readonly ICurrentContext _currentContext;
-        private readonly IPolicyRepository _policyRepository;
 
         public OrganizationUsersController(
             IOrganizationRepository organizationRepository,
@@ -35,8 +34,7 @@ namespace Bit.Api.Controllers
             ICollectionRepository collectionRepository,
             IGroupRepository groupRepository,
             IUserService userService,
-            ICurrentContext currentContext,
-            IPolicyRepository policyRepository)
+            ICurrentContext currentContext)
         {
             _organizationRepository = organizationRepository;
             _organizationUserRepository = organizationUserRepository;
@@ -45,7 +43,6 @@ namespace Bit.Api.Controllers
             _groupRepository = groupRepository;
             _userService = userService;
             _currentContext = currentContext;
-            _policyRepository = policyRepository;
         }
 
         [HttpGet("{id}")]

--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -560,17 +560,10 @@ namespace Bit.Api.Controllers
         [HttpGet("{id}/keys")]
         public async Task<OrganizationKeysResponseModel> GetKeys(string id)
         {
-            var user = await _userService.GetUserByPrincipalAsync(User);
-            if (user == null)
-            {
-                throw new UnauthorizedAccessException();
-            }
-            
-            // If the keys aren't populated, error out
             var org = await _organizationRepository.GetByIdAsync(new Guid(id));
-            if (org == null || org.PublicKey == null || org.PrivateKey == null)
+            if (org == null)
             {
-                throw new BadRequestException("Organization Keys are not available");
+                throw new NotFoundException();
             }
 
             return new OrganizationKeysResponseModel(org);
@@ -584,33 +577,8 @@ namespace Bit.Api.Controllers
             {
                 throw new UnauthorizedAccessException();
             }
-            
-            // Only Owners/Admins/Custom (w/ ManageResetPassword) can create org keys
-            var orgGuidId = new Guid(id);
-            var orgUser = await _organizationUserRepository.GetDetailsByUserAsync(user.Id, orgGuidId);
-            if (orgUser == null || orgUser.Type != OrganizationUserType.Admin && 
-                orgUser.Type != OrganizationUserType.Owner && orgUser.Type != OrganizationUserType.Custom)
-            {
-                throw new UnauthorizedAccessException();
-            }
 
-            if (orgUser.Type == OrganizationUserType.Custom)
-            {
-                var permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(orgUser.Permissions);
-                if (permissions == null || !permissions.ManageResetPassword)
-                {
-                    throw new UnauthorizedAccessException();
-                }
-            }
-            
-            // If the keys already exist, error out
-            var org = await _organizationRepository.GetByIdAsync(orgGuidId);
-            if (org == null || org.PublicKey != null && org.PrivateKey != null)
-            {
-                throw new BadRequestException("Organization Keys already exist");
-            }
-
-            await _organizationService.UpdateAsync(model.ToOrganization(org));
+            var org = await _organizationService.UpdateOrganizationKeysAsync(user.Id, new Guid(id), model.PublicKey, model.EncryptedPrivateKey);
             return new OrganizationKeysResponseModel(org);
         }
     }

--- a/src/Core/Models/Api/Response/OrganizationKeysResponseModel.cs
+++ b/src/Core/Models/Api/Response/OrganizationKeysResponseModel.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Bit.Core.Models.Table;
+
+namespace Bit.Core.Models.Api
+{
+    public class OrganizationKeysResponseModel : ResponseModel
+    {
+        public OrganizationKeysResponseModel(Organization org) : base("organizationKeys")
+        {
+            if (org == null)
+            {
+                throw new ArgumentNullException(nameof(org));
+            }
+            
+            PublicKey = org.PublicKey;
+            PrivateKey = org.PrivateKey;
+        }
+        
+        public string PublicKey { get; set; }
+        public string PrivateKey { get; set; }
+    }
+}

--- a/src/Core/Models/Api/Response/OrganizationUserResponseModel.cs
+++ b/src/Core/Models/Api/Response/OrganizationUserResponseModel.cs
@@ -100,10 +100,12 @@ namespace Bit.Core.Models.Api
             Kdf = orgUser.Kdf;
             KdfIterations = orgUser.KdfIterations;
             ResetPasswordKey = orgUser.ResetPasswordKey;
+            EncryptedPrivateKey = orgUser.EncryptedPrivateKey;
         }
         
         public KdfType Kdf { get; set; }
         public int KdfIterations { get; set; }
         public string ResetPasswordKey { get; set; }
+        public string EncryptedPrivateKey { get; set; }
     }
 }

--- a/src/Core/Models/Data/OrganizationUserResetPasswordDetails.cs
+++ b/src/Core/Models/Data/OrganizationUserResetPasswordDetails.cs
@@ -6,7 +6,7 @@ namespace Bit.Core.Models.Data
 {
     public class OrganizationUserResetPasswordDetails
     {
-        public OrganizationUserResetPasswordDetails(OrganizationUser orgUser, User user)
+        public OrganizationUserResetPasswordDetails(OrganizationUser orgUser, User user, Organization org)
         {
             if (orgUser == null)
             {
@@ -17,13 +17,20 @@ namespace Bit.Core.Models.Data
             {
                 throw new ArgumentNullException(nameof(user));
             }
+            
+            if (org == null)
+            {
+                throw new ArgumentNullException(nameof(org));
+            }
 
             Kdf = user.Kdf;
             KdfIterations = user.KdfIterations;
             ResetPasswordKey = orgUser.ResetPasswordKey;
+            EncryptedPrivateKey = org.PrivateKey;
         }
         public KdfType Kdf { get; set; }
         public int KdfIterations { get; set; }
         public string ResetPasswordKey { get; set; }
+        public string EncryptedPrivateKey { get; set; }
     }
 }

--- a/src/Core/Services/IOrganizationService.cs
+++ b/src/Core/Services/IOrganizationService.cs
@@ -4,6 +4,7 @@ using Bit.Core.Models.Table;
 using System;
 using System.Collections.Generic;
 using Bit.Core.Enums;
+using Bit.Core.Models.Api;
 using Bit.Core.Models.Data;
 
 namespace Bit.Core.Services
@@ -53,5 +54,6 @@ namespace Bit.Core.Services
             bool overwriteExisting);
         Task RotateApiKeyAsync(Organization organization);
         Task DeleteSsoUserAsync(Guid userId, Guid? organizationId);
+        Task<Organization> UpdateOrganizationKeysAsync(Guid userId, Guid orgId, string publicKey, string privateKey);
     }
 }

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -34,7 +34,7 @@ namespace Bit.Core.Services
             string token, string key);
         Task<IdentityResult> ChangePasswordAsync(User user, string masterPassword, string newMasterPassword, string key);
         Task<IdentityResult> SetPasswordAsync(User user, string newMasterPassword, string key, string orgIdentifier = null);
-        Task<IdentityResult> AdminResetPasswordAsync(User user, string newMasterPassword, string key);
+        Task<IdentityResult> AdminResetPasswordAsync(Guid orgId, Guid id, string newMasterPassword, string key);
         Task<IdentityResult> ChangeKdfAsync(User user, string masterPassword, string newMasterPassword, string key,
             KdfType kdf, int kdfIterations);
         Task<IdentityResult> UpdateKeyAsync(User user, string masterPassword, string key, string privateKey,

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -34,7 +34,7 @@ namespace Bit.Core.Services
             string token, string key);
         Task<IdentityResult> ChangePasswordAsync(User user, string masterPassword, string newMasterPassword, string key);
         Task<IdentityResult> SetPasswordAsync(User user, string newMasterPassword, string key, string orgIdentifier = null);
-        Task<IdentityResult> AdminResetPasswordAsync(Guid orgId, Guid id, string newMasterPassword, string key);
+        Task<IdentityResult> AdminResetPasswordAsync(OrganizationUserType type, Guid orgId, Guid id, string newMasterPassword, string key);
         Task<IdentityResult> ChangeKdfAsync(User user, string masterPassword, string newMasterPassword, string key,
             KdfType kdf, int kdfIterations);
         Task<IdentityResult> UpdateKeyAsync(User user, string masterPassword, string key, string privateKey,

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1417,14 +1417,17 @@ namespace Bit.Core.Services
         public async Task UpdateUserResetPasswordEnrollmentAsync(Guid organizationId, Guid organizationUserId, string resetPasswordKey, Guid? callingUserId)
         {
             var orgUser = await _organizationUserRepository.GetByOrganizationAsync(organizationId, organizationUserId);
-            if (!callingUserId.HasValue || orgUser == null || orgUser.UserId != callingUserId.Value ||
-                orgUser.Status != OrganizationUserStatusType.Confirmed ||
+            if (!callingUserId.HasValue || orgUser == null || orgUser.UserId != callingUserId.Value || 
                 orgUser.OrganizationId != organizationId)
             {
                 throw new BadRequestException("User not valid.");
             }
             
-            // TODO - Block certain org types from using this feature?
+            var org = await _organizationRepository.GetByIdAsync(organizationId);
+            if (org == null || !org.UseResetPassword)
+            {
+                throw new BadRequestException("Organization does not allow password reset enrollment.");
+            }
 
             orgUser.ResetPasswordKey = resetPasswordKey;
             await _organizationUserRepository.ReplaceAsync(orgUser);

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -689,6 +689,7 @@ namespace Bit.Core.Services
             user.Key = key;
 
             await _userRepository.ReplaceAsync(user);
+            // TODO Reset Password - Send email alerting user of changed password
             await _eventService.LogUserEventAsync(user.Id, EventType.User_ChangedPassword);
             await _pushService.PushLogOutAsync(user.Id);
 


### PR DESCRIPTION
## Objective
> Create an API that will `get` and `post` organization keys.  This API will be used to backfill existing organizations without the necessary keys. Client side encryption must happen beforehand (which is why it cannot be automated server side). Update existing `ResetPassword` APIs to include checks for org type and policy enforcement.

## Code Changes
- **OrganizationUsersController**: Added `PolicyRepository` to the class. Added `org` information to the `OrganizationUserResetPasswordDetailsResponseModel` in order to pass along the `EncryptedPrivateKey`. Added organization and policy checks to the `PutResetPassword`
- **OrganizationsController**: Added `GET` and `POST` method to retrieve and set the organization `Public/Private Keys`
- **OrganizationKeysResponseModel**: Created response model that returns the `Public/Private Keys` of the organization
- **OrganizationUserResponseModel**: Added `EncryptedPrivateKey` to the `OrganizationUserResetPasswordDetailsResponseModel`
- **OrganizationUserResetPasswordDetails**: Added `EncryptedPrivateKey` to the data model
- **OrganizationService**: Removed condition that the user needs to be confirmed to the org to enroll as users will now be able to enroll during the org invite flow.  Added organization and policy checks to the enrollment method.
- **IUserService**: Updated interface method to accept calling user's org user type
- **UserService**: Updated `AdminResetPasswordAsync` method to handle more validation (moved from controller)

## Dependencies
- [Server - Enterprise Policy](https://github.com/bitwarden/server/pull/1315)