### PR TITLE
Add Collections to public/groups API endpoint

### DIFF
--- a/src/Api/Public/Controllers/GroupsController.cs
+++ b/src/Api/Public/Controllers/GroupsController.cs
@@ -87,8 +87,12 @@ namespace Bit.Api.Public.Controllers
         public async Task<IActionResult> List()
         {
             var groups = await _groupRepository.GetManyByOrganizationIdAsync(_currentContext.OrganizationId.Value);
-            // TODO: Get all CollectionGroup associations for the organization and marry them up here for the response.
-            var groupResponses = groups.Select(g => new GroupResponseModel(g, null));
+            var groupResponses = new List<GroupResponseModel>();
+            foreach (var group in groups)
+            {
+                var groupWithCollections = await _groupRepository.GetByIdWithCollectionsAsync(group.Id);
+                groupResponses.Add(new GroupResponseModel(group, groupWithCollections.Item2));
+            }
             var response = new ListResponseModel<GroupResponseModel>(groupResponses);
             return new JsonResult(response);
         }


### PR DESCRIPTION
## Objective

This change set aims to fix #852. The `/public/groups` endpoint was not returning the 'Collections' for the 'Groups'. 

This seemed like the quickest route to implementing this change, but also has some drawbacks. It could end up with a lot of DB reads for an organization with a lot of 'Groups', but I didn't see any already implemented repository functions for either groups or collections that would easily achieve the desired result. If the potential number of DB reads is an issue for a reviewer, then I have another solution in mind. I could add a new function to the `IGroupRepository` called `GetManyWithCollectionsByOrganizationIdAsync`. This would aim to replace both the call to `GetManyByOrganizationIdAsync` and the `GetByIdWithCollectionsAsync` in the controller to a single repository call.

## Code Changes

* Use the `IGroupRepository.GetByIdWithCollectionsAsync` function to retrieve the 'Group' and linked 'Collections' by ID using the already retrieved `Groups` by `OrganizationId`.