### PR TITLE
Increase sales tax precision from 2 to 3 decimal places

### DIFF
--- a/src/Admin/Views/Tools/TaxRateAddEdit.cshtml
+++ b/src/Admin/Views/Tools/TaxRateAddEdit.cshtml
@@ -344,7 +344,7 @@
             <div class="form-group">
                 <label asp-for="Rate">Tax Rate</label>
                 <div class="input-group">
-                    <input type="text" class="form-control" asp-for="Rate" pattern="^\d{0,3}.\d{0,2}$" required>
+                    <input type="text" class="form-control" asp-for="Rate" pattern="^\d{0,3}.\d{0,3}$" required>
                     <div class="input-group-append">
                         <span class="input-group-text">%</span>
                     </div>

--- a/src/Sql/dbo/Stored Procedures/TaxRate_Create.sql
+++ b/src/Sql/dbo/Stored Procedures/TaxRate_Create.sql
@@ -3,7 +3,7 @@ CREATE PROCEDURE [dbo].[TaxRate_Create]
     @Country VARCHAR(50),
     @State VARCHAR(2),
     @PostalCode VARCHAR(10),
-    @Rate DECIMAL(5,2),
+    @Rate DECIMAL(6,3),
     @Active BIT
 AS
 BEGIN

--- a/src/Sql/dbo/Tables/TaxRate.sql
+++ b/src/Sql/dbo/Tables/TaxRate.sql
@@ -3,7 +3,7 @@ CREATE TABLE [dbo].[TaxRate] (
     [Country]           VARCHAR(50)         NOT NULL,
     [State]             VARCHAR(2)          NULL,
     [PostalCode]        VARCHAR(10)         NOT NULL,
-    [Rate]              DECIMAL(5,2)        NOT NULL,
+    [Rate]              DECIMAL(6,3)        NOT NULL,
     [Active]            BIT                 NOT NULL,
     CONSTRAINT [PK_TaxRate] PRIMARY KEY CLUSTERED ([Id] ASC)
 );

--- a/util/Migrator/DbScripts/2021-08-19_00_FixTaxRate.sql
+++ b/util/Migrator/DbScripts/2021-08-19_00_FixTaxRate.sql
@@ -5,3 +5,40 @@ BEGIN
     ALTER COLUMN 
         [Rate] DECIMAL(6,3) NOT NULL;
 END
+
+IF OBJECT_ID('[dbo].[TaxRate_Create]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[TaxRate_Create]
+END
+GO
+
+CREATE PROCEDURE [dbo].[TaxRate_Create]
+    @Id VARCHAR(40) OUTPUT,
+    @Country VARCHAR(50),
+    @State VARCHAR(2),
+    @PostalCode VARCHAR(10),
+    @Rate DECIMAL(6,3),
+    @Active BIT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    INSERT INTO [dbo].[TaxRate]
+    (
+        [Id],
+        [Country],
+        [State],
+        [PostalCode],
+        [Rate],
+        [Active]
+    )
+    VALUES
+    (
+        @Id,
+        @Country,
+        @State,
+        @PostalCode,
+        @Rate,
+        1
+    )
+END

--- a/util/Migrator/DbScripts/2021-08-19_00_FixTaxRate.sql
+++ b/util/Migrator/DbScripts/2021-08-19_00_FixTaxRate.sql
@@ -1,0 +1,7 @@
+IF OBJECT_ID('[dbo].[TaxRate]') IS NOT NULL
+BEGIN
+    ALTER TABLE 
+        [dbo].[TaxRate]
+    ALTER COLUMN 
+        [Rate] DECIMAL(6,3) NOT NULL;
+END


### PR DESCRIPTION
## Objective

Currently, we only allow sales tax to be entered with up to 2 decimal places of precision (e.g. 8.88%). However, some US jurisdictions have sales tax up to 3 decimal places of precision (e.g. 8.875%). If you try to enter sales tax up to 3 decimal places, it will either reject it as invalid (in the add-edit form) or round to 2 decimal places (if uploading a CSV).

The correct value is sent to Stripe, so I don't think this affects actual sales tax calculation, but it does mean that the rates saved in our database are out of step with Stripe.

## Code changes

* update `TaxRate.Rate` column to allow 3 digits of precision
* update `TaxRate_Create` function to allow 3 digits of precision
* add migrator script
* update `TaxRateAddEdit.cshtml` so that the form validation allows for 3 digits of precision.