### PR TITLE
Fallback for null/default database name

### DIFF
--- a/util/Setup/EnvironmentFileBuilder.cs
+++ b/util/Setup/EnvironmentFileBuilder.cs
@@ -62,7 +62,7 @@ namespace Bit.Setup
             var dbConnectionString = new SqlConnectionStringBuilder
             {
                 DataSource = "tcp:mssql,1433",
-                InitialCatalog = _context.Install?.Database,
+                InitialCatalog = _context.Install?.Database ?? "vault",
                 UserID = "sa",
                 Password = dbPassword,
                 MultipleActiveResultSets = false,


### PR DESCRIPTION
Fixes miss on https://github.com/bitwarden/server/pull/1397 where we're not providing a default value fallback for initial catalog and is causing build failures.

see: https://github.com/bitwarden/server/runs/2974259084?check_suite_focus=true#step:4:64 for example failure.