### PR TITLE
[Reset Password] Email template

### DIFF
--- a/src/Core/MailTemplates/Handlebars/AdminResetPassword.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/AdminResetPassword.html.hbs
@@ -1,0 +1,9 @@
+{{#>FullHtmlLayout}}
+<table width="100%" cellpadding="0" cellspacing="0" style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;" valign="top">
+            The master password for <b style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">{{UserName}}</b> has been changed by an administrator in your <b style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">{{OrgName}}</b> organization. If you did not initiate this request, please reach out to your administrator immediately.
+        </td>
+    </tr>
+</table>
+{{/FullHtmlLayout}}

--- a/src/Core/MailTemplates/Handlebars/AdminResetPassword.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/AdminResetPassword.text.hbs
@@ -1,0 +1,3 @@
+{{#>BasicTextLayout}}
+The master password for {{UserName}} has been changed by an administrator in your {{OrgName}} organization. If you did not initiate this request, please reach out to your administrator immediately.
+{{/BasicTextLayout}}

--- a/src/Core/Models/Mail/AdminResetPasswordViewModel.cs
+++ b/src/Core/Models/Mail/AdminResetPasswordViewModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Bit.Core.Models.Mail
+{
+    public class AdminResetPasswordViewModel : BaseMailModel
+    {
+        public string UserName { get; set; }
+        public string OrgName { get; set; }
+    }
+}

--- a/src/Core/Services/IMailService.cs
+++ b/src/Core/Services/IMailService.cs
@@ -40,5 +40,6 @@ namespace Bit.Core.Services
         Task SendEmergencyAccessRecoveryReminder(EmergencyAccess emergencyAccess, string initiatingName, string email);
         Task SendEmergencyAccessRecoveryTimedOut(EmergencyAccess ea, string initiatingName, string email);
         Task SendEnqueuedMailMessageAsync(IMailQueueMessage queueMessage);
+        Task SendAdminResetPasswordEmailAsync(string email, string userName, string orgName);
     }
 }

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -361,6 +361,19 @@ namespace Bit.Core.Services
             await AddMessageContentAsync(message, queueMessage.TemplateName, queueMessage.Model);
             await _mailDeliveryService.SendEmailAsync(message);
         }
+        
+        public async Task SendAdminResetPasswordEmailAsync(string email, string userName, string orgName)
+        {
+            var message = CreateDefaultMessage("Master Password Has Been Changed", email);
+            var model = new AdminResetPasswordViewModel()
+            {
+                UserName = CoreHelpers.SanitizeForEmail(userName),
+                OrgName = CoreHelpers.SanitizeForEmail(orgName),
+            };
+            await AddMessageContentAsync(message, "AdminResetPassword", model);
+            message.Category = "AdminResetPassword";
+            await _mailDeliveryService.SendEmailAsync(message);
+        }
 
         private Task EnqueueMailAsync(IMailQueueMessage queueMessage) =>
             _mailEnqueuingService.EnqueueAsync(queueMessage, SendEnqueuedMailMessageAsync);

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -689,7 +689,7 @@ namespace Bit.Core.Services
             user.Key = key;
 
             await _userRepository.ReplaceAsync(user);
-            // TODO Reset Password - Send email alerting user of changed password
+            await _mailService.SendAdminResetPasswordEmailAsync(user.Email, user.Name ?? user.Email, org.Name);
             await _eventService.LogUserEventAsync(user.Id, EventType.User_ChangedPassword);
             await _pushService.PushLogOutAsync(user.Id);
 

--- a/src/Core/Services/NoopImplementations/NoopMailService.cs
+++ b/src/Core/Services/NoopImplementations/NoopMailService.cs
@@ -158,5 +158,10 @@ namespace Bit.Core.Services
         {
             return Task.FromResult(0);
         }
+        
+        public Task SendAdminResetPasswordEmailAsync(string email, string userName, string orgName)
+        {
+            return Task.FromResult(0);
+        }
     }
 }


### PR DESCRIPTION
## Objective
> Send a notification email when an org user's password has been changed by an administrator

## Code Changes
- **MailTemplates/AdminResetPassword**: Created `html` and `text` versions of the email template
- **AdminResetPasswordViewModel**: Created view model to hold necessary data for email
- **IMailService**: Created interface method `SendAdminResetPasswordEmailAsync`
- **HandlebarsMailService**: Created method to populate and send email
- **UserService**: Replace `TODO` with call to the `mailService`
- **NoopMailService**: Added method to satisfy interface condition

## Screenshots
![10-reset-email](https://user-images.githubusercontent.com/26154748/119698069-7c5d9d80-be16-11eb-86d5-87989d8ea999.png)
