### PR TITLE
Support encrypted k8s kubeconfigs

### DIFF
--- a/src/Core/Models/Api/CipherFieldModel.cs
+++ b/src/Core/Models/Api/CipherFieldModel.cs
@@ -19,7 +19,7 @@ namespace Bit.Core.Models.Api
         public FieldType Type { get; set; }
         [EncryptedStringLength(1000)]
         public string Name { get; set; }
-        [EncryptedStringLength(5000)]
+        [EncryptedStringLength(15000)]
         public string Value { get; set; }
     }
 }


### PR DESCRIPTION
### **Overview**
We want to be able to store k8s kubeconfigs in custom fields.

### **Files changed**

**CipherFieldModel**: Allow up to 15000 character long Custom Field Values.
