### PR TITLE
Version bump 1.41.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
 	<PropertyGroup>
-		<Version>1.41.2</Version>
+		<Version>1.41.3</Version>
 		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<RootNamespace>Bit.$(MSBuildProjectName)</RootNamespace>
 	</PropertyGroup>


### PR DESCRIPTION
this is for dexterity as `rc` has already gotten the new version bump directly (because the manner of version tracking has diverged from the last release in `master`).