### PR TITLE
add ::ffff: to internal ip check

### DIFF
--- a/src/Icons/Services/IconFetchingService.cs
+++ b/src/Icons/Services/IconFetchingService.cs
@@ -427,7 +427,7 @@ namespace Bit.Icons.Services
             }
 
             var ipString = ip.ToString();
-            if (ipString == "::1" || ipString == "::" || ipString == "::ffff:")
+            if (ipString == "::1" || ipString == "::" || ipString.StartsWith("::ffff:"))
             {
                 return true;
             }

--- a/src/Icons/Services/IconFetchingService.cs
+++ b/src/Icons/Services/IconFetchingService.cs
@@ -7,7 +7,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Bit.Icons.Models;
 using Microsoft.Extensions.Logging;
-using System.Text.RegularExpressions;
 using System.Text;
 using AngleSharp.Html.Parser;
 
@@ -428,7 +427,7 @@ namespace Bit.Icons.Services
             }
 
             var ipString = ip.ToString();
-            if (ipString == "::1" || ipString == "::")
+            if (ipString == "::1" || ipString == "::" || ipString == "::ffff:")
             {
                 return true;
             }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The Bitwarden Icon component handles the fetching of website icons, which are then used and displayed by the client side applications. As this component parses the targeted domain from a fully user controlled HTTP path, multiple checks are deployed to ensure no internal system can be reached as this could leak information about the deployed systems or open ports. It was discovered that the deployed logic to detect internal IPv6 addresses is incorrectly implemented and can be bypassed.

The IPv6 standard allows mapping IPv4 addresses via the `::ffff:<ipv4 address>` syntax. The code is trying to detect certain IPv6 addresses but is failing to detect “::ffff:”. It is therefore possible to pass this check by configuring a domain, which DNS AAAA entry points to an internal system.

## Code changes
Added a check to label any IP string that starts with "::ffff:" as an "internal IP" that flows through existing logic to prevent their use.

## Testing requirements
Regression to ensure icons are still resolving under normal use cases.


## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
