### PR TITLE
[bug] Drop unused db column UsesCryptoAgent

### DIFF
--- a/util/Migrator/DbScripts/2021-11-09_00_DropUsesCryptoAgent.sql
+++ b/util/Migrator/DbScripts/2021-11-09_00_DropUsesCryptoAgent.sql
@@ -1,0 +1,22 @@
+IF COL_LENGTH('[dbo].[User]', 'UsesCryptoAgent') IS NOT NULL
+    BEGIN
+        ALTER TABLE
+            [dbo].[User]
+        DROP COLUMN
+            [UsesCryptoAgent]
+    END
+GO
+
+IF EXISTS(SELECT * FROM sys.views WHERE [Name] = 'UserView')
+    BEGIN
+        DROP VIEW [dbo].[UserView]
+    END
+GO
+
+CREATE VIEW [dbo].[UserView]
+AS
+SELECT
+    *
+FROM
+    [dbo].[User]
+GO


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
UsesCryptoAgent became UsesKeyConnector, but the column was not dropped from the table or view, creating errors during operations like account registration. 

## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
* No changes need, base creates are handled using the model, which is correct.
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
