### PR TITLE
Added middleware for general security headers

### DIFF
--- a/bitwarden_license/src/Sso/Startup.cs
+++ b/bitwarden_license/src/Sso/Startup.cs
@@ -95,6 +95,9 @@ namespace Bit.Sso
 
             app.UseSerilog(env, appLifetime, globalSettings);
 
+            // Add general security headers
+            app.UseMiddleware<SecurityHeadersMiddleware>();
+
             if (!env.IsDevelopment())
             {
                 var uri = new Uri(globalSettings.BaseServiceUri.Sso);

--- a/src/Admin/Startup.cs
+++ b/src/Admin/Startup.cs
@@ -115,6 +115,9 @@ namespace Bit.Admin
         {
             app.UseSerilog(env, appLifetime, globalSettings);
 
+            // Add general security headers
+            app.UseMiddleware<SecurityHeadersMiddleware>();
+
             if (globalSettings.SelfHosted)
             {
                 app.UsePathBase("/admin");

--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -169,6 +169,9 @@ namespace Bit.Api
             IdentityModelEventSource.ShowPII = true;
             app.UseSerilog(env, appLifetime, globalSettings);
 
+            // Add general security headers
+            app.UseMiddleware<SecurityHeadersMiddleware>();
+
             // Default Middleware
             app.UseDefaultMiddleware(env, globalSettings);
 

--- a/src/Billing/Startup.cs
+++ b/src/Billing/Startup.cs
@@ -82,6 +82,9 @@ namespace Bit.Billing
         {
             app.UseSerilog(env, appLifetime, globalSettings);
 
+            // Add general security headers
+            app.UseMiddleware<SecurityHeadersMiddleware>();
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/src/Core/Utilities/SecurityHeadersMiddleware.cs
+++ b/src/Core/Utilities/SecurityHeadersMiddleware.cs
@@ -1,0 +1,30 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+
+namespace Bit.Core.Utilities
+{
+    public sealed class SecurityHeadersMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public SecurityHeadersMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public Task Invoke(HttpContext context)
+        {
+            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+            context.Response.Headers.Add("x-frame-options", new StringValues("SAMEORIGIN"));
+
+            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+            context.Response.Headers.Add("x-xss-protection", new StringValues("1; mode=block"));
+
+            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+            context.Response.Headers.Add("x-content-type-options", new StringValues("nosniff"));
+
+            return _next(context);
+        }
+    }
+}

--- a/src/Events/Startup.cs
+++ b/src/Events/Startup.cs
@@ -90,6 +90,9 @@ namespace Bit.Events
         {
             app.UseSerilog(env, appLifetime, globalSettings);
 
+            // Add general security headers
+            app.UseMiddleware<SecurityHeadersMiddleware>();
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/src/EventsProcessor/Startup.cs
+++ b/src/EventsProcessor/Startup.cs
@@ -43,6 +43,8 @@ namespace Bit.EventsProcessor
         {
             IdentityModelEventSource.ShowPII = true;
             app.UseSerilog(env, appLifetime, globalSettings);
+            // Add general security headers
+            app.UseMiddleware<SecurityHeadersMiddleware>();
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {

--- a/src/Icons/Startup.cs
+++ b/src/Icons/Startup.cs
@@ -56,6 +56,9 @@ namespace Bit.Icons
         {
             app.UseSerilog(env, appLifetime, globalSettings);
 
+            // Add general security headers
+            app.UseMiddleware<SecurityHeadersMiddleware>();
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/src/Identity/Startup.cs
+++ b/src/Identity/Startup.cs
@@ -150,6 +150,9 @@ namespace Bit.Identity
 
             app.UseSerilog(env, appLifetime, globalSettings);
 
+            // Add general security headers
+            app.UseMiddleware<SecurityHeadersMiddleware>();
+
             if (!env.IsDevelopment())
             {
                 var uri = new Uri(globalSettings.BaseServiceUri.Identity);

--- a/src/Notifications/Startup.cs
+++ b/src/Notifications/Startup.cs
@@ -91,6 +91,9 @@ namespace Bit.Notifications
             IdentityModelEventSource.ShowPII = true;
             app.UseSerilog(env, appLifetime, globalSettings);
 
+            // Add general security headers
+            app.UseMiddleware<SecurityHeadersMiddleware>();
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
It was found that certain projects, such as APIs, are missing certain HTTP security headers in HTTP responses. This does not directly lead to a security issue, yet it might aid attackers in their efforts to exploit other problems, or take advantage of browser bugs.  Overall, missing security headers is a bad practice that should be avoided, even on `application/json` response content types.

## Code changes
Added a new middleware for generically settings security headers in HTTP responses. Applied middleware throughout all projects that expose HTTP endpoints.

## Testing requirements
General regression to ensure APIs are working as before.

## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
