### PR TITLE
Increasing production log level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,4 @@ bitwarden_license/src/Sso/wwwroot/css
 .github/test/build.secrets
 **/CoverageOutput/
 .idea/*
+**/**.swp

--- a/src/Admin/appsettings.Production.json
+++ b/src/Admin/appsettings.Production.json
@@ -23,10 +23,18 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Warning",
-      "System": "Warning",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    },
+    "Console": {
+      "IncludeScopes": true,
+      "LogLevel": {
+        "Default": "Warning",
+        "System": "Warning",
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information"
+      }
     }
   }
 }

--- a/src/Admin/appsettings.Production.json
+++ b/src/Admin/appsettings.Production.json
@@ -19,5 +19,14 @@
     "braintree": {
       "production": true
     }
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Warning",
+      "System": "Warning",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
   }
 }

--- a/src/Api/appsettings.Production.json
+++ b/src/Api/appsettings.Production.json
@@ -26,10 +26,18 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Warning",
-      "System": "Warning",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    },
+    "Console": {
+      "IncludeScopes": true,
+      "LogLevel": {
+          "Default": "Warning",
+          "System": "Warning",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Information"
+      }
     }
   }
 }

--- a/src/Api/appsettings.Production.json
+++ b/src/Api/appsettings.Production.json
@@ -22,5 +22,14 @@
     "bitPay": {
       "production": true
     }
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Warning",
+      "System": "Warning",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
   }
 }

--- a/src/Billing/appsettings.Production.json
+++ b/src/Billing/appsettings.Production.json
@@ -32,10 +32,18 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Warning",
-      "System": "Warning",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    },
+    "Console": {
+      "IncludeScopes": true,
+      "LogLevel": {
+          "Default": "Warning",
+          "System": "Warning",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Information"
+      }
     }
   }
 }

--- a/src/Billing/appsettings.Production.json
+++ b/src/Billing/appsettings.Production.json
@@ -28,5 +28,14 @@
       "production": true,
       "businessId": "4ZDA7DLUUJGMN"
     }
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Warning",
+      "System": "Warning",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
   }
 }

--- a/src/Events/appsettings.Production.json
+++ b/src/Events/appsettings.Production.json
@@ -16,5 +16,14 @@
       "internalSso": "https://sso.bitwarden.com",
       "internalPortal": "https://portal.bitwarden.com"
     }
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Warning",
+      "System": "Warning",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
   }
 }

--- a/src/Events/appsettings.Production.json
+++ b/src/Events/appsettings.Production.json
@@ -20,10 +20,18 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Warning",
-      "System": "Warning",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    },
+    "Console": {
+      "IncludeScopes": true,
+      "LogLevel": {
+          "Default": "Warning",
+          "System": "Warning",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Information"
+      }
     }
   }
 }

--- a/src/EventsProcessor/appsettings.Production.json
+++ b/src/EventsProcessor/appsettings.Production.json
@@ -2,10 +2,18 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Warning",
-      "System": "Warning",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    },
+    "Console": {
+      "IncludeScopes": true,
+      "LogLevel": {
+          "Default": "Warning",
+          "System": "Warning",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Information"
+      }
     }
   }
 }

--- a/src/Icons/appsettings.Production.json
+++ b/src/Icons/appsettings.Production.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {

--- a/src/Icons/appsettings.Production.json
+++ b/src/Icons/appsettings.Production.json
@@ -2,10 +2,18 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Warning",
-      "System": "Warning",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    },
+    "Console": {
+      "IncludeScopes": true,
+      "LogLevel": {
+          "Default": "Warning",
+          "System": "Warning",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Information"
+      }
     }
   }
 }

--- a/src/Identity/appsettings.Production.json
+++ b/src/Identity/appsettings.Production.json
@@ -19,5 +19,14 @@
     "braintree": {
       "production": true
     }
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Warning",
+      "System": "Warning",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
   }
 }

--- a/src/Identity/appsettings.Production.json
+++ b/src/Identity/appsettings.Production.json
@@ -23,10 +23,18 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Warning",
-      "System": "Warning",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    },
+    "Console": {
+      "IncludeScopes": true,
+      "LogLevel": {
+          "Default": "Warning",
+          "System": "Warning",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Information"
+      }
     }
   }
 }

--- a/src/Notifications/appsettings.Production.json
+++ b/src/Notifications/appsettings.Production.json
@@ -16,5 +16,14 @@
       "internalSso": "https://sso.bitwarden.com",
       "internalPortal": "https://portal.bitwarden.com"
     }
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Warning",
+      "System": "Warning",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
   }
 }

--- a/src/Notifications/appsettings.Production.json
+++ b/src/Notifications/appsettings.Production.json
@@ -20,10 +20,18 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Warning",
-      "System": "Warning",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    },
+    "Console": {
+      "IncludeScopes": true,
+      "LogLevel": {
+          "Default": "Warning",
+          "System": "Warning",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Information"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
We have not been setting custom log levels in Production. Because of this, we have been logging every successful request to STDOUT. The way the App Services and the VM services are set up, STDOUT is written to disk and the disk is filling up very quickly (~100GB per week) which maxes out the file system. 

This change removes the successful logs to the Console, but keeps any log level from Warning up. We can still use the Console logs for debugging purposes.

## Testing Notes
This has been deployed and tested on the QA environment. There was concern around not logging Event Logs (logs with the property Properties.EventId with a Log Level of `Information`), but since we are targeting only the Console output, it has been confirmed that the Event logs are logging to the DB properly while there is a decrease in console output.