### PR TITLE
[Provider] Resolve email not being url encoded

### DIFF
--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -660,8 +660,8 @@ namespace Bit.Core.Services
                 WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
                 SiteName = _globalSettings.SiteName,
                 ProviderId = provider.Id.ToString(),
-                Email = email,
-                Token = token,
+                Email = WebUtility.UrlEncode(email),
+                Token = WebUtility.UrlEncode(token),
             };
             await AddMessageContentAsync(message, "Provider.ProviderSetupInvite", model);
             message.Category = "ProviderSetupInvite";
@@ -674,11 +674,11 @@ namespace Bit.Core.Services
             var model = new ProviderUserInvitedViewModel
             {
                 ProviderName = CoreHelpers.SanitizeForEmail(providerName),
-                Email = WebUtility.UrlDecode(providerUser.Email),
+                Email = WebUtility.UrlEncode(providerUser.Email),
                 ProviderId = providerUser.ProviderId.ToString(),
                 ProviderUserId = providerUser.Id.ToString(),
                 ProviderNameUrlEncoded = WebUtility.UrlEncode(providerName),
-                Token = token,
+                Token = WebUtility.UrlEncode(token),
                 WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
                 SiteName = _globalSettings.SiteName,
             };


### PR DESCRIPTION
## Objective
The email part which is used to build the link were not url encoded, which caused some email addresses to not be handled correctly.

https://app.asana.com/0/1198901840263430/1200637533331096