### PR TITLE
Avoid sql connection timeout

### DIFF
--- a/src/Core/Repositories/IOrganizationUserRepository.cs
+++ b/src/Core/Repositories/IOrganizationUserRepository.cs
@@ -15,7 +15,7 @@ namespace Bit.Core.Repositories
         Task<ICollection<OrganizationUser>> GetManyByUserAsync(Guid userId);
         Task<ICollection<OrganizationUser>> GetManyByOrganizationAsync(Guid organizationId, OrganizationUserType? type);
         Task<int> GetCountByOrganizationAsync(Guid organizationId, string email, bool onlyRegisteredUsers);
-        Task<IEnumerable<string>> SelectKnownEmailsAsync(Guid organizationId, IEnumerable<string> emails, bool onlyRegisteredUsers);
+        Task<ICollection<string>> SelectKnownEmailsAsync(Guid organizationId, IEnumerable<string> emails, bool onlyRegisteredUsers);
         Task<OrganizationUser> GetByOrganizationAsync(Guid organizationId, Guid userId);
         Task<Tuple<OrganizationUser, ICollection<SelectionReadOnly>>> GetByIdWithCollectionsAsync(Guid id);
         Task<OrganizationUserUserDetails> GetDetailsByIdAsync(Guid id);

--- a/src/Core/Repositories/SqlServer/EventRepository.cs
+++ b/src/Core/Repositories/SqlServer/EventRepository.cs
@@ -164,9 +164,9 @@ namespace Bit.Core.Repositories.SqlServer
             eventsTable.Columns.Add(actingUserIdColumn);
             var deviceTypeColumn = new DataColumn(nameof(e.DeviceType), typeof(int));
             eventsTable.Columns.Add(deviceTypeColumn);
-            var ipAddressColumn = new DataColumn(nameof(e.IpAddress), e.IpAddress.GetType());
+            var ipAddressColumn = new DataColumn(nameof(e.IpAddress), typeof(string));
             eventsTable.Columns.Add(ipAddressColumn);
-            var dateColumn = new DataColumn(nameof(e.Date), e.Date.GetType());
+            var dateColumn = new DataColumn(nameof(e.Date), typeof(DateTime));
             eventsTable.Columns.Add(dateColumn);
 
             foreach (DataColumn col in eventsTable.Columns)

--- a/src/Core/Repositories/SqlServer/OrganizationUserRepository.cs
+++ b/src/Core/Repositories/SqlServer/OrganizationUserRepository.cs
@@ -76,7 +76,7 @@ namespace Bit.Core.Repositories.SqlServer
             }
         }
 
-        public async Task<IEnumerable<string>> SelectKnownEmailsAsync(Guid organizationId, IEnumerable<string> emails,
+        public async Task<ICollection<string>> SelectKnownEmailsAsync(Guid organizationId, IEnumerable<string> emails,
             bool onlyRegisteredUsers)
         {
             using (var connection = new SqlConnection(ConnectionString))

--- a/src/Core/Repositories/SqlServer/OrganizationUserRepository.cs
+++ b/src/Core/Repositories/SqlServer/OrganizationUserRepository.cs
@@ -86,7 +86,8 @@ namespace Bit.Core.Repositories.SqlServer
                     new { OrganizationId = organizationId, Emails = emails.ToArrayTVP("Email"), OnlyUsers = onlyRegisteredUsers },
                     commandType: CommandType.StoredProcedure);
 
-                return result;
+                // Return as a list to avoid timing out the sql connection
+                return result.ToList();
             }
         }
 


### PR DESCRIPTION
# Overview

#1408 didn't fix our connection closed issue. I don't really understand why the connection is closed, but most sprocs of this type return `ICollection` rather than `IEnumerable`, maybe that's why...