### PR TITLE
Retro fixes

### DIFF
--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -1,9 +1,6 @@
 name: QA Deploy
 
 on:
-  push:
-    branches:
-      - 'rc'
   workflow_dispatch:
     inputs: 
       migrateDb:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,7 @@ jobs:
           hub release edit \
             -a ./swagger.json \
             -a ./docker-stub.zip \
-            -m "Version $RELEASE_VERSION" \
+            -m "" \
             $TAG_VERSION
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,12 @@ jobs:
   upload:
     name: Upload
     runs-on: ubuntu-latest
-    needs: release
+    needs: 
+      - setup
+      - release
+    env:
+      RELEASE_VERSION: ${{ needs.setup.outputs.release_version }}
+      TAG_VERSION: ${{ needs.setup.outputs.tag_version }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
@@ -207,6 +212,6 @@ jobs:
             -a ./swagger.json \
             -a ./docker-stub.zip \
             -m "Version $RELEASE_VERSION" \
-            $RELEASE_TAG_NAME
+            $TAG_VERSION
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ env.RELEASE_TAG_NAME }}
-          release_name: ${{ env.RELEASE_NAME }}
+          release_name: Version ${{ env.RELEASE_NAME }}
           draft: true
           prerelease: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,15 @@ jobs:
       release_version: ${{ steps.create_tags.outputs.package_version }}
       tag_version: ${{ steps.create_tags.outputs.tag_version }}
     steps:
+      - name: Branch check
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/rc" ]]; then
+            echo "==================================="
+            echo "[!] Can only release from rc branch"
+            echo "==================================="
+            exit 1
+          fi
+
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 


### PR DESCRIPTION
## Summary
In the DevOps retro, we identified areas that could use improvement in the server deploys:

- fixing release asset uploads
- Automatically add "Version" to the release name
- Restrict the QA deploy to only a manual workflow trigger (for now)
- restrict prod release to only the rc branch