### PR TITLE
Protect user registration with captcha

### DIFF
--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -83,6 +83,7 @@ namespace Bit.Api.Controllers
 
         [HttpPost("register")]
         [AllowAnonymous]
+        [CaptchaProtected]
         public async Task PostRegister([FromBody]RegisterRequestModel model)
         {
             var result = await _userService.RegisterUserAsync(model.ToUser(), model.MasterPasswordHash,

--- a/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
+++ b/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
@@ -60,7 +60,7 @@ namespace Bit.Core.IdentityServer
             //}
 
             string bypassToken = null;
-            if (_captchaValidationService.ServiceEnabled && (_currentContext.IsBot || _captchaValidationService.RequireCaptcha))
+            if (_captchaValidationService.RequireCaptchaValidation(_currentContext))
             {
                 var user = await _userManager.FindByEmailAsync(context.UserName.ToLowerInvariant());
                 var captchaResponse = context.Request.Raw["captchaResponse"]?.ToString();
@@ -69,7 +69,7 @@ namespace Bit.Core.IdentityServer
                 {
                     context.Result = new GrantValidationResult(TokenRequestErrors.InvalidGrant, "Captcha required.",
                         new Dictionary<string, object> {
-                            { "HCaptcha_SiteKey", _captchaValidationService.SiteKey },
+                            { _captchaValidationService.SiteKeyResponseKeyName, _captchaValidationService.SiteKey },
                         });
                     return;
                 }

--- a/src/Core/Models/Api/Request/Accounts/RegisterRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/RegisterRequestModel.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 
 namespace Bit.Core.Models.Api
 {
-    public class RegisterRequestModel : IValidatableObject
+    public class RegisterRequestModel : IValidatableObject, ICaptchaProtectedModel
     {
         [StringLength(50)]
         public string Name { get; set; }
@@ -22,6 +22,7 @@ namespace Bit.Core.Models.Api
         public string MasterPasswordHash { get; set; }
         [StringLength(50)]
         public string MasterPasswordHint { get; set; }
+        public string CaptchaResponse { get; set; }
         public string Key { get; set; }
         public KeysRequestModel Keys { get; set; }
         public string Token { get; set; }

--- a/src/Core/Models/Api/Request/ICaptchaProtectedModel.cs
+++ b/src/Core/Models/Api/Request/ICaptchaProtectedModel.cs
@@ -1,0 +1,7 @@
+namespace Bit.Core.Models.Api
+{
+    public interface ICaptchaProtectedModel
+    {
+        string CaptchaResponse { get; set; }
+    }
+}

--- a/src/Core/Services/ICaptchaValidationService.cs
+++ b/src/Core/Services/ICaptchaValidationService.cs
@@ -1,13 +1,14 @@
 ﻿using System.Threading.Tasks;
+using Bit.Core.Context;
 using Bit.Core.Models.Table;
 
 namespace Bit.Core.Services
 {
     public interface ICaptchaValidationService
     {
-        bool ServiceEnabled { get; }
         string SiteKey { get; }
-        bool RequireCaptcha { get; }
+        string SiteKeyResponseKeyName { get; }
+        bool RequireCaptchaValidation(ICurrentContext currentContext);
         Task<bool> ValidateCaptchaResponseAsync(string captchResponse, string clientIpAddress);
         string GenerateCaptchaBypassToken(User user);
         bool ValidateCaptchaBypassToken(string encryptedToken, User user);

--- a/src/Core/Services/NoopImplementations/NoopCaptchaValidationService.cs
+++ b/src/Core/Services/NoopImplementations/NoopCaptchaValidationService.cs
@@ -1,13 +1,14 @@
 ﻿using System.Threading.Tasks;
+using Bit.Core.Context;
 using Bit.Core.Models.Table;
 
 namespace Bit.Core.Services
 {
     public class NoopCaptchaValidationService : ICaptchaValidationService
     {
-        public bool ServiceEnabled => false;
+        public string SiteKeyResponseKeyName => null;
         public string SiteKey => null;
-        public bool RequireCaptcha => false;
+        public bool RequireCaptchaValidation(ICurrentContext currentContext) => false;
 
         public string GenerateCaptchaBypassToken(User user) => "";
         public bool ValidateCaptchaBypassToken(string encryptedToken, User user) => false;

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -473,7 +473,7 @@ namespace Bit.Core.Settings
 
         public class CaptchaSettings
         {
-            public bool RequireCaptcha { get; set; } = false;
+            public bool ForceCaptchaRequired { get; set; } = false;
             public string HCaptchaSecretKey { get; set; }
             public string HCaptchaSiteKey { get; set; }
         }

--- a/src/Core/Utilities/CaptchaProtectedAttribute.cs
+++ b/src/Core/Utilities/CaptchaProtectedAttribute.cs
@@ -1,0 +1,37 @@
+using Bit.Core.Context;
+using Bit.Core.Exceptions;
+using Bit.Core.Services;
+using Bit.Core.Models.Api;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bit.Core.Utilities
+{
+    public class CaptchaProtectedAttribute : ActionFilterAttribute
+    {
+        public string ModelParameterName { get; set; } = "model";
+
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            var currentContext = context.HttpContext.RequestServices.GetRequiredService<ICurrentContext>();
+            var captchaValidationService = context.HttpContext.RequestServices.GetRequiredService<ICaptchaValidationService>();
+
+            if (captchaValidationService.ServiceEnabled && (currentContext.IsBot || captchaValidationService.RequireCaptcha))
+            {
+                var captchaResponse = (context.ActionArguments[ModelParameterName] as ICaptchaProtectedModel)?.CaptchaResponse;
+
+                if (string.IsNullOrWhiteSpace(captchaResponse))
+                {
+                    throw new BadRequestException("HCaptcha_SiteKey", captchaValidationService.SiteKey);
+                }
+
+                var captchaValid = captchaValidationService.ValidateCaptchaResponseAsync(captchaResponse,
+                    currentContext.IpAddress).GetAwaiter().GetResult();
+                if (!captchaValid)
+                {
+                    throw new BadRequestException("Captcha is invalid. Please refresh and try again");
+                }
+            }
+        }
+    }
+}

--- a/src/Core/Utilities/CaptchaProtectedAttribute.cs
+++ b/src/Core/Utilities/CaptchaProtectedAttribute.cs
@@ -16,13 +16,13 @@ namespace Bit.Core.Utilities
             var currentContext = context.HttpContext.RequestServices.GetRequiredService<ICurrentContext>();
             var captchaValidationService = context.HttpContext.RequestServices.GetRequiredService<ICaptchaValidationService>();
 
-            if (captchaValidationService.ServiceEnabled && (currentContext.IsBot || captchaValidationService.RequireCaptcha))
+            if (captchaValidationService.RequireCaptchaValidation(currentContext))
             {
                 var captchaResponse = (context.ActionArguments[ModelParameterName] as ICaptchaProtectedModel)?.CaptchaResponse;
 
                 if (string.IsNullOrWhiteSpace(captchaResponse))
                 {
-                    throw new BadRequestException("HCaptcha_SiteKey", captchaValidationService.SiteKey);
+                    throw new BadRequestException(captchaValidationService.SiteKeyResponseKeyName, captchaValidationService.SiteKey);
                 }
 
                 var captchaValid = captchaValidationService.ValidateCaptchaResponseAsync(captchaResponse,


### PR DESCRIPTION
# Overview

We want to increase protection of our API from bot spam. The `CaptchaProtectedAttribute` can be used to protect the endpoint.

Further captcha work should just need the attribute set and the model to implement `ICaptchaProtectedModel`. Client-side is more work, though, since we need to handle showing the captcha and sending the captcha response token.

# Files Changed
* **AccountsController**: Add `CaptchaProtected` to `register` endpoint
* **RegisterRequestModel**: Denote the request as a captch protected one.
* **ICaptchaProtectedModel**: specify the required properties for the `CaptchaProtected` attribute
* **CaptchaProtectedAttribute**: Attribute which ensures that contexts marked as bots need to have a valid captcha response associated with the request. The attribute assumes the http body stream has already been read into an action parameter. The `ModelParameterName` property must be set to the name of the endpoint method's model parameter.

# Testing

The attribute itself is not very unit-testable because of the reliance on ASP DI. We could extract the logic into the CaptchaService, but the DI needs to live in the attribute.

QA Testing should use the `captchaRequired` global setting introduced in #1469.