### PR TITLE
sanitize notification hub tag inputs

### DIFF
--- a/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
+++ b/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
@@ -11,6 +11,7 @@ using Bit.Core.Models;
 using Bit.Core.Models.Data;
 using Bit.Core.Repositories;
 using Bit.Core.Settings;
+using System.Text.RegularExpressions;
 
 namespace Bit.Core.Services
 {
@@ -181,7 +182,7 @@ namespace Bit.Core.Services
         public async Task SendPayloadToUserAsync(string userId, PushType type, object payload, string identifier,
             string deviceId = null)
         {
-            var tag = BuildTag($"template:payload_userId:{userId}", identifier);
+            var tag = BuildTag($"template:payload_userId:{SanitizeTagInput(userId)}", identifier);
             await SendPayloadAsync(tag, type, payload);
             if (InstallationDeviceEntity.IsInstallationDeviceId(deviceId))
             {
@@ -192,7 +193,7 @@ namespace Bit.Core.Services
         public async Task SendPayloadToOrganizationAsync(string orgId, PushType type, object payload, string identifier,
             string deviceId = null)
         {
-            var tag = BuildTag($"template:payload && organizationId:{orgId}", identifier);
+            var tag = BuildTag($"template:payload && organizationId:{SanitizeTagInput(orgId)}", identifier);
             await SendPayloadAsync(tag, type, payload);
             if (InstallationDeviceEntity.IsInstallationDeviceId(deviceId))
             {
@@ -216,7 +217,7 @@ namespace Bit.Core.Services
         {
             if (!string.IsNullOrWhiteSpace(identifier))
             {
-                tag += $" && !deviceIdentifier:{identifier}";
+                tag += $" && !deviceIdentifier:{SanitizeTagInput(identifier)}";
             }
 
             return $"({tag})";
@@ -230,6 +231,12 @@ namespace Bit.Core.Services
                     { "type",  ((byte)type).ToString() },
                     { "payload", JsonConvert.SerializeObject(payload) }
                 }, tag);
+        }
+
+        private string SanitizeTagInput(string input)
+        {
+            // Only allow a-z, A-Z, 0-9, and special characters -_:
+            return Regex.Replace(input, "[^a-zA-Z0-9-_:]", string.Empty);
         }
     }
 }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
It was found that the POST /send endpoint of the push controller receives the user id from the request body as a string before passing it to the push notification service. For the NotificationHub implementation, the user id is embedded unsanitized into the tag expression. This induces the risk of attackers injecting and modifying the tag expression syntax in order to send a notification to all organizations or all users available on the platform.

This could be potentially abused by attackers to spam or desynchronize the state of end-users devices and the Bitwarden API.

## Code changes
Added a `SanitizeTagInput()` function to the `NotificationHubPushNotificationService` implementation to ensure that unexpected characters that could conflict with tag expressions are not used with tag-building functions.

## Testing requirements
Regression test to be sure that mobile live sync via push notifications is still working as expected on iOS and Android in both cloud and self-hosted environments.


## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
