### PR TITLE
Only check assigned collections if lacking privs for all

### DIFF
--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -176,8 +176,7 @@ namespace Bit.Api.Controllers
             {
                 collection = await _collectionRepository.GetByIdAsync(id);
             }
-
-            if (await _currentContext.ViewAssignedCollections(orgId))
+            else if (await _currentContext.ViewAssignedCollections(orgId))
             {
                 collection = await _collectionRepository.GetByIdAsync(id, _currentContext.UserId.Value);
             }


### PR DESCRIPTION
# Overview

Asana Task: https://app.asana.com/0/1200804338582616/1201236375504840/f

While preparing our internal demo of these permissions changes I found an issue where Delete was being denied to a user with the `DeleteAnyCollection` permission. We were retrieving the collection, then overwriting it with null. We should only get an assigned collection if we cannot pull it based off the any permission