### PR TITLE
QA deploy without Publish Profiles

### DIFF
--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -128,12 +128,37 @@ jobs:
           echo "placeholder for updateing DB"
 
 
-  deploy-identity:
+  deploy:
     runs-on: ubuntu-latest
+    strategy:
     needs: 
       - reset-db
       - update-db
+      fail-fast: false
+      matrix:
+        include:
+          - name: Api
+            name_lower: api
+          - name: Admin
+            name_lower: admin
+          - name: Billing
+            name_lower: billing
+          - name: Events
+            name_lower: events
+          - name: Sso
+            name_lower: sso
+          - name: Portal
+            name_lower: portal
+          - name: Identity
+            name_lower: identity
     steps:
+      - name: Checkout custom AZ KV action
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          repository: joseph-flinn/get-keyvault-secrets
+          ref: refs/heads/add-dynamic-secret-support
+          path: ./github/actions/get-keyvault-secrets
+
       - name: Download aritifacts
         uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
@@ -146,24 +171,24 @@ jobs:
 
       - name: Retrieve secrets
         id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
+        uses: ./.github/actions/get-keyvault-secrets
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-identity-webapp-name"
+          secrets: "appservices-${{ matrix.name_lower }}-webapp-name:webapp-name"
 
       - name: Get Publish Profile
         id: get-pp
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
           resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-name }} 
+          appName: ${{ steps.retrieve-secrets.outputs.webapp-name }} 
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Deploy Identity
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
-          app-name: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-name }} 
+          app-name: ${{ steps.retrieve-secrets.outputs.webapp-name }} 
           slot-name: "staging"
           publish-profile: ${{ steps.get-pp.outputs.profile}} 
           package: ./Identity.zip
@@ -172,308 +197,7 @@ jobs:
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
           resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-name }} 
+          appName: ${{ steps.retrieve-secrets.outputs.webapp-name }} 
           reset: true
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-
-  deploy-api:
-    runs-on: ubuntu-latest
-    needs: 
-      - reset-db
-      - update-db
-    steps:
-      - name: Download aritifacts
-        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
-        with:
-          name: Api.zip
-
-      - name: Login to Azure
-        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
-        with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Retrieve secrets
-        id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
-        with:
-          keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-api-webapp-name"
-
-      - name: Get Publish Profile
-        id: get-pp
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-name }} 
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Deploy Api
-        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
-        with:
-          app-name: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-name }} 
-          slot-name: "staging"
-          publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-publish-profile }} 
-          package: ./Api.zip
-
-      - name: Reset Publish Profile
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-name }} 
-          reset: true
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-
-  deploy-billing:
-    runs-on: ubuntu-latest
-    needs: 
-      - reset-db
-      - update-db
-    steps:
-      - name: Download aritifacts
-        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
-        with:
-          name: Billing.zip
-
-      - name: Login to Azure
-        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
-        with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Retrieve secrets
-        id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
-        with:
-          keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-billing-webapp-name"
-
-      - name: Get Publish Profile
-        id: get-pp
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-name }} 
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Deploy Billing
-        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
-        with:
-          app-name: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-name }} 
-          slot-name: "staging"
-          publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-publish-profile }} 
-          package: ./Billing.zip
-
-      - name: Reset Publish Profile
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-name }} 
-          reset: true
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-
-  deploy-events:
-    runs-on: ubuntu-latest
-    needs: 
-      - reset-db
-      - update-db
-    steps:
-      - name: Download aritifacts
-        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
-        with:
-          name: Events.zip
-
-      - name: Login to Azure
-        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
-        with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Retrieve secrets
-        id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
-        with:
-          keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-events-webapp-name"
-
-      - name: Get Publish Profile
-        id: get-pp
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-name }} 
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Deploy Events
-        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
-        with:
-          app-name: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-name }} 
-          slot-name: "staging"
-          publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-publish-profile }} 
-          package: ./Events.zip
-
-      - name: Reset Publish Profile
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-name }} 
-          reset: true
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-
-  deploy-sso:
-    runs-on: ubuntu-latest
-    needs: 
-      - reset-db
-      - update-db
-    steps:
-      - name: Download aritifacts
-        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
-        with:
-          name: Sso.zip
-
-      - name: Login to Azure
-        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
-        with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Retrieve secrets
-        id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
-        with:
-          keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-sso-webapp-name"
-
-      - name: Get Publish Profile
-        id: get-pp
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-name }} 
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Deploy SSO
-        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
-        with:
-          app-name: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-name }} 
-          slot-name: "staging"
-          publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-publish-profile }} 
-          package: ./Sso.zip
-
-      - name: Reset Publish Profile
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-name }} 
-          reset: true
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-
-  deploy-portal:
-    runs-on: ubuntu-latest
-    needs: 
-      - reset-db
-      - update-db
-    steps:
-      - name: Download aritifacts
-        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
-        with:
-          name: Portal.zip
-
-      - name: Login to Azure
-        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
-        with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Retrieve secrets
-        id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
-        with:
-          keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-portal-webapp-name"
-
-      - name: Get Publish Profile
-        id: get-pp
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-name }} 
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Deploy Portal
-        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
-        with:
-          app-name: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-name }} 
-          slot-name: "staging"
-          publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-publish-profile }} 
-          package: ./Portal.zip
-
-      - name: Reset Publish Profile
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-name }} 
-          reset: true
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-
-  deploy-admin:
-    runs-on: ubuntu-latest
-    needs: 
-      - reset-db
-      - update-db
-    steps:
-      - name: Download aritifacts
-        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
-        with:
-          name: Admin.zip
-
-      - name: Login to Azure
-        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
-        with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Retrieve secrets
-        id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
-        with:
-          keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-admin-webapp-name"
-
-      - name: Get Publish Profile
-        id: get-pp
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-name }} 
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Deploy Admin
-        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
-        with:
-          app-name: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-name }} 
-          slot-name: "staging"
-          publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-publish-profile }} 
-          package: ./Admin.zip
-
-      - name: Reset Publish Profile
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-name }} 
-          reset: true
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -177,12 +177,12 @@ jobs:
           secrets: "subscription-id,
                     appservices-${{ matrix.name_lower }}-webapp-name:webapp-name"
 
-      - name: Get Publish Profile
-        run: |
-          echo 'WEBAPP_PUBLISHING_PROFILE=$(az webapp deployment list-publishing-profiles --name ${{ steps.retrieve-secrets.output.webapp-name }} --slot staging --resource-group "bitwarden-qa" --subscription ${{ steps.retrieve-secrets.output.webapp-name }})' >> $GITHUB_ENV
+      #- name: Get Publish Profile
+      #  run: |
+      #    echo 'WEBAPP_PUBLISHING_PROFILE=$(az webapp deployment list-publishing-profiles --name ${{ steps.retrieve-secrets.output.webapp-name }} --slot staging --resource-group "bitwarden-qa" --subscription ${{ steps.retrieve-secrets.output.webapp-name }})' >> $GITHUB_ENV
 
-          echo "::add-mask::$WEBAPP_PUBLISHING_PROFILE"
-          echo "::set-output name=publish-profile::$WEBAPP_PUBLISHING_PROFILE"
+      #    echo "::add-mask::$WEBAPP_PUBLISHING_PROFILE"
+      #    echo "::set-output name=publish-profile::$WEBAPP_PUBLISHING_PROFILE"
 
 
       #- name: Get Publish Profile
@@ -199,7 +199,7 @@ jobs:
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.webapp-name }} 
           slot-name: "staging"
-          publish-profile: ${{ steps.get-pp.outputs.profile}} 
+          #publish-profile: ${{ steps.get-pp.outputs.profile}} 
           package: ./${{ matrix.name }}.zip
 
       #- name: Reset Publish Profile

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -156,7 +156,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           repository: joseph-flinn/get-keyvault-secrets
-          ref: refs/heads/add-dynamic-secret-support
+          ref: 07b54e7df161105193fb62e3b594e496377f2e84
           path: ./.github/actions/get-keyvault-secrets
 
       - name: Download aritifacts

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Download aritifacts
         uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
-          name: Identity.zip
+          name: ${{ matrix.name }}.zip
 
       - name: Login to Azure
         uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
@@ -185,13 +185,13 @@ jobs:
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
-      - name: Deploy Identity
+      - name: Deploy App
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.webapp-name }} 
           slot-name: "staging"
           publish-profile: ${{ steps.get-pp.outputs.profile}} 
-          package: ./Identity.zip
+          package: ./${{ matrix.name }}.zip
 
       - name: Reset Publish Profile
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -149,16 +149,33 @@ jobs:
         uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-identity-webapp-name, 
-                    appservices-identity-webapp-publish-profile"
+          secrets: "appservices-identity-webapp-name"
+
+      - name: Get Publish Profile
+        id: get-pp
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-name }} 
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Deploy Identity
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-name }} 
           slot-name: "staging"
-          publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-publish-profile }} 
+          publish-profile: ${{ steps.get-pp.outputs.profile}} 
           package: ./Identity.zip
+
+      - name: Reset Publish Profile
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-name }} 
+          reset: true
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
 
   deploy-api:
@@ -182,8 +199,16 @@ jobs:
         uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-api-webapp-name, 
-                    appservices-api-webapp-publish-profile"
+          secrets: "appservices-api-webapp-name"
+
+      - name: Get Publish Profile
+        id: get-pp
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-name }} 
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Deploy Api
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
@@ -192,6 +217,15 @@ jobs:
           slot-name: "staging"
           publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-publish-profile }} 
           package: ./Api.zip
+
+      - name: Reset Publish Profile
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-name }} 
+          reset: true
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
 
   deploy-billing:
@@ -215,8 +249,16 @@ jobs:
         uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-billing-webapp-name, 
-                    appservices-billing-webapp-publish-profile"
+          secrets: "appservices-billing-webapp-name"
+
+      - name: Get Publish Profile
+        id: get-pp
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-name }} 
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Deploy Billing
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
@@ -225,6 +267,15 @@ jobs:
           slot-name: "staging"
           publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-publish-profile }} 
           package: ./Billing.zip
+
+      - name: Reset Publish Profile
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-name }} 
+          reset: true
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
 
   deploy-events:
@@ -248,8 +299,16 @@ jobs:
         uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-events-webapp-name, 
-                    appservices-events-webapp-publish-profile"
+          secrets: "appservices-events-webapp-name"
+
+      - name: Get Publish Profile
+        id: get-pp
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-name }} 
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Deploy Events
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
@@ -258,6 +317,15 @@ jobs:
           slot-name: "staging"
           publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-publish-profile }} 
           package: ./Events.zip
+
+      - name: Reset Publish Profile
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-name }} 
+          reset: true
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
 
   deploy-sso:
@@ -281,8 +349,16 @@ jobs:
         uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-sso-webapp-name, 
-                    appservices-sso-webapp-publish-profile"
+          secrets: "appservices-sso-webapp-name"
+
+      - name: Get Publish Profile
+        id: get-pp
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-name }} 
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Deploy SSO
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
@@ -291,6 +367,15 @@ jobs:
           slot-name: "staging"
           publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-publish-profile }} 
           package: ./Sso.zip
+
+      - name: Reset Publish Profile
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-name }} 
+          reset: true
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
 
   deploy-portal:
@@ -314,8 +399,16 @@ jobs:
         uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-portal-webapp-name, 
-                    appservices-portal-webapp-publish-profile"
+          secrets: "appservices-portal-webapp-name"
+
+      - name: Get Publish Profile
+        id: get-pp
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-name }} 
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Deploy Portal
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
@@ -324,6 +417,15 @@ jobs:
           slot-name: "staging"
           publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-publish-profile }} 
           package: ./Portal.zip
+
+      - name: Reset Publish Profile
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-name }} 
+          reset: true
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
 
   deploy-admin:
@@ -347,8 +449,16 @@ jobs:
         uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-admin-webapp-name, 
-                    appservices-admin-webapp-publish-profile"
+          secrets: "appservices-admin-webapp-name"
+
+      - name: Get Publish Profile
+        id: get-pp
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-name }} 
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Deploy Admin
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
@@ -357,4 +467,13 @@ jobs:
           slot-name: "staging"
           publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-publish-profile }} 
           package: ./Admin.zip
+
+      - name: Reset Publish Profile
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-name }} 
+          reset: true
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -181,7 +181,7 @@ jobs:
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
           resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.webapp-name }} 
+          appName: ${{ steps.retrieve-secrets.outputs.webapp-name }}/staging
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
@@ -197,7 +197,7 @@ jobs:
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
           resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.webapp-name }} 
+          appName: ${{ steps.retrieve-secrets.outputs.webapp-name }}/staging
           reset: true
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -130,10 +130,10 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    strategy:
     needs: 
       - reset-db
       - update-db
+    strategy:
       fail-fast: false
       matrix:
         include:

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -135,7 +135,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
+        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Identity.zip
 
@@ -185,7 +185,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
+        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Api.zip
 
@@ -235,7 +235,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
+        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Billing.zip
 
@@ -285,7 +285,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
+        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Events.zip
 
@@ -335,7 +335,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
+        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Sso.zip
 
@@ -385,7 +385,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
+        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Portal.zip
 
@@ -435,7 +435,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
+        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Admin.zip
 

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -157,7 +157,7 @@ jobs:
         with:
           repository: joseph-flinn/get-keyvault-secrets
           ref: refs/heads/add-dynamic-secret-support
-          path: ./github/actions/get-keyvault-secrets
+          path: ./.github/actions/get-keyvault-secrets
 
       - name: Download aritifacts
         uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -174,16 +174,25 @@ jobs:
         uses: ./.github/actions/get-keyvault-secrets
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-${{ matrix.name_lower }}-webapp-name:webapp-name"
+          secrets: "subscription-id,
+                    appservices-${{ matrix.name_lower }}-webapp-name:webapp-name"
 
       - name: Get Publish Profile
-        id: get-pp
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.webapp-name }}/staging
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
+        run: |
+          echo 'WEBAPP_PUBLISHING_PROFILE=$(az webapp deployment list-publishing-profiles --name ${{ steps.retrieve-secrets.output.webapp-name }} --slot staging --resource-group "bitwarden-qa" --subscription ${{ steps.retrieve-secrets.output.webapp-name }})' >> $GITHUB_ENV
+
+          echo "::add-mask::$WEBAPP_PUBLISHING_PROFILE"
+          echo "::set-output name=publish-profile::$WEBAPP_PUBLISHING_PROFILE"
+
+
+      #- name: Get Publish Profile
+      #  id: get-pp
+      #  uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+      #  with:
+      #    resourceGroupName: "bitwarden-qa"
+      #    appName: ${{ steps.retrieve-secrets.outputs.webapp-name }}/staging
+      #  env:
+      #    AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Deploy App
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
@@ -193,11 +202,11 @@ jobs:
           publish-profile: ${{ steps.get-pp.outputs.profile}} 
           package: ./${{ matrix.name }}.zip
 
-      - name: Reset Publish Profile
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.webapp-name }}/staging
-          reset: true
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
+      #- name: Reset Publish Profile
+      #  uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+      #  with:
+      #    resourceGroupName: "bitwarden-qa"
+      #    appName: ${{ steps.retrieve-secrets.outputs.webapp-name }}/staging
+      #    reset: true
+      #  env:
+      #    AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -177,36 +177,9 @@ jobs:
           secrets: "subscription-id,
                     appservices-${{ matrix.name_lower }}-webapp-name:webapp-name"
 
-      #- name: Get Publish Profile
-      #  run: |
-      #    echo 'WEBAPP_PUBLISHING_PROFILE=$(az webapp deployment list-publishing-profiles --name ${{ steps.retrieve-secrets.output.webapp-name }} --slot staging --resource-group "bitwarden-qa" --subscription ${{ steps.retrieve-secrets.output.webapp-name }})' >> $GITHUB_ENV
-
-      #    echo "::add-mask::$WEBAPP_PUBLISHING_PROFILE"
-      #    echo "::set-output name=publish-profile::$WEBAPP_PUBLISHING_PROFILE"
-
-
-      #- name: Get Publish Profile
-      #  id: get-pp
-      #  uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-      #  with:
-      #    resourceGroupName: "bitwarden-qa"
-      #    appName: ${{ steps.retrieve-secrets.outputs.webapp-name }}/staging
-      #  env:
-      #    AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
       - name: Deploy App
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.webapp-name }} 
           slot-name: "staging"
-          #publish-profile: ${{ steps.get-pp.outputs.profile}} 
           package: ./${{ matrix.name }}.zip
-
-      #- name: Reset Publish Profile
-      #  uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-      #  with:
-      #    resourceGroupName: "bitwarden-qa"
-      #    appName: ${{ steps.retrieve-secrets.outputs.webapp-name }}/staging
-      #    reset: true
-      #  env:
-      #    AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -155,7 +155,7 @@ jobs:
         id: get-pp
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-name }} 
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
@@ -171,7 +171,7 @@ jobs:
       - name: Reset Publish Profile
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-name }} 
           reset: true
         env:
@@ -205,7 +205,7 @@ jobs:
         id: get-pp
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-name }} 
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
@@ -221,7 +221,7 @@ jobs:
       - name: Reset Publish Profile
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-name }} 
           reset: true
         env:
@@ -255,7 +255,7 @@ jobs:
         id: get-pp
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-name }} 
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
@@ -271,7 +271,7 @@ jobs:
       - name: Reset Publish Profile
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-name }} 
           reset: true
         env:
@@ -305,7 +305,7 @@ jobs:
         id: get-pp
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-name }} 
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
@@ -321,7 +321,7 @@ jobs:
       - name: Reset Publish Profile
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-name }} 
           reset: true
         env:
@@ -355,7 +355,7 @@ jobs:
         id: get-pp
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-name }} 
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
@@ -371,7 +371,7 @@ jobs:
       - name: Reset Publish Profile
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-name }} 
           reset: true
         env:
@@ -405,7 +405,7 @@ jobs:
         id: get-pp
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-name }} 
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
@@ -421,7 +421,7 @@ jobs:
       - name: Reset Publish Profile
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-name }} 
           reset: true
         env:
@@ -455,7 +455,7 @@ jobs:
         id: get-pp
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-name }} 
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
@@ -471,7 +471,7 @@ jobs:
       - name: Reset Publish Profile
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-name }} 
           reset: true
         env:

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -174,8 +174,7 @@ jobs:
         uses: ./.github/actions/get-keyvault-secrets
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "subscription-id,
-                    appservices-${{ matrix.name_lower }}-webapp-name:webapp-name"
+          secrets: "appservices-${{ matrix.name_lower }}-webapp-name:webapp-name"
 
       - name: Deploy App
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31


### PR DESCRIPTION
## Summary
Since we are logging into Azure to grab the secrets from the AZ Key Vault, we do not need to use the publish profiles for deploying the Web Apps. 

Also cleaning up to use a matrix strategy instead of 7 separate jobs. This does rely on a custom Action found here: https://github.com/joseph-flinn/get-keyvault-secrets. A change was added in this Action to name the local secret something other than the name of the secret in the Azure KeyVault. 