### PR TITLE
Prevent sole owner from downgrading permissions

### DIFF
--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1453,7 +1453,7 @@ namespace Bit.Core.Services
             }
 
             if (user.Type != OrganizationUserType.Owner &&
-                !await HasConfirmedOwnersExceptAsync(user.OrganizationId, Enumerable.Empty<Guid>()))
+                !await HasConfirmedOwnersExceptAsync(user.OrganizationId, new[] {user.Id}))
             {
                 throw new BadRequestException("Organization must have at least one confirmed owner.");
             }


### PR DESCRIPTION
## Objective
Fix the following issue:

> An owner of an organization can downgrade their own role to a non-admin/non-owner role, leaving an organization without an Owner.

## Code changes

Fix the call to `HasConfirmedOwnersExceptAsync`.

`HasConfirmedOwnersExceptAsync` checks whether a specified Org (first argument) has any owners **other than** the specified orgUsers (second argument). The second argument was not specified, so this check wasn't working properly. Change this so that we pass in the Id of the orgUser being changed.