### PR TITLE
Enable key connector selfhost

### DIFF
--- a/util/Setup/CertBuilder.cs
+++ b/util/Setup/CertBuilder.cs
@@ -97,5 +97,19 @@ namespace Bit.Setup
                 Helpers.ShowBanner(_context, "WARNING", message, ConsoleColor.Yellow);
             }
         }
+
+        public void BuildForUpdater()
+        {
+            if (_context.Config.EnableKeyConnector && !File.Exists("/bitwarden/key-connector/bwkc.pfx"))
+            {
+                Directory.CreateDirectory("/bitwarden/key-connector/");
+                var KeyConnectorCertPassword = Helpers.GetValueFromEnvFile("key-connector",
+                    "keyConnectorSettings__certificate__filesystemPassword");
+                Helpers.Exec("openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout bwkc.key " +
+                             "-out bwkc.crt -subj \"/CN=Bitwarden Key Connector\" -days 36500");
+                Helpers.Exec("openssl pkcs12 -export -out /bitwarden/key-connector/bwkc.pfx -inkey bwkc.key " +
+                             $"-in bwkc.crt -passout pass:{KeyConnectorCertPassword}");
+            }
+        }
     }
 }

--- a/util/Setup/CertBuilder.cs
+++ b/util/Setup/CertBuilder.cs
@@ -103,12 +103,12 @@ namespace Bit.Setup
             if (_context.Config.EnableKeyConnector && !File.Exists("/bitwarden/key-connector/bwkc.pfx"))
             {
                 Directory.CreateDirectory("/bitwarden/key-connector/");
-                var KeyConnectorCertPassword = Helpers.GetValueFromEnvFile("key-connector",
+                var keyConnectorCertPassword = Helpers.GetValueFromEnvFile("key-connector",
                     "keyConnectorSettings__certificate__filesystemPassword");
                 Helpers.Exec("openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout bwkc.key " +
                              "-out bwkc.crt -subj \"/CN=Bitwarden Key Connector\" -days 36500");
                 Helpers.Exec("openssl pkcs12 -export -out /bitwarden/key-connector/bwkc.pfx -inkey bwkc.key " +
-                             $"-in bwkc.crt -passout pass:{KeyConnectorCertPassword}");
+                             $"-in bwkc.crt -passout pass:{keyConnectorCertPassword}");
             }
         }
     }

--- a/util/Setup/Configuration.cs
+++ b/util/Setup/Configuration.cs
@@ -100,7 +100,7 @@ namespace Bit.Setup
             "Learn more: https://nginx.org/en/docs/http/ngx_http_realip_module.html")]
         public List<string> RealIps { get; set; }
 
-        [Description("Enable Key Connector")]
+        [Description("Enable Key Connector (https://bitwarden.com/help/article/deploy-key-connector)")]
         public bool EnableKeyConnector { get; set; } = false;
 
         [YamlIgnore]

--- a/util/Setup/Configuration.cs
+++ b/util/Setup/Configuration.cs
@@ -100,6 +100,9 @@ namespace Bit.Setup
             "Learn more: https://nginx.org/en/docs/http/ngx_http_realip_module.html")]
         public List<string> RealIps { get; set; }
 
+        [Description("Enable Key Connector")]
+        public bool EnableKeyConnector { get; set; } = false;
+
         [YamlIgnore]
         public string Domain
         {

--- a/util/Setup/DockerComposeBuilder.cs
+++ b/util/Setup/DockerComposeBuilder.cs
@@ -50,6 +50,7 @@ namespace Bit.Setup
                     ComposeVersion = context.Config.ComposeVersion;
                 }
                 MssqlDataDockerVolume = context.Config.DatabaseDockerVolume;
+                EnableKeyConnector = context.Config.EnableKeyConnector;
                 HttpPort = context.Config.HttpPort;
                 HttpsPort = context.Config.HttpsPort;
                 if (!string.IsNullOrWhiteSpace(context.CoreVersion))
@@ -64,6 +65,7 @@ namespace Bit.Setup
 
             public string ComposeVersion { get; set; } = "3";
             public bool MssqlDataDockerVolume { get; set; }
+            public bool EnableKeyConnector { get; set; }
             public string HttpPort { get; set; }
             public string HttpsPort { get; set; }
             public bool HasPort => !string.IsNullOrWhiteSpace(HttpPort) || !string.IsNullOrWhiteSpace(HttpsPort);

--- a/util/Setup/EnvironmentFileBuilder.cs
+++ b/util/Setup/EnvironmentFileBuilder.cs
@@ -117,10 +117,10 @@ namespace Bit.Setup
                     ["keyConnectorSettings__webVaultUri"] = _context.Config.Url,
                     ["keyConnectorSettings__identityServerUri"] = "http://identity:5000",
                     ["keyConnectorSettings__database__provider"] = "json",
-                    ["keyConnectorSettings__database__jsonFilePath"] = "/etc/bitwarden/data.json",
+                    ["keyConnectorSettings__database__jsonFilePath"] = "/etc/bitwarden/key-connector/data.json",
                     ["keyConnectorSettings__rsaKey__provider"] = "certificate",
                     ["keyConnectorSettings__certificate__provider"] = "filesystem",
-                    ["keyConnectorSettings__certificate__filesystemPath"] = "/etc/bitwarden/bwkc.pfx",
+                    ["keyConnectorSettings__certificate__filesystemPath"] = "/etc/bitwarden/key-connector/bwkc.pfx",
                     ["keyConnectorSettings__certificate__filesystemPassword"] = Helpers.SecureRandomString(32, alpha: true, numeric: true),
                 };
             }

--- a/util/Setup/EnvironmentFileBuilder.cs
+++ b/util/Setup/EnvironmentFileBuilder.cs
@@ -110,20 +110,17 @@ namespace Bit.Setup
                 ["SA_PASSWORD"] = dbPassword,
             };
 
-            if (_context.Config.EnableKeyConnector)
+            _keyConnectorOverrideValues = new Dictionary<string, string>
             {
-                _keyConnectorOverrideValues = new Dictionary<string, string>
-                {
-                    ["keyConnectorSettings__webVaultUri"] = _context.Config.Url,
-                    ["keyConnectorSettings__identityServerUri"] = "http://identity:5000",
-                    ["keyConnectorSettings__database__provider"] = "json",
-                    ["keyConnectorSettings__database__jsonFilePath"] = "/etc/bitwarden/key-connector/data.json",
-                    ["keyConnectorSettings__rsaKey__provider"] = "certificate",
-                    ["keyConnectorSettings__certificate__provider"] = "filesystem",
-                    ["keyConnectorSettings__certificate__filesystemPath"] = "/etc/bitwarden/key-connector/bwkc.pfx",
-                    ["keyConnectorSettings__certificate__filesystemPassword"] = Helpers.SecureRandomString(32, alpha: true, numeric: true),
-                };
-            }
+                ["keyConnectorSettings__webVaultUri"] = _context.Config.Url,
+                ["keyConnectorSettings__identityServerUri"] = "http://identity:5000",
+                ["keyConnectorSettings__database__provider"] = "json",
+                ["keyConnectorSettings__database__jsonFilePath"] = "/etc/bitwarden/key-connector/data.json",
+                ["keyConnectorSettings__rsaKey__provider"] = "certificate",
+                ["keyConnectorSettings__certificate__provider"] = "filesystem",
+                ["keyConnectorSettings__certificate__filesystemPath"] = "/etc/bitwarden/key-connector/bwkc.pfx",
+                ["keyConnectorSettings__certificate__filesystemPassword"] = Helpers.SecureRandomString(32, alpha: true, numeric: true),
+            };
         }
 
         private void LoadExistingValues(IDictionary<string, string> _values, string file)

--- a/util/Setup/NginxConfigBuilder.cs
+++ b/util/Setup/NginxConfigBuilder.cs
@@ -70,6 +70,7 @@ namespace Bit.Setup
             {
                 Captcha = context.Config.Captcha;
                 Ssl = context.Config.Ssl;
+                EnableKeyConnector = context.Config.EnableKeyConnector;
                 Domain = context.Config.Domain;
                 Url = context.Config.Url;
                 RealIps = context.Config.RealIps;
@@ -117,6 +118,7 @@ namespace Bit.Setup
 
             public bool Captcha { get; set; }
             public bool Ssl { get; set; }
+            public bool EnableKeyConnector { get; set; }
             public string Domain { get; set; }
             public string Url { get; set; }
             public string CertificatePath { get; set; }

--- a/util/Setup/Program.cs
+++ b/util/Setup/Program.cs
@@ -291,6 +291,9 @@ namespace Bit.Setup
 
             var environmentFileBuilder = new EnvironmentFileBuilder(_context);
             environmentFileBuilder.BuildForUpdater();
+            
+            var certBuilder = new CertBuilder(_context);
+            certBuilder.BuildForUpdater();
 
             var nginxBuilder = new NginxConfigBuilder(_context);
             nginxBuilder.BuildForUpdater();

--- a/util/Setup/Templates/DockerCompose.hbs
+++ b/util/Setup/Templates/DockerCompose.hbs
@@ -202,6 +202,8 @@ services:
     restart: always
     volumes:
       - ../key-connector:/etc/bitwarden
+      - ../ca-certificates:/etc/bitwarden/ca-certificates
+      - ../logs/key-connector:/etc/bitwarden/logs
     env_file:
       - ../env/key-connector.override.env
     networks:

--- a/util/Setup/Templates/DockerCompose.hbs
+++ b/util/Setup/Templates/DockerCompose.hbs
@@ -201,7 +201,7 @@ services:
     container_name: bitwarden-key-connector
     restart: always
     volumes:
-      - ../key-connector:/etc/bitwarden
+      - ../key-connector:/etc/bitwarden/key-connector
       - ../ca-certificates:/etc/bitwarden/ca-certificates
       - ../logs/key-connector:/etc/bitwarden/logs
     env_file:

--- a/util/Setup/Templates/DockerCompose.hbs
+++ b/util/Setup/Templates/DockerCompose.hbs
@@ -194,6 +194,20 @@ services:
     networks:
       - default
       - public
+
+{{#if EnableKeyConnector}}
+  key-connector:
+    image: bitwarden/key-connector:latest
+    container_name: bitwarden-key-connector
+    restart: always
+    volumes:
+      - ../key-connector:/etc/bitwarden
+    env_file:
+      - ../env/key-connector.override.env
+    networks:
+      - default
+      - public
+{{/if}}
 {{#if MssqlDataDockerVolume}}
 
 volumes:

--- a/util/Setup/Templates/NginxConfig.hbs
+++ b/util/Setup/Templates/NginxConfig.hbs
@@ -166,4 +166,10 @@ server {
     include /etc/nginx/security-headers.conf;
     add_header X-Frame-Options SAMEORIGIN;
   }
+
+{{#if EnableKeyConnector}}
+  location /key-connector/ {
+    proxy_pass http://key-connector:5000/;
+  }
+{{/if}}
 }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Create a self host deploy model for the key connector.


## Code changes
* **util/Setup/CertBuilder.cs:**  Add the BuildForUpdater function to build the `bwkc.pfx` cert after initial self host installation
* **util/Setup/Configuration.cs:** Add the EnableKeyConnector boolean
* **util/Setup/DockerComposeBuilder.cs:** Add the EnableKeyConnector boolean. 
* **util/Setup/EnvironmentFileBuilder.cs:** Add the new key connector env file with default values
* **util/Setup/NginxConfigBuilder.cs:** Add the EnableKeyConnector boolean
* **util/Setup/Program.cs:** Call new Cert Builder BuildForUpdater function
* **util/Setup/Templates/DockerCompose.hbs:** Add the key connector service
* **util/Setup/Templates/NginxConfig.hbs:** Add the key-connector proxy


## Testing requirements
This needs thorough testing by someone who knows more about SSO and the key connector usage.

### Requirements
- git
- docker
- docker-compose
- dotnet 5.0

### Install & Dev/Test Setup
#### Clean install

1. Set up a clean install of the `dev` self-host server

####  Build new Setup image

1. clone `server` repo
2. `git switch feature/enable-key-connector-selfhost`
3. `cd server/util/Setup`
4. `./build.sh && docker build -t bitwarden/setup:dev .`

#### Edit scripts to use new Setup image
With the current way we are releasing the self host installation scripts, we need to make some modifications so that we don't pull the latest released `bitwarden/setup:dev` image. These are the original self-host install scripts and not their respective counterparts in the newly cloned `server` project.

1. edit bitwarden.sh
  a. change COREVERSION to latest
  b. add a return to the top of the downloadRunFile function
    ```
    function downloadRunFile() {
      return
      ...
    }
    ```
2. edit bwdata/scripts/run.sh
  a. add a return line to the pullSetup function
    ```
    function pullSetup() {
      return
      ...
    }
    ```

#### Update installation and enable key connector

1. run a `./bitwarden.sh update`
2. in the `bwdata/config.yml` file, enable the key connector by setting the `enable_key_connector` to `true`
3. run a `./bitwarden.sh update`
4. The key connector should now be set up and ready to use. I'm not sure how to test further.


## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
