### PR TITLE
Remove stale SsoUser objects from database

### DIFF
--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -576,7 +576,7 @@ namespace Bit.Sso.Controllers
 
         private async Task DeleteExistingSsoUserRecord(Guid userId, Guid orgId, OrganizationUser orgUser)
         {
-            var existingSsoUser = await _ssoUserRepository.GetByUserIdOrganizationId(orgId, userId);
+            var existingSsoUser = await _ssoUserRepository.GetByUserIdOrganizationIdAsync(orgId, userId);
             if (existingSsoUser != null)
             {
                 await _ssoUserRepository.DeleteAsync(userId, orgId);

--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -44,7 +44,7 @@ namespace Bit.Sso.Controllers
         private readonly IUserService _userService;
         private readonly II18nService _i18nService;
         private readonly UserManager<User> _userManager;
-        private readonly EventService _eventService;
+        private readonly Core.Services.IEventService _eventService;
 
         public AccountController(
             IAuthenticationSchemeProvider schemeProvider,
@@ -60,7 +60,7 @@ namespace Bit.Sso.Controllers
             IUserService userService,
             II18nService i18nService,
             UserManager<User> userManager,
-            EventService eventService)
+            Core.Services.IEventService eventService)
         {
             _schemeProvider = schemeProvider;
             _clientStore = clientStore;
@@ -457,8 +457,7 @@ namespace Bit.Sso.Controllers
                     throw new Exception(_i18nService.T("UserAlreadyInvited", email, organization.Name)); 
                 }
 
-                // Delete any existing SsoUser
-                // Sometimes the providerId in the claim can change and we need to make sure we're not creating duplicate entries
+                // Delete existing SsoUser (if any) - avoids error if providerId has changed and the sso link is stale
                 await DeleteExistingSsoUserRecord(existingUser.Id, orgId, orgUser);
 
                 // Accepted or Confirmed - create SSO link and return;

--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -519,6 +519,9 @@ namespace Bit.Sso.Controllers
                 await _organizationUserRepository.ReplaceAsync(orgUser);
             }
             
+            // Delete any stale user record to be safe
+            await DeleteExistingSsoUserRecord(existingUser.Id, orgId, orgUser);
+
             // Create sso user record
             await CreateSsoUserRecord(providerUserId, user.Id, orgId);
             

--- a/src/Core/Enums/EventType.cs
+++ b/src/Core/Enums/EventType.cs
@@ -48,6 +48,7 @@
         OrganizationUser_ResetPassword_Enroll = 1506,
         OrganizationUser_ResetPassword_Withdraw = 1507,
         OrganizationUser_AdminResetPassword = 1508,
+        OrganizationUser_ResetSsoLink = 1509,
 
         Organization_Updated = 1600,
         Organization_PurgedVault = 1601,

--- a/src/Core/Repositories/EntityFramework/SsoUserRepository.cs
+++ b/src/Core/Repositories/EntityFramework/SsoUserRepository.cs
@@ -25,7 +25,7 @@ namespace Bit.Core.Repositories.EntityFramework
             }
         }
 
-        public async Task<TableModel.SsoUser> GetByUserIdOrganizationId(Guid organizationId, Guid userId)
+        public async Task<TableModel.SsoUser> GetByUserIdOrganizationIdAsync(Guid organizationId, Guid userId)
         {
             using (var scope = ServiceScopeFactory.CreateScope())
             {

--- a/src/Core/Repositories/EntityFramework/SsoUserRepository.cs
+++ b/src/Core/Repositories/EntityFramework/SsoUserRepository.cs
@@ -24,5 +24,16 @@ namespace Bit.Core.Repositories.EntityFramework
                 await dbContext.SaveChangesAsync();
             }
         }
+
+        public async Task<TableModel.SsoUser> GetByUserIdOrganizationId(Guid organizationId, Guid userId)
+        {
+            using (var scope = ServiceScopeFactory.CreateScope())
+            {
+                var dbContext = GetDatabaseContext(scope);
+                var entity = await GetDbSet(dbContext)
+                    .FirstOrDefaultAsync(e => e.OrganizationId == organizationId && e.UserId == userId);
+                return entity;
+            }
+        }
     }
 }

--- a/src/Core/Repositories/ISsoUserRepository.cs
+++ b/src/Core/Repositories/ISsoUserRepository.cs
@@ -7,5 +7,6 @@ namespace Bit.Core.Repositories
     public interface ISsoUserRepository : IRepository<SsoUser, long>
     {
         Task DeleteAsync(Guid userId, Guid? organizationId);
+        Task<SsoUser> GetByUserIdOrganizationId(Guid organizationId, Guid userId);
     }
 }

--- a/src/Core/Repositories/ISsoUserRepository.cs
+++ b/src/Core/Repositories/ISsoUserRepository.cs
@@ -7,6 +7,6 @@ namespace Bit.Core.Repositories
     public interface ISsoUserRepository : IRepository<SsoUser, long>
     {
         Task DeleteAsync(Guid userId, Guid? organizationId);
-        Task<SsoUser> GetByUserIdOrganizationId(Guid organizationId, Guid userId);
+        Task<SsoUser> GetByUserIdOrganizationIdAsync(Guid organizationId, Guid userId);
     }
 }

--- a/src/Core/Repositories/SqlServer/SsoUserRepository.cs
+++ b/src/Core/Repositories/SqlServer/SsoUserRepository.cs
@@ -30,7 +30,7 @@ namespace Bit.Core.Repositories.SqlServer
             }
         }
 
-        public async Task<SsoUser> GetByUserIdOrganizationId(Guid organizationId, Guid userId)
+        public async Task<SsoUser> GetByUserIdOrganizationIdAsync(Guid organizationId, Guid userId)
         {
             using (var connection = new SqlConnection(ConnectionString))
             {

--- a/src/Core/Repositories/SqlServer/SsoUserRepository.cs
+++ b/src/Core/Repositories/SqlServer/SsoUserRepository.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using System.Data.SqlClient;
 using System.Data;
+using System.Linq;
 
 namespace Bit.Core.Repositories.SqlServer
 {
@@ -26,6 +27,19 @@ namespace Bit.Core.Repositories.SqlServer
                     $"[{Schema}].[SsoUser_Delete]",
                     new { UserId = userId, OrganizationId = organizationId },
                     commandType: CommandType.StoredProcedure);
+            }
+        }
+
+        public async Task<SsoUser> GetByUserIdOrganizationId(Guid organizationId, Guid userId)
+        {
+            using (var connection = new SqlConnection(ConnectionString))
+            {
+                var results = await connection.QueryAsync<SsoUser>(
+                    $"[{Schema}].[SsoUser_ReadByUserIdOrganizationId]",
+                    new { UserId = userId, OrganizationId = organizationId },
+                    commandType: CommandType.StoredProcedure);
+
+                return results.SingleOrDefault();
             }
         }
     }

--- a/src/Sql/Sql.sqlproj
+++ b/src/Sql/Sql.sqlproj
@@ -299,6 +299,7 @@
     <Build Include="dbo\Stored Procedures\User_ReadBySsoUserOrganizationIdExternalId.sql" />
     <Build Include="dbo\Stored Procedures\SsoUser_Update.sql" />
     <Build Include="dbo\Stored Procedures\SsoUser_ReadById.sql" />
+    <Build Include="dbo\Stored Procedures\SsoUser_ReadByUserIdOrganizationId.sql" />
     <Build Include="dbo\Stored Procedures\Cipher_DeleteByIdsOrganizationId.sql" />
     <Build Include="dbo\Stored Procedures\Cipher_SoftDeleteByIdsOrganizationId.sql" />
     <Build Include="dbo\Stored Procedures\Organization_ReadByIdentifier.sql" />

--- a/src/Sql/dbo/Stored Procedures/SsoUser_ReadByUserIdOrganizationId.sql
+++ b/src/Sql/dbo/Stored Procedures/SsoUser_ReadByUserIdOrganizationId.sql
@@ -1,4 +1,4 @@
-﻿CREATE PROCEDURE [dbo].[SsoUser_ReadyByUserIdOrganizationId]
+﻿CREATE PROCEDURE [dbo].[SsoUser_ReadByUserIdOrganizationId]
     @UserId UNIQUEIDENTIFIER,
     @OrganizationId UNIQUEIDENTIFIER
 AS

--- a/src/Sql/dbo/Stored Procedures/SsoUser_ReadByUserIdOrganizationId.sql
+++ b/src/Sql/dbo/Stored Procedures/SsoUser_ReadByUserIdOrganizationId.sql
@@ -1,0 +1,15 @@
+﻿CREATE PROCEDURE [dbo].[SsoUser_ReadyByUserIdOrganizationId]
+    @UserId UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        *
+    FROM
+        [dbo].[SsoUserView]
+    WHERE
+        [UserId] = @UserId
+        AND [OrganizationId] = @OrganizationId
+END

--- a/util/Migrator/DbScripts/2021-09-02_00_SsoUserReadyByUserIdOrganizationId.sql
+++ b/util/Migrator/DbScripts/2021-09-02_00_SsoUserReadyByUserIdOrganizationId.sql
@@ -1,0 +1,15 @@
+CREATE PROCEDURE [dbo].[SsoUser_ReadyByUserIdOrganizationId]
+    @UserId UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        *
+    FROM
+        [dbo].[SsoUserView]
+    WHERE
+        [UserId] = @UserId
+        AND [OrganizationId] = @OrganizationId
+END

--- a/util/Migrator/DbScripts/2021-09-02_00_SsoUserReadyByUserIdOrganizationId.sql
+++ b/util/Migrator/DbScripts/2021-09-02_00_SsoUserReadyByUserIdOrganizationId.sql
@@ -1,3 +1,9 @@
+IF OBJECT_ID('[dbo].[SsoUser_ReadByUserIdOrganizationId]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[SsoUser_ReadByUserIdOrganizationId]
+END
+GO
+
 CREATE PROCEDURE [dbo].[SsoUser_ReadByUserIdOrganizationId]
     @UserId UNIQUEIDENTIFIER,
     @OrganizationId UNIQUEIDENTIFIER

--- a/util/Migrator/DbScripts/2021-09-02_00_SsoUserReadyByUserIdOrganizationId.sql
+++ b/util/Migrator/DbScripts/2021-09-02_00_SsoUserReadyByUserIdOrganizationId.sql
@@ -1,4 +1,4 @@
-CREATE PROCEDURE [dbo].[SsoUser_ReadyByUserIdOrganizationId]
+CREATE PROCEDURE [dbo].[SsoUser_ReadByUserIdOrganizationId]
     @UserId UNIQUEIDENTIFIER,
     @OrganizationId UNIQUEIDENTIFIER
 AS


### PR DESCRIPTION
## Objective

Fix the following error: `Cannot insert duplicate key row in object 'dbo.SsoUser' with unique index 'IX_SsoUser_OrganizationIdUserId'`

This occurs sometimes when trying to log in using SSO.

## Cause

When a user registers for SSO, we store the `providerId` (unique identifier supplied by the IdP) in the `SsoUser` table. This is used to find the user when they log in via SSO. 

Some events can cause the `providerId` to change. When or how this can happen depends heavily on the Bitwarden SSO and IdP configuration, but for example, it may occur if the admin deletes and re-creates the user's account with the IdP.

When the SSO controller can't find the `providerId` in the `SsoUser` table, it assumes the user is not registered for SSO and will try to register the new `providerId` - this then causes duplicate entries and throws the error.

## Code changes

* Create new db procedures and repository method to get the existing `SsoUser`.
* Check for and delete any existing `SsoUser` entry before trying to create a new one. This should only be necessary in the existing user flow (i.e. user already has a Bitwarden account but we are registering a new SSO link). However, I've put it in the new user flow as well just to be safe, in case old data has been left by some obscure series of steps. (I'm not 100% sure of how exactly users are triggering this error in the wild.)
* Log this event. We had an existing event for unlinking the SSO, but that's initiated by the user - this seemed worth logging separately.

## Other repos

The new event has to be registered in:
* web: https://github.com/bitwarden/web/pull/1173
* jslib: https://github.com/bitwarden/jslib/pull/475