### PR TITLE
Self hosted web version bump v2.20.3

### DIFF
--- a/scripts/bitwarden.ps1
+++ b/scripts/bitwarden.ps1
@@ -27,7 +27,7 @@ $githubBaseUrl = "https://raw.githubusercontent.com/bitwarden/server/master"
 
 # Please do not create pull requests modifying the version numbers.
 $coreVersion = "1.41.3"
-$webVersion = "2.20.1"
+$webVersion = "2.20.3"
 
 # Functions
 

--- a/scripts/bitwarden.sh
+++ b/scripts/bitwarden.sh
@@ -35,7 +35,7 @@ GITHUB_BASE_URL="https://raw.githubusercontent.com/bitwarden/server/master"
 
 # Please do not create pull requests modifying the version numbers.
 COREVERSION="1.41.3"
-WEBVERSION="2.20.1"
+WEBVERSION="2.20.3"
 
 echo "bitwarden.sh version $COREVERSION"
 docker --version


### PR DESCRIPTION
For self-hosted deployment of version [2.20.3 of the web vault](https://github.com/bitwarden/web/releases/tag/v2.20.3).