### PR TITLE
[send.key] Update send.key when account encryption key is rotated

### DIFF
--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -289,27 +289,24 @@ namespace Bit.Api.Controllers
             if (model.Ciphers.Any())
             {
                 var existingCiphers = await _cipherRepository.GetManyByUserIdAsync(user.Id);
-                ciphers = existingCiphers
-                    .Join(model.Ciphers, c => c.Id, c => c.Id, (existing, c) => c.ToCipher(existing))
-                    .ToList();
+                ciphers.AddRange(existingCiphers
+                    .Join(model.Ciphers, c => c.Id, c => c.Id, (existing, c) => c.ToCipher(existing)));
             }
 
             var folders = new List<Folder>();
             if (model.Folders.Any())
             {
                 var existingFolders = await _folderRepository.GetManyByUserIdAsync(user.Id);
-                folders = existingFolders
-                    .Join(model.Folders, f => f.Id, f => f.Id, (existing, f) => f.ToFolder(existing))
-                    .ToList();
+                folders.AddRange(existingFolders
+                    .Join(model.Folders, f => f.Id, f => f.Id, (existing, f) => f.ToFolder(existing)));
             }
 
             var sends = new List<Send>();
             if (model.Sends?.Any() == true)
             {
                 var existingSends = await _sendRepository.GetManyByUserIdAsync(user.Id);
-                sends = existingSends
-                    .Join(model.Sends, s => s.Id, s => s.Id, (existing, s) => s.ToSend(existing, _sendService))
-                    .ToList();
+                sends.AddRange(existingSends
+                    .Join(model.Sends, s => s.Id, s => s.Id, (existing, s) => s.ToSend(existing, _sendService)));
             }
 
             var result = await _userService.UpdateKeyAsync(

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -285,7 +285,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            var ciphers = new List<Cipher>();
+            List<Cipher> ciphers = null;
             if (model.Ciphers.Any())
             {
                 var existingCiphers = await _cipherRepository.GetManyByUserIdAsync(user.Id);
@@ -294,7 +294,7 @@ namespace Bit.Api.Controllers
                     .ToList();
             }
 
-            var folders = new List<Folder>();
+            List<Folder> folders = null;
             if (model.Folders.Any())
             {
                 var existingFolders = await _folderRepository.GetManyByUserIdAsync(user.Id);
@@ -303,7 +303,7 @@ namespace Bit.Api.Controllers
                     .ToList();
             }
 
-            var sends = new List<Send>();
+            List<Send> sends = null;
             if (model.Sends?.Any() == true)
             {
                 var existingSends = await _sendRepository.GetManyByUserIdAsync(user.Id);

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -285,7 +285,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            List<Cipher> ciphers = null;
+            var ciphers = new List<Cipher>();
             if (model.Ciphers.Any())
             {
                 var existingCiphers = await _cipherRepository.GetManyByUserIdAsync(user.Id);
@@ -294,7 +294,7 @@ namespace Bit.Api.Controllers
                     .ToList();
             }
 
-            List<Folder> folders = null;
+            var folders = new List<Folder>();
             if (model.Folders.Any())
             {
                 var existingFolders = await _folderRepository.GetManyByUserIdAsync(user.Id);
@@ -303,7 +303,7 @@ namespace Bit.Api.Controllers
                     .ToList();
             }
 
-            List<Send> sends = null;
+            var sends = new List<Send>();
             if (model.Sends?.Any() == true)
             {
                 var existingSends = await _sendRepository.GetManyByUserIdAsync(user.Id);

--- a/src/Core/Models/Api/Request/Accounts/UpdateKeyRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/UpdateKeyRequestModel.cs
@@ -12,6 +12,7 @@ namespace Bit.Core.Models.Api
         public IEnumerable<CipherWithIdRequestModel> Ciphers { get; set; }
         [Required]
         public IEnumerable<FolderWithIdRequestModel> Folders { get; set; }
+        public IEnumerable<SendWithIdRequestModel> Sends { get; set; }
         [Required]
         public string PrivateKey { get; set; }
         [Required]

--- a/src/Core/Models/Api/Request/SendRequestModel.cs
+++ b/src/Core/Models/Api/Request/SendRequestModel.cs
@@ -130,4 +130,10 @@ namespace Bit.Core.Models.Api
             return existingSend;
         }
     }
+
+    public class SendWithIdRequestModel : SendRequestModel
+    {
+        [Required]
+        public Guid? Id { get; set; }
+    }
 }

--- a/src/Core/Repositories/ICipherRepository.cs
+++ b/src/Core/Repositories/ICipherRepository.cs
@@ -28,7 +28,7 @@ namespace Bit.Core.Repositories
         Task MoveAsync(IEnumerable<Guid> ids, Guid? folderId, Guid userId);
         Task DeleteByUserIdAsync(Guid userId);
         Task DeleteByOrganizationIdAsync(Guid organizationId);
-        Task UpdateUserKeysAndCiphersAsync(User user, IEnumerable<Cipher> ciphers, IEnumerable<Folder> folders);
+        Task UpdateUserKeysAndCiphersAsync(User user, IEnumerable<Cipher> ciphers, IEnumerable<Folder> folders, IEnumerable<Send> sends);
         Task UpdateCiphersAsync(Guid userId, IEnumerable<Cipher> ciphers);
         Task CreateAsync(IEnumerable<Cipher> ciphers, IEnumerable<Folder> folders);
         Task CreateAsync(IEnumerable<Cipher> ciphers, IEnumerable<Collection> collections,

--- a/src/Core/Repositories/SqlServer/CipherRepository.cs
+++ b/src/Core/Repositories/SqlServer/CipherRepository.cs
@@ -336,7 +336,7 @@ namespace Bit.Core.Repositories.SqlServer
 
                         // 3. Bulk copy into temp tables.
 
-                        if (ciphers.Any())
+                        if (ciphers?.Any() == true)
                         {
                             using (var bulkCopy = new SqlBulkCopy(connection, SqlBulkCopyOptions.KeepIdentity, transaction))
                             {
@@ -346,7 +346,7 @@ namespace Bit.Core.Repositories.SqlServer
                             }
                         }
 
-                        if (folders.Any())
+                        if (folders?.Any() == true)
                         {
                             using (var bulkCopy = new SqlBulkCopy(connection, SqlBulkCopyOptions.KeepIdentity, transaction))
                             {
@@ -356,7 +356,7 @@ namespace Bit.Core.Repositories.SqlServer
                             }
                         }
 
-                        if (sends.Any())
+                        if (sends?.Any() == true)
                         {
                             using (var bulkCopy = new SqlBulkCopy(connection, SqlBulkCopyOptions.KeepIdentity, transaction))
                             {
@@ -370,7 +370,7 @@ namespace Bit.Core.Repositories.SqlServer
 
                         var sql = string.Empty;
 
-                        if (ciphers.Any())
+                        if (ciphers?.Any() == true)
                         {
                             sql += @"
                                 UPDATE
@@ -387,7 +387,7 @@ namespace Bit.Core.Repositories.SqlServer
                                     C.[UserId] = @UserId";
                         }
 
-                        if (folders.Any())
+                        if (folders?.Any() == true)
                         {
                             sql += @"
                                 UPDATE
@@ -403,7 +403,7 @@ namespace Bit.Core.Repositories.SqlServer
                                     F.[UserId] = @UserId";
                         }
 
-                        if (sends.Any())
+                        if (sends?.Any() == true)
                         {
                             sql += @"
                                 UPDATE

--- a/src/Core/Repositories/SqlServer/CipherRepository.cs
+++ b/src/Core/Repositories/SqlServer/CipherRepository.cs
@@ -869,7 +869,7 @@ namespace Bit.Core.Repositories.SqlServer
             var s = sends.FirstOrDefault();
             if (s == null)
             {
-                throw new ApplicationException("Must have some ciphers to bulk import.");
+                throw new ApplicationException("Must have some Sends to bulk import.");
             }
 
             var sendsTable = new DataTable("SendsDataTable");

--- a/src/Core/Repositories/SqlServer/CipherRepository.cs
+++ b/src/Core/Repositories/SqlServer/CipherRepository.cs
@@ -282,7 +282,7 @@ namespace Bit.Core.Repositories.SqlServer
             }
         }
 
-        public Task UpdateUserKeysAndCiphersAsync(User user, IEnumerable<Cipher> ciphers, IEnumerable<Folder> folders)
+        public Task UpdateUserKeysAndCiphersAsync(User user, IEnumerable<Cipher> ciphers, IEnumerable<Folder> folders, IEnumerable<Send> sends)
         {
             using (var connection = new SqlConnection(ConnectionString))
             {
@@ -323,7 +323,11 @@ namespace Bit.Core.Repositories.SqlServer
 
                             SELECT TOP 0 *
                             INTO #TempFolder
-                            FROM [dbo].[Folder]";
+                            FROM [dbo].[Folder]
+
+                            SELECT TOP 0 *
+                            INTO #TempSend
+                            FROM [dbo].[Send]";
 
                         using (var cmd = new SqlCommand(sqlCreateTemp, connection, transaction))
                         {
@@ -348,6 +352,16 @@ namespace Bit.Core.Repositories.SqlServer
                             {
                                 bulkCopy.DestinationTableName = "#TempFolder";
                                 var dataTable = BuildFoldersTable(bulkCopy, folders);
+                                bulkCopy.WriteToServer(dataTable);
+                            }
+                        }
+
+                        if (sends.Any())
+                        {
+                            using (var bulkCopy = new SqlBulkCopy(connection, SqlBulkCopyOptions.KeepIdentity, transaction))
+                            {
+                                bulkCopy.DestinationTableName = "#TempSend";
+                                var dataTable = BuildSendsTable(bulkCopy, sends);
                                 bulkCopy.WriteToServer(dataTable);
                             }
                         }
@@ -389,9 +403,26 @@ namespace Bit.Core.Repositories.SqlServer
                                     F.[UserId] = @UserId";
                         }
 
+                        if (sends.Any())
+                        {
+                            sql += @"
+                                UPDATE
+                                    [dbo].[Send]
+                                SET
+                                    [Key] = TS.[Key],
+                                    [RevisionDate] = TS.[RevisionDate]
+                                FROM
+                                    [dbo].[Send] S
+                                INNER JOIN
+                                    #TempSend TS ON S.Id = TS.Id
+                                WHERE
+                                    S.[UserId] = @UserId";
+                        }
+
                         sql += @"
                             DROP TABLE #TempCipher
-                            DROP TABLE #TempFolder";
+                            DROP TABLE #TempFolder
+                            DROP TABLE #TempSend";
 
                         using (var cmd = new SqlCommand(sql, connection, transaction))
                         {
@@ -831,6 +862,82 @@ namespace Bit.Core.Repositories.SqlServer
             }
 
             return collectionCiphersTable;
+        }
+
+        private DataTable BuildSendsTable(SqlBulkCopy bulkCopy, IEnumerable<Send> sends)
+        {
+            var s = sends.FirstOrDefault();
+            if (s == null)
+            {
+                throw new ApplicationException("Must have some ciphers to bulk import.");
+            }
+
+            var sendsTable = new DataTable("SendsDataTable");
+
+            var idColumn = new DataColumn(nameof(s.Id), s.Id.GetType());
+            sendsTable.Columns.Add(idColumn);
+            var userIdColumn = new DataColumn(nameof(s.UserId), typeof(Guid));
+            sendsTable.Columns.Add(userIdColumn);
+            var organizationIdColumn = new DataColumn(nameof(s.OrganizationId), typeof(Guid));
+            sendsTable.Columns.Add(organizationIdColumn);
+            var typeColumn = new DataColumn(nameof(s.Type), s.Type.GetType());
+            sendsTable.Columns.Add(typeColumn);
+            var dataColumn = new DataColumn(nameof(s.Data), s.Data.GetType());
+            sendsTable.Columns.Add(dataColumn);
+            var keyColumn = new DataColumn(nameof(s.Key), s.Key.GetType());
+            sendsTable.Columns.Add(keyColumn);
+            var passwordColumn = new DataColumn(nameof(s.Password), typeof(string));
+            sendsTable.Columns.Add(passwordColumn);
+            var maxAccessCountColumn = new DataColumn(nameof(s.MaxAccessCount), typeof(int));
+            sendsTable.Columns.Add(maxAccessCountColumn);
+            var accessCountColumn = new DataColumn(nameof(s.AccessCount), s.AccessCount.GetType());
+            sendsTable.Columns.Add(accessCountColumn);
+            var creationDateColumn = new DataColumn(nameof(s.CreationDate), s.CreationDate.GetType());
+            sendsTable.Columns.Add(creationDateColumn);
+            var revisionDateColumn = new DataColumn(nameof(s.RevisionDate), s.RevisionDate.GetType());
+            sendsTable.Columns.Add(revisionDateColumn);
+            var expirationDateColumn = new DataColumn(nameof(s.ExpirationDate), typeof(DateTime));
+            sendsTable.Columns.Add(expirationDateColumn);
+            var deletionDateColumn = new DataColumn(nameof(s.DeletionDate), s.DeletionDate.GetType());
+            sendsTable.Columns.Add(deletionDateColumn);
+            var disabledColumn = new DataColumn(nameof(s.Disabled), s.Disabled.GetType());
+            sendsTable.Columns.Add(disabledColumn);
+            var hideEmailColumn = new DataColumn(nameof(s.HideEmail), typeof(bool));
+            sendsTable.Columns.Add(hideEmailColumn);
+
+            foreach (DataColumn col in sendsTable.Columns)
+            {
+                bulkCopy.ColumnMappings.Add(col.ColumnName, col.ColumnName);
+            }
+
+            var keys = new DataColumn[1];
+            keys[0] = idColumn;
+            sendsTable.PrimaryKey = keys;
+
+            foreach (var send in sends)
+            {
+                var row = sendsTable.NewRow();
+
+                row[idColumn] = send.Id;
+                row[userIdColumn] = send.UserId.HasValue ? (object)send.UserId.Value : DBNull.Value;
+                row[organizationIdColumn] = send.OrganizationId.HasValue ? (object)send.OrganizationId.Value : DBNull.Value;
+                row[typeColumn] = (short)send.Type;
+                row[dataColumn] = send.Data;
+                row[keyColumn] = send.Key;
+                row[passwordColumn] = send.Password;
+                row[maxAccessCountColumn] = send.MaxAccessCount.HasValue ? (object)send.MaxAccessCount : DBNull.Value;
+                row[accessCountColumn] = send.AccessCount;
+                row[creationDateColumn] = send.CreationDate;
+                row[revisionDateColumn] = send.RevisionDate;
+                row[expirationDateColumn] = send.ExpirationDate.HasValue ? (object)send.ExpirationDate : DBNull.Value;
+                row[deletionDateColumn] = send.DeletionDate;
+                row[disabledColumn] = send.Disabled;
+                row[hideEmailColumn] = send.HideEmail.HasValue ? (object)send.HideEmail : DBNull.Value;
+
+                sendsTable.Rows.Add(row);
+            }
+
+            return sendsTable;
         }
 
         public class CipherDetailsWithCollections : CipherDetails

--- a/src/Core/Repositories/SqlServer/CipherRepository.cs
+++ b/src/Core/Repositories/SqlServer/CipherRepository.cs
@@ -336,7 +336,7 @@ namespace Bit.Core.Repositories.SqlServer
 
                         // 3. Bulk copy into temp tables.
 
-                        if (ciphers?.Any() == true)
+                        if (ciphers.Any())
                         {
                             using (var bulkCopy = new SqlBulkCopy(connection, SqlBulkCopyOptions.KeepIdentity, transaction))
                             {
@@ -346,7 +346,7 @@ namespace Bit.Core.Repositories.SqlServer
                             }
                         }
 
-                        if (folders?.Any() == true)
+                        if (folders.Any())
                         {
                             using (var bulkCopy = new SqlBulkCopy(connection, SqlBulkCopyOptions.KeepIdentity, transaction))
                             {
@@ -356,7 +356,7 @@ namespace Bit.Core.Repositories.SqlServer
                             }
                         }
 
-                        if (sends?.Any() == true)
+                        if (sends.Any())
                         {
                             using (var bulkCopy = new SqlBulkCopy(connection, SqlBulkCopyOptions.KeepIdentity, transaction))
                             {
@@ -370,7 +370,7 @@ namespace Bit.Core.Repositories.SqlServer
 
                         var sql = string.Empty;
 
-                        if (ciphers?.Any() == true)
+                        if (ciphers.Any())
                         {
                             sql += @"
                                 UPDATE
@@ -387,7 +387,7 @@ namespace Bit.Core.Repositories.SqlServer
                                     C.[UserId] = @UserId";
                         }
 
-                        if (folders?.Any() == true)
+                        if (folders.Any())
                         {
                             sql += @"
                                 UPDATE
@@ -403,7 +403,7 @@ namespace Bit.Core.Repositories.SqlServer
                                     F.[UserId] = @UserId";
                         }
 
-                        if (sends?.Any() == true)
+                        if (sends.Any())
                         {
                             sql += @"
                                 UPDATE

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -38,7 +38,7 @@ namespace Bit.Core.Services
         Task<IdentityResult> ChangeKdfAsync(User user, string masterPassword, string newMasterPassword, string key,
             KdfType kdf, int kdfIterations);
         Task<IdentityResult> UpdateKeyAsync(User user, string masterPassword, string key, string privateKey,
-            IEnumerable<Cipher> ciphers, IEnumerable<Folder> folders);
+            IEnumerable<Cipher> ciphers, IEnumerable<Folder> folders, IEnumerable<Send> sends);
         Task<IdentityResult> RefreshSecurityStampAsync(User user, string masterPasswordHash);
         Task UpdateTwoFactorProviderAsync(User user, TwoFactorProviderType type, bool setEnabled = true);
         Task DisableTwoFactorProviderAsync(User user, TwoFactorProviderType type,

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -52,6 +52,7 @@ namespace Bit.Core.Services
         private readonly ICurrentContext _currentContext;
         private readonly GlobalSettings _globalSettings;
         private readonly IOrganizationService _organizationService;
+        private readonly ISendRepository _sendRepository;
 
         public UserService(
             IUserRepository userRepository,
@@ -79,7 +80,8 @@ namespace Bit.Core.Services
             IFido2 fido2,
             ICurrentContext currentContext,
             GlobalSettings globalSettings,
-            IOrganizationService organizationService)
+            IOrganizationService organizationService,
+            ISendRepository sendRepository)
             : base(
                   store,
                   optionsAccessor,
@@ -113,6 +115,7 @@ namespace Bit.Core.Services
             _currentContext = currentContext;
             _globalSettings = globalSettings;
             _organizationService = organizationService;
+            _sendRepository = sendRepository;
         }
 
         public Guid? GetProperUserId(ClaimsPrincipal principal)
@@ -726,7 +729,7 @@ namespace Bit.Core.Services
         }
 
         public async Task<IdentityResult> UpdateKeyAsync(User user, string masterPassword, string key, string privateKey,
-            IEnumerable<Cipher> ciphers, IEnumerable<Folder> folders)
+            IEnumerable<Cipher> ciphers, IEnumerable<Folder> folders, IEnumerable<Send> sends)
         {
             if (user == null)
             {
@@ -739,9 +742,9 @@ namespace Bit.Core.Services
                 user.SecurityStamp = Guid.NewGuid().ToString();
                 user.Key = key;
                 user.PrivateKey = privateKey;
-                if (ciphers.Any() || folders.Any())
+                if (ciphers.Any() || folders.Any() || sends.Any())
                 {
-                    await _cipherRepository.UpdateUserKeysAndCiphersAsync(user, ciphers, folders);
+                    await _cipherRepository.UpdateUserKeysAndCiphersAsync(user, ciphers, folders, sends);
                 }
                 else
                 {

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -742,7 +742,7 @@ namespace Bit.Core.Services
                 user.SecurityStamp = Guid.NewGuid().ToString();
                 user.Key = key;
                 user.PrivateKey = privateKey;
-                if (ciphers.Any() || folders.Any() || sends.Any())
+                if (ciphers?.Any() == true || folders?.Any() == true || sends?.Any() == true)
                 {
                     await _cipherRepository.UpdateUserKeysAndCiphersAsync(user, ciphers, folders, sends);
                 }

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -742,7 +742,7 @@ namespace Bit.Core.Services
                 user.SecurityStamp = Guid.NewGuid().ToString();
                 user.Key = key;
                 user.PrivateKey = privateKey;
-                if (ciphers?.Any() == true || folders?.Any() == true || sends?.Any() == true)
+                if (ciphers.Any() || folders.Any() || sends.Any())
                 {
                     await _cipherRepository.UpdateUserKeysAndCiphersAsync(user, ciphers, folders, sends);
                 }

--- a/test/Api.Test/Controllers/AccountsControllerTests.cs
+++ b/test/Api.Test/Controllers/AccountsControllerTests.cs
@@ -30,6 +30,8 @@ namespace Bit.Api.Test.Controllers
         private readonly ISsoUserRepository _ssoUserRepository;
         private readonly IUserRepository _userRepository;
         private readonly IUserService _userService;
+        private readonly ISendRepository _sendRepository;
+        private readonly ISendService _sendService;
 
         public AccountsControllerTests()
         {
@@ -41,6 +43,8 @@ namespace Bit.Api.Test.Controllers
             _organizationUserRepository = Substitute.For<IOrganizationUserRepository>();
             _paymentService = Substitute.For<IPaymentService>();
             _globalSettings = new GlobalSettings();
+            _sendRepository = Substitute.For<ISendRepository>();
+            _sendService = Substitute.For<ISendService>();
             _sut = new AccountsController(
                 _globalSettings,
                 _cipherRepository,
@@ -50,7 +54,9 @@ namespace Bit.Api.Test.Controllers
                 _paymentService,
                 _ssoUserRepository,
                 _userRepository,
-                _userService
+                _userService,
+                _sendRepository,
+                _sendService
             );
         }
 

--- a/test/Core.Test/Services/UserServiceTests.cs
+++ b/test/Core.Test/Services/UserServiceTests.cs
@@ -45,6 +45,7 @@ namespace Bit.Core.Test.Services
         private readonly CurrentContext _currentContext;
         private readonly GlobalSettings _globalSettings;
         private readonly IOrganizationService _organizationService;
+        private readonly ISendRepository _sendRepository;
 
         public UserServiceTests()
         {
@@ -74,6 +75,7 @@ namespace Bit.Core.Test.Services
             _currentContext = new CurrentContext();
             _globalSettings = new GlobalSettings();
             _organizationService = Substitute.For<IOrganizationService>();
+            _sendRepository = Substitute.For<ISendRepository>();
 
             _sut = new UserService(
                 _userRepository,
@@ -101,7 +103,8 @@ namespace Bit.Core.Test.Services
                 _fido2,
                 _currentContext,
                 _globalSettings,
-                _organizationService
+                _organizationService,
+                _sendRepository
             );
         }
 


### PR DESCRIPTION
## Objective

Fix the following defect:

> When a user rotates their account's encryption key, Sends that were made prior to the key rotation are now broken/unreadable. 

This happens because `send.key` is not updated when the account's encryption key is rotated. `send.key` is the Send's encryption key, itself encrypted with the user's account encryption key. So after their account encryption key is rotated, they are unable to decode the send encryption key to decode the Send.

The Send is still accessible via the URL because accessing a Send uses the encryption key contained in the URL.

## Code changes

I have largely followed the existing pattern used for updating ciphers and folders when the account encryption key is rotated.

1. `web` - `change-password.component`. Decrypt and re-encrypt `send.key` when the account encryption key is rotated. Add the updated sends in the existing `updateKeyRequest` that is sent to the server. PR: https://github.com/bitwarden/web/pull/1049
    * `jslib` contains the updates to class definitions. PR: https://github.com/bitwarden/jslib/pull/418
2. `AccountsController` - match up the Sends to be updated with the existing Sends on the server and pass to `userService`
3. `UserService` - pass through to `cipherRepository`
4. `CipherRepository` - create a new temp Send table, bulk copy the updated Sends into it, then `UPDATE` the real table with the new data.

Notes/comments:
* It seems like `CipherRepository` is increasingly doing work that is not strictly related to ciphers (e.g. updating the account key, updating folders, updating Sends). However, we want to do this work in a single db commit, so it makes sense to do it all in one place. I followed the existing pattern here, but I'm open to any suggestions of a refactor.
* This is designed to be backwards-compatible with older clients that are not sending `updateKeyRequest.sends`, and also with clients that have already rotated their encryption key and corrupted their Sends.
* I was also unsure whether sending the whole Send object back to the server was unnecessary when we're only updating a single property (`send.key`). In the end I decided it was easier to stick with existing classes and patterns rather than reinventing the wheel - and Send metadata is fairly lean.