### PR TITLE
Add EF crypto agent migrations

### DIFF
--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -613,7 +613,6 @@ namespace Bit.Sso.Controllers
                 OrganizationId = orgUser.OrganizationId
             }; 
             await _ssoUserRepository.CreateAsync(ssoUser);
-            await _eventService.LogOrganizationUserEventAsync(orgUser, EventType.OrganizationUser_LinkedSso);
         }
 
         private void ProcessLoginCallback(AuthenticateResult externalResult,

--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -463,7 +463,7 @@ namespace Bit.Sso.Controllers
                 await DeleteExistingSsoUserRecord(existingUser.Id, orgId, orgUser);
 
                 // Accepted or Confirmed - create SSO link and return;
-                await CreateSsoUserRecord(providerUserId, existingUser.Id, orgId);
+                await CreateSsoUserRecord(providerUserId, existingUser.Id, orgUser);
                 return existingUser;
             }
 
@@ -544,7 +544,7 @@ namespace Bit.Sso.Controllers
             await DeleteExistingSsoUserRecord(user.Id, orgId, orgUser);
 
             // Create sso user record
-            await CreateSsoUserRecord(providerUserId, user.Id, orgId);
+            await CreateSsoUserRecord(providerUserId, user.Id, orgUser);
             
             return user;
         }
@@ -604,15 +604,16 @@ namespace Bit.Sso.Controllers
                 await _eventService.LogOrganizationUserEventAsync(orgUser, EventType.OrganizationUser_ResetSsoLink);
             }
         }
-        private async Task CreateSsoUserRecord(string providerUserId, Guid userId, Guid orgId)
+        private async Task CreateSsoUserRecord(string providerUserId, Guid userId, OrganizationUser orgUser)
         {
             var ssoUser = new SsoUser
             {
                 ExternalId = providerUserId,
                 UserId = userId,
-                OrganizationId = orgId
+                OrganizationId = orgUser.OrganizationId
             }; 
             await _ssoUserRepository.CreateAsync(ssoUser);
+            await _eventService.LogOrganizationUserEventAsync(orgUser, EventType.OrganizationUser_LinkedSso);
         }
 
         private void ProcessLoginCallback(AuthenticateResult externalResult,

--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -604,6 +604,7 @@ namespace Bit.Sso.Controllers
                 await _eventService.LogOrganizationUserEventAsync(orgUser, EventType.OrganizationUser_ResetSsoLink);
             }
         }
+
         private async Task CreateSsoUserRecord(string providerUserId, Guid userId, OrganizationUser orgUser)
         {
             var ssoUser = new SsoUser
@@ -611,7 +612,7 @@ namespace Bit.Sso.Controllers
                 ExternalId = providerUserId,
                 UserId = userId,
                 OrganizationId = orgUser.OrganizationId
-            }; 
+            };
             await _ssoUserRepository.CreateAsync(ssoUser);
         }
 

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -119,7 +119,7 @@ namespace Bit.Api.Controllers
 
             if (user.UsesKeyConnector)
             {
-                throw new BadRequestException("You cannot change your email when using Customer Managed Encryption");
+                throw new BadRequestException("You cannot change your email when using Key Connector.");
             }
 
             if (!await _userService.CheckPasswordAsync(user, model.MasterPasswordHash))
@@ -142,7 +142,7 @@ namespace Bit.Api.Controllers
 
             if (user.UsesKeyConnector)
             {
-                throw new BadRequestException("You cannot change your email when using Customer Managed Encryption");
+                throw new BadRequestException("You cannot change your email when using Key Connector.");
             }
 
             var result = await _userService.ChangeEmailAsync(user, model.MasterPasswordHash, model.NewEmail,

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -368,7 +368,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            var result = await _userService.RefreshSecurityStampAsync(user, model.MasterPasswordHash);
+            var result = await _userService.RefreshSecurityStampAsync(user, model.Secret);
             if (result.Succeeded)
             {
                 return;

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -778,11 +778,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            var valid = user.UsesCryptoAgent && !model.SuppliedMasterPassword()
-                ? await _userService.VerifyOTPAsync(user, model.OTP)
-                : await _userService.CheckPasswordAsync(user, model.MasterPasswordHash);
-
-            if (!valid)
+            if (!await _userService.VerifyPasswordOrOTPAsync(user, model.Secret))
             {
                 await Task.Delay(2000);
                 throw new BadRequestException("MasterPasswordHash", "Invalid password.");
@@ -800,11 +796,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            var valid = user.UsesCryptoAgent && !model.SuppliedMasterPassword()
-                ? await _userService.VerifyOTPAsync(user, model.OTP)
-                : await _userService.CheckPasswordAsync(user, model.MasterPasswordHash);
-
-            if (!valid)
+            if (!await _userService.VerifyPasswordOrOTPAsync(user, model.Secret))
             {
                 await Task.Delay(2000);
                 throw new BadRequestException("MasterPasswordHash", "Invalid password.");

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -490,7 +490,7 @@ namespace Bit.Api.Controllers
 
             if (!await _userService.VerifyPasswordOrOTPAsync(user, model.Secret))
             {
-                ModelState.AddModelError("MasterPasswordHash", "Invalid password.");
+                ModelState.AddModelError(string.Empty, "Authentication failed.");
                 await Task.Delay(2000);
             }
             else
@@ -781,7 +781,7 @@ namespace Bit.Api.Controllers
             if (!await _userService.VerifyPasswordOrOTPAsync(user, model.Secret))
             {
                 await Task.Delay(2000);
-                throw new BadRequestException("MasterPasswordHash", "Invalid password.");
+                throw new BadRequestException(string.Empty, "Authentication failed.");
             }
 
             return new ApiKeyResponseModel(user);
@@ -799,7 +799,7 @@ namespace Bit.Api.Controllers
             if (!await _userService.VerifyPasswordOrOTPAsync(user, model.Secret))
             {
                 await Task.Delay(2000);
-                throw new BadRequestException("MasterPasswordHash", "Invalid password.");
+                throw new BadRequestException(string.Empty, "Authentication failed.");
             }
 
             await _userService.RotateApiKeyAsync(user);

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -513,7 +513,7 @@ namespace Bit.Api.Controllers
 
             if (!await _userService.VerifyPasswordOrOTPAsync(user, model.Secret))
             {
-                ModelState.AddModelError(string.Empty, "Authentication failed.");
+                ModelState.AddModelError(string.Empty, "User verification failed.");
                 await Task.Delay(2000);
             }
             else
@@ -804,7 +804,7 @@ namespace Bit.Api.Controllers
             if (!await _userService.VerifyPasswordOrOTPAsync(user, model.Secret))
             {
                 await Task.Delay(2000);
-                throw new BadRequestException(string.Empty, "Authentication failed.");
+                throw new BadRequestException(string.Empty, "User verification failed.");
             }
 
             return new ApiKeyResponseModel(user);
@@ -822,7 +822,7 @@ namespace Bit.Api.Controllers
             if (!await _userService.VerifyPasswordOrOTPAsync(user, model.Secret))
             {
                 await Task.Delay(2000);
-                throw new BadRequestException(string.Empty, "Authentication failed.");
+                throw new BadRequestException(string.Empty, "User verification failed.");
             }
 
             await _userService.RotateApiKeyAsync(user);

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -768,11 +768,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            var valid = user.UsesCryptoAgent && !model.SuppliedMasterPassword()
-                ? await _userService.VerifyOtp(user, model.OTP)
-                : await _userService.CheckPasswordAsync(user, model.MasterPasswordHash);
-
-            if (!valid)
+            if (!await _userService.VerifyPasswordOrOTPAsync(user, model))
             {
                 await Task.Delay(2000);
                 throw new BadRequestException("MasterPasswordHash", "Invalid password.");

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -488,7 +488,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            if (!await _userService.CheckPasswordAsync(user, model.MasterPasswordHash))
+            if (!await _userService.VerifyPasswordOrOTPAsync(user, model.Secret))
             {
                 ModelState.AddModelError("MasterPasswordHash", "Invalid password.");
                 await Task.Delay(2000);

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -117,6 +117,11 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
+            if (user.UsesCryptoAgent)
+            {
+                throw new BadRequestException("You cannot change your email when using Customer Managed Encryption");
+            }
+
             if (!await _userService.CheckPasswordAsync(user, model.MasterPasswordHash))
             {
                 await Task.Delay(2000);
@@ -133,6 +138,11 @@ namespace Bit.Api.Controllers
             if (user == null)
             {
                 throw new UnauthorizedAccessException();
+            }
+
+            if (user.UsesCryptoAgent)
+            {
+                throw new BadRequestException("You cannot change your email when using Customer Managed Encryption");
             }
 
             var result = await _userService.ChangeEmailAsync(user, model.MasterPasswordHash, model.NewEmail,

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -117,7 +117,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            if (user.UsesCryptoAgent)
+            if (user.UsesKeyConnector)
             {
                 throw new BadRequestException("You cannot change your email when using Customer Managed Encryption");
             }
@@ -140,7 +140,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            if (user.UsesCryptoAgent)
+            if (user.UsesKeyConnector)
             {
                 throw new BadRequestException("You cannot change your email when using Customer Managed Encryption");
             }
@@ -265,8 +265,8 @@ namespace Bit.Api.Controllers
             throw new BadRequestException(ModelState);
         }
 
-        [HttpPost("set-crypto-agent-key")]
-        public async Task PostSetCryptoAgentKeyAsync([FromBody]SetCryptoAgentKeyRequestModel model)
+        [HttpPost("set-key-connector-key")]
+        public async Task PostSetKeyConnectorKeyAsync([FromBody]SetKeyConnectorKeyRequestModel model)
         {
             var user = await _userService.GetUserByPrincipalAsync(User);
             if (user == null)
@@ -274,7 +274,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            var result = await _userService.SetCryptoAgentKeyAsync(model.ToUser(user), model.Key, model.OrgIdentifier);
+            var result = await _userService.SetKeyConnectorKeyAsync(model.ToUser(user), model.Key, model.OrgIdentifier);
             if (result.Succeeded)
             {
                 return;
@@ -288,8 +288,8 @@ namespace Bit.Api.Controllers
             throw new BadRequestException(ModelState);
         }
 
-        [HttpPost("convert-to-crypto-agent")]
-        public async Task PostConvertToCryptoAgent()
+        [HttpPost("convert-to-key-connector")]
+        public async Task PostConvertToKeyConnector()
         {
             var user = await _userService.GetUserByPrincipalAsync(User);
             if (user == null)
@@ -297,7 +297,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            var result = await _userService.ConvertToCryptoAgentAsync(user);
+            var result = await _userService.ConvertToKeyConnectorAsync(user);
             if (result.Succeeded)
             {
                 return;
@@ -857,7 +857,7 @@ namespace Bit.Api.Controllers
         public async Task PostRequestOTP()
         {
             var user = await _userService.GetUserByPrincipalAsync(User);
-            if (user is not { UsesCryptoAgent: true })
+            if (user is not { UsesKeyConnector: true })
             {
                 throw new UnauthorizedAccessException();
             }
@@ -869,7 +869,7 @@ namespace Bit.Api.Controllers
         public async Task VerifyOtp([FromBody]VerifyOtpRequestModel model)
         {
             var user = await _userService.GetUserByPrincipalAsync(User);
-            if (user is not { UsesCryptoAgent: true })
+            if (user is not { UsesKeyConnector: true })
             {
                 throw new UnauthorizedAccessException();
             }

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -841,7 +841,7 @@ namespace Bit.Api.Controllers
         }
 
         [HttpPost("verify-otp")]
-        public async Task VerifyOtp([FromBody]VerityOtpRequestModel model)
+        public async Task VerifyOtp([FromBody]VerifyOtpRequestModel model)
         {
             var user = await _userService.GetUserByPrincipalAsync(User);
             if (user is not { UsesCryptoAgent: true })

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -779,7 +779,7 @@ namespace Bit.Api.Controllers
             }
 
             var valid = user.UsesCryptoAgent && !model.SuppliedMasterPassword()
-                ? await _userService.VerifyOtp(user, model.OTP)
+                ? await _userService.VerifyOTPAsync(user, model.OTP)
                 : await _userService.CheckPasswordAsync(user, model.MasterPasswordHash);
 
             if (!valid)
@@ -801,7 +801,7 @@ namespace Bit.Api.Controllers
             }
 
             var valid = user.UsesCryptoAgent && !model.SuppliedMasterPassword()
-                ? await _userService.VerifyOtp(user, model.OTP)
+                ? await _userService.VerifyOTPAsync(user, model.OTP)
                 : await _userService.CheckPasswordAsync(user, model.MasterPasswordHash);
 
             if (!valid)
@@ -847,7 +847,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            await _userService.SendOTP(user);
+            await _userService.SendOTPAsync(user);
         }
 
         [HttpPost("verify-otp")]
@@ -859,7 +859,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            if (!await _userService.VerifyOtp(user, model.Otp))
+            if (!await _userService.VerifyOTPAsync(user, model.Otp))
             {
                 await Task.Delay(2000);
                 throw new BadRequestException("Token", "Invalid token");

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -837,5 +837,21 @@ namespace Bit.Api.Controllers
 
             await _userService.SendOTP(user);
         }
+
+        [HttpPost("verify-otp")]
+        public async Task VerifyOtp([FromBody]VerityOtpRequestModel model)
+        {
+            var user = await _userService.GetUserByPrincipalAsync(User);
+            if (user is not { UsesCryptoAgent: true })
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            if (!await _userService.VerifyOtp(user, model.Otp))
+            {
+                await Task.Delay(2000);
+                throw new BadRequestException("Token", "Invalid token");
+            }
+        }
     }
 }

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -768,7 +768,11 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            if (!await _userService.VerifyPasswordOrOTPAsync(user, model))
+            var valid = user.UsesCryptoAgent && !model.SuppliedMasterPassword()
+                ? await _userService.VerifyOtp(user, model.OTP)
+                : await _userService.CheckPasswordAsync(user, model.MasterPasswordHash);
+
+            if (!valid)
             {
                 await Task.Delay(2000);
                 throw new BadRequestException("MasterPasswordHash", "Invalid password.");

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -288,6 +288,29 @@ namespace Bit.Api.Controllers
             throw new BadRequestException(ModelState);
         }
 
+        [HttpPost("convert-to-crypto-agent")]
+        public async Task PostConvertToCryptoAgent()
+        {
+            var user = await _userService.GetUserByPrincipalAsync(User);
+            if (user == null)
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            var result = await _userService.ConvertToCryptoAgentAsync(user);
+            if (result.Succeeded)
+            {
+                return;
+            }
+
+            foreach (var error in result.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error.Description);
+            }
+
+            throw new BadRequestException(ModelState);
+        }
+
         [HttpPost("kdf")]
         public async Task PostKdf([FromBody]KdfRequestModel model)
         {

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -560,7 +560,7 @@ namespace Bit.Api.Controllers
 
             if (!await _userService.VerifyPasswordOrOTPAsync(user, model.Secret))
             {
-                ModelState.AddModelError("MasterPasswordHash", "Invalid password.");
+                ModelState.AddModelError(string.Empty, "Authentication failed.");
                 await Task.Delay(2000);
                 throw new BadRequestException(ModelState);
             }

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -558,11 +558,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            var valid = user.UsesCryptoAgent && !model.SuppliedMasterPassword()
-                ? await _userService.VerifyOTPAsync(user, model.OTP)
-                : await _userService.CheckPasswordAsync(user, model.MasterPasswordHash);
-
-            if (!valid)
+            if (!await _userService.VerifyPasswordOrOTPAsync(user, model.Secret))
             {
                 ModelState.AddModelError("MasterPasswordHash", "Invalid password.");
                 await Task.Delay(2000);

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -560,7 +560,7 @@ namespace Bit.Api.Controllers
 
             if (!await _userService.VerifyPasswordOrOTPAsync(user, model.Secret))
             {
-                ModelState.AddModelError(string.Empty, "Authentication failed.");
+                ModelState.AddModelError(string.Empty, "User verification failed.");
                 await Task.Delay(2000);
                 throw new BadRequestException(ModelState);
             }

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -558,7 +558,11 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            if (!await _userService.VerifyPasswordOrOTPAsync(user, model))
+            var valid = user.UsesCryptoAgent && !model.SuppliedMasterPassword()
+                ? await _userService.VerifyOtp(user, model.OTP)
+                : await _userService.CheckPasswordAsync(user, model.MasterPasswordHash);
+
+            if (!valid)
             {
                 ModelState.AddModelError("MasterPasswordHash", "Invalid password.");
                 await Task.Delay(2000);

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -559,7 +559,7 @@ namespace Bit.Api.Controllers
             }
 
             var valid = user.UsesCryptoAgent && !model.SuppliedMasterPassword()
-                ? await _userService.VerifyOtp(user, model.OTP)
+                ? await _userService.VerifyOTPAsync(user, model.OTP)
                 : await _userService.CheckPasswordAsync(user, model.MasterPasswordHash);
 
             if (!valid)

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -558,7 +558,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            if (!await _userService.CheckPasswordAsync(user, model.MasterPasswordHash))
+            if (!await _userService.VerifyPasswordOrOTPAsync(user, model))
             {
                 ModelState.AddModelError("MasterPasswordHash", "Invalid password.");
                 await Task.Delay(2000);

--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -26,7 +26,6 @@ namespace Bit.Api.Controllers
         private readonly IGroupRepository _groupRepository;
         private readonly IUserService _userService;
         private readonly ICurrentContext _currentContext;
-        private readonly ISsoConfigRepository _ssoConfigRepository;
 
         public OrganizationUsersController(
             IOrganizationRepository organizationRepository,
@@ -35,8 +34,7 @@ namespace Bit.Api.Controllers
             ICollectionRepository collectionRepository,
             IGroupRepository groupRepository,
             IUserService userService,
-            ICurrentContext currentContext,
-            ISsoConfigRepository ssoConfigRepository)
+            ICurrentContext currentContext)
         {
             _organizationRepository = organizationRepository;
             _organizationUserRepository = organizationUserRepository;
@@ -45,7 +43,6 @@ namespace Bit.Api.Controllers
             _groupRepository = groupRepository;
             _userService = userService;
             _currentContext = currentContext;
-            _ssoConfigRepository = ssoConfigRepository;
         }
 
         [HttpGet("{id}")]

--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -336,16 +336,6 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
-            var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(orgGuidId);
-            if (ssoConfig != null)
-            {
-                var ssoConfigData = ssoConfig.GetData();
-                if (ssoConfigData.UseCryptoAgent)
-                {
-                    throw new BadRequestException("You cannot delete an Organization that is using Customer Managed Encryption.");
-                }
-            }
-
             var userId = _userService.GetProperUserId(User);
             var result = await _organizationService.DeleteUsersAsync(orgGuidId, model.Ids, userId.Value);
             return new ListResponseModel<OrganizationUserBulkResponseModel>(result.Select(r =>

--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -413,7 +413,7 @@ namespace Bit.Api.Controllers
             if (!await _userService.VerifyPasswordOrOTPAsync(user, model.Secret))
             {
                 await Task.Delay(2000);
-                throw new BadRequestException("MasterPasswordHash", "Invalid password.");
+                throw new BadRequestException(string.Empty, "Authentication failed.");
             }
             else
             {

--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -640,14 +640,7 @@ namespace Bit.Api.Controllers
             }
 
             var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(id);
-            if (ssoConfig == null)
-            {
-                ssoConfig = model.ToSsoConfig(id);
-            }
-            else
-            {
-                ssoConfig = model.ToSsoConfig(ssoConfig);
-            }
+            ssoConfig = ssoConfig == null ? model.ToSsoConfig(id) : model.ToSsoConfig(ssoConfig);
 
             await _ssoConfigService.SaveAsync(ssoConfig);
 

--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -413,7 +413,7 @@ namespace Bit.Api.Controllers
             if (!await _userService.VerifyPasswordOrOTPAsync(user, model.Secret))
             {
                 await Task.Delay(2000);
-                throw new BadRequestException(string.Empty, "Authentication failed.");
+                throw new BadRequestException(string.Empty, "User verification failed.");
             }
             else
             {

--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -410,7 +410,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            if (!await _userService.CheckPasswordAsync(user, model.MasterPasswordHash))
+            if (!await _userService.VerifyPasswordOrOTPAsync(user, model.Secret))
             {
                 await Task.Delay(2000);
                 throw new BadRequestException("MasterPasswordHash", "Invalid password.");

--- a/src/Api/Controllers/TwoFactorController.cs
+++ b/src/Api/Controllers/TwoFactorController.cs
@@ -379,7 +379,7 @@ namespace Bit.Api.Controllers
             if (!await _userService.VerifyPasswordOrOTPAsync(user, secret))
             {
                 await Task.Delay(2000);
-                throw new BadRequestException(string.Empty, "Authentication failed.");
+                throw new BadRequestException(string.Empty, "User verification failed.");
             }
 
             if (premium && !(await _userService.CanAccessPremium(user)))

--- a/src/Api/Controllers/TwoFactorController.cs
+++ b/src/Api/Controllers/TwoFactorController.cs
@@ -82,7 +82,7 @@ namespace Bit.Api.Controllers
         [HttpPost("get-authenticator")]
         public async Task<TwoFactorAuthenticatorResponseModel> GetAuthenticator([FromBody]TwoFactorRequestModel model)
         {
-            var user = await CheckAsync(model.MasterPasswordHash, false);
+            var user = await CheckAsync(model.Secret, false);
             var response = new TwoFactorAuthenticatorResponseModel(user);
             return response;
         }
@@ -92,7 +92,7 @@ namespace Bit.Api.Controllers
         public async Task<TwoFactorAuthenticatorResponseModel> PutAuthenticator(
             [FromBody]UpdateTwoFactorAuthenticatorRequestModel model)
         {
-            var user = await CheckAsync(model.MasterPasswordHash, false);
+            var user = await CheckAsync(model.Secret, false);
             model.ToUser(user);
 
             if (!await _userManager.VerifyTwoFactorTokenAsync(user,
@@ -110,7 +110,7 @@ namespace Bit.Api.Controllers
         [HttpPost("get-yubikey")]
         public async Task<TwoFactorYubiKeyResponseModel> GetYubiKey([FromBody]TwoFactorRequestModel model)
         {
-            var user = await CheckAsync(model.MasterPasswordHash, true);
+            var user = await CheckAsync(model.Secret, true);
             var response = new TwoFactorYubiKeyResponseModel(user);
             return response;
         }
@@ -119,7 +119,7 @@ namespace Bit.Api.Controllers
         [HttpPost("yubikey")]
         public async Task<TwoFactorYubiKeyResponseModel> PutYubiKey([FromBody]UpdateTwoFactorYubicoOtpRequestModel model)
         {
-            var user = await CheckAsync(model.MasterPasswordHash, true);
+            var user = await CheckAsync(model.Secret, true);
             model.ToUser(user);
 
             await ValidateYubiKeyAsync(user, nameof(model.Key1), model.Key1);
@@ -136,7 +136,7 @@ namespace Bit.Api.Controllers
         [HttpPost("get-duo")]
         public async Task<TwoFactorDuoResponseModel> GetDuo([FromBody]TwoFactorRequestModel model)
         {
-            var user = await CheckAsync(model.MasterPasswordHash, true);
+            var user = await CheckAsync(model.Secret, true);
             var response = new TwoFactorDuoResponseModel(user);
             return response;
         }
@@ -145,7 +145,7 @@ namespace Bit.Api.Controllers
         [HttpPost("duo")]
         public async Task<TwoFactorDuoResponseModel> PutDuo([FromBody]UpdateTwoFactorDuoRequestModel model)
         {
-            var user = await CheckAsync(model.MasterPasswordHash, true);
+            var user = await CheckAsync(model.Secret, true);
             try
             {
                 var duoApi = new DuoApi(model.IntegrationKey, model.SecretKey, model.Host);
@@ -166,7 +166,7 @@ namespace Bit.Api.Controllers
         public async Task<TwoFactorDuoResponseModel> GetOrganizationDuo(string id,
             [FromBody]TwoFactorRequestModel model)
         {
-            var user = await CheckAsync(model.MasterPasswordHash, false);
+            var user = await CheckAsync(model.Secret, false);
 
             var orgIdGuid = new Guid(id);
             if (!await _currentContext.ManagePolicies(orgIdGuid))
@@ -189,7 +189,7 @@ namespace Bit.Api.Controllers
         public async Task<TwoFactorDuoResponseModel> PutOrganizationDuo(string id,
             [FromBody]UpdateTwoFactorDuoRequestModel model)
         {
-            var user = await CheckAsync(model.MasterPasswordHash, false);
+            var user = await CheckAsync(model.Secret, false);
 
             var orgIdGuid = new Guid(id);
             if (!await _currentContext.ManagePolicies(orgIdGuid))
@@ -223,7 +223,7 @@ namespace Bit.Api.Controllers
         [HttpPost("get-webauthn")]
         public async Task<TwoFactorWebAuthnResponseModel> GetWebAuthn([FromBody]TwoFactorRequestModel model)
         {
-            var user = await CheckAsync(model.MasterPasswordHash, true);
+            var user = await CheckAsync(model.Secret, true);
             var response = new TwoFactorWebAuthnResponseModel(user);
             return response;
         }
@@ -231,7 +231,7 @@ namespace Bit.Api.Controllers
         [HttpPost("get-webauthn-challenge")]
         public async Task<CredentialCreateOptions> GetWebAuthnChallenge([FromBody]TwoFactorRequestModel model)
         {
-            var user = await CheckAsync(model.MasterPasswordHash, true);
+            var user = await CheckAsync(model.Secret, true);
             var reg = await _userService.StartWebAuthnRegistrationAsync(user);
             return reg;
         }
@@ -240,7 +240,7 @@ namespace Bit.Api.Controllers
         [HttpPost("webauthn")]
         public async Task<TwoFactorWebAuthnResponseModel> PutWebAuthn([FromBody]TwoFactorWebAuthnRequestModel model)
         {
-            var user = await CheckAsync(model.MasterPasswordHash, true);
+            var user = await CheckAsync(model.Secret, true);
 
             var success = await _userService.CompleteWebAuthRegistrationAsync(
                 user, model.Id.Value, model.Name, model.DeviceResponse);
@@ -255,7 +255,7 @@ namespace Bit.Api.Controllers
         [HttpDelete("webauthn")]
         public async Task<TwoFactorWebAuthnResponseModel> DeleteWebAuthn([FromBody]TwoFactorWebAuthnDeleteRequestModel model)
         {
-            var user = await CheckAsync(model.MasterPasswordHash, true);
+            var user = await CheckAsync(model.Secret, true);
             await _userService.DeleteWebAuthnKeyAsync(user, model.Id.Value);
             var response = new TwoFactorWebAuthnResponseModel(user);
             return response;
@@ -264,7 +264,7 @@ namespace Bit.Api.Controllers
         [HttpPost("get-email")]
         public async Task<TwoFactorEmailResponseModel> GetEmail([FromBody]TwoFactorRequestModel model)
         {
-            var user = await CheckAsync(model.MasterPasswordHash, false);
+            var user = await CheckAsync(model.Secret, false);
             var response = new TwoFactorEmailResponseModel(user);
             return response;
         }
@@ -272,7 +272,7 @@ namespace Bit.Api.Controllers
         [HttpPost("send-email")]
         public async Task SendEmail([FromBody]TwoFactorEmailRequestModel model)
         {
-            var user = await CheckAsync(model.MasterPasswordHash, false);
+            var user = await CheckAsync(model.Secret, false);
             model.ToUser(user);
             await _userService.SendTwoFactorEmailAsync(user);
         }
@@ -299,7 +299,7 @@ namespace Bit.Api.Controllers
         [HttpPost("email")]
         public async Task<TwoFactorEmailResponseModel> PutEmail([FromBody]UpdateTwoFactorEmailRequestModel model)
         {
-            var user = await CheckAsync(model.MasterPasswordHash, false);
+            var user = await CheckAsync(model.Secret, false);
             model.ToUser(user);
 
             if (!await _userManager.VerifyTwoFactorTokenAsync(user,
@@ -318,7 +318,7 @@ namespace Bit.Api.Controllers
         [HttpPost("disable")]
         public async Task<TwoFactorProviderResponseModel> PutDisable([FromBody]TwoFactorProviderRequestModel model)
         {
-            var user = await CheckAsync(model.MasterPasswordHash, false);
+            var user = await CheckAsync(model.Secret, false);
             await _userService.DisableTwoFactorProviderAsync(user, model.Type.Value, _organizationService);
             var response = new TwoFactorProviderResponseModel(model.Type.Value, user);
             return response;
@@ -329,7 +329,7 @@ namespace Bit.Api.Controllers
         public async Task<TwoFactorProviderResponseModel> PutOrganizationDisable(string id,
             [FromBody]TwoFactorProviderRequestModel model)
         {
-            var user = await CheckAsync(model.MasterPasswordHash, false);
+            var user = await CheckAsync(model.Secret, false);
 
             var orgIdGuid = new Guid(id);
             if (!await _currentContext.ManagePolicies(orgIdGuid))
@@ -351,7 +351,7 @@ namespace Bit.Api.Controllers
         [HttpPost("get-recover")]
         public async Task<TwoFactorRecoverResponseModel> GetRecover([FromBody]TwoFactorRequestModel model)
         {
-            var user = await CheckAsync(model.MasterPasswordHash, false);
+            var user = await CheckAsync(model.Secret, false);
             var response = new TwoFactorRecoverResponseModel(user);
             return response;
         }
@@ -368,7 +368,7 @@ namespace Bit.Api.Controllers
             }
         }
 
-        private async Task<User> CheckAsync(string masterPasswordHash, bool premium)
+        private async Task<User> CheckAsync(string secret, bool premium)
         {
             var user = await _userService.GetUserByPrincipalAsync(User);
             if (user == null)
@@ -376,7 +376,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            if (!await _userService.CheckPasswordAsync(user, masterPasswordHash))
+            if (!await _userService.VerifyPasswordOrOTPAsync(user, secret))
             {
                 await Task.Delay(2000);
                 throw new BadRequestException("MasterPasswordHash", "Invalid password.");

--- a/src/Api/Controllers/TwoFactorController.cs
+++ b/src/Api/Controllers/TwoFactorController.cs
@@ -379,7 +379,7 @@ namespace Bit.Api.Controllers
             if (!await _userService.VerifyPasswordOrOTPAsync(user, secret))
             {
                 await Task.Delay(2000);
-                throw new BadRequestException("MasterPasswordHash", "Invalid password.");
+                throw new BadRequestException(string.Empty, "Authentication failed.");
             }
 
             if (premium && !(await _userService.CanAccessPremium(user)))

--- a/src/Core/Enums/EventType.cs
+++ b/src/Core/Enums/EventType.cs
@@ -49,11 +49,16 @@
         OrganizationUser_ResetPassword_Withdraw = 1507,
         OrganizationUser_AdminResetPassword = 1508,
         OrganizationUser_ResetSsoLink = 1509,
+        OrganizationUser_LinkedSso = 1510,
 
         Organization_Updated = 1600,
         Organization_PurgedVault = 1601,
         // Organization_ClientExportedVault = 1602,
         Organization_VaultAccessed = 1603,
+        Organization_EnabledSso = 1604,
+        Organization_DisabledSso = 1605,
+        Organization_EnabledKeyConnector = 1606,
+        Organization_DisabledKeyConnector = 1607,
 
         Policy_Updated = 1700,
         

--- a/src/Core/Enums/EventType.cs
+++ b/src/Core/Enums/EventType.cs
@@ -49,7 +49,6 @@
         OrganizationUser_ResetPassword_Withdraw = 1507,
         OrganizationUser_AdminResetPassword = 1508,
         OrganizationUser_ResetSsoLink = 1509,
-        OrganizationUser_LinkedSso = 1510,
 
         Organization_Updated = 1600,
         Organization_PurgedVault = 1601,

--- a/src/Core/IdentityServer/BaseRequestValidator.cs
+++ b/src/Core/IdentityServer/BaseRequestValidator.cs
@@ -176,7 +176,7 @@ namespace Bit.Core.IdentityServer
                 customResponse.Add("TwoFactorToken", token);
             }
 
-            SetSuccessResult(context, user, claims, customResponse);
+            await SetSuccessResult(context, user, claims, customResponse);
         }
 
         protected async Task BuildTwoFactorResultAsync(User user, Organization organization, T context)
@@ -256,7 +256,7 @@ namespace Bit.Core.IdentityServer
 
         protected abstract void SetSsoResult(T context, Dictionary<string, object> customResponse);
 
-        protected abstract void SetSuccessResult(T context, User user, List<Claim> claims,
+        protected abstract Task SetSuccessResult(T context, User user, List<Claim> claims,
             Dictionary<string, object> customResponse);
 
         protected abstract void SetErrorResult(T context, Dictionary<string, object> customResponse);

--- a/src/Core/IdentityServer/CustomTokenRequestValidator.cs
+++ b/src/Core/IdentityServer/CustomTokenRequestValidator.cs
@@ -90,13 +90,10 @@ namespace Bit.Core.IdentityServer
                 var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(organizationId);
                 var ssoConfigData = ssoConfig.GetData();
 
-                if (ssoConfigData is { UseCryptoAgent: true } && !string.IsNullOrEmpty(ssoConfigData.CryptoAgentUrl))
+                if (ssoConfigData is { UseKeyConnector: true } && !string.IsNullOrEmpty(ssoConfigData.KeyConnectorUrl))
                 {
-                    context.Result.CustomResponse["CryptoAgentUrl"] = ssoConfigData.CryptoAgentUrl;
+                    context.Result.CustomResponse["KeyConnectorUrl"] = ssoConfigData.KeyConnectorUrl;
                     // Prevent clients redirecting to set-password
-                    // TODO: Figure out if we can move this logic to the clients since this might break older clients
-                    //  although we will have issues either way with some clients supporting crypto anent and some not
-                    //  suggestion: We should roll out the clients before enabling it server wise
                     context.Result.CustomResponse["ResetMasterPassword"] = false;
                 }
             }

--- a/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
+++ b/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
@@ -106,13 +106,14 @@ namespace Bit.Core.IdentityServer
             return (user, true);
         }
 
-        protected override void SetSuccessResult(ResourceOwnerPasswordValidationContext context, User user,
+        protected override Task SetSuccessResult(ResourceOwnerPasswordValidationContext context, User user,
             List<Claim> claims, Dictionary<string, object> customResponse)
         {
             context.Result = new GrantValidationResult(user.Id.ToString(), "Application",
                 identityProvider: "bitwarden",
                 claims: claims.Count > 0 ? claims : null,
                 customResponse: customResponse);
+            return Task.CompletedTask;
         }
 
         protected override void SetTwoFactorResult(ResourceOwnerPasswordValidationContext context,

--- a/src/Core/MailTemplates/Handlebars/OTPEmail.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/OTPEmail.html.hbs
@@ -2,7 +2,12 @@
 <table width="100%" cellpadding="0" cellspacing="0" style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
     <tr style="margin: 0; box-sizing: border-box;">
         <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;" valign="top">
-            Your two-step verification code is: <b style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">{{Token}}</b>
+            Your email verification code is: <b style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">{{Token}}</b>
+        </td>
+    </tr>
+    <tr style="margin: 0; box-sizing: border-box;">
+        <td class="content-block last" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0; -webkit-text-size-adjust: none;" valign="top">
+            Use this code to complete the protected action in Bitwarden.
         </td>
     </tr>
 </table>

--- a/src/Core/MailTemplates/Handlebars/OTPEmail.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/OTPEmail.html.hbs
@@ -1,0 +1,9 @@
+﻿{{#>FullHtmlLayout}}
+<table width="100%" cellpadding="0" cellspacing="0" style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+    <tr style="margin: 0; box-sizing: border-box;">
+        <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;" valign="top">
+            Your two-step verification code is: <b style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">{{Token}}</b>
+        </td>
+    </tr>
+</table>
+{{/FullHtmlLayout}}

--- a/src/Core/MailTemplates/Handlebars/OTPEmail.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/OTPEmail.text.hbs
@@ -1,0 +1,3 @@
+﻿{{#>BasicTextLayout}}
+Your two-step verification code is: {{Token}}
+{{/BasicTextLayout}}

--- a/src/Core/MailTemplates/Handlebars/OTPEmail.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/OTPEmail.text.hbs
@@ -1,3 +1,5 @@
 ﻿{{#>BasicTextLayout}}
-Your two-step verification code is: {{Token}}
+Your email verification code is: {{Token}}
+
+Use this code to complete the protected action in Bitwarden.
 {{/BasicTextLayout}}

--- a/src/Core/Models/Api/Request/Accounts/DeleteAccountRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/DeleteAccountRequestModel.cs
@@ -2,9 +2,5 @@
 
 namespace Bit.Core.Models.Api
 {
-    public class DeleteAccountRequestModel
-    {
-        [Required]
-        public string MasterPasswordHash { get; set; }
-    }
+    public class DeleteAccountRequestModel : VerifyPasswordRequestModel { }
 }

--- a/src/Core/Models/Api/Request/Accounts/EmailRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/EmailRequestModel.cs
@@ -1,18 +1,15 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.Utilities;
+using Bit.Core.Models.Api;
 
 namespace Bit.Core.Models.Api
 {
-    public class EmailRequestModel
+    public class EmailRequestModel : VerifyPasswordRequestModel
     {
         [Required]
         [StrictEmailAddress]
         [StringLength(256)]
         public string NewEmail { get; set; }
-        [Required]
-        [StringLength(300)]
-        public string MasterPasswordHash { get; set; }
         [Required]
         [StringLength(300)]
         public string NewMasterPasswordHash { get; set; }

--- a/src/Core/Models/Api/Request/Accounts/EmailTokenRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/EmailTokenRequestModel.cs
@@ -1,16 +1,14 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.Utilities;
+using Bit.Core.Models.Api;
 
 namespace Bit.Core.Models.Api
 {
-    public class EmailTokenRequestModel
+    public class EmailTokenRequestModel : VerifyPasswordRequestModel
     {
         [Required]
         [StrictEmailAddress]
         [StringLength(256)]
         public string NewEmail { get; set; }
-        [Required]
-        [StringLength(300)]
-        public string MasterPasswordHash { get; set; }
     }
 }

--- a/src/Core/Models/Api/Request/Accounts/PasswordRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/PasswordRequestModel.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace Bit.Core.Models.Api
 {
-    public class PasswordRequestModel
+    public class PasswordRequestModel : VerifyPasswordRequestModel
     {
-        [Required]
-        [StringLength(300)]
-        public string MasterPasswordHash { get; set; }
         [Required]
         [StringLength(300)]
         public string NewMasterPasswordHash { get; set; }

--- a/src/Core/Models/Api/Request/Accounts/SecurityStampRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/SecurityStampRequestModel.cs
@@ -1,10 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
-
-namespace Bit.Core.Models.Api
+﻿namespace Bit.Core.Models.Api
 {
-    public class SecurityStampRequestModel
-    {
-        [Required]
-        public string MasterPasswordHash { get; set; }
-    }
+    public class SecurityStampRequestModel : VerifyPasswordRequestModel { }
 }

--- a/src/Core/Models/Api/Request/Accounts/SetKeyConnectorKeyRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/SetKeyConnectorKeyRequestModel.cs
@@ -4,7 +4,7 @@ using Bit.Core.Models.Table;
 
 namespace Bit.Core.Models.Api.Request.Accounts
 {
-    public class SetCryptoAgentKeyRequestModel
+    public class SetKeyConnectorKeyRequestModel
     {
         [Required]
         public string Key { get; set; }

--- a/src/Core/Models/Api/Request/Accounts/VerifyOtpRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/VerifyOtpRequestModel.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Bit.Core.Models.Api
+{
+    public class VerityOtpRequestModel
+    {
+        [Required]
+        public string Otp { get; set; }
+    }
+}

--- a/src/Core/Models/Api/Request/Accounts/VerifyOtpRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/VerifyOtpRequestModel.cs
@@ -2,7 +2,7 @@
 
 namespace Bit.Core.Models.Api
 {
-    public class VerityOtpRequestModel
+    public class VerifyOtpRequestModel
     {
         [Required]
         public string Otp { get; set; }

--- a/src/Core/Models/Api/Request/Accounts/VerifyPasswordRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/VerifyPasswordRequestModel.cs
@@ -9,6 +9,8 @@ namespace Bit.Core.Models.Api
         public string MasterPasswordHash { get; set; }
         public string OTP { get; set; }
 
+        public string Secret => SuppliedMasterPassword() ? MasterPasswordHash : OTP;
+
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
             if (string.IsNullOrEmpty(MasterPasswordHash) && string.IsNullOrEmpty(OTP))

--- a/src/Core/Models/Api/Request/Accounts/VerifyPasswordRequestModel.cs
+++ b/src/Core/Models/Api/Request/Accounts/VerifyPasswordRequestModel.cs
@@ -1,12 +1,25 @@
-﻿using System;
+﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace Bit.Core.Models.Api
 {
-    public class VerifyPasswordRequestModel
+    public class VerifyPasswordRequestModel : IValidatableObject
     {
-        [Required]
         [StringLength(300)]
         public string MasterPasswordHash { get; set; }
+        public string OTP { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (string.IsNullOrEmpty(MasterPasswordHash) && string.IsNullOrEmpty(OTP))
+            {
+                yield return new ValidationResult("MasterPasswordHash or OTP must be supplied.");
+            }
+        }
+
+        public bool SuppliedMasterPassword()
+        {
+            return !string.IsNullOrEmpty(MasterPasswordHash);
+        }
     }
 }

--- a/src/Core/Models/Api/Request/ApiKeyRequestModel.cs
+++ b/src/Core/Models/Api/Request/ApiKeyRequestModel.cs
@@ -1,24 +1,4 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-
-namespace Bit.Core.Models.Api
+﻿namespace Bit.Core.Models.Api
 {
-    public class ApiKeyRequestModel : IValidatableObject
-    {
-        public string MasterPasswordHash { get; set; }
-        public string OTP { get; set; }
-
-        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-        {
-            if (string.IsNullOrEmpty(MasterPasswordHash) && string.IsNullOrEmpty(OTP))
-            {
-                yield return new ValidationResult("MasterPasswordHash or OTP must be supplied.");
-            }
-        }
-
-        public bool SuppliedMasterPassword()
-        {
-            return !string.IsNullOrEmpty(MasterPasswordHash);
-        }
-    }
+    public class ApiKeyRequestModel : VerifyPasswordRequestModel { }
 }

--- a/src/Core/Models/Api/Request/ApiKeyRequestModel.cs
+++ b/src/Core/Models/Api/Request/ApiKeyRequestModel.cs
@@ -1,10 +1,24 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace Bit.Core.Models.Api
 {
-    public class ApiKeyRequestModel
+    public class ApiKeyRequestModel : IValidatableObject
     {
-        [Required]
         public string MasterPasswordHash { get; set; }
+        public string OTP { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (string.IsNullOrEmpty(MasterPasswordHash) && string.IsNullOrEmpty(OTP))
+            {
+                yield return new ValidationResult("MasterPasswordHash or OTP must be supplied.");
+            }
+        }
+
+        public bool SuppliedMasterPassword()
+        {
+            return !string.IsNullOrEmpty(MasterPasswordHash);
+        }
     }
 }

--- a/src/Core/Models/Api/Request/CipherPurgeRequestModel.cs
+++ b/src/Core/Models/Api/Request/CipherPurgeRequestModel.cs
@@ -1,10 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
-
-namespace Bit.Core.Models.Api
+﻿namespace Bit.Core.Models.Api
 {
-    public class CipherPurgeRequestModel
-    {
-        [Required]
-        public string MasterPasswordHash { get; set; }
-    }
+    public class CipherPurgeRequestModel: VerifyPasswordRequestModel { }
 }

--- a/src/Core/Models/Api/Request/Organizations/OrganizationDeleteRequestModel.cs
+++ b/src/Core/Models/Api/Request/Organizations/OrganizationDeleteRequestModel.cs
@@ -1,10 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
-
-namespace Bit.Core.Models.Api
+﻿namespace Bit.Core.Models.Api
 {
-    public class OrganizationDeleteRequestModel
-    {
-        [Required]
-        public string MasterPasswordHash { get; set; }
-    }
+    public class OrganizationDeleteRequestModel : VerifyPasswordRequestModel { }
 }

--- a/src/Core/Models/Api/Request/Organizations/OrganizationSsoRequestModel.cs
+++ b/src/Core/Models/Api/Request/Organizations/OrganizationSsoRequestModel.cs
@@ -8,7 +8,6 @@ using Bit.Core.Sso;
 using U2F.Core.Utils;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using System.Text.Json;
 using System.Text.RegularExpressions;
 using Bit.Core.Models.Table;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -39,41 +38,6 @@ namespace Bit.Core.Models.Api
     public class SsoConfigurationDataRequest : IValidatableObject
     {
         public SsoConfigurationDataRequest() {}
-
-        public SsoConfigurationDataRequest(SsoConfigurationData configurationData)
-        {
-            ConfigType = configurationData.ConfigType;
-            UseCryptoAgent = configurationData.UseCryptoAgent;
-            CryptoAgentUrl = configurationData.CryptoAgentUrl;
-            Authority = configurationData.Authority;
-            ClientId = configurationData.ClientId;
-            ClientSecret = configurationData.ClientSecret;
-            MetadataAddress = configurationData.MetadataAddress;
-            RedirectBehavior = configurationData.RedirectBehavior;
-            GetClaimsFromUserInfoEndpoint = configurationData.GetClaimsFromUserInfoEndpoint;
-            IdpEntityId = configurationData.IdpEntityId;
-            IdpBindingType = configurationData.IdpBindingType;
-            IdpSingleSignOnServiceUrl = configurationData.IdpSingleSignOnServiceUrl;
-            IdpSingleLogoutServiceUrl = configurationData.IdpSingleLogoutServiceUrl;
-            IdpArtifactResolutionServiceUrl = configurationData.IdpArtifactResolutionServiceUrl;
-            IdpX509PublicCert = configurationData.IdpX509PublicCert;
-            IdpOutboundSigningAlgorithm = configurationData.IdpOutboundSigningAlgorithm;
-            IdpAllowUnsolicitedAuthnResponse = configurationData.IdpAllowUnsolicitedAuthnResponse;
-            IdpDisableOutboundLogoutRequests = configurationData.IdpDisableOutboundLogoutRequests;
-            IdpWantAuthnRequestsSigned = configurationData.IdpWantAuthnRequestsSigned;
-            SpNameIdFormat = configurationData.SpNameIdFormat;
-            SpOutboundSigningAlgorithm = configurationData.SpOutboundSigningAlgorithm ?? SamlSigningAlgorithms.Sha256;
-            SpSigningBehavior = configurationData.SpSigningBehavior;
-            SpWantAssertionsSigned = configurationData.SpWantAssertionsSigned;
-            SpValidateCertificates = configurationData.SpValidateCertificates;
-            SpMinIncomingSigningAlgorithm = configurationData.SpMinIncomingSigningAlgorithm ?? SamlSigningAlgorithms.Sha256;
-            AdditionalScopes = configurationData.AdditionalScopes;
-            AdditionalUserIdClaimTypes = configurationData.AdditionalUserIdClaimTypes;
-            AdditionalEmailClaimTypes = configurationData.AdditionalEmailClaimTypes;
-            AdditionalNameClaimTypes = configurationData.AdditionalNameClaimTypes;
-            AcrValues = configurationData.AcrValues;
-            ExpectedReturnAcrValue = configurationData.ExpectedReturnAcrValue;
-        }
 
         [Required]
         public SsoType ConfigType { get; set; }

--- a/src/Core/Models/Api/Request/Organizations/OrganizationSsoRequestModel.cs
+++ b/src/Core/Models/Api/Request/Organizations/OrganizationSsoRequestModel.cs
@@ -42,9 +42,8 @@ namespace Bit.Core.Models.Api
         [Required]
         public SsoType ConfigType { get; set; }
 
-        // Crypto Agent
-        public bool UseCryptoAgent { get; set; }
-        public string CryptoAgentUrl { get; set; }
+        public bool UseKeyConnector { get; set; }
+        public string KeyConnectorUrl { get; set; }
 
         // OIDC
         public string Authority { get; set; }
@@ -160,8 +159,8 @@ namespace Bit.Core.Models.Api
             return new SsoConfigurationData
             {
                 ConfigType = ConfigType,
-                UseCryptoAgent = UseCryptoAgent,
-                CryptoAgentUrl = CryptoAgentUrl,
+                UseKeyConnector = UseKeyConnector,
+                KeyConnectorUrl = KeyConnectorUrl,
                 Authority = Authority,
                 ClientId = ClientId,
                 ClientSecret = ClientSecret,

--- a/src/Core/Models/Api/Request/TwoFactorRequestModels.cs
+++ b/src/Core/Models/Api/Request/TwoFactorRequestModels.cs
@@ -258,11 +258,7 @@ namespace Bit.Core.Models.Api
         public TwoFactorProviderType? Type { get; set; }
     }
 
-    public class TwoFactorRequestModel
-    {
-        [Required]
-        public string MasterPasswordHash { get; set; }
-    }
+    public class TwoFactorRequestModel : VerifyPasswordRequestModel { }
 
     public class TwoFactorRecoveryRequestModel : TwoFactorEmailRequestModel
     {

--- a/src/Core/Models/Api/Response/OrganizationUserResponseModel.cs
+++ b/src/Core/Models/Api/Response/OrganizationUserResponseModel.cs
@@ -79,6 +79,7 @@ namespace Bit.Core.Models.Api
             Email = organizationUser.Email;
             TwoFactorEnabled = twoFactorEnabled;
             SsoBound = !string.IsNullOrWhiteSpace(organizationUser.SsoExternalId);
+            ResetPasswordEnrolled = ResetPasswordEnrolled && !organizationUser.UsesKeyConnector;
         }
 
         public string Name { get; set; }

--- a/src/Core/Models/Api/Response/ProfileOrganizationResponseModel.cs
+++ b/src/Core/Models/Api/Response/ProfileOrganizationResponseModel.cs
@@ -41,8 +41,8 @@ namespace Bit.Core.Models.Api
             if (organization.SsoConfig != null)
             {
                 var ssoConfigData = SsoConfigurationData.Deserialize(organization.SsoConfig);
-                UsesCryptoAgent = ssoConfigData.UseCryptoAgent && !string.IsNullOrEmpty(ssoConfigData.CryptoAgentUrl);
-                CryptoAgentUrl = ssoConfigData.CryptoAgentUrl;
+                UsesKeyConnector = ssoConfigData.UseKeyConnector && !string.IsNullOrEmpty(ssoConfigData.KeyConnectorUrl);
+                KeyConnectorUrl = ssoConfigData.KeyConnectorUrl;
             }
         }
 
@@ -74,7 +74,7 @@ namespace Bit.Core.Models.Api
         public bool HasPublicAndPrivateKeys { get; set; }
         public string ProviderId { get; set; }
         public string ProviderName { get; set; }
-        public bool UsesCryptoAgent { get; set; }
-        public string CryptoAgentUrl { get; set; }
+        public bool UsesKeyConnector { get; set; }
+        public string KeyConnectorUrl { get; set; }
     }
 }

--- a/src/Core/Models/Api/Response/ProfileOrganizationResponseModel.cs
+++ b/src/Core/Models/Api/Response/ProfileOrganizationResponseModel.cs
@@ -38,6 +38,12 @@ namespace Bit.Core.Models.Api
             UserId = organization.UserId?.ToString();
             ProviderId = organization.ProviderId?.ToString();
             ProviderName = organization.ProviderName;
+            if (organization.SsoConfig != null)
+            {
+                var ssoConfigData = SsoConfigurationData.Deserialize(organization.SsoConfig);
+                UsesCryptoAgent = ssoConfigData.UseCryptoAgent && !string.IsNullOrEmpty(ssoConfigData.CryptoAgentUrl);
+                CryptoAgentUrl = ssoConfigData.CryptoAgentUrl;
+            }
         }
 
         public string Id { get; set; }
@@ -68,5 +74,7 @@ namespace Bit.Core.Models.Api
         public bool HasPublicAndPrivateKeys { get; set; }
         public string ProviderId { get; set; }
         public string ProviderName { get; set; }
+        public bool UsesCryptoAgent { get; set; }
+        public string CryptoAgentUrl { get; set; }
     }
 }

--- a/src/Core/Models/Api/Response/ProfileResponseModel.cs
+++ b/src/Core/Models/Api/Response/ProfileResponseModel.cs
@@ -31,6 +31,7 @@ namespace Bit.Core.Models.Api
             PrivateKey = user.PrivateKey;
             SecurityStamp = user.SecurityStamp;
             ForcePasswordReset = user.ForcePasswordReset;
+            UsesCryptoAgent = user.UsesCryptoAgent;
             Organizations = organizationsUserDetails?.Select(o => new ProfileOrganizationResponseModel(o));
             Providers = providerUserDetails?.Select(p => new ProfileProviderResponseModel(p));
             ProviderOrganizations =
@@ -49,6 +50,7 @@ namespace Bit.Core.Models.Api
         public string PrivateKey { get; set; }
         public string SecurityStamp { get; set; }
         public bool ForcePasswordReset { get; set; }
+        public bool UsesCryptoAgent { get; set; }
         public IEnumerable<ProfileOrganizationResponseModel> Organizations { get; set; }
         public IEnumerable<ProfileProviderResponseModel> Providers { get; set; }
         public IEnumerable<ProfileProviderOrganizationResponseModel> ProviderOrganizations { get; set; }

--- a/src/Core/Models/Api/Response/ProfileResponseModel.cs
+++ b/src/Core/Models/Api/Response/ProfileResponseModel.cs
@@ -31,7 +31,7 @@ namespace Bit.Core.Models.Api
             PrivateKey = user.PrivateKey;
             SecurityStamp = user.SecurityStamp;
             ForcePasswordReset = user.ForcePasswordReset;
-            UsesCryptoAgent = user.UsesCryptoAgent;
+            UsesKeyConnector = user.UsesKeyConnector;
             Organizations = organizationsUserDetails?.Select(o => new ProfileOrganizationResponseModel(o));
             Providers = providerUserDetails?.Select(p => new ProfileProviderResponseModel(p));
             ProviderOrganizations =
@@ -50,7 +50,7 @@ namespace Bit.Core.Models.Api
         public string PrivateKey { get; set; }
         public string SecurityStamp { get; set; }
         public bool ForcePasswordReset { get; set; }
-        public bool UsesCryptoAgent { get; set; }
+        public bool UsesKeyConnector { get; set; }
         public IEnumerable<ProfileOrganizationResponseModel> Organizations { get; set; }
         public IEnumerable<ProfileProviderResponseModel> Providers { get; set; }
         public IEnumerable<ProfileProviderOrganizationResponseModel> ProviderOrganizations { get; set; }

--- a/src/Core/Models/Data/OrganizationUserOrganizationDetails.cs
+++ b/src/Core/Models/Data/OrganizationUserOrganizationDetails.cs
@@ -33,5 +33,6 @@ namespace Bit.Core.Models.Data
         public string PrivateKey { get; set; }
         public Guid? ProviderId { get; set; }
         public string ProviderName { get; set; }
+        public string SsoConfig { get; set; }
     }
 }

--- a/src/Core/Models/Data/OrganizationUserUserDetails.cs
+++ b/src/Core/Models/Data/OrganizationUserUserDetails.cs
@@ -23,6 +23,7 @@ namespace Bit.Core.Models.Data
         public string SsoExternalId { get; set; }
         public string Permissions { get; set; }
         public string ResetPasswordKey { get; set; }
+        public bool UsesKeyConnector { get; set; }
 
         public Dictionary<TwoFactorProviderType, TwoFactorProvider> GetTwoFactorProviders()
         {

--- a/src/Core/Models/Data/SsoConfigurationData.cs
+++ b/src/Core/Models/Data/SsoConfigurationData.cs
@@ -31,9 +31,8 @@ namespace Bit.Core.Models.Data
 
         public SsoType ConfigType { get; set; }
 
-        // Crypto Agent
-        public bool UseCryptoAgent { get; set; }
-        public string CryptoAgentUrl { get; set; }
+        public bool UseKeyConnector { get; set; }
+        public string KeyConnectorUrl { get; set; }
 
         // OIDC
         public string Authority { get; set; }

--- a/src/Core/Models/Data/SsoConfigurationData.cs
+++ b/src/Core/Models/Data/SsoConfigurationData.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using Bit.Core.Enums;
 using Bit.Core.Sso;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -12,6 +13,21 @@ namespace Bit.Core.Models.Data
         private const string _oidcSigninPath = "/oidc-signin";
         private const string _oidcSignedOutPath = "/oidc-signedout";
         private const string _saml2ModulePath = "/saml2";
+
+        private static JsonSerializerOptions _jsonSerializerOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+
+        public static SsoConfigurationData Deserialize(string data)
+        {
+            return JsonSerializer.Deserialize<SsoConfigurationData>(data, _jsonSerializerOptions);
+        }
+
+        public string Serialize()
+        {
+            return JsonSerializer.Serialize(this, _jsonSerializerOptions);
+        }
 
         public SsoType ConfigType { get; set; }
 

--- a/src/Core/Models/Table/SsoConfig.cs
+++ b/src/Core/Models/Table/SsoConfig.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Text.Json;
 using Bit.Core.Models.Data;
 
 namespace Bit.Core.Models.Table
@@ -13,11 +12,6 @@ namespace Bit.Core.Models.Table
         public DateTime CreationDate { get; internal set; } = DateTime.UtcNow;
         public DateTime RevisionDate { get; internal set; } = DateTime.UtcNow;
 
-        private JsonSerializerOptions _jsonSerializerOptions = new()
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        };
-
         public void SetNewId()
         {
             // int will be auto-populated
@@ -26,12 +20,12 @@ namespace Bit.Core.Models.Table
 
         public SsoConfigurationData GetData()
         {
-            return JsonSerializer.Deserialize<SsoConfigurationData>(Data, _jsonSerializerOptions);
+            return SsoConfigurationData.Deserialize(Data);
         }
 
         public void SetData(SsoConfigurationData data)
         {
-            Data = JsonSerializer.Serialize(data, _jsonSerializerOptions);
+            Data = data.Serialize();
         }
     }
 }

--- a/src/Core/Models/Table/User.cs
+++ b/src/Core/Models/Table/User.cs
@@ -58,7 +58,7 @@ namespace Bit.Core.Models.Table
         public DateTime CreationDate { get; internal set; } = DateTime.UtcNow;
         public DateTime RevisionDate { get; internal set; } = DateTime.UtcNow;
         public bool ForcePasswordReset { get; set; }
-        public bool UsesCryptoAgent { get; set; }
+        public bool UsesKeyConnector { get; set; }
 
         public void SetNewId()
         {

--- a/src/Core/Services/IMailService.cs
+++ b/src/Core/Services/IMailService.cs
@@ -49,5 +49,6 @@ namespace Bit.Core.Services
         Task SendProviderConfirmedEmailAsync(string providerName, string email);
         Task SendProviderUserRemoved(string providerName, string email);
         Task SendUpdatedTempPasswordEmailAsync(string email, string userName);
+        Task SendOTPEmailAsync(string email, string token);
     }
 }

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -34,8 +34,8 @@ namespace Bit.Core.Services
             string token, string key);
         Task<IdentityResult> ChangePasswordAsync(User user, string masterPassword, string newMasterPassword, string key);
         Task<IdentityResult> SetPasswordAsync(User user, string newMasterPassword, string key, string orgIdentifier = null);
-        Task<IdentityResult> SetCryptoAgentKeyAsync(User user, string key, string orgIdentifier);
-        Task<IdentityResult> ConvertToCryptoAgentAsync(User user);
+        Task<IdentityResult> SetKeyConnectorKeyAsync(User user, string key, string orgIdentifier);
+        Task<IdentityResult> ConvertToKeyConnectorAsync(User user);
         Task<IdentityResult> AdminResetPasswordAsync(OrganizationUserType type, Guid orgId, Guid id, string newMasterPassword, string key);
         Task<IdentityResult> UpdateTempPasswordAsync(User user, string newMasterPassword, string key, string hint);
         Task<IdentityResult> ChangeKdfAsync(User user, string masterPassword, string newMasterPassword, string key,

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -8,6 +8,7 @@ using Bit.Core.Enums;
 using Bit.Core.Models;
 using Bit.Core.Models.Business;
 using Fido2NetLib;
+using Bit.Core.Models.Api;
 
 namespace Bit.Core.Services
 {
@@ -76,5 +77,6 @@ namespace Bit.Core.Services
         string GetUserName(ClaimsPrincipal principal);
         Task SendOTP(User user);
         Task<bool> VerifyOtp(User user, string token);
+        Task<bool> VerifyPasswordOrOTPAsync(User user, VerifyPasswordRequestModel model);
     }
 }

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -75,8 +75,8 @@ namespace Bit.Core.Services
         Task<string> GenerateSignInTokenAsync(User user, string purpose);
         Task RotateApiKeyAsync(User user);
         string GetUserName(ClaimsPrincipal principal);
-        Task SendOTP(User user);
-        Task<bool> VerifyOtp(User user, string token);
+        Task SendOTPAsync(User user);
+        Task<bool> VerifyOTPAsync(User user, string token);
         Task<bool> VerifyPasswordOrOTPAsync(User user, string secret);
     }
 }

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -77,6 +77,5 @@ namespace Bit.Core.Services
         string GetUserName(ClaimsPrincipal principal);
         Task SendOTP(User user);
         Task<bool> VerifyOtp(User user, string token);
-        Task<bool> VerifyPasswordOrOTPAsync(User user, VerifyPasswordRequestModel model);
     }
 }

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -77,5 +77,6 @@ namespace Bit.Core.Services
         string GetUserName(ClaimsPrincipal principal);
         Task SendOTP(User user);
         Task<bool> VerifyOtp(User user, string token);
+        Task<bool> VerifyPasswordOrOTPAsync(User user, string secret);
     }
 }

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -35,6 +35,7 @@ namespace Bit.Core.Services
         Task<IdentityResult> ChangePasswordAsync(User user, string masterPassword, string newMasterPassword, string key);
         Task<IdentityResult> SetPasswordAsync(User user, string newMasterPassword, string key, string orgIdentifier = null);
         Task<IdentityResult> SetCryptoAgentKeyAsync(User user, string key, string orgIdentifier);
+        Task<IdentityResult> ConvertToCryptoAgentAsync(User user);
         Task<IdentityResult> AdminResetPasswordAsync(OrganizationUserType type, Guid orgId, Guid id, string newMasterPassword, string key);
         Task<IdentityResult> UpdateTempPasswordAsync(User user, string newMasterPassword, string key, string hint);
         Task<IdentityResult> ChangeKdfAsync(User user, string masterPassword, string newMasterPassword, string key,

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -8,7 +8,6 @@ using Bit.Core.Enums;
 using Bit.Core.Models;
 using Bit.Core.Models.Business;
 using Fido2NetLib;
-using Bit.Core.Models.Api;
 
 namespace Bit.Core.Services
 {

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -74,5 +74,7 @@ namespace Bit.Core.Services
         Task<string> GenerateSignInTokenAsync(User user, string purpose);
         Task RotateApiKeyAsync(User user);
         string GetUserName(ClaimsPrincipal principal);
+        Task SendOTP(User user);
+        Task<bool> VerifyOtp(User user, string token);
     }
 }

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -755,5 +755,20 @@ namespace Bit.Core.Services
             message.Category = "UpdatedTempPassword";
             await _mailDeliveryService.SendEmailAsync(message);
         }
+
+        public async Task SendOTPEmailAsync(string email, string token)
+        {
+            var message = CreateDefaultMessage("Your OTP Verification Code", email);
+            var model = new EmailTokenViewModel
+            {
+                Token = token,
+                WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
+                SiteName = _globalSettings.SiteName,
+            };
+            await AddMessageContentAsync(message, "OTPEmail", model);
+            message.MetaData.Add("SendGridBypassListManagement", true);
+            message.Category = "OTP";
+            await _mailDeliveryService.SendEmailAsync(message);
+        }
     }
 }

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -758,7 +758,7 @@ namespace Bit.Core.Services
 
         public async Task SendOTPEmailAsync(string email, string token)
         {
-            var message = CreateDefaultMessage("Your OTP Verification Code", email);
+            var message = CreateDefaultMessage("Your Email Verification Code", email);
             var model = new EmailTokenViewModel
             {
                 Token = token,

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -909,10 +909,13 @@ namespace Bit.Core.Services
         public async Task DeleteAsync(Organization organization)
         {
             var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(organization.Id);
-            var ssoConfigData = ssoConfig.GetData();
-            if (ssoConfigData.UseCryptoAgent)
+            if (ssoConfig != null)
             {
-                throw new BadRequestException("You cannot delete an Organization that is using Customer Managed Encryption.");
+                var ssoConfigData = ssoConfig.GetData();
+                if (ssoConfigData.UseCryptoAgent)
+                {
+                    throw new BadRequestException("You cannot delete an Organization that is using Customer Managed Encryption.");
+                }
             }
 
             if (!string.IsNullOrWhiteSpace(organization.GatewaySubscriptionId))

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -908,6 +908,13 @@ namespace Bit.Core.Services
 
         public async Task DeleteAsync(Organization organization)
         {
+            var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(organization.Id);
+            var ssoConfigData = ssoConfig.GetData();
+            if (ssoConfigData.UseCryptoAgent)
+            {
+                throw new BadRequestException("You cannot delete an Organization that is using Customer Managed Encryption.");
+            }
+
             if (!string.IsNullOrWhiteSpace(organization.GatewaySubscriptionId))
             {
                 try

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -909,13 +909,9 @@ namespace Bit.Core.Services
         public async Task DeleteAsync(Organization organization)
         {
             var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(organization.Id);
-            if (ssoConfig != null)
+            if (ssoConfig?.GetData()?.UseCryptoAgent == true)
             {
-                var ssoConfigData = ssoConfig.GetData();
-                if (ssoConfigData.UseCryptoAgent)
-                {
-                    throw new BadRequestException("You cannot delete an Organization that is using Customer Managed Encryption.");
-                }
+                throw new BadRequestException("You cannot delete an Organization that is using Customer Managed Encryption.");
             }
 
             if (!string.IsNullOrWhiteSpace(organization.GatewaySubscriptionId))

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -911,7 +911,7 @@ namespace Bit.Core.Services
             var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(organization.Id);
             if (ssoConfig?.GetData()?.UseKeyConnector == true)
             {
-                throw new BadRequestException("You cannot delete an Organization that is using Customer Managed Encryption.");
+                throw new BadRequestException("You cannot delete an Organization that is using Key Connector.");
             }
 
             if (!string.IsNullOrWhiteSpace(organization.GatewaySubscriptionId))

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -909,7 +909,7 @@ namespace Bit.Core.Services
         public async Task DeleteAsync(Organization organization)
         {
             var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(organization.Id);
-            if (ssoConfig?.GetData()?.UseCryptoAgent == true)
+            if (ssoConfig?.GetData()?.UseKeyConnector == true)
             {
                 throw new BadRequestException("You cannot delete an Organization that is using Customer Managed Encryption.");
             }

--- a/src/Core/Services/Implementations/PolicyService.cs
+++ b/src/Core/Services/Implementations/PolicyService.cs
@@ -77,6 +77,7 @@ namespace Bit.Core.Services
                     break;
                 
                case PolicyType.RequireSso:
+               case PolicyType.MaximumVaultTimeout:
                    if (policy.Enabled)
                    {
                        var singleOrg = await _policyRepository.GetByOrganizationIdTypeAsync(org.Id, PolicyType.SingleOrg);

--- a/src/Core/Services/Implementations/PolicyService.cs
+++ b/src/Core/Services/Implementations/PolicyService.cs
@@ -69,9 +69,9 @@ namespace Bit.Core.Services
                         }
 
                         var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(org.Id);
-                        if (ssoConfig?.GetData()?.UseCryptoAgent == true)
+                        if (ssoConfig?.GetData()?.UseKeyConnector == true)
                         {
-                            throw new BadRequestException("CryptoAgent is enabled.");
+                            throw new BadRequestException("KeyConnector is enabled.");
                         }
                     }
                     break;

--- a/src/Core/Services/Implementations/SsoConfigService.cs
+++ b/src/Core/Services/Implementations/SsoConfigService.cs
@@ -35,12 +35,12 @@ namespace Bit.Core.Services
                 config.CreationDate = now;
             }
 
-            if (config.GetData().UseCryptoAgent)
+            if (config.GetData().UseKeyConnector)
             {
                 var policy = await _policyRepository.GetByOrganizationIdTypeAsync(config.OrganizationId, PolicyType.SingleOrg);
                 if (policy is not { Enabled: true })
                 {
-                    throw new BadRequestException("CryptoAgent requires Single Organization to be enabled");
+                    throw new BadRequestException("KeyConnector requires Single Organization to be enabled");
                 }
             }
 
@@ -52,9 +52,9 @@ namespace Bit.Core.Services
                 await _eventService.LogOrganizationEventAsync(organization, e);
             }
 
-            if (oldConfig?.GetData()?.UseCryptoAgent != config.GetData().UseCryptoAgent)
+            if (oldConfig?.GetData()?.UseKeyConnector != config.GetData().UseKeyConnector)
             {
-                var e = config.GetData().UseCryptoAgent ? EventType.Organization_EnabledKeyConnector : EventType.Organization_DisabledKeyConnector;
+                var e = config.GetData().UseKeyConnector ? EventType.Organization_EnabledKeyConnector : EventType.Organization_DisabledKeyConnector;
                 await _eventService.LogOrganizationEventAsync(organization, e);
             }
 

--- a/src/Core/Services/Implementations/SsoConfigService.cs
+++ b/src/Core/Services/Implementations/SsoConfigService.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Bit.Core.Enums;
+using Bit.Core.Exceptions;
 using Bit.Core.Models.Table;
 using Bit.Core.Repositories;
 
@@ -8,11 +10,14 @@ namespace Bit.Core.Services
     public class SsoConfigService : ISsoConfigService
     {
         private readonly ISsoConfigRepository _ssoConfigRepository;
+        private readonly IPolicyRepository _policyRepository;
 
         public SsoConfigService(
-            ISsoConfigRepository ssoConfigRepository)
+            ISsoConfigRepository ssoConfigRepository,
+            IPolicyRepository policyRepository)
         {
             _ssoConfigRepository = ssoConfigRepository;
+            _policyRepository = policyRepository;
         }
 
         public async Task SaveAsync(SsoConfig config)
@@ -23,6 +28,16 @@ namespace Bit.Core.Services
             {
                 config.CreationDate = now;
             }
+
+            if (config.GetData().UseCryptoAgent)
+            {
+                var policy = await _policyRepository.GetByOrganizationIdTypeAsync(config.OrganizationId, PolicyType.SingleOrg);
+                if (policy is not { Enabled: true })
+                {
+                    throw new BadRequestException("CryptoAgent requires Single Organization to be enabled");
+                }
+            }
+
             await _ssoConfigRepository.UpsertAsync(config);
         }
     }

--- a/src/Core/Services/Implementations/SsoConfigService.cs
+++ b/src/Core/Services/Implementations/SsoConfigService.cs
@@ -11,13 +11,19 @@ namespace Bit.Core.Services
     {
         private readonly ISsoConfigRepository _ssoConfigRepository;
         private readonly IPolicyRepository _policyRepository;
+        private readonly IOrganizationRepository _organizationRepository;
+        private readonly IEventService _eventService;
 
         public SsoConfigService(
             ISsoConfigRepository ssoConfigRepository,
-            IPolicyRepository policyRepository)
+            IPolicyRepository policyRepository,
+            IOrganizationRepository organizationRepository,
+            IEventService eventService)
         {
             _ssoConfigRepository = ssoConfigRepository;
             _policyRepository = policyRepository;
+            _organizationRepository = organizationRepository;
+            _eventService = eventService;
         }
 
         public async Task SaveAsync(SsoConfig config)
@@ -36,6 +42,20 @@ namespace Bit.Core.Services
                 {
                     throw new BadRequestException("CryptoAgent requires Single Organization to be enabled");
                 }
+            }
+
+            var oldConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(config.OrganizationId);
+            var organization = await _organizationRepository.GetByIdAsync(config.OrganizationId);
+            if (oldConfig?.Enabled != config.Enabled)
+            {
+                var e = config.Enabled ? EventType.Organization_EnabledSso : EventType.Organization_DisabledSso;
+                await _eventService.LogOrganizationEventAsync(organization, e);
+            }
+
+            if (oldConfig?.GetData()?.UseCryptoAgent != config.GetData().UseCryptoAgent)
+            {
+                var e = config.GetData().UseCryptoAgent ? EventType.Organization_EnabledKeyConnector : EventType.Organization_DisabledKeyConnector;
+                await _eventService.LogOrganizationEventAsync(organization, e);
             }
 
             await _ssoConfigRepository.UpsertAsync(config);

--- a/src/Core/Services/Implementations/SsoConfigService.cs
+++ b/src/Core/Services/Implementations/SsoConfigService.cs
@@ -45,6 +45,11 @@ namespace Bit.Core.Services
             }
 
             var oldConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(config.OrganizationId);
+            if (oldConfig?.GetData()?.UseKeyConnector == true && !config.GetData().UseKeyConnector)
+            {
+                throw new BadRequestException("KeyConnector cannot be disabled at this moment.");
+            }
+
             var organization = await _organizationRepository.GetByIdAsync(config.OrganizationId);
             if (oldConfig?.Enabled != config.Enabled)
             {

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -737,7 +737,12 @@ namespace Bit.Core.Services
             {
                 throw new NotFoundException();
             }
-            
+
+            if (user.UsesKeyConnector)
+            {
+                throw new BadRequestException("Cannot reset password of a user with key connector.");
+            }
+
             var result = await UpdatePasswordHash(user, newMasterPassword);
             if (!result.Succeeded)
             {

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -21,6 +21,7 @@ using Newtonsoft.Json;
 using Microsoft.AspNetCore.DataProtection;
 using Fido2NetLib;
 using Fido2NetLib.Objects;
+using Bit.Core.Models.Api;
 
 namespace Bit.Core.Services
 {
@@ -1372,6 +1373,13 @@ namespace Bit.Core.Services
         {
             return base.VerifyUserTokenAsync(user, TokenOptions.DefaultEmailProvider,
                 "otp:" + user.Email, token);
+        }
+
+        public async Task<bool> VerifyPasswordOrOTPAsync(User user, VerifyPasswordRequestModel model)
+        {
+            return user.UsesCryptoAgent && !model.SuppliedMasterPassword()
+                ? await VerifyOtp(user, model.OTP)
+                : await CheckPasswordAsync(user, model.MasterPasswordHash);
         }
     }
 }

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -655,7 +655,6 @@ namespace Bit.Core.Services
             user.UsesCryptoAgent = true;
 
             await _userRepository.ReplaceAsync(user);
-            // TODO: Use correct event
             await _eventService.LogUserEventAsync(user.Id, EventType.User_ChangedPassword);
 
             await _organizationService.AcceptUserAsync(orgIdentifier, user, this);
@@ -681,7 +680,6 @@ namespace Bit.Core.Services
             user.UsesCryptoAgent = true;
 
             await _userRepository.ReplaceAsync(user);
-            // TODO: Use correct event
             await _eventService.LogUserEventAsync(user.Id, EventType.User_ChangedPassword);
 
             return IdentityResult.Success;

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -1350,5 +1350,28 @@ namespace Bit.Core.Services
             user.RevisionDate = DateTime.UtcNow;
             await _userRepository.ReplaceAsync(user);
         }
+
+        public async Task SendOTP(User user)
+        {
+            if (user.Email == null)
+            {
+                throw new BadRequestException("No user email.");
+            }
+
+            if (!user.UsesCryptoAgent)
+            {
+                throw new BadRequestException("Not using crypto agent.");
+            }
+
+            var token = await base.GenerateUserTokenAsync(user, TokenOptions.DefaultEmailProvider,
+                "otp:" + user.Email);
+            await _mailService.SendOTPEmailAsync(user.Email, token);
+        }
+
+        public Task<bool> VerifyOtp(User user, string token)
+        {
+            return base.VerifyUserTokenAsync(user, TokenOptions.DefaultEmailProvider,
+                "otp:" + user.Email, token);
+        }
     }
 }

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -1378,5 +1378,12 @@ namespace Bit.Core.Services
             return base.VerifyUserTokenAsync(user, TokenOptions.DefaultEmailProvider,
                 "otp:" + user.Email, token);
         }
+
+        public async Task<bool> VerifyPasswordOrOTPAsync(User user, string secret)
+        {
+            return user.UsesCryptoAgent
+                ? await VerifyOtp(user, secret)
+                : await CheckPasswordAsync(user, secret);
+        }
     }
 }

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -829,7 +829,7 @@ namespace Bit.Core.Services
             }
 
             var validSecret = user.UsesCryptoAgent
-                ? await VerifyOtp(user, secret)
+                ? await VerifyOTPAsync(user, secret)
                 : await CheckPasswordAsync(user, secret);
 
             if (validSecret)
@@ -1356,7 +1356,7 @@ namespace Bit.Core.Services
             await _userRepository.ReplaceAsync(user);
         }
 
-        public async Task SendOTP(User user)
+        public async Task SendOTPAsync(User user)
         {
             if (user.Email == null)
             {
@@ -1373,7 +1373,7 @@ namespace Bit.Core.Services
             await _mailService.SendOTPEmailAsync(user.Email, token);
         }
 
-        public Task<bool> VerifyOtp(User user, string token)
+        public Task<bool> VerifyOTPAsync(User user, string token)
         {
             return base.VerifyUserTokenAsync(user, TokenOptions.DefaultEmailProvider,
                 "otp:" + user.Email, token);
@@ -1382,7 +1382,7 @@ namespace Bit.Core.Services
         public async Task<bool> VerifyPasswordOrOTPAsync(User user, string secret)
         {
             return user.UsesCryptoAgent
-                ? await VerifyOtp(user, secret)
+                ? await VerifyOTPAsync(user, secret)
                 : await CheckPasswordAsync(user, secret);
         }
     }

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -1374,12 +1374,5 @@ namespace Bit.Core.Services
             return base.VerifyUserTokenAsync(user, TokenOptions.DefaultEmailProvider,
                 "otp:" + user.Email, token);
         }
-
-        public async Task<bool> VerifyPasswordOrOTPAsync(User user, VerifyPasswordRequestModel model)
-        {
-            return user.UsesCryptoAgent && !model.SuppliedMasterPassword()
-                ? await VerifyOtp(user, model.OTP)
-                : await CheckPasswordAsync(user, model.MasterPasswordHash);
-        }
     }
 }

--- a/src/Core/Services/NoopImplementations/NoopMailService.cs
+++ b/src/Core/Services/NoopImplementations/NoopMailService.cs
@@ -200,5 +200,10 @@ namespace Bit.Core.Services
         {
             return Task.FromResult(0);
         }
+
+        public Task SendOTPEmailAsync(string email, string token)
+        {
+            return Task.FromResult(0);
+        }
     }
 }

--- a/src/Core/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Core/Utilities/ServiceCollectionExtensions.cs
@@ -175,7 +175,7 @@ namespace Bit.Core.Utilities
             services.AddScoped<IEmergencyAccessService, EmergencyAccessService>();
             services.AddSingleton<IDeviceService, DeviceService>();
             services.AddSingleton<IAppleIapService, AppleIapService>();
-            services.AddSingleton<ISsoConfigService, SsoConfigService>();
+            services.AddScoped<ISsoConfigService, SsoConfigService>();
             services.AddScoped<ISendService, SendService>();
         }
 

--- a/src/Sql/dbo/Stored Procedures/User_Create.sql
+++ b/src/Sql/dbo/Stored Procedures/User_Create.sql
@@ -31,7 +31,7 @@
     @RevisionDate DATETIME2(7),
     @ApiKey VARCHAR(30),
     @ForcePasswordReset BIT = 0,
-    @UsesCryptoAgent BIT = 0
+    @UsesKeyConnector BIT = 0
 AS
 BEGIN
     SET NOCOUNT ON
@@ -70,7 +70,7 @@ BEGIN
         [RevisionDate],
         [ApiKey],
         [ForcePasswordReset],
-        [UsesCryptoAgent]
+        [UsesKeyConnector]
     )
     VALUES
     (
@@ -106,6 +106,6 @@ BEGIN
         @RevisionDate,
         @ApiKey,
         @ForcePasswordReset,
-        @UsesCryptoAgent
+        @UsesKeyConnector
     )
 END

--- a/src/Sql/dbo/Stored Procedures/User_Update.sql
+++ b/src/Sql/dbo/Stored Procedures/User_Update.sql
@@ -31,7 +31,7 @@
     @RevisionDate DATETIME2(7),
     @ApiKey VARCHAR(30),
     @ForcePasswordReset BIT = 0,
-    @UsesCryptoAgent BIT = 0
+    @UsesKeyConnector BIT = 0
 AS
 BEGIN
     SET NOCOUNT ON
@@ -70,7 +70,7 @@ BEGIN
         [RevisionDate] = @RevisionDate,
         [ApiKey] = @ApiKey,
         [ForcePasswordReset] = @ForcePasswordReset,
-        [UsesCryptoAgent] = @UsesCryptoAgent
+        [UsesKeyConnector] = @UsesKeyConnector
     WHERE
         [Id] = @Id
 END

--- a/src/Sql/dbo/Tables/User.sql
+++ b/src/Sql/dbo/Tables/User.sql
@@ -31,7 +31,7 @@
     [RevisionDate]                    DATETIME2 (7)    NOT NULL,
     [ApiKey]                          VARCHAR (30)     NOT NULL,
     [ForcePasswordReset]              BIT              NOT NULL,
-    [UsesCryptoAgent]                 BIT              NOT NULL,
+    [UsesKeyConnector]                BIT              NOT NULL,
     CONSTRAINT [PK_User] PRIMARY KEY CLUSTERED ([Id] ASC)
 );
 

--- a/src/Sql/dbo/Views/OrganizationUserOrganizationDetailsView.sql
+++ b/src/Sql/dbo/Views/OrganizationUserOrganizationDetailsView.sql
@@ -29,7 +29,8 @@ SELECT
     SU.[ExternalId] SsoExternalId,
     OU.[Permissions],
     PO.[ProviderId],
-    P.[Name] ProviderName
+    P.[Name] ProviderName,
+    SS.[Data] SsoConfig
 FROM
     [dbo].[OrganizationUser] OU
 INNER JOIN
@@ -40,3 +41,5 @@ LEFT JOIN
     [dbo].[ProviderOrganization] PO ON PO.[OrganizationId] = O.[Id]
 LEFT JOIN
     [dbo].[Provider] P ON P.[Id] = PO.[ProviderId]
+LEFT JOIN
+    [dbo].[SsoConfig] SS ON SS.[OrganizationId] = OU.[OrganizationId]

--- a/src/Sql/dbo/Views/OrganizationUserUserDetailsView.sql
+++ b/src/Sql/dbo/Views/OrganizationUserUserDetailsView.sql
@@ -14,7 +14,8 @@ SELECT
     OU.[ExternalId],
     SU.[ExternalId] SsoExternalId,
     OU.[Permissions],
-    OU.[ResetPasswordKey]
+    OU.[ResetPasswordKey],
+    U.[UsesKeyConnector]
 FROM
     [dbo].[OrganizationUser] OU
 LEFT JOIN

--- a/test/Api.Test/Controllers/AccountsControllerTests.cs
+++ b/test/Api.Test/Controllers/AccountsControllerTests.cs
@@ -406,6 +406,8 @@ namespace Bit.Api.Test.Controllers
 
         private void ConfigureUserServiceToAcceptPasswordFor(User user)
         {
+            _userService.CheckPasswordAsync(user, Arg.Any<string>())
+                        .Returns(Task.FromResult(true));
             _userService.VerifyPasswordOrOTPAsync(user, Arg.Any<string>())
                         .Returns(Task.FromResult(true));
         }

--- a/test/Api.Test/Controllers/AccountsControllerTests.cs
+++ b/test/Api.Test/Controllers/AccountsControllerTests.cs
@@ -55,7 +55,6 @@ namespace Bit.Api.Test.Controllers
                 _organizationUserRepository,
                 _providerUserRepository,
                 _paymentService,
-                _ssoUserRepository,
                 _userRepository,
                 _userService,
                 _sendRepository,

--- a/test/Api.Test/Controllers/AccountsControllerTests.cs
+++ b/test/Api.Test/Controllers/AccountsControllerTests.cs
@@ -406,7 +406,7 @@ namespace Bit.Api.Test.Controllers
 
         private void ConfigureUserServiceToAcceptPasswordFor(User user)
         {
-            _userService.CheckPasswordAsync(user, Arg.Any<string>())
+            _userService.VerifyPasswordOrOTPAsync(user, Arg.Any<string>())
                         .Returns(Task.FromResult(true));
         }
 

--- a/test/Core.Test/Services/PolicyServiceTests.cs
+++ b/test/Core.Test/Services/PolicyServiceTests.cs
@@ -127,7 +127,7 @@ namespace Bit.Core.Test.Services
         }
 
         [Theory, CustomAutoData(typeof(SutProviderCustomization))]
-        public async Task SaveAsync_SingleOrg_CryptoAgentEnabled_ThrowsBadRequest([PolicyFixtures.Policy(Enums.PolicyType.SingleOrg)] Core.Models.Table.Policy policy, SutProvider<PolicyService> sutProvider)
+        public async Task SaveAsync_SingleOrg_KeyConnectorEnabled_ThrowsBadRequest([PolicyFixtures.Policy(Enums.PolicyType.SingleOrg)] Core.Models.Table.Policy policy, SutProvider<PolicyService> sutProvider)
         {
             policy.Enabled = false;
 
@@ -138,7 +138,7 @@ namespace Bit.Core.Test.Services
             });
 
             var ssoConfig = new SsoConfig { Enabled = true };
-            var data = new SsoConfigurationData { UseCryptoAgent = true };
+            var data = new SsoConfigurationData { UseKeyConnector = true };
             ssoConfig.SetData(data);
 
             sutProvider.GetDependency<ISsoConfigRepository>()
@@ -151,7 +151,7 @@ namespace Bit.Core.Test.Services
                     Substitute.For<IOrganizationService>(),
                     Guid.NewGuid()));
 
-            Assert.Contains("CryptoAgent is enabled.", badRequestException.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("KeyConnector is enabled.", badRequestException.Message, StringComparison.OrdinalIgnoreCase);
 
             await sutProvider.GetDependency<IPolicyRepository>()
                 .DidNotReceiveWithAnyArgs()

--- a/test/Core.Test/Services/SsoConfigServiceTests.cs
+++ b/test/Core.Test/Services/SsoConfigServiceTests.cs
@@ -21,7 +21,7 @@ namespace Bit.Core.Test.Services
             var ssoConfig = new SsoConfig
             {
                 Id = 1,
-                Data = "TESTDATA",
+                Data = "{}",
                 Enabled = true,
                 OrganizationId = Guid.NewGuid(),
                 CreationDate = utcNow.AddDays(-10),
@@ -48,7 +48,7 @@ namespace Bit.Core.Test.Services
             var ssoConfig = new SsoConfig
             {
                 Id = default,
-                Data = "TESTDATA",
+                Data = "{}",
                 Enabled = true,
                 OrganizationId = Guid.NewGuid(),
                 CreationDate = utcNow.AddDays(-10),

--- a/util/Migrator/DbScripts/2021-11-02_00_CryptoAgent.sql
+++ b/util/Migrator/DbScripts/2021-11-02_00_CryptoAgent.sql
@@ -299,3 +299,35 @@ FROM
     [dbo].[Provider] P ON P.[Id] = PO.[ProviderId]
         LEFT JOIN
     [dbo].[SsoConfig] SS ON SS.[OrganizationId] = OU.[OrganizationId]
+GO
+
+IF EXISTS(SELECT * FROM sys.views WHERE [Name] = 'OrganizationUserUserDetailsView')
+    BEGIN
+        DROP VIEW [dbo].[OrganizationUserUserDetailsView]
+    END
+GO
+
+CREATE VIEW [dbo].[OrganizationUserUserDetailsView]
+AS
+SELECT
+    OU.[Id],
+    OU.[UserId],
+    OU.[OrganizationId],
+    U.[Name],
+    ISNULL(U.[Email], OU.[Email]) Email,
+    U.[TwoFactorProviders],
+    U.[Premium],
+    OU.[Status],
+    OU.[Type],
+    OU.[AccessAll],
+    OU.[ExternalId],
+    SU.[ExternalId] SsoExternalId,
+    OU.[Permissions],
+    OU.[ResetPasswordKey],
+    U.[UsesKeyConnector]
+FROM
+    [dbo].[OrganizationUser] OU
+LEFT JOIN
+    [dbo].[User] U ON U.[Id] = OU.[UserId]
+LEFT JOIN
+    [dbo].[SsoUser] SU ON SU.[UserId] = OU.[UserId] AND SU.[OrganizationId] = OU.[OrganizationId]

--- a/util/Migrator/DbScripts/2021-11-02_00_CryptoAgent.sql
+++ b/util/Migrator/DbScripts/2021-11-02_00_CryptoAgent.sql
@@ -237,3 +237,56 @@ BEGIN
     WHERE
         [Id] = @Id
 END
+GO
+
+IF EXISTS(SELECT * FROM sys.views WHERE [Name] = 'OrganizationUserOrganizationDetailsView')
+BEGIN
+    DROP VIEW [dbo].[OrganizationUserOrganizationDetailsView]
+END
+GO
+
+CREATE VIEW [dbo].[OrganizationUserOrganizationDetailsView]
+AS
+SELECT
+    OU.[UserId],
+    OU.[OrganizationId],
+    O.[Name],
+    O.[Enabled],
+    O.[UsePolicies],
+    O.[UseSso],
+    O.[UseGroups],
+    O.[UseDirectory],
+    O.[UseEvents],
+    O.[UseTotp],
+    O.[Use2fa],
+    O.[UseApi],
+    O.[UseResetPassword],
+    O.[SelfHost],
+    O.[UsersGetPremium],
+    O.[Seats],
+    O.[MaxCollections],
+    O.[MaxStorageGb],
+    O.[Identifier],
+    OU.[Key],
+    OU.[ResetPasswordKey],
+    O.[PublicKey],
+    O.[PrivateKey],
+    OU.[Status],
+    OU.[Type],
+    SU.[ExternalId] SsoExternalId,
+    OU.[Permissions],
+    PO.[ProviderId],
+    P.[Name] ProviderName,
+    SS.[Data] SsoConfig
+FROM
+    [dbo].[OrganizationUser] OU
+        INNER JOIN
+    [dbo].[Organization] O ON O.[Id] = OU.[OrganizationId]
+        LEFT JOIN
+    [dbo].[SsoUser] SU ON SU.[UserId] = OU.[UserId] AND SU.[OrganizationId] = OU.[OrganizationId]
+        LEFT JOIN
+    [dbo].[ProviderOrganization] PO ON PO.[OrganizationId] = O.[Id]
+        LEFT JOIN
+    [dbo].[Provider] P ON P.[Id] = PO.[ProviderId]
+        LEFT JOIN
+    [dbo].[SsoConfig] SS ON SS.[OrganizationId] = OU.[OrganizationId]

--- a/util/Migrator/DbScripts/2021-11-02_00_CryptoAgent.sql
+++ b/util/Migrator/DbScripts/2021-11-02_00_CryptoAgent.sql
@@ -1,24 +1,33 @@
-IF COL_LENGTH('[dbo].[User]', 'UsesCryptoAgent') IS NULL
+IF COL_LENGTH('[dbo].[User]', 'UsesCryptoAgent') IS NOT NULL
+    BEGIN
+        ALTER TABLE
+            [dbo].[User]
+        DROP COLUMN
+            [UsesCryptoAgent]
+    END
+GO
+
+IF COL_LENGTH('[dbo].[User]', 'UsesKeyConnector') IS NULL
     BEGIN
         ALTER TABLE
             [dbo].[User]
         ADD
-            [UsesCryptoAgent] BIT NULL
+            [UsesKeyConnector] BIT NULL
     END
 GO
 
 UPDATE
     [dbo].[User]
 SET
-    [UsesCryptoAgent] = 0
+    [UsesKeyConnector] = 0
 WHERE
-    [UsesCryptoAgent] IS NULL
+    [UsesKeyConnector] IS NULL
 GO
 
 ALTER TABLE
     [dbo].[User]
 ALTER COLUMN
-    [UsesCryptoAgent] BIT NOT NULL
+    [UsesKeyConnector] BIT NOT NULL
 GO
 
 -- View: User
@@ -75,7 +84,7 @@ CREATE PROCEDURE [dbo].[User_Create]
     @RevisionDate DATETIME2(7),
     @ApiKey VARCHAR(30),
     @ForcePasswordReset BIT = 0,
-    @UsesCryptoAgent BIT = 0
+    @UsesKeyConnector BIT = 0
 AS
 BEGIN
     SET NOCOUNT ON
@@ -114,7 +123,7 @@ BEGIN
         [RevisionDate],
         [ApiKey],
         [ForcePasswordReset],
-        [UsesCryptoAgent]
+        [UsesKeyConnector]
     )
     VALUES
     (
@@ -150,7 +159,7 @@ BEGIN
         @RevisionDate,
         @ApiKey,
         @ForcePasswordReset,
-        @UsesCryptoAgent
+        @UsesKeyConnector
     )
 END
 GO
@@ -194,7 +203,7 @@ CREATE PROCEDURE [dbo].[User_Update]
     @RevisionDate DATETIME2(7),
     @ApiKey VARCHAR(30),
     @ForcePasswordReset BIT = 0,
-    @UsesCryptoAgent BIT = 0
+    @UsesKeyConnector BIT = 0
 AS
 BEGIN
     SET NOCOUNT ON
@@ -233,7 +242,7 @@ BEGIN
         [RevisionDate] = @RevisionDate,
         [ApiKey] = @ApiKey,
         [ForcePasswordReset] = @ForcePasswordReset,
-        [UsesCryptoAgent] = @UsesCryptoAgent
+        [UsesKeyConnector] = @UsesKeyConnector
     WHERE
         [Id] = @Id
 END

--- a/util/MySqlMigrations/Migrations/20211108031338_CryptoAgent.Designer.cs
+++ b/util/MySqlMigrations/Migrations/20211108031338_CryptoAgent.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using Bit.Core.Repositories.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Bit.MySqlMigrations.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20211108031338_CryptoAgent")]
+    partial class CryptoAgent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/util/MySqlMigrations/Migrations/20211108031338_CryptoAgent.cs
+++ b/util/MySqlMigrations/Migrations/20211108031338_CryptoAgent.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Bit.MySqlMigrations.Migrations
+{
+    public partial class CryptoAgent : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "UsesKeyConnector",
+                table: "User",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UsesKeyConnector",
+                table: "User");
+        }
+    }
+}

--- a/util/MySqlMigrations/Scripts/2021-11-08_00_CryptoAgent.sql
+++ b/util/MySqlMigrations/Scripts/2021-11-08_00_CryptoAgent.sql
@@ -1,0 +1,9 @@
+﻿START TRANSACTION;
+
+ALTER TABLE `User` ADD `UsesKeyConnector` tinyint(1) NOT NULL DEFAULT FALSE;
+
+INSERT INTO `__EFMigrationsHistory` (`MigrationId`, `ProductVersion`)
+VALUES ('20211108031338_CryptoAgent', '5.0.9');
+
+COMMIT;
+

--- a/util/PostgresMigrations/Migrations/20211108014546_CryptoAgent.Designer.cs
+++ b/util/PostgresMigrations/Migrations/20211108014546_CryptoAgent.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Bit.Core.Repositories.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Bit.PostgresMigrations.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20211108014546_CryptoAgent")]
+    partial class CryptoAgent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/util/PostgresMigrations/Migrations/20211108014546_CryptoAgent.cs
+++ b/util/PostgresMigrations/Migrations/20211108014546_CryptoAgent.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Bit.PostgresMigrations.Migrations
+{
+    public partial class CryptoAgent : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "UsesKeyConnector",
+                table: "User",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UsesKeyConnector",
+                table: "User");
+        }
+    }
+}

--- a/util/PostgresMigrations/Scripts/2021-11-08_00_CryptoAgent.psql
+++ b/util/PostgresMigrations/Scripts/2021-11-08_00_CryptoAgent.psql
@@ -1,0 +1,9 @@
+﻿START TRANSACTION;
+
+ALTER TABLE "User" ADD "UsesKeyConnector" boolean NOT NULL DEFAULT FALSE;
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('20211108014546_CryptoAgent', '5.0.9');
+
+COMMIT;
+


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Follow-up from #1623: Adds EF migration scripts for Postgres and MySQL for the `User.UsesCryptoAgent` column.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Generated migrations using the wiki instructions: see `util/MySqlMigrations` and `util/PostgresMigrations`.

Note: I have dated these migrations as of today, because I figured that keeping true chronological order was more important than trying to backdate them to match the MSSQL date.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

None, QA does not test EF providers at this time (afaik).

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
