### PR TITLE
Verify Send file does not exist before saving file

### DIFF
--- a/src/Core/Services/Implementations/SendService.cs
+++ b/src/Core/Services/Implementations/SendService.cs
@@ -130,6 +130,11 @@ namespace Bit.Core.Services
 
             var data = JsonConvert.DeserializeObject<SendFileData>(send.Data);
 
+            if (data.Validated)
+            {
+                throw new BadRequestException("File has already been uploaded.");
+            }
+
             await _sendFileStorageService.UploadNewFileAsync(stream, send, data.Id);
 
             if (!await ValidateSendFile(send))

--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -79,6 +79,7 @@ namespace Bit.Core.Test.Services
             List<ImportedOrganizationUser> newUsers)
         {
             org.UseDirectory = true;
+            org.Seats = newUsers.Count + existingUsers.Count + 1;
             var reInvitedUser = existingUsers.First();
             reInvitedUser.ExternalId = null;
             newUsers.Add(new ImportedOrganizationUser


### PR DESCRIPTION
# Overview

The self-hosted Send file upload endpoint is not currently verifying that the send's file hasn't already been uploaded. Send is intended to be an immutable piece of information, so we shouldn't allow this behavior.

# Files Changed
* **SendService.cs**: Refuse to write data if the Send has already been validated. Note: validation is completed once a Send's file has been written to the storage solution.