### PR TITLE
Bump Saml2 dependency to 2.8.0

### DIFF
--- a/bitwarden_license/src/Sso/Sso.csproj
+++ b/bitwarden_license/src/Sso/Sso.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Sso' " />
   <ItemGroup>
     <PackageReference Include="NewRelic.Agent" Version="8.41.0" />
-    <PackageReference Include="Sustainsys.Saml2.AspNetCore2" Version="2.7.0" />
+    <PackageReference Include="Sustainsys.Saml2.AspNetCore2" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Objective
With the move to .NET 5 in #1386, we missed upgrading a dependency which didn't support .NET 5 properly at it's current version.

The error described in https://github.com/Sustainsys/Saml2/issues/1252#issuecomment-730076827 seems similar to what we are currently experiencing, and version 2.8.0, adds support for detecting .NET 5 properly.

Note: This will be cherry picked to `rc`.