### PR TITLE
[Key Connector] Add ApiUseKeyConnector flag to token response

### DIFF
--- a/src/Core/IdentityServer/CustomTokenRequestValidator.cs
+++ b/src/Core/IdentityServer/CustomTokenRequestValidator.cs
@@ -95,7 +95,8 @@ namespace Bit.Core.IdentityServer
             if (context.Result.ValidatedRequest.GrantType == "client_credentials")
             {
                 if (user.UsesKeyConnector) {
-                    // KeyConnectorUrl is configured in the CLI client, just disable master password reset
+                    // KeyConnectorUrl is configured in the CLI client, we just need to tell the client to use it
+                    context.Result.CustomResponse["ApiUseKeyConnector"] = true;
                     context.Result.CustomResponse["ResetMasterPassword"] = false;
                 }
                 return;


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

> In CLI, if the key connector URL is saved via the `config` command, then it will always try to use key connector - even on an account that still has a MP. URLs should be a set-and-forget kind of exercise.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/IdentityServer/CustomTokenRequestValidator.cs** - if the user is logging in with an api key and uses Key Connector, return an additional flag in the response. If the CLI detects this flag, it will use the locally configured Key Connector endpoint.

Depends on https://github.com/bitwarden/jslib/pull/544

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

User should be able to:
* configure --key-connector endpoint in CLI
* log in using `--apikey` to both KC and MP accounts without having to change configuration

## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
