### PR TITLE
[Reset Password v1] Updated force password reset models

### DIFF
--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -799,8 +799,8 @@ namespace Bit.Api.Controllers
             }
         }
         
-        [HttpPost("update-temp-password")]
-        public async Task PostUpdateTempPasswordAsync([FromBody]UpdateTempPasswordRequestModel model)
+        [HttpPut("update-temp-password")]
+        public async Task PutUpdateTempPasswordAsync([FromBody]UpdateTempPasswordRequestModel model)
         {
             var user = await _userService.GetUserByPrincipalAsync(User);
             if (user == null)
@@ -808,7 +808,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            var result = await _userService.UpdateTempPasswordAsync(user, model.NewMasterPasswordHash, model.Key);
+            var result = await _userService.UpdateTempPasswordAsync(user, model.NewMasterPasswordHash, model.Key, model.MasterPasswordHint);
             if (result.Succeeded)
             {
                 return;

--- a/src/Core/Models/Api/Request/Accounts/UpdateTempPasswordRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/UpdateTempPasswordRequestModel.cs
@@ -1,7 +1,10 @@
-﻿namespace Bit.Core.Models.Api.Request.Accounts
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Bit.Core.Models.Api.Request.Accounts
 {
     public class UpdateTempPasswordRequestModel : OrganizationUserResetPasswordRequestModel
     {
-        
+        [StringLength(50)]
+        public string MasterPasswordHint { get; set; }
     }
 }

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -35,7 +35,7 @@ namespace Bit.Core.Services
         Task<IdentityResult> ChangePasswordAsync(User user, string masterPassword, string newMasterPassword, string key);
         Task<IdentityResult> SetPasswordAsync(User user, string newMasterPassword, string key, string orgIdentifier = null);
         Task<IdentityResult> AdminResetPasswordAsync(OrganizationUserType type, Guid orgId, Guid id, string newMasterPassword, string key);
-        Task<IdentityResult> UpdateTempPasswordAsync(User user, string newMasterPassword, string key);
+        Task<IdentityResult> UpdateTempPasswordAsync(User user, string newMasterPassword, string key, string hint);
         Task<IdentityResult> ChangeKdfAsync(User user, string masterPassword, string newMasterPassword, string key,
             KdfType kdf, int kdfIterations);
         Task<IdentityResult> UpdateKeyAsync(User user, string masterPassword, string key, string privateKey,

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -700,7 +700,7 @@ namespace Bit.Core.Services
             return IdentityResult.Success;
         }
         
-        public async Task<IdentityResult> UpdateTempPasswordAsync(User user, string newMasterPassword, string key)
+        public async Task<IdentityResult> UpdateTempPasswordAsync(User user, string newMasterPassword, string key, string hint)
         {
             if (!user.ForcePasswordReset)
             {
@@ -716,6 +716,7 @@ namespace Bit.Core.Services
             user.RevisionDate = user.AccountRevisionDate = DateTime.UtcNow;
             user.ForcePasswordReset = false;
             user.Key = key;
+            user.MasterPasswordHint = hint;
 
             await _userRepository.ReplaceAsync(user);
             await _mailService.SendUpdatedTempPasswordEmailAsync(user.Email, user.Name ?? user.Email);


### PR DESCRIPTION
## Objective
> Expand `UpdateTempPassword` model to include master password hint. Update method from `POST` to `PUT`.

## Code Changes
- **AccountsController**: Change `HTTP` method from `POST` to `PUT`. Update method name and add `MasterPasswordHint` as a parameter.
- **UpdateTempPasswordRequestModel**: Added `MasterPasswordHint`
- **IUserService/UserService**: Updated user record with passed in `MasterPasswordHint`