### PR TITLE
Support RSA 4096 keys in password history

### DIFF
--- a/src/Core/Models/Api/CipherLoginModel.cs
+++ b/src/Core/Models/Api/CipherLoginModel.cs
@@ -52,7 +52,7 @@ namespace Bit.Core.Models.Api
         [EncryptedStringLength(1000)]
         public string Username { get; set; }
         [EncryptedString]
-        [EncryptedStringLength(1000)]
+        [EncryptedStringLength(5000)]
         public string Password { get; set; }
         public DateTime? PasswordRevisionDate { get; set; }
         [EncryptedString]

--- a/src/Core/Models/Api/CipherPasswordHistoryModel.cs
+++ b/src/Core/Models/Api/CipherPasswordHistoryModel.cs
@@ -16,7 +16,7 @@ namespace Bit.Core.Models.Api
         }
 
         [EncryptedString]
-        [EncryptedStringLength(2000)]
+        [EncryptedStringLength(5000)]
         [Required]
         public string Password { get; set; }
         [Required]


### PR DESCRIPTION
## Objective

Bugfix:

> In #1236 we increased the encrypted character limit for custom fields to support storage of things like an SSH key. However, we did not increase the Password History's encrypted character limit (For hidden fields specifically) to match the 5k limit, so editing an SSH key is impossible (Unless you just delete the fields and make new ones)

See https://app.asana.com/0/1169444489336079/1200488309521384/f.

## Code change
Increase the `EncryptedStringLength` on `CipherPasswordHistoryModel` to match the changes in #1236.

@MGibson1 do you have any concerns here? Does it change our answer to increasing the size of the password field as well?