### PR TITLE
[Provider] Include disabled providers in sync response

### DIFF
--- a/src/Core/Models/Api/Response/ProfileResponseModel.cs
+++ b/src/Core/Models/Api/Response/ProfileResponseModel.cs
@@ -31,7 +31,7 @@ namespace Bit.Core.Models.Api
             PrivateKey = user.PrivateKey;
             SecurityStamp = user.SecurityStamp;
             Organizations = organizationsUserDetails?.Select(o => new ProfileOrganizationResponseModel(o));
-            Providers = providerUserDetails?.Where(p => p.Enabled).Select(p => new ProfileProviderResponseModel(p));
+            Providers = providerUserDetails?.Select(p => new ProfileProviderResponseModel(p));
             ProviderOrganizations =
                 providerUserOrganizationDetails?.Select(po => new ProfileProviderOrganizationResponseModel(po));
         }


### PR DESCRIPTION
## Objective
If a provider is disabled, the sync would not send the provider but would include the provider orgs. This caused decryption errors where the org keys could not be decrypted.

Since we seem to include disabled orgs in the sync response, I changed it to include disabled providers. Which solves the issue.