### PR TITLE
B64 encode azure messages

### DIFF
--- a/src/Admin/HostedServices/AzureQueueMailHostedService.cs
+++ b/src/Admin/HostedServices/AzureQueueMailHostedService.cs
@@ -38,7 +38,7 @@ namespace Bit.Admin.HostedServices
 
             _jsonSerializer = JsonSerializer.Create(new JsonSerializerSettings
             {
-                Converters = new JsonConverter[] { new MailQueueMessageConverter(), new EncodedStringConverter() }
+                Converters = new JsonConverter[] { new MailQueueMessageConverter() }
             });
         }
 

--- a/src/Admin/HostedServices/AzureQueueMailHostedService.cs
+++ b/src/Admin/HostedServices/AzureQueueMailHostedService.cs
@@ -38,7 +38,7 @@ namespace Bit.Admin.HostedServices
 
             _jsonSerializer = JsonSerializer.Create(new JsonSerializerSettings
             {
-                Converters = new[] { new EncodedStringConverter() },
+                Converters = new JsonConverter[] { new MailQueueMessageConverter(), new EncodedStringConverter() }
             });
         }
 
@@ -79,14 +79,14 @@ namespace Bit.Admin.HostedServices
                         var token = JToken.Parse(message.MessageText);
                         if (token is JArray)
                         {
-                            foreach (var mailQueueMessage in token.ToObject<List<MailQueueMessage>>(_jsonSerializer))
+                            foreach (var mailQueueMessage in token.ToObject<List<IMailQueueMessage>>(_jsonSerializer))
                             {
                                 await _mailService.SendEnqueuedMailMessageAsync(mailQueueMessage);
                             }
                         }
                         else if (token is JObject)
                         {
-                            var mailQueueMessage = token.ToObject<MailQueueMessage>();
+                            var mailQueueMessage = token.ToObject<IMailQueueMessage>();
                             await _mailService.SendEnqueuedMailMessageAsync(mailQueueMessage);
                         }
                     }

--- a/src/Core/Models/Mail/IMailQueueMessage.cs
+++ b/src/Core/Models/Mail/IMailQueueMessage.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.Generic;
 
 namespace Bit.Core.Models.Mail
 {
     public interface IMailQueueMessage
     {
+        Type ModelType { get; }
         string Subject { get; set; }
         IEnumerable<string> ToEmails { get; set; }
         IEnumerable<string> BccEmails { get; set; }

--- a/src/Core/Models/Mail/MailQueueMessage.cs
+++ b/src/Core/Models/Mail/MailQueueMessage.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
-using System.Reflection;
+using Bit.Core.Utilities;
+using Newtonsoft.Json;
 
 namespace Bit.Core.Models.Mail
 {
     public class MailQueueMessage : IMailQueueMessage
     {
         public Type ModelType => Model?.GetType();
+        [JsonConverter(typeof(EncodedStringConverter))]
         public string Subject { get; set; }
         public IEnumerable<string> ToEmails { get; set; }
         public IEnumerable<string> BccEmails { get; set; }
@@ -29,6 +31,7 @@ namespace Bit.Core.Models.Mail
 
     public class MailQueueMessage<T> : IMailQueueMessage
     {
+        [JsonConverter(typeof(EncodedStringConverter))]
         public string Subject { get; set; }
         public IEnumerable<string> ToEmails { get; set; }
         public IEnumerable<string> BccEmails { get; set; }

--- a/src/Core/Models/Mail/MailQueueMessage.cs
+++ b/src/Core/Models/Mail/MailQueueMessage.cs
@@ -1,9 +1,12 @@
+using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Bit.Core.Models.Mail
 {
     public class MailQueueMessage : IMailQueueMessage
     {
+        public Type ModelType => Model?.GetType();
         public string Subject { get; set; }
         public IEnumerable<string> ToEmails { get; set; }
         public IEnumerable<string> BccEmails { get; set; }
@@ -22,5 +25,31 @@ namespace Bit.Core.Models.Mail
             TemplateName = templateName;
             Model = model;
         }
+    }
+
+    public class MailQueueMessage<T> : IMailQueueMessage
+    {
+        public string Subject { get; set; }
+        public IEnumerable<string> ToEmails { get; set; }
+        public IEnumerable<string> BccEmails { get; set; }
+        public string Category { get; set; }
+        public string TemplateName { get; set; }
+        public T Model { get; set; }
+        Type IMailQueueMessage.ModelType => typeof(T);
+        object IMailQueueMessage.Model { get => Model; set => Model = (T)value; }
+
+        public MailQueueMessage() { }
+
+        public MailQueueMessage(MailMessage message, string templateName, T model)
+        {
+            Subject = message.Subject;
+            ToEmails = message.ToEmails;
+            BccEmails = message.BccEmails;
+            Category = string.IsNullOrEmpty(message.Category) ? templateName : message.Category;
+            TemplateName = templateName;
+            Model = model;
+        }
+
+
     }
 }

--- a/src/Core/Models/Mail/OrganizationUserInvitedViewModel.cs
+++ b/src/Core/Models/Mail/OrganizationUserInvitedViewModel.cs
@@ -1,13 +1,20 @@
-﻿namespace Bit.Core.Models.Mail
+﻿using Bit.Core.Utilities;
+using Newtonsoft.Json;
+
+namespace Bit.Core.Models.Mail
 {
     public class OrganizationUserInvitedViewModel : BaseMailModel
     {
+        [JsonConverter(typeof(EncodedStringConverter))]
         public string OrganizationName { get; set; }
         public string OrganizationId { get; set; }
         public string OrganizationUserId { get; set; }
+        [JsonConverter(typeof(EncodedStringConverter))]
         public string Email { get; set; }
+        [JsonConverter(typeof(EncodedStringConverter))]
         public string OrganizationNameUrlEncoded { get; set; }
         public string Token { get; set; }
+        [JsonConverter(typeof(EncodedStringConverter))]
         public string Url => string.Format("{0}/accept-organization?organizationId={1}&" +
             "organizationUserId={2}&email={3}&organizationName={4}&token={5}",
             WebVaultUrl,

--- a/src/Core/Services/Implementations/AzureQueueService.cs
+++ b/src/Core/Services/Implementations/AzureQueueService.cs
@@ -17,10 +17,6 @@ namespace Bit.Core.Services
         {
             _queueClient = queueClient;
             _jsonSettings = jsonSettings;
-            if (!_jsonSettings.Converters.Any(c => c.GetType() == typeof(EncodedStringConverter)))
-            {
-                _jsonSettings.Converters.Add(new EncodedStringConverter());
-            }
         }
 
         public async Task CreateAsync(T message) => await CreateManyAsync(new[] { message });

--- a/src/Core/Utilities/CircularJsonConverter.cs
+++ b/src/Core/Utilities/CircularJsonConverter.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace Bit.Core.Utilities
+{
+    public abstract class CircularJsonConverter : JsonConverter
+    {
+        public void RemoveConverterAndAct(JsonSerializer serializer, Action action)
+        {
+            var (converter, index) = serializer.Converters.Select((c, i) => (c, i)).FirstOrDefault(t => t.Item1.GetType() == this.GetType());
+            serializer.Converters.RemoveAt(index);
+
+            action();
+
+            if (converter != null)
+            {
+                serializer.Converters.Insert(index, converter);
+            }
+        }
+    }
+}

--- a/src/Core/Utilities/CircularJsonConverter.cs
+++ b/src/Core/Utilities/CircularJsonConverter.cs
@@ -9,7 +9,10 @@ namespace Bit.Core.Utilities
         public void RemoveConverterAndAct(JsonSerializer serializer, Action action)
         {
             var (converter, index) = serializer.Converters.Select((c, i) => (c, i)).FirstOrDefault(t => t.Item1.GetType() == this.GetType());
-            serializer.Converters.RemoveAt(index);
+            if (converter != null)
+            {
+                serializer.Converters.RemoveAt(index);
+            }
 
             action();
 

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -24,6 +24,7 @@ using Bit.Core.Models.Table;
 using IdentityModel;
 using System.Text.Json;
 using Bit.Core.Enums.Provider;
+using Newtonsoft.Json.Linq;
 
 namespace Bit.Core.Utilities
 {
@@ -875,6 +876,11 @@ namespace Bit.Core.Utilities
             }
             
             return claims;
+        }
+
+        public static JProperty GetJProperty(JObject obj, string name)
+        {
+            return obj.Properties().FirstOrDefault(p => string.Equals(name, p.Name, StringComparison.InvariantCultureIgnoreCase));
         }
 
         public static T LoadClassFromJsonData<T>(string jsonData) where T : new()

--- a/src/Core/Utilities/MailQueueMessageConverter.cs
+++ b/src/Core/Utilities/MailQueueMessageConverter.cs
@@ -1,0 +1,42 @@
+using System;
+using Bit.Core.Models.Mail;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Bit.Core.Utilities
+{
+    public class MailQueueMessageConverter : CircularJsonConverter
+    {
+        public override bool CanConvert(Type objectType) => typeof(IMailQueueMessage).IsAssignableFrom(objectType);
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var result = existingValue;
+
+            RemoveConverterAndAct(serializer, () =>
+            {
+                JObject o = JObject.Load(reader);
+                var modelTypeName = CoreHelpers.GetJProperty(o, nameof(IMailQueueMessage.ModelType));
+                if (modelTypeName != null)
+                {
+                    Type modelType = Type.GetType(modelTypeName.Value.ToString());
+                    Type messageType = typeof(MailQueueMessage<>).MakeGenericType(modelType);
+                    result = o.ToObject(messageType, serializer);
+                }
+                else
+                {
+                    result = o.ToObject(typeof(MailQueueMessage), serializer);
+                }
+            });
+
+            return result;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            RemoveConverterAndAct(serializer, () =>
+            {
+                serializer.Serialize(writer, value);
+            });
+        }
+    }
+}


### PR DESCRIPTION
# Overview

#1425 attempted to fix unicode azure queue messages. However, `HtmlEncode` does not encode all illegal characters. This just encodes all strings as an object, signifying it as base 64 encoded.

If the token is a string it falls back to unencoded values. This should allow safe draining of an existing queue.

I also had to add logic to correctly identify MailQueueMessage model types in order to correctly apply the custom converters. Newtonsoft does not appear to support circular deserializations from custom converters. CircularJsonConverter provides a helper method to remove itself and re-add it after serializer work is done.

# Files changed
* **AzureQueueMailHostedService**: Handle mail message model deserialization properly
* **MailQueueMessage**: Add `ModelType` to allow for conversion between Queue messages and well-known class types
* **CircularJsonConverter**: Newtonsoft doesn't support converters calling default conversion on their own types. This class provides a helper method to remove itself from the converter array, do something, and re-add it
* **CoreHelpers**: Add a helper to grab a particular property from a JObject. 
* **EncodedStringConverter**: Write string as b64 encoded objects. Read strings as either strings if not encoded or decode and read if they're an object
* **MailQueueMessageConverter**: Convert MailQueueMessages to well-known class types.