### PR TITLE
Initial db work

### DIFF
--- a/src/Core/Models/EntityFramework/OrganizationSponsorship.cs
+++ b/src/Core/Models/EntityFramework/OrganizationSponsorship.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using AutoMapper;
+
+namespace Bit.Core.Models.EntityFramework
+{
+    public class OrganizationSponsorship : Table.OrganizationSponsorship
+    {
+        public virtual Installation Installation { get; set; }
+        public virtual Organization SponsoringOrganization { get; set; }
+        public virtual Organization SponsoredOrganization { get; set; }
+    }
+
+    public class OrganizationSponsorshipMapperProfile : Profile
+    {
+        public OrganizationSponsorshipMapperProfile()
+        {
+            CreateMap<Table.OrganizationSponsorship, OrganizationSponsorship>().ReverseMap();
+        }
+    }
+}

--- a/src/Core/Models/Table/OrganizationSponsorship.cs
+++ b/src/Core/Models/Table/OrganizationSponsorship.cs
@@ -7,15 +7,14 @@ namespace Bit.Core.Models.Table
     public class OrganizationSponsorship : ITableObject<Guid>
     {
         public Guid Id { get; set; }
-        public Guid InstallationId { get; set; }
+        public Guid? InstallationId { get; set; }
         [Required]
         public Guid SponsoringOrganizationId { get; set; }
         [Required]
         public Guid SponsoringOrganizationUserId { get; set; }
-        public Guid SponsoringUserId { get; set; }
+        public Guid? SponsoredOrganizationId { get; set; }
         [MaxLength(256)]
         public string OfferedToEmail { get; set; }
-        public Guid? SponsoredOrganizationId { get; set; }
         [Required]
         public bool CloudSponsor { get; set; }
         public DateTime? LastSyncDate { get; set; }

--- a/src/Core/Repositories/EntityFramework/DatabaseContext.cs
+++ b/src/Core/Repositories/EntityFramework/DatabaseContext.cs
@@ -26,6 +26,7 @@ namespace Bit.Core.Repositories.EntityFramework
         public DbSet<GroupUser> GroupUsers { get; set; }
         public DbSet<Installation> Installations { get; set; }
         public DbSet<Organization> Organizations { get; set; }
+        public DbSet<OrganizationSponsorship> organizationSponsorships { get; set; }
         public DbSet<OrganizationUser> OrganizationUsers { get; set; }
         public DbSet<Policy> Policies { get; set; }
         public DbSet<Provider> Providers { get; set; }
@@ -55,6 +56,7 @@ namespace Bit.Core.Repositories.EntityFramework
             var eGroupUser = builder.Entity<GroupUser>();
             var eInstallation = builder.Entity<Installation>();
             var eOrganization = builder.Entity<Organization>();
+            var eOrganizationSponsorship = builder.Entity<OrganizationSponsorship>();
             var eOrganizationUser = builder.Entity<OrganizationUser>();
             var ePolicy = builder.Entity<Policy>();
             var eProvider = builder.Entity<Provider>();
@@ -76,6 +78,7 @@ namespace Bit.Core.Repositories.EntityFramework
             eGroup.Property(c => c.Id).ValueGeneratedNever();
             eInstallation.Property(c => c.Id).ValueGeneratedNever();
             eOrganization.Property(c => c.Id).ValueGeneratedNever();
+            eOrganizationSponsorship.Property(c => c.Id).ValueGeneratedNever();
             eOrganizationUser.Property(c => c.Id).ValueGeneratedNever();
             ePolicy.Property(c => c.Id).ValueGeneratedNever();
             eProvider.Property(c => c.Id).ValueGeneratedNever();
@@ -115,6 +118,7 @@ namespace Bit.Core.Repositories.EntityFramework
             eGroupUser.ToTable(nameof(GroupUser));
             eInstallation.ToTable(nameof(Installation));
             eOrganization.ToTable(nameof(Organization));
+            eOrganizationSponsorship.ToTable(nameof(OrganizationSponsorship));
             eOrganizationUser.ToTable(nameof(OrganizationUser));
             ePolicy.ToTable(nameof(Policy));
             eProvider.ToTable(nameof(Provider));

--- a/src/Core/Repositories/EntityFramework/OrganizationSponsorshipRepository.cs
+++ b/src/Core/Repositories/EntityFramework/OrganizationSponsorshipRepository.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using EFModel = Bit.Core.Models.EntityFramework;
+using TableModel = Bit.Core.Models.Table;
+
+namespace Bit.Core.Repositories.EntityFramework
+{
+    public class OrganizationSponsorshipRepository : Repository<TableModel.OrganizationSponsorship, EFModel.OrganizationSponsorship, Guid>, IOrganizationSponsorshipRepository
+    {
+        public OrganizationSponsorshipRepository(IServiceScopeFactory serviceScopeFactory, IMapper mapper) :
+        base(serviceScopeFactory, mapper, (DatabaseContext context) => context.organizationSponsorships)
+        {
+        }
+
+        public async Task<TableModel.OrganizationSponsorship> GetByOfferedToEmailAsync(string email)
+        {
+            using (var scope = ServiceScopeFactory.CreateScope())
+            {
+                var dbContext = GetDatabaseContext(scope);
+                var orgSponsorship = await GetDbSet(dbContext).Where(e => e.OfferedToEmail == email)
+                    .FirstOrDefaultAsync();
+                return orgSponsorship;
+            }
+        }
+        public async Task<TableModel.OrganizationSponsorship> GetBySponsoredOrganizationIdAsync(Guid sponsoredOrganizationId)
+        {
+            using (var scope = ServiceScopeFactory.CreateScope())
+            {
+                var dbContext = GetDatabaseContext(scope);
+                var orgSponsorship = await GetDbSet(dbContext).Where(e => e.SponsoredOrganizationId == sponsoredOrganizationId)
+                    .FirstOrDefaultAsync();
+                return orgSponsorship;
+            }
+        }
+        public async Task<TableModel.OrganizationSponsorship> GetBySponsoringOrganizationUserIdAsync(Guid sponsoringOrganizationUserId)
+        {
+            using (var scope = ServiceScopeFactory.CreateScope())
+            {
+                var dbContext = GetDatabaseContext(scope);
+                var orgSponsorship = await GetDbSet(dbContext).Where(e => e.SponsoringOrganizationUserId == sponsoringOrganizationUserId)
+                    .FirstOrDefaultAsync();
+                return orgSponsorship;
+            }
+        }
+    }
+}

--- a/src/Core/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Core/Utilities/ServiceCollectionExtensions.cs
@@ -101,6 +101,7 @@ namespace Bit.Core.Utilities
                 services.AddSingleton<IInstallationRepository, EntityFrameworkRepos.InstallationRepository>();
                 services.AddSingleton<IMaintenanceRepository, EntityFrameworkRepos.MaintenanceRepository>();
                 services.AddSingleton<IOrganizationRepository, EntityFrameworkRepos.OrganizationRepository>();
+                services.AddSingleton<IOrganizationSponsorshipRepository, EntityFrameworkRepos.OrganizationSponsorshipRepository>();
                 services.AddSingleton<IOrganizationUserRepository, EntityFrameworkRepos.OrganizationUserRepository>();
                 services.AddSingleton<IPolicyRepository, EntityFrameworkRepos.PolicyRepository>();
                 services.AddSingleton<ISendRepository, EntityFrameworkRepos.SendRepository>();
@@ -127,6 +128,7 @@ namespace Bit.Core.Utilities
                 services.AddSingleton<IInstallationRepository, SqlServerRepos.InstallationRepository>();
                 services.AddSingleton<IMaintenanceRepository, SqlServerRepos.MaintenanceRepository>();
                 services.AddSingleton<IOrganizationRepository, SqlServerRepos.OrganizationRepository>();
+                services.AddSingleton<IOrganizationSponsorshipRepository, SqlServerRepos.OrganizationSponsorshipRepository>();
                 services.AddSingleton<IOrganizationUserRepository, SqlServerRepos.OrganizationUserRepository>();
                 services.AddSingleton<IPolicyRepository, SqlServerRepos.PolicyRepository>();
                 services.AddSingleton<ISendRepository, SqlServerRepos.SendRepository>();

--- a/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_Create.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_Create.sql
@@ -1,8 +1,14 @@
 CREATE PROCEDURE [dbo].[OrganizationSponsorship_Create]
     @Id UNIQUEIDENTIFIER OUTPUT,
+    @InstallationId UNIQUEIDENTIFIER,
     @SponsoringOrganizationId UNIQUEIDENTIFIER,
     @SponsoringOrganizationUserID UNIQUEIDENTIFIER,
-    @OfferedToEmail NVARCHAR(256) -- Should not be null
+    @SponsoredOrganizationId UNIQUEIDENTIFIER,
+    @OfferedToEmail NVARCHAR(256),
+    @CloudSponsor BIT,
+    @LastSyncDate DATETIME2 (7),
+    @TimesRenewedWithoutValidation TINYINT,
+    @SponsorshipLapsedDate DATETIME2 (7)
 AS
 BEGIN
     SET NOCOUNT ON
@@ -10,18 +16,28 @@ BEGIN
     INSERT INTO [dbo].[OrganizationSponsorship]
     (
         [Id],
+        [InstallationId],
         [SponsoringOrganizationId],
         [SponsoringOrganizationUserID],
+        [SponsoredOrganizationId],
+        [OfferedToEmail],
         [CloudSponsor],
-        [OfferedToEmail]
+        [LastSyncDate],
+        [TimesRenewedWithoutValidation],
+        [SponsorshipLapsedDate]
     )
     VALUES
     (
         @Id,
+        @InstallationId,
         @SponsoringOrganizationId,
         @SponsoringOrganizationUserID,
-        1, -- Should only be called by cloud sponsorship
-        @OfferedToEmail
+        @SponsoredOrganizationId,
+        @OfferedToEmail,
+        @CloudSponsor,
+        @LastSyncDate,
+        @TimesRenewedWithoutValidation,
+        @SponsorshipLapsedDate
     )
 END
 GO

--- a/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_Create.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_Create.sql
@@ -1,0 +1,27 @@
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_Create]
+    @Id UNIQUEIDENTIFIER OUTPUT,
+    @SponsoringOrganizationId UNIQUEIDENTIFIER,
+    @SponsoringOrganizationUserID UNIQUEIDENTIFIER,
+    @OfferedToEmail NVARCHAR(256) -- Should not be null
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    INSERT INTO [dbo].[OrganizationSponsorship]
+    (
+        [Id],
+        [SponsoringOrganizationId],
+        [SponsoringOrganizationUserID],
+        [CloudSponsor],
+        [OfferedToEmail]
+    )
+    VALUES
+    (
+        @Id,
+        @SponsoringOrganizationId,
+        @SponsoringOrganizationUserID,
+        1, -- Should only be called by cloud sponsorship
+        @OfferedToEmail
+    )
+END
+GO

--- a/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_DeleteById.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_DeleteById.sql
@@ -1,0 +1,17 @@
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_DeleteById]
+    @Id UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    BEGIN TRANSACTION OrgSponsorship_DeleteById
+
+        DELETE
+        FROM
+            [dbo].[OrganizationSponsorship]
+        WHERE
+            [Id] = @Id
+
+    COMMIT TRANSACTION OrgSponsorship_DeleteById
+END
+GO

--- a/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_ReadById.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_ReadById.sql
@@ -1,0 +1,14 @@
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_ReadById]
+    @Id UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        *
+    FROM
+        [dbo].[OrganizationSponsorshipView]
+    WHERE
+        [Id] = @Id
+END
+GO

--- a/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_ReadByOfferedToEmail.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_ReadByOfferedToEmail.sql
@@ -1,0 +1,14 @@
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_ReadByOfferedToEmail]
+    @OfferedToEmail NVARCHAR (256) -- Should not be null
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        *
+    FROM
+        [dbo].[OrganizationSponsorshipView]
+    WHERE
+        [OfferedToEmail] = @OfferedToEmail
+END
+GO

--- a/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_ReadBySponsoredOrganizationId.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_ReadBySponsoredOrganizationId.sql
@@ -1,0 +1,14 @@
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_ReadBySponsoredOrganizationId]
+    @SponsoredOrganizationId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        *
+    FROM
+        [dbo].[OrganizationSponsorshipView]
+    WHERE
+        [SponsoredOrganizationId] = @SponsoredOrganizationId
+END
+GO

--- a/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_ReadBySponsoringOrganiationUserId.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_ReadBySponsoringOrganiationUserId.sql
@@ -1,0 +1,14 @@
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_ReadBySponsoringOrganizationUserId]
+    @SponsoringOrganizationUserId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        *
+    FROM
+        [dbo].[OrganizationSponsorshipView]
+    WHERE
+        [SponsoringOrganizationUserId] = @SponsoringOrganizationUserId
+END
+GO

--- a/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_Update.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_Update.sql
@@ -1,0 +1,19 @@
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_Update]
+    @Id UNIQUEIDENTIFIER,
+    @SponsoredOrganizationId UNIQUEIDENTIFIER,
+    @TimesRenewedWithoutValidation TINYINT,
+    @SponsorshipLapsedDate DATETIME2 (7)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    UPDATE
+        [dbo].[OrganizationSponsorship]
+    SET
+        [SponsoredOrganizationId] = @SponsoredOrganizationId,
+        [TimesRenewedWithoutValidation] = @TimesRenewedWithoutValidation,
+        [SponsorshipLapsedDate] = @SponsorshipLapsedDate
+    WHERE
+        [Id] = @Id
+END
+GO

--- a/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_Update.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_Update.sql
@@ -1,6 +1,12 @@
 CREATE PROCEDURE [dbo].[OrganizationSponsorship_Update]
     @Id UNIQUEIDENTIFIER,
+    @InstallationId UNIQUEIDENTIFIER,
+    @SponsoringOrganizationId UNIQUEIDENTIFIER,
+    @SponsoringOrganizationUserID UNIQUEIDENTIFIER,
     @SponsoredOrganizationId UNIQUEIDENTIFIER,
+    @OfferedToEmail NVARCHAR(256),
+    @CloudSponsor BIT,
+    @LastSyncDate DATETIME2 (7),
     @TimesRenewedWithoutValidation TINYINT,
     @SponsorshipLapsedDate DATETIME2 (7)
 AS
@@ -10,7 +16,13 @@ BEGIN
     UPDATE
         [dbo].[OrganizationSponsorship]
     SET
+        [InstallationId] = @InstallationId,
+        [SponsoringOrganizationId] = @SponsoringOrganizationId,
+        [SponsoringOrganizationUserID] = @SponsoringOrganizationUserID,
         [SponsoredOrganizationId] = @SponsoredOrganizationId,
+        [OfferedToEmail] = @OfferedToEmail,
+        [CloudSponsor] = @CloudSponsor,
+        [LastSyncDate] = @LastSyncDate,
         [TimesRenewedWithoutValidation] = @TimesRenewedWithoutValidation,
         [SponsorshipLapsedDate] = @SponsorshipLapsedDate
     WHERE

--- a/src/Sql/dbo/Tables/OrganizationSponsorship.sql
+++ b/src/Sql/dbo/Tables/OrganizationSponsorship.sql
@@ -1,0 +1,41 @@
+CREATE TABLE [dbo].[OrganizationSponsorship] (
+    [Id]                            UNIQUEIDENTIFIER NOT NULL,
+    [InstallationId]                UNIQUEIDENTIFIER NULL,
+    [SponsoringOrganizationId]      UNIQUEIDENTIFIER NOT NULL,
+    [SponsorginOrganizationUserID]  UNIQUEIDENTIFIER NOT NULL,
+    [SponsoredOrganizationId]       UNIQUEIDENTIFIER NULL,
+    [OfferedToEmail]                NVARCHAR (256)   NULL,
+    [CloudSponsor]                  BIT              NULL,
+    [LastSyncDate]                  DATETIME2 (7)    NULL,
+    [TimesRenewedWithoutValidation] TINYINT          DEFAULT 0,
+    [SponsorshipLapsedDate]         DATETIME2 (7)    NULL,
+    CONSTRAINT [PK_OrganizationSponsorship] PRIMARY KEY CLUSTERED ([Id] ASC),
+    CONSTRAINT [FK_OrganizationSponsorship_InstallationId] FOREIGN KEY ([InstallationId]) REFERENCES [dbo].[Installation] ([Id]),
+    CONSTRAINT [FK_OrganizationSponsorship_SponsoringOrg] FOREIGN KEY ([SponsoringOrganizationId]) REFERENCES [dbo].[Organization] ([Id]),
+    CONSTRAINT [FK_OrganizationSponsorship_SponsoredOrg] FOREIGN KEY ([SponsoredOrganizationId]) REFERENCES [dbo].[Organization] ([Id]),
+);
+
+
+GO
+CREATE NONCLUSTERED INDEX [IX_OrganizationSponsorship_InstallationId]
+    ON [dbo].[Organization]([Id] ASC, [InstallationId] ASC)
+    WHERE [InstallationId] IS NOT NULL;
+
+GO
+CREATE NONCLUSTERED INDEX [IX_OrganizationSponsorship_SponsoringOrganizationId]
+    ON [dbo].[Organization]([Id] ASC, [SponsoringOrganizationId] ASC)
+
+GO
+CREATE NONCLUSTERED INDEX [IX_OrganizationSponsorship_SponsoringOrganizationUserId]
+    ON [dbo].[Organization]([Id] ASC, [SponsorginOrganizationUserID] ASC)
+
+GO
+CREATE NONCLUSTERED INDEX [IX_OrganizationSponsorship_OfferedToEmail]
+    ON [dbo].[Organization]([Id] ASC, [OfferedToEmail] ASC)
+    WHERE [OfferedToEmail] IS NOT NULL;
+
+GO
+CREATE NONCLUSTERED INDEX [IX_OrganizationSponsorship_SponsoredOrganizationID]
+    ON [dbo].[Organization]([Id] ASC, [SponsoredOrganizationId] ASC)
+    WHERE [SponsoredOrganizationId] IS NOT NULL;
+

--- a/test/Core.Test/AutoFixture/EntityFrameworkRepositoryFixtures.cs
+++ b/test/Core.Test/AutoFixture/EntityFrameworkRepositoryFixtures.cs
@@ -76,6 +76,7 @@ namespace Bit.Core.Test.AutoFixture.EntityFrameworkRepositoryFixtures
                         cfg.AddProfile<GroupUserMapperProfile>();
                         cfg.AddProfile<InstallationMapperProfile>();
                         cfg.AddProfile<OrganizationMapperProfile>();
+                        cfg.AddProfile<OrganizationSponsorshipMapperProfile>();
                         cfg.AddProfile<OrganizationUserMapperProfile>();
                         cfg.AddProfile<ProviderMapperProfile>();
                         cfg.AddProfile<ProviderUserMapperProfile>();

--- a/test/Core.Test/AutoFixture/OrganizationSponsorshipFixtures.cs
+++ b/test/Core.Test/AutoFixture/OrganizationSponsorshipFixtures.cs
@@ -1,0 +1,59 @@
+using AutoFixture;
+using TableModel = Bit.Core.Models.Table;
+using AutoFixture.Kernel;
+using System;
+using Bit.Core.Repositories.EntityFramework;
+using Bit.Core.Test.AutoFixture.EntityFrameworkRepositoryFixtures;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Bit.Core.Test.AutoFixture.OrganizationUserFixtures;
+
+namespace Bit.Core.Test.AutoFixture.OrganizationSponsorshipFixtures
+{
+    internal class OrganizationSponsorshipBuilder : ISpecimenBuilder
+    {
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var type = request as Type;
+            if (type == null || type != typeof(TableModel.OrganizationSponsorship))
+            {
+                return new NoSpecimen();
+            }
+
+            var fixture = new Fixture();
+            var obj = fixture.WithAutoNSubstitutions().Create<TableModel.OrganizationSponsorship>();
+            return obj;
+        }
+    }
+
+    internal class EfOrganizationSponsorship : ICustomization
+    {
+        public void Customize(IFixture fixture)
+        {
+            fixture.Customizations.Add(new IgnoreVirtualMembersCustomization());
+            fixture.Customizations.Add(new GlobalSettingsBuilder());
+            fixture.Customizations.Add(new OrganizationSponsorshipBuilder());
+            fixture.Customizations.Add(new OrganizationUserBuilder());
+            fixture.Customizations.Add(new EfRepositoryListBuilder<OrganizationSponsorshipRepository>());
+            fixture.Customizations.Add(new EfRepositoryListBuilder<OrganizationRepository>());
+        }
+    }
+
+    internal class EfOrganizationSponsorshipAutoDataAttribute : CustomAutoDataAttribute
+    {
+        public EfOrganizationSponsorshipAutoDataAttribute() : base(new SutProviderCustomization(), new EfOrganizationSponsorship())
+        { }
+    }
+
+    internal class InlineEfOrganizationSponsorshipAutoDataAttribute : InlineCustomAutoDataAttribute
+    {
+        public InlineEfOrganizationSponsorshipAutoDataAttribute(params object[] values) : base(new[] { typeof(SutProviderCustomization),
+            typeof(EfOrganizationSponsorship) }, values)
+        { }
+    }
+}

--- a/test/Core.Test/Repositories/EntityFramework/EqualityComparers/OrganizationSponsorshipCompare.cs
+++ b/test/Core.Test/Repositories/EntityFramework/EqualityComparers/OrganizationSponsorshipCompare.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Bit.Core.Models.Table;
+
+namespace Bit.Core.Test.Repositories.EntityFramework.EqualityComparers
+{
+    public class OrganizationSponsorshipCompare : IEqualityComparer<OrganizationSponsorship>
+    {
+        public bool Equals(OrganizationSponsorship x, OrganizationSponsorship y)
+        {
+            return x.InstallationId.Equals(y.InstallationId) &&
+                x.SponsoringOrganizationId.Equals(y.SponsoringOrganizationId) &&
+                x.SponsoringOrganizationUserId.Equals(y.SponsoringOrganizationUserId) &&
+                x.SponsoredOrganizationId.Equals(y.SponsoredOrganizationId) &&
+                x.OfferedToEmail.Equals(y.OfferedToEmail) &&
+                x.CloudSponsor.Equals(y.CloudSponsor) &&
+                x.TimesRenewedWithoutValidation.Equals(y.TimesRenewedWithoutValidation) &&
+                x.SponsorshipLapsedDate.ToString().Equals(y.SponsorshipLapsedDate.ToString());
+        }
+
+        public int GetHashCode([DisallowNull] OrganizationSponsorship obj)
+        {
+            return base.GetHashCode();
+        }
+    }
+}

--- a/test/Core.Test/Repositories/EntityFramework/OrganizationSponsorshipRepositoryTests.cs
+++ b/test/Core.Test/Repositories/EntityFramework/OrganizationSponsorshipRepositoryTests.cs
@@ -1,0 +1,138 @@
+using EfRepo = Bit.Core.Repositories.EntityFramework;
+using SqlRepo = Bit.Core.Repositories.SqlServer;
+using System.Collections.Generic;
+using System.Linq;
+using TableModel = Bit.Core.Models.Table;
+using Xunit;
+using Bit.Core.Test.Repositories.EntityFramework.EqualityComparers;
+using Bit.Core.Test.AutoFixture.Attributes;
+using Bit.Core.Test.AutoFixture.OrganizationSponsorshipFixtures;
+
+namespace Bit.Core.Test.Repositories.EntityFramework
+{
+    public class OrganizationSponsorshipRepositoryTests
+    {
+        [CiSkippedTheory, EfOrganizationSponsorshipAutoData]
+        public async void CreateAsync_Works_DataMatches(
+            TableModel.OrganizationSponsorship organizationSponsorship, TableModel.Organization sponsoringOrg,
+            List<EfRepo.OrganizationRepository> efOrgRepos,
+            SqlRepo.OrganizationRepository sqlOrganizationRepo,
+            SqlRepo.OrganizationSponsorshipRepository sqlOrganizationSponsorshipRepo,
+            OrganizationSponsorshipCompare equalityComparer,
+            List<EfRepo.OrganizationSponsorshipRepository> suts)
+        {
+            organizationSponsorship.InstallationId = null;
+            organizationSponsorship.SponsoredOrganizationId = null;
+
+            var savedOrganizationSponsorships = new List<TableModel.OrganizationSponsorship>();
+            foreach (var (sut, orgRepo) in suts.Zip(efOrgRepos))
+            {
+                var efSponsoringOrg = await orgRepo.CreateAsync(sponsoringOrg);
+                sut.ClearChangeTracking();
+                organizationSponsorship.SponsoringOrganizationId = efSponsoringOrg.Id;
+
+                await sut.CreateAsync(organizationSponsorship);
+                sut.ClearChangeTracking();
+
+                var savedOrganizationSponsorship = await sut.GetByIdAsync(organizationSponsorship.Id);
+                savedOrganizationSponsorships.Add(savedOrganizationSponsorship);
+            }
+
+            var sqlSponsoringOrg = await sqlOrganizationRepo.CreateAsync(sponsoringOrg);
+            organizationSponsorship.SponsoringOrganizationId = sqlSponsoringOrg.Id;
+
+            var sqlOrganizationSponsorship = await sqlOrganizationSponsorshipRepo.CreateAsync(organizationSponsorship);
+            savedOrganizationSponsorships.Add(await sqlOrganizationSponsorshipRepo.GetByIdAsync(sqlOrganizationSponsorship.Id));
+
+            var distinctItems = savedOrganizationSponsorships.Distinct(equalityComparer);
+            Assert.True(!distinctItems.Skip(1).Any());
+        }
+
+        [CiSkippedTheory, EfOrganizationSponsorshipAutoData]
+        public async void ReplaceAsync_Works_DataMatches(TableModel.OrganizationSponsorship postOrganizationSponsorship,
+            TableModel.OrganizationSponsorship replaceOrganizationSponsorship, TableModel.Organization sponsoringOrg,
+            List<EfRepo.OrganizationRepository> efOrgRepos,
+            SqlRepo.OrganizationRepository sqlOrganizationRepo,
+            SqlRepo.OrganizationSponsorshipRepository sqlOrganizationSponsorshipRepo,
+            OrganizationSponsorshipCompare equalityComparer, List<EfRepo.OrganizationSponsorshipRepository> suts)
+        {
+            postOrganizationSponsorship.InstallationId = null;
+            postOrganizationSponsorship.SponsoredOrganizationId = null;
+            replaceOrganizationSponsorship.InstallationId = null;
+            replaceOrganizationSponsorship.SponsoredOrganizationId = null;
+
+            var savedOrganizationSponsorships = new List<TableModel.OrganizationSponsorship>();
+            foreach (var (sut, orgRepo) in suts.Zip(efOrgRepos))
+            {
+                var efSponsoringOrg = await orgRepo.CreateAsync(sponsoringOrg);
+                sut.ClearChangeTracking();
+                postOrganizationSponsorship.SponsoringOrganizationId = efSponsoringOrg.Id;
+                replaceOrganizationSponsorship.SponsoringOrganizationId = efSponsoringOrg.Id;
+
+                var postEfOrganizationSponsorship = await sut.CreateAsync(postOrganizationSponsorship);
+                sut.ClearChangeTracking();
+
+                replaceOrganizationSponsorship.Id = postEfOrganizationSponsorship.Id;
+                await sut.ReplaceAsync(replaceOrganizationSponsorship);
+                sut.ClearChangeTracking();
+
+                var replacedOrganizationSponsorship = await sut.GetByIdAsync(replaceOrganizationSponsorship.Id);
+                savedOrganizationSponsorships.Add(replacedOrganizationSponsorship);
+            }
+
+            var sqlSponsoringOrg = await sqlOrganizationRepo.CreateAsync(sponsoringOrg);
+            postOrganizationSponsorship.SponsoringOrganizationId = sqlSponsoringOrg.Id;
+
+            var postSqlOrganization = await sqlOrganizationSponsorshipRepo.CreateAsync(postOrganizationSponsorship);
+            replaceOrganizationSponsorship.Id = postSqlOrganization.Id;
+            await sqlOrganizationSponsorshipRepo.ReplaceAsync(replaceOrganizationSponsorship);
+            savedOrganizationSponsorships.Add(await sqlOrganizationSponsorshipRepo.GetByIdAsync(replaceOrganizationSponsorship.Id));
+
+            var distinctItems = savedOrganizationSponsorships.Distinct(equalityComparer);
+            Assert.True(!distinctItems.Skip(1).Any());
+        }
+
+        [CiSkippedTheory, EfOrganizationSponsorshipAutoData]
+        public async void DeleteAsync_Works_DataMatches(TableModel.OrganizationSponsorship organizationSponsorship,
+            TableModel.Organization sponsoringOrg,
+            List<EfRepo.OrganizationRepository> efOrgRepos,
+            SqlRepo.OrganizationRepository sqlOrganizationRepo,
+            SqlRepo.OrganizationSponsorshipRepository sqlOrganizationSponsorshipRepo,
+            List<EfRepo.OrganizationSponsorshipRepository> suts)
+        {
+            organizationSponsorship.InstallationId = null;
+            organizationSponsorship.SponsoredOrganizationId = null;
+
+            foreach (var (sut, orgRepo) in suts.Zip(efOrgRepos))
+            {
+                var efSponsoringOrg = await orgRepo.CreateAsync(sponsoringOrg);
+                sut.ClearChangeTracking();
+                organizationSponsorship.SponsoringOrganizationId = efSponsoringOrg.Id;
+
+                var postEfOrganizationSponsorship = await sut.CreateAsync(organizationSponsorship);
+                sut.ClearChangeTracking();
+
+                var savedEfOrganizationSponsorship = await sut.GetByIdAsync(postEfOrganizationSponsorship.Id);
+                sut.ClearChangeTracking();
+                Assert.True(savedEfOrganizationSponsorship != null);
+
+                await sut.DeleteAsync(savedEfOrganizationSponsorship);
+                sut.ClearChangeTracking();
+
+                savedEfOrganizationSponsorship = await sut.GetByIdAsync(savedEfOrganizationSponsorship.Id);
+                Assert.True(savedEfOrganizationSponsorship == null);
+            }
+
+            var sqlSponsoringOrg = await sqlOrganizationRepo.CreateAsync(sponsoringOrg);
+            organizationSponsorship.SponsoringOrganizationId = sqlSponsoringOrg.Id;
+
+            var postSqlOrganizationSponsorship = await sqlOrganizationSponsorshipRepo.CreateAsync(organizationSponsorship);
+            var savedSqlOrganizationSponsorship = await sqlOrganizationSponsorshipRepo.GetByIdAsync(postSqlOrganizationSponsorship.Id);
+            Assert.True(savedSqlOrganizationSponsorship != null);
+
+            await sqlOrganizationSponsorshipRepo.DeleteAsync(postSqlOrganizationSponsorship);
+            savedSqlOrganizationSponsorship = await sqlOrganizationSponsorshipRepo.GetByIdAsync(postSqlOrganizationSponsorship.Id);
+            Assert.True(savedSqlOrganizationSponsorship == null);
+        }
+    }
+}

--- a/util/Migrator/DbScripts/2021-11-02_00_OrganizationSponsorship.sql
+++ b/util/Migrator/DbScripts/2021-11-02_00_OrganizationSponsorship.sql
@@ -1,0 +1,286 @@
+-- Create Organization Sponsorships table
+IF OBJECT_ID('[dbo].[OrganizationSponsorship]') IS NULL
+BEGIN
+CREATE TABLE [dbo].[OrganizationSponsorship] (
+    [Id]                            UNIQUEIDENTIFIER NOT NULL,
+    [InstallationId]                UNIQUEIDENTIFIER NULL,
+    [SponsoringOrganizationId]      UNIQUEIDENTIFIER NOT NULL,
+    [SponsoringOrganizationUserID]  UNIQUEIDENTIFIER NOT NULL,
+    [SponsoredOrganizationId]       UNIQUEIDENTIFIER NULL,
+    [OfferedToEmail]                NVARCHAR (256)   NULL,
+    [CloudSponsor]                  BIT              NULL,
+    [LastSyncDate]                  DATETIME2 (7)    NULL,
+    [TimesRenewedWithoutValidation] TINYINT          DEFAULT 0,
+    [SponsorshipLapsedDate]         DATETIME2 (7)    NULL,
+    CONSTRAINT [PK_OrganizationSponsorship] PRIMARY KEY CLUSTERED ([Id] ASC),
+    CONSTRAINT [FK_OrganizationSponsorship_InstallationId] FOREIGN KEY ([InstallationId]) REFERENCES [dbo].[Installation] ([Id]),
+    CONSTRAINT [FK_OrganizationSponsorship_SponsoringOrg] FOREIGN KEY ([SponsoringOrganizationId]) REFERENCES [dbo].[Organization] ([Id]),
+    CONSTRAINT [FK_OrganizationSponsorship_SponsoredOrg] FOREIGN KEY ([SponsoredOrganizationId]) REFERENCES [dbo].[Organization] ([Id]),
+);
+END
+GO
+
+
+-- Create indexes
+IF NOT EXISTS(SELECT name FROM sys.indexes WHERE name = 'IX_OrganizationSponsorship_InstallationId')
+BEGIN
+CREATE NONCLUSTERED INDEX [IX_OrganizationSponsorship_InstallationId]
+    ON [dbo].[OrganizationSponsorship]([InstallationId] ASC)
+    WHERE [InstallationId] IS NOT NULL;
+END
+GO
+
+IF NOT EXISTS(SELECT name FROM sys.indexes WHERE name = 'IX_OrganizationSponsorship_SponsoringOrganizationId')
+BEGIN
+CREATE NONCLUSTERED INDEX [IX_OrganizationSponsorship_SponsoringOrganizationId]
+    ON [dbo].[OrganizationSponsorship]([SponsoringOrganizationId] ASC)
+END
+GO
+
+IF NOT EXISTS(SELECT name FROM sys.indexes WHERE name = 'IX_OrganizationSponsorship_SponsoringOrganizationUserId')
+BEGIN
+CREATE NONCLUSTERED INDEX [IX_OrganizationSponsorship_SponsoringOrganizationUserId]
+    ON [dbo].[OrganizationSponsorship]([SponsoringOrganizationUserID] ASC)
+END
+GO
+
+IF NOT EXISTS(SELECT name FROM sys.indexes WHERE name = 'IX_OrganizationSponsorship_OfferedToEmail')
+BEGIN
+CREATE NONCLUSTERED INDEX [IX_OrganizationSponsorship_OfferedToEmail]
+    ON [dbo].[OrganizationSponsorship]([OfferedToEmail] ASC)
+    WHERE [OfferedToEmail] IS NOT NULL;
+END
+GO
+
+IF NOT EXISTS(SELECT name FROM sys.indexes WHERE name = 'IX_OrganizationSponsorship_SponsoredOrganizationID')
+BEGIN
+CREATE NONCLUSTERED INDEX [IX_OrganizationSponsorship_SponsoredOrganizationID]
+    ON [dbo].[OrganizationSponsorship]([SponsoredOrganizationId] ASC)
+    WHERE [SponsoredOrganizationId] IS NOT NULL;
+END
+GO
+
+
+-- Create View
+IF EXISTS(SELECT * FROM sys.views WHERE [Name] = 'OrganizationSponsorshipView')
+BEGIN
+    DROP VIEW [dbo].[OrganizationSponsorshipView];
+END
+GO
+
+CREATE VIEW [dbo].[OrganizationSponsorshipView]
+AS
+SELECT
+    *
+FROM
+    [dbo].[OrganizationSponsorship]
+GO
+
+
+-- OrganizationSponsorship_ReadById
+IF OBJECT_ID('[dbo].[OrganizationSponsorship_ReadById]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationSponsorship_ReadById]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_ReadById]
+    @Id UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        *
+    FROM
+        [dbo].[OrganizationSponsorshipView]
+    WHERE
+        [Id] = @Id
+END
+GO
+
+
+-- OrganizationSponsorship_Create
+IF OBJECT_ID('[dbo].[OrganizationSponsorship_Create]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationSponsorship_Create]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_Create]
+    @Id UNIQUEIDENTIFIER OUTPUT,
+    @InstallationId UNIQUEIDENTIFIER,
+    @SponsoringOrganizationId UNIQUEIDENTIFIER,
+    @SponsoringOrganizationUserID UNIQUEIDENTIFIER,
+    @SponsoredOrganizationId UNIQUEIDENTIFIER,
+    @OfferedToEmail NVARCHAR(256),
+    @CloudSponsor BIT,
+    @LastSyncDate DATETIME2 (7),
+    @TimesRenewedWithoutValidation TINYINT,
+    @SponsorshipLapsedDate DATETIME2 (7)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    INSERT INTO [dbo].[OrganizationSponsorship]
+    (
+        [Id],
+        [InstallationId],
+        [SponsoringOrganizationId],
+        [SponsoringOrganizationUserID],
+        [SponsoredOrganizationId],
+        [OfferedToEmail],
+        [CloudSponsor],
+        [LastSyncDate],
+        [TimesRenewedWithoutValidation],
+        [SponsorshipLapsedDate]
+    )
+    VALUES
+    (
+        @Id,
+        @InstallationId,
+        @SponsoringOrganizationId,
+        @SponsoringOrganizationUserID,
+        @SponsoredOrganizationId,
+        @OfferedToEmail,
+        @CloudSponsor,
+        @LastSyncDate,
+        @TimesRenewedWithoutValidation,
+        @SponsorshipLapsedDate
+    )
+END
+GO
+
+-- OrganizationSponsorship_Update
+IF OBJECT_ID('[dbo].[OrganizationSponsorship_Update]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationSponsorship_Update]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_Update]
+    @Id UNIQUEIDENTIFIER,
+    @InstallationId UNIQUEIDENTIFIER,
+    @SponsoringOrganizationId UNIQUEIDENTIFIER,
+    @SponsoringOrganizationUserID UNIQUEIDENTIFIER,
+    @SponsoredOrganizationId UNIQUEIDENTIFIER,
+    @OfferedToEmail NVARCHAR(256),
+    @CloudSponsor BIT,
+    @LastSyncDate DATETIME2 (7),
+    @TimesRenewedWithoutValidation TINYINT,
+    @SponsorshipLapsedDate DATETIME2 (7)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    UPDATE
+        [dbo].[OrganizationSponsorship]
+    SET
+        [InstallationId] = @InstallationId,
+        [SponsoringOrganizationId] = @SponsoringOrganizationId,
+        [SponsoringOrganizationUserID] = @SponsoringOrganizationUserID,
+        [SponsoredOrganizationId] = @SponsoredOrganizationId,
+        [OfferedToEmail] = @OfferedToEmail,
+        [CloudSponsor] = @CloudSponsor,
+        [LastSyncDate] = @LastSyncDate,
+        [TimesRenewedWithoutValidation] = @TimesRenewedWithoutValidation,
+        [SponsorshipLapsedDate] = @SponsorshipLapsedDate
+    WHERE
+        [Id] = @Id
+END
+GO
+
+
+-- OrganizationSponsorship_DeleteById
+IF OBJECT_ID('[dbo].[OrganizationSponsorship_DeleteById]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationSponsorship_DeleteById]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_DeleteById]
+    @Id UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    BEGIN TRANSACTION OrgSponsorship_DeleteById
+
+        DELETE
+        FROM
+            [dbo].[OrganizationSponsorship]
+        WHERE
+            [Id] = @Id
+
+    COMMIT TRANSACTION OrgSponsorship_DeleteById
+END
+GO
+
+
+-- OrganizationSponsorship_ReadBySponsoringOrganizationUserId
+IF OBJECT_ID('[dbo].[OrganizationSponsorship_ReadBySponsoringOrganizationUserId]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationSponsorship_ReadBySponsoringOrganizationUserId]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_ReadBySponsoringOrganizationUserId]
+    @SponsoringOrganizationUserId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        *
+    FROM
+        [dbo].[OrganizationSponsorshipView]
+    WHERE
+        [SponsoringOrganizationUserId] = @SponsoringOrganizationUserId
+END
+GO
+
+
+
+-- OrganizationSponsorship_ReadBySponsoredOrganizationId
+IF OBJECT_ID('[dbo].[OrganizationSponsorship_ReadBySponsoredOrganizationId]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationSponsorship_ReadBySponsoredOrganizationId]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_ReadBySponsoredOrganizationId]
+    @SponsoredOrganizationId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        *
+    FROM
+        [dbo].[OrganizationSponsorshipView]
+    WHERE
+        [SponsoredOrganizationId] = @SponsoredOrganizationId
+END
+GO
+
+-- OrganizationSponsorship_ReadByOfferedToEmail
+IF OBJECT_ID('[dbo].[OrganizationSponsorship_ReadByOfferedToEmail]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationSponsorship_ReadByOfferedToEmail]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_ReadByOfferedToEmail]
+    @OfferedToEmail NVARCHAR (256) -- Should not be null
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        *
+    FROM
+        [dbo].[OrganizationSponsorshipView]
+    WHERE
+        [OfferedToEmail] = @OfferedToEmail
+END
+GO

--- a/util/MySqlMigrations/Migrations/20211102213543_OrganizationSponsorship.Designer.cs
+++ b/util/MySqlMigrations/Migrations/20211102213543_OrganizationSponsorship.Designer.cs
@@ -3,60 +3,59 @@ using System;
 using Bit.Core.Repositories.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
-namespace Bit.PostgresMigrations.Migrations
+namespace Bit.MySqlMigrations.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20211102213543_OrganizationSponsorship")]
+    partial class OrganizationSponsorship
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("Npgsql:CollationDefinition:postgresIndetermanisticCollation", "en-u-ks-primary,en-u-ks-primary,icu,False")
-                .HasAnnotation("Relational:MaxIdentifierLength", 63)
-                .HasAnnotation("ProductVersion", "5.0.9")
-                .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+                .HasAnnotation("Relational:MaxIdentifierLength", 64)
+                .HasAnnotation("ProductVersion", "5.0.9");
 
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.Cipher", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("Attachments")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Data")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("DeletedDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Favorites")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Folders")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid?>("OrganizationId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<byte?>("Reprompt")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<DateTime>("RevisionDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<byte>("Type")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<Guid?>("UserId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.HasKey("Id");
 
@@ -70,23 +69,23 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.Collection", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ExternalId")
                         .HasMaxLength(300)
-                        .HasColumnType("character varying(300)");
+                        .HasColumnType("varchar(300)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("OrganizationId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("RevisionDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.HasKey("Id");
 
@@ -98,10 +97,10 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.CollectionCipher", b =>
                 {
                     b.Property<Guid>("CollectionId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("CipherId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.HasKey("CollectionId", "CipherId");
 
@@ -113,16 +112,16 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.CollectionGroup", b =>
                 {
                     b.Property<Guid>("CollectionId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("GroupId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<bool>("HidePasswords")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("ReadOnly")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.HasKey("CollectionId", "GroupId");
 
@@ -134,19 +133,19 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.CollectionUser", b =>
                 {
                     b.Property<Guid>("CollectionId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("OrganizationUserId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<bool>("HidePasswords")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("ReadOnly")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<Guid?>("UserId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.HasKey("CollectionId", "OrganizationUserId");
 
@@ -161,31 +160,31 @@ namespace Bit.PostgresMigrations.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Identifier")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<string>("PushToken")
                         .HasMaxLength(255)
-                        .HasColumnType("character varying(255)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<DateTime>("RevisionDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<byte>("Type")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<Guid>("UserId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.HasKey("Id");
 
@@ -197,41 +196,41 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.EmergencyAccess", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Email")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("varchar(256)");
 
                     b.Property<Guid?>("GranteeId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("GrantorId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("KeyEncrypted")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("LastNotificationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<DateTime?>("RecoveryInitiatedDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<DateTime>("RevisionDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<byte>("Status")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<byte>("Type")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<int>("WaitTimeDays")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -245,53 +244,53 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.Event", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid?>("ActingUserId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid?>("CipherId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid?>("CollectionId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("Date")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<byte?>("DeviceType")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<Guid?>("GroupId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("IpAddress")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<Guid?>("OrganizationId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid?>("OrganizationUserId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid?>("PolicyId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid?>("ProviderId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid?>("ProviderOrganizationId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid?>("ProviderUserId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<int>("Type")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<Guid?>("UserId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.HasKey("Id");
 
@@ -301,19 +300,19 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.Folder", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("RevisionDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<Guid>("UserId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.HasKey("Id");
 
@@ -326,39 +325,39 @@ namespace Bit.PostgresMigrations.Migrations
                 {
                     b.Property<string>("Key")
                         .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<string>("ClientId")
                         .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<DateTime?>("ConsumedDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Data")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Description")
                         .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<DateTime?>("ExpirationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("SessionId")
                         .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
+                        .HasColumnType("varchar(100)");
 
                     b.Property<string>("SubjectId")
                         .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<string>("Type")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.HasKey("Key");
 
@@ -368,27 +367,27 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.Group", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<bool>("AccessAll")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ExternalId")
                         .HasMaxLength(300)
-                        .HasColumnType("character varying(300)");
+                        .HasColumnType("varchar(300)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
+                        .HasColumnType("varchar(100)");
 
                     b.Property<Guid>("OrganizationId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("RevisionDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.HasKey("Id");
 
@@ -400,13 +399,13 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.GroupUser", b =>
                 {
                     b.Property<Guid>("GroupId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("OrganizationUserId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid?>("UserId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.HasKey("GroupId", "OrganizationUserId");
 
@@ -420,21 +419,21 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.Installation", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Email")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("varchar(256)");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Key")
                         .HasMaxLength(150)
-                        .HasColumnType("character varying(150)");
+                        .HasColumnType("varchar(150)");
 
                     b.HasKey("Id");
 
@@ -444,71 +443,70 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.Organization", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("ApiKey")
                         .HasMaxLength(30)
-                        .HasColumnType("character varying(30)");
+                        .HasColumnType("varchar(30)");
 
                     b.Property<string>("BillingEmail")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("varchar(256)");
 
                     b.Property<string>("BusinessAddress1")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<string>("BusinessAddress2")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<string>("BusinessAddress3")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<string>("BusinessCountry")
                         .HasMaxLength(2)
-                        .HasColumnType("character varying(2)");
+                        .HasColumnType("varchar(2)");
 
                     b.Property<string>("BusinessName")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<string>("BusinessTaxNumber")
                         .HasMaxLength(30)
-                        .HasColumnType("character varying(30)");
+                        .HasColumnType("varchar(30)");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<DateTime?>("ExpirationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<byte?>("Gateway")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<string>("GatewayCustomerId")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<string>("GatewaySubscriptionId")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<string>("Identifier")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)")
-                        .UseCollation("postgresIndetermanisticCollation");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<string>("LicenseKey")
                         .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
+                        .HasColumnType("varchar(100)");
 
                     b.Property<int?>("MaxAutoscaleSeats")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<short?>("MaxCollections")
                         .HasColumnType("smallint");
@@ -518,71 +516,71 @@ namespace Bit.PostgresMigrations.Migrations
 
                     b.Property<string>("Name")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<DateTime?>("OwnersNotifiedOfAutoscaling")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Plan")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<byte>("PlanType")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<string>("PrivateKey")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("PublicKey")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ReferenceData")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("RevisionDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int?>("Seats")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<bool>("SelfHost")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<long?>("Storage")
                         .HasColumnType("bigint");
 
                     b.Property<string>("TwoFactorProviders")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("Use2fa")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("UseApi")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("UseDirectory")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("UseEvents")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("UseGroups")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("UsePolicies")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("UseResetPassword")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("UseSso")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("UseTotp")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("UsersGetPremium")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.HasKey("Id");
 
@@ -592,35 +590,35 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.OrganizationSponsorship", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<bool>("CloudSponsor")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<Guid?>("InstallationId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime?>("LastSyncDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("OfferedToEmail")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("varchar(256)");
 
                     b.Property<Guid?>("SponsoredOrganizationId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("SponsoringOrganizationId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("SponsoringOrganizationUserId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime?>("SponsorshipLapsedDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<byte>("TimesRenewedWithoutValidation")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.HasKey("Id");
 
@@ -636,45 +634,45 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.OrganizationUser", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<bool>("AccessAll")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Email")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("varchar(256)");
 
                     b.Property<string>("ExternalId")
                         .HasMaxLength(300)
-                        .HasColumnType("character varying(300)");
+                        .HasColumnType("varchar(300)");
 
                     b.Property<string>("Key")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("OrganizationId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("Permissions")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ResetPasswordKey")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("RevisionDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<byte>("Status")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<byte>("Type")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<Guid?>("UserId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.HasKey("Id");
 
@@ -688,25 +686,25 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.Policy", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Data")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<Guid>("OrganizationId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("RevisionDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<byte>("Type")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.HasKey("Id");
 
@@ -718,46 +716,46 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.Provider.Provider", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("BillingEmail")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("BusinessAddress1")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("BusinessAddress2")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("BusinessAddress3")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("BusinessCountry")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("BusinessName")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("BusinessTaxNumber")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("RevisionDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<byte>("Status")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<bool>("UseEvents")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.HasKey("Id");
 
@@ -767,25 +765,25 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.Provider.ProviderOrganization", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Key")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("OrganizationId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("ProviderId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("RevisionDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Settings")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.HasKey("Id");
 
@@ -799,34 +797,34 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.Provider.ProviderUser", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Email")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Key")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Permissions")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("ProviderId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("RevisionDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<byte>("Status")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<byte>("Type")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<Guid?>("UserId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.HasKey("Id");
 
@@ -840,50 +838,50 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.Send", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<int>("AccessCount")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Data")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("DeletionDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<bool>("Disabled")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<DateTime?>("ExpirationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<bool?>("HideEmail")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Key")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<int?>("MaxAccessCount")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<Guid?>("OrganizationId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("Password")
                         .HasMaxLength(300)
-                        .HasColumnType("character varying(300)");
+                        .HasColumnType("varchar(300)");
 
                     b.Property<DateTime>("RevisionDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<byte>("Type")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<Guid?>("UserId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.HasKey("Id");
 
@@ -898,23 +896,22 @@ namespace Bit.PostgresMigrations.Migrations
                 {
                     b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint")
-                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+                        .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Data")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<Guid>("OrganizationId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("RevisionDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.HasKey("Id");
 
@@ -927,22 +924,20 @@ namespace Bit.PostgresMigrations.Migrations
                 {
                     b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint")
-                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+                        .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ExternalId")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)")
-                        .UseCollation("postgresIndetermanisticCollation");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<Guid?>("OrganizationId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("UserId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.HasKey("Id");
 
@@ -957,25 +952,25 @@ namespace Bit.PostgresMigrations.Migrations
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("varchar(40)");
 
                     b.Property<bool>("Active")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Country")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<string>("PostalCode")
                         .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
+                        .HasColumnType("varchar(10)");
 
                     b.Property<decimal>("Rate")
-                        .HasColumnType("numeric");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<string>("State")
                         .HasMaxLength(2)
-                        .HasColumnType("character varying(2)");
+                        .HasColumnType("varchar(2)");
 
                     b.HasKey("Id");
 
@@ -985,42 +980,42 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.Transaction", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<decimal>("Amount")
-                        .HasColumnType("numeric");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Details")
                         .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
+                        .HasColumnType("varchar(100)");
 
                     b.Property<byte?>("Gateway")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<string>("GatewayId")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<Guid?>("OrganizationId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<byte?>("PaymentMethodType")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<bool?>("Refunded")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<decimal?>("RefundedAmount")
-                        .HasColumnType("numeric");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<byte>("Type")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<Guid?>("UserId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.HasKey("Id");
 
@@ -1035,30 +1030,29 @@ namespace Bit.PostgresMigrations.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("integer")
-                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+                        .HasColumnType("int");
 
                     b.Property<string>("AppId")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<string>("Challenge")
                         .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("KeyHandle")
                         .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<Guid>("UserId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("Version")
                         .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
+                        .HasColumnType("varchar(20)");
 
                     b.HasKey("Id");
 
@@ -1070,118 +1064,117 @@ namespace Bit.PostgresMigrations.Migrations
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.User", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("AccountRevisionDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ApiKey")
                         .IsRequired()
                         .HasMaxLength(30)
-                        .HasColumnType("character varying(30)");
+                        .HasColumnType("varchar(30)");
 
                     b.Property<DateTime>("CreationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Culture")
                         .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
+                        .HasColumnType("varchar(10)");
 
                     b.Property<string>("Email")
                         .IsRequired()
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)")
-                        .UseCollation("postgresIndetermanisticCollation");
+                        .HasColumnType("varchar(256)");
 
                     b.Property<bool>("EmailVerified")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("EquivalentDomains")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ExcludedGlobalEquivalentDomains")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("ForcePasswordReset")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<byte?>("Gateway")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<string>("GatewayCustomerId")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<string>("GatewaySubscriptionId")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<byte>("Kdf")
-                        .HasColumnType("smallint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<int>("KdfIterations")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("Key")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("LicenseKey")
                         .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
+                        .HasColumnType("varchar(100)");
 
                     b.Property<string>("MasterPassword")
                         .HasMaxLength(300)
-                        .HasColumnType("character varying(300)");
+                        .HasColumnType("varchar(300)");
 
                     b.Property<string>("MasterPasswordHint")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<short?>("MaxStorageGb")
                         .HasColumnType("smallint");
 
                     b.Property<string>("Name")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<bool>("Premium")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<DateTime?>("PremiumExpirationDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("PrivateKey")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("PublicKey")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ReferenceData")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("RenewalReminderDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<DateTime>("RevisionDate")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("SecurityStamp")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<long?>("Storage")
                         .HasColumnType("bigint");
 
                     b.Property<string>("TwoFactorProviders")
-                        .HasColumnType("text");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("TwoFactorRecoveryCode")
                         .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
+                        .HasColumnType("varchar(32)");
 
                     b.Property<bool>("UsesCryptoAgent")
-                        .HasColumnType("boolean");
+                        .HasColumnType("tinyint(1)");
 
                     b.HasKey("Id");
 

--- a/util/MySqlMigrations/Migrations/20211102213543_OrganizationSponsorship.cs
+++ b/util/MySqlMigrations/Migrations/20211102213543_OrganizationSponsorship.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Bit.MySqlMigrations.Migrations
+{
+    public partial class OrganizationSponsorship : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "UsesCryptoAgent",
+                table: "User",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateTable(
+                name: "OrganizationSponsorship",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci"),
+                    InstallationId = table.Column<Guid>(type: "char(36)", nullable: true, collation: "ascii_general_ci"),
+                    SponsoringOrganizationId = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci"),
+                    SponsoringOrganizationUserId = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci"),
+                    SponsoredOrganizationId = table.Column<Guid>(type: "char(36)", nullable: true, collation: "ascii_general_ci"),
+                    OfferedToEmail = table.Column<string>(type: "varchar(256)", maxLength: 256, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CloudSponsor = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    LastSyncDate = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    TimesRenewedWithoutValidation = table.Column<byte>(type: "tinyint unsigned", nullable: false),
+                    SponsorshipLapsedDate = table.Column<DateTime>(type: "datetime(6)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OrganizationSponsorship", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OrganizationSponsorship_Installation_InstallationId",
+                        column: x => x.InstallationId,
+                        principalTable: "Installation",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_OrganizationSponsorship_Organization_SponsoredOrganizationId",
+                        column: x => x.SponsoredOrganizationId,
+                        principalTable: "Organization",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_OrganizationSponsorship_Organization_SponsoringOrganizationId",
+                        column: x => x.SponsoringOrganizationId,
+                        principalTable: "Organization",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizationSponsorship_InstallationId",
+                table: "OrganizationSponsorship",
+                column: "InstallationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizationSponsorship_SponsoredOrganizationId",
+                table: "OrganizationSponsorship",
+                column: "SponsoredOrganizationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizationSponsorship_SponsoringOrganizationId",
+                table: "OrganizationSponsorship",
+                column: "SponsoringOrganizationId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OrganizationSponsorship");
+
+            migrationBuilder.DropColumn(
+                name: "UsesCryptoAgent",
+                table: "User");
+        }
+    }
+}

--- a/util/MySqlMigrations/Migrations/DatabaseContextModelSnapshot.cs
+++ b/util/MySqlMigrations/Migrations/DatabaseContextModelSnapshot.cs
@@ -585,6 +585,50 @@ namespace Bit.MySqlMigrations.Migrations
                     b.ToTable("Organization");
                 });
 
+            modelBuilder.Entity("Bit.Core.Models.EntityFramework.OrganizationSponsorship", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("char(36)");
+
+                    b.Property<bool>("CloudSponsor")
+                        .HasColumnType("tinyint(1)");
+
+                    b.Property<Guid?>("InstallationId")
+                        .HasColumnType("char(36)");
+
+                    b.Property<DateTime?>("LastSyncDate")
+                        .HasColumnType("datetime(6)");
+
+                    b.Property<string>("OfferedToEmail")
+                        .HasMaxLength(256)
+                        .HasColumnType("varchar(256)");
+
+                    b.Property<Guid?>("SponsoredOrganizationId")
+                        .HasColumnType("char(36)");
+
+                    b.Property<Guid>("SponsoringOrganizationId")
+                        .HasColumnType("char(36)");
+
+                    b.Property<Guid>("SponsoringOrganizationUserId")
+                        .HasColumnType("char(36)");
+
+                    b.Property<DateTime?>("SponsorshipLapsedDate")
+                        .HasColumnType("datetime(6)");
+
+                    b.Property<byte>("TimesRenewedWithoutValidation")
+                        .HasColumnType("tinyint unsigned");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("InstallationId");
+
+                    b.HasIndex("SponsoredOrganizationId");
+
+                    b.HasIndex("SponsoringOrganizationId");
+
+                    b.ToTable("OrganizationSponsorship");
+                });
+
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.OrganizationUser", b =>
                 {
                     b.Property<Guid>("Id")
@@ -1127,6 +1171,9 @@ namespace Bit.MySqlMigrations.Migrations
                         .HasMaxLength(32)
                         .HasColumnType("varchar(32)");
 
+                    b.Property<bool>("UsesCryptoAgent")
+                        .HasColumnType("tinyint(1)");
+
                     b.HasKey("Id");
 
                     b.ToTable("User");
@@ -1290,6 +1337,29 @@ namespace Bit.MySqlMigrations.Migrations
                     b.Navigation("Group");
 
                     b.Navigation("OrganizationUser");
+                });
+
+            modelBuilder.Entity("Bit.Core.Models.EntityFramework.OrganizationSponsorship", b =>
+                {
+                    b.HasOne("Bit.Core.Models.EntityFramework.Installation", "Installation")
+                        .WithMany()
+                        .HasForeignKey("InstallationId");
+
+                    b.HasOne("Bit.Core.Models.EntityFramework.Organization", "SponsoredOrganization")
+                        .WithMany()
+                        .HasForeignKey("SponsoredOrganizationId");
+
+                    b.HasOne("Bit.Core.Models.EntityFramework.Organization", "SponsoringOrganization")
+                        .WithMany()
+                        .HasForeignKey("SponsoringOrganizationId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Installation");
+
+                    b.Navigation("SponsoredOrganization");
+
+                    b.Navigation("SponsoringOrganization");
                 });
 
             modelBuilder.Entity("Bit.Core.Models.EntityFramework.OrganizationUser", b =>

--- a/util/MySqlMigrations/Scripts/2021-11-02_00_OrganizationSponsorship.sql
+++ b/util/MySqlMigrations/Scripts/2021-11-02_00_OrganizationSponsorship.sql
@@ -1,0 +1,31 @@
+START TRANSACTION;
+
+ALTER TABLE `User` ADD `UsesCryptoAgent` tinyint(1) NOT NULL DEFAULT FALSE;
+
+CREATE TABLE `OrganizationSponsorship` (
+    `Id` char(36) COLLATE ascii_general_ci NOT NULL,
+    `InstallationId` char(36) COLLATE ascii_general_ci NULL,
+    `SponsoringOrganizationId` char(36) COLLATE ascii_general_ci NOT NULL,
+    `SponsoringOrganizationUserId` char(36) COLLATE ascii_general_ci NOT NULL,
+    `SponsoredOrganizationId` char(36) COLLATE ascii_general_ci NULL,
+    `OfferedToEmail` varchar(256) CHARACTER SET utf8mb4 NULL,
+    `CloudSponsor` tinyint(1) NOT NULL,
+    `LastSyncDate` datetime(6) NULL,
+    `TimesRenewedWithoutValidation` tinyint unsigned NOT NULL,
+    `SponsorshipLapsedDate` datetime(6) NULL,
+    CONSTRAINT `PK_OrganizationSponsorship` PRIMARY KEY (`Id`),
+    CONSTRAINT `FK_OrganizationSponsorship_Installation_InstallationId` FOREIGN KEY (`InstallationId`) REFERENCES `Installation` (`Id`) ON DELETE RESTRICT,
+    CONSTRAINT `FK_OrganizationSponsorship_Organization_SponsoredOrganizationId` FOREIGN KEY (`SponsoredOrganizationId`) REFERENCES `Organization` (`Id`) ON DELETE RESTRICT,
+    CONSTRAINT `FK_OrganizationSponsorship_Organization_SponsoringOrganizationId` FOREIGN KEY (`SponsoringOrganizationId`) REFERENCES `Organization` (`Id`) ON DELETE CASCADE
+) CHARACTER SET utf8mb4;
+
+CREATE INDEX `IX_OrganizationSponsorship_InstallationId` ON `OrganizationSponsorship` (`InstallationId`);
+
+CREATE INDEX `IX_OrganizationSponsorship_SponsoredOrganizationId` ON `OrganizationSponsorship` (`SponsoredOrganizationId`);
+
+CREATE INDEX `IX_OrganizationSponsorship_SponsoringOrganizationId` ON `OrganizationSponsorship` (`SponsoringOrganizationId`);
+
+INSERT INTO `__EFMigrationsHistory` (`MigrationId`, `ProductVersion`)
+VALUES ('20211102213543_OrganizationSponsorship', '5.0.9');
+
+COMMIT;

--- a/util/PostgresMigrations/Migrations/20211102205745_OrganizationSponsorship.Designer.cs
+++ b/util/PostgresMigrations/Migrations/20211102205745_OrganizationSponsorship.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Bit.Core.Repositories.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Bit.PostgresMigrations.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20211102205745_OrganizationSponsorship")]
+    partial class OrganizationSponsorship
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/util/PostgresMigrations/Migrations/20211102205745_OrganizationSponsorship.cs
+++ b/util/PostgresMigrations/Migrations/20211102205745_OrganizationSponsorship.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Bit.PostgresMigrations.Migrations
+{
+    public partial class OrganizationSponsorship : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "UsesCryptoAgent",
+                table: "User",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateTable(
+                name: "OrganizationSponsorship",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    InstallationId = table.Column<Guid>(type: "uuid", nullable: true),
+                    SponsoringOrganizationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SponsoringOrganizationUserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SponsoredOrganizationId = table.Column<Guid>(type: "uuid", nullable: true),
+                    OfferedToEmail = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    CloudSponsor = table.Column<bool>(type: "boolean", nullable: false),
+                    LastSyncDate = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    TimesRenewedWithoutValidation = table.Column<byte>(type: "smallint", nullable: false),
+                    SponsorshipLapsedDate = table.Column<DateTime>(type: "timestamp without time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OrganizationSponsorship", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OrganizationSponsorship_Installation_InstallationId",
+                        column: x => x.InstallationId,
+                        principalTable: "Installation",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_OrganizationSponsorship_Organization_SponsoredOrganizationId",
+                        column: x => x.SponsoredOrganizationId,
+                        principalTable: "Organization",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_OrganizationSponsorship_Organization_SponsoringOrganization~",
+                        column: x => x.SponsoringOrganizationId,
+                        principalTable: "Organization",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizationSponsorship_InstallationId",
+                table: "OrganizationSponsorship",
+                column: "InstallationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizationSponsorship_SponsoredOrganizationId",
+                table: "OrganizationSponsorship",
+                column: "SponsoredOrganizationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizationSponsorship_SponsoringOrganizationId",
+                table: "OrganizationSponsorship",
+                column: "SponsoringOrganizationId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OrganizationSponsorship");
+
+            migrationBuilder.DropColumn(
+                name: "UsesCryptoAgent",
+                table: "User");
+        }
+    }
+}

--- a/util/PostgresMigrations/Scripts/2021-11-02_00_OrganizationSponsorship.psql
+++ b/util/PostgresMigrations/Scripts/2021-11-02_00_OrganizationSponsorship.psql
@@ -1,0 +1,31 @@
+START TRANSACTION;
+
+ALTER TABLE "User" ADD "UsesCryptoAgent" boolean NOT NULL DEFAULT FALSE;
+
+CREATE TABLE "OrganizationSponsorship" (
+    "Id" uuid NOT NULL,
+    "InstallationId" uuid NULL,
+    "SponsoringOrganizationId" uuid NOT NULL,
+    "SponsoringOrganizationUserId" uuid NOT NULL,
+    "SponsoredOrganizationId" uuid NULL,
+    "OfferedToEmail" character varying(256) NULL,
+    "CloudSponsor" boolean NOT NULL,
+    "LastSyncDate" timestamp without time zone NULL,
+    "TimesRenewedWithoutValidation" smallint NOT NULL,
+    "SponsorshipLapsedDate" timestamp without time zone NULL,
+    CONSTRAINT "PK_OrganizationSponsorship" PRIMARY KEY ("Id"),
+    CONSTRAINT "FK_OrganizationSponsorship_Installation_InstallationId" FOREIGN KEY ("InstallationId") REFERENCES "Installation" ("Id") ON DELETE RESTRICT,
+    CONSTRAINT "FK_OrganizationSponsorship_Organization_SponsoredOrganizationId" FOREIGN KEY ("SponsoredOrganizationId") REFERENCES "Organization" ("Id") ON DELETE RESTRICT,
+    CONSTRAINT "FK_OrganizationSponsorship_Organization_SponsoringOrganization~" FOREIGN KEY ("SponsoringOrganizationId") REFERENCES "Organization" ("Id") ON DELETE CASCADE
+);
+
+CREATE INDEX "IX_OrganizationSponsorship_InstallationId" ON "OrganizationSponsorship" ("InstallationId");
+
+CREATE INDEX "IX_OrganizationSponsorship_SponsoredOrganizationId" ON "OrganizationSponsorship" ("SponsoredOrganizationId");
+
+CREATE INDEX "IX_OrganizationSponsorship_SponsoringOrganizationId" ON "OrganizationSponsorship" ("SponsoringOrganizationId");
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('20211102205745_OrganizationSponsorship', '5.0.9');
+
+COMMIT;


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
This is the initial groundwork for basic crud functionality for organization sponsorship of other organizations through our families for enterprise program.


## Code changes
Adds sql and ef project objects and migrations for creating an OrganizationSponsorship table as well as the associated sprocs and view.

* **EF/OrganizationSponsorship:** EF model with foreign key associations. Note: SponsoringOrganizatioonUserId is not a foreign key because these OrgUsers may be hosted on a self-hosted instance.
* **Table/OrganizationSponsorship**:
  * `SponsoredUserId` is not needed and irrelevant data
  * `Guid?` for optional non-nullable type (also makes EF foreign key constraint nullable)
* **EF/DatabaseContext + ServiceCollectionExtension + EntityFrameworkRepositoryFixtures**: Add OrganizationSponsorship as a known repository type
* **EF/OrganizationSponsorshipRepository**: EF implementation of specialty methods currently in use in `OrganizationSponsorshipsController`
* **Stored Procedures/OganizationSponsorship_***: Sprocs for OrganizationSponsorship
* **Sql/**/Tables/OrganizationSponsorship**: Table definition for organization sponsorship

###Testing
Basic testing exists for CRUD methods to ensure the same objects are produced by EF and MSSQL sprocs,
* **OrganizationSponsorshipFixtures**: Test fixtures for OrganziationSponsorship
* **OrganizationSponsorshipCompare**: Comparer for OrganizationSponsorship table object
* **OrganizationSponsorshipRepositoryTests**: Tests for CRUD operations. Optional foreign keys are nulled out for simplicity

### DB migrations
All other files are db migration scripts


## Before you submit
- [x] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
