### PR TITLE
Add logic to handle providers password reseting users

### DIFF
--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -284,16 +284,16 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
             
-            // Get the calling user's Type for this organization and pass it along
-            var orgType = await _currentContext.OrganizationOwner(orgGuidId)
+            // Get the users role, since provider users aren't a member of the organization we use the owner check
+            var orgUserType = await _currentContext.OrganizationOwner(orgGuidId)
                 ? OrganizationUserType.Owner
                 : _currentContext.Organizations?.FirstOrDefault(o => o.Id == orgGuidId)?.Type;
-            if (orgType == null)
+            if (orgUserType == null)
             {
                 throw new NotFoundException();
             }
 
-            var result = await _userService.AdminResetPasswordAsync(orgType.Value, orgGuidId, new Guid(id), model.NewMasterPasswordHash, model.Key);
+            var result = await _userService.AdminResetPasswordAsync(orgUserType.Value, orgGuidId, new Guid(id), model.NewMasterPasswordHash, model.Key);
             if (result.Succeeded)
             {
                 return;


### PR DESCRIPTION
## Objective
Since providers are not actual members of an org, the `orgType` is null. To avoid this I've added a check which uses the current context to determine if the user acts in the capacity of an Owner and if so, sets the type to Owner before retrieving the users actual role.

Resolves https://app.asana.com/0/1200578627114106/1201175460950262
Note: Will be cherry picked to `rc`.