### PR TITLE
QA auto slot swapping

### DIFF
--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -15,7 +15,6 @@ on:
 
 jobs:
   build:
-    if: false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -109,7 +108,6 @@ jobs:
 
 
   reset-db:
-    if: false
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -120,8 +118,7 @@ jobs:
           echo "placeholder for loading test dataset"
 
   update-db:
-    if: false
-    #if: ${{ github.events.inputs.migrateDb }} == "true"
+    if: ${{ github.events.inputs.migrateDb }} == "true"
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -132,7 +129,6 @@ jobs:
 
 
   deploy:
-    if: false
     runs-on: ubuntu-latest
     needs: 
       - reset-db
@@ -191,7 +187,7 @@ jobs:
 
   swap-identity:
     runs-on: ubuntu-latest
-    #needs: deploy
+    needs: deploy
     steps:
       - name: Checkout custom AZ KV action
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
@@ -246,8 +242,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: swap-identity
     strategy:
-      #max-parallel: 1
-      #fail-fast: false
+      fail-fast: false
       matrix:
         include:
           - name: Api
@@ -339,15 +334,6 @@ jobs:
       - name: Make sure staging endpoint is alive
         run: |
           sleep 60  # I don't think the admin portal has an alive endpoint
-          #while true
-          #do
-          #  STATUS=$( curl -is https://$WEBAPP_NAME.azurewebsites.net/alive | head -1 )
-          #  if [[ "$STATUS" == *"200 OK"* ]]; then
-          #    break
-          #  fi
-          #  echo -e "STAUS=$STATUS\nsleeping for 2 seconds"
-          #  sleep 2;
-          #done
 
       - name: Swap Admin
         run: az webapp deployment slot swap -g bitwarden-qa -n $ADMIN_WEBAPP_NAME --slot staging --target-slot production

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -128,12 +128,37 @@ jobs:
           echo "placeholder for updateing DB"
 
 
-  deploy-identity:
+  deploy:
     runs-on: ubuntu-latest
+    strategy:
     needs: 
       - reset-db
       - update-db
+      fail-fast: false
+      matrix:
+        include:
+          - name: Api
+            name_lower: api
+          - name: Admin
+            name_lower: admin
+          - name: Billing
+            name_lower: billing
+          - name: Events
+            name_lower: events
+          - name: Sso
+            name_lower: sso
+          - name: Portal
+            name_lower: portal
+          - name: Identity
+            name_lower: identity
     steps:
+      - name: Checkout custom AZ KV action
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          repository: joseph-flinn/get-keyvault-secrets
+          ref: refs/heads/add-dynamic-secret-support
+          path: ./github/actions/get-keyvault-secrets
+
       - name: Download aritifacts
         uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
@@ -146,24 +171,24 @@ jobs:
 
       - name: Retrieve secrets
         id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
+        uses: ./.github/actions/get-keyvault-secrets
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-identity-webapp-name"
+          secrets: "appservices-${{ matrix.name_lower }}-webapp-name:webapp-name"
 
       - name: Get Publish Profile
         id: get-pp
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
           resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-name }} 
+          appName: ${{ steps.retrieve-secrets.outputs.webapp-name }} 
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Deploy Identity
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
-          app-name: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-name }} 
+          app-name: ${{ steps.retrieve-secrets.outputs.webapp-name }} 
           slot-name: "staging"
           publish-profile: ${{ steps.get-pp.outputs.profile}} 
           package: ./Identity.zip
@@ -172,308 +197,7 @@ jobs:
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
           resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-name }} 
+          appName: ${{ steps.retrieve-secrets.outputs.webapp-name }} 
           reset: true
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-
-  deploy-api:
-    runs-on: ubuntu-latest
-    needs: 
-      - reset-db
-      - update-db
-    steps:
-      - name: Download aritifacts
-        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
-        with:
-          name: Api.zip
-
-      - name: Login to Azure
-        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
-        with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Retrieve secrets
-        id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
-        with:
-          keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-api-webapp-name"
-
-      - name: Get Publish Profile
-        id: get-pp
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-name }} 
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Deploy Api
-        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
-        with:
-          app-name: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-name }} 
-          slot-name: "staging"
-          publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-publish-profile }} 
-          package: ./Api.zip
-
-      - name: Reset Publish Profile
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-name }} 
-          reset: true
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-
-  deploy-billing:
-    runs-on: ubuntu-latest
-    needs: 
-      - reset-db
-      - update-db
-    steps:
-      - name: Download aritifacts
-        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
-        with:
-          name: Billing.zip
-
-      - name: Login to Azure
-        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
-        with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Retrieve secrets
-        id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
-        with:
-          keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-billing-webapp-name"
-
-      - name: Get Publish Profile
-        id: get-pp
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-name }} 
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Deploy Billing
-        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
-        with:
-          app-name: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-name }} 
-          slot-name: "staging"
-          publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-publish-profile }} 
-          package: ./Billing.zip
-
-      - name: Reset Publish Profile
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-name }} 
-          reset: true
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-
-  deploy-events:
-    runs-on: ubuntu-latest
-    needs: 
-      - reset-db
-      - update-db
-    steps:
-      - name: Download aritifacts
-        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
-        with:
-          name: Events.zip
-
-      - name: Login to Azure
-        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
-        with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Retrieve secrets
-        id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
-        with:
-          keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-events-webapp-name"
-
-      - name: Get Publish Profile
-        id: get-pp
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-name }} 
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Deploy Events
-        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
-        with:
-          app-name: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-name }} 
-          slot-name: "staging"
-          publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-publish-profile }} 
-          package: ./Events.zip
-
-      - name: Reset Publish Profile
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-name }} 
-          reset: true
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-
-  deploy-sso:
-    runs-on: ubuntu-latest
-    needs: 
-      - reset-db
-      - update-db
-    steps:
-      - name: Download aritifacts
-        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
-        with:
-          name: Sso.zip
-
-      - name: Login to Azure
-        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
-        with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Retrieve secrets
-        id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
-        with:
-          keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-sso-webapp-name"
-
-      - name: Get Publish Profile
-        id: get-pp
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-name }} 
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Deploy SSO
-        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
-        with:
-          app-name: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-name }} 
-          slot-name: "staging"
-          publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-publish-profile }} 
-          package: ./Sso.zip
-
-      - name: Reset Publish Profile
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-name }} 
-          reset: true
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-
-  deploy-portal:
-    runs-on: ubuntu-latest
-    needs: 
-      - reset-db
-      - update-db
-    steps:
-      - name: Download aritifacts
-        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
-        with:
-          name: Portal.zip
-
-      - name: Login to Azure
-        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
-        with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Retrieve secrets
-        id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
-        with:
-          keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-portal-webapp-name"
-
-      - name: Get Publish Profile
-        id: get-pp
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-name }} 
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Deploy Portal
-        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
-        with:
-          app-name: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-name }} 
-          slot-name: "staging"
-          publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-publish-profile }} 
-          package: ./Portal.zip
-
-      - name: Reset Publish Profile
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-name }} 
-          reset: true
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-
-  deploy-admin:
-    runs-on: ubuntu-latest
-    needs: 
-      - reset-db
-      - update-db
-    steps:
-      - name: Download aritifacts
-        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
-        with:
-          name: Admin.zip
-
-      - name: Login to Azure
-        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
-        with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Retrieve secrets
-        id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
-        with:
-          keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-admin-webapp-name"
-
-      - name: Get Publish Profile
-        id: get-pp
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-name }} 
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Deploy Admin
-        uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
-        with:
-          app-name: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-name }} 
-          slot-name: "staging"
-          publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-publish-profile }} 
-          package: ./Admin.zip
-
-      - name: Reset Publish Profile
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-name }} 
-          reset: true
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -177,12 +177,12 @@ jobs:
           secrets: "subscription-id,
                     appservices-${{ matrix.name_lower }}-webapp-name:webapp-name"
 
-      - name: Get Publish Profile
-        run: |
-          echo 'WEBAPP_PUBLISHING_PROFILE=$(az webapp deployment list-publishing-profiles --name ${{ steps.retrieve-secrets.output.webapp-name }} --slot staging --resource-group "bitwarden-qa" --subscription ${{ steps.retrieve-secrets.output.webapp-name }})' >> $GITHUB_ENV
+      #- name: Get Publish Profile
+      #  run: |
+      #    echo 'WEBAPP_PUBLISHING_PROFILE=$(az webapp deployment list-publishing-profiles --name ${{ steps.retrieve-secrets.output.webapp-name }} --slot staging --resource-group "bitwarden-qa" --subscription ${{ steps.retrieve-secrets.output.webapp-name }})' >> $GITHUB_ENV
 
-          echo "::add-mask::$WEBAPP_PUBLISHING_PROFILE"
-          echo "::set-output name=publish-profile::$WEBAPP_PUBLISHING_PROFILE"
+      #    echo "::add-mask::$WEBAPP_PUBLISHING_PROFILE"
+      #    echo "::set-output name=publish-profile::$WEBAPP_PUBLISHING_PROFILE"
 
 
       #- name: Get Publish Profile
@@ -199,7 +199,7 @@ jobs:
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.webapp-name }} 
           slot-name: "staging"
-          publish-profile: ${{ steps.get-pp.outputs.profile}} 
+          #publish-profile: ${{ steps.get-pp.outputs.profile}} 
           package: ./${{ matrix.name }}.zip
 
       #- name: Reset Publish Profile

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -117,6 +117,7 @@ jobs:
           echo "placeholder for cleaning DB"
           echo "placeholder for loading test dataset"
 
+
   update-db:
     if: ${{ github.events.inputs.migrateDb }} == "true"
     runs-on: ubuntu-latest
@@ -153,13 +154,6 @@ jobs:
           echo "NAME_LOWER: $NAME_LOWER"
           echo "::set-output name=name_lower::$NAME_LOWER"
 
-      - name: Checkout custom AZ KV action
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-        with:
-          repository: joseph-flinn/get-keyvault-secrets
-          ref: 07b54e7df161105193fb62e3b594e496377f2e84
-          path: ./.github/actions/get-keyvault-secrets
-
       - name: Download aritifacts
         uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
@@ -172,10 +166,12 @@ jobs:
 
       - name: Retrieve secrets
         id: retrieve-secrets
-        uses: ./.github/actions/get-keyvault-secrets
-        with:
-          keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-${{ steps.setup.outputs.name_lower }}-webapp-name:webapp-name"
+        env:
+           VAULT_NAME: "bitwarden-qa-kv"
+        run: |
+          webapp_name=$(az keyvault secret show --vault-name $VAULT_NAME --name appservices-${{ steps.setup.outputs.name_lower }}-webapp-name --query value --output tsv)
+          echo "::add-mask::$webapp_name"
+          echo "::set-output name=webapp-name::$webapp_name"
 
       - name: Deploy App
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
@@ -189,13 +185,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy
     steps:
-      - name: Checkout custom AZ KV action
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-        with:
-          repository: joseph-flinn/get-keyvault-secrets
-          ref: 07b54e7df161105193fb62e3b594e496377f2e84
-          path: ./.github/actions/get-keyvault-secrets
-
       - name: Login to Azure
         uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
         with:
@@ -203,20 +192,22 @@ jobs:
 
       - name: Retrieve secrets
         id: retrieve-secrets
-        uses: ./.github/actions/get-keyvault-secrets
-        with:
-          keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-identity-webapp-name:IDENTITY_WEBAPP_NAME"
+        env:
+           VAULT_NAME: "bitwarden-qa-kv"
+        run: |
+          identity_webapp_name=$(az keyvault secret show --vault-name $VAULT_NAME --name appservices-identity-webapp-name --query value --output tsv)
+          echo "::add-mask::$identity_webapp_name"
+          echo "::set-output name=identity-webapp-name::$identity_webapp_name"
 
       - name: Start staging slot
-        run: az webapp start --name $IDENTITY_WEBAPP_NAME --resource-group bitwarden-qa --slot staging
+        run: az webapp start --name ${{ steps.retrieve-secrets.outputs.identity-webapp-name }} --resource-group bitwarden-qa --slot staging
 
       - name: Make sure staging endpoint is alive
         run: |
           SUCCESS="no"
           while read OUTPUT
           do
-            STATUS=$( curl -is https://$IDENTITY_WEBAPP_NAME-staging.azurewebsites.net/.well-known/openid-configuration/jwks | head -1 )
+            STATUS=$( curl -is https://${{ steps.retrieve-secrets.outputs.identity-webapp-name }}-staging.azurewebsites.net/.well-known/openid-configuration/jwks | head -1 )
             if [[ "$STATUS" == *"200 OK"* ]]; then
               echo "It is live!"
               SUCCESS="yes"
@@ -229,13 +220,12 @@ jobs:
           if [[ "$SUCCESS" == "no" ]]; then
             exit 1
           fi
-            
 
       - name: Swap Identity
-        run: az webapp deployment slot swap -g bitwarden-qa -n $IDENTITY_WEBAPP_NAME --slot staging --target-slot production
+        run: az webapp deployment slot swap -g bitwarden-qa -n ${{ steps.retrieve-secrets.outputs.identity-webapp-name }} --slot staging --target-slot production
 
       - name: Stop staging slot
-        run: az webapp stop --name $IDENTITY_WEBAPP_NAME --resource-group bitwarden-qa --slot staging
+        run: az webapp stop --name ${{ steps.retrieve-secrets.outputs.identity-webapp-name }} --resource-group bitwarden-qa --slot staging
 
 
   swap-slots:
@@ -257,13 +247,6 @@ jobs:
           NAME_LOWER=$(echo "${{ matrix.name }}" | awk '{print tolower($0)}')
           echo "::set-output name=name_lower::$NAME_LOWER"
 
-      - name: Checkout custom AZ KV action
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-        with:
-          repository: joseph-flinn/get-keyvault-secrets
-          ref: 07b54e7df161105193fb62e3b594e496377f2e84
-          path: ./.github/actions/get-keyvault-secrets
-
       - name: Login to Azure
         uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
         with:
@@ -271,20 +254,22 @@ jobs:
 
       - name: Retrieve secrets
         id: retrieve-secrets
-        uses: ./.github/actions/get-keyvault-secrets
-        with:
-          keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-${{ steps.setup.outputs.name_lower }}-webapp-name:WEBAPP_NAME"
+        env:
+           VAULT_NAME: "bitwarden-qa-kv"
+        run: |
+          webapp_name=$(az keyvault secret show --vault-name $VAULT_NAME --name appservices-${{ steps.setup.outputs.name_lower }}-webapp-name --query value --output tsv)
+          echo "::add-mask::$webapp_name"
+          echo "::set-output name=webapp-name::$webapp_name"
 
       - name: Start staging slot
-        run: az webapp start --name $WEBAPP_NAME --resource-group bitwarden-qa --slot staging
+        run: az webapp start --name ${{ steps.retrieve-secrets.outputs.webapp-name }}  --resource-group bitwarden-qa --slot staging
 
       - name: Make sure staging endpoint is alive
         run: |
           SUCCESS="no"
           while read OUTPUT
           do
-            STATUS=$( curl -is https://$WEBAPP_NAME-staging.azurewebsites.net/alive | head -1 )
+            STATUS=$( curl -is https://${{ steps.retrieve-secrets.outputs.webapp-name }}-staging.azurewebsites.net/alive | head -1 )
             if [[ "$STATUS" == *"200 OK"* ]]; then
               echo "It is live!"
               SUCCESS="yes"
@@ -299,23 +284,16 @@ jobs:
           fi
 
       - name: Swap slots
-        run: az webapp deployment slot swap -g bitwarden-qa -n $WEBAPP_NAME --slot staging --target-slot production
+        run: az webapp deployment slot swap -g bitwarden-qa -n ${{ steps.retrieve-secrets.outputs.webapp-name }} --slot staging --target-slot production
 
       - name: Stop staging slot
-        run: az webapp stop --name $WEBAPP_NAME --resource-group bitwarden-qa --slot staging
+        run: az webapp stop --name ${{ steps.retrieve-secrets.outputs.webapp-name }} --resource-group bitwarden-qa --slot staging
 
 
   swap-admin:
     runs-on: ubuntu-latest
     needs: swap-slots
     steps:
-      - name: Checkout custom AZ KV action
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-        with:
-          repository: joseph-flinn/get-keyvault-secrets
-          ref: 07b54e7df161105193fb62e3b594e496377f2e84
-          path: ./.github/actions/get-keyvault-secrets
-
       - name: Login to Azure
         uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
         with:
@@ -323,20 +301,22 @@ jobs:
 
       - name: Retrieve secrets
         id: retrieve-secrets
-        uses: ./.github/actions/get-keyvault-secrets
-        with:
-          keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-admin-webapp-name:ADMIN_WEBAPP_NAME"
+        env:
+           VAULT_NAME: "bitwarden-qa-kv"
+        run: |
+          admin_webapp_name=$(az keyvault secret show --vault-name $VAULT_NAME --name appservices-admin-webapp-name --query value --output tsv)
+          echo "::add-mask::$admin_webapp_name"
+          echo "::set-output name=admin-webapp-name::$admin_webapp_name"
 
       - name: Start staging slot
-        run: az webapp start --name $ADMIN_WEBAPP_NAME --resource-group bitwarden-qa --slot staging
+        run: az webapp start --name ${{ steps.retrieve-secrets.outputs.admin-webapp-name }} --resource-group bitwarden-qa --slot staging
 
       - name: Make sure staging endpoint is alive
         run: |
           sleep 60  # I don't think the admin portal has an alive endpoint
 
       - name: Swap Admin
-        run: az webapp deployment slot swap -g bitwarden-qa -n $ADMIN_WEBAPP_NAME --slot staging --target-slot production
+        run: az webapp deployment slot swap -g bitwarden-qa -n ${{ steps.retrieve-secrets.outputs.admin-webapp-name }} --slot staging --target-slot production
 
       - name: Stop staging slot
-        run: az webapp stop --name $ADMIN_WEBAPP_NAME --resource-group bitwarden-qa --slot staging
+        run: az webapp stop --name ${{ steps.retrieve-secrets.outputs.admin-webapp-name }} --resource-group bitwarden-qa --slot staging

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -213,14 +213,16 @@ jobs:
 
       - name: Make sure it endpoint is alive
         run: |
-          while true
+          count=0
+          while count -ne 150
           do
-            STATUS=$( curl -is https://$IDENTITY_WEBAPP_NAME.azurewebsites.net/.well-known/oepnid-configuration/jwks | head -1 )
+            STATUS=$( curl -is https://$IDENTITY_WEBAPP_NAME.azurewebsites.net/.well-known/openid-configuration/jwks | head -1 )
             if [[ "$STATUS" == *"200 OK"* ]]; then
               break
             fi
             echo -e "STAUS=$STATUS\nsleeping for 2 seconds"
             sleep 2;
+            count=$count+1
           done
 
       - name: Swap Identity
@@ -273,7 +275,8 @@ jobs:
 
       - name: Make sure it endpoint is alive
         run: |
-          while true
+          count=0
+          while count -ne 150
           do
             STATUS=$( curl -is https://$WEBAPP_NAME.azurewebsites.net/alive | head -1 )
             if [[ "$STATUS" == *"200 OK"* ]]; then
@@ -281,6 +284,7 @@ jobs:
             fi
             echo -e "STAUS=$STATUS\nsleeping for 2 seconds"
             sleep 2;
+            count=$count+1
           done
 
       - name: Swap slots

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -238,10 +238,15 @@ jobs:
       matrix:
         include:
           - name: Api
+            sleep_time: 0
           - name: Billing
+            sleep_time: 30
           - name: Events
+            sleep_time: 60
           - name: Sso
+            sleep_time: 90
           - name: Portal
+            sleep_time: 120
     steps:
       - name: Setup
         id: setup
@@ -284,7 +289,9 @@ jobs:
           done < <(seq 150)
 
       - name: Swap slots
-        run: az webapp deployment slot swap -g bitwarden-qa -n $WEBAPP_NAME --slot staging --target-slot production
+        run: |
+          sleep ${{ matrix.sleep_time }}
+          az webapp deployment slot swap -g bitwarden-qa -n $WEBAPP_NAME --slot staging --target-slot production
 
       - name: Stop staging slot
         run: az webapp stop --name $WEBAPP_NAME --resource-group bitwarden-qa --slot staging

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -234,19 +234,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: swap-identity
     strategy:
+      max-parallel: 1
       fail-fast: false
       matrix:
         include:
           - name: Api
-            sleep_time: 0
           - name: Billing
-            sleep_time: 30
           - name: Events
-            sleep_time: 60
           - name: Sso
-            sleep_time: 90
           - name: Portal
-            sleep_time: 120
     steps:
       - name: Setup
         id: setup

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -213,8 +213,13 @@ jobs:
 
       - name: Make sure it endpoint is alive
         run: |
-          while [ "$( curl -is https://$IDENTITY_WEBAPP_NAME.azurewebsites.net/.well-known/oepnid-configuration/jwks | head -1 )" =! *"200 OK"* ]
+          while true
           do
+            STATUS=$( curl -is https://$IDENTITY_WEBAPP_NAME.azurewebsites.net/.well-known/oepnid-configuration/jwks | head -1 )
+            if [[ "$STATUS" == *"200 OK"* ]]; then
+              break
+            fi
+            echo -e "STAUS=$STATUS\nsleeping for 2 seconds"
             sleep 2;
           done
 
@@ -268,8 +273,13 @@ jobs:
 
       - name: Make sure it endpoint is alive
         run: |
-          while [ "$( curl -is https://$WEBAPP_NAME.azurewebsites.net/.well-known/oepnid-configuration/jwks | head -1 )" =! *"200 OK"* ]
+          while true
           do
+            STATUS=$( curl -is https://$WEBAPP_NAME.azurewebsites.net/alive | head -1 )
+            if [[ "$STATUS" == *"200 OK"* ]]; then
+              break
+            fi
+            echo -e "STAUS=$STATUS\nsleeping for 2 seconds"
             sleep 2;
           done
 
@@ -308,10 +318,16 @@ jobs:
 
       - name: Make sure it endpoint is alive
         run: |
-          while [ "$( curl -is https://$ADMIN_WEBAPP_NAME.azurewebsites.net/.well-known/oepnid-configuration/jwks | head -1 )" =! *"200 OK"* ]
-          do
-            sleep 2;
-          done
+          sleep 60  # I don't think the admin portal has an alive endpoint
+          #while true
+          #do
+          #  STATUS=$( curl -is https://$WEBAPP_NAME.azurewebsites.net/alive | head -1 )
+          #  if [[ "$STATUS" == *"200 OK"* ]]; then
+          #    break
+          #  fi
+          #  echo -e "STAUS=$STATUS\nsleeping for 2 seconds"
+          #  sleep 2;
+          #done
 
       - name: Swap Admin
         run: az webapp deployment slot swap -g bitwarden-qa -n $ADMIN_WEBAPP_NAME --slot staging --target-slot production

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -234,7 +234,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: swap-identity
     strategy:
-      max-parallel: 1
+      #max-parallel: 1
       #fail-fast: false
       matrix:
         include:

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -279,7 +279,7 @@ jobs:
         uses: ./.github/actions/get-keyvault-secrets
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-identity-webapp-name:WEBAPP_NAME"
+          secrets: "appservices-${{ steps.setup.outputs.name_lower }}-webapp-name:WEBAPP_NAME"
 
       - name: Start staging slot
         run: az webapp start --name $WEBAPP_NAME --resource-group bitwarden-qa --slot staging
@@ -331,7 +331,7 @@ jobs:
         uses: ./.github/actions/get-keyvault-secrets
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-identity-webapp-name:ADMIN_WEBAPP_NAME"
+          secrets: "appservices-admin-webapp-name:ADMIN_WEBAPP_NAME"
 
       - name: Start staging slot
         run: az webapp start --name $ADMIN_WEBAPP_NAME --resource-group bitwarden-qa --slot staging

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -217,16 +217,23 @@ jobs:
 
       - name: Make sure staging endpoint is alive
         run: |
+          SUCCESS="no"
           while read OUTPUT
           do
             STATUS=$( curl -is https://$IDENTITY_WEBAPP_NAME-staging.azurewebsites.net/.well-known/openid-configuration/jwks | head -1 )
             if [[ "$STATUS" == *"200 OK"* ]]; then
               echo "It is live!"
+              SUCCESS="yes"
               break
             fi
             echo -e "STAUS=$STATUS\nRetrying: $OUTPUT"
             sleep 4;
           done < <(seq 15)
+
+          if [[ "$SUCCESS" == "no" ]]; then
+            exit 1
+          fi
+            
 
       - name: Swap Identity
         run: az webapp deployment slot swap -g bitwarden-qa -n $IDENTITY_WEBAPP_NAME --slot staging --target-slot production
@@ -279,16 +286,22 @@ jobs:
 
       - name: Make sure staging endpoint is alive
         run: |
+          SUCCESS="no"
           while read OUTPUT
           do
             STATUS=$( curl -is https://$WEBAPP_NAME-staging.azurewebsites.net/alive | head -1 )
             if [[ "$STATUS" == *"200 OK"* ]]; then
               echo "It is live!"
+              SUCCESS="yes"
               break
             fi
             echo -e "STAUS=$STATUS\nRetrying: $OUTPUT"
             sleep 4;
           done < <(seq 15)
+
+          if [[ "$SUCCESS" == "no" ]]; then
+            exit 1
+          fi
 
       - name: Swap slots
         run: az webapp deployment slot swap -g bitwarden-qa -n $WEBAPP_NAME --slot staging --target-slot production

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -156,7 +156,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           repository: joseph-flinn/get-keyvault-secrets
-          ref: refs/heads/add-dynamic-secret-support
+          ref: 07b54e7df161105193fb62e3b594e496377f2e84
           path: ./.github/actions/get-keyvault-secrets
 
       - name: Download aritifacts

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Download aritifacts
         uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
-          name: Identity.zip
+          name: ${{ matrix.name }}.zip
 
       - name: Login to Azure
         uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
@@ -185,13 +185,13 @@ jobs:
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
-      - name: Deploy Identity
+      - name: Deploy App
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.webapp-name }} 
           slot-name: "staging"
           publish-profile: ${{ steps.get-pp.outputs.profile}} 
-          package: ./Identity.zip
+          package: ./${{ matrix.name }}.zip
 
       - name: Reset Publish Profile
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -149,16 +149,33 @@ jobs:
         uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-identity-webapp-name, 
-                    appservices-identity-webapp-publish-profile"
+          secrets: "appservices-identity-webapp-name"
+
+      - name: Get Publish Profile
+        id: get-pp
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-name }} 
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Deploy Identity
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-name }} 
           slot-name: "staging"
-          publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-publish-profile }} 
+          publish-profile: ${{ steps.get-pp.outputs.profile}} 
           package: ./Identity.zip
+
+      - name: Reset Publish Profile
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-name }} 
+          reset: true
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
 
   deploy-api:
@@ -182,8 +199,16 @@ jobs:
         uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-api-webapp-name, 
-                    appservices-api-webapp-publish-profile"
+          secrets: "appservices-api-webapp-name"
+
+      - name: Get Publish Profile
+        id: get-pp
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-name }} 
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Deploy Api
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
@@ -192,6 +217,15 @@ jobs:
           slot-name: "staging"
           publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-publish-profile }} 
           package: ./Api.zip
+
+      - name: Reset Publish Profile
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-name }} 
+          reset: true
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
 
   deploy-billing:
@@ -215,8 +249,16 @@ jobs:
         uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-billing-webapp-name, 
-                    appservices-billing-webapp-publish-profile"
+          secrets: "appservices-billing-webapp-name"
+
+      - name: Get Publish Profile
+        id: get-pp
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-name }} 
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Deploy Billing
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
@@ -225,6 +267,15 @@ jobs:
           slot-name: "staging"
           publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-publish-profile }} 
           package: ./Billing.zip
+
+      - name: Reset Publish Profile
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-name }} 
+          reset: true
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
 
   deploy-events:
@@ -248,8 +299,16 @@ jobs:
         uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-events-webapp-name, 
-                    appservices-events-webapp-publish-profile"
+          secrets: "appservices-events-webapp-name"
+
+      - name: Get Publish Profile
+        id: get-pp
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-name }} 
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Deploy Events
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
@@ -258,6 +317,15 @@ jobs:
           slot-name: "staging"
           publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-publish-profile }} 
           package: ./Events.zip
+
+      - name: Reset Publish Profile
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-name }} 
+          reset: true
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
 
   deploy-sso:
@@ -281,8 +349,16 @@ jobs:
         uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-sso-webapp-name, 
-                    appservices-sso-webapp-publish-profile"
+          secrets: "appservices-sso-webapp-name"
+
+      - name: Get Publish Profile
+        id: get-pp
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-name }} 
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Deploy SSO
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
@@ -291,6 +367,15 @@ jobs:
           slot-name: "staging"
           publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-publish-profile }} 
           package: ./Sso.zip
+
+      - name: Reset Publish Profile
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-name }} 
+          reset: true
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
 
   deploy-portal:
@@ -314,8 +399,16 @@ jobs:
         uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-portal-webapp-name, 
-                    appservices-portal-webapp-publish-profile"
+          secrets: "appservices-portal-webapp-name"
+
+      - name: Get Publish Profile
+        id: get-pp
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-name }} 
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Deploy Portal
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
@@ -324,6 +417,15 @@ jobs:
           slot-name: "staging"
           publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-publish-profile }} 
           package: ./Portal.zip
+
+      - name: Reset Publish Profile
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-name }} 
+          reset: true
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
 
   deploy-admin:
@@ -347,8 +449,16 @@ jobs:
         uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-admin-webapp-name, 
-                    appservices-admin-webapp-publish-profile"
+          secrets: "appservices-admin-webapp-name"
+
+      - name: Get Publish Profile
+        id: get-pp
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-name }} 
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Deploy Admin
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
@@ -357,4 +467,13 @@ jobs:
           slot-name: "staging"
           publish-profile: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-publish-profile }} 
           package: ./Admin.zip
+
+      - name: Reset Publish Profile
+        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+        with:
+          resrouceGroupName: "bitwarden-qa"
+          appName: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-name }} 
+          reset: true
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -215,17 +215,18 @@ jobs:
       - name: Start staging slot
         run: az webapp start --name $IDENTITY_WEBAPP_NAME --resource-group bitwarden-qa --slot staging
 
-      - name: Make sure it endpoint is alive
+      - name: Make sure staging endpoint is alive
         run: |
           while read OUTPUT
           do
-            STATUS=$( curl -is https://$IDENTITY_WEBAPP_NAME.azurewebsites.net/.well-known/openid-configuration/jwks | head -1 )
+            STATUS=$( curl -is https://$IDENTITY_WEBAPP_NAME-staging.azurewebsites.net/alive | head -1 )
             if [[ "$STATUS" == *"200 OK"* ]]; then
+              echo "It is live!"
               break
             fi
-            echo -e "STAUS=$STATUS\nsleeping for 2 seconds"
-            sleep 2;
-          done < <(seq 150)
+            echo -e "STAUS=$STATUS\nRetrying: $OUTPUT"
+            sleep 4;
+          done < <(seq 15)
 
       - name: Swap Identity
         run: az webapp deployment slot swap -g bitwarden-qa -n $IDENTITY_WEBAPP_NAME --slot staging --target-slot production
@@ -276,17 +277,18 @@ jobs:
       - name: Start staging slot
         run: az webapp start --name $WEBAPP_NAME --resource-group bitwarden-qa --slot staging
 
-      - name: Make sure it endpoint is alive
+      - name: Make sure staging endpoint is alive
         run: |
           while read OUTPUT
           do
-            STATUS=$( curl -is https://$WEBAPP_NAME.azurewebsites.net/alive | head -1 )
+            STATUS=$( curl -is https://$WEBAPP_NAME-staging.azurewebsites.net/alive | head -1 )
             if [[ "$STATUS" == *"200 OK"* ]]; then
+              echo "It is live!"
               break
             fi
-            echo -e "STAUS=$STATUS\nsleeping for 2 seconds"
-            sleep 2;
-          done < <(seq 150)
+            echo -e "STAUS=$STATUS\nRetrying: $OUTPUT"
+            sleep 4;
+          done < <(seq 15)
 
       - name: Swap slots
         run: az webapp deployment slot swap -g bitwarden-qa -n $WEBAPP_NAME --slot staging --target-slot production
@@ -321,7 +323,7 @@ jobs:
       - name: Start staging slot
         run: az webapp start --name $ADMIN_WEBAPP_NAME --resource-group bitwarden-qa --slot staging
 
-      - name: Make sure it endpoint is alive
+      - name: Make sure staging endpoint is alive
         run: |
           sleep 60  # I don't think the admin portal has an alive endpoint
           #while true

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -213,8 +213,7 @@ jobs:
 
       - name: Make sure it endpoint is alive
         run: |
-          count=0
-          while count -ne 150
+          while read OUTPUT
           do
             STATUS=$( curl -is https://$IDENTITY_WEBAPP_NAME.azurewebsites.net/.well-known/openid-configuration/jwks | head -1 )
             if [[ "$STATUS" == *"200 OK"* ]]; then
@@ -222,8 +221,7 @@ jobs:
             fi
             echo -e "STAUS=$STATUS\nsleeping for 2 seconds"
             sleep 2;
-            count=$count+1
-          done
+          done < <(seq 150)
 
       - name: Swap Identity
         run: az webapp deployment slot swap -g bitwarden-qa -n $IDENTITY_WEBAPP_NAME --slot staging --target-slot production
@@ -275,8 +273,7 @@ jobs:
 
       - name: Make sure it endpoint is alive
         run: |
-          count=0
-          while count -ne 150
+          while read OUTPUT
           do
             STATUS=$( curl -is https://$WEBAPP_NAME.azurewebsites.net/alive | head -1 )
             if [[ "$STATUS" == *"200 OK"* ]]; then
@@ -284,8 +281,7 @@ jobs:
             fi
             echo -e "STAUS=$STATUS\nsleeping for 2 seconds"
             sleep 2;
-            count=$count+1
-          done
+          done < <(seq 150)
 
       - name: Swap slots
         run: az webapp deployment slot swap -g bitwarden-qa -n $WEBAPP_NAME --slot staging --target-slot production

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -185,8 +185,7 @@ jobs:
 
   swap-identity:
     runs-on: ubuntu-latest
-    needs: 
-      - deploy
+    needs: deploy
     steps:
       - name: Checkout custom AZ KV action
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
@@ -226,8 +225,7 @@ jobs:
 
   swap-slots:
     runs-on: ubuntu-latest
-    needs: 
-      - swap-identity
+    needs: swap-identity
     strategy:
       fail-fast: false
       matrix:
@@ -284,7 +282,7 @@ jobs:
 
   swap-admin:
     runs-on: ubuntu-latest
-    needs: deploy
+    needs: swap-slots
     steps:
       - name: Checkout custom AZ KV action
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -148,7 +148,9 @@ jobs:
       - name: Setup
         id: setup
         run: |
-          NAME_LOWER=$(echo "${ matrix.name }" | awk '{print tolower($0)}')
+          NAME_LOWER=$(echo "${{ matrix.name }}" | awk '{print tolower($0)}')
+          echo "Matrix name: ${{ matrix.name }}"
+          echo "NAME_LOWER: $NAME_LOWER"
           echo "::set-output name=name_lower::$NAME_LOWER"
 
       - name: Checkout custom AZ KV action
@@ -241,7 +243,7 @@ jobs:
       - name: Setup
         id: setup
         run: |
-          NAME_LOWER=$(echo "${ matrix.name }" | awk '{print tolower($0)}')
+          NAME_LOWER=$(echo "${{ matrix.name }}" | awk '{print tolower($0)}')
           echo "::set-output name=name_lower::$NAME_LOWER"
 
       - name: Checkout custom AZ KV action

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -138,20 +138,19 @@ jobs:
       matrix:
         include:
           - name: Api
-            name_lower: api
           - name: Admin
-            name_lower: admin
           - name: Billing
-            name_lower: billing
           - name: Events
-            name_lower: events
           - name: Sso
-            name_lower: sso
           - name: Portal
-            name_lower: portal
           - name: Identity
-            name_lower: identity
     steps:
+      - name: Setup
+        id: setup
+        run: |
+          NAME_LOWER=$(echo "${ matrix.name }" | awk '{print tolower($0)}')
+          echo "::set-output name=name_lower::$NAME_LOWER"
+
       - name: Checkout custom AZ KV action
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
@@ -174,7 +173,7 @@ jobs:
         uses: ./.github/actions/get-keyvault-secrets
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-${{ matrix.name_lower }}-webapp-name:webapp-name"
+          secrets: "appservices-${{ steps.setup.outputs.name_lower }}-webapp-name:webapp-name"
 
       - name: Deploy App
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
@@ -182,3 +181,73 @@ jobs:
           app-name: ${{ steps.retrieve-secrets.outputs.webapp-name }} 
           slot-name: "staging"
           package: ./${{ matrix.name }}.zip
+
+
+  swap-identity:
+    runs-on: ubuntu-latest
+    needs: 
+      - deploy
+    steps:
+      - name: Checkout custom AZ KV action
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          repository: joseph-flinn/get-keyvault-secrets
+          ref: 07b54e7df161105193fb62e3b594e496377f2e84
+          path: ./.github/actions/get-keyvault-secrets
+
+      - name: Login to Azure
+        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
+        with:
+          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
+
+      - name: Retrieve secrets
+        id: retrieve-secrets
+        uses: ./.github/actions/get-keyvault-secrets
+        with:
+          keyvault: "bitwarden-qa-kv"
+          secrets: "appservices-identity-webapp-name:IDENTITY_WEBAPP_NAME"
+
+      - name: Start staging slot
+        run: az webapp start --name $IDENTITY_WEBAPP_NAME --resource-group bitwarden-qa --slot staging
+
+      - name: Make sure it endpoint is alive
+        run: |
+          while [ "$( curl -is https://$IDENTITY_WEBAPP_NAME.azurewebsites.net/.well-known/oepnid-configuration/jwks | head -1 )" =! *"200 OK"* ]
+          do
+            sleep 2;
+          done
+
+      - name: Swap Identity
+        run: az webapp deployment slot swap -g bitwarden-qa -n $IDENTITY_WEBAPP_NAME --slot staging --target-slot production
+
+      - name: Stop staging slot
+        run: az webapp stop --name $IDENTITY_WEBAPP_NAME --resource-group bitwarden-qa --slot staging
+
+
+  swap-slots:
+    runs-on: ubuntu-latest
+    needs: 
+      - swap-identity
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Api
+          - name: Admin
+          - name: Billing
+          - name: Events
+          - name: Sso
+          - name: Portal
+          - name: Identity
+    steps:
+      - name: Setup
+        id: setup
+        run: |
+          NAME_LOWER=$(echo "${ matrix.name }" | awk '{print tolower($0)}')
+          echo "::set-output name=name_lower::$NAME_LOWER"
+
+
+  swap-admin:
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -181,7 +181,7 @@ jobs:
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
           resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.webapp-name }} 
+          appName: ${{ steps.retrieve-secrets.outputs.webapp-name }}/staging
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
@@ -197,7 +197,7 @@ jobs:
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
           resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.webapp-name }} 
+          appName: ${{ steps.retrieve-secrets.outputs.webapp-name }}/staging
           reset: true
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -130,10 +130,10 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    strategy:
     needs: 
       - reset-db
       - update-db
+    strategy:
       fail-fast: false
       matrix:
         include:

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -135,7 +135,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
+        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Identity.zip
 
@@ -185,7 +185,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
+        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Api.zip
 
@@ -235,7 +235,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
+        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Billing.zip
 
@@ -285,7 +285,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
+        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Events.zip
 
@@ -335,7 +335,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
+        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Sso.zip
 
@@ -385,7 +385,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
+        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Portal.zip
 
@@ -435,7 +435,7 @@ jobs:
       - update-db
     steps:
       - name: Download aritifacts
-        uses: actions/download-artifact@v158ca71f7c614ae705e79f25522ef4658df18253
+        uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253
         with:
           name: Admin.zip
 

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build:
+    if: false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -108,6 +109,7 @@ jobs:
 
 
   reset-db:
+    if: false
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -118,7 +120,8 @@ jobs:
           echo "placeholder for loading test dataset"
 
   update-db:
-    if: ${{ github.events.inputs.migrateDb }} == "true"
+    if: false
+    #if: ${{ github.events.inputs.migrateDb }} == "true"
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -129,6 +132,7 @@ jobs:
 
 
   deploy:
+    if: false
     runs-on: ubuntu-latest
     needs: 
       - reset-db
@@ -187,7 +191,7 @@ jobs:
 
   swap-identity:
     runs-on: ubuntu-latest
-    needs: deploy
+    #needs: deploy
     steps:
       - name: Checkout custom AZ KV action
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -246,8 +246,77 @@ jobs:
           NAME_LOWER=$(echo "${ matrix.name }" | awk '{print tolower($0)}')
           echo "::set-output name=name_lower::$NAME_LOWER"
 
+      - name: Checkout custom AZ KV action
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          repository: joseph-flinn/get-keyvault-secrets
+          ref: 07b54e7df161105193fb62e3b594e496377f2e84
+          path: ./.github/actions/get-keyvault-secrets
+
+      - name: Login to Azure
+        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
+        with:
+          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
+
+      - name: Retrieve secrets
+        id: retrieve-secrets
+        uses: ./.github/actions/get-keyvault-secrets
+        with:
+          keyvault: "bitwarden-qa-kv"
+          secrets: "appservices-identity-webapp-name:WEBAPP_NAME"
+
+      - name: Start staging slot
+        run: az webapp start --name $WEBAPP_NAME --resource-group bitwarden-qa --slot staging
+
+      - name: Make sure it endpoint is alive
+        run: |
+          while [ "$( curl -is https://$WEBAPP_NAME.azurewebsites.net/.well-known/oepnid-configuration/jwks | head -1 )" =! *"200 OK"* ]
+          do
+            sleep 2;
+          done
+
+      - name: Swap slots
+        run: az webapp deployment slot swap -g bitwarden-qa -n $WEBAPP_NAME --slot staging --target-slot production
+
+      - name: Stop staging slot
+        run: az webapp stop --name $WEBAPP_NAME --resource-group bitwarden-qa --slot staging
+
 
   swap-admin:
     runs-on: ubuntu-latest
     needs: deploy
     steps:
+      - name: Checkout custom AZ KV action
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          repository: joseph-flinn/get-keyvault-secrets
+          ref: 07b54e7df161105193fb62e3b594e496377f2e84
+          path: ./.github/actions/get-keyvault-secrets
+
+      - name: Login to Azure
+        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
+        with:
+          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
+
+      - name: Retrieve secrets
+        id: retrieve-secrets
+        uses: ./.github/actions/get-keyvault-secrets
+        with:
+          keyvault: "bitwarden-qa-kv"
+          secrets: "appservices-identity-webapp-name:ADMIN_WEBAPP_NAME"
+
+      - name: Start staging slot
+        run: az webapp start --name $ADMIN_WEBAPP_NAME --resource-group bitwarden-qa --slot staging
+
+      - name: Make sure it endpoint is alive
+        run: |
+          while [ "$( curl -is https://$ADMIN_WEBAPP_NAME.azurewebsites.net/.well-known/oepnid-configuration/jwks | head -1 )" =! *"200 OK"* ]
+          do
+            sleep 2;
+          done
+
+      - name: Swap Admin
+        run: az webapp deployment slot swap -g bitwarden-qa -n $ADMIN_WEBAPP_NAME --slot staging --target-slot production
+
+      - name: Stop staging slot
+        run: az webapp stop --name $ADMIN_WEBAPP_NAME --resource-group bitwarden-qa --slot staging

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -219,7 +219,7 @@ jobs:
         run: |
           while read OUTPUT
           do
-            STATUS=$( curl -is https://$IDENTITY_WEBAPP_NAME-staging.azurewebsites.net/alive | head -1 )
+            STATUS=$( curl -is https://$IDENTITY_WEBAPP_NAME-staging.azurewebsites.net/.well-known/openid-configuration/jwks | head -1 )
             if [[ "$STATUS" == *"200 OK"* ]]; then
               echo "It is live!"
               break

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -157,7 +157,7 @@ jobs:
         with:
           repository: joseph-flinn/get-keyvault-secrets
           ref: refs/heads/add-dynamic-secret-support
-          path: ./github/actions/get-keyvault-secrets
+          path: ./.github/actions/get-keyvault-secrets
 
       - name: Download aritifacts
         uses: actions/download-artifact@158ca71f7c614ae705e79f25522ef4658df18253

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -174,16 +174,25 @@ jobs:
         uses: ./.github/actions/get-keyvault-secrets
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "appservices-${{ matrix.name_lower }}-webapp-name:webapp-name"
+          secrets: "subscription-id,
+                    appservices-${{ matrix.name_lower }}-webapp-name:webapp-name"
 
       - name: Get Publish Profile
-        id: get-pp
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.webapp-name }}/staging
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
+        run: |
+          echo 'WEBAPP_PUBLISHING_PROFILE=$(az webapp deployment list-publishing-profiles --name ${{ steps.retrieve-secrets.output.webapp-name }} --slot staging --resource-group "bitwarden-qa" --subscription ${{ steps.retrieve-secrets.output.webapp-name }})' >> $GITHUB_ENV
+
+          echo "::add-mask::$WEBAPP_PUBLISHING_PROFILE"
+          echo "::set-output name=publish-profile::$WEBAPP_PUBLISHING_PROFILE"
+
+
+      #- name: Get Publish Profile
+      #  id: get-pp
+      #  uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+      #  with:
+      #    resourceGroupName: "bitwarden-qa"
+      #    appName: ${{ steps.retrieve-secrets.outputs.webapp-name }}/staging
+      #  env:
+      #    AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Deploy App
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
@@ -193,11 +202,11 @@ jobs:
           publish-profile: ${{ steps.get-pp.outputs.profile}} 
           package: ./${{ matrix.name }}.zip
 
-      - name: Reset Publish Profile
-        uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-        with:
-          resourceGroupName: "bitwarden-qa"
-          appName: ${{ steps.retrieve-secrets.outputs.webapp-name }}/staging
-          reset: true
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
+      #- name: Reset Publish Profile
+      #  uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
+      #  with:
+      #    resourceGroupName: "bitwarden-qa"
+      #    appName: ${{ steps.retrieve-secrets.outputs.webapp-name }}/staging
+      #    reset: true
+      #  env:
+      #    AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -177,36 +177,9 @@ jobs:
           secrets: "subscription-id,
                     appservices-${{ matrix.name_lower }}-webapp-name:webapp-name"
 
-      #- name: Get Publish Profile
-      #  run: |
-      #    echo 'WEBAPP_PUBLISHING_PROFILE=$(az webapp deployment list-publishing-profiles --name ${{ steps.retrieve-secrets.output.webapp-name }} --slot staging --resource-group "bitwarden-qa" --subscription ${{ steps.retrieve-secrets.output.webapp-name }})' >> $GITHUB_ENV
-
-      #    echo "::add-mask::$WEBAPP_PUBLISHING_PROFILE"
-      #    echo "::set-output name=publish-profile::$WEBAPP_PUBLISHING_PROFILE"
-
-
-      #- name: Get Publish Profile
-      #  id: get-pp
-      #  uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-      #  with:
-      #    resourceGroupName: "bitwarden-qa"
-      #    appName: ${{ steps.retrieve-secrets.outputs.webapp-name }}/staging
-      #  env:
-      #    AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
       - name: Deploy App
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.webapp-name }} 
           slot-name: "staging"
-          #publish-profile: ${{ steps.get-pp.outputs.profile}} 
           package: ./${{ matrix.name }}.zip
-
-      #- name: Reset Publish Profile
-      #  uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
-      #  with:
-      #    resourceGroupName: "bitwarden-qa"
-      #    appName: ${{ steps.retrieve-secrets.outputs.webapp-name }}/staging
-      #    reset: true
-      #  env:
-      #    AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -235,7 +235,7 @@ jobs:
     needs: swap-identity
     strategy:
       max-parallel: 1
-      fail-fast: false
+      #fail-fast: false
       matrix:
         include:
           - name: Api
@@ -285,9 +285,7 @@ jobs:
           done < <(seq 150)
 
       - name: Swap slots
-        run: |
-          sleep ${{ matrix.sleep_time }}
-          az webapp deployment slot swap -g bitwarden-qa -n $WEBAPP_NAME --slot staging --target-slot production
+        run: az webapp deployment slot swap -g bitwarden-qa -n $WEBAPP_NAME --slot staging --target-slot production
 
       - name: Stop staging slot
         run: az webapp stop --name $WEBAPP_NAME --resource-group bitwarden-qa --slot staging

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -233,12 +233,10 @@ jobs:
       matrix:
         include:
           - name: Api
-          - name: Admin
           - name: Billing
           - name: Events
           - name: Sso
           - name: Portal
-          - name: Identity
     steps:
       - name: Setup
         id: setup

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -155,7 +155,7 @@ jobs:
         id: get-pp
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-name }} 
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
@@ -171,7 +171,7 @@ jobs:
       - name: Reset Publish Profile
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-identity-webapp-name }} 
           reset: true
         env:
@@ -205,7 +205,7 @@ jobs:
         id: get-pp
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-name }} 
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
@@ -221,7 +221,7 @@ jobs:
       - name: Reset Publish Profile
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-api-webapp-name }} 
           reset: true
         env:
@@ -255,7 +255,7 @@ jobs:
         id: get-pp
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-name }} 
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
@@ -271,7 +271,7 @@ jobs:
       - name: Reset Publish Profile
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-billing-webapp-name }} 
           reset: true
         env:
@@ -305,7 +305,7 @@ jobs:
         id: get-pp
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-name }} 
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
@@ -321,7 +321,7 @@ jobs:
       - name: Reset Publish Profile
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-events-webapp-name }} 
           reset: true
         env:
@@ -355,7 +355,7 @@ jobs:
         id: get-pp
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-name }} 
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
@@ -371,7 +371,7 @@ jobs:
       - name: Reset Publish Profile
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-sso-webapp-name }} 
           reset: true
         env:
@@ -405,7 +405,7 @@ jobs:
         id: get-pp
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-name }} 
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
@@ -421,7 +421,7 @@ jobs:
       - name: Reset Publish Profile
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-portal-webapp-name }} 
           reset: true
         env:
@@ -455,7 +455,7 @@ jobs:
         id: get-pp
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-name }} 
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
@@ -471,7 +471,7 @@ jobs:
       - name: Reset Publish Profile
         uses: aliencube/publish-profile-actions@0689f99a0d742938bbe312db9e366e8716cb0855
         with:
-          resrouceGroupName: "bitwarden-qa"
+          resourceGroupName: "bitwarden-qa"
           appName: ${{ steps.retrieve-secrets.outputs.appservices-admin-webapp-name }} 
           reset: true
         env:

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -174,8 +174,7 @@ jobs:
         uses: ./.github/actions/get-keyvault-secrets
         with:
           keyvault: "bitwarden-qa-kv"
-          secrets: "subscription-id,
-                    appservices-${{ matrix.name_lower }}-webapp-name:webapp-name"
+          secrets: "appservices-${{ matrix.name_lower }}-webapp-name:webapp-name"
 
       - name: Deploy App
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31


### PR DESCRIPTION
## Summary
Adding auto slot swapping to the QA deploy pipeline to help the overall work flow. Depends on https://github.com/bitwarden/server/pull/1380

This follows the same steps as manually deploying:
1. deploy code
2. start staging slot
3. warmup slot by pinging /alive (or similar)
4. swap slot
5. stop staging slot

Identity goes first, the rest except for Admin, then Admin