### PR TITLE
[BUG] Addressed Special Characters Showing as HTML Encoded Values in OrganizationName in Emails

### DIFF
--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -151,7 +151,7 @@ namespace Bit.Core.Services
             var model = new OrganizationUserAcceptedViewModel
             {
                 OrganizationId = organization.Id,
-                OrganizationName = CoreHelpers.SanitizeForEmail(organization.Name),
+                OrganizationName = organization.Name,
                 UserIdentifier = userIdentifier,
                 WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
                 SiteName = _globalSettings.SiteName
@@ -166,7 +166,7 @@ namespace Bit.Core.Services
             var message = CreateDefaultMessage($"You Have Been Confirmed To {organizationName}", email);
             var model = new OrganizationUserConfirmedViewModel
             {
-                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName),
+                OrganizationName = organizationName,
                 WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
                 SiteName = _globalSettings.SiteName
             };
@@ -189,7 +189,7 @@ namespace Bit.Core.Services
             var messageModels = invites.Select(invite => CreateMessage(invite.orgUser.Email,
                 new OrganizationUserInvitedViewModel
                 {
-                    OrganizationName = CoreHelpers.SanitizeForEmail(organizationName),
+                    OrganizationName = organizationName,
                     Email = WebUtility.UrlEncode(invite.orgUser.Email),
                     OrganizationId = invite.orgUser.OrganizationId.ToString(),
                     OrganizationUserId = invite.orgUser.Id.ToString(),
@@ -209,7 +209,7 @@ namespace Bit.Core.Services
             var message = CreateDefaultMessage($"You have been removed from {organizationName}", email);
             var model = new OrganizationUserRemovedForPolicyTwoStepViewModel
             {
-                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName),
+                OrganizationName = organizationName,
                 WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
                 SiteName = _globalSettings.SiteName
             };
@@ -349,7 +349,7 @@ namespace Bit.Core.Services
             var message = CreateDefaultMessage($"You have been removed from {organizationName}", email);
             var model = new OrganizationUserRemovedForPolicySingleOrgViewModel
             {
-                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName),
+                OrganizationName = organizationName,
                 WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
                 SiteName = _globalSettings.SiteName
             };


### PR DESCRIPTION
### Related Work
[Asana Ticket](https://app.asana.com/0/1183359552741420/1200482002473403/f)
[Github Issue](https://github.com/bitwarden/server/issues/1395)
[PR that introduced the issue](https://github.com/bitwarden/server/pull/1138)

### Objective
> Special characters should display as expected in emails containing an `OrganizationName`. 

### Code Changes
* Removed the calls to `CoreHelpers.SanitizeForEmail` from any `OrganizationName` values that passed through that method.
    * `OrganizationName` is showing incorrectly in emails because we are escaping the value twice: once in the service when we call `CoreHelpers.SanitizeForEmail` on all `OrganizationName` values, and once in the template when we don't explicitly tell [Handlebars](https://handlebarsjs.com/guide/#html-escaping) not to escape the value we already escaped. There are two paths forward for this: relying on our own encoding function for these values or relying on Handlebars. Safe html templating is the main points of Handlebars, and our function includes some formatting rules that don't apply well to this use case (i.e replacing '@' with '[at]') so I went with using Handlebars for these, and using `SanitizeForEmail` only when needed.

### Screenshots
![Screen Shot 2021-07-20 at 11 25 02 AM](https://user-images.githubusercontent.com/15897251/126351274-103b68cb-bfc7-4627-ae96-e30b82047e8a.png)
![Screen Shot 2021-07-20 at 11 25 11 AM](https://user-images.githubusercontent.com/15897251/126351289-3a59362c-65a9-4820-ad7e-8215a75d35b2.png)
![Screen Shot 2021-07-20 at 11 25 18 AM](https://user-images.githubusercontent.com/15897251/126351307-4af0ef06-8fa6-4128-84ef-6b919895094b.png)
![Screen Shot 2021-07-20 at 11 25 25 AM](https://user-images.githubusercontent.com/15897251/126351332-932ef379-3682-4676-8aeb-6504d27d35a1.png)
![Screen Shot 2021-07-20 at 11 25 33 AM](https://user-images.githubusercontent.com/15897251/126351354-df96b87f-b1fb-45de-9939-083d689ee01c.png)
