### PR TITLE
Fix UserKdf and UserApiKey migrations to only update null values

### DIFF
--- a/util/Migrator/DbScripts/2018-08-14_00_UserKdf.sql
+++ b/util/Migrator/DbScripts/2018-08-14_00_UserKdf.sql
@@ -13,6 +13,10 @@ UPDATE
 SET
     [Kdf] = 0,
     [KdfIterations] = 5000
+WHERE
+    [Kdf] IS NULL
+OR
+    [KdfIterations] IS NULL
 GO
 
 ALTER TABLE

--- a/util/Migrator/DbScripts/2020-10-28_00_UserApiKey.sql
+++ b/util/Migrator/DbScripts/2020-10-28_00_UserApiKey.sql
@@ -51,6 +51,8 @@ UPDATE
     [dbo].[User]
 SET
     [ApiKey] = (SELECT [dbo].[SecureRandomString]())
+WHERE
+    [ApiKey] IS NULL
 GO
 
 -- Change dbo.User.ApiKey to not null to enforece all future users to have one on create


### PR DESCRIPTION
The migration file `2018-08-14_00_UserKdf.sql` was updating the values in columns `Kdf` and `KdfIterations` which caused issues logging in if the previous values were different. This now only updates if the `Kdf` or `KdfIterations` values are `NULL`.

The migration file `2018-10-28_00_UserApiKey.sql` is updating each user's `ApiKey` every time the migration is ran which will cause the user to have to retrieve the new key from the web interface.  This now only updates if the `ApiKey` value is `NULL`.