### PR TITLE
remove dynamic names from admin confirm dialogs

### DIFF
--- a/src/Admin/Views/Organizations/Edit.cshtml
+++ b/src/Admin/Views/Organizations/Edit.cshtml
@@ -305,7 +305,7 @@
             Enterprise Trial
         </button>
         <form asp-action="Delete" asp-route-id="@Model.Organization.Id"
-              onsubmit="return confirm('Are you sure you want to delete this organization (@Model.Organization.Name)?')">
+              onsubmit="return confirm('Are you sure you want to delete this organization?')">
             <button class="btn btn-danger" type="submit">Delete</button>
         </form>
     </div>

--- a/src/Admin/Views/Organizations/View.cshtml
+++ b/src/Admin/Views/Organizations/View.cshtml
@@ -8,6 +8,6 @@
 <h2>Information</h2>
 @await Html.PartialAsync("_ViewInformation", Model)
 <form asp-action="Delete" asp-route-id="@Model.Organization.Id"
-      onsubmit="return confirm('Are you sure you want to delete this organization (@Model.Organization.Name)?')">
+      onsubmit="return confirm('Are you sure you want to delete this organization?')">
     <button class="btn btn-danger" type="submit">Delete</button>
 </form>

--- a/src/Admin/Views/Users/Edit.cshtml
+++ b/src/Admin/Views/Users/Edit.cshtml
@@ -157,7 +157,7 @@
             Upgrade Premium
         </button>
         <form asp-action="Delete" asp-route-id="@Model.User.Id"
-              onsubmit="return confirm('Are you sure you want to delete this user (@Model.User.Email)?')">
+              onsubmit="return confirm('Are you sure you want to delete this user?')">
             <button class="btn btn-danger" type="submit">Delete</button>
         </form>
     </div>

--- a/src/Admin/Views/Users/View.cshtml
+++ b/src/Admin/Views/Users/View.cshtml
@@ -8,6 +8,6 @@
 <h2>Information</h2>
 @await Html.PartialAsync("_ViewInformation", Model)
 <form asp-action="Delete" asp-route-id="@Model.User.Id"
-      onsubmit="return confirm('Are you sure you want to delete this user (@Model.User.Email)?')">
+      onsubmit="return confirm('Are you sure you want to delete this user?')">
     <button class="btn btn-danger" type="submit">Delete</button>
 </form>


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Do not personalize delete messages.

## Code changes
Remove org name and email from delete messages.

## Testing requirements
Ensure that confirmation messages are still presented when deleting users and orgs from admin portal.

## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
