### PR TITLE
Add teams trial button to Edit Org Page

### DIFF
--- a/src/Admin/Views/Organizations/Edit.cshtml
+++ b/src/Admin/Views/Organizations/Edit.cshtml
@@ -6,7 +6,7 @@
 @section Scripts {
     <script>
         (() => {
-                document.getElementById('teams-trial').addEventListener('click', () => {
+            document.getElementById('teams-trial').addEventListener('click', () => {
                 if (document.getElementById('@(nameof(Model.PlanType))').value !==
                     '@((byte)Bit.Core.Enums.PlanType.Free)') {
                     alert('Organization is not on a free plan.');
@@ -37,7 +37,7 @@
                 document.getElementById('@(nameof(Model.ExpirationDate))').value = '@Model.FourteenDayExpirationDate';
                 document.getElementById('@(nameof(Model.SalesAssistedTrialStarted))').value = true;
 
-                        });
+            });
 
             document.getElementById('enterprise-trial').addEventListener('click', () => {
                 if (document.getElementById('@(nameof(Model.PlanType))').value !==


### PR DESCRIPTION
## Objective
To make it easier for sales to add a teams trial, a button should be added to the Admin - Edit Org page.
It should behave similar to the Enterprise Trial button but reduce the enabled feature-set for a Teams Trial.

Asana ticket: https://app.asana.com/0/1153292148278596/1201050666414720

## Code Changes
- **src\Admin\Views\Organizations\Edit.cshtml**:  
  - Added teams trial button
  - Set PlanName to 'Teams (Trial)
  - Set features according to Team plan

## Screenshots
![image](https://user-images.githubusercontent.com/2670567/138601864-fa2d528f-074b-4897-8f66-0e59f561f1de.png)
