### PR TITLE
Bumping the SqlClient version to fix MARS TDS errors

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -58,7 +58,7 @@
     <PackageReference Include="U2F.Core" Version="1.0.4" />
     <PackageReference Include="Otp.NET" Version="1.2.2" />
     <PackageReference Include="YubicoDotNetClient" Version="1.2.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

We've been experiencing MARS TDS header errors again. MS Support has pointed to a possible solution here: https://github.com/microsoft/dotnet/issues/1263. This PR bumps the `System.Data.SqlClient` to the minimum version suggested in that solution.