### PR TITLE
validate service url schema

### DIFF
--- a/src/Core/Models/Api/Request/Organizations/OrganizationSsoRequestModel.cs
+++ b/src/Core/Models/Api/Request/Organizations/OrganizationSsoRequestModel.cs
@@ -160,19 +160,19 @@ namespace Bit.Core.Models.Api
                         new[] { nameof(IdpSingleSignOnServiceUrl) });
                 }
 
-                if (ContainsHtmlMetaCharacters(IdpSingleSignOnServiceUrl))
+                if (InvalidServiceUrl(IdpSingleSignOnServiceUrl))
                 {
                     yield return new ValidationResult(i18nService.GetLocalizedHtmlString("IdpSingleSignOnServiceUrlInvalid"),
                         new[] { nameof(IdpSingleSignOnServiceUrl) });
                 }
 
-                if (ContainsHtmlMetaCharacters(IdpArtifactResolutionServiceUrl))
+                if (InvalidServiceUrl(IdpArtifactResolutionServiceUrl))
                 {
                     yield return new ValidationResult(i18nService.GetLocalizedHtmlString("IdpArtifactResolutionServiceUrlInvalid"),
                         new[] { nameof(IdpArtifactResolutionServiceUrl) });
                 }
 
-                if (ContainsHtmlMetaCharacters(IdpSingleLogoutServiceUrl))
+                if (InvalidServiceUrl(IdpSingleLogoutServiceUrl))
                 {
                     yield return new ValidationResult(i18nService.GetLocalizedHtmlString("IdpSingleLogoutServiceUrlInvalid"),
                         new[] { nameof(IdpSingleLogoutServiceUrl) });
@@ -260,11 +260,15 @@ namespace Bit.Core.Models.Api
                 RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
         }
 
-        private bool ContainsHtmlMetaCharacters(string url)
+        private bool InvalidServiceUrl(string url)
         {
             if (string.IsNullOrWhiteSpace(url))
             {
                 return false;
+            }
+            if (!url.StartsWith("http://") && !url.StartsWith("https://"))
+            {
+                return true;
             }
             return Regex.IsMatch(url, "[<>\"]");
         }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Prevent malicious service URLs from containing some other schema than HTTP/S. This is an additional improvement on top of https://github.com/bitwarden/server/pull/1691


## Code changes
Extend validate functions in `SsoConfigurationDataRequest.cs`.

## Testing requirements
Ensure that you can't save a service URL with a schema other than HTTP/S.

## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
