### PR TITLE
Pin versions of actions in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Set up cloc
         run: |
@@ -27,34 +27,33 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Set up NuGet
-        uses: nuget/setup-nuget@v1
+        uses: nuget/setup-nuget@04b0c2b8d1b97922f67eca497d7cf0bf17b8ffe1
         with:
           nuget-version: 'latest'
 
       - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v1
+        uses: microsoft/setup-msbuild@c26a08ba26249b81327e26f6ef381897b6a8754d
 
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: '10.x'
+          node-version: '14'
 
       - name: Print environment
         run: |
-          nuget help | grep "Version"
+          nuget help | grep Version
           msbuild -version
           dotnet --info
           node --version
           npm --version
-          Write-Output "GitHub ref: $env:GITHUB_REF"
-          Write-Output "GitHub event: $env:GITHUB_EVENT"
-        shell: pwsh
+          echo "GitHub ref: $GITHUB_REF"
+          echo "GitHub event: $GITHUB_EVENT"
         env:
           GITHUB_REF: ${{ github.ref }}
           GITHUB_EVENT: ${{ github.event_name }}
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Restore
         run: msbuild /t:restore
@@ -73,9 +72,9 @@ jobs:
     needs: testing
     steps:
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: '10.x'
+          node-version: '14'
 
       - name: Set up gulp
         run: npm i -g gulp
@@ -88,9 +87,8 @@ jobs:
           npm --version
           gulp --version
           docker --version
-          Write-Output "GitHub ref: $env:GITHUB_REF"
-          Write-Output "GitHub event: $env:GITHUB_EVENT"
-        shell: pwsh
+          echo "GitHub ref: $GITHUB_REF"
+          echo "GitHub event: $GITHUB_EVENT"
         env:
           GITHUB_REF: ${{ github.ref }}
           GITHUB_EVENT: ${{ github.event_name }}
@@ -128,7 +126,7 @@ jobs:
           DCT_DELEGATE_KEY: ${{ steps.retrieve-secrets.outputs.dct-delegate-2-key }}
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Restore
         run: dotnet tool restore
@@ -176,7 +174,7 @@ jobs:
           cd docker-stub; zip -r ../docker-stub.zip *; cd ..
 
       - name: Upload docker stub artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: docker-stub.zip
           path: ./docker-stub.zip
@@ -193,7 +191,7 @@ jobs:
           swaggerGen: 'True'
 
       - name: Upload swagger artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: swagger.json
           path: ./swagger.json

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -18,7 +18,7 @@ jobs:
       tag_version: ${{ steps.create_tags.outputs.tag_version }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Create Deploy version vars
         id: create_tags
@@ -87,14 +87,14 @@ jobs:
       TAG_VERSION: ${{ needs.setup.outputs.tag_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           ref: ${{ env.TAG_VERSION }}
 
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: '10.x'
+          node-version: '14'
 
       - name: Print Environment
         run: |
@@ -140,7 +140,7 @@ jobs:
           GULP: ${{ matrix.gulp }}
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: ${{ env.SERVICE_NAME }}.zip
           path: ${{ env.BASE_PATH }}/src/${{ env.SERVICE_NAME }}/${{ env.SERVICE_NAME }}.zip
@@ -160,7 +160,7 @@ jobs:
     needs: build
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Identity.zip
 
@@ -178,7 +178,7 @@ jobs:
                     appservices-identity-webapp-publish-profile"
 
       - name: Deploy Identity
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-name }} 
           slot-name: "staging"
@@ -191,7 +191,7 @@ jobs:
     needs: build
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Api.zip
 
@@ -209,7 +209,7 @@ jobs:
                     appservices-api-webapp-publish-profile"
 
       - name: Deploy Api
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-name }} 
           slot-name: "staging"
@@ -222,7 +222,7 @@ jobs:
     needs: build
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Billing.zip
 
@@ -240,7 +240,7 @@ jobs:
                     appservices-billing-webapp-publish-profile"
 
       - name: Deploy Billing
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-name }} 
           slot-name: "staging"
@@ -253,7 +253,7 @@ jobs:
     needs: build
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Events.zip
 
@@ -271,7 +271,7 @@ jobs:
                     appservices-events-webapp-publish-profile"
 
       - name: Deploy Events
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-name }} 
           slot-name: "staging"
@@ -284,7 +284,7 @@ jobs:
     needs: build
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Sso.zip
 
@@ -302,7 +302,7 @@ jobs:
                     appservices-sso-webapp-publish-profile"
 
       - name: Deploy SSO
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-name }} 
           slot-name: "staging"
@@ -315,7 +315,7 @@ jobs:
     needs: build
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Portal.zip
 
@@ -333,7 +333,7 @@ jobs:
                     appservices-portal-webapp-publish-profile"
 
       - name: Deploy Portal
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-name }} 
           slot-name: "staging"
@@ -346,7 +346,7 @@ jobs:
     needs: build
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Admin.zip
 
@@ -364,7 +364,7 @@ jobs:
                     appservices-admin-webapp-publish-profile"
 
       - name: Deploy Admin
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-name }} 
           slot-name: "staging"

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -41,12 +41,12 @@ jobs:
             base_path: .
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: '10.x'
+          node-version: '14'
 
       - name: Print Environment
         run: |
@@ -92,7 +92,7 @@ jobs:
           GULP: ${{ matrix.gulp }}
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: ${{ env.SERVICE_NAME }}.zip
           path: ${{ env.BASE_PATH }}/src/${{ env.SERVICE_NAME }}/${{ env.SERVICE_NAME }}.zip
@@ -135,7 +135,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Identity.zip
 
@@ -153,7 +153,7 @@ jobs:
                     appservices-identity-webapp-publish-profile"
 
       - name: Deploy Identity
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-name }} 
           slot-name: "staging"
@@ -168,7 +168,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Api.zip
 
@@ -186,7 +186,7 @@ jobs:
                     appservices-api-webapp-publish-profile"
 
       - name: Deploy Api
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-name }} 
           slot-name: "staging"
@@ -201,7 +201,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Billing.zip
 
@@ -219,7 +219,7 @@ jobs:
                     appservices-billing-webapp-publish-profile"
 
       - name: Deploy Billing
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-name }} 
           slot-name: "staging"
@@ -234,7 +234,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Events.zip
 
@@ -252,7 +252,7 @@ jobs:
                     appservices-events-webapp-publish-profile"
 
       - name: Deploy Events
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-name }} 
           slot-name: "staging"
@@ -267,7 +267,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Sso.zip
 
@@ -285,7 +285,7 @@ jobs:
                     appservices-sso-webapp-publish-profile"
 
       - name: Deploy SSO
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-name }} 
           slot-name: "staging"
@@ -300,7 +300,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Portal.zip
 
@@ -318,7 +318,7 @@ jobs:
                     appservices-portal-webapp-publish-profile"
 
       - name: Deploy Portal
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-name }} 
           slot-name: "staging"
@@ -333,7 +333,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Admin.zip
 
@@ -351,7 +351,7 @@ jobs:
                     appservices-admin-webapp-publish-profile"
 
       - name: Deploy Admin
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-name }} 
           slot-name: "staging"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       tag_version: ${{ steps.create_tags.outputs.tag_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Create Release Vars
         id: create_tags
@@ -43,7 +43,7 @@ jobs:
 
       - name: Create Draft Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -63,9 +63,8 @@ jobs:
         run: |
           whoami
           docker --version
-          Write-Output "GitHub ref: $env:GITHUB_REF"
-          Write-Output "GitHub event: $env:GITHUB_EVENT"
-        shell: pwsh
+          echo "GitHub ref: $GITHUB_REF"
+          echo "GitHub event: $GITHUB_EVENT"
         env:
           GITHUB_REF: ${{ github.ref }}
           GITHUB_EVENT: ${{ github.event_name }}
@@ -102,7 +101,7 @@ jobs:
           DCT_DELEGATE_KEY: ${{ steps.retrieve-secrets.outputs.dct-delegate-2-key }}
           
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Restore
         run: dotnet tool restore
@@ -182,7 +181,7 @@ jobs:
           cd docker-stub; zip -r ../docker-stub.zip *; cd ..
 
       - name: Upload docker stub artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: docker-stub.zip
           path: ./docker-stub.zip
@@ -206,7 +205,7 @@ jobs:
           swaggerGen: 'True'
 
       - name: Upload swagger artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: swagger.json
           path: ./swagger.json


### PR DESCRIPTION
This pins all action versions in the workflows to commit hashes. This protects us from any malicious changes to the actions in case people force push tags.