### PR TITLE
Move localhost services settings to development settings file

### DIFF
--- a/src/Admin/appsettings.Development.json
+++ b/src/Admin/appsettings.Development.json
@@ -1,0 +1,20 @@
+{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://localhost:8080",
+      "api": "http://localhost:4000",
+      "identity": "http://localhost:33656",
+      "admin": "http://localhost:62911",
+      "notifications": "http://localhost:61840",
+      "sso": "http://localhost:51822",
+      "portal": "http://localhost:52313",
+      "internalNotifications": "http://localhost:61840",
+      "internalAdmin": "http://localhost:62911",
+      "internalIdentity": "http://localhost:33656",
+      "internalApi": "http://localhost:4000",
+      "internalVault": "http://localhost:4001",
+      "internalSso": "http://localhost:51822",
+      "internalPortal": "http://localhost:52313"
+    }
+  }
+}

--- a/src/Admin/appsettings.json
+++ b/src/Admin/appsettings.json
@@ -4,22 +4,6 @@
     "siteName": "Bitwarden",
     "projectName": "Admin",
     "stripeApiKey": "SECRET",
-    "baseServiceUri": {
-      "vault": "https://localhost:8080",
-      "api": "http://localhost:4000",
-      "identity": "http://localhost:33656",
-      "admin": "http://localhost:62911",
-      "notifications": "http://localhost:61840",
-      "sso": "http://localhost:51822",
-      "portal": "http://localhost:52313",
-      "internalNotifications": "http://localhost:61840",
-      "internalAdmin": "http://localhost:62911",
-      "internalIdentity": "http://localhost:33656",
-      "internalApi": "http://localhost:4000",
-      "internalVault": "http://localhost:4001",
-      "internalSso": "http://localhost:51822",
-      "internalPortal": "http://localhost:52313"
-    },
     "sqlServer": {
       "connectionString": "SECRET"
     },

--- a/src/Api/appsettings.Development.json
+++ b/src/Api/appsettings.Development.json
@@ -1,0 +1,20 @@
+{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://localhost:8080",
+      "api": "http://localhost:4000",
+      "identity": "http://localhost:33656",
+      "admin": "http://localhost:62911",
+      "notifications": "http://localhost:61840",
+      "sso": "http://localhost:51822",
+      "portal": "http://localhost:52313",
+      "internalNotifications": "http://localhost:61840",
+      "internalAdmin": "http://localhost:62911",
+      "internalIdentity": "http://localhost:33656",
+      "internalApi": "http://localhost:4000",
+      "internalVault": "http://localhost:4001",
+      "internalSso": "http://localhost:51822",
+      "internalPortal": "http://localhost:52313"
+    }
+  }
+}

--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -4,22 +4,6 @@
     "siteName": "Bitwarden",
     "projectName": "Api",
     "stripeApiKey": "SECRET",
-    "baseServiceUri": {
-      "vault": "https://localhost:8080",
-      "api": "http://localhost:4000",
-      "identity": "http://localhost:33656",
-      "admin": "http://localhost:62911",
-      "notifications": "http://localhost:61840",
-      "sso": "http://localhost:51822",
-      "portal": "http://localhost:52313",
-      "internalNotifications": "http://localhost:61840",
-      "internalAdmin": "http://localhost:62911",
-      "internalIdentity": "http://localhost:33656",
-      "internalApi": "http://localhost:4000",
-      "internalVault": "http://localhost:4001",
-      "internalSso": "http://localhost:51822",
-      "internalPortal": "http://localhost:52313"
-    },
     "sqlServer": {
       "connectionString": "SECRET"
     },

--- a/src/Billing/appsettings.Development.json
+++ b/src/Billing/appsettings.Development.json
@@ -1,0 +1,20 @@
+{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://localhost:8080",
+      "api": "http://localhost:4000",
+      "identity": "http://localhost:33656",
+      "admin": "http://localhost:62911",
+      "notifications": "http://localhost:61840",
+      "sso": "http://localhost:51822",
+      "portal": "http://localhost:52313",
+      "internalNotifications": "http://localhost:61840",
+      "internalAdmin": "http://localhost:62911",
+      "internalIdentity": "http://localhost:33656",
+      "internalApi": "http://localhost:4000",
+      "internalVault": "http://localhost:4001",
+      "internalSso": "http://localhost:51822",
+      "internalPortal": "http://localhost:52313"
+    }
+  }
+}

--- a/src/Billing/appsettings.json
+++ b/src/Billing/appsettings.json
@@ -4,22 +4,6 @@
     "siteName": "Bitwarden",
     "projectName": "Billing",
     "stripeApiKey": "SECRET",
-    "baseServiceUri": {
-      "vault": "https://localhost:8080",
-      "api": "http://localhost:4000",
-      "identity": "http://localhost:33656",
-      "admin": "http://localhost:62911",
-      "notifications": "http://localhost:61840",
-      "sso": "http://localhost:51822",
-      "portal": "http://localhost:52313",
-      "internalNotifications": "http://localhost:61840",
-      "internalAdmin": "http://localhost:62911",
-      "internalIdentity": "http://localhost:33656",
-      "internalApi": "http://localhost:4000",
-      "internalVault": "http://localhost:4001",
-      "internalSso": "http://localhost:51822",
-      "internalPortal": "http://localhost:52313"
-    },
     "sqlServer": {
       "connectionString": "SECRET"
     },

--- a/src/Events/appsettings.Development.json
+++ b/src/Events/appsettings.Development.json
@@ -1,0 +1,20 @@
+{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://localhost:8080",
+      "api": "http://localhost:4000",
+      "identity": "http://localhost:33656",
+      "admin": "http://localhost:62911",
+      "notifications": "http://localhost:61840",
+      "sso": "http://localhost:51822",
+      "portal": "http://localhost:52313",
+      "internalNotifications": "http://localhost:61840",
+      "internalAdmin": "http://localhost:62911",
+      "internalIdentity": "http://localhost:33656",
+      "internalApi": "http://localhost:4000",
+      "internalVault": "http://localhost:4001",
+      "internalSso": "http://localhost:51822",
+      "internalPortal": "http://localhost:52313"
+    }
+  }
+}

--- a/src/Events/appsettings.json
+++ b/src/Events/appsettings.json
@@ -2,22 +2,6 @@
   "globalSettings": {
     "selfHosted": false,
     "projectName": "Events",
-    "baseServiceUri": {
-      "vault": "https://localhost:8080",
-      "api": "http://localhost:4000",
-      "identity": "http://localhost:33656",
-      "admin": "http://localhost:62911",
-      "notifications": "http://localhost:61840",
-      "sso": "http://localhost:51822",
-      "portal": "http://localhost:52313",
-      "internalNotifications": "http://localhost:61840",
-      "internalAdmin": "http://localhost:62911",
-      "internalIdentity": "http://localhost:33656",
-      "internalApi": "http://localhost:4000",
-      "internalVault": "http://localhost:4001",
-      "internalSso": "http://localhost:51822",
-      "internalPortal": "http://localhost:52313"
-    },
     "sqlServer": {
       "connectionString": "SECRET"
     },

--- a/src/Identity/appsettings.Development.json
+++ b/src/Identity/appsettings.Development.json
@@ -1,0 +1,20 @@
+{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://localhost:8080",
+      "api": "http://localhost:4000",
+      "identity": "http://localhost:33656",
+      "admin": "http://localhost:62911",
+      "notifications": "http://localhost:61840",
+      "sso": "http://localhost:51822",
+      "portal": "http://localhost:52313",
+      "internalNotifications": "http://localhost:61840",
+      "internalAdmin": "http://localhost:62911",
+      "internalIdentity": "http://localhost:33656",
+      "internalApi": "http://localhost:4000",
+      "internalVault": "http://localhost:4001",
+      "internalSso": "http://localhost:51822",
+      "internalPortal": "http://localhost:52313"
+    }
+  }
+}

--- a/src/Identity/appsettings.json
+++ b/src/Identity/appsettings.json
@@ -5,22 +5,6 @@
     "projectName": "Identity",
     "stripeApiKey": "SECRET",
     "oidcIdentityClientKey": "SECRET",
-    "baseServiceUri": {
-      "vault": "https://localhost:8080",
-      "api": "http://localhost:4000",
-      "identity": "http://localhost:33656",
-      "admin": "http://localhost:62911",
-      "notifications": "http://localhost:61840",
-      "sso": "http://localhost:51822",
-      "portal": "http://localhost:52313",
-      "internalNotifications": "http://localhost:61840",
-      "internalAdmin": "http://localhost:62911",
-      "internalIdentity": "http://localhost:33656",
-      "internalApi": "http://localhost:4000",
-      "internalVault": "http://localhost:4001",
-      "internalSso": "http://localhost:51822",
-      "internalPortal": "http://localhost:52313"
-    },
     "sqlServer": {
       "connectionString": "SECRET"
     },

--- a/src/Notifications/appsettings.Development.json
+++ b/src/Notifications/appsettings.Development.json
@@ -1,0 +1,20 @@
+{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://localhost:8080",
+      "api": "http://localhost:4000",
+      "identity": "http://localhost:33656",
+      "admin": "http://localhost:62911",
+      "notifications": "http://localhost:61840",
+      "sso": "http://localhost:51822",
+      "portal": "http://localhost:52313",
+      "internalNotifications": "http://localhost:61840",
+      "internalAdmin": "http://localhost:62911",
+      "internalIdentity": "http://localhost:33656",
+      "internalApi": "http://localhost:4000",
+      "internalVault": "http://localhost:4001",
+      "internalSso": "http://localhost:51822",
+      "internalPortal": "http://localhost:52313"
+    }
+  }
+}

--- a/src/Notifications/appsettings.json
+++ b/src/Notifications/appsettings.json
@@ -2,22 +2,6 @@
   "globalSettings": {
     "selfHosted": false,
     "projectName": "Notifications",
-    "baseServiceUri": {
-      "vault": "https://localhost:8080",
-      "api": "http://localhost:4000",
-      "identity": "http://localhost:33656",
-      "admin": "http://localhost:62911",
-      "notifications": "http://localhost:61840",
-      "sso": "http://localhost:51822",
-      "portal": "http://localhost:52313",
-      "internalNotifications": "http://localhost:61840",
-      "internalAdmin": "http://localhost:62911",
-      "internalIdentity": "http://localhost:33656",
-      "internalApi": "http://localhost:4000",
-      "internalVault": "http://localhost:4001",
-      "internalSso": "http://localhost:51822",
-      "internalPortal": "http://localhost:52313"
-    },
     "sqlServer": {
       "connectionString": "SECRET"
     },


### PR DESCRIPTION
# Overview

#1263 simplified `global.override.env` for self-hosted installs, but in so doing allowed spuriously set configurables to persist through to production instances.

We were using `appsettings.json` to store development service default locations. This PR moves those `baseUrl` settings out to `appsettings.Development.json`, which should be used only in development environments.
 
> **NOTE:** We also have several `appsettings.SelfHosted.json` files, which null out these base urls, but nowhere do we set `ASPNETCORE_ENVIRONMENT=SelfHosted`, so they are unused.

>⚠️ Development builds will need to set `ASPNETCORE_ENVIRONMENT=Development in order for service URLs to stay where they are expected ⚠️ 

# Testing

We will need to pull deploy at least one self hosted instance based off of this branch to confirm that these settings are indeed left null to be properly populated by the logic in #1263