### PR TITLE
Add Slack alerts for Build workflow failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,10 +166,6 @@ jobs:
           pwd
           ls -atlh ../../../
 
-      - name: TEST FAILURE
-        if: ${{ matrix.service_name }} == 'Admin'
-        run: exit 1
-
       - name: Upload service artifact
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:


### PR DESCRIPTION
This PR adds a notify action that will send out a Slack alert if any of the jobs fail in the `build` workflow.