### PR TITLE
[Provider] Prevent including pending organizations in SyncResponse

### DIFF
--- a/src/Core/Models/Data/Provider/ProviderUserProviderDetails.cs
+++ b/src/Core/Models/Data/Provider/ProviderUserProviderDetails.cs
@@ -14,5 +14,6 @@ namespace Bit.Core.Models.Data
         public bool Enabled { get; set; }
         public string Permissions { get; set; }
         public bool UseEvents { get; set; }
+        public ProviderStatusType ProviderStatus { get; set; }
     }
 }

--- a/src/Core/Repositories/EntityFramework/Queries/ProviderUserProviderDetailsReadByUserIdStatusQuery.cs
+++ b/src/Core/Repositories/EntityFramework/Queries/ProviderUserProviderDetailsReadByUserIdStatusQuery.cs
@@ -21,7 +21,7 @@ namespace Bit.Core.Repositories.EntityFramework.Queries
                 join p in dbContext.Providers
                     on pu.ProviderId equals p.Id into p_g
                 from p in p_g.DefaultIfEmpty()
-                where pu.UserId == _userId && (_status == null || pu.Status == _status)
+                where pu.UserId == _userId && p.Status != ProviderStatusType.Pending && (_status == null || pu.Status == _status)
                 select new { pu, p };
             return query.Select(x => new ProviderUserProviderDetails() 
             {
@@ -34,6 +34,7 @@ namespace Bit.Core.Repositories.EntityFramework.Queries
                 Enabled = x.p.Enabled,
                 Permissions = x.pu.Permissions,
                 UseEvents = x.p.UseEvents,
+                ProviderStatus = x.p.Status,
             });
         }
     }

--- a/src/Sql/dbo/Stored Procedures/ProviderUserProviderDetails_ReadByUserIdStatus.sql
+++ b/src/Sql/dbo/Stored Procedures/ProviderUserProviderDetails_ReadByUserIdStatus.sql
@@ -11,5 +11,6 @@ BEGIN
         [dbo].[ProviderUserProviderDetailsView]
     WHERE
         [UserId] = @UserId
+        AND [ProviderStatus] != 0 -- Not Pending
         AND (@Status IS NULL OR [Status] = @Status)
 END

--- a/src/Sql/dbo/Views/ProviderUserProviderDetailsView.sql
+++ b/src/Sql/dbo/Views/ProviderUserProviderDetailsView.sql
@@ -9,7 +9,8 @@ SELECT
     PU.[Type],
     P.[Enabled],
     PU.[Permissions],
-    P.[UseEvents]
+    P.[UseEvents],
+    P.[Status] ProviderStatus
 FROM
     [dbo].[ProviderUser] PU
 LEFT JOIN

--- a/util/Migrator/DbScripts/2021-07-22_00_Provider.sql
+++ b/util/Migrator/DbScripts/2021-07-22_00_Provider.sql
@@ -950,7 +950,8 @@ SELECT
     PU.[Type],
     P.[Enabled],
     PU.[Permissions],
-    P.[UseEvents]
+    P.[UseEvents],
+    P.[Status] ProviderStatus
 FROM
     [dbo].[ProviderUser] PU
 LEFT JOIN
@@ -976,7 +977,8 @@ BEGIN
         [dbo].[ProviderUserProviderDetailsView]
     WHERE
         [UserId] = @UserId
-    AND (@Status IS NULL OR [Status] = @Status)
+        AND [ProviderStatus] != 0 -- Not Pending
+        AND (@Status IS NULL OR [Status] = @Status)
 END
 GO
 


### PR DESCRIPTION
## Objective
The sync response included pending providers which resulted in funny behavior. To resolve this, I've excluded pending providers from showing up in the UI.