### PR TITLE
Creat TVP prior to opening sql connection

### DIFF
--- a/src/Core/Repositories/SqlServer/OrganizationUserRepository.cs
+++ b/src/Core/Repositories/SqlServer/OrganizationUserRepository.cs
@@ -79,11 +79,12 @@ namespace Bit.Core.Repositories.SqlServer
         public async Task<ICollection<string>> SelectKnownEmailsAsync(Guid organizationId, IEnumerable<string> emails,
             bool onlyRegisteredUsers)
         {
+            var emailsTvp = emails.ToArrayTVP("Email");
             using (var connection = new SqlConnection(ConnectionString))
             {
                 var result = await connection.QueryAsync<string>(
                     "[dbo].[OrganizationUser_SelectKnownEmails]",
-                    new { OrganizationId = organizationId, Emails = emails.ToArrayTVP("Email"), OnlyUsers = onlyRegisteredUsers },
+                    new { OrganizationId = organizationId, Emails = emailsTvp, OnlyUsers = onlyRegisteredUsers },
                     commandType: CommandType.StoredProcedure);
 
                 // Return as a list to avoid timing out the sql connection
@@ -342,11 +343,12 @@ namespace Bit.Core.Repositories.SqlServer
                 organizationUser.SetNewId();
             }
 
+            var orgUsersTVP = organizationUsers.ToTvp();
             using (var connection = new SqlConnection(ConnectionString))
             {
                 var results = await connection.ExecuteAsync(
                     $"[{Schema}].[{Table}_CreateMany]",
-                    new { OrganizationUsersInput = organizationUsers.ToTvp() },
+                    new { OrganizationUsersInput = orgUsersTVP },
                     commandType: CommandType.StoredProcedure);
             }
         }
@@ -358,11 +360,12 @@ namespace Bit.Core.Repositories.SqlServer
                 return;
             }
 
+            var orgUsersTVP = organizationUsers.ToTvp();
             using (var connection = new SqlConnection(ConnectionString))
             {
                 var results = await connection.ExecuteAsync(
                     $"[{Schema}].[{Table}_UpdateMany]",
-                    new { OrganizationUsersInput = organizationUsers.ToTvp() },
+                    new { OrganizationUsersInput = orgUsersTVP },
                     commandType: CommandType.StoredProcedure);
             }
         }


### PR DESCRIPTION
# Overview
#1409 Still didn't fix our sql connection closed issue. My thinking is now that the connection is timing out and closing _before_ we ever use it. This would be due to TVP creation taking a long time. we should generate those prior to ever creating a sql connection