### PR TITLE
[Reset Password] Disable Force Password Reset

### DIFF
--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -690,7 +690,10 @@ namespace Bit.Core.Services
 
             user.RevisionDate = user.AccountRevisionDate = DateTime.UtcNow;
             user.Key = key;
-            user.ForcePasswordReset = true;
+            /* 
+            The reset password flow is disabled for the September 2021 release.
+            user.ForcePasswordReset = true; 
+            */
 
             await _userRepository.ReplaceAsync(user);
             await _mailService.SendAdminResetPasswordEmailAsync(user.Email, user.Name ?? user.Email, org.Name);


### PR DESCRIPTION
## Objective
> Disable Force Password Reset for the September 2021 release

## Code Changes
- **UserService**: Disable trigger for downstream force password resets in all clients

## Note
- This is only being merged with the `rc` branch