### PR TITLE
use fixed-time comparison of secrets

### DIFF
--- a/src/Api/Utilities/ApiHelpers.cs
+++ b/src/Api/Utilities/ApiHelpers.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Bit.Core.Utilities;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.EventGrid;
 using Microsoft.Azure.EventGrid.Models;
@@ -48,7 +49,7 @@ namespace Bit.Api.Utilities
         {
             var queryKey = request.Query["key"];
 
-            if (queryKey != EventGridKey)
+            if (!CoreHelpers.FixedTimeEquals(queryKey, EventGridKey))
             {
                 return new UnauthorizedObjectResult("Authentication failed. Please use a valid key.");
             }

--- a/src/Billing/Controllers/AppleController.cs
+++ b/src/Billing/Controllers/AppleController.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Core;
+using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -34,7 +35,7 @@ namespace Bit.Billing.Controllers
 
             var key = HttpContext.Request.Query.ContainsKey("key") ?
                 HttpContext.Request.Query["key"].ToString() : null;
-            if (key != _billingSettings.AppleWebhookKey)
+            if (!CoreHelpers.FixedTimeEquals(key, _billingSettings.AppleWebhookKey))
             {
                 return new BadRequestResult();
             }

--- a/src/Billing/Controllers/BitPayController.cs
+++ b/src/Billing/Controllers/BitPayController.cs
@@ -49,7 +49,7 @@ namespace Bit.Billing.Controllers
         [HttpPost("ipn")]
         public async Task<IActionResult> PostIpn([FromBody] BitPayEventModel model, [FromQuery] string key)
         {
-            if (key != _billingSettings.BitPayWebhookKey)
+            if (!CoreHelpers.FixedTimeEquals(key, _billingSettings.BitPayWebhookKey))
             {
                 return new BadRequestResult();
             }

--- a/src/Billing/Controllers/FreshdeskController.cs
+++ b/src/Billing/Controllers/FreshdeskController.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using System.ComponentModel.DataAnnotations;
 
 using Bit.Core.Settings;
+using Bit.Core.Utilities;
 
 namespace Bit.Billing.Controllers
 {
@@ -57,7 +58,7 @@ namespace Bit.Billing.Controllers
 
             var key = HttpContext.Request.Query.ContainsKey("key") ?
                 HttpContext.Request.Query["key"].ToString() : null;
-            if (key != _billingSettings.FreshdeskWebhookKey)
+            if (!CoreHelpers.FixedTimeEquals(key, _billingSettings.FreshdeskWebhookKey))
             {
                 return new BadRequestResult();
             }

--- a/src/Billing/Controllers/PayPalController.cs
+++ b/src/Billing/Controllers/PayPalController.cs
@@ -3,6 +3,7 @@ using Bit.Core.Enums;
 using Bit.Core.Models.Table;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
+using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -56,7 +57,7 @@ namespace Bit.Billing.Controllers
 
             var key = HttpContext.Request.Query.ContainsKey("key") ?
                 HttpContext.Request.Query["key"].ToString() : null;
-            if (key != _billingSettings.PayPal.WebhookKey)
+            if (!CoreHelpers.FixedTimeEquals(key, _billingSettings.PayPal.WebhookKey))
             {
                 _logger.LogWarning("PayPal webhook key is incorrect or does not exist.");
                 return new BadRequestResult();

--- a/src/Billing/Controllers/StripeController.cs
+++ b/src/Billing/Controllers/StripeController.cs
@@ -80,7 +80,7 @@ namespace Bit.Billing.Controllers
         [HttpPost("webhook")]
         public async Task<IActionResult> PostWebhook([FromQuery] string key)
         {
-            if (key != _billingSettings.StripeWebhookKey)
+            if (!CoreHelpers.FixedTimeEquals(key, _billingSettings.StripeWebhookKey))
             {
                 return new BadRequestResult();
             }

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -893,7 +893,7 @@ namespace Bit.Core.Services
                 return false;
             }
 
-            if (string.Compare(user.TwoFactorRecoveryCode, recoveryCode, true) != 0)
+            if (!CoreHelpers.FixedTimeEquals(user.TwoFactorRecoveryCode, recoveryCode))
             {
                 return false;
             }

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -921,5 +921,11 @@ namespace Bit.Core.Utilities
                 return text;
             }
         }
+
+        public static bool FixedTimeEquals(string input1, string input2)
+        {
+            return CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(input1), Encoding.UTF8.GetBytes(input2));
+        }
     }
 }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Several occasions were found where use of time-unsafe string comparison, for instance when comparing the authentication secret supplied to the several WebHook billing controllers. This induces the risk of attackers abusing the linear relationship between the runtime of the comparison and the equivalent prefix-strings of the operands. This could be abused by attackers to accumulate and measure the exact runtime of requests allowing extracting to extract the token character per character.

## Code changes
Implement a `FixedTimeEquals` Core helper function and implement it in several locations such as billing webhooks, azure storage functions, and 2FA recovery token checks.

## Testing requirements
Regressions on:

- Ensure that all billing services are still functioning via their webhook callbacks. 
- Make sure Send file uploads are working as expected.
- Make sure 2FA recovery is still working.


## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
