### PR TITLE
Prevent XSS possibility from SSO SAML Service URLs

### DIFF
--- a/src/Core/Models/Api/Request/Organizations/OrganizationSsoRequestModel.cs
+++ b/src/Core/Models/Api/Request/Organizations/OrganizationSsoRequestModel.cs
@@ -159,6 +159,25 @@ namespace Bit.Core.Models.Api
                     yield return new ValidationResult(i18nService.GetLocalizedHtmlString("IdpSingleSignOnServiceUrlValidationError"),
                         new[] { nameof(IdpSingleSignOnServiceUrl) });
                 }
+
+                if (ContainsHtmlMetaCharacters(IdpSingleSignOnServiceUrl))
+                {
+                    yield return new ValidationResult(i18nService.GetLocalizedHtmlString("IdpSingleSignOnServiceUrlInvalid"),
+                        new[] { nameof(IdpSingleSignOnServiceUrl) });
+                }
+
+                if (ContainsHtmlMetaCharacters(IdpArtifactResolutionServiceUrl))
+                {
+                    yield return new ValidationResult(i18nService.GetLocalizedHtmlString("IdpArtifactResolutionServiceUrlInvalid"),
+                        new[] { nameof(IdpArtifactResolutionServiceUrl) });
+                }
+
+                if (ContainsHtmlMetaCharacters(IdpSingleLogoutServiceUrl))
+                {
+                    yield return new ValidationResult(i18nService.GetLocalizedHtmlString("IdpSingleLogoutServiceUrlInvalid"),
+                        new[] { nameof(IdpSingleLogoutServiceUrl) });
+                }
+
                 if (!string.IsNullOrWhiteSpace(IdpX509PublicCert))
                 {
                     // Validate the certificate is in a valid format
@@ -239,6 +258,15 @@ namespace Bit.Core.Models.Api
                 @"(((BEGIN|END) CERTIFICATE)|([\-\n\r\t\s\f]))",
                 string.Empty,
                 RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        }
+
+        private bool ContainsHtmlMetaCharacters(string url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                return false;
+            }
+            return Regex.IsMatch(url, "[<>]");
         }
     }
 }

--- a/src/Core/Models/Api/Request/Organizations/OrganizationSsoRequestModel.cs
+++ b/src/Core/Models/Api/Request/Organizations/OrganizationSsoRequestModel.cs
@@ -266,7 +266,7 @@ namespace Bit.Core.Models.Api
             {
                 return false;
             }
-            return Regex.IsMatch(url, "[<>]");
+            return Regex.IsMatch(url, "[<>\"]");
         }
     }
 }

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -442,19 +442,19 @@
   <data name="RequestId" xml:space="preserve">
     <value>Request ID</value>
   </data>
-  <data name="Redirecting">
+  <data name="Redirecting" xml:space="preserve">
     <value>Redirecting</value>
   </data>
-  <data name="RedirectingMessage">
+  <data name="RedirectingMessage" xml:space="preserve">
     <value>You are now being returned to the application. Once complete, you may close this tab.</value>
   </data>
-  <data name="IfIdpWantAuthnRequestsSigned">
+  <data name="IfIdpWantAuthnRequestsSigned" xml:space="preserve">
     <value>If IdP Wants Authn Requests Signed</value>
   </data>
-  <data name="Always">
+  <data name="Always" xml:space="preserve">
     <value>Always</value>
   </data>
-  <data name="Never">
+  <data name="Never" xml:space="preserve">
     <value>Never</value>
   </data>
   <data name="IdpX509PublicCertValidationError" xml:space="preserve">
@@ -466,33 +466,33 @@
   <data name="IdpX509PublicCertCryptographicExceptionValidationError" xml:space="preserve">
     <value>The IdP public certificate provided does not appear to be a valid certificate, please ensure this is a valid, Base64 encoded PEM or CER format public certificate valid for signing: {0}</value>
   </data>
-  <data name="CopyCallbackPath">
+  <data name="CopyCallbackPath" xml:space="preserve">
     <value>Copy the OIDC callback path to your clipboard</value>
   </data>
-  <data name="CopySignedOutCallbackPath">
+  <data name="CopySignedOutCallbackPath" xml:space="preserve">
     <value>Copy the OIDC signed out callback path to your clipboard</value>
   </data>
-  <data name="CopySpEntityId">
+  <data name="CopySpEntityId" xml:space="preserve">
     <value>Copy the SP Entity Id to your clipboard</value>
   </data>
-  <data name="CopySpMetadataUrl">
+  <data name="CopySpMetadataUrl" xml:space="preserve">
     <value>Copy the SAML 2.0 Metadata URL to your clipboard</value>
   </data>
-  <data name="LaunchSpMetadataUrl">
+  <data name="LaunchSpMetadataUrl" xml:space="preserve">
     <value>View the SAML 2.0 Metadata (opens in a new window)</value>
   </data>
-  <data name="CopySpAcsUrl">
+  <data name="CopySpAcsUrl" xml:space="preserve">
     <value>Copy the Assertion Consumer Service (ACS) URL to your clipboard</value>
   </data>
-  <data name="HttpRedirect">
+  <data name="HttpRedirect" xml:space="preserve">
     <value>Redirect</value>
     <comment>A SAML binding type, Redirect</comment>
   </data>
-  <data name="HttpPost">
+  <data name="HttpPost" xml:space="preserve">
     <value>HTTP POST</value>
     <comment>A SAML binding type, HTTP POST</comment>
   </data>
-  <data name="Artifact">
+  <data name="Artifact" xml:space="preserve">
     <value>Artifact</value>
     <comment>A SAML binding type, Artifact</comment>
   </data>
@@ -666,5 +666,14 @@
   </data>
   <data name="ResetPasswordAutoEnrollCheckbox" xml:space="preserve">
     <value>Require new users to be enrolled automatically</value>
+  </data>
+  <data name="IdpArtifactResolutionServiceUrlInvalid" xml:space="preserve">
+    <value>Artifact resolution service URL contains illegal characters.</value>
+  </data>
+  <data name="IdpSingleLogoutServiceUrlInvalid" xml:space="preserve">
+    <value>Single log out service URL contains illegal characters.</value>
+  </data>
+  <data name="IdpSingleSignOnServiceUrlInvalid" xml:space="preserve">
+    <value>Single sign on service URL contains illegal characters.</value>
   </data>
 </root>


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
It was found that the SAML2 library Sustainsys.Saml2 used for the SAML SSO login does not properly sanitize parameters like the SAML2 IdP service URL before embedding them directly into HTML markup with string.Format when using the POST Binding. This induces the risk of attackers injecting malicious markup and constructing a malicious site that could be abused for phishing or leverages malicious JavaScript that is executed in the name of the victim on old browsers. A fully-blown Cross-Site Scripting vulnerability is prevented by modern browsers due to a strict Content-Security Policy set by the library preventing this from being a critical issue.

## Code changes
Added checks on the SSO configuration APIs to validate the SAML service URLs to make sure that they do not contain HTML characters such as `< > "`. We don't expect that real service URLs will ever need these characters.

## Testing requirements
Make sure that proper SSO configurations can be made still and that you cannot save service URLs with these characters, such as:

```
https://bitwarden.com/?sso="><img src=x onerror=window["ale"+"rt"](document.domain)> hi
```


## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
