### PR TITLE
[Reset Password] Fixed helper utility for org user updates

### DIFF
--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -167,7 +167,7 @@ namespace Bit.Core.Utilities
                 (nameof(OrganizationUser.CreationDate), typeof(DateTime), ou => ou.CreationDate),
                 (nameof(OrganizationUser.RevisionDate), typeof(DateTime), ou => ou.RevisionDate),
                 (nameof(OrganizationUser.Permissions), typeof(string), ou => ou.Permissions),
-                (nameof(OrganizationUser.ResetPasswordKey), typeof(Guid), ou => ou.UserId),
+                (nameof(OrganizationUser.ResetPasswordKey), typeof(string), ou => ou.ResetPasswordKey),
             };
 
             foreach (var (name, type, getter) in columnData)


### PR DESCRIPTION
## Objective
> Fix the issue where all users being confirmed into an organization were having the `resetPasswordKey` set unintentionally. 

## Code Changes
- **CoreHelpers**: Update `ResetPasswordKey` column to be reflected by a value type of `string` and any existing `ResetPasswordKey` 