### PR TITLE
Fixing the docker image build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -294,7 +294,12 @@ jobs:
         uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60  # v2.0.10
         with:
           name: ${{ matrix.service_name }}.zip
-          path: ${{ matrix.base_path }}/${{ matrix.service_name }}/obj/build-output/publish
+          path: ${{ matrix.base_path }}/${{ matrix.service_name }}
+
+      - name: Setup build artifact
+        run: |
+          mkdir -p ${{ matrix.base_path}}/${{ matrix.service_name}}/obj/build-output/publish
+          unzip ${{ matrix.service_name }}.zip -d ${{ matrix.base_path}}/${{ matrix.service_name}}/obj/build-output/publish
 
       - name: Build Docker images
         run: |


### PR DESCRIPTION
## Summary

With the move to using pre-built assets, we need to utilize those assets when building the docker images. There was a mixup with what format the assets are being stored as and then used (GitHub zips all of assets regardless if they are already zipped archives, resulting in zipped zips). 