### PR TITLE
Always enable events for providers

### DIFF
--- a/bitwarden_license/src/CommCore/Services/ProviderService.cs
+++ b/bitwarden_license/src/CommCore/Services/ProviderService.cs
@@ -59,6 +59,7 @@ namespace Bit.CommCore.Services
             {
                 Status = ProviderStatusType.Pending,
                 Enabled = true,
+                UseEvents = true,
             };
             await _providerRepository.CreateAsync(provider);
 

--- a/src/Admin/Models/ProviderEditModel.cs
+++ b/src/Admin/Models/ProviderEditModel.cs
@@ -18,7 +18,6 @@ namespace Bit.Admin.Models
             BusinessName = provider.BusinessName;
             BillingEmail = provider.BillingEmail;
             Enabled = provider.Enabled;
-            UseEvents = provider.UseEvents;
         }
 
         public bool Enabled { get; set; }
@@ -26,14 +25,12 @@ namespace Bit.Admin.Models
         public string BusinessName { get; set; }
         public string Name { get; set; }
         [Display(Name = "Events")]
-        public bool UseEvents { get; set; }
         
         public Provider ToProvider(Provider existingProvider)
         {
             existingProvider.Name = Name;
             existingProvider.BusinessName = BusinessName;
             existingProvider.BillingEmail = BillingEmail?.ToLowerInvariant()?.Trim();
-            existingProvider.UseEvents = UseEvents;
             existingProvider.Enabled = Enabled;
             return existingProvider;
         }

--- a/src/Admin/Views/Providers/Edit.cshtml
+++ b/src/Admin/Views/Providers/Edit.cshtml
@@ -39,11 +39,6 @@
             </div>
         </div>
     </div>
-    <h2>Features</h2>
-    <div class="form-check">
-        <input type="checkbox" class="form-check-input" asp-for="UseEvents">
-        <label class="form-check-label" asp-for="UseEvents"></label>
-    </div>
 </form>
 <div class="d-flex mt-4">
     <button type="submit" class="btn btn-primary" form="edit-form">Save</button>


### PR DESCRIPTION
# overview

Closes https://app.asana.com/0/0/1200645727236051/f

Providers should always have events enabled. This is done by just forcing it true upon creation and removing the option to edit that flag.

# Files Changed
* **providerService**: set `UseEvents` to true upon creation
* **ProviderEditModel**: Remove `UseEvents` from the edit model -> Admin portal can no longer edit this field
* **Edit.cshtml**: Remove `UseEvents` field from edit view