### PR TITLE
Change protected release branch to `release`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,7 +299,7 @@ jobs:
         if: ${{ matrix.dotnet }}
         run: |
           mkdir -p ${{ matrix.base_path}}/${{ matrix.service_name }}/obj/build-output/publish
-          unzip ${{ matrix.service_name }}.zip -d ${{ matrix.base_path}}/${{ matrix.service_name }}/obj/build-output/publish
+          unzip ${{ matrix.service_name }}.zip -d ${{ matrix.base_path }}/${{ matrix.service_name }}/obj/build-output/publish
 
       - name: Build Docker images
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           if [[ "$GITHUB_REF" != "refs/heads/release" ]]; then
             echo "==================================="
-            echo "[!] Can only release from the 'release' branches"
+            echo "[!] Can only release from the 'release' branch"
             echo "==================================="
             exit 1
           fi


### PR DESCRIPTION
## Summary

We are updating our release branching strategy by adding a short lived `release` branch and constraining all releases to come from that branch. We also are providing a bit more flexibility to run the release of `release` from the CI code in `master` (running the workflow from `master`)