### PR TITLE
[Reset Password] Update Custom orgs for UseResetPassword

### DIFF
--- a/util/Migrator/DbScripts/2021-06-15_00_UseResetPasswordCustomOrg.sql
+++ b/util/Migrator/DbScripts/2021-06-15_00_UseResetPasswordCustomOrg.sql
@@ -1,0 +1,6 @@
+-- For Enterprise (annual/monthly) and Custom (internal) orgs, enable potential use of UseResetPassword
+UPDATE
+    [dbo].[Organization]
+SET
+    [UseResetPassword] = (CASE WHEN [PlanType] = 10 OR [PlanType] = 11 OR [PlanType] = 6 THEN 1 ELSE 0 END)
+GO

--- a/util/Migrator/DbScripts/2021-06-15_00_UseResetPasswordCustomOrg.sql
+++ b/util/Migrator/DbScripts/2021-06-15_00_UseResetPasswordCustomOrg.sql
@@ -2,5 +2,5 @@
 UPDATE
     [dbo].[Organization]
 SET
-    [UseResetPassword] = (CASE WHEN [PlanType] = 10 OR [PlanType] = 11 OR [PlanType] = 6 THEN 1 ELSE 0 END)
+    [UseResetPassword] = (CASE WHEN [PlanType] IN (10, 11, 6) THEN 1 ELSE [UseResetPassword] END)
 GO


### PR DESCRIPTION
## Objective
> For internal testing purposes, allow `Custom` organizations to `UseResetPassword`.

## Code Changes
- **2021-06-15_00_UseResetPasswordCustomOrg.sql**: Update `UseResetPassword` on the `Organization` table to be set to `true` for Enterprise (annual/monthly) and Custom org types.  Remember this does NOT turn on the policy, it just enables the organization to see the policy.