### PR TITLE
Provider qa feedback

### DIFF
--- a/src/Core/MailTemplates/Handlebars/Provider/ProviderSetupInvite.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/Provider/ProviderSetupInvite.html.hbs
@@ -8,7 +8,7 @@
     <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
         <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none; text-align: center;" valign="top" align="center">
             <a href="{{{Url}}}" clicktracking=off target="_blank" style="color: #ffffff; text-decoration: none; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; background-color: #175DDC; border-color: #175DDC; border-style: solid; border-width: 10px 20px; margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
-                Set up Provider Now
+                Set Up Provider Now
             </a>
         </td>
     </tr>

--- a/src/Core/Models/Api/Request/Providers/ProviderOrganizationCreateRequestModel.cs
+++ b/src/Core/Models/Api/Request/Providers/ProviderOrganizationCreateRequestModel.cs
@@ -6,6 +6,7 @@ namespace Bit.Core.Models.Api.Request
     public class ProviderOrganizationCreateRequestModel
     {
         [Required]
+        [StringLength(256)]
         [StrictEmailAddress]
         public string ClientOwnerEmail { get; set; }
         [Required]

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1488,8 +1488,8 @@ namespace Bit.Core.Services
                 var orgUsers = keyedOrganizationUsers.GetValueOrDefault(user.Id, new List<OrganizationUser>());
                 try
                 {
-                    if (organization.PlanType == PlanType.Free && orgUser.Type == OrganizationUserType.Admin
-                        || orgUser.Type == OrganizationUserType.Owner)
+                    if (organization.PlanType == PlanType.Free && (orgUser.Type == OrganizationUserType.Admin
+                        || orgUser.Type == OrganizationUserType.Owner))
                     {
                         // Since free organizations only supports a few users there is not much point in avoiding N+1 queries for this.
                         var adminCount = await _organizationUserRepository.GetCountByFreeOrganizationAdminUserAsync(user.Id);

--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -21,6 +21,7 @@ using Organization = Bit.Core.Models.Table.Organization;
 using OrganizationUser = Bit.Core.Models.Table.OrganizationUser;
 using Policy = Bit.Core.Models.Table.Policy;
 using Bit.Core.Test.AutoFixture.PolicyFixtures;
+using LinqToDB;
 
 namespace Bit.Core.Test.Services
 {
@@ -584,10 +585,12 @@ namespace Bit.Core.Test.Services
                 () => sutProvider.Sut.ConfirmUserAsync(confirmingUser.OrganizationId, orgUser.Id, key, confirmingUser.Id, userService));
             Assert.Contains("User not valid.", exception.Message);
         }
-        
-        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
-        public async Task ConfirmUser_AlreadyAdmin(Organization org, OrganizationUser confirmingUser,
-            [OrganizationUser(OrganizationUserStatusType.Accepted, OrganizationUserType.Admin)]OrganizationUser orgUser, User user,
+
+        [Theory]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, OrganizationUserType.Admin)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, OrganizationUserType.Owner)]
+        public async Task ConfirmUserToFree_AlreadyFreeAdminOrOwner_Throws(PlanType planType, OrganizationUserType userType, Organization org, OrganizationUser confirmingUser,
+            [OrganizationUser(OrganizationUserStatusType.Accepted)] OrganizationUser orgUser, User user,
             string key, SutProvider<OrganizationService> sutProvider)
         {
             var organizationUserRepository = sutProvider.GetDependency<IOrganizationUserRepository>();
@@ -598,6 +601,7 @@ namespace Bit.Core.Test.Services
             org.PlanType = PlanType.Free;
             orgUser.OrganizationId = confirmingUser.OrganizationId = org.Id;
             orgUser.UserId = user.Id;
+            orgUser.Type = userType;
             organizationUserRepository.GetManyAsync(default).ReturnsForAnyArgs(new[] {orgUser});
             organizationUserRepository.GetCountByFreeOrganizationAdminUserAsync(orgUser.UserId.Value).Returns(1);
             organizationRepository.GetByIdAsync(org.Id).Returns(org);
@@ -607,6 +611,55 @@ namespace Bit.Core.Test.Services
                 () => sutProvider.Sut.ConfirmUserAsync(orgUser.OrganizationId, orgUser.Id, key, confirmingUser.Id, userService));
             Assert.Contains("User can only be an admin of one free organization.", exception.Message);
         }
+
+        [Theory]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.Custom, OrganizationUserType.Admin)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.Custom, OrganizationUserType.Owner)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.EnterpriseAnnually, OrganizationUserType.Admin)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.EnterpriseAnnually, OrganizationUserType.Owner)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.EnterpriseAnnually2019, OrganizationUserType.Admin)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.EnterpriseAnnually2019, OrganizationUserType.Owner)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.EnterpriseMonthly, OrganizationUserType.Admin)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.EnterpriseMonthly, OrganizationUserType.Owner)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.EnterpriseMonthly2019, OrganizationUserType.Admin)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.EnterpriseMonthly2019, OrganizationUserType.Owner)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.FamiliesAnnually, OrganizationUserType.Admin)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.FamiliesAnnually, OrganizationUserType.Owner)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.FamiliesAnnually2019, OrganizationUserType.Admin)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.FamiliesAnnually2019, OrganizationUserType.Owner)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.TeamsAnnually, OrganizationUserType.Admin)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.TeamsAnnually, OrganizationUserType.Owner)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.TeamsAnnually2019, OrganizationUserType.Admin)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.TeamsAnnually2019, OrganizationUserType.Owner)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.TeamsMonthly, OrganizationUserType.Admin)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.TeamsMonthly, OrganizationUserType.Owner)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.TeamsMonthly2019, OrganizationUserType.Admin)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, PlanType.TeamsMonthly2019, OrganizationUserType.Owner)]
+        public async Task ConfirmUserToNonFree_AlreadyFreeAdminOrOwner_DoesNotThrow(PlanType planType, OrganizationUserType orgUserType, Organization org, OrganizationUser confirmingUser,
+            [OrganizationUser(OrganizationUserStatusType.Accepted)] OrganizationUser orgUser, User user,
+            string key, SutProvider<OrganizationService> sutProvider)
+        {
+            var organizationUserRepository = sutProvider.GetDependency<IOrganizationUserRepository>();
+            var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
+            var userService = Substitute.For<IUserService>();
+            var userRepository = sutProvider.GetDependency<IUserRepository>();
+
+            org.PlanType = planType;
+            orgUser.OrganizationId = confirmingUser.OrganizationId = org.Id;
+            orgUser.UserId = user.Id;
+            orgUser.Type = orgUserType;
+            organizationUserRepository.GetManyAsync(default).ReturnsForAnyArgs(new[] { orgUser });
+            organizationUserRepository.GetCountByFreeOrganizationAdminUserAsync(orgUser.UserId.Value).Returns(1);
+            organizationRepository.GetByIdAsync(org.Id).Returns(org);
+            userRepository.GetManyAsync(default).ReturnsForAnyArgs(new[] { user });
+
+            await sutProvider.Sut.ConfirmUserAsync(orgUser.OrganizationId, orgUser.Id, key, confirmingUser.Id, userService);
+
+            await sutProvider.GetDependency<IEventService>().Received(1).LogOrganizationUserEventAsync(orgUser, EventType.OrganizationUser_Confirmed);
+            await sutProvider.GetDependency<IMailService>().Received(1).SendOrganizationConfirmedEmailAsync(org.Name, user.Email);
+            await organizationUserRepository.Received(1).ReplaceManyAsync(Arg.Is<List<OrganizationUser>>(users => users.Contains(orgUser) && users.Count == 1));
+        }
+
 
         [Theory, CustomAutoData(typeof(SutProviderCustomization))]
         public async Task ConfirmUser_SingleOrgPolicy(Organization org, OrganizationUser confirmingUser,


### PR DESCRIPTION
# Overview

QA feedback fixes on:


# Files Changed
* **ProviderService**: Server-side Validate organization is of an allowed type prior to adding to provider
* **ProviderSetupInvite.html.hbs**: title case buttons
* **ProviderOrganizationCreateRequestModel**: Limit email length to match other emails
* **OrganizationService**: Fix bug where users owning a free org could not join another org of any type.
* **OrganizationServiceTests**: Add tests for free org owners being allowed to join another organization.

# Draft Reason

Outstanding discussion on email validation requiring top-level domain. Stripe requires it, and ICANN recommends it. Still it's technically not required (https://en.wikipedia.org/wiki/Email_address#Examples)