### PR TITLE
Fix for Identity.pfx containing multiple certs

### DIFF
--- a/util/Setup/Program.cs
+++ b/util/Setup/Program.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Globalization;
 using System.Net.Http;
-using LinqToDB.Tools;
 
 namespace Bit.Setup
 {


### PR DESCRIPTION
This PR fixes `Identity.pfx` if it contains multiple certs.  It works by using `openssl` to output information about the `Identity.pfx` PKCS12 bag.  If the line `-----BEGIN CERTIFICATE-----` is detected more than once, we need to regenerate the `Identity.pfx` cert/bag.  This code will be ran when the `update` flag is used when calling the `Setup` image.