### PR TITLE
Add support for international domain names (IDN) in email addresses

### DIFF
--- a/src/Core/Models/Api/Request/EmergencyAccessRequstModels.cs
+++ b/src/Core/Models/Api/Request/EmergencyAccessRequstModels.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.Utilities;
 using Bit.Core.Models.Table;
 
 namespace Bit.Core.Models.Api.Request
@@ -6,7 +7,7 @@ namespace Bit.Core.Models.Api.Request
     public class EmergencyAccessInviteRequestModel
     {
         [Required]
-        [EmailAddress]
+        [StrictEmailAddress]
         [StringLength(256)]
         public string Email { get; set; }
         [Required]

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -395,7 +395,7 @@ namespace Bit.Core.Services
         {
             return new MailMessage
             {
-                ToEmails = toEmails.Select((string toEmail) => CoreHelpers.PunyEncode(toEmail)),
+                ToEmails = toEmails,
                 Subject = subject,
                 MetaData = new Dictionary<string, object>()
             };

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -395,7 +395,7 @@ namespace Bit.Core.Services
         {
             return new MailMessage
             {
-                ToEmails = toEmails,
+                ToEmails = toEmails.Select((string toEmail) => CoreHelpers.PunyEncode(toEmail)),
                 Subject = subject,
                 MetaData = new Dictionary<string, object>()
             };

--- a/src/Core/Services/Implementations/PostalMailDeliveryService.cs
+++ b/src/Core/Services/Implementations/PostalMailDeliveryService.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Microsoft.AspNetCore.Hosting;
 using System.Text;
+using Bit.Core.Utilities;
 
 namespace Bit.Core.Services
 {
@@ -25,13 +26,16 @@ namespace Bit.Core.Services
             IWebHostEnvironment hostingEnvironment,
             IHttpClientFactory clientFactory)
         {
+            var postalDomain = CoreHelpers.PunyEncode(globalSettings.Mail.PostalDomain);
+            var replyToEmail = CoreHelpers.PunyEncode(globalSettings.Mail.ReplyToEmail);
+
             _globalSettings = globalSettings;
             _logger = logger;
             _clientFactory = clientFactory;
             _baseTag = $"Env_{hostingEnvironment.EnvironmentName}-" +
                 $"Server_{globalSettings.ProjectName?.Replace(' ', '_')}";
-            _from = $"\"{globalSettings.SiteName}\" <no-reply@{_globalSettings.Mail.PostalDomain}>";
-            _reply = $"\"{globalSettings.SiteName}\" <{globalSettings.Mail.ReplyToEmail}>";
+            _from = $"\"{globalSettings.SiteName}\" <no-reply@{postalDomain}>";
+            _reply = $"\"{globalSettings.SiteName}\" <{replyToEmail}>";
         }
 
         public async Task SendEmailAsync(Models.Mail.MailMessage message)
@@ -50,7 +54,7 @@ namespace Bit.Core.Services
             };
             foreach (var address in message.ToEmails)
             {
-                request.to.Add(address);
+                request.to.Add(CoreHelpers.PunyEncode(address));
             }
 
             if (message.BccEmails != null)
@@ -58,7 +62,7 @@ namespace Bit.Core.Services
                 request.bcc = new List<string>();
                 foreach (var address in message.BccEmails)
                 {
-                    request.bcc.Add(address);
+                    request.bcc.Add(CoreHelpers.PunyEncode(address));
                 }
             }
 

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -514,31 +514,6 @@ namespace Bit.Core.Utilities
             }
         }
 
-        public static string PunyDecode(string text)
-        {
-            if (text == "")
-            {
-                return "";
-            }
-
-            if (text == null)
-            {
-                return null;
-            }
-
-            if (!text.Contains("@"))
-            {
-                // Assume domain name or non-email address
-                var idn = new IdnMapping();
-                return idn.GetUnicode(text);
-            }
-            else
-            {
-                // Assume email address
-                return MailboxAddress.DecodeAddrspec(text);
-            }
-        }
-
         public static string FormatLicenseSignatureValue(object val)
         {
             if (val == null)

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -27,6 +27,7 @@ using Bit.Core.Enums.Provider;
 using Azure.Storage.Queues;
 using Azure.Storage.Queues.Models;
 using System.Threading;
+using MimeKit;
 
 namespace Bit.Core.Utilities
 {
@@ -490,14 +491,52 @@ namespace Bit.Core.Utilities
 
         public static string PunyEncode(string text)
         {
-            var idn = new IdnMapping();
-            return idn.GetAscii(text);
+            if (text == "")
+            {
+                return "";
+            }
+
+            if (text == null)
+            {
+                return null;
+            }
+
+            if (!text.Contains("@"))
+            {
+                // Assume domain name or non-email address
+                var idn = new IdnMapping();
+                return idn.GetAscii(text);
+            }
+            else
+            {
+                // Assume email address
+                return MailboxAddress.EncodeAddrspec(text);
+            }
         }
 
         public static string PunyDecode(string text)
         {
-            var idn = new IdnMapping();
-            return idn.GetUnicode(text);
+            if (text == "")
+            {
+                return "";
+            }
+
+            if (text == null)
+            {
+                return null;
+            }
+
+            if (!text.Contains("@"))
+            {
+                // Assume domain name or non-email address
+                var idn = new IdnMapping();
+                return idn.GetUnicode(text);
+            }
+            else
+            {
+                // Assume email address
+                return MailboxAddress.DecodeAddrspec(text);
+            }
         }
 
         public static string FormatLicenseSignatureValue(object val)

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -488,6 +488,18 @@ namespace Bit.Core.Utilities
             return Convert.FromBase64String(output);
         }
 
+        public static string PunyEncode(string text)
+        {
+            var idn = new IdnMapping();
+            return idn.GetAscii(text);
+        }
+
+        public static string PunyDecode(string text)
+        {
+            var idn = new IdnMapping();
+            return idn.GetUnicode(text);
+        }
+
         public static string FormatLicenseSignatureValue(object val)
         {
             if (val == null)

--- a/src/Core/Utilities/StrictEmailAddressAttribute.cs
+++ b/src/Core/Utilities/StrictEmailAddressAttribute.cs
@@ -7,7 +7,7 @@ namespace Bit.Core.Utilities
     public class StrictEmailAddressAttribute : ValidationAttribute
     {
         public StrictEmailAddressAttribute()
-            : base("The {0} field is not a valid e-mail address.")
+            : base("The {0} field is not a supported e-mail address format.")
         {}
         
         public override bool IsValid(object value)

--- a/src/Core/Utilities/StrictEmailAddressAttribute.cs
+++ b/src/Core/Utilities/StrictEmailAddressAttribute.cs
@@ -39,7 +39,7 @@ namespace Bit.Core.Utilities
             * Allows any char in second-level domain name, including unicode and symbols
             * Requires at least one period (.) separating SLD from TLD
             * Must end in a letter (including unicode)
-            See the unit tests for examples of what is intended to be allowed.
+            See the unit tests for examples of what is allowed.
             **/
             var emailFormat = @"[\x00-\x7F]+@.+\.\p{L}+$";
             if (!Regex.IsMatch(emailAddress, emailFormat))

--- a/src/Core/Utilities/StrictEmailAddressAttribute.cs
+++ b/src/Core/Utilities/StrictEmailAddressAttribute.cs
@@ -31,7 +31,18 @@ namespace Bit.Core.Utilities
                 return false;
             }
 
-            if (!Regex.IsMatch(emailAddress, @"@.+\.[A-Za-z0-9]+$"))
+            /**
+            The regex below is intended to catch edge cases that are not handled by the general parsing check above.
+            This enforces the following rules:
+            * Requires ASCII only in the local-part (code points 0-127)
+            * Requires an @ symbol
+            * Allows any char in second-level domain name, including unicode and symbols
+            * Requires at least one period (.) separating SLD from TLD
+            * Must end in a letter (including unicode)
+            See the unit tests for examples of what is intended to be allowed.
+            **/
+            var emailFormat = @"[\x00-\x7F]+@.+\.\p{L}+$";
+            if (!Regex.IsMatch(emailAddress, emailFormat))
             {
                 return false;
             }

--- a/test/Core.Test/Utilities/CoreHelpersTests.cs
+++ b/test/Core.Test/Utilities/CoreHelpersTests.cs
@@ -216,5 +216,23 @@ namespace Bit.Core.Test.Utilities
             // Assert
             Assert.Equal(startingUri, newUri.ToString());
         }
+
+        [Theory]
+        [InlineData("bücher.com", "xn--bcher-kva.com")]
+        [InlineData("ascii.com", "ascii.com")]
+        public void PunyEncode_Success(string text, string expected)
+        {
+            var actual = CoreHelpers.PunyEncode(text);
+            Assert.Equal(actual, expected);
+        }
+
+        [Theory]
+        [InlineData("xn--bcher-kva.com", "bücher.com")]
+        [InlineData("ascii.com", "ascii.com")]
+        public void PunyDecode_Success(string text, string expected)
+        {
+            var actual = CoreHelpers.PunyDecode(text);
+            Assert.Equal(actual, expected);
+        }
     }
 }

--- a/test/Core.Test/Utilities/CoreHelpersTests.cs
+++ b/test/Core.Test/Utilities/CoreHelpersTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Bit.Core.Utilities;
 using Xunit;
+using MimeKit;
 
 namespace Bit.Core.Test.Utilities
 {
@@ -219,20 +220,30 @@ namespace Bit.Core.Test.Utilities
 
         [Theory]
         [InlineData("bücher.com", "xn--bcher-kva.com")]
+        [InlineData("hello@bücher.com", "hello@xn--bcher-kva.com")]
+        [InlineData("hello@world.cömé", "hello@world.xn--cm-cja4c")]
+        [InlineData("hello@bücher.cömé", "hello@xn--bcher-kva.xn--cm-cja4c")]
         [InlineData("ascii.com", "ascii.com")]
+        [InlineData("", "")]
+        [InlineData(null, null)]
         public void PunyEncode_Success(string text, string expected)
         {
             var actual = CoreHelpers.PunyEncode(text);
-            Assert.Equal(actual, expected);
+            Assert.Equal(expected, actual);
         }
 
         [Theory]
-        [InlineData("xn--bcher-kva.com", "bücher.com")]
+        [InlineData("bücher.com", "xn--bcher-kva.com")]
+        [InlineData("hello@bücher.com", "hello@xn--bcher-kva.com")]
+        [InlineData("hello@world.cömé", "hello@world.xn--cm-cja4c")]
+        [InlineData("hello@bücher.cömé", "hello@xn--bcher-kva.xn--cm-cja4c")]
         [InlineData("ascii.com", "ascii.com")]
-        public void PunyDecode_Success(string text, string expected)
+        [InlineData("", "")]
+        [InlineData(null, null)]
+        public void PunyDecode_Success(string expected, string text)
         {
             var actual = CoreHelpers.PunyDecode(text);
-            Assert.Equal(actual, expected);
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/test/Core.Test/Utilities/CoreHelpersTests.cs
+++ b/test/Core.Test/Utilities/CoreHelpersTests.cs
@@ -232,20 +232,5 @@ namespace Bit.Core.Test.Utilities
             var actual = CoreHelpers.PunyEncode(text);
             Assert.Equal(expected, actual);
         }
-
-        [Theory]
-        [InlineData("bücher.com", "xn--bcher-kva.com")]
-        [InlineData("bücher.cömé", "xn--bcher-kva.xn--cm-cja4c")]
-        [InlineData("hello@bücher.com", "hello@xn--bcher-kva.com")]
-        [InlineData("hello@world.cömé", "hello@world.xn--cm-cja4c")]
-        [InlineData("hello@bücher.cömé", "hello@xn--bcher-kva.xn--cm-cja4c")]
-        [InlineData("ascii.com", "ascii.com")]
-        [InlineData("", "")]
-        [InlineData(null, null)]
-        public void PunyDecode_Success(string expected, string text)
-        {
-            var actual = CoreHelpers.PunyDecode(text);
-            Assert.Equal(expected, actual);
-        }
     }
 }

--- a/test/Core.Test/Utilities/CoreHelpersTests.cs
+++ b/test/Core.Test/Utilities/CoreHelpersTests.cs
@@ -220,6 +220,7 @@ namespace Bit.Core.Test.Utilities
 
         [Theory]
         [InlineData("bücher.com", "xn--bcher-kva.com")]
+        [InlineData("bücher.cömé", "xn--bcher-kva.xn--cm-cja4c")]
         [InlineData("hello@bücher.com", "hello@xn--bcher-kva.com")]
         [InlineData("hello@world.cömé", "hello@world.xn--cm-cja4c")]
         [InlineData("hello@bücher.cömé", "hello@xn--bcher-kva.xn--cm-cja4c")]
@@ -234,6 +235,7 @@ namespace Bit.Core.Test.Utilities
 
         [Theory]
         [InlineData("bücher.com", "xn--bcher-kva.com")]
+        [InlineData("bücher.cömé", "xn--bcher-kva.xn--cm-cja4c")]
         [InlineData("hello@bücher.com", "hello@xn--bcher-kva.com")]
         [InlineData("hello@world.cömé", "hello@world.xn--cm-cja4c")]
         [InlineData("hello@bücher.cömé", "hello@xn--bcher-kva.xn--cm-cja4c")]

--- a/test/Core.Test/Utilities/StrictEmailAddressAttributeTests.cs
+++ b/test/Core.Test/Utilities/StrictEmailAddressAttributeTests.cs
@@ -10,6 +10,8 @@ namespace Bit.Core.Test.Utilities
         [InlineData("hello@world.planet.com")]  // subdomain
         [InlineData("hello+1@world.com")]       // alias
         [InlineData("hello.there@world.com")]   // period in local-part
+        [InlineData("hello@wörldé.com")]        // unicode domain
+        [InlineData("hello@world.cömé")]        // unicode top-level domain
         public void IsValid_ReturnsTrueWhenValid(string email)
         {
             var sut = new StrictEmailAddressAttribute();
@@ -43,6 +45,7 @@ namespace Bit.Core.Test.Utilities
         [InlineData("hellothere@.worldcom")]                // domain beginning with dot
         [InlineData("hellothere@worldcom.")]                // domain ending in dot
         [InlineData("hellothere@world.com-")]               // domain ending in hyphen
+        [InlineData("héllö@world.com")]                     // unicode in local-part
         public void IsValid_ReturnsFalseWhenInvalid(string email)
         {
             var sut = new StrictEmailAddressAttribute();


### PR DESCRIPTION
## Objective

Add [punycode](https://en.wikipedia.org/wiki/Punycode) support to handle [international domain names](https://en.wikipedia.org/wiki/Internationalized_domain_name) (IDNs) in our mail services.

IDNs are basically domain names with non-ASCII characters. e.g. `bücher.com`. However, the SMTP protocol does not support unicode, so any unicode needs to be encoded as punycode before being sent to the server. (SMTPUTF8 exists, but support varies, and in any case it's not supported by AmazonSES.)

Punycode uses ASCII to represent unicode. So for example, `bücher.com` becomes `xn--bcher-kva.com`.

[AmazonSES requires punyencoding](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/troubleshoot-error-messages.html). At the moment, any email sent to an IDN from our cloud instance is throwing an error.

For self-hosted users, it depends on what their SMTP server supports. It may be that some don't need this because they're already using SMTPUTF8. However, this will add backwards compatibility so that they don't have to worry about that.

Note that punycode is only for representing **domain names**, including the top-level domain name (`.com`). It is not used for encoding the local-part (to the left of the `@` symbol). [AmazonSES requires that the local-part is ASCII only](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/troubleshoot-error-messages.html), as do most major mail providers, so it makes sense for us to impose this limitation as well.

## Code changes
* `strictEmailAddressAttribute.cs`
   * revise the regex to ban unicode in the local-part, but allow it in the domain names. See the fairly detailed comment in the code. Unit tests are really helping here to prevent regressions when changing this.
   * adjust the error message to talk about email addresses being _supported_ rather than being _valid_ (I think it was @Greenderella who pointed out that there may be perfectly "valid" email addresses that we just don't support due to technical limitations, so let's be a bit more inclusive about it)
   * tests have also been updated
* `coreHelpers.cs` - add `punyEncode`. This does what it says.
   * it handles `""` and `null` gracefully, so that we don't have to check that everywhere
   * the `IdnMapper.GetAscii` method handles domain names, but not email addresses
   * the `MailboxAddress.EncodeAddrspec` method handles email addresses, but not domain names
   * to distinguish between these, I've just checked for the presence of an `@`. This is obviously not a perfect test, but you only punyencode emails or domains, domains don't have `@` and if you're encoding an email then I assume you've already checked it's valid.
   * I originally had a `punyDecode` helper, but that's not needed anywhere. We just punyencode and send it to the SMTP server - I can't see where we'd need a decode method. So I removed it.
   * add tests
* update the 3 mail services (AmazonSES, MailKit and Postman) to punyencode any email address - generally the "reply to", recipient, and BCC.
* incidental change: apply `strictEmailAddressAttribute` to the emergency access invite request model. We need to make sure that we can send emails to the emergency access grantee, and if there are any problems with this, the grantor should be notified immediately (before an emergency arises).

## Testing

I haven't been able to verify email delivery because:
* I don't have a unicode domain
* for AmazonSES, our testing facilities are locked to predefined domains

Any help or suggestions from the team on how to test this would be appreciated.