### PR TITLE
uncomment to require auth-email header

### DIFF
--- a/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
+++ b/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
@@ -50,13 +50,12 @@ namespace Bit.Core.IdentityServer
 
         public async Task ValidateAsync(ResourceOwnerPasswordValidationContext context)
         {
-            // Uncomment whenever we want to require the `auth-email` header
-            //if (!AuthEmailHeaderIsValid(context))
-            //{
-            //    context.Result = new GrantValidationResult(TokenRequestErrors.InvalidGrant,
-            //        "Auth-Email header invalid.");
-            //    return;
-            //}
+            if (!AuthEmailHeaderIsValid(context))
+            {
+                context.Result = new GrantValidationResult(TokenRequestErrors.InvalidGrant,
+                    "Auth-Email header invalid.");
+                return;
+            }
 
             string bypassToken = null;
             if (_captchaValidationService.RequireCaptchaValidation(_currentContext))


### PR DESCRIPTION
Enable `Auth-Email` header requirement during login requests.