### PR TITLE
Add autoscale to SSO auto provision

### DIFF
--- a/bitwarden_license/src/Sso/Startup.cs
+++ b/bitwarden_license/src/Sso/Startup.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Logging;
+using Stripe;
 
 namespace Bit.Sso
 {
@@ -33,6 +34,9 @@ namespace Bit.Sso
 
             // Settings
             var globalSettings = services.AddGlobalSettingsServices(Configuration);
+
+            // Stripe Billing
+            StripeConfiguration.ApiKey = globalSettings.StripeApiKey;
 
             // Data Protection
             services.AddCustomDataProtectionServices(Environment, globalSettings);

--- a/src/Core/Services/IPaymentService.cs
+++ b/src/Core/Services/IPaymentService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Bit.Core.Models.Table;
 using Bit.Core.Models.Business;
 using Bit.Core.Enums;
@@ -15,8 +16,8 @@ namespace Bit.Core.Services
            short additionalStorageGb, int additionalSeats, bool premiumAccessAddon, TaxInfo taxInfo);
         Task<string> PurchasePremiumAsync(User user, PaymentMethodType paymentMethodType, string paymentToken,
             short additionalStorageGb, TaxInfo taxInfo);
-        Task<string> AdjustSeatsAsync(Organization organization, Models.StaticStore.Plan plan, int additionalSeats);
-        Task<string> AdjustStorageAsync(IStorableSubscriber storableSubscriber, int additionalStorage, string storagePlanId);
+        Task<string> AdjustSeatsAsync(Organization organization, Models.StaticStore.Plan plan, int additionalSeats, DateTime? prorationDate = null);
+        Task<string> AdjustStorageAsync(IStorableSubscriber storableSubscriber, int additionalStorage, string storagePlanId, DateTime? prorationDate = null);
         Task CancelSubscriptionAsync(ISubscriber subscriber, bool endOfPeriod = false,
             bool skipInAppPurchaseCheck = false);
         Task ReinstateSubscriptionAsync(ISubscriber subscriber);

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -477,7 +477,7 @@ namespace Bit.Core.Services
                 }
             }
 
-            var paymentIntentClientSecret = await _paymentService.AdjustSeatsAsync(organization, plan, additionalSeats);
+            var paymentIntentClientSecret = await _paymentService.AdjustSeatsAsync(organization, plan, additionalSeats, prorationDate);
             await _referenceEventService.RaiseEventAsync(
                 new ReferenceEvent(ReferenceEventType.AdjustSeats, organization)
                 {

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -679,7 +679,7 @@ namespace Bit.Core.Services
         }
 
         private async Task<string> FinalizeSubscriptionChangeAsync(IStorableSubscriber storableSubscriber,
-            SubscriptionUpdate subscriptionUpdate)
+            SubscriptionUpdate subscriptionUpdate, DateTime? prorationDate)
         {
             var sub = await _stripeAdapter.SubscriptionGetAsync(storableSubscriber.GatewaySubscriptionId);
             if (sub == null)
@@ -687,7 +687,7 @@ namespace Bit.Core.Services
                 throw new GatewayException("Subscription not found.");
             }
 
-            var prorationDate = DateTime.UtcNow;
+            prorationDate ??= DateTime.UtcNow;
             var collectionMethod = sub.CollectionMethod;
             var daysUntilDue = sub.DaysUntilDue;
             var chargeNow = collectionMethod == "charge_automatically";
@@ -793,15 +793,15 @@ namespace Bit.Core.Services
             return paymentIntentClientSecret;
         }
 
-        public Task<string> AdjustSeatsAsync(Organization organization, StaticStore.Plan plan, int additionalSeats)
+        public Task<string> AdjustSeatsAsync(Organization organization, StaticStore.Plan plan, int additionalSeats, DateTime? prorationDate = null)
         {
-            return FinalizeSubscriptionChangeAsync(organization, new SeatSubscriptionUpdate(organization, plan, additionalSeats));
+            return FinalizeSubscriptionChangeAsync(organization, new SeatSubscriptionUpdate(organization, plan, additionalSeats), prorationDate);
         }
 
         public Task<string> AdjustStorageAsync(IStorableSubscriber storableSubscriber, int additionalStorage,
-            string storagePlanId)
+            string storagePlanId, DateTime? prorationDate = null)
         {
-            return FinalizeSubscriptionChangeAsync(storableSubscriber, new StorageSubscriptionUpdate(storagePlanId, additionalStorage));
+            return FinalizeSubscriptionChangeAsync(storableSubscriber, new StorageSubscriptionUpdate(storagePlanId, additionalStorage), prorationDate);
         }
 
         public async Task CancelAndRecoverChargesAsync(ISubscriber subscriber)


### PR DESCRIPTION
# Overview

#1585 introduced autoscaling for Invites and Directory Connector, but failed to do that same for SSO automatic provisioning.

This PR closes that gap. Asana task: https://app.asana.com/0/1200804338582616/1201180208263722/f

# Files Changed
* **AccountController**: Scale seats if needed. If user interaction is needed or we fail to scale, roll back the transaction
* **Startup**: Add the Stripe API key to the SSO project @bitwarden/dept-devops, this means we'll need to ensure the key is present in our global settings for SSO project.
* **IPaymentService/StripePaymentService/OrganizationService**: Make sure we pass proration date to the subscription upgrade tasks. That way we can ensure a zero-cost revert if we need to.

# Candidate for `RC` cherry pick

As this is fixing a defect in a merged feature, I'm planning on cherry picking this to `rc`

