### PR TITLE
Invite Client owner at time of client org creation

### DIFF
--- a/bitwarden_license/src/CommCore/Services/ProviderService.cs
+++ b/bitwarden_license/src/CommCore/Services/ProviderService.cs
@@ -7,6 +7,7 @@ using Bit.Core.Enums.Provider;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Business;
 using Bit.Core.Models.Business.Provider;
+using Bit.Core.Models.Data;
 using Bit.Core.Models.Table;
 using Bit.Core.Models.Table.Provider;
 using Bit.Core.Repositories;
@@ -374,7 +375,8 @@ namespace Bit.CommCore.Services
             await _eventService.LogProviderOrganizationEventAsync(providerOrganization, EventType.ProviderOrganization_Added);
         }
 
-        public async Task<ProviderOrganization> CreateOrganizationAsync(Guid providerId, OrganizationSignup organizationSignup, User user)
+        public async Task<ProviderOrganization> CreateOrganizationAsync(Guid providerId,
+            OrganizationSignup organizationSignup, string clientOwnerEmail, User user)
         {
             var (organization, _) = await _organizationService.SignUpAsync(organizationSignup, true);
 
@@ -387,6 +389,15 @@ namespace Bit.CommCore.Services
 
             await _providerOrganizationRepository.CreateAsync(providerOrganization);
             await _eventService.LogProviderOrganizationEventAsync(providerOrganization, EventType.ProviderOrganization_Created);
+
+            await _organizationService.InviteUserAsync(organization.Id, user.Id, null, new OrganizationUserInvite
+            {
+                Emails = new[] { clientOwnerEmail },
+                AccessAll = true,
+                Type = OrganizationUserType.Owner,
+                Permissions = null,
+                Collections = Array.Empty<SelectionReadOnly>(),
+            });
 
             return providerOrganization;
         }

--- a/src/Api/Controllers/ProviderOrganizationsController.cs
+++ b/src/Api/Controllers/ProviderOrganizationsController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Bit.Core.Context;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Api;
+using Bit.Core.Models.Api.Request;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Utilities;
@@ -62,7 +63,7 @@ namespace Bit.Api.Controllers
 
         [HttpPost("")]
         [SelfHosted(NotSelfHostedOnly = true)]
-        public async Task<ProviderOrganizationResponseModel> Post(Guid providerId, [FromBody]OrganizationCreateRequestModel model)
+        public async Task<ProviderOrganizationResponseModel> Post(Guid providerId, [FromBody] ProviderOrganizationCreateRequestModel model)
         {
             var user = await _userService.GetUserByPrincipalAsync(User);
             if (user == null)
@@ -75,8 +76,8 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
-            var organizationSignup = model.ToOrganizationSignup(user);
-            var result = await _providerService.CreateOrganizationAsync(providerId, organizationSignup, user);
+            var organizationSignup = model.OrganizationCreateRequest.ToOrganizationSignup(user);
+            var result = await _providerService.CreateOrganizationAsync(providerId, organizationSignup, model.ClientOwnerEmail, user);
             return new ProviderOrganizationResponseModel(result);
         }
 

--- a/src/Core/Models/Api/Request/Providers/ProviderOrganizationCreateRequestModel.cs
+++ b/src/Core/Models/Api/Request/Providers/ProviderOrganizationCreateRequestModel.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+using Bit.Core.Utilities;
+
+namespace Bit.Core.Models.Api.Request
+{
+    public class ProviderOrganizationCreateRequestModel
+    {
+        [Required]
+        [StrictEmailAddress]
+        public string ClientOwnerEmail { get; set; }
+        [Required]
+        public OrganizationCreateRequestModel OrganizationCreateRequest { get; set; }
+    }
+}

--- a/src/Core/Services/IProviderService.cs
+++ b/src/Core/Services/IProviderService.cs
@@ -25,7 +25,8 @@ namespace Bit.Core.Services
             Guid deletingUserId);
 
         Task AddOrganization(Guid providerId, Guid organizationId, Guid addingUserId, string key);
-        Task<ProviderOrganization> CreateOrganizationAsync(Guid providerId, OrganizationSignup organizationSignup, User user);
+        Task<ProviderOrganization> CreateOrganizationAsync(Guid providerId, OrganizationSignup organizationSignup,
+            string clientOwnerEmail, User user);
         Task RemoveOrganization(Guid providerId, Guid providerOrganizationId, Guid removingUserId);
     }
 }

--- a/src/Core/Services/NoopImplementations/NoopProviderService.cs
+++ b/src/Core/Services/NoopImplementations/NoopProviderService.cs
@@ -29,7 +29,7 @@ namespace Bit.Core.Services
         public Task<List<Tuple<ProviderUser, string>>> DeleteUsersAsync(Guid providerId, IEnumerable<Guid> providerUserIds, Guid deletingUserId) => throw new NotImplementedException();
 
         public Task AddOrganization(Guid providerId, Guid organizationId, Guid addingUserId, string key) => throw new NotImplementedException();
-        public Task<ProviderOrganization> CreateOrganizationAsync(Guid providerId, OrganizationSignup organizationSignup, User user) => throw new NotImplementedException();
+        public Task<ProviderOrganization> CreateOrganizationAsync(Guid providerId, OrganizationSignup organizationSignup, string clientOwnerEmail, User user) => throw new NotImplementedException();
 
         public Task RemoveOrganization(Guid providerId, Guid providerOrganizationId, Guid removingUserId) => throw new NotImplementedException();
     }


### PR DESCRIPTION
# Overview

We want to require a client organization owner immediately upon creating a provider client org. This eases the flow for provider client organization setup by not requiring a separate initial invite to an owner as a first-task.