### PR TITLE
[Reset Password] Added new event type for admin password reset

### DIFF
--- a/src/Core/Enums/EventType.cs
+++ b/src/Core/Enums/EventType.cs
@@ -46,6 +46,7 @@
         OrganizationUser_UnlinkedSso = 1505,
         OrganizationUser_ResetPassword_Enroll = 1506,
         OrganizationUser_ResetPassword_Withdraw = 1507,
+        OrganizationUser_AdminResetPassword = 1508,
 
         Organization_Updated = 1600,
         Organization_PurgedVault = 1601,

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -690,7 +690,7 @@ namespace Bit.Core.Services
 
             await _userRepository.ReplaceAsync(user);
             // TODO Reset Password - Send email alerting user of changed password
-            await _eventService.LogUserEventAsync(user.Id, EventType.User_ChangedPassword);
+            await _eventService.LogOrganizationUserEventAsync(orgUser, EventType.OrganizationUser_AdminResetPassword);
             await _pushService.PushLogOutAsync(user.Id);
 
             return IdentityResult.Success;


### PR DESCRIPTION
## Objective
> Create new event type to handle an administrator changing an organization user's master password.

## Code Changes
- **EventType.cs**: Added `OrganizationUser_AdminResetPassword` event type enumeration
- **UserService.cs**: Updated event firing to pass in `orgUser` and the new event type