### PR TITLE
Requeue item on exception, don't swallow it

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
 	<PropertyGroup>
-		<Version>1.41.5</Version>
+		<Version>1.41.6</Version>
 		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<RootNamespace>Bit.$(MSBuildProjectName)</RootNamespace>
 	</PropertyGroup>


### PR DESCRIPTION
Fixed event processor queue not to swallow exceptions but instead allow them to be thrown so the queue item isn't deleted when falling through and instead times out and is visible again in the queue.

+ Version bump, v1.41.6