### PR TITLE
Remove double HTML encoding in mail templates

### DIFF
--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -151,7 +151,7 @@ namespace Bit.Core.Services
             var model = new OrganizationUserAcceptedViewModel
             {
                 OrganizationId = organization.Id,
-                OrganizationName = CoreHelpers.SanitizeForEmail(organization.Name, false),
+                OrganizationName = CoreHelpers.SanitizeForEmail(organization.Name),
                 UserIdentifier = userIdentifier,
                 WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
                 SiteName = _globalSettings.SiteName
@@ -166,7 +166,7 @@ namespace Bit.Core.Services
             var message = CreateDefaultMessage($"You Have Been Confirmed To {organizationName}", email);
             var model = new OrganizationUserConfirmedViewModel
             {
-                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName, false),
+                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName),
                 WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
                 SiteName = _globalSettings.SiteName
             };
@@ -189,7 +189,7 @@ namespace Bit.Core.Services
             var messageModels = invites.Select(invite => CreateMessage(invite.orgUser.Email,
                 new OrganizationUserInvitedViewModel
                 {
-                    OrganizationName = CoreHelpers.SanitizeForEmail(organizationName, false),
+                    OrganizationName = CoreHelpers.SanitizeForEmail(organizationName),
                     Email = WebUtility.UrlEncode(invite.orgUser.Email),
                     OrganizationId = invite.orgUser.OrganizationId.ToString(),
                     OrganizationUserId = invite.orgUser.Id.ToString(),
@@ -209,7 +209,7 @@ namespace Bit.Core.Services
             var message = CreateDefaultMessage($"You have been removed from {organizationName}", email);
             var model = new OrganizationUserRemovedForPolicyTwoStepViewModel
             {
-                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName, false),
+                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName),
                 WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
                 SiteName = _globalSettings.SiteName
             };
@@ -302,7 +302,7 @@ namespace Bit.Core.Services
             var message = CreateDefaultMessage("License Expired", emails);
             var model = new LicenseExpiredViewModel
             {
-                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName, false),
+                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName),
             };
             await AddMessageContentAsync(message, "LicenseExpired", model);
             message.Category = "LicenseExpired";
@@ -349,7 +349,7 @@ namespace Bit.Core.Services
             var message = CreateDefaultMessage($"You have been removed from {organizationName}", email);
             var model = new OrganizationUserRemovedForPolicySingleOrgViewModel
             {
-                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName, false),
+                OrganizationName = CoreHelpers.SanitizeForEmail(organizationName),
                 WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
                 SiteName = _globalSettings.SiteName
             };

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -555,7 +555,7 @@ namespace Bit.Core.Utilities
             return sb.ToString();
         }
 
-        public static string SanitizeForEmail(string value, bool htmlEncode = false)
+        public static string SanitizeForEmail(string value)
         {
             var cleanedValue = value.Replace("@", "[at]");
             var regexOptions = RegexOptions.CultureInvariant |
@@ -568,7 +568,7 @@ namespace Bit.Core.Utilities
                 cleanedValue = Regex.Replace(cleanedValue, @"((^|\b)(\w*)://)",
                     string.Empty, regexOptions);
             }
-            return htmlEncode ? HttpUtility.HtmlEncode(cleanedValue) : cleanedValue;
+            return cleanedValue;
         }
 
         public static string DateTimeToTableStorageKey(DateTime? date = null)

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -555,7 +555,7 @@ namespace Bit.Core.Utilities
             return sb.ToString();
         }
 
-        public static string SanitizeForEmail(string value)
+        public static string SanitizeForEmail(string value, bool htmlEncode = false)
         {
             var cleanedValue = value.Replace("@", "[at]");
             var regexOptions = RegexOptions.CultureInvariant |
@@ -568,7 +568,7 @@ namespace Bit.Core.Utilities
                 cleanedValue = Regex.Replace(cleanedValue, @"((^|\b)(\w*)://)",
                     string.Empty, regexOptions);
             }
-            return cleanedValue;
+            return htmlEncode ? HttpUtility.HtmlEncode(cleanedValue) : cleanedValue;
         }
 
         public static string DateTimeToTableStorageKey(DateTime? date = null)

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -555,7 +555,7 @@ namespace Bit.Core.Utilities
             return sb.ToString();
         }
 
-        public static string SanitizeForEmail(string value, bool htmlEncode = true)
+        public static string SanitizeForEmail(string value, bool htmlEncode = false)
         {
             var cleanedValue = value.Replace("@", "[at]");
             var regexOptions = RegexOptions.CultureInvariant |


### PR DESCRIPTION
## Objective
Fix https://app.asana.com/0/1169444489336079/1200280826782266/f:

>If a user's name has an accented character, their name will be encoded in the Emergency Access contact email as it's Unicode character. 
>
>For instance: "Tío Ròjo" gets encoded as "T&#237;o R&#242;jo". 
>
>This only seems to happen if the person that is inviting another person to be their Emergency Access contact has an accent in their name. This does not appear to be an issue the other way around.

## Cause

This is caused by double-HTML escaping.
* We HML-encode strings by default in `CoreHelpers.SanitizeForEmail`
* Handlebars.Net implements the HandlebarsJS spec, which [also HTML-encodes strings by default when using the double-curly bracket syntax](https://handlebarsjs.com/guide/expressions.html#html-escaping). (e.g. `{{ string }}`) This is what we use throughout our templates.

For example, if a string contains the character `ß`:
* It is HTML-encoded by our `CoreHelpers` method and becomes `&#223;` (valid HTML)
* `&#223;` is HTML-encoded a second time by Handlebars.Net and becomes `&amp;#223;` (the ampersand is escaped unnecessarily)

You can disable HTML-encoding in Handlebars by using the triple-curly bracket syntax `{{{ string }}}`, and we already do that for URLs. Or you may be able to disable it with config options. But it seems much safer to leave HTML-escaping to Handlebars and just disable it in our helper method.

## Code changes

* change default parameter in `SanitizeForEmail` so that it does not HTML-encode by default
* remove unnecessary parameters in calls

The bug report only mentioned user emails/names, but this will change the behaviour for any string that is fed through the helper method and then into Handlebars, including people's names and the password recovery hint. For some reason, Organization names had already received this treatment and were not being double-escaped.

Note that `SanitizeForEmail` is only used in `HandlebarsMailService`, so changing the default shouldn't affect any other parts of the app. If we're leaving HTML-encoding to the mailService, then this is a sensible default.