### PR TITLE
Create sponsorship offer

### DIFF
--- a/src/Core/Services/IOrganizationSponsorshipService.cs
+++ b/src/Core/Services/IOrganizationSponsorshipService.cs
@@ -5,6 +5,7 @@ namespace Bit.Core.Services
 {
     public interface IOrganizationSponsorshipService
     {
+        Task<bool> ValidateRedemptionTokenAsync(string encryptedToken);
         Task OfferSponsorshipAsync(Organization sponsoringOrg, OrganizationUser sponsoringOrgUser, string sponsoredEmail);
         Task SetUpSponsorshipAsync(OrganizationSponsorship sponsorship, Organization sponsoredOrganization);
         Task RemoveSponsorshipAsync(OrganizationSponsorship sponsorship);

--- a/src/Core/Services/Implementations/OrganizationSponsorshipService.cs
+++ b/src/Core/Services/Implementations/OrganizationSponsorshipService.cs
@@ -2,27 +2,89 @@ using System;
 using System.Threading.Tasks;
 using Bit.Core.Models.Table;
 using Bit.Core.Repositories;
+using Microsoft.AspNetCore.DataProtection;
 
 namespace Bit.Core.Services
 {
     public class OrganizationSponsorshipService : IOrganizationSponsorshipService
     {
-        private readonly IOrganizationSponsorshipRepository _organizationSponsorshipRepository;
+        private const string FamiliesForEnterpriseTokenName = "FamiliesForEnterpriseToken";
+        private const string TokenClearTextPrefix = "BWOrganizationSponsorship_";
 
-        public OrganizationSponsorshipService(IOrganizationSponsorshipRepository organizationSponsorshipRepository)
+        private readonly IOrganizationSponsorshipRepository _organizationSponsorshipRepository;
+        private readonly IDataProtector _dataProtector;
+
+        public OrganizationSponsorshipService(IOrganizationSponsorshipRepository organizationSponsorshipRepository,
+            IDataProtector dataProtector)
         {
             _organizationSponsorshipRepository = organizationSponsorshipRepository;
+            _dataProtector = dataProtector;
         }
+
+        public async Task<bool> ValidateRedemptionTokenAsync(string encryptedToken)
+        {
+            if (!encryptedToken.StartsWith(TokenClearTextPrefix))
+            {
+                return false;
+            }
+
+            var decryptedToken = _dataProtector.Unprotect(encryptedToken);
+            var dataParts = decryptedToken.Split(' ');
+
+            if (dataParts.Length != 2)
+            {
+                return false;
+            }
+
+            if (dataParts[0].Equals(FamiliesForEnterpriseTokenName))
+            {
+                if (!Guid.TryParse(dataParts[1], out Guid sponsorshipId))
+                {
+                    return false;
+                }
+
+                var sponsorship = await _organizationSponsorshipRepository.GetByIdAsync(sponsorshipId);
+                return sponsorship != null;
+            }
+
+            return false;
+        }
+
+        private string RedemptionToken(Guid sponsorshipId) =>
+            string.Concat(
+                TokenClearTextPrefix,
+                _dataProtector.Protect($"{FamiliesForEnterpriseTokenName} {sponsorshipId}")
+            );
 
         public async Task OfferSponsorshipAsync(Organization sponsoringOrg, OrganizationUser sponsoringOrgUser, string sponsoredEmail)
         {
-            // TODO: send sponsorship email, update sponsorship with offered email
-            throw new NotImplementedException();
+            var sponsorship = new OrganizationSponsorship
+            {
+                SponsoringOrganizationId = sponsoringOrg.Id,
+                SponsoringOrganizationUserId = sponsoringOrgUser.Id,
+                OfferedToEmail = sponsoredEmail,
+                CloudSponsor = true,
+            };
+
+            try
+            {
+                sponsorship = await _organizationSponsorshipRepository.CreateAsync(sponsorship);
+
+                // TODO: send email to sponsoredEmail w/ redemption token link
+            }
+            catch
+            {
+                if (sponsorship.Id != default)
+                {
+                    await _organizationSponsorshipRepository.DeleteAsync(sponsorship);
+                }
+                throw;
+            }
         }
 
         public async Task SetUpSponsorshipAsync(OrganizationSponsorship sponsorship, Organization sponsoredOrganization)
         {
-            // TODO: set up sponsorship
+            // TODO: set up sponsorship, remember remove offeredToEmail from sponsorship
             throw new NotImplementedException();
         }
 

--- a/test/Common/Helpers/AssertHelper.cs
+++ b/test/Common/Helpers/AssertHelper.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+using System.IO;
+using System.Linq;
+using Xunit;
+using System;
+using Newtonsoft.Json;
+
+namespace Bit.Test.Common.Helpers
+{
+    public static class AssertHelper
+    {
+        public static void AssertPropertyEqual(object expected, object actual, params string[] excludedPropertyStrings)
+        {
+            var relevantExcludedProperties = excludedPropertyStrings.Where(name => !name.Contains('.')).ToList();
+            if (expected == null)
+            {
+                Assert.Null(actual);
+                return;
+            }
+
+            if (actual == null)
+            {
+                throw new Exception("Expected object is null but actual is not");
+            }
+
+            foreach (var expectedPi in expected.GetType().GetProperties().Where(pi => !relevantExcludedProperties.Contains(pi.Name)))
+            {
+                var actualPi = actual.GetType().GetProperty(expectedPi.Name);
+
+                if (actualPi == null)
+                {
+                    var settings = new JsonSerializerSettings { Formatting = Formatting.Indented };
+                    throw new Exception(string.Concat($"Expected actual object to contain a property named {expectedPi.Name}, but it does not\n",
+                    $"Expected:\n{JsonConvert.SerializeObject(expected, settings)}\n",
+                    $"Actual:\n{JsonConvert.SerializeObject(actual, new JsonSerializerSettings { Formatting = Formatting.Indented })}"));
+                }
+
+                if (expectedPi.PropertyType == typeof(string) || expectedPi.PropertyType.IsValueType)
+                {
+                    Assert.Equal(expectedPi.GetValue(expected), actualPi.GetValue(actual));
+                }
+                else
+                {
+                    var prefix = $"{expectedPi.PropertyType.Name}.";
+                    var nextExcludedProperties = excludedPropertyStrings.Where(name => name.StartsWith(prefix))
+                        .Select(name => name[prefix.Length..]).ToArray();
+                    AssertPropertyEqual(expectedPi.GetValue(expected), actualPi.GetValue(actual), nextExcludedProperties);
+                }
+            }
+        }
+
+        public static Predicate<T> AssertEqualExpectedPredicate<T>(T expected) => (actual) =>
+        {
+            Assert.Equal(expected, actual);
+            return true;
+        };
+    }
+}

--- a/test/Core.Test/Services/OrganizationSponsorshipServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationSponsorshipServiceTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Bit.Core.Models.Table;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Bit.Test.Common.Helpers;
+using Microsoft.IdentityModel.Tokens;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    [SutProviderCustomize]
+    public class OrganizationSponsorshipServiceTests
+    {
+        private bool sponsorshipValidator(OrganizationSponsorship sponsorship, OrganizationSponsorship expectedSponsorship)
+        {
+            try
+            {
+                AssertHelper.AssertPropertyEqual(sponsorship, expectedSponsorship, nameof(OrganizationSponsorship.Id));
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        [Theory]
+        [BitAutoData]
+        public async Task OfferSponsorship_CreatesSponsorship(Organization sponsoringOrg, OrganizationUser sponsoringOrgUser,
+            string sponsoredEmail, SutProvider<OrganizationSponsorshipService> sutProvider)
+        {
+            await sutProvider.Sut.OfferSponsorshipAsync(sponsoringOrg, sponsoringOrgUser, sponsoredEmail);
+
+            var expectedSponsorship = new OrganizationSponsorship
+            {
+                SponsoringOrganizationId = sponsoringOrg.Id,
+                SponsoringOrganizationUserId = sponsoringOrgUser.Id,
+                OfferedToEmail = sponsoredEmail,
+                CloudSponsor = true,
+            };
+
+            await sutProvider.GetDependency<IOrganizationSponsorshipRepository>().Received(1)
+                .CreateAsync(Arg.Is<OrganizationSponsorship>(s => sponsorshipValidator(s, expectedSponsorship)));
+            // TODO: Validate email called with appropriate token.s
+        }
+
+        [Theory]
+        [BitAutoData]
+        public async Task OfferSponsorship_CreateSponsorshipThrows_RevertsDatabase(Organization sponsoringOrg, OrganizationUser sponsoringOrgUser,
+            string sponsoredEmail, SutProvider<OrganizationSponsorshipService> sutProvider)
+        {
+            var expectedException = new Exception();
+            OrganizationSponsorship createdSponsorship = null;
+            sutProvider.GetDependency<IOrganizationSponsorshipRepository>().CreateAsync(default).ThrowsForAnyArgs(callInfo =>
+            {
+                createdSponsorship = callInfo.ArgAt<OrganizationSponsorship>(0);
+                createdSponsorship.Id = Guid.NewGuid();
+                return expectedException;
+            });
+
+            var actualException = await Assert.ThrowsAsync<Exception>(() => sutProvider.Sut.OfferSponsorshipAsync(sponsoringOrg, sponsoringOrgUser, sponsoredEmail));
+            Assert.Same(expectedException, actualException);
+
+            await sutProvider.GetDependency<IOrganizationSponsorshipRepository>().Received(1)
+                .DeleteAsync(createdSponsorship);
+        }
+    }
+}


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Asana task: https://app.asana.com/0/0/1200984489361681/f

Adds the OrganizationSponsorship service methods to send a sponsorship offer.


## Code changes

* **OrganizationSponsorshipController**: Flush out offer endpoint. Limit all endpoints to cloud only.
* **OrganizationSponsoshipService**:
  * Create and validate sponsorship tokens
  * Flush out offer sponsorship method. Note: requires mail service changes.
### Tests
* **Controller**: Test redeem endpoint now that we have the token provider.
* **service**: Test offer redeem method. Failures and success tested.
* **AssertHelper**: Copied from mobile repo, tests equivalence of objects.


## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
