### PR TITLE
Minor typo in logging

### DIFF
--- a/src/Core/Services/Implementations/AmazonSesMailDeliveryService.cs
+++ b/src/Core/Services/Implementations/AmazonSesMailDeliveryService.cs
@@ -121,7 +121,7 @@ namespace Bit.Core.Services
             }
             catch (Exception e)
             {
-                _logger.LogWarning(e, "Failed to send email. Re-retying...");
+                _logger.LogWarning(e, "Failed to send email. Retrying...");
                 await SendAsync(request, true);
                 throw e;
             }


### PR DESCRIPTION
## Objective

There was a minor typo in a warning log statement. This change set aims to fix the typo.

I was looking through the bitwarden/server codebase and GItHub issues to find potential issues to fix and help with. While doing that, I found this typo and thought I would try to get this addressed as my first contribution, so I could learn the contribution process. I have agreed to the Bitwarden Contribution License Agreement. I also saw I might need to either create a GitHub issue or a Community Forum post and link it in this PR, but I figured this was so small, it might not be needed. If it is or if I missed anything else I should have done, please let me know.

## Code Changes

* Fix typo in a logging statement in `AmazonSesMailDeliveryService`.