### PR TITLE
Android FIDO2 Asset Links

### DIFF
--- a/util/Setup/AssetLinksBuilder.cs
+++ b/util/Setup/AssetLinksBuilder.cs
@@ -1,0 +1,35 @@
+using System.IO;
+
+namespace Bit.Setup
+{
+    public class AssetLinksBuilder
+    {
+        private readonly Context _context;
+
+        public AssetLinksBuilder(Context context)
+        {
+            _context = context;
+        }
+
+        public void Build()
+        {
+            var model = new TemplateModel
+            {
+                Url = _context.Config.Url
+            };
+
+            Helpers.WriteLine(_context, "Building Asset Links For Fido2.");
+            Directory.CreateDirectory("/bitwarden/web/");
+            var template = Helpers.ReadTemplate("AssetLinks");
+            using (var sw = File.CreateText("/bitwarden/web/assetlinks.json"))
+            {
+                sw.Write(template(model));
+            }
+        }
+
+        public class TemplateModel
+        {
+            public string Url { get; set; }
+        }
+    }
+}

--- a/util/Setup/Program.cs
+++ b/util/Setup/Program.cs
@@ -102,6 +102,9 @@ namespace Bit.Setup
             var appIdBuilder = new AppIdBuilder(_context);
             appIdBuilder.Build();
 
+            var assetLinksBuilder = new AssetLinksBuilder(_context);
+            assetLinksBuilder.Build();
+
             var dockerComposeBuilder = new DockerComposeBuilder(_context);
             dockerComposeBuilder.BuildForInstaller();
 
@@ -274,6 +277,9 @@ namespace Bit.Setup
 
             var appIdBuilder = new AppIdBuilder(_context);
             appIdBuilder.Build();
+
+            var assetLinksBuilder = new AssetLinksBuilder(_context);
+            assetLinksBuilder.Build();
 
             var dockerComposeBuilder = new DockerComposeBuilder(_context);
             dockerComposeBuilder.BuildForUpdater();

--- a/util/Setup/Templates/AssetLinks.hbs
+++ b/util/Setup/Templates/AssetLinks.hbs
@@ -17,8 +17,15 @@
         "target":{
             "namespace":"android_app",
             "package_name":"com.x8bit.bitwarden",
-            "sha256_cert_fingerprints":[
-                "2C:"
+            "md5_cert_fingerprints":[
+                "BE:9E:C3:1A:F7:2B:4E:1B:0F:69:A0:7D:4C:60:EC:BD",
+                "28:F6:CE:D1:65:B8:66:60:CE:1D:3C:36:4F:41:57:10"
+            ],"sha1_cert_fingerprints":[
+                "75:41:85:CD:4C:DF:DE:59:87:48:B0:43:04:8B:FE:59:A1:72:64:C2",
+                "A5:20:9B:A6:B2:70:62:DC:02:64:E3:CE:A6:65:3A:62:E3:C1:B3:F8"
+            ],"sha256_cert_fingerprints":[
+                "24:E0:6C:04:C2:08:04:8F:19:F1:C9:93:B4:DD:A4:43:0E:A8:B0:6D:B8:37:5E:A0:E3:7B:83:46:96:B9:AC:3A",
+                "16:E6:C0:3F:F9:55:50:82:E7:B5:2B:C7:73:56:69:62:1E:CB:C0:EA:03:6A:2F:E5:99:E3:D7:34:AC:B2:CE:03"
             ]
         }
     }

--- a/util/Setup/Templates/AssetLinks.hbs
+++ b/util/Setup/Templates/AssetLinks.hbs
@@ -1,0 +1,25 @@
+[
+    {
+        "relation":[
+            "delegate_permission/common.handle_all_urls",
+            "delegate_permission/common.get_login_creds"
+        ],
+        "target":{
+            "namespace":"web",
+            "site":"{{{Url}}}"
+        }
+    },
+    {
+        "relation":[
+            "delegate_permission/common.handle_all_urls",
+            "delegate_permission/common.get_login_creds"
+        ],
+        "target":{
+            "namespace":"android_app",
+            "package_name":"com.x8bit.bitwarden",
+            "sha256_cert_fingerprints":[
+                "2C:"
+            ]
+        }
+    }
+]

--- a/util/Setup/Templates/NginxConfig.hbs
+++ b/util/Setup/Templates/NginxConfig.hbs
@@ -84,6 +84,16 @@ server {
     add_header Content-Type $fido_content_type;
   }
 
+  location = /.well-known/assetlinks.json {
+    proxy_pass http://web:5000/assetlinks.json;
+{{#if Ssl}}
+    include /etc/nginx/security-headers-ssl.conf;
+{{/if}}
+    include /etc/nginx/security-headers.conf;    
+    proxy_hide_header Content-Type;
+    add_header Content-Type application/json;
+  }
+
   location = /duo-connector.html {
     proxy_pass http://web:5000/duo-connector.html;
   }


### PR DESCRIPTION
Added assetlinks for Android FIDO2 authentication.  Details on what/why can be found here:  https://developers.google.com/identity/fido/android/native-apps

Element 0 of each cert fingerprint is for our release build.  Element 1 (and beyond in the future) is for debugging.

Credit goes to https://github.com/DestruidorPT/server/commit/cee9e5b2e12b92b68b4b42b9f603be93bce0b231 for the implementation