### PR TITLE
Use RequestSizeLimit for all file upload endpoints

### DIFF
--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -8,6 +8,7 @@ using Bit.Core.Models.Api;
 using Bit.Core.Exceptions;
 using Bit.Core.Services;
 using Bit.Core.Context;
+using Bit.Core.Utilities;
 using Bit.Api.Utilities;
 using System.Collections.Generic;
 using Bit.Core.Models.Table;
@@ -585,7 +586,7 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
-            if (request.FileSize > CipherService.MAX_FILE_SIZE && !_globalSettings.SelfHosted)
+            if (request.FileSize > CipherService.MAX_FILE_SIZE)
             {
                 throw new BadRequestException($"Max file size is {CipherService.MAX_FILE_SIZE_READABLE}.");
             }
@@ -623,6 +624,7 @@ namespace Bit.Api.Controllers
         }
 
         [HttpPost("{id}/attachment/{attachmentId}")]
+        [SelfHosted(SelfHostedOnly = true)]
         [RequestSizeLimit(Constants.FileSize501mb)]
         [DisableFormValueModelBinding]
         public async Task PostFileForExistingAttachment(string id, string attachmentId)
@@ -630,11 +632,6 @@ namespace Bit.Api.Controllers
             if (!Request?.ContentType.Contains("multipart/") ?? true)
             {
                 throw new BadRequestException("Invalid content.");
-            }
-
-            if (!_globalSettings.SelfHosted)
-            {
-                throw new BadRequestException("Invalid endpoint for non self-hosted servers.");
             }
 
             var userId = _userService.GetProperUserId(User).Value;
@@ -653,6 +650,7 @@ namespace Bit.Api.Controllers
         }
 
         [HttpPost("{id}/attachment")]
+        [Obsolete("Deprecated Attachments API", false)]
         [RequestSizeLimit(Constants.FileSize101mb)]
         [DisableFormValueModelBinding]
         public async Task<CipherResponseModel> PostAttachment(string id)
@@ -804,11 +802,6 @@ namespace Bit.Api.Controllers
             if (!Request?.ContentType.Contains("multipart/") ?? true)
             {
                 throw new BadRequestException("Invalid content.");
-            }
-
-            if (Request.ContentLength > Constants.FileSize101mb)
-            {
-                throw new BadRequestException("Max file size is 100 MB.");
             }
         }
     }

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -167,6 +167,7 @@ namespace Bit.Api.Controllers
         }
 
         [HttpPost("file")]
+        [Obsolete("Deprecated File Send API", false)]
         [RequestSizeLimit(Constants.FileSize101mb)]
         [DisableFormValueModelBinding]
         public async Task<SendResponseModel> PostFile()
@@ -174,11 +175,6 @@ namespace Bit.Api.Controllers
             if (!Request?.ContentType.Contains("multipart/") ?? true)
             {
                 throw new BadRequestException("Invalid content.");
-            }
-
-            if (Request.ContentLength > Constants.FileSize101mb)
-            {
-                throw new BadRequestException("Max file size is 100 MB.");
             }
 
             Send send = null;
@@ -250,6 +246,7 @@ namespace Bit.Api.Controllers
         }
 
         [HttpPost("{id}/file/{fileId}")]
+        [SelfHosted(SelfHostedOnly = true)]
         [RequestSizeLimit(Constants.FileSize501mb)]
         [DisableFormValueModelBinding]
         public async Task PostFileForExistingSend(string id, string fileId)
@@ -257,11 +254,6 @@ namespace Bit.Api.Controllers
             if (!Request?.ContentType.Contains("multipart/") ?? true)
             {
                 throw new BadRequestException("Invalid content.");
-            }
-
-            if (Request.ContentLength > Constants.FileSize101mb && !_globalSettings.SelfHosted)
-            {
-                throw new BadRequestException("Max file size for direct upload is 100 MB.");
             }
 
             var send = await _sendRepository.GetByIdAsync(new Guid(id));


### PR DESCRIPTION
## Objective

Further refactor and fixes after #1479.

QA feedback was that upload limits were not being enforced for cipher attachments using Azure uploads on self-hosted instances. That made me review this whole issue again and I realised that I hadn't thought through all the different combinations of upload methods + deployment options.

## Code changes

This has gone through a few changes over a few PRs - I recommend checking it out locally and reviewing all upload endpoints rather than necessarily just looking at this diff.

* Where a file is being uploaded directly to an endpoint, enforce upload size limits via `RequestSizeLimit` instead of `if` statements. 
   * `RequestSizeLimit` is required to raise the default limit of ~30mb, and then anything that exceeds that limit will be caught by the `RequestSizeLimit` middleware and not any `if` statement in the code. We still had redundant `if` statements floating around which are misleading. 
   * However, note that the `v2` upload endpoint still uses an `if` statement because it's reading the upload metadata sent by the client, not the upload data itself.
* Enforce the following upload limits:
  * Legacy uploads using the old endpoint: 101mb (for self-hosted and cloud) (@MGibson1 we discussed raising this for self-hosted but on second thoughts I decided not to change the logic of a deprecated endpoint)
  * Direct (local) uploads using the new endpoint: 501mb for self-hosted. This endpoint has been blocked off for non-self-hosted because it is never used in cloud.
  * Azure uploads: 501mb for self-hosted and cloud
* Added the [Obsolete](https://docs.microsoft.com/en-us/dotnet/api/system.obsoleteattribute?view=net-5.0) attribute to the legacy endpoints. It won't stop it compiling but I wanted something akin to the `@Deprecated` decorator in the client to clearly mark current v. legacy endpoints.

Currently `RequestSizeLimit` throws a 413 error which is not properly handled. However, our `ExceptionHandlerFilterAttribute` appears to be too late in the middleware chain to properly handle it, and I wanted to get this PR in so we can cut `rc`. We don't handle this error at the moment, and the `v2` endpoint returns a graceful error message for all current clients. It might be an unhandled exception for legacy uploads, but again, that's not actually new behaviour. I would like to revisit this but didn't think it was worth holding it up for.