### PR TITLE
Fix typo in bulk reinvinte migration

### DIFF
--- a/util/Migrator/DbScripts/2021-05-11_00_BulkReinvite.sql
+++ b/util/Migrator/DbScripts/2021-05-11_00_BulkReinvite.sql
@@ -1,6 +1,6 @@
 ﻿IF OBJECT_ID('[dbo].[OrganizationUser_ReadByIds]') IS NOT NULL
 BEGIN
-    DROP FUNCTION [dbo].[OrganizationUser_ReadByIds]
+    DROP PROCEDURE [dbo].[OrganizationUser_ReadByIds]
 END
 GO
 


### PR DESCRIPTION
Prevents re-running the migration.