### PR TITLE
Default QA Deploy to Production Slot

### DIFF
--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -206,5 +206,4 @@ jobs:
         uses: azure/webapps-deploy@798e43877120eda6a2a690a4f212c545e586ae31
         with:
           app-name: ${{ steps.retrieve-secrets.outputs.webapp-name }} 
-          slot-name: "staging"
           package: ./${{ matrix.name }}.zip


### PR DESCRIPTION
## Summary

Defaulting to deploy to the production slot in QA instead of the staging slot