### PR TITLE
Add OrganizationUser_ReadByMinimumRole to Sql.sqlproj

### DIFF
--- a/src/Sql/Sql.sqlproj
+++ b/src/Sql/Sql.sqlproj
@@ -132,6 +132,7 @@
     <Build Include="dbo\Stored Procedures\OrganizationUser_ReadByUserId.sql" />
     <Build Include="dbo\Stored Procedures\OrganizationUser_ReadCountByFreeOrganizationAdminUser.sql" />
     <Build Include="dbo\Stored Procedures\User_ReadAccountRevisionDateById.sql" />
+    <Build Include="dbo\Stored Procedures\OrganizationUser_ReadByMinimumRole.sql" />
     <Build Include="dbo\Stored Procedures\OrganizationUser_ReadCountByOrganizationId.sql" />
     <Build Include="dbo\Stored Procedures\OrganizationUser_ReadCountByOnlyOwner.sql" />
     <Build Include="dbo\Stored Procedures\OrganizationUser_SelectKnownEmails.sql" />

--- a/util/Migrator/DbScripts/2021-08-12_00_ReadByMinimumRoleCheckStatus.sql
+++ b/util/Migrator/DbScripts/2021-08-12_00_ReadByMinimumRoleCheckStatus.sql
@@ -17,6 +17,6 @@ BEGIN
         [dbo].[OrganizationUserUserDetailsView]
     WHERE
         OrganizationId = @OrganizationId 
-        AND Status = 2
+        AND Status = 2 -- 2 = Confirmed 
         AND [Type] <= @MinRole
 END


### PR DESCRIPTION
Resolves VS not showing `OrganizationUser_ReadByMinimumRole.sql` in the *Solution Explorer*, and *Scheme Compare* attempting to delete the stored procedure.