### PR TITLE
Add configuration support for QA cloud environment

### DIFF
--- a/bitwarden_license/src/Portal/appsettings.QA.json
+++ b/bitwarden_license/src/Portal/appsettings.QA.json
@@ -1,0 +1,23 @@
+{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://vault.qa.bitwarden.pw",
+      "api": "https://api.qa.bitwarden.pw",
+      "identity": "https://identity.qa.bitwarden.pw",
+      "admin": "https://admin.qa.bitwarden.pw",
+      "notifications": "https://notifications.qa.bitwarden.pw",
+      "sso": "https://sso.qa.bitwarden.pw",
+      "portal": "http://portal.qa.bitwarden.pw",
+      "internalNotifications": "https://notifications.qa.bitwarden.pw",
+      "internalAdmin": "https://admin.qa.bitwarden.pw",
+      "internalIdentity": "https://identity.qa.bitwarden.pw",
+      "internalApi": "https://api.qa.bitwarden.pw",
+      "internalVault": "https://vault.qa.bitwarden.pw",
+      "internalSso": "https://sso.qa.bitwarden.pw",
+      "internalPortal": "https://portal.qa.bitwarden.pw"
+    },
+    "braintree": {
+      "production": false
+    }
+  }
+}

--- a/bitwarden_license/src/Sso/appsettings.QA.json
+++ b/bitwarden_license/src/Sso/appsettings.QA.json
@@ -1,0 +1,32 @@
+{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://vault.qa.bitwarden.pw",
+      "api": "https://api.qa.bitwarden.pw",
+      "identity": "https://identity.qa.bitwarden.pw",
+      "admin": "https://admin.qa.bitwarden.pw",
+      "notifications": "https://notifications.qa.bitwarden.pw",
+      "sso": "https://sso.qa.bitwarden.pw",
+      "portal": "http://portal.qa.bitwarden.pw",
+      "internalNotifications": "https://notifications.qa.bitwarden.pw",
+      "internalAdmin": "https://admin.qa.bitwarden.pw",
+      "internalIdentity": "https://identity.qa.bitwarden.pw",
+      "internalApi": "https://api.qa.bitwarden.pw",
+      "internalVault": "https://vault.qa.bitwarden.pw",
+      "internalSso": "https://sso.qa.bitwarden.pw",
+      "internalPortal": "https://portal.qa.bitwarden.pw"
+    },
+    "braintree": {
+      "production": false
+    },
+    "sso": {
+      "saml": {
+        "NameIdFormat": "Unspecified",
+        "WantAssertionsSigned": true,
+        "OutboundSigningAlgorithm": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+        "SigningBehavior": "IfIdpWantAuthnRequestsSigned",
+        "ValidateCertificates": false
+      }
+    }
+  }
+}

--- a/src/Admin/appsettings.QA.json
+++ b/src/Admin/appsettings.QA.json
@@ -1,0 +1,40 @@
+﻿{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://vault.qa.bitwarden.pw",
+      "api": "https://api.qa.bitwarden.pw",
+      "identity": "https://identity.qa.bitwarden.pw",
+      "admin": "https://admin.qa.bitwarden.pw",
+      "notifications": "https://notifications.qa.bitwarden.pw",
+      "sso": "https://sso.qa.bitwarden.pw",
+      "portal": "http://portal.qa.bitwarden.pw",
+      "internalNotifications": "https://notifications.qa.bitwarden.pw",
+      "internalAdmin": "https://admin.qa.bitwarden.pw",
+      "internalIdentity": "https://identity.qa.bitwarden.pw",
+      "internalApi": "https://api.qa.bitwarden.pw",
+      "internalVault": "https://vault.qa.bitwarden.pw",
+      "internalSso": "https://sso.qa.bitwarden.pw",
+      "internalPortal": "https://portal.qa.bitwarden.pw"
+    },
+    "braintree": {
+      "production": false
+    }
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    },
+    "Console": {
+      "IncludeScopes": true,
+      "LogLevel": {
+        "Default": "Warning",
+        "System": "Warning",
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information"
+      }
+    }
+  }
+}

--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -136,7 +136,7 @@ namespace Bit.Api
                 config.Conventions.Add(new PublicApiControllersModelConvention());
             }).AddNewtonsoftJson(options =>
             {
-                if (Environment.IsProduction() && Configuration["swaggerGen"] != "true")
+                if ((Environment.IsProduction() || Environment.IsEnvironment("QA")) && Configuration["swaggerGen"] != "true")
                 {
                     options.SerializerSettings.ContractResolver = new DefaultContractResolver();
                 }

--- a/src/Api/appsettings.QA.json
+++ b/src/Api/appsettings.QA.json
@@ -1,0 +1,43 @@
+﻿{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://vault.qa.bitwarden.pw",
+      "api": "https://api.qa.bitwarden.pw",
+      "identity": "https://identity.qa.bitwarden.pw",
+      "admin": "https://admin.qa.bitwarden.pw",
+      "notifications": "https://notifications.qa.bitwarden.pw",
+      "sso": "https://sso.qa.bitwarden.pw",
+      "portal": "http://portal.qa.bitwarden.pw",
+      "internalNotifications": "https://notifications.qa.bitwarden.pw",
+      "internalAdmin": "https://admin.qa.bitwarden.pw",
+      "internalIdentity": "https://identity.qa.bitwarden.pw",
+      "internalApi": "https://api.qa.bitwarden.pw",
+      "internalVault": "https://vault.qa.bitwarden.pw",
+      "internalSso": "https://sso.qa.bitwarden.pw",
+      "internalPortal": "https://portal.qa.bitwarden.pw"
+    },
+    "braintree": {
+      "production": false
+    },
+    "bitPay": {
+      "production": false
+    }
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    },
+    "Console": {
+      "IncludeScopes": true,
+      "LogLevel": {
+          "Default": "Warning",
+          "System": "Warning",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Information"
+      }
+    }
+  }
+}

--- a/src/Billing/Controllers/PayPalController.cs
+++ b/src/Billing/Controllers/PayPalController.cs
@@ -48,6 +48,7 @@ namespace Bit.Billing.Controllers
         [HttpPost("ipn")]
         public async Task<IActionResult> PostIpn()
         {
+            _logger.LogWarning("PayPal webhook has been hit.");
             if (HttpContext?.Request?.Query == null)
             {
                 return new BadRequestResult();

--- a/src/Billing/Controllers/PayPalController.cs
+++ b/src/Billing/Controllers/PayPalController.cs
@@ -48,7 +48,7 @@ namespace Bit.Billing.Controllers
         [HttpPost("ipn")]
         public async Task<IActionResult> PostIpn()
         {
-            _logger.LogInformation("PayPal webhook has been hit.");
+            _logger.LogDebug("PayPal webhook has been hit.");
             if (HttpContext?.Request?.Query == null)
             {
                 return new BadRequestResult();

--- a/src/Billing/Controllers/PayPalController.cs
+++ b/src/Billing/Controllers/PayPalController.cs
@@ -57,6 +57,7 @@ namespace Bit.Billing.Controllers
                 HttpContext.Request.Query["key"].ToString() : null;
             if (key != _billingSettings.PayPal.WebhookKey)
             {
+                _logger.LogWarning("PayPal webhook key is incorrect or does not exist.");
                 return new BadRequestResult();
             }
 

--- a/src/Billing/Controllers/PayPalController.cs
+++ b/src/Billing/Controllers/PayPalController.cs
@@ -48,7 +48,7 @@ namespace Bit.Billing.Controllers
         [HttpPost("ipn")]
         public async Task<IActionResult> PostIpn()
         {
-            _logger.LogWarning("PayPal webhook has been hit.");
+            _logger.LogInformation("PayPal webhook has been hit.");
             if (HttpContext?.Request?.Query == null)
             {
                 return new BadRequestResult();

--- a/src/Billing/Controllers/StripeController.cs
+++ b/src/Billing/Controllers/StripeController.cs
@@ -104,10 +104,6 @@ namespace Bit.Billing.Controllers
                 _logger.LogWarning("Getting test events in production.");
                 return new BadRequestResult();
             }
-            else if (_hostingEnvironment.IsEnvironment("QA"))
-            {
-                _logger.LogWarning("Getting events in QA.");
-            }
 
             var subDeleted = parsedEvent.Type.Equals("customer.subscription.deleted");
             var subUpdated = parsedEvent.Type.Equals("customer.subscription.updated");

--- a/src/Billing/Controllers/StripeController.cs
+++ b/src/Billing/Controllers/StripeController.cs
@@ -99,7 +99,7 @@ namespace Bit.Billing.Controllers
                 return new BadRequestResult();
             }
 
-            if (_hostingEnvironment.IsProduction() && !parsedEvent.Livemode)
+            if ((_hostingEnvironment.IsProduction() || _hostingEnvironment.IsEnvironment("QA")) && !parsedEvent.Livemode)
             {
                 _logger.LogWarning("Getting test events in production.");
                 return new BadRequestResult();

--- a/src/Billing/Controllers/StripeController.cs
+++ b/src/Billing/Controllers/StripeController.cs
@@ -99,10 +99,14 @@ namespace Bit.Billing.Controllers
                 return new BadRequestResult();
             }
 
-            if ((_hostingEnvironment.IsProduction() || _hostingEnvironment.IsEnvironment("QA")) && !parsedEvent.Livemode)
+            if (_hostingEnvironment.IsProduction() && !parsedEvent.Livemode)
             {
                 _logger.LogWarning("Getting test events in production.");
                 return new BadRequestResult();
+            }
+            else if (_hostingEnvironment.IsEnvironment("QA"))
+            {
+                _logger.LogWarning("Getting events in QA.");
             }
 
             var subDeleted = parsedEvent.Type.Equals("customer.subscription.deleted");

--- a/src/Billing/appsettings.QA.json
+++ b/src/Billing/appsettings.QA.json
@@ -1,0 +1,49 @@
+﻿{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://vault.qa.bitwarden.pw",
+      "api": "https://api.qa.bitwarden.pw",
+      "identity": "https://identity.qa.bitwarden.pw",
+      "admin": "https://admin.qa.bitwarden.pw",
+      "notifications": "https://notifications.qa.bitwarden.pw",
+      "sso": "https://sso.qa.bitwarden.pw",
+      "portal": "http://portal.qa.bitwarden.pw",
+      "internalNotifications": "https://notifications.qa.bitwarden.pw",
+      "internalAdmin": "https://admin.qa.bitwarden.pw",
+      "internalIdentity": "https://identity.qa.bitwarden.pw",
+      "internalApi": "https://api.qa.bitwarden.pw",
+      "internalVault": "https://vault.qa.bitwarden.pw",
+      "internalSso": "https://sso.qa.bitwarden.pw",
+      "internalPortal": "https://portal.qa.bitwarden.pw"
+    },
+    "braintree": {
+      "production": false
+    },
+    "bitPay": {
+      "production": false
+    }
+  },
+  "billingSettings": {
+    "payPal": {
+      "production": false,
+      "businessId": "AD3LAUZSNVPJY"
+    }
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    },
+    "Console": {
+      "IncludeScopes": true,
+      "LogLevel": {
+          "Default": "Warning",
+          "System": "Warning",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Information"
+      }
+    }
+  }
+}

--- a/src/Core/Services/Implementations/AppleIapService.cs
+++ b/src/Core/Services/Implementations/AppleIapService.cs
@@ -43,8 +43,8 @@ namespace Bit.Core.Services
                 return null;
             }
             var validEnvironment = _globalSettings.AppleIap.AppInReview ||
-                (!_hostingEnvironment.IsProduction() && receiptStatus.Environment == "Sandbox") ||
-                (_hostingEnvironment.IsProduction() && receiptStatus.Environment != "Sandbox");
+                (!(_hostingEnvironment.IsProduction() || _hostingEnvironment.IsEnvironment("QA")) && receiptStatus.Environment == "Sandbox") ||
+                ((_hostingEnvironment.IsProduction() || _hostingEnvironment.IsEnvironment("QA")) && receiptStatus.Environment != "Sandbox");
             var validProductBundle = receiptStatus.Receipt.BundleId == "com.bitwarden.desktop" ||
                 receiptStatus.Receipt.BundleId == "com.8bit.bitwarden";
             var validProduct = receiptStatus.LatestReceiptInfo.LastOrDefault()?.ProductId == "premium_annually";

--- a/src/Events/appsettings.QA.json
+++ b/src/Events/appsettings.QA.json
@@ -1,0 +1,37 @@
+﻿{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://vault.qa.bitwarden.pw",
+      "api": "https://api.qa.bitwarden.pw",
+      "identity": "https://identity.qa.bitwarden.pw",
+      "admin": "https://admin.qa.bitwarden.pw",
+      "notifications": "https://notifications.qa.bitwarden.pw",
+      "sso": "https://sso.qa.bitwarden.pw",
+      "portal": "http://portal.qa.bitwarden.pw",
+      "internalNotifications": "https://notifications.qa.bitwarden.pw",
+      "internalAdmin": "https://admin.qa.bitwarden.pw",
+      "internalIdentity": "https://identity.qa.bitwarden.pw",
+      "internalApi": "https://api.qa.bitwarden.pw",
+      "internalVault": "https://vault.qa.bitwarden.pw",
+      "internalSso": "https://sso.qa.bitwarden.pw",
+      "internalPortal": "https://portal.qa.bitwarden.pw"
+    }
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    },
+    "Console": {
+      "IncludeScopes": true,
+      "LogLevel": {
+          "Default": "Warning",
+          "System": "Warning",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Information"
+      }
+    }
+  }
+}

--- a/src/EventsProcessor/appsettings.QA.json
+++ b/src/EventsProcessor/appsettings.QA.json
@@ -1,0 +1,19 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    },
+    "Console": {
+      "IncludeScopes": true,
+      "LogLevel": {
+          "Default": "Warning",
+          "System": "Warning",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Information"
+      }
+    }
+  }
+}

--- a/src/Icons/appsettings.QA.json
+++ b/src/Icons/appsettings.QA.json
@@ -1,0 +1,19 @@
+{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    },
+    "Console": {
+      "IncludeScopes": true,
+      "LogLevel": {
+          "Default": "Warning",
+          "System": "Warning",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Information"
+      }
+    }
+  }
+}

--- a/src/Identity/appsettings.QA.json
+++ b/src/Identity/appsettings.QA.json
@@ -1,0 +1,40 @@
+﻿{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://vault.qa.bitwarden.pw",
+      "api": "https://api.qa.bitwarden.pw",
+      "identity": "https://identity.qa.bitwarden.pw",
+      "admin": "https://admin.qa.bitwarden.pw",
+      "notifications": "https://notifications.qa.bitwarden.pw",
+      "sso": "https://sso.qa.bitwarden.pw",
+      "portal": "http://portal.qa.bitwarden.pw",
+      "internalNotifications": "https://notifications.qa.bitwarden.pw",
+      "internalAdmin": "https://admin.qa.bitwarden.pw",
+      "internalIdentity": "https://identity.qa.bitwarden.pw",
+      "internalApi": "https://api.qa.bitwarden.pw",
+      "internalVault": "https://vault.qa.bitwarden.pw",
+      "internalSso": "https://sso.qa.bitwarden.pw",
+      "internalPortal": "https://portal.qa.bitwarden.pw"
+    },
+    "braintree": {
+      "production": false
+    }
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    },
+    "Console": {
+      "IncludeScopes": true,
+      "LogLevel": {
+          "Default": "Warning",
+          "System": "Warning",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Information"
+      }
+    }
+  }
+}

--- a/src/Notifications/appsettings.QA.json
+++ b/src/Notifications/appsettings.QA.json
@@ -1,0 +1,37 @@
+﻿{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://vault.qa.bitwarden.pw",
+      "api": "https://api.qa.bitwarden.pw",
+      "identity": "https://identity.qa.bitwarden.pw",
+      "admin": "https://admin.qa.bitwarden.pw",
+      "notifications": "https://notifications.qa.bitwarden.pw",
+      "sso": "https://sso.qa.bitwarden.pw",
+      "portal": "http://portal.qa.bitwarden.pw",
+      "internalNotifications": "https://notifications.qa.bitwarden.pw",
+      "internalAdmin": "https://admin.qa.bitwarden.pw",
+      "internalIdentity": "https://identity.qa.bitwarden.pw",
+      "internalApi": "https://api.qa.bitwarden.pw",
+      "internalVault": "https://vault.qa.bitwarden.pw",
+      "internalSso": "https://sso.qa.bitwarden.pw",
+      "internalPortal": "https://portal.qa.bitwarden.pw"
+    }
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    },
+    "Console": {
+      "IncludeScopes": true,
+      "LogLevel": {
+          "Default": "Warning",
+          "System": "Warning",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Information"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

We need to expand the configurations of the backend services to allow for hosting the QA environment along side Production while acting as much like Production as possible.

The ASPNETCORE_ENVIRONMENT AppSetting in the Azure App Services has been updated in the QA environment to be "QA"