### PR TITLE
Feature/sync Enable hcaptcha on login

### DIFF
--- a/bitwarden_license/src/CommCore/Services/ProviderService.cs
+++ b/bitwarden_license/src/CommCore/Services/ProviderService.cs
@@ -88,7 +88,8 @@ namespace Bit.CommCore.Services
                 throw new BadRequestException("Provider is already setup.");
             }
 
-            if (!CoreHelpers.TokenIsValid("ProviderSetupInvite", _dataProtector, token, owner.Email, provider.Id, _globalSettings))
+            if (!CoreHelpers.TokenIsValid("ProviderSetupInvite", _dataProtector, token, owner.Email, provider.Id,
+                _globalSettings.OrganizationInviteExpirationHours))
             {
                 throw new BadRequestException("Invalid token.");
             }
@@ -196,7 +197,8 @@ namespace Bit.CommCore.Services
                 throw new BadRequestException("Already accepted.");
             }
 
-            if (!CoreHelpers.TokenIsValid("ProviderUserInvite", _dataProtector, token, user.Email, providerUser.Id, _globalSettings))
+            if (!CoreHelpers.TokenIsValid("ProviderUserInvite", _dataProtector, token, user.Email, providerUser.Id,
+                _globalSettings.OrganizationInviteExpirationHours))
             {
                 throw new BadRequestException("Invalid token.");
             }

--- a/src/Core/IdentityServer/BaseRequestValidator.cs
+++ b/src/Core/IdentityServer/BaseRequestValidator.cs
@@ -129,7 +129,7 @@ namespace Bit.Core.IdentityServer
                     await BuildErrorResultAsync("No device information provided.", false, context, user);
                     return;
                 }
-                await BuildSuccessResultAsync(user, context, device, twoFactorRequest && twoFactorRemember, twoFactorRequest);
+                await BuildSuccessResultAsync(user, context, device, twoFactorRequest && twoFactorRemember);
             }
             else
             {
@@ -142,7 +142,7 @@ namespace Bit.Core.IdentityServer
 
         protected abstract Task<(User, bool)> ValidateContextAsync(T context);
 
-        protected async Task BuildSuccessResultAsync(User user, T context, Device device, bool sendRememberToken, bool twoFactorVerified)
+        protected async Task BuildSuccessResultAsync(User user, T context, Device device, bool sendRememberToken)
         {
             await _eventService.LogUserEventAsync(user.Id, EventType.User_LoggedIn);
 
@@ -167,7 +167,6 @@ namespace Bit.Core.IdentityServer
             customResponse.Add("ResetMasterPassword", string.IsNullOrWhiteSpace(user.MasterPassword));
             customResponse.Add("Kdf", (byte)user.Kdf);
             customResponse.Add("KdfIterations", user.KdfIterations);
-            customResponse.Add("TwoFactorVerified", twoFactorVerified);
 
             if (sendRememberToken)
             {

--- a/src/Core/IdentityServer/BaseRequestValidator.cs
+++ b/src/Core/IdentityServer/BaseRequestValidator.cs
@@ -129,7 +129,7 @@ namespace Bit.Core.IdentityServer
                     await BuildErrorResultAsync("No device information provided.", false, context, user);
                     return;
                 }
-                await BuildSuccessResultAsync(user, context, device, twoFactorRequest && twoFactorRemember);
+                await BuildSuccessResultAsync(user, context, device, twoFactorRequest && twoFactorRemember, twoFactorRequest);
             }
             else
             {
@@ -142,7 +142,7 @@ namespace Bit.Core.IdentityServer
 
         protected abstract Task<(User, bool)> ValidateContextAsync(T context);
 
-        protected async Task BuildSuccessResultAsync(User user, T context, Device device, bool sendRememberToken)
+        protected async Task BuildSuccessResultAsync(User user, T context, Device device, bool sendRememberToken, bool twoFactorVerified)
         {
             await _eventService.LogUserEventAsync(user.Id, EventType.User_LoggedIn);
 
@@ -167,6 +167,7 @@ namespace Bit.Core.IdentityServer
             customResponse.Add("ResetMasterPassword", string.IsNullOrWhiteSpace(user.MasterPassword));
             customResponse.Add("Kdf", (byte)user.Kdf);
             customResponse.Add("KdfIterations", user.KdfIterations);
+            customResponse.Add("TwoFactorVerified", twoFactorVerified);
 
             if (sendRememberToken)
             {

--- a/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
+++ b/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
@@ -62,10 +62,11 @@ namespace Bit.Core.IdentityServer
 
             if (_captchaValidationService.ServiceEnabled && _currentContext.IsBot)
             {
-                var captchaResponse = context.Request.Raw["CaptchaResponse"]?.ToString();
+                var captchaResponse = context.Request.Raw["captchaResponse"]?.ToString();
                 if (string.IsNullOrWhiteSpace(captchaResponse))
                 {
-                    context.Result = new GrantValidationResult(TokenRequestErrors.InvalidGrant, "Captcha required.");
+                    context.Result = new GrantValidationResult(TokenRequestErrors.InvalidGrant, "Captcha required.",
+                        new Dictionary<string, object> { { "HCaptcha_SiteKey", _captchaValidationService.SiteKey } });
                     return;
                 }
 

--- a/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
+++ b/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
@@ -62,7 +62,7 @@ namespace Bit.Core.IdentityServer
 
             await ValidateAsync(context, context.Request);
 
-            if (_captchaValidationService.ServiceEnabled && _currentContext.IsBot)
+            if (_captchaValidationService.ServiceEnabled && (_currentContext.IsBot || _captchaValidationService.RequireCaptcha))
             {
                 var twoFactorVerified = context.Result.CustomResponse.ContainsKey("TwoFactorVerified") ?
                     (bool)context.Result.CustomResponse["TwoFactorVerified"] :
@@ -70,7 +70,7 @@ namespace Bit.Core.IdentityServer
                 var captchaResponse = context.Request.Raw["captchaResponse"]?.ToString();
                 if (string.IsNullOrWhiteSpace(captchaResponse) && !twoFactorVerified)
                 {
-                    context.Result = new GrantValidationResult(TokenRequestErrors.InvalidGrant, "Captcha required.",
+                    context.Result = new GrantValidationResult(TokenRequestErrors.InvalidGrant, "Captcha required. Please refresh and try again",
                         new Dictionary<string, object> { { "HCaptcha_SiteKey", _captchaValidationService.SiteKey } });
                     return;
                 }

--- a/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
+++ b/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
@@ -70,7 +70,7 @@ namespace Bit.Core.IdentityServer
                 var captchaResponse = context.Request.Raw["captchaResponse"]?.ToString();
                 if (string.IsNullOrWhiteSpace(captchaResponse) && !twoFactorVerified)
                 {
-                    context.Result = new GrantValidationResult(TokenRequestErrors.InvalidGrant, "Captcha required. Please refresh and try again",
+                    context.Result = new GrantValidationResult(TokenRequestErrors.InvalidGrant, "Captcha required.",
                         new Dictionary<string, object> { { "HCaptcha_SiteKey", _captchaValidationService.SiteKey } });
                     return;
                 }
@@ -81,7 +81,7 @@ namespace Bit.Core.IdentityServer
                         _currentContext.IpAddress);
                     if (!captchaValid)
                     {
-                        await BuildErrorResultAsync("Captcha is invalid.", false, context, null);
+                        await BuildErrorResultAsync("Captcha is invalid. Please refresh and try again", false, context, null);
                         return;
                     }
                 }

--- a/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
+++ b/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
@@ -87,7 +87,7 @@ namespace Bit.Core.IdentityServer
             await ValidateAsync(context, context.Request);
             if (context.Result.CustomResponse != null && bypassToken != null)
             {
-                context.Result.CustomResponse["HCaptcha_BypassKey"] = bypassToken;
+                context.Result.CustomResponse["CaptchaBypassToken"] = bypassToken;
             }
         }
 

--- a/src/Core/Services/ICaptchaValidationService.cs
+++ b/src/Core/Services/ICaptchaValidationService.cs
@@ -5,6 +5,7 @@ namespace Bit.Core.Services
     public interface ICaptchaValidationService
     {
         bool ServiceEnabled { get; }
+        string SiteKey { get; }
         Task<bool> ValidateCaptchaResponseAsync(string captchResponse, string clientIpAddress);
     }
 }

--- a/src/Core/Services/ICaptchaValidationService.cs
+++ b/src/Core/Services/ICaptchaValidationService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Bit.Core.Models.Table;
 
 namespace Bit.Core.Services
 {
@@ -8,5 +9,7 @@ namespace Bit.Core.Services
         string SiteKey { get; }
         bool RequireCaptcha { get; }
         Task<bool> ValidateCaptchaResponseAsync(string captchResponse, string clientIpAddress);
+        string GenerateCaptchaBypassToken(User user);
+        bool ValidateCaptchaBypassToken(string encryptedToken, User user);
     }
 }

--- a/src/Core/Services/ICaptchaValidationService.cs
+++ b/src/Core/Services/ICaptchaValidationService.cs
@@ -6,6 +6,7 @@ namespace Bit.Core.Services
     {
         bool ServiceEnabled { get; }
         string SiteKey { get; }
+        bool RequireCaptcha { get; }
         Task<bool> ValidateCaptchaResponseAsync(string captchResponse, string clientIpAddress);
     }
 }

--- a/src/Core/Services/Implementations/EmergencyAccessService.cs
+++ b/src/Core/Services/Implementations/EmergencyAccessService.cs
@@ -115,7 +115,8 @@ namespace Bit.Core.Services
                 throw new BadRequestException("Emergency Access not valid.");
             }
 
-            if (!CoreHelpers.TokenIsValid("EmergencyAccessInvite", _dataProtector, token, user.Email, emergencyAccessId, _globalSettings))
+            if (!CoreHelpers.TokenIsValid("EmergencyAccessInvite", _dataProtector, token, user.Email, emergencyAccessId,
+                _globalSettings.OrganizationInviteExpirationHours))
             {
                 throw new BadRequestException("Invalid token.");
             }

--- a/src/Core/Services/Implementations/HCaptchaValidationService.cs
+++ b/src/Core/Services/Implementations/HCaptchaValidationService.cs
@@ -25,6 +25,7 @@ namespace Bit.Core.Services
         }
 
         public bool ServiceEnabled => true;
+        public string SiteKey => _globalSettings.Captcha.HCaptchaSiteKey;
 
         public async Task<bool> ValidateCaptchaResponseAsync(string captchResponse, string clientIpAddress)
         {
@@ -43,7 +44,7 @@ namespace Bit.Core.Services
                 {
                     { "response", captchResponse.TrimStart("hcaptcha|".ToCharArray()) },
                     { "secret", _globalSettings.Captcha.HCaptchaSecretKey },
-                    { "sitekey", _globalSettings.Captcha.HCaptchaSiteKey },
+                    { "sitekey", SiteKey },
                     { "remoteip", clientIpAddress }
                 })
             };

--- a/src/Core/Services/Implementations/HCaptchaValidationService.cs
+++ b/src/Core/Services/Implementations/HCaptchaValidationService.cs
@@ -26,6 +26,7 @@ namespace Bit.Core.Services
 
         public bool ServiceEnabled => true;
         public string SiteKey => _globalSettings.Captcha.HCaptchaSiteKey;
+        public bool RequireCaptcha => _globalSettings.Captcha.RequireCaptcha;
 
         public async Task<bool> ValidateCaptchaResponseAsync(string captchResponse, string clientIpAddress)
         {

--- a/src/Core/Services/NoopImplementations/NoopCaptchaValidationService.cs
+++ b/src/Core/Services/NoopImplementations/NoopCaptchaValidationService.cs
@@ -5,6 +5,7 @@ namespace Bit.Core.Services
     public class NoopCaptchaValidationService : ICaptchaValidationService
     {
         public bool ServiceEnabled => false;
+        public string SiteKey => null;
 
         public Task<bool> ValidateCaptchaResponseAsync(string captchResponse, string clientIpAddress)
         {

--- a/src/Core/Services/NoopImplementations/NoopCaptchaValidationService.cs
+++ b/src/Core/Services/NoopImplementations/NoopCaptchaValidationService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Bit.Core.Models.Table;
 
 namespace Bit.Core.Services
 {
@@ -7,6 +8,9 @@ namespace Bit.Core.Services
         public bool ServiceEnabled => false;
         public string SiteKey => null;
         public bool RequireCaptcha => false;
+
+        public string GenerateCaptchaBypassToken(User user) => "";
+        public bool ValidateCaptchaBypassToken(string encryptedToken, User user) => false;
 
         public Task<bool> ValidateCaptchaResponseAsync(string captchResponse, string clientIpAddress)
         {

--- a/src/Core/Services/NoopImplementations/NoopCaptchaValidationService.cs
+++ b/src/Core/Services/NoopImplementations/NoopCaptchaValidationService.cs
@@ -6,6 +6,7 @@ namespace Bit.Core.Services
     {
         public bool ServiceEnabled => false;
         public string SiteKey => null;
+        public bool RequireCaptcha => false;
 
         public Task<bool> ValidateCaptchaResponseAsync(string captchResponse, string clientIpAddress)
         {

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -473,6 +473,7 @@ namespace Bit.Core.Settings
 
         public class CaptchaSettings
         {
+            public bool RequireCaptcha { get; set; } = false;
             public string HCaptchaSecretKey { get; set; }
             public string HCaptchaSiteKey { get; set; }
         }

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -611,11 +611,12 @@ namespace Bit.Core.Utilities
         public static bool UserInviteTokenIsValid(IDataProtector protector, string token, string userEmail,
             Guid orgUserId, GlobalSettings globalSettings)
         {
-            return TokenIsValid("OrganizationUserInvite", protector, token, userEmail, orgUserId, globalSettings);
+            return TokenIsValid("OrganizationUserInvite", protector, token, userEmail, orgUserId,
+                globalSettings.OrganizationInviteExpirationHours);
         }
 
         public static bool TokenIsValid(string firstTokenPart, IDataProtector protector, string token, string userEmail,
-            Guid id, GlobalSettings globalSettings)
+            Guid id, double expirationInHours)
         {
             var invalid = true;
             try
@@ -627,7 +628,7 @@ namespace Bit.Core.Utilities
                     dataParts[2].Equals(userEmail, StringComparison.InvariantCultureIgnoreCase))
                 {
                     var creationTime = FromEpocMilliseconds(Convert.ToInt64(dataParts[3]));
-                    var expTime = creationTime.AddHours(globalSettings.OrganizationInviteExpirationHours);
+                    var expTime = creationTime.AddHours(expirationInHours);
                     invalid = expTime < DateTime.UtcNow;
                 }
             }

--- a/src/Core/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Core/Utilities/ServiceCollectionExtensions.cs
@@ -306,7 +306,7 @@ namespace Bit.Core.Utilities
                 services.AddSingleton<IReferenceEventService, AzureQueueReferenceEventService>();
             }
 
-            if (!globalSettings.SelfHosted && CoreHelpers.SettingHasValue(globalSettings.Captcha?.HCaptchaSecretKey) &&
+            if (CoreHelpers.SettingHasValue(globalSettings.Captcha?.HCaptchaSecretKey) &&
                 CoreHelpers.SettingHasValue(globalSettings.Captcha?.HCaptchaSiteKey))
             {
                 services.AddSingleton<ICaptchaValidationService, HCaptchaValidationService>();


### PR DESCRIPTION
# Overview

Required hcaptcha solution if Cloudflare suspects the current request is coming from a bot. The context is updated in #1398.

There are two primary changes in this PR.
1. **Site Key Changes:** Return the hcaptcha public key to the requesting client to grab an appropriate captcha challenge
2. **Validate Captcha upon successful username/password validation:** Alter captcha validation time to protect from password brute-forcing, but not from MFA. MFA will be protected by other means. Captcha will be responsible for keeping information about username and password from leaking on brute-force attempts. This separation is because the captcha verification is a nonce and incompatible with our current authentication flow, hitting the same endpoint repeatedly with increasing amounts of authentication information.

# Files Changed
## Site Key Changes
* **ICaptchaValidationService/HCaptchaValidationService/NoopCaptchaValidationService**: Make SiteKey available to respond to clients with it
* **ResourceOwnerPasswordValidator**: Add captcha Site key to the error response if captcha is required

## Validate Captcha upon successful username/password validation
* **BaseRequestValidator**: Add on CustomResponse so `ResourceOwnerPasswordValidator` can determine is a successful authentication required two-factor. If two-factor was involved, captcha has already been checked so we can skip validation.
* **ResourceOwnerPasswordValidator**: Validate the request prior to determining if Captcha is required. This allows us to require captcha only in the case that either the authentication is successful and MFA isn't required or unseccessfull _because_ MFA is required

# Testing note

I don't know of a way to force cloudflare to think you're a bot for QA testing, so I've provided a global setting to always force captcha for all user/pass auth requests. This is enabled by setting `globaSettings__captcha__requireCaptcha = true`.