### PR TITLE
Fix SQL connection string

### DIFF
--- a/util/Setup/EnvironmentFileBuilder.cs
+++ b/util/Setup/EnvironmentFileBuilder.cs
@@ -70,12 +70,12 @@ namespace Bit.Setup
                 ConnectTimeout = 30,
                 TrustServerCertificate = true,
                 PersistSecurityInfo = false
-            }.ConnectionString;
+            }.ConnectionString.Replace("\"", "\\\"");
 
             _globalOverrideValues = new Dictionary<string, string>
             {
                 ["globalSettings__baseServiceUri__vault"] = _context.Config.Url,
-                ["globalSettings__sqlServer__connectionString"] = $"'{dbConnectionString}'",
+                ["globalSettings__sqlServer__connectionString"] = $"\"{dbConnectionString}\"",
                 ["globalSettings__identityServer__certificatePassword"] = _context.Install?.IdentityCertPassword,
                 ["globalSettings__internalIdentityKey"] = _context.Stub ? "RANDOM_IDENTITY_KEY" :
                     Helpers.SecureRandomString(64, alpha: true, numeric: true),

--- a/util/Setup/Program.cs
+++ b/util/Setup/Program.cs
@@ -193,7 +193,7 @@ namespace Bit.Setup
             {
                 Helpers.WriteLine(_context, "Migrating database.");
                 var vaultConnectionString = Helpers.GetValueFromEnvFile("global",
-                    "globalSettings__sqlServer__connectionString");
+                    "globalSettings__sqlServer__connectionString").Replace("\\\"", "\"");
                 var migrator = new DbMigrator(vaultConnectionString, null);
                 var success = migrator.MigrateMsSqlDatabase(false);
                 if (success)


### PR DESCRIPTION
Using single quotes surrounding the SQL connection string was going to possibly introduce problems between new installations and old.  Updated so that we can keep the current double quotes surrounding the string and just escape any other quotes using a call to the `Replace` method.  Tested and works with spaces in the name of the vault.