### PR TITLE
[Reset Password] - BUG - Upgrade request model Keys null check

### DIFF
--- a/src/Core/Models/Api/Request/Organizations/OrganizationUpgradeRequestModel.cs
+++ b/src/Core/Models/Api/Request/Organizations/OrganizationUpgradeRequestModel.cs
@@ -34,7 +34,7 @@ namespace Bit.Core.Models.Api
                 }
             };
 
-            Keys.ToOrganizationUpgrade(orgUpgrade);
+            Keys?.ToOrganizationUpgrade(orgUpgrade);
 
             return orgUpgrade;
         }


### PR DESCRIPTION
## Objective
> Upgrading an organization that already has the `Public/Private` keypair would throw an error because the `Keys` property on the `OrganizationUpgradeRequestModel` was `null`.

## Code Changes
- **OrganizationUpgradeRequestModel**: Added missing null check when performing an action on the `Keys` property

## Release Candidate
- This will be cherry-picked for the upcoming release