### PR TITLE
Use invoice to pay if subscription set to invoice

### DIFF
--- a/src/Core/Models/Business/SubscriptionUpdate.cs
+++ b/src/Core/Models/Business/SubscriptionUpdate.cs
@@ -1,0 +1,94 @@
+using System.Linq;
+using Bit.Core.Models.Table;
+using Stripe;
+using StaticStore = Bit.Core.Models.StaticStore;
+
+namespace Bit.Core.Models.Business
+{
+    public abstract class SubscriptionUpdate
+    {
+        protected abstract string PlanId { get; }
+
+        public abstract SubscriptionItemOptions RevertItemOptions(Subscription subscription);
+        public abstract SubscriptionItemOptions UpgradeItemOptions(Subscription subscription);
+        protected SubscriptionItem SubscriptionItem(Subscription subscription) =>
+            subscription.Items?.Data?.FirstOrDefault(i => i.Plan.Id == PlanId);
+    }
+
+
+    public class SeatSubscriptionUpdate : SubscriptionUpdate
+    {
+        private readonly Organization _organization;
+        private readonly StaticStore.Plan _plan;
+        private readonly long? _additionalSeats;
+        protected override string PlanId => _plan.StripeSeatPlanId;
+
+        public SeatSubscriptionUpdate(Organization organization, StaticStore.Plan plan, long? additionalSeats)
+        {
+            _organization = organization;
+            _plan = plan;
+            _additionalSeats = additionalSeats;
+        }
+
+        public override SubscriptionItemOptions UpgradeItemOptions(Subscription subscription)
+        {
+            var item = SubscriptionItem(subscription);
+            return new SubscriptionItemOptions
+            {
+                Id = item?.Id,
+                Plan = PlanId,
+                Quantity = _additionalSeats,
+                Deleted = (item?.Id != null && _additionalSeats == 0) ? true : (bool?)null,
+            };
+        }
+
+        public override SubscriptionItemOptions RevertItemOptions(Subscription subscription)
+        {
+            var item = SubscriptionItem(subscription);
+            return new SubscriptionItemOptions
+            {
+                Id = item?.Id,
+                Plan = PlanId,
+                Quantity = _organization.Seats,
+                Deleted = item?.Id != null ? true : (bool?)null,
+            };
+        }
+    }
+
+    public class StorageSubscriptionUpdate : SubscriptionUpdate
+    {
+        private readonly string _plan;
+        private readonly long? _additionalStorage;
+        protected override string PlanId => _plan;
+
+        public StorageSubscriptionUpdate(string plan, long? additionalStorage)
+        {
+            _plan = plan;
+            _additionalStorage = additionalStorage;
+        }
+
+        public override SubscriptionItemOptions UpgradeItemOptions(Subscription subscription)
+        {
+            var item = SubscriptionItem(subscription);
+            return new SubscriptionItemOptions
+            {
+                Id = item?.Id,
+                Plan = _plan,
+                Quantity = _additionalStorage,
+                Deleted = (item?.Id != null && _additionalStorage == 0) ? true : (bool?)null,
+            };
+        }
+
+        public override SubscriptionItemOptions RevertItemOptions(Subscription subscription)
+        {
+            var item = SubscriptionItem(subscription);
+            return new SubscriptionItemOptions
+            {
+                Id = item?.Id,
+                Plan = _plan,
+                Quantity = item?.Quantity ?? 0,
+                Deleted = item?.Id != null ? true : (bool?)null,
+            };
+        }
+    }
+}

--- a/src/Core/Services/IPaymentService.cs
+++ b/src/Core/Services/IPaymentService.cs
@@ -15,6 +15,7 @@ namespace Bit.Core.Services
            short additionalStorageGb, int additionalSeats, bool premiumAccessAddon, TaxInfo taxInfo);
         Task<string> PurchasePremiumAsync(User user, PaymentMethodType paymentMethodType, string paymentToken,
             short additionalStorageGb, TaxInfo taxInfo);
+        Task<string> AdjustSeatsAsync(Organization organization, Models.StaticStore.Plan plan, int additionalSeats);
         Task<string> AdjustStorageAsync(IStorableSubscriber storableSubscriber, int additionalStorage, string storagePlanId);
         Task CancelSubscriptionAsync(ISubscriber subscriber, bool endOfPeriod = false,
             bool skipInAppPurchaseCheck = false);

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -357,7 +357,7 @@ namespace Bit.Core.Services
 
             if (organization.Seats == null)
             {
-                throw new BadRequestException("Organization is not seat limits, no need to adjust seats");
+                throw new BadRequestException("Organization has no seat limit, no need to adjust seats");
             }
 
             if (string.IsNullOrWhiteSpace(organization.GatewayCustomerId))

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -106,7 +106,7 @@ namespace Bit.Core.Services
 
             if (taxInfo != null && !string.IsNullOrWhiteSpace(taxInfo.BillingAddressCountry) && !string.IsNullOrWhiteSpace(taxInfo.BillingAddressPostalCode))
             {
-                var taxRateSearch = new TaxRate()
+                var taxRateSearch = new TaxRate
                 {
                     Country = taxInfo.BillingAddressCountry,
                     PostalCode = taxInfo.BillingAddressPostalCode
@@ -221,7 +221,7 @@ namespace Bit.Core.Services
 
             if (taxInfo != null && !string.IsNullOrWhiteSpace(taxInfo.BillingAddressCountry) && !string.IsNullOrWhiteSpace(taxInfo.BillingAddressPostalCode))
             {
-                var taxRateSearch = new TaxRate()
+                var taxRateSearch = new TaxRate
                 {
                     Country = taxInfo.BillingAddressCountry,
                     PostalCode = taxInfo.BillingAddressPostalCode


### PR DESCRIPTION
# Overview

Asana task: https://app.asana.com/0/1200804338582616/1200931743286135/f

Our current method for updating Stripe subscriptions assumes a lot about the way Stripe is set up for that customer. As we expand our business clientele, we're experiencing more unique situations that we want to honor while allowing in-application, self-served expansion.

In short, we need to allow accounts which are set up to invoice, to invoice with the terms set up in Stripe rather than assuming a NET-1 payment period that we auto-charge or fail. Stripe will now be the Source Of Truth for how to charge a customer.

#### A Note On Scope

The original scope of this ticket was to enable invoices for seat expansion, but it turns out that the implementation for seat adjustments is roughly identical to storage adjustments. So...

* Expand self-serve seat adjustment to allow invoices
* Expand self-serve storage adjustment to allow invoices

# Files Changed

* **IPaymentService**: Add AdjustSeats to payment service to reduce duplicate code.
* **OrganizationService**: Extract all the subscription logic to the PaymentService and just handle organization validation for expansion here.
* **StripePaymentService**: Expand support to invoicing. Abstract charging to seats and storage. This works by just requiring an update and revert `SubscriptionItemOptions` to allow updates and reversions of the subscription. 

# Testing

I looked into getting some automated unit testing on these methods, but we would need to set up standard Stripe customers/subscriptions to use for testing and share our test api key with our pipeline. I want to think more on how best to do that, and this is blocking further work on subscription updates.

## Reductions 

All reductions to either seats or storage should credit the Stripe account balance the appropriate amount and this balance should be displayed in the `Billing` section of the Organization Settings

## Additions

Seat and Storage additions should behave identically.

### Automatically Charge Subscriptions

This is the default for all Subscriptions created. Behavior for these accounts should be unchaged -- immediate charge for all payment options and failure to expand if payment fails.

Special care should be given to ensuring the Stripe subscription and Bitwarden subscription do not get out of sync (for example, 5 Strip seats charged and Bitwarden showing only 4 seats)

### Invoice Subscriptions

Stripe must be set up to reflect this scenario. From the Admin panel of the organization, click the `Gateway Subscription Id` link at the bottom of the page. This will open Stripe to the appropriate subscription, be sure to select test data.

Go to Actions -> Update Subscription. Change `Automatically charge a payment method on file` to `Email invoice to the customer to pay automatically`. Set some number of days the invoice is due in.

Upon expansion, the customer should be sent an invoice regardless of if a valid payment method is on file.
> **Note:** Stripe will not actually send an email for test data. Check the logs on the invoice to ensure that the email _would_ have been sent, if it were real

Check the due date on the invoice and ensure it matches the `Payment due ... days` setting you chose earlier. Also ensure this setting hasn't changed for the subscription.

Any further billing tests not covered here should be completed as well. 