### PR TITLE
Increase nginx request timouts for org imports

### DIFF
--- a/util/Setup/Templates/NginxConfig.hbs
+++ b/util/Setup/Templates/NginxConfig.hbs
@@ -122,6 +122,13 @@ server {
     proxy_pass http://api:5000/;
   }
 
+  location /api/public/organization/import {
+    proxy_pass http://api:5000/public/organization/import;
+    proxy_read_timeout 1h;
+    proxy_connect_timeout 1h;
+    proxy_send_timeout 1h;
+  }
+
   location /icons/ {
     proxy_pass http://icons:5000/;
   }

--- a/util/Setup/Templates/NginxConfig.hbs
+++ b/util/Setup/Templates/NginxConfig.hbs
@@ -120,13 +120,13 @@ server {
 
   location /api/ {
     proxy_pass http://api:5000/;
-  }
 
-  location /api/public/organization/import {
-    proxy_pass http://api:5000/public/organization/import;
-    proxy_read_timeout 1h;
-    proxy_connect_timeout 1h;
-    proxy_send_timeout 1h;
+      location /api/public/organization/import {
+        proxy_pass http://api:5000/public/organization/import;
+        proxy_read_timeout 1h;
+        proxy_connect_timeout 1h;
+        proxy_send_timeout 1h;
+      }
   }
 
   location /icons/ {


### PR DESCRIPTION
# Overview

Organization imports of large enough size will quickly blow past our 1 minutes limits on nginx api calls. This increases timeout limit for specifically for those calls.