### PR TITLE
Change Release workflow to allow releases from 'rc' and 'hotfix' branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -378,8 +378,10 @@ jobs:
       - name: Make Docker stub
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix'
         run: |
-          if [[ "${{ github.ref }}" == "rc" ]] || [[ "${{ github.ref }}" == "hotfix" ]]; then
+          if [[ "${{ github.ref }}" == "rc" ]]; then
             SETUP_IMAGE="bitwarden/setup:rc"
+          elif [[ "${{ github.ref }}" == "hotfix" ]]; then
+            SETUP_IMAGE="bitwarden/setup:hotfix"
           else
             SETUP_IMAGE="bitwarden/setup:dev"
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,7 +299,8 @@ jobs:
         if: ${{ matrix.dotnet }}
         run: |
           mkdir -p ${{ matrix.base_path}}/${{ matrix.service_name }}/obj/build-output/publish
-          unzip ${{ matrix.service_name }}.zip -d ${{ matrix.base_path }}/${{ matrix.service_name }}/obj/build-output/publish
+          unzip ${{ matrix.service_name }}.zip \
+            -d ${{ matrix.base_path }}/${{ matrix.service_name }}/obj/build-output/publish
 
       - name: Build Docker images
         run: |
@@ -312,10 +313,16 @@ jobs:
           fi
 
       - name: Tag rc
-        if: github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix'
+        if: github.ref == 'refs/heads/rc'
         run: |
           docker tag ${{ matrix.docker_repo }}/${{ steps.setup.outputs.service_name }} \
             ${{ matrix.docker_repo }}/${{ steps.setup.outputs.service_name }}:rc
+
+      - name: Tag hotfix
+        if: github.ref == 'refs/heads/hotfix'
+        run: |
+          docker tag ${{ matrix.docker_repo }}/${{ steps.setup.outputs.service_name }} \
+            ${{ matrix.docker_repo }}/${{ steps.setup.outputs.service_name }}:hotfix
 
       - name: Tag dev
         if: github.ref == 'refs/heads/master'
@@ -328,15 +335,24 @@ jobs:
         run: docker images
 
       - name: Docker Trust setup
-        if: matrix.docker_repo == 'bitwarden' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix')
+        if: |
+          matrix.docker_repo == 'bitwarden'
+          && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix')
+        env:
+          DCT_REPO_PASSPHRASE: ${{ steps.retrieve-secrets.outputs.dct-delegate-2-repo-passphrase }}
         run: |
           echo "DOCKER_CONTENT_TRUST=1" >> $GITHUB_ENV
-          echo "DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE=${{ steps.retrieve-secrets.outputs.dct-delegate-2-repo-passphrase }}" >> $GITHUB_ENV
+          echo "DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE=$DCT_REPO_PASSPHRASE" >> $GITHUB_ENV
 
       - name: Push rc images
-        if: github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix'
+        if: github.ref == 'refs/heads/rc'
         run: |
           docker push ${{ matrix.docker_repo }}/${{ steps.setup.outputs.service_name }}:rc
+
+      - name: Push hotfix images
+        if: github.ref == 'refs/heads/hotfix'
+        run: |
+          docker push ${{ matrix.docker_repo }}/${{ steps.setup.outputs.service_name }}:hotfix
 
       - name: Push dev images
         if: github.ref == 'refs/heads/master'
@@ -421,7 +437,10 @@ jobs:
       - upload
     steps:
       - name: Check if any job failed
-        if: ${{ (github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/rc') || (github.ref == 'refs/heads/hotfix') }}
+        if: |
+          github.ref == 'refs/heads/master'
+          || github.ref == 'refs/heads/rc'
+          || github.ref == 'refs/heads/hotfix'
         env:
           CLOC_STATUS: ${{ needs.cloc.result }}
           TESTING_STATUS: ${{ needs.testing.result }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -260,7 +260,7 @@ jobs:
           creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Log into Docker
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/release'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix'
         env:
           DOCKER_USERNAME: ${{ steps.retrieve-secrets.outputs.docker-username }}
           DOCKER_PASSWORD: ${{ steps.retrieve-secrets.outputs.docker-password }}
@@ -272,7 +272,7 @@ jobs:
           fi
 
       - name: Setup Docker Trust
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/release'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix'
         env:
           DCT_DELEGATION_KEY_ID: "c9bde8ec820701516491e5e03d3a6354e7bd66d05fa3df2b0062f68b116dc59c"
           DCT_DELEGATE_KEY: ${{ steps.retrieve-secrets.outputs.dct-delegate-2-key }}
@@ -312,7 +312,7 @@ jobs:
           fi
 
       - name: Tag rc
-        if: github.ref == 'refs/heads/rc'
+        if: github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix'
         run: |
           docker tag ${{ matrix.docker_repo }}/${{ steps.setup.outputs.service_name }} \
             ${{ matrix.docker_repo }}/${{ steps.setup.outputs.service_name }}:rc
@@ -323,24 +323,18 @@ jobs:
           docker tag ${{ matrix.docker_repo }}/${{ steps.setup.outputs.service_name }} \
             ${{ matrix.docker_repo }}/${{ steps.setup.outputs.service_name }}:dev
 
-      - name: Tag latest
-        if: github.ref == 'refs/heads/release'
-        run: |
-          docker tag ${{ matrix.docker_repo }}/${{ steps.setup.outputs.service_name }} \
-            ${{ matrix.docker_repo }}/${{ steps.setup.outputs.service_name }}:latest
-
       - name: List Docker images
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/release'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix'
         run: docker images
 
       - name: Docker Trust setup
-        if: matrix.docker_repo == 'bitwarden' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/release')
+        if: matrix.docker_repo == 'bitwarden' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix')
         run: |
           echo "DOCKER_CONTENT_TRUST=1" >> $GITHUB_ENV
           echo "DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE=${{ steps.retrieve-secrets.outputs.dct-delegate-2-repo-passphrase }}" >> $GITHUB_ENV
 
       - name: Push rc images
-        if: github.ref == 'refs/heads/rc'
+        if: github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix'
         run: |
           docker push ${{ matrix.docker_repo }}/${{ steps.setup.outputs.service_name }}:rc
 
@@ -349,13 +343,8 @@ jobs:
         run: |
           docker push ${{ matrix.docker_repo }}/${{ steps.setup.outputs.service_name }}:dev
 
-      - name: Push latest images
-        if: github.ref == 'refs/heads/release'
-        run: |
-          docker push ${{ matrix.docker_repo }}/${{ steps.setup.outputs.service_name }}:latest
-
       - name: Log out of Docker
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/release'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix'
         run: docker logout
 
 
@@ -371,12 +360,10 @@ jobs:
         run: dotnet tool restore
 
       - name: Make Docker stub
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/release'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix'
         run: |
-          if [[ "${{ github.ref }}" == "rc" ]]; then
+          if [[ "${{ github.ref }}" == "rc" ]] || [[ "${{ github.ref }}" == "hotfix" ]]; then
             SETUP_IMAGE="bitwarden/setup:rc"
-          elif [[ "${{ github.ref }}" == "release" ]]; then
-            SETUP_IMAGE="bitwarden/setup:latest"
           else
             SETUP_IMAGE="bitwarden/setup:dev"
           fi
@@ -391,7 +378,7 @@ jobs:
           cd docker-stub; zip -r ../docker-stub.zip *; cd ..
 
       - name: Upload Docker stub artifact
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/release'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix'
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: docker-stub.zip
@@ -434,7 +421,7 @@ jobs:
       - upload
     steps:
       - name: Check if any job failed
-        if: ${{ (github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/rc') }}
+        if: ${{ (github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/rc') || (github.ref == 'refs/heads/hotfix') }}
         env:
           CLOC_STATUS: ${{ needs.cloc.result }}
           TESTING_STATUS: ${{ needs.testing.result }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,7 @@ jobs:
     needs: setup
     env:
       _RELEASE_VERSION: ${{ needs.setup.outputs.release_version }}
+      _BRANCH_NAME: ${{ needs.setup.outputs.branch-name }}
     strategy:
       fail-fast: false
       matrix:
@@ -164,23 +165,28 @@ jobs:
           echo "::set-output name=service_name::$SERVICE_NAME"
 
       - name: Pull latest selfhost RC image
-        run: docker pull bitwarden/${{ steps.setup.outputs.service_name }}:rc
+        env:
+          SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
+        run: docker pull bitwarden/$SERVICE_NAME:$_BRANCH_NAME
 
       - name: Tag version and latest
+        env:
+          SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
         run: |
-          docker tag bitwarden/${{ steps.setup.outputs.service_name }}:rc bitwarden/${{ steps.setup.outputs.service_name }}:$_RELEASE_VERSION
-          docker tag bitwarden/${{ steps.setup.outputs.service_name }}:rc bitwarden/${{ steps.setup.outputs.service_name }}:latest
+          docker tag bitwarden/$SERVICE_NAME:$_BRANCH_NAME bitwarden/$SERVICE_NAME:$_RELEASE_VERSION
+          docker tag bitwarden/$SERVICE_NAME:$_BRANCH_NAME bitwarden/$SERVICE_NAME:latest
 
       - name: List Docker images
         run: docker images
 
       - name: Push version and latest image
-        run: |
-          docker push bitwarden/${{ steps.setup.outputs.service_name }}:$_RELEASE_VERSION
-          docker push bitwarden/${{ steps.setup.outputs.service_name }}:latest
         env:
           DOCKER_CONTENT_TRUST: 1
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
+          SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
+        run: |
+          docker push bitwarden/$SERVICE_NAME:$_RELEASE_VERSION
+          docker push bitwarden/$SERVICE_NAME:latest
 
       - name: Log out of Docker
         run: docker logout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,19 +163,21 @@ jobs:
           echo "SERVICE_NAME: $SERVICE_NAME"
           echo "::set-output name=service_name::$SERVICE_NAME"
 
-      - name: Pull latest selfhost Release image
-        run: docker pull bitwarden/${{ steps.setup.outputs.service_name }}:latest
+      - name: Pull latest selfhost RC image
+        run: docker pull bitwarden/${{ steps.setup.outputs.service_name }}:rc
 
-      - name: Tag version
+      - name: Tag version and latest
         run: |
-          docker tag bitwarden/${{ steps.setup.outputs.service_name }}:latest bitwarden/${{ steps.setup.outputs.service_name }}:$_RELEASE_VERSION
+          docker tag bitwarden/${{ steps.setup.outputs.service_name }}:rc bitwarden/${{ steps.setup.outputs.service_name }}:$_RELEASE_VERSION
+          docker tag bitwarden/${{ steps.setup.outputs.service_name }}:rc bitwarden/${{ steps.setup.outputs.service_name }}:latest
 
       - name: List Docker images
         run: docker images
 
-      - name: Push latest image
+      - name: Push version and latest image
         run: |
           docker push bitwarden/${{ steps.setup.outputs.service_name }}:$_RELEASE_VERSION
+          docker push bitwarden/${{ steps.setup.outputs.service_name }}:latest
         env:
           DOCKER_CONTENT_TRUST: 1
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,20 +12,19 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       release_version: ${{ steps.version.outputs.package }}
+      branch-name: ${{ steps.branch.outputs.branch-name }}
     steps:
       - name: Branch check
         run: |
-          if [[ "$GITHUB_REF" != "refs/heads/release" ]]; then
+          if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ "$GITHUB_REF" != "refs/heads/hotfix" ]]; then
             echo "==================================="
-            echo "[!] Can only release from the 'release' branch"
+            echo "[!] Can only release from the 'rc' or 'hotfix' branches"
             echo "==================================="
             exit 1
           fi
 
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-        with:
-          ref: release
 
       - name: Check Release Version
         id: version
@@ -41,6 +40,12 @@ jobs:
           fi
 
           echo "::set-output name=package::$version"
+
+      - name: Get branch name
+        id: branch
+        run: |
+          BRANCH_NAME=$(basename ${{ github.ref }})
+          echo "::set-output name=branch-name::$BRANCH_NAME"
 
 
   deploy:
@@ -72,7 +77,7 @@ jobs:
         with:
           workflow: build.yml
           workflow_conclusion: success
-          branch: release
+          branch: ${{ needs.setup.outputs.branch-name }}
           artifacts: ${{ matrix.name }}.zip
 
       - name: Login to Azure
@@ -191,7 +196,7 @@ jobs:
         with:
           workflow: build.yml
           workflow_conclusion: success
-          branch: release
+          branch: ${{ needs.setup.outputs.branch-name }}
           artifacts: "docker-stub.zip,
                       swagger.json"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
           echo "SERVICE_NAME: $SERVICE_NAME"
           echo "::set-output name=service_name::$SERVICE_NAME"
 
-      - name: Pull latest selfhost RC image
+      - name: Pull latest selfhost image
         env:
           SERVICE_NAME: ${{ steps.setup.outputs.service_name }}
         run: docker pull bitwarden/$SERVICE_NAME:$_BRANCH_NAME


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Changes our `release` workflow to allow releases from only `rc` and `hotfix` branches.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **release.yml:** Adds step to the `setup` job to find the branch name and set it as an output for the job.  Changes the rest of the workflow to use that new branch variable. Changes Docker job to grab the `rc` image and tag it as `latest` and the version of release.
* **build.yml:** Changes Docker to tag images as `rc` when building on the `rc` or `hotfix` branches.

## Before you submit
- [X] I have checked for workflow **linting** errors (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
