### PR TITLE
[Reset Password v1] Update Temporary Password API

### DIFF
--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -797,5 +797,28 @@ namespace Bit.Api.Controllers
                 return response;
             }
         }
+        
+        [HttpPost("update-temp-password")]
+        public async Task PostUpdateTempPasswordAsync([FromBody]UpdateTempPasswordRequestModel model)
+        {
+            var user = await _userService.GetUserByPrincipalAsync(User);
+            if (user == null)
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            var result = await _userService.UpdateTempPasswordAsync(user, model.NewMasterPasswordHash, model.Key);
+            if (result.Succeeded)
+            {
+                return;
+            }
+
+            foreach (var error in result.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error.Description);
+            }
+
+            throw new BadRequestException(ModelState);
+        }
     }
 }

--- a/src/Core/Enums/EventType.cs
+++ b/src/Core/Enums/EventType.cs
@@ -10,6 +10,7 @@
         User_FailedLogIn = 1005,
         User_FailedLogIn2fa = 1006,
         User_ClientExportedVault = 1007,
+        User_UpdatedTempPassword = 1008,
 
         Cipher_Created = 1100,
         Cipher_Updated = 1101,

--- a/src/Core/MailTemplates/Handlebars/UpdatedTempPassword.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/UpdatedTempPassword.html.hbs
@@ -1,0 +1,9 @@
+{{#>FullHtmlLayout}}
+<table width="100%" cellpadding="0" cellspacing="0" style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;" valign="top">
+            The temporary master password set by an administrator for <b style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">{{UserName}}</b> has been changed. If you did not initiate this request, please reach out to your administrator immediately.
+        </td>
+    </tr>
+</table>
+{{/FullHtmlLayout}}

--- a/src/Core/MailTemplates/Handlebars/UpdatedTempPassword.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/UpdatedTempPassword.text.hbs
@@ -1,0 +1,3 @@
+{{#>BasicTextLayout}}
+The temporary master password set by an administrator for {{UserName}} has been changed. If you did not initiate this request, please reach out to your administrator immediately.
+{{/BasicTextLayout}}

--- a/src/Core/Models/Api/Request/Accounts/UpdateTempPasswordRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/UpdateTempPasswordRequestModel.cs
@@ -1,0 +1,7 @@
+﻿namespace Bit.Core.Models.Api.Request.Accounts
+{
+    public class UpdateTempPasswordRequestModel : OrganizationUserResetPasswordRequestModel
+    {
+        
+    }
+}

--- a/src/Core/Models/Mail/UpdateTempPasswordViewModel.cs
+++ b/src/Core/Models/Mail/UpdateTempPasswordViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace Bit.Core.Models.Mail
+{
+    public class UpdateTempPasswordViewModel
+    {
+        public string UserName { get; set; }
+    }
+}

--- a/src/Core/Services/IMailService.cs
+++ b/src/Core/Services/IMailService.cs
@@ -46,5 +46,6 @@ namespace Bit.Core.Services
         Task SendProviderInviteEmailAsync(string providerName, ProviderUser providerUser, string token, string email);
         Task SendProviderConfirmedEmailAsync(string providerName, string email);
         Task SendProviderUserRemoved(string providerName, string email);
+        Task SendUpdatedTempPasswordEmailAsync(string email, string userName);
     }
 }

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -35,6 +35,7 @@ namespace Bit.Core.Services
         Task<IdentityResult> ChangePasswordAsync(User user, string masterPassword, string newMasterPassword, string key);
         Task<IdentityResult> SetPasswordAsync(User user, string newMasterPassword, string key, string orgIdentifier = null);
         Task<IdentityResult> AdminResetPasswordAsync(OrganizationUserType type, Guid orgId, Guid id, string newMasterPassword, string key);
+        Task<IdentityResult> UpdateTempPasswordAsync(User user, string newMasterPassword, string key);
         Task<IdentityResult> ChangeKdfAsync(User user, string masterPassword, string newMasterPassword, string key,
             KdfType kdf, int kdfIterations);
         Task<IdentityResult> UpdateKeyAsync(User user, string masterPassword, string key, string privateKey,

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -714,5 +714,17 @@ namespace Bit.Core.Services
             message.Category = "ProviderUserRemoved";
             await _mailDeliveryService.SendEmailAsync(message);
         }
+        
+        public async Task SendUpdatedTempPasswordEmailAsync(string email, string userName)
+        {
+            var message = CreateDefaultMessage("Master Password Has Been Changed", email);
+            var model = new UpdateTempPasswordViewModel()
+            {
+                UserName = CoreHelpers.SanitizeForEmail(userName)
+            };
+            await AddMessageContentAsync(message, "UpdatedTempPassword", model);
+            message.Category = "UpdatedTempPassword";
+            await _mailDeliveryService.SendEmailAsync(message);
+        }
     }
 }

--- a/src/Core/Services/NoopImplementations/NoopMailService.cs
+++ b/src/Core/Services/NoopImplementations/NoopMailService.cs
@@ -185,5 +185,10 @@ namespace Bit.Core.Services
         {
             return Task.FromResult(0);
         }
+        
+        public Task SendUpdatedTempPasswordEmailAsync(string email, string userName)
+        {
+            return Task.FromResult(0);
+        }
     }
 }


### PR DESCRIPTION
## Objective
> Create an API to handle a user updating their temporary master password.

## Code Changes
- **AccountsController**: Add `update-temp-password` API
- **EventType**: Add `User_UpdatedTempPassword` for handling events in the web client
- **MailTemplates/UpdatedTempPassword**: Added `text` and `html` email templates for when the action is completed
- **UpdateTempPasswordRequestModel**: Created request model that extends the `OrganizationUserResetPasswordRequestModel`
- **UpdateTempPasswordViewModel**: Created email template data object
- **Interfaces**: Added method relating to updating the user's temp password
- **HandlebarsMailService**: Created `SendUpdatedTempPasswordEmailAsync` method to populate and send email 
- **UserService**: Updated the `AdminResetPasswordAsync` method to flip the user's `ForcePasswordReset` flag when updating the record. Created `UpdateTempPasswordAsync` method to handle updating a user's temporary password. 
- **NoopMailService**: Added stubbed interface method