### PR TITLE
Change display name of provider view properties

### DIFF
--- a/src/Admin/Models/ProviderEditModel.cs
+++ b/src/Admin/Models/ProviderEditModel.cs
@@ -21,7 +21,9 @@ namespace Bit.Admin.Models
         }
 
         public bool Enabled { get; set; }
+        [Display(Name = "Billing Email")]
         public string BillingEmail { get; set; }
+        [Display(Name = "Business Name")]
         public string BusinessName { get; set; }
         public string Name { get; set; }
         [Display(Name = "Events")]


### PR DESCRIPTION
# Overview

Fixes: https://app.asana.com/0/0/1200687814632008/f

Fixes the lack of space in admin view of provider models. Note: ProviderAdmin info section is being updated in another PR

![image](https://user-images.githubusercontent.com/18214891/127894395-32e0a755-a2fa-4c3a-a862-a760972124d3.png)
