### PR TITLE
Fix sales tax error if using PayPal or credit

### DIFF
--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -513,7 +513,8 @@ namespace Bit.Core.Services
                     var previewInvoice = await invoiceService.UpcomingAsync(new UpcomingInvoiceOptions
                     {
                         Customer = customer.Id,
-                        SubscriptionItems = ToInvoiceSubscriptionItemOptions(subCreateOptions.Items)
+                        SubscriptionItems = ToInvoiceSubscriptionItemOptions(subCreateOptions.Items),
+                        SubscriptionDefaultTaxRates = subCreateOptions.DefaultTaxRates,
                     });
 
                     if (previewInvoice.AmountDue > 0)
@@ -599,7 +600,8 @@ namespace Bit.Core.Services
                     var previewInvoice = await invoiceService.UpcomingAsync(new UpcomingInvoiceOptions
                     {
                         Customer = customer.Id,
-                        SubscriptionItems = ToInvoiceSubscriptionItemOptions(subCreateOptions.Items)
+                        SubscriptionItems = ToInvoiceSubscriptionItemOptions(subCreateOptions.Items),
+                        SubscriptionDefaultTaxRates = subCreateOptions.DefaultTaxRates,
                     });
                     if (previewInvoice.AmountDue > 0)
                     {


### PR DESCRIPTION
## Objective

Fix this bug: https://app.asana.com/0/1169444489336079/1200794072145614/f

When signing up to Premium from a jurisdiction with sales tax, PayPal payments would throw an error: "This customer has no attached payment source or default payment method." The PayPal transaction would be processed and then immediately reversed.

## Cause

When creating a new premium subscription, we look up the applicable tax rate and add it to the new Stripe Subscription object. That means that Stripe knows about the sales tax, it'll appear on the invoice, and if the user is paying by card, the card will be charged for the correct amount.

However, if the user is paying via PayPal, then we process the payment through Braintree before the Stripe Subscription object is created. We create an upcoming invoice (`previewInvoice`) using the Stripe API, and then use the amount of that invoice for the amount to be charged.

The problem was that we were not adding the sales tax rate to the upcoming invoice object. PayPal would be charged the sales tax exclusive amount (e.g. $10.00), Stripe would create a new subscription for the sales tax inclusive amount ($10.89). I assume the fairly cryptic error message is that there is no payment method saved to pay the shortfall.

## Code changes

* add the tax rate to the `previewInvoice` object. This pattern is used for both PayPal and account credit, so both have been updated. Although it hasn't come up so far, I am quite sure you would have a similar error if paying in account credit and you had more than the tax-exclusive amount but less than the tax-inclusive amount.

I reviewed the rest of `StripePaymentService`, but I didn't see anywhere else that used this pattern, so I don't think this bug affects any other payment flow.