### PR TITLE
Prevent error when using WebAuthn as non premium user

### DIFF
--- a/src/Core/IdentityServer/BaseRequestValidator.cs
+++ b/src/Core/IdentityServer/BaseRequestValidator.cs
@@ -433,6 +433,11 @@ namespace Bit.Core.IdentityServer
                     }
                     else if (type == TwoFactorProviderType.WebAuthn)
                     {
+                        if (token == null)
+                        {
+                            return null;
+                        }
+
                         return JsonSerializer.Deserialize<Dictionary<string, object>>(token);
                     }
                     else if (type == TwoFactorProviderType.Email)

--- a/src/Core/Models/TwoFactorProvider.cs
+++ b/src/Core/Models/TwoFactorProvider.cs
@@ -131,6 +131,7 @@ namespace Bit.Core.Models
                 case TwoFactorProviderType.Duo:
                 case TwoFactorProviderType.YubiKey:
                 case TwoFactorProviderType.U2f:
+                case TwoFactorProviderType.WebAuthn:
                     return true;
                 default:
                     return false;


### PR DESCRIPTION
## Objective
WebAuthn was incorrectly marked as a non-premium option in one of the functions which caused it to return null which threw an error on the Json deserializer.

### Code Changes
- **src/Core/IdentityServer/BaseRequestValidator.cs**: Correctly handle null.
- **src/Core/Models/TwoFactorProvider.cs**: Mark WebAuthn as a premium two-factor provider

https://github.com/bitwarden/server/pull/903#pullrequestreview-660238483