### PR TITLE
Require valid Send-Id header for access requests

### DIFF
--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -11,6 +11,7 @@ using Bit.Core.Utilities;
 using Bit.Core.Settings;
 using Bit.Core.Models.Api.Response;
 using Bit.Core.Enums;
+using Bit.Core.Context;
 using Microsoft.Azure.EventGrid.Models;
 using Bit.Api.Utilities;
 using System.Collections.Generic;
@@ -31,6 +32,7 @@ namespace Bit.Api.Controllers
         private readonly ISendFileStorageService _sendFileStorageService;
         private readonly ILogger<SendsController> _logger;
         private readonly GlobalSettings _globalSettings;
+        private readonly ICurrentContext _currentContext;
 
         public SendsController(
             ISendRepository sendRepository,
@@ -38,7 +40,8 @@ namespace Bit.Api.Controllers
             ISendService sendService,
             ISendFileStorageService sendFileStorageService,
             ILogger<SendsController> logger,
-            GlobalSettings globalSettings)
+            GlobalSettings globalSettings,
+            ICurrentContext currentContext)
         {
             _sendRepository = sendRepository;
             _userService = userService;
@@ -46,12 +49,20 @@ namespace Bit.Api.Controllers
             _sendFileStorageService = sendFileStorageService;
             _logger = logger;
             _globalSettings = globalSettings;
+            _currentContext = currentContext;
         }
 
         [AllowAnonymous]
         [HttpPost("access/{id}")]
         public async Task<IActionResult> Access(string id, [FromBody] SendAccessRequestModel model)
         {
+            // Uncomment whenever we want to require the `send-id` header
+            if (!_currentContext.HttpContext.Request.Headers.ContainsKey("Send-Id") ||
+                _currentContext.HttpContext.Request.Headers["Send-Id"] != id)
+            {
+                throw new BadRequestException("Invalid Send-Id header.");
+            }
+
             var guid = new Guid(CoreHelpers.Base64UrlDecode(id));
             var (send, passwordRequired, passwordInvalid) =
                 await _sendService.AccessAsync(guid, model.Password);

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -57,11 +57,11 @@ namespace Bit.Api.Controllers
         public async Task<IActionResult> Access(string id, [FromBody] SendAccessRequestModel model)
         {
             // Uncomment whenever we want to require the `send-id` header
-            if (!_currentContext.HttpContext.Request.Headers.ContainsKey("Send-Id") ||
-                _currentContext.HttpContext.Request.Headers["Send-Id"] != id)
-            {
-                throw new BadRequestException("Invalid Send-Id header.");
-            }
+            //if (!_currentContext.HttpContext.Request.Headers.ContainsKey("Send-Id") ||
+            //    _currentContext.HttpContext.Request.Headers["Send-Id"] != id)
+            //{
+            //    throw new BadRequestException("Invalid Send-Id header.");
+            //}
 
             var guid = new Guid(CoreHelpers.Base64UrlDecode(id));
             var (send, passwordRequired, passwordInvalid) =
@@ -94,6 +94,13 @@ namespace Bit.Api.Controllers
         public async Task<IActionResult> GetSendFileDownloadData(string encodedSendId,
             string fileId, [FromBody] SendAccessRequestModel model)
         {
+            // Uncomment whenever we want to require the `send-id` header
+            //if (!_currentContext.HttpContext.Request.Headers.ContainsKey("Send-Id") ||
+            //    _currentContext.HttpContext.Request.Headers["Send-Id"] != encodedSendId)
+            //{
+            //    throw new BadRequestException("Invalid Send-Id header.");
+            //}
+
             var sendId = new Guid(CoreHelpers.Base64UrlDecode(encodedSendId));
             var send = await _sendRepository.GetByIdAsync(sendId);
 

--- a/test/Api.Test/Controllers/SendsControllerTests.cs
+++ b/test/Api.Test/Controllers/SendsControllerTests.cs
@@ -1,5 +1,6 @@
 using AutoFixture.Xunit2;
 using Bit.Api.Controllers;
+using Bit.Core.Context;
 using Bit.Core.Enums;
 using Bit.Core.Models.Api;
 using Bit.Core.Models.Table;
@@ -28,6 +29,7 @@ namespace Bit.Api.Test.Controllers
         private readonly ISendService _sendService;
         private readonly ISendFileStorageService _sendFileStorageService;
         private readonly ILogger<SendsController> _logger;
+        private readonly ICurrentContext _currentContext;
 
         public SendsControllerTests()
         {
@@ -37,6 +39,7 @@ namespace Bit.Api.Test.Controllers
             _sendFileStorageService = Substitute.For<ISendFileStorageService>();
             _globalSettings = new GlobalSettings();
             _logger = Substitute.For<ILogger<SendsController>>();
+            _currentContext = Substitute.For<ICurrentContext>();
 
             _sut = new SendsController(
                 _sendRepository,
@@ -44,7 +47,8 @@ namespace Bit.Api.Test.Controllers
                 _sendService,
                 _sendFileStorageService,
                 _logger,
-                _globalSettings
+                _globalSettings,
+                _currentContext
             );
         }
 


### PR DESCRIPTION
## Objective
Make sure that all Send access requests have a valid Send-Id header.

See related changes to jslib: https://github.com/bitwarden/jslib/pull/400.

This is such a simple check, I didn't think it was worth filtering for password-protected Sends only. Better to check & reject at the earliest opportunity.