### PR TITLE
Add captcha option to Nginx config

### DIFF
--- a/util/Setup/Configuration.cs
+++ b/util/Setup/Configuration.cs
@@ -37,6 +37,9 @@ namespace Bit.Setup
             "Learn more: https://docs.docker.com/compose/compose-file/compose-versioning/")]
         public string ComposeVersion { get; set; }
 
+        [Description("Configure Nginx for Captcha.")]
+        public bool Captcha { get; set; } = false;
+
         [Description("Configure Nginx for SSL.")]
         public bool Ssl { get; set; } = true;
 

--- a/util/Setup/NginxConfigBuilder.cs
+++ b/util/Setup/NginxConfigBuilder.cs
@@ -68,6 +68,7 @@ namespace Bit.Setup
 
             public TemplateModel(Context context)
             {
+                Captcha = context.Config.Captcha;
                 Ssl = context.Config.Ssl;
                 Domain = context.Config.Domain;
                 Url = context.Config.Url;
@@ -114,6 +115,7 @@ namespace Bit.Setup
                 }
             }
 
+            public bool Captcha { get; set; }
             public bool Ssl { get; set; }
             public string Domain { get; set; }
             public string Url { get; set; }

--- a/util/Setup/Templates/NginxConfig.hbs
+++ b/util/Setup/Templates/NginxConfig.hbs
@@ -114,6 +114,16 @@ server {
     proxy_pass http://web:5000/sso-connector.html;
   }
 
+{{#if Captcha}}
+  location = /captcha-connector.html {
+  proxy_pass http://web:5000/captcha-connector.html;
+  }
+  
+  location = /captcha-mobile-connector.html {
+  proxy_pass http://web:5000/captcha-mobile-connector.html;
+  }
+{{/if}}
+
   location /attachments/ {
     proxy_pass http://attachments:5000/;
   }

--- a/util/Setup/Templates/NginxConfig.hbs
+++ b/util/Setup/Templates/NginxConfig.hbs
@@ -116,11 +116,11 @@ server {
 
 {{#if Captcha}}
   location = /captcha-connector.html {
-  proxy_pass http://web:5000/captcha-connector.html;
+    proxy_pass http://web:5000/captcha-connector.html;
   }
   
   location = /captcha-mobile-connector.html {
-  proxy_pass http://web:5000/captcha-mobile-connector.html;
+    proxy_pass http://web:5000/captcha-mobile-connector.html;
   }
 {{/if}}
 


### PR DESCRIPTION
# Overview

Optionally adds endpoint configurations for captcha to a self-hosted nginx configuration.

Note: this will be cherry picked to `rc`