### PR TITLE
Fix attachments typo

### DIFF
--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -10,8 +10,8 @@ namespace Bit.Core.Settings
         public GlobalSettings()
         {
             BaseServiceUri = new BaseServiceUriSettings(this);
-            Attachment = new FileStorageSettings(this, "attchments", "attchments");
-            Send = new FileStorageSettings(this, "attchments/send", "attchments/send");
+            Attachment = new FileStorageSettings(this, "attachments", "attachments");
+            Send = new FileStorageSettings(this, "attachments/send", "attachments/send");
             DataProtection = new DataProtectionSettings(this);
         }
 


### PR DESCRIPTION
Fixes typo `attchments` which breaks attachments and send files.

Temporary fix is to set these two lines in `global.override.env`:

```INI
globalSettings__attachment__baseDirectory=/etc/bitwarden/core/attachments
globalSettings__send__baseDirectory=/etc/bitwarden/core/attachments/send
```

See #1367 