### PR TITLE
Revert removal of create log dir for business portal

### DIFF
--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -124,6 +124,7 @@ function Docker-Compose-Volumes {
     Create-Dir "logs/nginx"
     Create-Dir "logs/notifications"
     Create-Dir "logs/sso"
+    Create-Dir "logs/portal"
     Create-Dir "mssql/backups"
     Create-Dir "mssql/data"
 }

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -133,6 +133,7 @@ function dockerComposeVolumes() {
     createDir "logs/nginx"
     createDir "logs/notifications"
     createDir "logs/sso"
+    createDir "logs/portal"
     createDir "mssql/backups"
     createDir "mssql/data"
 }


### PR DESCRIPTION
## Objective
Partial revert of #1614 in which I removed the `createDir logs/portal`. Since the scripts are self-updated and used for new installs of older versions we cannot safely remove it yet.

Resolves #1636 