### PR TITLE
Extract single-org policy check to OrganizationService

### DIFF
--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -28,7 +28,6 @@ namespace Bit.Api.Controllers
         private readonly IPaymentService _paymentService;
         private readonly ICurrentContext _currentContext;
         private readonly GlobalSettings _globalSettings;
-        private readonly IPolicyRepository _policyRepository;
 
         public OrganizationsController(
             IOrganizationRepository organizationRepository,
@@ -37,8 +36,7 @@ namespace Bit.Api.Controllers
             IUserService userService,
             IPaymentService paymentService,
             ICurrentContext currentContext,
-            GlobalSettings globalSettings,
-            IPolicyRepository policyRepository)
+            GlobalSettings globalSettings)
         {
             _organizationRepository = organizationRepository;
             _organizationUserRepository = organizationUserRepository;
@@ -47,7 +45,6 @@ namespace Bit.Api.Controllers
             _paymentService = paymentService;
             _currentContext = currentContext;
             _globalSettings = globalSettings;
-            _policyRepository = policyRepository;
         }
 
         [HttpGet("{id}")]
@@ -163,24 +160,8 @@ namespace Bit.Api.Controllers
                 throw new Exception("Invalid plan selected.");
             }
 
-            var policies = await _policyRepository.GetManyByUserIdAsync(user.Id);
-            var orgUsers = await _organizationUserRepository.GetManyByUserAsync(user.Id);
-
-            var orgsWithSingleOrgPolicy = policies.Where(p => p.Enabled && p.Type == PolicyType.SingleOrg)
-                .Select(p => p.OrganizationId);
-            var blockedBySingleOrgPolicy = orgUsers.Any(ou => ou.Type != OrganizationUserType.Owner &&
-                                                        ou.Type != OrganizationUserType.Admin &&
-                                                        ou.Status != OrganizationUserStatusType.Invited &&
-                                                        orgsWithSingleOrgPolicy.Contains(ou.OrganizationId));
-
-            if (blockedBySingleOrgPolicy)
-            {
-                throw new Exception("You may not create an organization. You belong to an organization " +
-                    "which has a policy that prohibits you from being a member of any other organization.");
-            }
-
             var organizationSignup = model.ToOrganizationSignup(user);
-            var result = await _organizationService.SignUpAsync(organizationSignup);
+            var result = await _organizationService.SignUpAsync(organizationSignup, user);
             return new OrganizationResponseModel(result.Item1);
         }
 
@@ -198,13 +179,6 @@ namespace Bit.Api.Controllers
             if (license == null)
             {
                 throw new BadRequestException("Invalid license");
-            }
-
-            var policies = await _policyRepository.GetManyByUserIdAsync(user.Id);
-            if (policies.Any(policy => policy.Enabled && policy.Type == PolicyType.SingleOrg))
-            {
-                throw new Exception("You may not create an organization. You belong to an organization " +
-                     "which has a policy that prohibits you from being a member of any other organization.");
             }
 
             var result = await _organizationService.SignUpAsync(license, user, model.Key,

--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -161,7 +161,7 @@ namespace Bit.Api.Controllers
             }
 
             var organizationSignup = model.ToOrganizationSignup(user);
-            var result = await _organizationService.SignUpAsync(organizationSignup, user);
+            var result = await _organizationService.SignUpAsync(organizationSignup);
             return new OrganizationResponseModel(result.Item1);
         }
 

--- a/src/Core/Services/IOrganizationService.cs
+++ b/src/Core/Services/IOrganizationService.cs
@@ -19,7 +19,7 @@ namespace Bit.Core.Services
         Task<string> AdjustStorageAsync(Guid organizationId, short storageAdjustmentGb);
         Task<string> AdjustSeatsAsync(Guid organizationId, int seatAdjustment);
         Task VerifyBankAsync(Guid organizationId, int amount1, int amount2);
-        Task<Tuple<Organization, OrganizationUser>> SignUpAsync(OrganizationSignup organizationSignup, User owner);
+        Task<Tuple<Organization, OrganizationUser>> SignUpAsync(OrganizationSignup organizationSignup);
         Task<Tuple<Organization, OrganizationUser>> SignUpAsync(OrganizationLicense license, User owner,
             string ownerKey, string collectionName, string publicKey, string privateKey);
         Task UpdateLicenseAsync(Guid organizationId, OrganizationLicense license);

--- a/src/Core/Services/IOrganizationService.cs
+++ b/src/Core/Services/IOrganizationService.cs
@@ -19,7 +19,7 @@ namespace Bit.Core.Services
         Task<string> AdjustStorageAsync(Guid organizationId, short storageAdjustmentGb);
         Task<string> AdjustSeatsAsync(Guid organizationId, int seatAdjustment);
         Task VerifyBankAsync(Guid organizationId, int amount1, int amount2);
-        Task<Tuple<Organization, OrganizationUser>> SignUpAsync(OrganizationSignup organizationSignup);
+        Task<Tuple<Organization, OrganizationUser>> SignUpAsync(OrganizationSignup organizationSignup, User owner);
         Task<Tuple<Organization, OrganizationUser>> SignUpAsync(OrganizationLicense license, User owner,
             string ownerKey, string collectionName, string publicKey, string privateKey);
         Task UpdateLicenseAsync(Guid organizationId, OrganizationLicense license);

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -636,7 +636,7 @@ namespace Bit.Core.Services
                                                               orgsWithSingleOrgPolicy.Contains(ou.OrganizationId));
             if (blockedBySingleOrgPolicy)
             {
-                throw new BadRequestException("You may not create an organization. You belong to an organization" +
+                throw new BadRequestException("You may not create an organization. You belong to an organization " +
                     "which has a policy that prohibits you from being a member of any other organization.");
             }
         }

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -549,7 +549,7 @@ namespace Bit.Core.Services
             }
         }
 
-        public async Task<Tuple<Organization, OrganizationUser>> SignUpAsync(OrganizationSignup signup, User owner)
+        public async Task<Tuple<Organization, OrganizationUser>> SignUpAsync(OrganizationSignup signup)
         {
             var plan = StaticStore.Plans.FirstOrDefault(p => p.Type == signup.Plan && !p.Disabled);
             if (plan == null)
@@ -557,7 +557,7 @@ namespace Bit.Core.Services
                 throw new BadRequestException("Plan not found.");
             }
 
-            await ValidateSignUpPoliciesAsync(owner.Id);
+            await ValidateSignUpPoliciesAsync(signup.Owner.Id);
             ValidateOrganizationUpgradeParameters(plan, signup);
 
             var organization = new Organization

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -549,7 +549,7 @@ namespace Bit.Core.Services
             }
         }
 
-        public async Task<Tuple<Organization, OrganizationUser>> SignUpAsync(OrganizationSignup signup)
+        public async Task<Tuple<Organization, OrganizationUser>> SignUpAsync(OrganizationSignup signup, User owner)
         {
             var plan = StaticStore.Plans.FirstOrDefault(p => p.Type == signup.Plan && !p.Disabled);
             if (plan == null)
@@ -557,6 +557,7 @@ namespace Bit.Core.Services
                 throw new BadRequestException("Plan not found.");
             }
 
+            await ValidateSignUpPoliciesAsync(owner.Id);
             ValidateOrganizationUpgradeParameters(plan, signup);
 
             var organization = new Organization
@@ -622,6 +623,24 @@ namespace Bit.Core.Services
             return returnValue;
         }
 
+        private async Task ValidateSignUpPoliciesAsync(Guid ownerId)
+        {
+            var policies = await _policyRepository.GetManyByUserIdAsync(ownerId);
+            var orgUsers = await _organizationUserRepository.GetManyByUserAsync(ownerId);
+
+            var orgsWithSingleOrgPolicy = policies.Where(p => p.Enabled && p.Type == PolicyType.SingleOrg)
+                .Select(p => p.OrganizationId);
+            var blockedBySingleOrgPolicy = orgUsers.Any(ou => ou is {Type: OrganizationUserType.Owner} &&
+                                                              ou.Type != OrganizationUserType.Admin &&
+                                                              ou.Status != OrganizationUserStatusType.Invited &&
+                                                              orgsWithSingleOrgPolicy.Contains(ou.OrganizationId));
+            if (blockedBySingleOrgPolicy)
+            {
+                throw new BadRequestException("You may not create an organization. You belong to an organization" +
+                    "which has a policy that prohibits you from being a member of any other organization.");
+            }
+        }
+
         public async Task<Tuple<Organization, OrganizationUser>> SignUpAsync(
             OrganizationLicense license, User owner, string ownerKey, string collectionName, string publicKey,
             string privateKey)
@@ -648,6 +667,8 @@ namespace Bit.Core.Services
             {
                 throw new BadRequestException("License is already in use by another organization.");
             }
+
+            await ValidateSignUpPoliciesAsync(owner.Id);
 
             var organization = new Organization
             {


### PR DESCRIPTION
## Objective
We evaluated the single-org policy in the `OrganizationsController`. However it seems more reasonable to perform this check inside the service instead, since that's where we do the other checks.

Note: I found the single-org policy behavior to be in-consistent between self-hosted and cloud. On self-hosted we have no "exclusions" for owners and admins (#1171). I've added the exceptions to self-hosted let me know if this is incorrect @eliykat .

### Testing Considerations
We should do a regression sweep to verify the policy still triggers as expected.