### PR TITLE
Record when a provider user accesses a clients vault

### DIFF
--- a/bitwarden_license/src/CommCore/Services/ProviderService.cs
+++ b/bitwarden_license/src/CommCore/Services/ProviderService.cs
@@ -413,7 +413,7 @@ namespace Bit.CommCore.Services
                 throw new BadRequestException("Invalid organization.");
             }
 
-            if (!await _organizationService.HasConfirmedOwnersExceptAsync(providerOrganization.OrganizationId, new Guid[] {}))
+            if (!await _organizationService.HasConfirmedOwnersExceptAsync(providerOrganization.OrganizationId, new Guid[] { }, includeProvider: false))
             {
                 throw new BadRequestException("Organization needs to have at least one confirmed owner.");
             }

--- a/bitwarden_license/src/CommCore/Services/ProviderService.cs
+++ b/bitwarden_license/src/CommCore/Services/ProviderService.cs
@@ -27,6 +27,7 @@ namespace Bit.CommCore.Services
         private readonly IProviderRepository _providerRepository;
         private readonly IProviderUserRepository _providerUserRepository;
         private readonly IProviderOrganizationRepository _providerOrganizationRepository;
+        private readonly IOrganizationRepository _organizationRepository;
         private readonly IUserRepository _userRepository;
         private readonly IUserService _userService;
         private readonly IOrganizationService _organizationService;
@@ -34,11 +35,13 @@ namespace Bit.CommCore.Services
         public ProviderService(IProviderRepository providerRepository, IProviderUserRepository providerUserRepository,
             IProviderOrganizationRepository providerOrganizationRepository, IUserRepository userRepository,
             IUserService userService, IOrganizationService organizationService, IMailService mailService,
-            IDataProtectionProvider dataProtectionProvider, IEventService eventService, GlobalSettings globalSettings)
+            IDataProtectionProvider dataProtectionProvider, IEventService eventService,
+            IOrganizationRepository organizationRepository, GlobalSettings globalSettings)
         {
             _providerRepository = providerRepository;
             _providerUserRepository = providerUserRepository;
             _providerOrganizationRepository = providerOrganizationRepository;
+            _organizationRepository = organizationRepository;
             _userRepository = userRepository;
             _userService = userService;
             _organizationService = organizationService;
@@ -418,6 +421,15 @@ namespace Bit.CommCore.Services
             await _providerOrganizationRepository.DeleteAsync(providerOrganization);
             await _eventService.LogProviderOrganizationEventAsync(providerOrganization, EventType.ProviderOrganization_Removed);
         }
+
+        public async Task LogProviderAccessToOrganization(Guid organizationId)
+        {
+            var providerOrganization = await _providerOrganizationRepository.GetByOrganizationId(organizationId);
+            var organization = await _organizationRepository.GetByIdAsync(organizationId);
+            await _eventService.LogProviderOrganizationEventAsync(providerOrganization, EventType.ProviderOrganization_VaultAccessed);
+            await _eventService.LogOrganizationEventAsync(organization, EventType.Organization_VaultAccessed);
+        }
+
 
         private async Task SendInviteAsync(ProviderUser providerUser, Provider provider)
         {

--- a/bitwarden_license/src/CommCore/Services/ProviderService.cs
+++ b/bitwarden_license/src/CommCore/Services/ProviderService.cs
@@ -405,7 +405,7 @@ namespace Bit.CommCore.Services
             return providerOrganization;
         }
 
-        public async Task RemoveOrganization(Guid providerId, Guid providerOrganizationId, Guid removingUserId)
+        public async Task RemoveOrganizationAsync(Guid providerId, Guid providerOrganizationId, Guid removingUserId)
         {
             var providerOrganization = await _providerOrganizationRepository.GetByIdAsync(providerOrganizationId);
             if (providerOrganization == null || providerOrganization.ProviderId != providerId)
@@ -422,12 +422,23 @@ namespace Bit.CommCore.Services
             await _eventService.LogProviderOrganizationEventAsync(providerOrganization, EventType.ProviderOrganization_Removed);
         }
 
-        public async Task LogProviderAccessToOrganization(Guid organizationId)
+        public async Task LogProviderAccessToOrganizationAsync(Guid organizationId)
         {
+            if (organizationId == default)
+            {
+                return;
+            }
+
             var providerOrganization = await _providerOrganizationRepository.GetByOrganizationId(organizationId);
             var organization = await _organizationRepository.GetByIdAsync(organizationId);
-            await _eventService.LogProviderOrganizationEventAsync(providerOrganization, EventType.ProviderOrganization_VaultAccessed);
-            await _eventService.LogOrganizationEventAsync(organization, EventType.Organization_VaultAccessed);
+            if (providerOrganization != null)
+            {
+                await _eventService.LogProviderOrganizationEventAsync(providerOrganization, EventType.ProviderOrganization_VaultAccessed);
+            }
+            if (organization != null)
+            {
+                await _eventService.LogOrganizationEventAsync(organization, EventType.Organization_VaultAccessed);
+            }
         }
 
 

--- a/bitwarden_license/test/CmmCore.Test/Services/ProviderServiceTests.cs
+++ b/bitwarden_license/test/CmmCore.Test/Services/ProviderServiceTests.cs
@@ -490,7 +490,7 @@ namespace Bit.CommCore.Test.Services
             sutProvider.GetDependency<IProviderRepository>().GetByIdAsync(provider.Id).Returns(provider);
             sutProvider.GetDependency<IProviderOrganizationRepository>().GetByIdAsync(providerOrganization.Id)
                 .Returns(providerOrganization);
-            sutProvider.GetDependency<IOrganizationService>().HasConfirmedOwnersExceptAsync(default, default)
+            sutProvider.GetDependency<IOrganizationService>().HasConfirmedOwnersExceptAsync(default, default, default)
                 .ReturnsForAnyArgs(false);
 
             var exception = await Assert.ThrowsAsync<BadRequestException>(
@@ -506,7 +506,7 @@ namespace Bit.CommCore.Test.Services
             sutProvider.GetDependency<IProviderRepository>().GetByIdAsync(provider.Id).Returns(provider);
             var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
             providerOrganizationRepository.GetByIdAsync(providerOrganization.Id).Returns(providerOrganization);
-            sutProvider.GetDependency<IOrganizationService>().HasConfirmedOwnersExceptAsync(default, default)
+            sutProvider.GetDependency<IOrganizationService>().HasConfirmedOwnersExceptAsync(default, default, default)
                 .ReturnsForAnyArgs(true);
 
             await sutProvider.Sut.RemoveOrganization(provider.Id, providerOrganization.Id, user.Id);

--- a/bitwarden_license/test/CmmCore.Test/Services/ProviderServiceTests.cs
+++ b/bitwarden_license/test/CmmCore.Test/Services/ProviderServiceTests.cs
@@ -465,7 +465,7 @@ namespace Bit.CommCore.Test.Services
                 .ReturnsNull();
 
             var exception = await Assert.ThrowsAsync<BadRequestException>(
-                () => sutProvider.Sut.RemoveOrganization(provider.Id, providerOrganization.Id, user.Id));
+                () => sutProvider.Sut.RemoveOrganizationAsync(provider.Id, providerOrganization.Id, user.Id));
             Assert.Equal("Invalid organization.", exception.Message);
         }
 
@@ -478,7 +478,7 @@ namespace Bit.CommCore.Test.Services
                 .Returns(providerOrganization);
 
             var exception = await Assert.ThrowsAsync<BadRequestException>(
-                () => sutProvider.Sut.RemoveOrganization(provider.Id, providerOrganization.Id, user.Id));
+                () => sutProvider.Sut.RemoveOrganizationAsync(provider.Id, providerOrganization.Id, user.Id));
             Assert.Equal("Invalid organization.", exception.Message);
         }
 
@@ -494,7 +494,7 @@ namespace Bit.CommCore.Test.Services
                 .ReturnsForAnyArgs(false);
 
             var exception = await Assert.ThrowsAsync<BadRequestException>(
-                () => sutProvider.Sut.RemoveOrganization(provider.Id, providerOrganization.Id, user.Id));
+                () => sutProvider.Sut.RemoveOrganizationAsync(provider.Id, providerOrganization.Id, user.Id));
             Assert.Equal("Organization needs to have at least one confirmed owner.", exception.Message);
         }
 
@@ -509,7 +509,7 @@ namespace Bit.CommCore.Test.Services
             sutProvider.GetDependency<IOrganizationService>().HasConfirmedOwnersExceptAsync(default, default, default)
                 .ReturnsForAnyArgs(true);
 
-            await sutProvider.Sut.RemoveOrganization(provider.Id, providerOrganization.Id, user.Id);
+            await sutProvider.Sut.RemoveOrganizationAsync(provider.Id, providerOrganization.Id, user.Id);
             await providerOrganizationRepository.Received().DeleteAsync(providerOrganization);
             await sutProvider.GetDependency<IEventService>().Received()
                 .LogProviderOrganizationEventAsync(providerOrganization, EventType.ProviderOrganization_Removed);

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -230,7 +230,7 @@ namespace Bit.Api.Controllers
             var providerId = await _currentContext.ProviderIdForOrg(orgIdGuid);
             if (providerId.HasValue)
             {
-                await _providerService.LogProviderAccessToOrganization(orgIdGuid);
+                await _providerService.LogProviderAccessToOrganizationAsync(orgIdGuid);
             }
             return new ListResponseModel<CipherMiniDetailsResponseModel>(responses);
         }

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -29,6 +29,7 @@ namespace Bit.Api.Controllers
         private readonly ICipherService _cipherService;
         private readonly IUserService _userService;
         private readonly IAttachmentStorageService _attachmentStorageService;
+        private readonly IProviderService _providerService;
         private readonly ICurrentContext _currentContext;
         private readonly ILogger<CiphersController> _logger;
         private readonly GlobalSettings _globalSettings;
@@ -39,6 +40,7 @@ namespace Bit.Api.Controllers
             ICipherService cipherService,
             IUserService userService,
             IAttachmentStorageService attachmentStorageService,
+            IProviderService providerService,
             ICurrentContext currentContext,
             ILogger<CiphersController> logger,
             GlobalSettings globalSettings)
@@ -48,6 +50,7 @@ namespace Bit.Api.Controllers
             _cipherService = cipherService;
             _userService = userService;
             _attachmentStorageService = attachmentStorageService;
+            _providerService = providerService;
             _currentContext = currentContext;
             _logger = logger;
             _globalSettings = globalSettings;
@@ -223,6 +226,12 @@ namespace Bit.Api.Controllers
 
             var responses = ciphers.Select(c => new CipherMiniDetailsResponseModel(c, _globalSettings,
                 collectionCiphersGroupDict));
+
+            var providerId = await _currentContext.ProviderIdForOrg(orgIdGuid);
+            if (providerId.HasValue)
+            {
+                await _providerService.LogProviderAccessToOrganization(orgIdGuid);
+            }
             return new ListResponseModel<CipherMiniDetailsResponseModel>(responses);
         }
 

--- a/src/Api/Controllers/ProviderOrganizationsController.cs
+++ b/src/Api/Controllers/ProviderOrganizationsController.cs
@@ -91,7 +91,7 @@ namespace Bit.Api.Controllers
             }
 
             var userId = _userService.GetProperUserId(User);
-            await _providerService.RemoveOrganization(providerId, id, userId.Value);
+            await _providerService.RemoveOrganizationAsync(providerId, id, userId.Value);
         }
     }
 }

--- a/src/Core/Enums/EventType.cs
+++ b/src/Core/Enums/EventType.cs
@@ -52,6 +52,7 @@
         Organization_Updated = 1600,
         Organization_PurgedVault = 1601,
         // Organization_ClientExportedVault = 1602,
+        Organization_VaultAccessed = 1603,
 
         Policy_Updated = 1700,
         
@@ -63,5 +64,6 @@
         ProviderOrganization_Created = 1900,
         ProviderOrganization_Added = 1901,
         ProviderOrganization_Removed = 1902,
+        ProviderOrganization_VaultAccessed = 1903,
     }
 }

--- a/src/Core/Services/IOrganizationService.cs
+++ b/src/Core/Services/IOrganizationService.cs
@@ -59,6 +59,6 @@ namespace Bit.Core.Services
         Task RotateApiKeyAsync(Organization organization);
         Task DeleteSsoUserAsync(Guid userId, Guid? organizationId);
         Task<Organization> UpdateOrganizationKeysAsync(Guid orgId, string publicKey, string privateKey);
-        Task<bool> HasConfirmedOwnersExceptAsync(Guid organizationId, IEnumerable<Guid> organizationUsersId);
+        Task<bool> HasConfirmedOwnersExceptAsync(Guid organizationId, IEnumerable<Guid> organizationUsersId, bool includeProvider = true);
     }
 }

--- a/src/Core/Services/IProviderService.cs
+++ b/src/Core/Services/IProviderService.cs
@@ -28,5 +28,6 @@ namespace Bit.Core.Services
         Task<ProviderOrganization> CreateOrganizationAsync(Guid providerId, OrganizationSignup organizationSignup,
             string clientOwnerEmail, User user);
         Task RemoveOrganization(Guid providerId, Guid providerOrganizationId, Guid removingUserId);
+        Task LogProviderAccessToOrganization(Guid organizationId);
     }
 }

--- a/src/Core/Services/IProviderService.cs
+++ b/src/Core/Services/IProviderService.cs
@@ -27,7 +27,7 @@ namespace Bit.Core.Services
         Task AddOrganization(Guid providerId, Guid organizationId, Guid addingUserId, string key);
         Task<ProviderOrganization> CreateOrganizationAsync(Guid providerId, OrganizationSignup organizationSignup,
             string clientOwnerEmail, User user);
-        Task RemoveOrganization(Guid providerId, Guid providerOrganizationId, Guid removingUserId);
-        Task LogProviderAccessToOrganization(Guid organizationId);
+        Task RemoveOrganizationAsync(Guid providerId, Guid providerOrganizationId, Guid removingUserId);
+        Task LogProviderAccessToOrganizationAsync(Guid organizationId);
     }
 }

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1689,11 +1689,16 @@ namespace Bit.Core.Services
             return result;
         }
 
-        public async Task<bool> HasConfirmedOwnersExceptAsync(Guid organizationId, IEnumerable<Guid> organizationUsersId)
+        public async Task<bool> HasConfirmedOwnersExceptAsync(Guid organizationId, IEnumerable<Guid> organizationUsersId, bool includeProvider = true)
         {
             var confirmedOwners = await GetConfirmedOwnersAsync(organizationId);
             var confirmedOwnersIds = confirmedOwners.Select(u => u.Id);
-            return confirmedOwnersIds.Except(organizationUsersId).Any() || (await _currentContext.ProviderIdForOrg(organizationId)).HasValue;
+            bool hasOtherOwner = confirmedOwnersIds.Except(organizationUsersId).Any();
+            if (!hasOtherOwner && includeProvider)
+            {
+                return (await _currentContext.ProviderIdForOrg(organizationId)).HasValue;
+            }
+            return hasOtherOwner;
         }
 
         public async Task UpdateUserGroupsAsync(OrganizationUser organizationUser, IEnumerable<Guid> groupIds, Guid? loggedInUserId)

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1693,7 +1693,7 @@ namespace Bit.Core.Services
         {
             var confirmedOwners = await GetConfirmedOwnersAsync(organizationId);
             var confirmedOwnersIds = confirmedOwners.Select(u => u.Id);
-            return confirmedOwnersIds.Except(organizationUsersId).Any();
+            return confirmedOwnersIds.Except(organizationUsersId).Any() || (await _currentContext.ProviderIdForOrg(organizationId)).HasValue;
         }
 
         public async Task UpdateUserGroupsAsync(OrganizationUser organizationUser, IEnumerable<Guid> groupIds, Guid? loggedInUserId)

--- a/src/Core/Services/NoopImplementations/NoopProviderService.cs
+++ b/src/Core/Services/NoopImplementations/NoopProviderService.cs
@@ -31,7 +31,7 @@ namespace Bit.Core.Services
         public Task AddOrganization(Guid providerId, Guid organizationId, Guid addingUserId, string key) => throw new NotImplementedException();
         public Task<ProviderOrganization> CreateOrganizationAsync(Guid providerId, OrganizationSignup organizationSignup, string clientOwnerEmail, User user) => throw new NotImplementedException();
 
-        public Task RemoveOrganization(Guid providerId, Guid providerOrganizationId, Guid removingUserId) => throw new NotImplementedException();
-        public Task LogProviderAccessToOrganization(Guid organizationId) => throw new NotImplementedException();
+        public Task RemoveOrganizationAsync(Guid providerId, Guid providerOrganizationId, Guid removingUserId) => throw new NotImplementedException();
+        public Task LogProviderAccessToOrganizationAsync(Guid organizationId) => throw new NotImplementedException();
     }
 }

--- a/src/Core/Services/NoopImplementations/NoopProviderService.cs
+++ b/src/Core/Services/NoopImplementations/NoopProviderService.cs
@@ -32,5 +32,6 @@ namespace Bit.Core.Services
         public Task<ProviderOrganization> CreateOrganizationAsync(Guid providerId, OrganizationSignup organizationSignup, string clientOwnerEmail, User user) => throw new NotImplementedException();
 
         public Task RemoveOrganization(Guid providerId, Guid providerOrganizationId, Guid removingUserId) => throw new NotImplementedException();
+        public Task LogProviderAccessToOrganization(Guid organizationId) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
# Overview

Fixes https://app.asana.com/0/0/1200645727236042/f
Also allows providers to invite users of any type in their owned organizations regardless of whether an owner is confirmed.

Adds events for both providers and client organizations to track when providers access the client organization vault.

# Files Changed
* **ProviderService/NoopProviderService**: Adds helper method to add events to provider organization and the client organizations's event lists that a provider user accessed the client's vault
* **CiphersController**: User the above helper if the current context has access through a provider. **NOTE** this logs an event even if the current context has access through being an org member.
* **EventType**: Add the new event types
* **OrganizationService**: Relax owner requirement for provider orgs. We don't need to worry as much about orphaning these orgs since they belong to providers