### PR TITLE
Remove default request size limit for direct uploads

### DIFF
--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -622,12 +622,18 @@ namespace Bit.Api.Controllers
         }
 
         [HttpPost("{id}/attachment/{attachmentId}")]
+        [DisableRequestSizeLimit]
         [DisableFormValueModelBinding]
         public async Task PostFileForExistingAttachment(string id, string attachmentId)
         {
             if (!Request?.ContentType.Contains("multipart/") ?? true)
             {
                 throw new BadRequestException("Invalid content.");
+            }
+
+            if (!_globalSettings.SelfHosted)
+            {
+                throw new BadRequestException("Invalid endpoint for non self-hosted servers.");
             }
 
             var userId = _userService.GetProperUserId(User).Value;

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -249,6 +249,7 @@ namespace Bit.Api.Controllers
         }
 
         [HttpPost("{id}/file/{fileId}")]
+        [DisableRequestSizeLimit]
         [DisableFormValueModelBinding]
         public async Task PostFileForExistingSend(string id, string fileId)
         {


### PR DESCRIPTION
## Objective

Self-hosted users were reporting that they were unable to upload a file Send greater than about 35mb. Note that you must be using direct uploads to reproduce this error - it occurs on the `Api/SendsController/PostFileForExistingSend` endpoint.

This is the problem ([source](https://github.com/aspnet/Announcements/issues/267)):
> Starting in ASP.NET Core 2.0.0, both Kestrel and HttpSys will be enforcing a a 30MB (~28.6 MiB) max request body size limit.
> If the request body size exceeds the configured max request body size limit, the call to Request.Body.ReadAsync will throw an IOException. If this exception is uncaught, Kestrel will respond with a 413 Payload Too Large response and HttpSys will respond with a generic 500 Internal Server Error response.

The intended file size limit is contained in the logic of the body of `PostFileForExistingSend`:
* if the user is self-hosted - no limit
* if the user is on cloud/prod - 100 mb.

## Code changes

There are a few options here:

* disable the request size limit (this PR). If we add `[DisableRequestSizeLimit]`, it'll disable this limit and just let us check the body size ourselves in the controller action (which we already do). This seems like the most straightforward fix.

* however, it might be better to short-circuit the http request earlier in the pipeline (closer to how the `RequestSizeLimit` attribute works). We could use a custom Resource Filter on the route to conditionally check the request body size earlier, instead of letting the request all the way through to the action. I started working on this, but thought I'd check first whether this is actually worth doing.