### PR TITLE
set MaxResponseContentBufferSize to 5 MB

### DIFF
--- a/src/Icons/Services/IconFetchingService.cs
+++ b/src/Icons/Services/IconFetchingService.cs
@@ -54,6 +54,7 @@ namespace Bit.Icons.Services
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
             });
             _httpClient.Timeout = TimeSpan.FromSeconds(20);
+            _httpClient.MaxResponseContentBufferSize = 5000000; // 5 MB
         }
 
         public async Task<IconResult> GetIconAsync(string domain)


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The Icon service is using the DotNet HttpClient to retrieve the specified domains index page as well as the pages icon. It was discovered that the default maximum response size of 2GB is used. As the returned index page is parsed into a HTML DOM structure, which consumes additional memory resources, an attacker could abuse this behavior to cause a denial service of the server.

## Code changes
Set the `HttpClient.MaxResponseContentBufferSize` property to 5MB.

See: https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.maxresponsecontentbuffersize?view=net-5.0

## Testing requirements
Regression to make sure icons are resolving under normal use cases.


## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
