### PR TITLE
Added a button for resending provider setup emails

### DIFF
--- a/bitwarden_license/src/CommCore/Services/ProviderService.cs
+++ b/bitwarden_license/src/CommCore/Services/ProviderService.cs
@@ -71,9 +71,7 @@ namespace Bit.CommCore.Services
                 Status = ProviderUserStatusType.Confirmed,
             };
             await _providerUserRepository.CreateAsync(providerUser);
-
-            var token = _dataProtector.Protect($"ProviderSetupInvite {provider.Id} {owner.Email} {CoreHelpers.ToEpocMilliseconds(DateTime.UtcNow)}");
-            await _mailService.SendProviderSetupInviteEmailAsync(provider, token, owner.Email);
+            await SendProviderSetupInviteEmailAsync(provider, owner.Email);
         }
 
         public async Task<Provider> CompleteSetupAsync(Provider provider, Guid ownerUserId, string token, string key)

--- a/bitwarden_license/test/CmmCore.Test/Services/ProviderServiceTests.cs
+++ b/bitwarden_license/test/CmmCore.Test/Services/ProviderServiceTests.cs
@@ -115,7 +115,7 @@ namespace Bit.CommCore.Test.Services
         {
             provider.Id = default;
             
-            await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.InviteUserAsync(provider.Id, default, default));
+            await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.InviteUserAsync(provider.Id, default));
         }
         
         [Theory, CustomAutoData(typeof(SutProviderCustomization))]
@@ -127,7 +127,7 @@ namespace Bit.CommCore.Test.Services
 
             providerUserInvite.Emails = null;
             
-            await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.InviteUserAsync(provider.Id, default, providerUserInvite));
+            await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.InviteUserAsync(provider.Id, providerUserInvite));
         }
         
         [Theory, CustomAutoData(typeof(SutProviderCustomization))]
@@ -139,7 +139,7 @@ namespace Bit.CommCore.Test.Services
             var providerUserRepository = sutProvider.GetDependency<IProviderUserRepository>();
             providerUserRepository.GetCountByProviderAsync(default, default, default).ReturnsForAnyArgs(1);
 
-            var result = await sutProvider.Sut.InviteUserAsync(provider.Id, default, providerUserInvite);
+            var result = await sutProvider.Sut.InviteUserAsync(provider.Id, providerUserInvite);
             Assert.Empty(result);
         }
         
@@ -152,7 +152,7 @@ namespace Bit.CommCore.Test.Services
             var providerUserRepository = sutProvider.GetDependency<IProviderUserRepository>();
             providerUserRepository.GetCountByProviderAsync(default, default, default).ReturnsForAnyArgs(0);
 
-            var result = await sutProvider.Sut.InviteUserAsync(provider.Id, default, providerUserInvite);
+            var result = await sutProvider.Sut.InviteUserAsync(provider.Id, providerUserInvite);
             Assert.Equal(providerUserInvite.Emails.Count(), result.Count);
             Assert.True(result.TrueForAll(pu => pu.Status == ProviderUserStatusType.Invited), "Status must be invited");
             Assert.True(result.TrueForAll(pu => pu.ProviderId == provider.Id), "Provider Id must be correct");
@@ -175,7 +175,7 @@ namespace Bit.CommCore.Test.Services
             var providerUserRepository = sutProvider.GetDependency<IProviderUserRepository>();
             providerUserRepository.GetManyAsync(default).ReturnsForAnyArgs(providerUsers.ToList());
 
-            var result = await sutProvider.Sut.ResendInvitesAsync(provider.Id, default, providerUsers.Select(pu => pu.Id));
+            var result = await sutProvider.Sut.ResendInvitesAsync(provider.Id, providerUsers.Select(pu => pu.Id));
             Assert.Equal("", result[0].Item2);
             Assert.Equal("User invalid.", result[1].Item2);
             Assert.Equal("User invalid.", result[2].Item2);
@@ -197,7 +197,7 @@ namespace Bit.CommCore.Test.Services
             var providerUserRepository = sutProvider.GetDependency<IProviderUserRepository>();
             providerUserRepository.GetManyAsync(default).ReturnsForAnyArgs(providerUsers.ToList());
 
-            var result = await sutProvider.Sut.ResendInvitesAsync(provider.Id, default, providerUsers.Select(pu => pu.Id));
+            var result = await sutProvider.Sut.ResendInvitesAsync(provider.Id, providerUsers.Select(pu => pu.Id));
             Assert.True(result.All(r => r.Item2 == ""));
         }
 

--- a/src/Admin/Controllers/ProvidersController.cs
+++ b/src/Admin/Controllers/ProvidersController.cs
@@ -133,5 +133,12 @@ namespace Bit.Admin.Controllers
 
             return RedirectToAction("Index");
         }
+
+        public async Task<IActionResult> ResendInvite(Guid userId, Guid providerId)
+        {
+            await _providerService.ResendProviderSetupInviteEmailAsync(providerId, userId);
+            TempData["InviteResentTo"] = userId;
+            return RedirectToAction("Edit", new { id = providerId });
+        }
     }
 }

--- a/src/Admin/Models/ProviderViewModel.cs
+++ b/src/Admin/Models/ProviderViewModel.cs
@@ -14,17 +14,11 @@ namespace Bit.Admin.Models
         {
             Provider = provider;
             UserCount = providerUsers.Count();
-
-            ProviderAdmins = string.Join(", ",
-                providerUsers
-                    .Where(u => u.Type == ProviderUserType.ProviderAdmin && u.Status == ProviderUserStatusType.Confirmed)
-                    .Select(u => u.Email));
+            ProviderAdmins = providerUsers.Where(u => u.Type == ProviderUserType.ProviderAdmin);
         }
 
         public int UserCount { get; set; }
-
         public Provider Provider { get; set; }
-        
-        public string ProviderAdmins { get; set; }
+        public IEnumerable<ProviderUserUserDetails> ProviderAdmins { get; set; }
     }
 }

--- a/src/Admin/Views/Providers/Admins.cshtml
+++ b/src/Admin/Views/Providers/Admins.cshtml
@@ -1,0 +1,58 @@
+@model ProviderViewModel
+<h2>Provider Admins</h2>
+<div class="row">
+    <div class="col-8">
+        <div class="table-responsive">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th style="width: 190px;">Email</th>
+                        <th style="width: 40px;">Status</th>
+                        <th style="width: 30px;"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @if(!Model.ProviderAdmins.Any())
+                    {
+                        <tr>
+                            <td colspan="6">No results to list.</td>
+                        </tr>
+                    }
+                    else
+                    {
+                        @foreach(var admin in Model.ProviderAdmins)
+                        {
+                            <tr>
+                                <td class="align-middle">
+                                    @admin.Email
+                                </td>
+                                <td class="align-middle">
+                                    @admin.Status
+                                </td>
+                                <td>
+                                    @if(admin.Status.Equals(ProviderUserStatusType.Confirmed) 
+                                        && @Model.Provider.Status.Equals(ProviderStatusType.Pending))
+                                    {
+                                        @if(@TempData["InviteResentTo"] != null && @TempData["InviteResentTo"].ToString() == @admin.UserId.Value.ToString())
+                                        {
+                                            <button class="btn btn-outline-success btn-sm disabled" disabled>Invite Resent!</button>
+                                        }
+                                        else
+                                        {
+                                            <a class="btn btn-outline-secondary btn-sm" 
+                                                data-id="@admin.Id" asp-controller="Providers" 
+                                                asp-action="ResendInvite" asp-route-userId="@admin.UserId" 
+                                                asp-route-providerId="@Model.Provider.Id">
+                                                Resend Setup Invite
+                                            </a>
+                                        }
+                                    }
+                                </td>
+                            </tr>
+                        }
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/src/Admin/Views/Providers/Edit.cshtml
+++ b/src/Admin/Views/Providers/Edit.cshtml
@@ -7,6 +7,7 @@
 
 <h2>Provider Information</h2>
 @await Html.PartialAsync("_ViewInformation", Model)
+@await Html.PartialAsync("Admins", Model)
 <form method="post" id="edit-form">
     <h2>General</h2>
     <div class="row">

--- a/src/Admin/Views/Providers/View.cshtml
+++ b/src/Admin/Views/Providers/View.cshtml
@@ -7,6 +7,7 @@
 
 <h2>Information</h2>
 @await Html.PartialAsync("_ViewInformation", Model)
+@await Html.PartialAsync("Admins", Model)
 <form asp-action="Delete" asp-route-id="@Model.Provider.Id"
       onsubmit="return confirm('Are you sure you want to delete this provider (@Model.Provider.Name)?')">
     <button class="btn btn-danger" type="submit">Delete</button>

--- a/src/Admin/Views/Providers/_ViewInformation.cshtml
+++ b/src/Admin/Views/Providers/_ViewInformation.cshtml
@@ -9,9 +9,6 @@
     <dt class="col-sm-4 col-lg-3">Users</dt>
     <dd class="col-sm-8 col-lg-9">@Model.UserCount</dd>
     
-    <dt class="col-sm-4 col-lg-3">ProviderAdmins</dt>
-    <dd class="col-sm-8 col-lg-9">@(string.IsNullOrWhiteSpace(Model.ProviderAdmins) ? "None" : Model.ProviderAdmins)</dd>
-
     <dt class="col-sm-4 col-lg-3">Created</dt>
     <dd class="col-sm-8 col-lg-9">@Model.Provider.CreationDate.ToString()</dd>
 

--- a/src/Admin/Views/_ViewImports.cshtml
+++ b/src/Admin/Views/_ViewImports.cshtml
@@ -1,5 +1,6 @@
 @using Microsoft.AspNetCore.Identity
 @using Bit.Admin
 @using Bit.Admin.Models
+@using Bit.Core.Enums.Provider
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper "*, Admin"

--- a/src/Api/Controllers/ProviderUsersController.cs
+++ b/src/Api/Controllers/ProviderUsersController.cs
@@ -67,8 +67,7 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
-            var userId = _userService.GetProperUserId(User);
-            await _providerService.InviteUserAsync(providerId, userId.Value, new ProviderUserInvite(model));
+            await _providerService.InviteUserAsync(providerId, new ProviderUserInvite(model));
         }
         
         [HttpPost("reinvite")]
@@ -79,8 +78,7 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
-            var userId = _userService.GetProperUserId(User);
-            var result = await _providerService.ResendInvitesAsync(providerId, userId.Value, model.Ids);
+            var result = await _providerService.ResendInvitesAsync(providerId, model.Ids);
             return new ListResponseModel<ProviderUserBulkResponseModel>(
                 result.Select(t => new ProviderUserBulkResponseModel(t.Item1.Id, t.Item2)));
         }
@@ -93,8 +91,7 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
-            var userId = _userService.GetProperUserId(User);
-            await _providerService.ResendInvitesAsync(providerId, userId.Value, new [] { id });
+            await _providerService.ResendInvitesAsync(providerId, new [] { id });
         }
 
         [HttpPost("{id:guid}/accept")]

--- a/src/Core/Services/IProviderService.cs
+++ b/src/Core/Services/IProviderService.cs
@@ -14,9 +14,8 @@ namespace Bit.Core.Services
         Task<Provider> CompleteSetupAsync(Provider provider, Guid ownerUserId, string token, string key);
         Task UpdateAsync(Provider provider, bool updateBilling = false);
 
-        Task<List<ProviderUser>> InviteUserAsync(Guid providerId, Guid invitingUserId, ProviderUserInvite providerUserInvite);
-        Task<List<Tuple<ProviderUser, string>>> ResendInvitesAsync(Guid providerId, Guid invitingUserId,
-            IEnumerable<Guid> providerUsersId);
+        Task<List<ProviderUser>> InviteUserAsync(Guid providerId, ProviderUserInvite providerUserInvite);
+        Task<List<Tuple<ProviderUser, string>>> ResendInvitesAsync(Guid providerId, IEnumerable<Guid> providerUsersId);
         Task<ProviderUser> AcceptUserAsync(Guid providerUserId, User user, string token);
         Task<List<Tuple<ProviderUser, string>>> ConfirmUsersAsync(Guid providerId, Dictionary<Guid, string> keys, Guid confirmingUserId);
 
@@ -27,5 +26,6 @@ namespace Bit.Core.Services
         Task AddOrganization(Guid providerId, Guid organizationId, Guid addingUserId, string key);
         Task<ProviderOrganization> CreateOrganizationAsync(Guid providerId, OrganizationSignup organizationSignup, User user);
         Task RemoveOrganization(Guid providerId, Guid providerOrganizationId, Guid removingUserId);
+        Task ResendProviderSetupInviteEmailAsync(Guid providerId, Guid userId);
     }
 }

--- a/src/Core/Services/NoopImplementations/NoopProviderService.cs
+++ b/src/Core/Services/NoopImplementations/NoopProviderService.cs
@@ -16,9 +16,9 @@ namespace Bit.Core.Services
 
         public Task UpdateAsync(Provider provider, bool updateBilling = false) => throw new NotImplementedException();
 
-        public Task<List<ProviderUser>> InviteUserAsync(Guid providerId, Guid invitingUserId, ProviderUserInvite providerUserInvite) => throw new NotImplementedException();
+        public Task<List<ProviderUser>> InviteUserAsync(Guid providerId, ProviderUserInvite providerUserInvite) => throw new NotImplementedException();
 
-        public Task<List<Tuple<ProviderUser, string>>> ResendInvitesAsync(Guid providerId, Guid invitingUserId, IEnumerable<Guid> providerUsersId) => throw new NotImplementedException();
+        public Task<List<Tuple<ProviderUser, string>>> ResendInvitesAsync(Guid providerId, IEnumerable<Guid> providerUsersId) => throw new NotImplementedException();
 
         public Task<ProviderUser> AcceptUserAsync(Guid providerUserId, User user, string token) => throw new NotImplementedException();
 
@@ -32,5 +32,6 @@ namespace Bit.Core.Services
         public Task<ProviderOrganization> CreateOrganizationAsync(Guid providerId, OrganizationSignup organizationSignup, User user) => throw new NotImplementedException();
 
         public Task RemoveOrganization(Guid providerId, Guid providerOrganizationId, Guid removingUserId) => throw new NotImplementedException();
+        public Task ResendProviderSetupInviteEmailAsync(Guid providerId, Guid userId) => throw new NotImplementedException();
     }
 }

--- a/src/Sql/dbo/Stored Procedures/Event_ReadPageByProviderId.sql
+++ b/src/Sql/dbo/Stored Procedures/Event_ReadPageByProviderId.sql
@@ -16,7 +16,7 @@ BEGIN
         [Date] >= @StartDate
         AND (@BeforeDate IS NOT NULL OR [Date] <= @EndDate)
         AND (@BeforeDate IS NULL OR [Date] < @BeforeDate)
-        AND [Providerid] = @ProviderId
+        AND [ProviderId] = @ProviderId
     ORDER BY [Date] DESC
     OFFSET 0 ROWS
     FETCH NEXT @PageSize ROWS ONLY


### PR DESCRIPTION
### Related Work
[Asana ticket
](https://app.asana.com/0/1183359552741420/1200645727236050/f)

### Objective
> Add ability to re-send email invite for provider creation in Bitwarden admin portal. 

### Code Changes
* Changed the type of `ProviderViewModel.ProviderAdmins` from a list of strings containing emails to a list of provider users.
* Changed the subsequent section on the provider view into a more fleshed out grid with a list of admins, statuses, and a space for actions.
* Added a button to this space for resending the setup invite
* New controller + service methods to facilitate the resend
* [Not totally necassary refactor]: I removed `invitingUserId` from the Provider invite service methods, as it wasn't used and I didn't have that data to supply here.

### Demo
https://user-images.githubusercontent.com/15897251/127671809-c73f561c-c723-4bfe-8518-6a80236d71fb.mov

