### PR TITLE
Redefine cipher "share" to "move to organization"

### DIFF
--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -175,7 +175,7 @@ namespace Bit.Api.Controllers
                 (Guid?)null : new Guid(model.OrganizationId);
             if (cipher.OrganizationId != modelOrgId)
             {
-                throw new BadRequestException("Organization mismatch. Re-sync if you recently shared this item, " +
+                throw new BadRequestException("Organization mismatch. Re-sync if you recently moved this item, " +
                     "then try again.");
             }
 
@@ -528,7 +528,7 @@ namespace Bit.Api.Controllers
             {
                 if (!ciphersDict.ContainsKey(cipher.Id.Value))
                 {
-                    throw new BadRequestException("Trying to share ciphers that you do not own.");
+                    throw new BadRequestException("Trying to move ciphers that you do not own.");
                 }
 
                 shareCiphers.Add((cipher.ToCipher(ciphersDict[cipher.Id.Value]), cipher.LastKnownRevisionDate));

--- a/src/Core/MailTemplates/Handlebars/Welcome.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/Welcome.html.hbs
@@ -35,7 +35,7 @@
     <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
         <td class="h3" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 18px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; font-weight: bold; padding: 0 0 5px;" valign="top">
             <br style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;" />
-            Securely Share with Bitwarden Organizations
+            Securely Share using Bitwarden Organizations
         </td>
     </tr>
     <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">

--- a/src/Core/MailTemplates/Handlebars/Welcome.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/Welcome.text.hbs
@@ -16,7 +16,7 @@ Download Options
 http://www.bitwarden.com/download
 
 
-Securely Share with Bitwarden Organizations
+Securely Share using Bitwarden Organizations
 ============
 
 Bitwarden makes it easy to securely share passwords for teams and enterprises through Organizations. Join an Organization if invited, or launch a new one anytime from the Web Vault ({{WebVaultUrl}}/?utm_source=welcome_email&utm_medium=email) with the + New Organization button.


### PR DESCRIPTION
# Overview

The term "Share" is confusing to users because it implies maintaining ownership and control of a cipher while allowing others to access it as well. It also implies the ability to revoke access or to stop sharing -- neither of these things is true.

When a cipher is "shared" it is irrevocably taken over by an organization. This occurs for good cryptographic and security reasons. The better solution to this is to revise the communication around "sharing." To that end, this work changes the term "share" to "move to organization". Additionally, email communications should not imply users can share with organizations. Instead, users can share items with each other _using_ or _through_ organizations.

# Files Changed
* **CiphersController**: Update error response to use `move` instead of `share`
* **MailTempltates**: use `using` to clarify that users are not maintaining ownership of moved items.