### PR TITLE
Allow managers to create self-assigned collections

### DIFF
--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -121,8 +121,11 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
+            var assignUserToCollection = !(await _currentContext.EditAnyCollection(orgIdGuid)) &&
+                await _currentContext.EditAssignedCollections(orgIdGuid);
+
             await _collectionService.SaveAsync(collection, model.Groups?.Select(g => g.ToSelectionReadOnly()),
-                !await _currentContext.ViewAllCollections(orgIdGuid) ? _currentContext.UserId : null);
+                assignUserToCollection ? _currentContext.UserId : null);
             return new CollectionResponseModel(collection);
         }
 

--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -292,7 +292,7 @@ namespace Bit.Core.Context
 
         public async Task<bool> CreateNewCollections(Guid orgId)
         {
-            return await OrganizationAdmin(orgId) || (Organizations?.Any(o => o.Id == orgId
+            return await OrganizationManager(orgId) || (Organizations?.Any(o => o.Id == orgId
                         && (o.Permissions?.CreateNewCollections ?? false)) ?? false);
         }
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
#1594 split collections permissions, but removed the ability for managers to create self-assigned collections. This adds that ability back in while making it self-consistent that the ability to create collections enables you to see all collections that exist, but not edit or delete them.


## Code changes
We need to make the permissions Roles self-consistent with building those roles from custom permissions. Because of this, permissions validations all go through specific permission helpers.

* **collectionsController**: Update the ability to create a collection to assign the user to that collection if they can create a collection, but have edit permissions for assigned collections only. This emulates the way that Manager role existed before the change while allowing a `Create` only custom role to still not be auto-assigned. They just need to be not allowed to edit assigned permissions.
* **CurrentContext**: Change create collections split-out to require at least manager role rather than admin.

## Testing requirements
Please test manager role can create and is assigned the collection (unless they have edit all collections permission).

Please test a create-only user is not assigned the collection and not allowed to edit it.

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [x] This change requires a **documentation update** (notify the documentation team)
- [x] This change has particular **deployment requirements** (notify the DevOps team)
  - **This will be a hotfix item impacting the API project**
