### PR TITLE
Early return default on null user

### DIFF
--- a/src/Core/IdentityServer/BaseRequestValidator.cs
+++ b/src/Core/IdentityServer/BaseRequestValidator.cs
@@ -474,9 +474,15 @@ namespace Bit.Core.IdentityServer
         protected async Task<bool> KnownDeviceAsync(User user, ValidatedTokenRequest request) =>
             (await GetKnownDeviceAsync(user, request)) != default;
 
-        protected async Task<Device> GetKnownDeviceAsync(User user, ValidatedTokenRequest request) =>
-            await _deviceRepository.GetByIdentifierAsync(GetDeviceFromRequest(request).Identifier, user.Id);
+        protected async Task<Device> GetKnownDeviceAsync(User user, ValidatedTokenRequest request)
+        {
+            if (user == null)
+            {
+                return default;
+            }
 
+            return await _deviceRepository.GetByIdentifierAsync(GetDeviceFromRequest(request).Identifier, user.Id);
+        }
         private async Task<Device> SaveDeviceAsync(User user, ValidatedTokenRequest request)
         {
             var device = GetDeviceFromRequest(request);


### PR DESCRIPTION
# Overview

Asana task: https://app.asana.com/0/1200804338582616/1201222385016289/f

Unknown users are throwing 500s due to null object error when accessing `user.Id`. Clearly, no known device exists for an unknown user, so we can early return default from the device recovery method.