### PR TITLE
Removing redundant cert reference

### DIFF
--- a/util/Setup/CertBuilder.cs
+++ b/util/Setup/CertBuilder.cs
@@ -77,7 +77,7 @@ namespace Bit.Setup
             Helpers.Exec("openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout identity.key " +
                 "-out identity.crt -subj \"/CN=Bitwarden IdentityServer\" -days 36500");
             Helpers.Exec("openssl pkcs12 -export -out /bitwarden/identity/identity.pfx -inkey identity.key " +
-                $"-in identity.crt -certfile identity.crt -passout pass:{_context.Install.IdentityCertPassword}");
+                $"-in identity.crt -passout pass:{_context.Install.IdentityCertPassword}");
 
             Helpers.WriteLine(_context);
 


### PR DESCRIPTION
## Summary
With the version bump .NET, the requirements of the Identity server SSL cert changed. This fix follows the advice from this issue: https://github.com/dotnet/runtime/issues/44535#issuecomment-725616327

## Testing
- This was tested in a local self-host build and it confirms this is the solution.