### PR TITLE
Fix null error when provisioning new SSO user

### DIFF
--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -520,7 +520,7 @@ namespace Bit.Sso.Controllers
             }
             
             // Delete any stale user record to be safe
-            await DeleteExistingSsoUserRecord(existingUser.Id, orgId, orgUser);
+            await DeleteExistingSsoUserRecord(user.Id, orgId, orgUser);
 
             // Create sso user record
             await CreateSsoUserRecord(providerUserId, user.Id, orgId);


### PR DESCRIPTION
## Objective

After my changes in https://github.com/bitwarden/server/pull/1560, server is throwing the following error when provisioning a new SSO user:

```
021-09-10 02:28:14.276 +00:00 [Error] An unhandled exception has occurred while executing the request.
System.NullReferenceException: Object reference not set to an instance of an object.
  at Bit.Sso.Controllers.AccountController.AutoProvisionUserAsync(String provider, 
String providerUserId, IEnumerable`1 claims, String userIdentifier, SsoConfigurationData config) 
in /home/runner/work/server/server/bitwarden_license/src/Sso/Controllers/AccountController.cs:line 523
```

## Code changes

Fix variable name - in the new user flow, I was referring to `existingUser` (which is null in this part of the code) instead of the newly provisioned `user` object.

**Note: this will be cherry-picked to rc**