### PR TITLE
Fix stripe invoice time on seat adjust

### DIFF
--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -432,7 +432,7 @@ namespace Bit.Core.Services
                 },
                 ProrationBehavior = "always_invoice",
                 CollectionMethod = "send_invoice",
-                DaysUntilDue = sub.DaysUntilDue ?? 1,
+                DaysUntilDue = daysUntilDue ?? 1,
                 ProrationDate = prorationDate,
             };
 

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -414,8 +414,9 @@ namespace Bit.Core.Services
 
             var prorationDate = DateTime.UtcNow;
             var seatItem = sub.Items?.Data?.FirstOrDefault(i => i.Plan.Id == plan.StripeSeatPlanId);
-            // Retain original collection method
+            // Retain original collection method and days util due
             var collectionMethod = sub.CollectionMethod;
+            var daysUntilDue = sub.DaysUntilDue;
 
             var subUpdateOptions = new SubscriptionUpdateOptions
             {
@@ -430,8 +431,8 @@ namespace Bit.Core.Services
                     }
                 },
                 ProrationBehavior = "always_invoice",
-                DaysUntilDue = 1,
                 CollectionMethod = "send_invoice",
+                DaysUntilDue = sub.DaysUntilDue ?? 1,
                 ProrationDate = prorationDate,
             };
 
@@ -485,17 +486,19 @@ namespace Bit.Core.Services
                         //  being applied forward to the next month's invoice
                         ProrationBehavior = "none",
                         CollectionMethod = collectionMethod,
+                        DaysUntilDue = daysUntilDue,
                     });
                     throw;
                 }
             }
 
-            // Change back the subscription collection method
-            if (collectionMethod != "send_invoice")
+            // Change back the subscription collection method and/or days until due
+            if (collectionMethod != "send_invoice" || daysUntilDue == null)
             {
                 await subscriptionService.UpdateAsync(sub.Id, new SubscriptionUpdateOptions
                 {
                     CollectionMethod = collectionMethod,
+                    DaysUntilDue = daysUntilDue,
                 });
             }
 

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -889,7 +889,18 @@ namespace Bit.Core.Services
                     if (cardPaymentMethodId == null)
                     {
                         // We're going to delete this draft invoice, it can't be paid
-                        await invoiceService.DeleteAsync(invoice.Id);
+                        try
+                        {
+                            await invoiceService.DeleteAsync(invoice.Id);
+                        }
+                        catch
+                        {
+                            await invoiceService.FinalizeInvoiceAsync(invoice.Id, new InvoiceFinalizeOptions
+                            {
+                                AutoAdvance = false
+                            });
+                            await invoiceService.VoidInvoiceAsync(invoice.Id);
+                        }
                         throw new BadRequestException("No payment method is available.");
                     }
                 }


### PR DESCRIPTION
# Overview

Fixes two issues
1. Failed Subscription updates going through stripe would always create pending invoices that would, by default, eventually be auto-completed.
  * This occured because Stripe does not allow deletion of subscription update invoices. The behavior seems odd to me, but presumably it is because it implies deletion of the subscription, which is not desired.
  * We now catch failures deleting a subscription to finalize and void them.
2. Using the add/remove seats buttons under and Organizations Subscription settings would update the invoice due-by date to 1 day. We do this to quickly fail in the event of an escaped expansion, but a successful charge (and successful revert) now updates this pay-by date back to the original setting.

# Testing considerations

There should be two main avenues for testing
1. an organization that has a registered payment type
  * expected behavior: success without any changes to the subscription other than a new invoice for the new seats and updated purchase quanitites
2. An organization that is paying exclusively via invoice/PO.
  * expected behavior: failure without any changes to the subscription (amount, prices, collection type and due-by date)

Stripe dashboard access to our testing environment is required to confirm no new pending/paid invoices exist on update failures. And subscription changes only in the ways predicted.

It is probably a good idea to test the other payment types: paypayl, various crypto

> Note: removing seats should work for both of the above payment types