### PR TITLE
[Provider] Add support for business portal

### DIFF
--- a/bitwarden_license/src/Portal/EnterprisePortalCurrentContext.cs
+++ b/bitwarden_license/src/Portal/EnterprisePortalCurrentContext.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Bit.Core.Repositories;
 using System.Linq;
 using System.Collections.Generic;
+using Bit.Core.Enums;
 using Bit.Core.Models.Data;
 using Bit.Core.Utilities;
 
@@ -69,6 +70,47 @@ namespace Bit.Portal
                 Id = ou.OrganizationId,
                 Type = ou.Type
             }).ToList();
+
+            // Add all provider orgs.
+            var providerOrgs = await GetProviderOrganizations();
+            Organizations.AddRange(providerOrgs.Select(po => new CurrentContentOrganization
+            {
+                Id = po.OrganizationId,
+                Type = OrganizationUserType.Owner,
+            }));
+            // Yes this is ugly, but the business portal is deprecated.
+            OrganizationsDetails.AddRange(providerOrgs.Select(pu => new OrganizationUserOrganizationDetails
+            {
+                OrganizationId = pu.OrganizationId,
+                UserId = pu.UserId,
+                Name = pu.Name,
+                UsePolicies = pu.UsePolicies,
+                UseSso = pu.UseSso,
+                UseGroups = pu.UseGroups,
+                UseDirectory = pu.UseDirectory,
+                UseEvents = pu.UseEvents,
+                UseTotp = pu.UseTotp,
+                Use2fa = pu.Use2fa,
+                UseApi = pu.UseApi,
+                UseResetPassword = pu.UseResetPassword,
+                SelfHost = pu.SelfHost,
+                UsersGetPremium = pu.UsersGetPremium,
+                Seats = pu.Seats,
+                MaxCollections = pu.MaxCollections,
+                MaxStorageGb = pu.MaxStorageGb,
+                Key = pu.Key,
+                Status = OrganizationUserStatusType.Confirmed,
+                Type = OrganizationUserType.Owner,
+                Enabled = pu.Enabled,
+                SsoExternalId = null,
+                Identifier = pu.Identifier,
+                Permissions = null,
+                ResetPasswordKey = null,
+                PublicKey = pu.PublicKey,
+                PrivateKey = pu.PrivateKey,
+                ProviderId = pu.ProviderId,
+                ProviderName = pu.ProviderName,
+            }));
 
             if (SelectedOrganizationId == null && HttpContext.Request.Cookies.ContainsKey("SelectedOrganization") &&
                 Guid.TryParse(HttpContext.Request.Cookies["SelectedOrganization"], out var selectedOrgId))

--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -441,7 +441,7 @@ namespace Bit.Core.Context
             };
         }
 
-        private async Task<IEnumerable<ProviderUserOrganizationDetails>> GetProviderOrganizations()
+        protected async Task<IEnumerable<ProviderUserOrganizationDetails>> GetProviderOrganizations()
         {
             if (_providerUserOrganizations == null)
             {


### PR DESCRIPTION
## Objective
A provider user were not able to access the business portal for a client organization. I added a quick fix for this since the plan is to deprecated the portal in the long term.

### Code Changes
- **src/Core/Context/CurrentContext.cs**: Changed `GetProviderOrganizations` to be accessible from classes extending CurrentContext.
- **bitwarden_license/src/Portal/EnterprisePortalCurrentContext.cs**: Added logic for loading org details through a provider. The `OrganizationsDetails` is a bit of a quick fix where I cast `ProviderUserOrganizationDetails` to `OrganizationUserOrganizationDetails`. Ideally this would have been done cleaner but it feels like wasted effort.

Note: We may want to cherry pick this to `rc`, pending QA's approval.