### PR TITLE
Add New Relic monitoring package to Notifications project

### DIFF
--- a/src/Notifications/Notifications.csproj
+++ b/src/Notifications/Notifications.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="5.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="5.0.9" />
+    <PackageReference Include="NewRelic.Agent" Version="8.41.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Notifications/newrelic.config
+++ b/src/Notifications/newrelic.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0"?>
+<configuration xmlns="urn:newrelic-config">
+  <application></application>
+  <service licenseKey="SECRET"></service>
+  <log directory="/home/LogFiles/NewRelic" level="info"></log>
+</configuration>


### PR DESCRIPTION
Added `New Relic` NuGet package to the `Notifications` project in order to send monitoring data to New Relic.