### PR TITLE
add missing csrf token validation to admin

### DIFF
--- a/src/Admin/Controllers/ProvidersController.cs
+++ b/src/Admin/Controllers/ProvidersController.cs
@@ -70,6 +70,7 @@ namespace Bit.Admin.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create(CreateProviderModel model)
         {
             if (!ModelState.IsValid)

--- a/src/Admin/Controllers/ToolsController.cs
+++ b/src/Admin/Controllers/ToolsController.cs
@@ -60,6 +60,7 @@ namespace Bit.Admin.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> ChargeBraintree(ChargeBraintreeModel model)
         {
             if (!ModelState.IsValid)
@@ -121,6 +122,7 @@ namespace Bit.Admin.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> CreateTransaction(CreateUpdateTransactionModel model)
         {
             if (!ModelState.IsValid)
@@ -150,6 +152,7 @@ namespace Bit.Admin.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> EditTransaction(Guid id, CreateUpdateTransactionModel model)
         {
             if (!ModelState.IsValid)
@@ -173,6 +176,7 @@ namespace Bit.Admin.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> PromoteAdmin(PromoteAdminModel model)
         {
             if (!ModelState.IsValid)
@@ -208,6 +212,7 @@ namespace Bit.Admin.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> GenerateLicense(LicenseModel model)
         {
             if (!ModelState.IsValid)
@@ -316,6 +321,7 @@ namespace Bit.Admin.Controllers
             return View(model);
         }
 
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> TaxRateUpload(IFormFile file)
         {
             if (file == null || file.Length == 0)
@@ -382,6 +388,7 @@ namespace Bit.Admin.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> TaxRateAddEdit(TaxRateAddEditModel model) 
         {
             var existingRateCheck = await _taxRateRepository.GetByLocationAsync(new TaxRate() { Country = model.Country, PostalCode = model.PostalCode });
@@ -411,17 +418,6 @@ namespace Bit.Admin.Controllers
             else
             {
                 await _paymentService.CreateTaxRateAsync(taxRate);
-            }
-
-            return RedirectToAction("TaxRate");
-        }
-
-        [HttpPost]
-        public async Task<IActionResult> TaxRateUpdate(TaxRate model) 
-        {
-            if (!string.IsNullOrWhiteSpace(model.Id))
-            {
-                await _paymentService.UpdateTaxRateAsync(model);
             }
 
             return RedirectToAction("TaxRate");


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Several instances of a missing ValidateAntiForgeryToken attribute were found in the admin panel on actions like PromoteAdmin or CreateTransaction. This could be abused by attackers to perform a handful of actions including the promotion of organization administrators or the creation of transactions.


## Code changes
Add `ValidateAntiForgeryToken` attribute to various actions where it was found missing.

## Testing requirements
Regression and Provider and Tools forms in the admin portal to ensure that they still function without error.

## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
