### PR TITLE
Update QA Deploy workflow with fix for zip archive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,6 +167,7 @@ jobs:
           pwd
           ls -atlh ../../../
 
+      # This isn't using the Zip archive created from the last step.
       - name: Upload service artifact
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -86,8 +86,12 @@ jobs:
           echo "NAME_LOWER: $NAME_LOWER"
           echo "::set-output name=name_lower::$NAME_LOWER"
 
-          BRANCH_NAME=$(echo "{{ github.ref }}" | awk '{split($0, a, "/"); print a[3]}')
+          BRANCH_NAME=$(echo "$GITHUB_REF" | awk '{split($0, a, "/"); print a[3]}')
+          echo "GITHUB_REF: $GITHUB_REF"
+          echo "BRANCH_NAME: $BRANCH_NAME"
           echo "::set-output name=branch_name::$BRANCH_NAME"
+
+          mkdir publish
 
       - name: Download latest ${{ matrix.name }} asset from ${{ env.branch_name }}
         uses: bitwarden/gh-actions/download-artifacts@23433be15ed6fd046ce12b6889c5184a8d9c8783
@@ -98,6 +102,17 @@ jobs:
           workflow_conclusion: success
           branch: ${{ env.branch_name }}
           artifacts: ${{ matrix.name }}.zip
+          path: publish
+
+      - name: Zip extracted artifact
+        run: |
+          cd publish
+          zip -r ${{ matrix.name }}.zip .
+          mv ${{ matrix.name }}.zip ../
+          cd ..
+
+          pwd
+          ls -atlh
 
       - name: Login to Azure
         uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a


### PR DESCRIPTION
- Added a `zip` step to the `QA Deploy` workflow because our `download-artifacts` action automatically unzips the archive.