### PR TITLE
[SSO Auto Enroll] Add API for auto enroll status retrieval

### DIFF
--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -152,8 +152,20 @@ namespace Bit.Api.Controllers
         [HttpGet("{identifier}/auto-enroll-status")]
         public async Task<OrganizationAutoEnrollStatusResponseModel> GetAutoEnrollStatus(string identifier)
         {
+            var user = await _userService.GetUserByPrincipalAsync(User);
+            if (user == null)
+            {
+                throw new UnauthorizedAccessException();
+            }
+            
             var organization = await _organizationRepository.GetByIdentifierAsync(identifier);
             if (organization == null)
+            {
+                throw new NotFoundException();
+            }
+
+            var organizationUser = await _organizationUserRepository.GetByOrganizationAsync(organization.Id, user.Id);
+            if (organizationUser == null)
             {
                 throw new NotFoundException();
             }

--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -10,10 +10,12 @@ using Bit.Core.Exceptions;
 using Bit.Core.Services;
 using Bit.Core.Context;
 using Bit.Api.Utilities;
+using Bit.Core.Models.Api.Response;
 using Bit.Core.Models.Business;
 using Bit.Core.Models.Data;
 using Bit.Core.Utilities;
 using Bit.Core.Settings;
+using Newtonsoft.Json;
 
 namespace Bit.Api.Controllers
 {
@@ -23,6 +25,7 @@ namespace Bit.Api.Controllers
     {
         private readonly IOrganizationRepository _organizationRepository;
         private readonly IOrganizationUserRepository _organizationUserRepository;
+        private readonly IPolicyRepository _policyRepository;
         private readonly IOrganizationService _organizationService;
         private readonly IUserService _userService;
         private readonly IPaymentService _paymentService;
@@ -32,6 +35,7 @@ namespace Bit.Api.Controllers
         public OrganizationsController(
             IOrganizationRepository organizationRepository,
             IOrganizationUserRepository organizationUserRepository,
+            IPolicyRepository policyRepository,
             IOrganizationService organizationService,
             IUserService userService,
             IPaymentService paymentService,
@@ -40,6 +44,7 @@ namespace Bit.Api.Controllers
         {
             _organizationRepository = organizationRepository;
             _organizationUserRepository = organizationUserRepository;
+            _policyRepository = policyRepository;
             _organizationService = organizationService;
             _userService = userService;
             _paymentService = paymentService;
@@ -142,6 +147,26 @@ namespace Bit.Api.Controllers
                 OrganizationUserStatusType.Confirmed);
             var responses = organizations.Select(o => new ProfileOrganizationResponseModel(o));
             return new ListResponseModel<ProfileOrganizationResponseModel>(responses);
+        }
+        
+        [HttpGet("{identifier}/auto-enroll-status")]
+        public async Task<OrganizationAutoEnrollStatusResponseModel> GetAutoEnrollStatus(string identifier)
+        {
+            var organization = await _organizationRepository.GetByIdentifierAsync(identifier);
+            if (organization == null)
+            {
+                throw new NotFoundException();
+            }
+
+            var resetPasswordPolicy =
+                await _policyRepository.GetByOrganizationIdTypeAsync(organization.Id, PolicyType.ResetPassword);
+            if (resetPasswordPolicy == null || !resetPasswordPolicy.Enabled || resetPasswordPolicy.Data == null)
+            {
+                return new OrganizationAutoEnrollStatusResponseModel(organization.Id, false);
+            }
+            
+            var data = JsonConvert.DeserializeObject<ResetPasswordDataModel>(resetPasswordPolicy.Data);
+            return new OrganizationAutoEnrollStatusResponseModel(organization.Id, data?.AutoEnrollEnabled ?? false);
         }
 
         [HttpPost("")]

--- a/src/Core/Models/Api/Response/OrganizationAutoEnrollStatusResponseModel.cs
+++ b/src/Core/Models/Api/Response/OrganizationAutoEnrollStatusResponseModel.cs
@@ -4,13 +4,13 @@ namespace Bit.Core.Models.Api.Response
 {
     public class OrganizationAutoEnrollStatusResponseModel : ResponseModel
     {
-        public OrganizationAutoEnrollStatusResponseModel(Guid orgId, bool autoEnrollEnabled) : base("organizationAutoEnrollStatus")
+        public OrganizationAutoEnrollStatusResponseModel(Guid orgId, bool resetPasswordEnabled) : base("organizationAutoEnrollStatus")
         {
             Id = orgId.ToString();
-            AutoEnrollEnabled = autoEnrollEnabled;
+            ResetPasswordEnabled = resetPasswordEnabled;
         }
         
         public string Id { get; set; }
-        public bool AutoEnrollEnabled { get; set; }
+        public bool ResetPasswordEnabled { get; set; }
     }
 }

--- a/src/Core/Models/Api/Response/OrganizationAutoEnrollStatusResponseModel.cs
+++ b/src/Core/Models/Api/Response/OrganizationAutoEnrollStatusResponseModel.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Bit.Core.Models.Api.Response
+{
+    public class OrganizationAutoEnrollStatusResponseModel : ResponseModel
+    {
+        public OrganizationAutoEnrollStatusResponseModel(Guid orgId, bool autoEnrollEnabled) : base("organizationAutoEnrollStatus")
+        {
+            Id = orgId.ToString();
+            AutoEnrollEnabled = autoEnrollEnabled;
+        }
+        
+        public string Id { get; set; }
+        public bool AutoEnrollEnabled { get; set; }
+    }
+}


### PR DESCRIPTION
## Objective
> Add an API to retrieve the organization's `Auto Enroll` status via `SSO identifier`. This alleviates downstream issues with clients not having access to all necessary information.

## Code Changes
- **OrganizationsController**: Added `GetAutoEnrollStatus` API
- **OrganizationAutoEnrollStatusResponseModel**: Added response model that will return the `Organization ID` and a `bool` indicating whether or not the `Auto Enroll` policy option is enabled.

## Notes
- Will be merged into `master` and `rc`