### PR TITLE
Split dev env settings to development settings file

### DIFF
--- a/bitwarden_license/src/Portal/appsettings.Development.json
+++ b/bitwarden_license/src/Portal/appsettings.Development.json
@@ -1,0 +1,20 @@
+{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://localhost:8080",
+      "api": "http://localhost:4000",
+      "identity": "http://localhost:33656",
+      "admin": "http://localhost:62911",
+      "notifications": "http://localhost:61840",
+      "sso": "http://localhost:51822",
+      "portal": "http://localhost:52313",
+      "internalNotifications": "http://localhost:61840",
+      "internalAdmin": "http://localhost:62911",
+      "internalIdentity": "http://localhost:33656",
+      "internalApi": "http://localhost:4000",
+      "internalVault": "http://localhost:4001",
+      "internalSso": "http://localhost:51822",
+      "internalPortal": "http://localhost:52313"
+    }
+  }
+}

--- a/bitwarden_license/src/Portal/appsettings.json
+++ b/bitwarden_license/src/Portal/appsettings.json
@@ -4,22 +4,6 @@
     "siteName": "Bitwarden",
     "projectName": "Business Portal",
     "stripeApiKey": "SECRET",
-    "baseServiceUri": {
-      "vault": "https://localhost:8080",
-      "api": "http://localhost:4000",
-      "identity": "http://localhost:33656",
-      "admin": "http://localhost:62911",
-      "notifications": "http://localhost:61840",
-      "sso": "http://localhost:51822",
-      "portal": "http://localhost:52313",
-      "internalNotifications": "http://localhost:61840",
-      "internalAdmin": "http://localhost:62911",
-      "internalIdentity": "http://localhost:33656",
-      "internalApi": "http://localhost:4000",
-      "internalVault": "http://localhost:4001",
-      "internalSso": "http://localhost:51822",
-      "internalPortal": "http://localhost:52313"
-    },
     "sqlServer": {
       "connectionString": "SECRET"
     },

--- a/bitwarden_license/src/Sso/appsettings.Development.json
+++ b/bitwarden_license/src/Sso/appsettings.Development.json
@@ -1,0 +1,20 @@
+{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://localhost:8080",
+      "api": "http://localhost:4000",
+      "identity": "http://localhost:33656",
+      "admin": "http://localhost:62911",
+      "notifications": "http://localhost:61840",
+      "sso": "http://localhost:51822",
+      "portal": "http://localhost:52313",
+      "internalNotifications": "http://localhost:61840",
+      "internalAdmin": "http://localhost:62911",
+      "internalIdentity": "http://localhost:33656",
+      "internalApi": "http://localhost:4000",
+      "internalVault": "http://localhost:4001",
+      "internalSso": "http://localhost:51822",
+      "internalPortal": "http://localhost:52313"
+    }
+  }
+}

--- a/bitwarden_license/src/Sso/appsettings.json
+++ b/bitwarden_license/src/Sso/appsettings.json
@@ -5,22 +5,6 @@
     "projectName": "SSO",
     "stripeApiKey": "SECRET",
     "oidcIdentityClientKey": "SECRET",
-    "baseServiceUri": {
-      "vault": "https://localhost:8080",
-      "api": "http://localhost:4000",
-      "identity": "http://localhost:33656",
-      "admin": "http://localhost:62911",
-      "notifications": "http://localhost:61840",
-      "sso": "http://localhost:51822",
-      "portal": "http://localhost:52313",
-      "internalNotifications": "http://localhost:61840",
-      "internalAdmin": "http://localhost:62911",
-      "internalIdentity": "http://localhost:33656",
-      "internalApi": "http://localhost:4000",
-      "internalVault": "http://localhost:4001",
-      "internalSso": "http://localhost:51822",
-      "internalPortal": "http://localhost:52313"
-    },
     "sqlServer": {
       "connectionString": "SECRET"
     },

--- a/src/Admin/appsettings.Development.json
+++ b/src/Admin/appsettings.Development.json
@@ -15,6 +15,10 @@
       "internalVault": "http://localhost:4001",
       "internalSso": "http://localhost:51822",
       "internalPortal": "http://localhost:52313"
+    },
+    "send": {
+      "connectionString": "SECRET",
+      "baseUrl": "http://localhost:4000/sendfiles/"
     }
   }
 }

--- a/src/Admin/appsettings.json
+++ b/src/Admin/appsettings.json
@@ -42,8 +42,7 @@
       "region": "SECRET"
     },
     "send": {
-      "connectionString": "SECRET",
-      "baseUrl": "http://localhost:4000/sendfiles/"
+      "connectionString": "SECRET"
     }
   },
   "adminSettings": {

--- a/src/Api/appsettings.Development.json
+++ b/src/Api/appsettings.Development.json
@@ -15,6 +15,14 @@
       "internalVault": "http://localhost:4001",
       "internalSso": "http://localhost:51822",
       "internalPortal": "http://localhost:52313"
+    },
+    "attachment": {
+      "connectionString": "SECRET",
+      "baseUrl": "http://localhost:4000/attachments/"
+    },
+    "send": {
+      "connectionString": "SECRET",
+      "baseUrl": "http://localhost:4000/sendfiles/"
     }
   }
 }

--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -25,12 +25,10 @@
       "connectionString": "SECRET"
     },
     "attachment": {
-      "connectionString": "SECRET",
-      "baseUrl": "http://localhost:4000/attachments/"
+      "connectionString": "SECRET"
     },
     "send": {
-      "connectionString": "SECRET",
-      "baseUrl": "http://localhost:4000/sendfiles/"
+      "connectionString": "SECRET"
     },
     "documentDb": {
       "uri": "SECRET",


### PR DESCRIPTION
# Overview

I missed a few critical appsettings.json urls in my first PR, #1423.  This removes the remaining URLs.

It also occurs to me in the future, we should derive the mail `replyToEmail` from the domain of a self-hosted instance rather than force it to be `@bitwarden.com`