### PR TITLE
Allow bypass of captcha token if the device is known

### DIFF
--- a/src/Core/IdentityServer/BaseRequestValidator.cs
+++ b/src/Core/IdentityServer/BaseRequestValidator.cs
@@ -471,12 +471,18 @@ namespace Bit.Core.IdentityServer
             }
         }
 
+        protected async Task<bool> KnownDeviceAsync(User user, ValidatedTokenRequest request) =>
+            (await GetKnownDeviceAsync(user, request)) != default;
+
+        protected async Task<Device> GetKnownDeviceAsync(User user, ValidatedTokenRequest request) =>
+            await _deviceRepository.GetByIdentifierAsync(GetDeviceFromRequest(request).Identifier, user.Id);
+
         private async Task<Device> SaveDeviceAsync(User user, ValidatedTokenRequest request)
         {
             var device = GetDeviceFromRequest(request);
             if (device != null)
             {
-                var existingDevice = await _deviceRepository.GetByIdentifierAsync(device.Identifier, user.Id);
+                var existingDevice = await GetKnownDeviceAsync(user, request);
                 if (existingDevice == null)
                 {
                     device.UserId = user.Id;

--- a/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
+++ b/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
@@ -58,9 +58,10 @@ namespace Bit.Core.IdentityServer
             }
 
             string bypassToken = null;
-            if (_captchaValidationService.RequireCaptchaValidation(_currentContext))
+            var user = await _userManager.FindByEmailAsync(context.UserName.ToLowerInvariant());
+            var unknownDevice = !await KnownDeviceAsync(user, context.Request);
+            if (!unknownDevice && _captchaValidationService.RequireCaptchaValidation(_currentContext))
             {
-                var user = await _userManager.FindByEmailAsync(context.UserName.ToLowerInvariant());
                 var captchaResponse = context.Request.Raw["captchaResponse"]?.ToString();
 
                 if (string.IsNullOrWhiteSpace(captchaResponse))


### PR DESCRIPTION
# Overview

Captcha activation on our cloud instance has caused all CLI authentications using username + password to provide a captcha key.

The thought was that this would be a rare authentication flow rather than a change to the intended path. This is recorded in this CLI issue: https://github.com/bitwarden/cli/issues/383

As a partial remediation, this work bypasses any captcha if the device ID of the client is already associated to the user. This way, any device can only require captcha on the first login. There is an increase in risk for compromised known hardware, but largely that would be an already lost situation.

# Files Changed
* **BaseRequestValidator**: Provide knownDevice helper
* **ResourceOwnerPasswordValidator**: Require captcha only for unknown device && captcha required from captcha service.