### PR TITLE
Fix Return to Vault button

### DIFF
--- a/bitwarden_license/src/Portal/Controllers/AuthController.cs
+++ b/bitwarden_license/src/Portal/Controllers/AuthController.cs
@@ -2,17 +2,21 @@
 using Bit.Portal.Utilities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Bit.Core.Settings;
 
 namespace Bit.Portal.Controllers
 {
     public class AuthController : Controller
     {
         private readonly EnterprisePortalTokenSignInManager _signInManager;
+        private readonly GlobalSettings _globalSettings;
 
         public AuthController(
-            EnterprisePortalTokenSignInManager signInManager)
+            EnterprisePortalTokenSignInManager signInManager,
+            GlobalSettings globalSettings)
         {
             _signInManager = signInManager;
+            _globalSettings = globalSettings;
         }
 
         [HttpGet("~/login")]
@@ -58,6 +62,13 @@ namespace Bit.Portal.Controllers
         public IActionResult AccessDenied()
         {
             return View();
+        }
+
+        [HttpGet("~/vault")]
+        public async Task<RedirectResult> Vault()
+        {
+            await _signInManager.SignOutAsync();
+            return Redirect(_globalSettings.BaseServiceUri.Vault);
         }
     }
 }

--- a/bitwarden_license/src/Portal/Controllers/AuthController.cs
+++ b/bitwarden_license/src/Portal/Controllers/AuthController.cs
@@ -2,21 +2,17 @@
 using Bit.Portal.Utilities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Bit.Core.Settings;
 
 namespace Bit.Portal.Controllers
 {
     public class AuthController : Controller
     {
         private readonly EnterprisePortalTokenSignInManager _signInManager;
-        private readonly GlobalSettings _globalSettings;
 
         public AuthController(
-            EnterprisePortalTokenSignInManager signInManager,
-            GlobalSettings globalSettings)
+            EnterprisePortalTokenSignInManager signInManager)
         {
             _signInManager = signInManager;
-            _globalSettings = globalSettings;
         }
 
         [HttpGet("~/login")]
@@ -62,13 +58,6 @@ namespace Bit.Portal.Controllers
         public IActionResult AccessDenied()
         {
             return View();
-        }
-
-        [HttpGet("~/vault")]
-        public async Task<RedirectResult> Vault()
-        {
-            await _signInManager.SignOutAsync();
-            return Redirect(_globalSettings.BaseServiceUri.Vault);
         }
     }
 }

--- a/bitwarden_license/src/Portal/Views/Shared/_Layout.cshtml
+++ b/bitwarden_license/src/Portal/Views/Shared/_Layout.cshtml
@@ -71,7 +71,7 @@
                                 </div>
                             </div>
                             <div class="dropdown-divider"></div>
-                            <a class="dropdown-item" href="#">
+                            <a class="dropdown-item" asp-area="" asp-controller="Auth" asp-action="Vault">
                                 <i class="fa fa-fw fa-share fa-flip-horizontal" aria-hidden="true"></i>
                                 Return to My Vault
                             </a>

--- a/bitwarden_license/src/Portal/Views/Shared/_Layout.cshtml
+++ b/bitwarden_license/src/Portal/Views/Shared/_Layout.cshtml
@@ -71,10 +71,6 @@
                                 </div>
                             </div>
                             <div class="dropdown-divider"></div>
-                            <a class="dropdown-item" href="#">
-                                <i class="fa fa-fw fa-share fa-flip-horizontal" aria-hidden="true"></i>
-                                Return to My Vault
-                            </a>
                             <form asp-controller="Auth" asp-action="Logout" method="post">
                                 <button type="submit" class="dropdown-item">
                                     <i class="fa fa-fw fa-sign-out" aria-hidden="true"></i>

--- a/bitwarden_license/src/Portal/Views/Shared/_Layout.cshtml
+++ b/bitwarden_license/src/Portal/Views/Shared/_Layout.cshtml
@@ -71,7 +71,7 @@
                                 </div>
                             </div>
                             <div class="dropdown-divider"></div>
-                            <a class="dropdown-item" asp-area="" asp-controller="Auth" asp-action="Vault">
+                            <a class="dropdown-item" href="#">
                                 <i class="fa fa-fw fa-share fa-flip-horizontal" aria-hidden="true"></i>
                                 Return to My Vault
                             </a>


### PR DESCRIPTION
## Objective

Fix bitwarden/web#1057: 
>The Return to My Vault link from User menu in Bitwarden Business Portal does not work. The link seems to point to https://portal.bitwarden.com/# instead of https://vault.bitwarden.com/#

## Code changes

* Add new action in the `AuthController` - I assume that we want to log the user out of the Business Portal as part of this flow, so it seemed like the most logical place to put it
* Wire up the button to the new action