### PR TITLE
added a status check to the read by minimum role proc

### DIFF
--- a/src/Core/Repositories/EntityFramework/OrganizationUserRepository.cs
+++ b/src/Core/Repositories/EntityFramework/OrganizationUserRepository.cs
@@ -397,7 +397,9 @@ namespace Bit.Core.Repositories.EntityFramework
                 var dbContext = GetDatabaseContext(scope);
                 var query = dbContext.OrganizationUsers
                     .Include(e => e.User)
-                    .Where(e => e.OrganizationId.Equals(organizationId) && e.Type <= minRole)
+                    .Where(e => e.OrganizationId.Equals(organizationId) && 
+                        e.Type <= minRole &&
+                        e.Status == OrganizationUserStatusType.Confirmed)
                     .Select(e => new OrganizationUserUserDetails() {
                         Id = e.Id,
                         Email = e.Email ?? e.User.Email

--- a/src/Sql/dbo/Stored Procedures/OrganizationUser_ReadByMinimumRole.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationUser_ReadByMinimumRole.sql
@@ -11,5 +11,6 @@ BEGIN
         [dbo].[OrganizationUserUserDetailsView]
     WHERE
         OrganizationId = @OrganizationId 
+        AND Status = 2 -- 2 = Confirmed 
         AND [Type] <= @MinRole
 END

--- a/util/Migrator/DbScripts/2021-07-15_00_OrganizationUserReadByMinimumRole.sql
+++ b/util/Migrator/DbScripts/2021-07-15_00_OrganizationUserReadByMinimumRole.sql
@@ -17,5 +17,6 @@ BEGIN
         [dbo].[OrganizationUserUserDetailsView]
     WHERE
         OrganizationId = @OrganizationId 
+        AND Status = 2
         AND [Type] <= @MinRole
 END


### PR DESCRIPTION
Addresses the bug in the comments of [this Asana task](https://app.asana.com/0/inbox/1183359552741416/1200413094875933/1200593226297689/f).

### Issue
>  Possible defect found on this one - the confirmation email is sent to all admin & owners (as expected), however, if an organization owner/admin user has not yet been confirmed, they still receive the email to confirm.. even if that means confirming themselves. 

### Steps to Reproduce:
* In your organization, invite a new owner 
* In your organization, invite a new admin (so now you have two invited users - one admin, and one owner)
* Accept the invitation as the new owner you invited
* Check email

Result:
* Existing owner receives confirmation email (expected, good)
* New owner receives confirmation email (unexpected - can they confirm themselves?)
* New admin receives confirmation email (unexpected - this user has not even accepted the invitation yet)

### Code Changes
This was a simple issue. I wasn't checking for only confirmed users in a new stored procedure that was written to gather the recipients of the new "User X needs to be confirmed" email template. Because this hasn't been released yet and is such a minor change I opted for just editing the existing migration instead of creating a new one.
