### PR TITLE
Fix .NET naming and download link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Please read the [Setup guide](https://github.com/bitwarden/server/blob/master/SE
 
 ### Requirements
 
-- [.NET Core 5.0 SDK](https://www.microsoft.com/net/download/core)
+- [.NET 5.0 SDK](https://dotnet.microsoft.com/download)
 - [SQL Server 2017](https://docs.microsoft.com/en-us/sql/index)
 
 *These dependencies are free to use.*


### PR DESCRIPTION
With the 5.0 release, Microsoft renamed .NET Core back to just .NET to alleviate the confusion and to signal the way forward.

Also, the download link has changed, and I have updated it to reflect as such.

Source: https://devblogs.microsoft.com/dotnet/introducing-net-5/