### PR TITLE
Reference Events Fixups

### DIFF
--- a/src/Core/Enums/ReferenceEventType.cs
+++ b/src/Core/Enums/ReferenceEventType.cs
@@ -32,7 +32,7 @@ namespace Bit.Core.Enums
         DirectorySynced,
         [EnumMember(Value = "vault-imported")]
         VaultImported,
-        [EnumMember(Value = "secret-added")]
+        [EnumMember(Value = "cipher-created")]
         CipherCreated,
         [EnumMember(Value = "group-created")]
         GroupCreated,

--- a/src/Core/Models/Business/ReferenceEvent.cs
+++ b/src/Core/Models/Business/ReferenceEvent.cs
@@ -60,6 +60,6 @@ namespace Bit.Core.Models.Business
 
         public string EventRaisedByUser { get; set; }
 
-        public bool SalesAssistedTrialStarted { get; set; }
+        public bool? SalesAssistedTrialStarted { get; set; }
     }
 }

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1981,11 +1981,8 @@ namespace Bit.Core.Services
                 }
             }
             
-            if (_currentContext.ClientId == BitwardenClient.DirectoryConnector)
-            {
-                await _referenceEventService.RaiseEventAsync(
-                    new ReferenceEvent(ReferenceEventType.DirectorySynced, organization));
-            }
+            await _referenceEventService.RaiseEventAsync(
+                new ReferenceEvent(ReferenceEventType.DirectorySynced, organization));
         }
 
         public async Task RotateApiKeyAsync(Organization organization)


### PR DESCRIPTION
Resolves a few issues related to https://app.asana.com/0/inbox/1183359552741416/1200418300903249/1200626574801815/f

1. SalesAssistedTrial was showing on every event, which it shouldn't be, and made it nullable to stop that.
2. The CipherCreated had an improper value from before the event name was changed.
3. The DirectorySynced event wasn't figured because it was looking for the DirectoryConnector client ID, but in using the DC it looks like the client ID is the organization API key. The import method is only referenced from the org api and directory connector, so there is not a need to check this if we consider them the same client.  