### PR TITLE
Fix upload limits for direct uploads (again)

### DIFF
--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -17,6 +17,7 @@ using Microsoft.Azure.EventGrid.Models;
 using Bit.Core.Models.Data;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using Bit.Core;
 
 namespace Bit.Api.Controllers
 {
@@ -652,7 +653,7 @@ namespace Bit.Api.Controllers
         }
 
         [HttpPost("{id}/attachment")]
-        [RequestSizeLimit(105_906_176)]
+        [RequestSizeLimit(Constants.FileSize101mb)]
         [DisableFormValueModelBinding]
         public async Task<CipherResponseModel> PostAttachment(string id)
         {
@@ -676,7 +677,7 @@ namespace Bit.Api.Controllers
         }
 
         [HttpPost("{id}/attachment-admin")]
-        [RequestSizeLimit(105_906_176)]
+        [RequestSizeLimit(Constants.FileSize101mb)]
         [DisableFormValueModelBinding]
         public async Task<CipherMiniResponseModel> PostAttachmentAdmin(string id)
         {
@@ -709,7 +710,7 @@ namespace Bit.Api.Controllers
         }
 
         [HttpPost("{id}/attachment/{attachmentId}/share")]
-        [RequestSizeLimit(105_906_176)]
+        [RequestSizeLimit(Constants.FileSize101mb)]
         [DisableFormValueModelBinding]
         public async Task PostAttachmentShare(string id, string attachmentId, Guid organizationId)
         {
@@ -805,7 +806,7 @@ namespace Bit.Api.Controllers
                 throw new BadRequestException("Invalid content.");
             }
 
-            if (Request.ContentLength > 105906176) // 101 MB, give em' 1 extra MB for cushion
+            if (Request.ContentLength > Constants.FileSize101mb)
             {
                 throw new BadRequestException("Max file size is 100 MB.");
             }

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -623,7 +623,7 @@ namespace Bit.Api.Controllers
         }
 
         [HttpPost("{id}/attachment/{attachmentId}")]
-        [DisableRequestSizeLimit]
+        [RequestSizeLimit(Constants.FileSize501mb)]
         [DisableFormValueModelBinding]
         public async Task PostFileForExistingAttachment(string id, string attachmentId)
         {

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -19,6 +19,7 @@ using Bit.Core.Models.Table;
 using Newtonsoft.Json;
 using Bit.Core.Models.Data;
 using Microsoft.Extensions.Logging;
+using Bit.Core;
 
 namespace Bit.Api.Controllers
 {
@@ -166,7 +167,7 @@ namespace Bit.Api.Controllers
         }
 
         [HttpPost("file")]
-        [RequestSizeLimit(105_906_176)]
+        [RequestSizeLimit(Constants.FileSize101mb)]
         [DisableFormValueModelBinding]
         public async Task<SendResponseModel> PostFile()
         {
@@ -175,7 +176,7 @@ namespace Bit.Api.Controllers
                 throw new BadRequestException("Invalid content.");
             }
 
-            if (Request.ContentLength > 105906176) // 101 MB, give em' 1 extra MB for cushion
+            if (Request.ContentLength > Constants.FileSize101mb)
             {
                 throw new BadRequestException("Max file size is 100 MB.");
             }
@@ -258,7 +259,7 @@ namespace Bit.Api.Controllers
                 throw new BadRequestException("Invalid content.");
             }
 
-            if (Request.ContentLength > 105906176 && !_globalSettings.SelfHosted) // 101 MB, give em' 1 extra MB for cushion
+            if (Request.ContentLength > Constants.FileSize101mb && !_globalSettings.SelfHosted)
             {
                 throw new BadRequestException("Max file size for direct upload is 100 MB.");
             }

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -250,7 +250,7 @@ namespace Bit.Api.Controllers
         }
 
         [HttpPost("{id}/file/{fileId}")]
-        [DisableRequestSizeLimit]
+        [RequestSizeLimit(Constants.FileSize501mb)]
         [DisableFormValueModelBinding]
         public async Task PostFileForExistingSend(string id, string fileId)
         {

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -3,6 +3,10 @@
     public static class Constants
     {
         public const int BypassFiltersEventId = 12482444;
+
+        // File size limits - give 1 MB extra for cushion
+        public const long FileSize101mb = 101L * 1024L * 1024L;
+        public const long FileSize501mb = 501L * 1024L * 1024L;
     }
 
     public static class TokenPurposes 

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -4,7 +4,9 @@
     {
         public const int BypassFiltersEventId = 12482444;
 
-        // File size limits - give 1 MB extra for cushion
+        // File size limits - give 1 MB extra for cushion.
+        // Note: if request size limits are changed, 'client_max_body_size'
+        // in nginx/proxy.conf may also need to be updated accordingly.
         public const long FileSize101mb = 101L * 1024L * 1024L;
         public const long FileSize501mb = 501L * 1024L * 1024L;
     }

--- a/src/Core/Services/Implementations/CipherService.cs
+++ b/src/Core/Services/Implementations/CipherService.cs
@@ -18,7 +18,7 @@ namespace Bit.Core.Services
 {
     public class CipherService : ICipherService
     {
-        public const long MAX_FILE_SIZE = 500L * 1024L * 1024L; // 500MB
+        public const long MAX_FILE_SIZE = Constants.FileSize501mb;
         public const string MAX_FILE_SIZE_READABLE = "500 MB";
         private readonly ICipherRepository _cipherRepository;
         private readonly IFolderRepository _folderRepository;

--- a/src/Core/Services/Implementations/SendService.cs
+++ b/src/Core/Services/Implementations/SendService.cs
@@ -17,7 +17,7 @@ namespace Bit.Core.Services
 {
     public class SendService : ISendService
     {
-        public const long MAX_FILE_SIZE = 500L * 1024L * 1024L; // 500MB
+        public const long MAX_FILE_SIZE = Constants.FileSize501mb;
         public const string MAX_FILE_SIZE_READABLE = "500 MB";
         private readonly ISendRepository _sendRepository;
         private readonly IUserRepository _userRepository;

--- a/util/Nginx/proxy.conf
+++ b/util/Nginx/proxy.conf
@@ -4,7 +4,7 @@ proxy_set_header        X-Real-IP         $remote_addr;
 proxy_set_header        X-Forwarded-For   $proxy_add_x_forwarded_for;
 proxy_set_header        X-Url-Scheme      $scheme;
 proxy_set_header        X-Forwarded-Proto $scheme;
-client_max_body_size    105m;
+client_max_body_size    505m;
 client_body_buffer_size 128k;
 proxy_connect_timeout   90;
 proxy_send_timeout      90;


### PR DESCRIPTION
## Objective

In #1406, I removed request size limits on endpoints used by self-hosted servers to upload attachments and file Sends. I did this because the default request size limit in ASP .Net Core is ~30mb, and this was preventing file uploads for self-hosted users.

This worked when testing locally, however a test deployment found that nginx currently limits requests to 105mb, so we have to raise that limit as well.

I also discussed this further with @cscharf and decided that we should re-instate size request limits for self-hosted users, because size limitations are enforced by clients across the board (regardless of whether it's self-hosted or not), and the server should be consistent with this.

## Code changes
* refactor: move all file size numbers to constants (no magic numbers)
* add `requestSizeLimit` to the required endpoints and set to 501mb (refer to discussion in #1406 about appropriate endpoints if required)
* change `client_max_body_size` in `nginx/proxy.conf` to 505mb (previously 105mb, kept the same buffer). [nginx docs reference](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size)