### PR TITLE
[Reset Password] Admin page updates

### DIFF
--- a/src/Admin/Models/OrganizationEditModel.cs
+++ b/src/Admin/Models/OrganizationEditModel.cs
@@ -37,6 +37,7 @@ namespace Bit.Admin.Models
             UseTotp = org.UseTotp;
             Use2fa = org.Use2fa;
             UseApi = org.UseApi;
+            UseResetPassword = org.UseResetPassword;
             SelfHost = org.SelfHost;
             UsersGetPremium = org.UsersGetPremium;
             MaxStorageGb = org.MaxStorageGb;
@@ -86,6 +87,8 @@ namespace Bit.Admin.Models
         public bool Use2fa { get; set; }
         [Display(Name = "API")]
         public bool UseApi{ get; set; }
+        [Display(Name = "Reset Password")]
+        public bool UseResetPassword { get; set; }
         [Display(Name = "Self Host")]
         public bool SelfHost { get; set; }
         [Display(Name = "Users Get Premium")]
@@ -122,6 +125,7 @@ namespace Bit.Admin.Models
             existingOrganization.UseTotp = UseTotp;
             existingOrganization.Use2fa = Use2fa;
             existingOrganization.UseApi = UseApi;
+            existingOrganization.UseResetPassword = UseResetPassword;
             existingOrganization.SelfHost = SelfHost;
             existingOrganization.UsersGetPremium = UsersGetPremium;
             existingOrganization.MaxStorageGb = MaxStorageGb;

--- a/src/Admin/Models/OrganizationViewModel.cs
+++ b/src/Admin/Models/OrganizationViewModel.cs
@@ -16,6 +16,7 @@ namespace Bit.Admin.Models
             IEnumerable<Policy> policies)
         {
             Organization = org;
+            HasPublicPrivateKeys = org.PublicKey != null && org.PrivateKey != null;
             UserCount = orgUsers.Count();
             CipherCount = ciphers.Count();
             CollectionCount = collections.Count();
@@ -39,5 +40,6 @@ namespace Bit.Admin.Models
         public int CollectionCount { get; set; }
         public int GroupCount { get; set; }
         public int PolicyCount { get; set; }
+        public bool HasPublicPrivateKeys { get; set; }
     }
 }

--- a/src/Admin/Views/Organizations/Edit.cshtml
+++ b/src/Admin/Views/Organizations/Edit.cshtml
@@ -178,6 +178,10 @@
         <input type="checkbox" class="form-check-input" asp-for="UseEvents">
         <label class="form-check-label" asp-for="UseEvents"></label>
     </div>
+    <div class="form-check">
+        <input type="checkbox" class="form-check-input" asp-for="UseResetPassword">
+        <label class="form-check-label" asp-for="UseResetPassword"></label>
+    </div>
     <div class="form-check mb-3">
         <input type="checkbox" class="form-check-input" asp-for="UsersGetPremium">
         <label class="form-check-label" asp-for="UsersGetPremium"></label>

--- a/src/Admin/Views/Organizations/_ViewInformation.cshtml
+++ b/src/Admin/Views/Organizations/_ViewInformation.cshtml
@@ -32,6 +32,9 @@
 
     <dt class="col-sm-4 col-lg-3">Policies</dt>
     <dd class="col-sm-8 col-lg-9">@Model.PolicyCount</dd>
+    
+    <dt class="col-sm-4 col-lg-3">Public/Private Keys</dt>
+    <dd class="col-sm-8 col-lg-9">@(Model.HasPublicPrivateKeys ? "Yes" : "No")</dd>
 
     <dt class="col-sm-4 col-lg-3">Created</dt>
     <dd class="col-sm-8 col-lg-9">@Model.Organization.CreationDate.ToString()</dd>


### PR DESCRIPTION
## Objective
> Update the `Admin` project to allow administrators to adjust whether or not an organization has the ability to enable `Reset Password` and see if that organization has the necessary `Public/Private Keys` to do the reset operation.

## Code Changes
- **OrganizationEditModel**: Added `UseResetPassword` field. Adjusted boolean value during existing org transform and constructor.
- **OrganizationViewModel**: Added `HasPublicPrivateKeys` boolean field and adjusted value in constructor.
- **OrganizationsEdit.cshtml**: Added `checkbox` for `UseResetPassword` value
- **_ViewInformation.cshtml**:  Added `PublicPrivate Keys` row

## Screenshots
![11-admin-org-info](https://user-images.githubusercontent.com/26154748/120859702-33aa9080-c54a-11eb-804a-fc03516092a5.png)
![12-admin-org-features](https://user-images.githubusercontent.com/26154748/120859703-34432700-c54a-11eb-8136-397073ba9043.png)
