### PR TITLE
addressed bugs and concerns around special characters in email templates

### DIFF
--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -151,7 +151,7 @@ namespace Bit.Core.Services
             var model = new OrganizationUserAcceptedViewModel
             {
                 OrganizationId = organization.Id,
-                OrganizationName = CoreHelpers.SanitizeForEmail(organization.Name),
+                OrganizationName = CoreHelpers.SanitizeForEmail(organization.Name, false),
                 UserIdentifier = userIdentifier,
                 WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
                 SiteName = _globalSettings.SiteName
@@ -166,7 +166,7 @@ namespace Bit.Core.Services
             var message = CreateDefaultMessage($"You Have Been Confirmed To {organizationName}", email);
             var model = new OrganizationUserConfirmedViewModel
             {
-                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName),
+                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName, false),
                 WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
                 SiteName = _globalSettings.SiteName
             };
@@ -189,7 +189,7 @@ namespace Bit.Core.Services
             var messageModels = invites.Select(invite => CreateMessage(invite.orgUser.Email,
                 new OrganizationUserInvitedViewModel
                 {
-                    OrganizationName = CoreHelpers.SanitizeForEmail(organizationName),
+                    OrganizationName = CoreHelpers.SanitizeForEmail(organizationName, false),
                     Email = WebUtility.UrlEncode(invite.orgUser.Email),
                     OrganizationId = invite.orgUser.OrganizationId.ToString(),
                     OrganizationUserId = invite.orgUser.Id.ToString(),
@@ -209,7 +209,7 @@ namespace Bit.Core.Services
             var message = CreateDefaultMessage($"You have been removed from {organizationName}", email);
             var model = new OrganizationUserRemovedForPolicyTwoStepViewModel
             {
-                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName),
+                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName, false),
                 WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
                 SiteName = _globalSettings.SiteName
             };
@@ -302,7 +302,7 @@ namespace Bit.Core.Services
             var message = CreateDefaultMessage("License Expired", emails);
             var model = new LicenseExpiredViewModel
             {
-                OrganizationName = organizationName,
+                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName, false),
             };
             await AddMessageContentAsync(message, "LicenseExpired", model);
             message.Category = "LicenseExpired";
@@ -349,7 +349,7 @@ namespace Bit.Core.Services
             var message = CreateDefaultMessage($"You have been removed from {organizationName}", email);
             var model = new OrganizationUserRemovedForPolicySingleOrgViewModel
             {
-                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName),
+                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName, false),
                 WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
                 SiteName = _globalSettings.SiteName
             };

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -555,12 +555,13 @@ namespace Bit.Core.Utilities
             return sb.ToString();
         }
 
-        public static string SanitizeForEmail(string value)
+        public static string SanitizeForEmail(string value, bool htmlEncode = true)
         {
             var cleanedValue = value.Replace("@", "[at]")
+                .Replace(".", "[dot]")
                 .Replace("http://", string.Empty)
                 .Replace("https://", string.Empty);
-            return HttpUtility.HtmlEncode(cleanedValue);
+            return htmlEncode ? HttpUtility.HtmlEncode(cleanedValue) : cleanedValue;
         }
 
         public static string DateTimeToTableStorageKey(DateTime? date = null)

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -557,10 +557,17 @@ namespace Bit.Core.Utilities
 
         public static string SanitizeForEmail(string value, bool htmlEncode = true)
         {
-            var cleanedValue = value.Replace("@", "[at]")
-                .Replace(".", "[dot]")
-                .Replace("http://", string.Empty)
-                .Replace("https://", string.Empty);
+            var cleanedValue = value.Replace("@", "[at]");
+            var regexOptions = RegexOptions.CultureInvariant |
+                RegexOptions.Singleline |
+                RegexOptions.IgnoreCase;
+            cleanedValue = Regex.Replace(cleanedValue, @"(\.\w)",
+                    m => string.Concat("[dot]", m.ToString().Last()), regexOptions);
+            while (Regex.IsMatch(cleanedValue, @"((^|\b)(\w*)://)", regexOptions))
+            {
+                cleanedValue = Regex.Replace(cleanedValue, @"((^|\b)(\w*)://)",
+                    string.Empty, regexOptions);
+            }
             return htmlEncode ? HttpUtility.HtmlEncode(cleanedValue) : cleanedValue;
         }
 


### PR DESCRIPTION


### Related Work
[Asana Ticket](https://app.asana.com/0/1183359552741420/1200482002473403/f)
[Github Issue](https://github.com/bitwarden/server/issues/1395)
[PR that introduced the issue](https://github.com/bitwarden/server/pull/1138)
[Previous PR for the same central issue](https://github.com/bitwarden/server/pull/1476)

### Objective
> Special characters should display as expected in emails containing an `OrganizationName`. Links should not be displayed as URLs no matter how smart the email client is. 

### Code Changes
* Added a boolean `htmlEncode` to our email sanitize function so we don't double escape special characters in handlebar templates, and specifically told OrganizationName not to become HtmlEncoded.
* Added a `. -> [dot]` conversion in the same method to avoid abuse of OrganizationName to inject links into emails, and to keep high profile email clients like Gmail from being able to infer a link. 

### Screenshots
Please see screenshots in the closed PR to see examples of all emails. The new one here is different in that I sent it to Gmail instead of smtp4dev to ensure the link didn't... link.
<img width="891" alt="Screen Shot 2021-07-20 at 4 15 18 PM" src="https://user-images.githubusercontent.com/15897251/126389507-4b809b6c-647e-48fc-a400-d89102af4e0b.png">