### PR TITLE
[Business Portal] BUG Fix localization

### DIFF
--- a/src/Core/Properties/AssemblyInfo.cs
+++ b/src/Core/Properties/AssemblyInfo.cs
@@ -2,3 +2,4 @@
 using Microsoft.Extensions.Localization;
 
 [assembly: ResourceLocation("Resources")]
+[assembly: RootNamespace("Bit.Core")]


### PR DESCRIPTION
## Objective
> Business portal building assembly isn't correctly finding the shared resource strings for translation

## Code Changes
- **AssemblyInfo**: Added `RootNamespace` of `Bit.Core` to fix localization