### PR TITLE
Fix conflicting group permissions

### DIFF
--- a/src/Core/Repositories/EntityFramework/CollectionRepository.cs
+++ b/src/Core/Repositories/EntityFramework/CollectionRepository.cs
@@ -70,8 +70,8 @@ namespace Bit.Core.Repositories.EntityFramework
             using (var scope = ServiceScopeFactory.CreateScope())
             {
                 var dbContext = GetDatabaseContext(scope);
-                var query = new UserCollectionDetailsQuery(userId);
-                var collection = await query.Run(dbContext).FirstOrDefaultAsync();
+                var query = new CollectionReadByIdUserId(id, userId).Run(dbContext);
+                var collection = await query.FirstOrDefaultAsync();
                 return collection;
             }
         }
@@ -138,9 +138,9 @@ namespace Bit.Core.Repositories.EntityFramework
             using (var scope = ServiceScopeFactory.CreateScope())
             {
                 var dbContext = GetDatabaseContext(scope);
-                var query = new UserCollectionDetailsQuery(userId).Run(dbContext);
-                var data = await query.ToListAsync();
-                return data.GroupBy(c => c.Id).Select(c => c.First()).ToList();
+                var query = new CollectionReadByUserId(userId).Run(dbContext);
+                var collections = await query.ToListAsync();
+                return collections;
             }
         }
 

--- a/src/Core/Repositories/EntityFramework/Queries/CollectionReadByIdUserId.cs
+++ b/src/Core/Repositories/EntityFramework/Queries/CollectionReadByIdUserId.cs
@@ -1,0 +1,24 @@
+using System.Linq;
+using Bit.Core.Models.EntityFramework;
+using System;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data;
+
+namespace Bit.Core.Repositories.EntityFramework.Queries
+{
+    public class CollectionReadByIdUserId : CollectionReadByUserId
+    {
+        private readonly Guid _id;
+
+        public CollectionReadByIdUserId(Guid id, Guid userId) : base(userId)
+        {
+            _id = id;
+        }
+
+        public override IQueryable<CollectionDetails> Run(DatabaseContext dbContext)
+        {
+            var query = base.Run(dbContext);
+            return query.Where(c => c.Id == _id);
+        }
+    }
+}

--- a/src/Core/Repositories/EntityFramework/Queries/CollectionReadByIdUserId.cs
+++ b/src/Core/Repositories/EntityFramework/Queries/CollectionReadByIdUserId.cs
@@ -1,7 +1,5 @@
 using System.Linq;
-using Bit.Core.Models.EntityFramework;
 using System;
-using Bit.Core.Enums;
 using Bit.Core.Models.Data;
 
 namespace Bit.Core.Repositories.EntityFramework.Queries

--- a/src/Core/Repositories/EntityFramework/Queries/CollectionReadByUserId.cs
+++ b/src/Core/Repositories/EntityFramework/Queries/CollectionReadByUserId.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using System;
+using Bit.Core.Models.Data;
+
+namespace Bit.Core.Repositories.EntityFramework.Queries
+{
+    public class CollectionReadByUserId : UserCollectionDetailsQuery
+    {
+        private readonly Guid _userId;
+
+        public CollectionReadByUserId(Guid userId) : base(userId)
+        {
+            _userId = userId;
+        }
+
+        public override IQueryable<CollectionDetails> Run(DatabaseContext dbContext)
+        {
+            var query = base.Run(dbContext);
+            return query
+                .GroupBy(c => c.Id)
+                .Select(g => new CollectionDetails
+                {
+                    Id = g.Key,
+                    OrganizationId = g.FirstOrDefault().OrganizationId,
+                    Name = g.FirstOrDefault().Name,
+                    ExternalId = g.FirstOrDefault().ExternalId,
+                    CreationDate = g.FirstOrDefault().CreationDate,
+                    RevisionDate = g.FirstOrDefault().RevisionDate,
+                    ReadOnly = g.Min(c => c.ReadOnly),
+                    HidePasswords = g.Min(c => c.HidePasswords)
+                });
+        }
+    }
+}

--- a/src/Core/Repositories/SqlServer/CollectionRepository.cs
+++ b/src/Core/Repositories/SqlServer/CollectionRepository.cs
@@ -104,11 +104,7 @@ namespace Bit.Core.Repositories.SqlServer
                     new { UserId = userId },
                     commandType: CommandType.StoredProcedure);
 
-                // Return distinct Id results.
-                return results
-                    .GroupBy(c => c.Id)
-                    .Select(c => c.First())
-                    .ToList();
+                return results.ToList();
             }
         }
 

--- a/src/Core/Repositories/SqlServer/CollectionRepository.cs
+++ b/src/Core/Repositories/SqlServer/CollectionRepository.cs
@@ -107,21 +107,7 @@ namespace Bit.Core.Repositories.SqlServer
                 // Return distinct Id results.
                 return results
                     .GroupBy(c => c.Id)
-                    .Select(grouping =>
-                    { 
-                        var first = grouping.First();
-                        if (first.HidePasswords)
-                        {
-                            first.HidePasswords = !grouping.Any(c => !c.HidePasswords);
-                        }
-
-                        if (first.ReadOnly)
-                        {
-                            first.ReadOnly = !grouping.Any(c => !c.ReadOnly);
-                        }
-                        
-                        return first;
-                    })
+                    .Select(c => c.First())
                     .ToList();
             }
         }

--- a/src/Core/Repositories/SqlServer/CollectionRepository.cs
+++ b/src/Core/Repositories/SqlServer/CollectionRepository.cs
@@ -107,7 +107,21 @@ namespace Bit.Core.Repositories.SqlServer
                 // Return distinct Id results.
                 return results
                     .GroupBy(c => c.Id)
-                    .Select(c => c.First())
+                    .Select(grouping =>
+                    { 
+                        var first = grouping.First();
+                        if (first.HidePasswords)
+                        {
+                            first.HidePasswords = !grouping.Any(c => !c.HidePasswords);
+                        }
+
+                        if (first.ReadOnly)
+                        {
+                            first.ReadOnly = !grouping.Any(c => !c.ReadOnly);
+                        }
+                        
+                        return first;
+                    })
                     .ToList();
             }
         }

--- a/src/Sql/dbo/Stored Procedures/Collection_ReadByIdUserId.sql
+++ b/src/Sql/dbo/Stored Procedures/Collection_ReadByIdUserId.sql
@@ -4,12 +4,24 @@
 AS
 BEGIN
     SET NOCOUNT ON
-    SELECT TOP 1
-        *
+    SELECT
+        Id,
+        OrganizationId,
+        [Name],
+        CreationDate,
+        RevisionDate,
+        ExternalId,
+        MIN([ReadOnly]) AS [ReadOnly],
+        MIN([HidePasswords]) AS [HidePasswords]
     FROM
         [dbo].[UserCollectionDetails](@UserId)
     WHERE
         [Id] = @Id
-    ORDER BY
-        [ReadOnly] ASC
+    GROUP BY
+        Id,
+        OrganizationId,
+        [Name],
+        CreationDate,
+        RevisionDate,
+        ExternalId
 END

--- a/src/Sql/dbo/Stored Procedures/Collection_ReadByUserId.sql
+++ b/src/Sql/dbo/Stored Procedures/Collection_ReadByUserId.sql
@@ -5,7 +5,21 @@ BEGIN
     SET NOCOUNT ON
 
     SELECT
-        *
+        Id,
+        OrganizationId,
+        [Name],
+        CreationDate,
+        RevisionDate,
+        ExternalId,
+        MIN([ReadOnly]) AS [ReadOnly],
+        MIN([HidePasswords]) AS [HidePasswords]
     FROM
         [dbo].[UserCollectionDetails](@UserId)
+    GROUP BY
+        Id,
+        OrganizationId,
+        [Name],
+        CreationDate,
+        RevisionDate,
+        ExternalId
 END

--- a/util/Migrator/DbScripts/2021-07-22_00_FixCollectionReadBy.sql
+++ b/util/Migrator/DbScripts/2021-07-22_00_FixCollectionReadBy.sql
@@ -1,0 +1,66 @@
+﻿IF OBJECT_ID('[dbo].[Collection_ReadByUserId]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Collection_ReadByUserId]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Collection_ReadByUserId]
+    @UserId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        Id,
+        OrganizationId,
+        [Name],
+        CreationDate,
+        RevisionDate,
+        ExternalId,
+        MIN([ReadOnly]) AS [ReadOnly],
+        MIN([HidePasswords]) AS [HidePasswords]
+    FROM
+        [dbo].[UserCollectionDetails](@UserId)
+    GROUP BY
+        Id,
+        OrganizationId,
+        [Name],
+        CreationDate,
+        RevisionDate,
+        ExternalId
+END
+GO
+
+IF OBJECT_ID('[dbo].[Collection_ReadByIdUserId]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Collection_ReadByIdUserId]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Collection_ReadByIdUserId]
+    @Id UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+    SELECT
+        Id,
+        OrganizationId,
+        [Name],
+        CreationDate,
+        RevisionDate,
+        ExternalId,
+        MIN([ReadOnly]) AS [ReadOnly],
+        MIN([HidePasswords]) AS [HidePasswords]
+    FROM
+        [dbo].[UserCollectionDetails](@UserId)
+    WHERE
+        [Id] = @Id
+    GROUP BY
+        Id,
+        OrganizationId,
+        [Name],
+        CreationDate,
+        RevisionDate,
+        ExternalId
+END


### PR DESCRIPTION
## Objective

Fix #1450:

> If a user is assigned to multiple groups with contradicting permissions (read-only vs. read-write), the group that comes first alphabetically gets precedence.

The problem is that `collectionRepository.GetManyByUserIdAsync` gets all relevant `collectionDetails` matching an id, but then just takes the first one without doing any reconciliation of permission levels.

## Code changes

Update `collectionRepository.GetManyByUserIdAsync` so that after getting the first `collectionDetails` result, it reconciles its permissions with the other results and returns a modified object with the highest permissions available to the user. This fixes the defect.

## Other changes

I also considered whether this change needed to be made anywhere else. The only other repository methods returning a `collectionDetails` object are `GetByIdAsync` and `GetByIdWithGroupsAsync`, which both rely on the `Collection_ReadyByIdUserId` SQL procedure. That SQL procedure returns the top result after sorting by `ReadOnly` ascending, ensuring that it'll always get the row with the highest `ReadOnly` permission. However, that may not be the row with the highest `HidePasswords` permission - so in theory it could have a similar problem. 

That said, I haven't tried to fix this for now because it's not actually causing any problems in practice, so I wasn't sure whether changing the SQL procedure would be messing with things unnecessarily. I could also be misunderstanding the intended return value. Whoever does code review - let me know if you think I should change this while I'm here.