### PR TITLE
[Key Connector] Fix policy checks and other pre-reqs

### DIFF
--- a/src/Core/Services/Implementations/PolicyService.cs
+++ b/src/Core/Services/Implementations/PolicyService.cs
@@ -61,10 +61,20 @@ namespace Bit.Core.Services
                     break;
                 
                case PolicyType.RequireSso:
+                   if (policy.Enabled)
+                    {
+                        await DependsOnSingleOrgAsync(org);
+                    }
+                    else
+                    {
+                        await RequiredByKeyConnectorAsync(org);
+                    }
+                    break;
+
                case PolicyType.MaximumVaultTimeout:
                    if (policy.Enabled)
                    {
-                        await RequiredBySingleOrgAsync(org);
+                        await DependsOnSingleOrgAsync(org);
                    }
                    break;
             }
@@ -125,7 +135,7 @@ namespace Bit.Core.Services
             await _eventService.LogPolicyEventAsync(policy, Enums.EventType.Policy_Updated);
         }
 
-        private async Task RequiredBySingleOrgAsync(Organization org)
+        private async Task DependsOnSingleOrgAsync(Organization org)
         {
             var singleOrg = await _policyRepository.GetByOrganizationIdTypeAsync(org.Id, PolicyType.SingleOrg);
             if (singleOrg?.Enabled != true)

--- a/src/Core/Services/Implementations/PolicyService.cs
+++ b/src/Core/Services/Implementations/PolicyService.cs
@@ -54,25 +54,9 @@ namespace Bit.Core.Services
                 case PolicyType.SingleOrg:
                     if (!policy.Enabled)
                     {
-                        var requireSso =
-                            await _policyRepository.GetByOrganizationIdTypeAsync(org.Id, PolicyType.RequireSso);
-                        if (requireSso?.Enabled == true)
-                        {
-                            throw new BadRequestException("Single Sign-On Authentication policy is enabled.");
-                        }
-
-                        var vaultTimeout =
-                            await _policyRepository.GetByOrganizationIdTypeAsync(org.Id, PolicyType.MaximumVaultTimeout);
-                        if (vaultTimeout?.Enabled == true)
-                        {
-                            throw new BadRequestException("Maximum Vault Timeout policy is enabled.");
-                        }
-
-                        var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(org.Id);
-                        if (ssoConfig?.GetData()?.UseKeyConnector == true)
-                        {
-                            throw new BadRequestException("Key Connector is enabled.");
-                        }
+                        await RequiredBySsoAsync(org);
+                        await RequiredByVaultTimeoutAsync(org);
+                        await RequiredByKeyConnectorAsync(org);
                     }
                     break;
                 
@@ -80,11 +64,7 @@ namespace Bit.Core.Services
                case PolicyType.MaximumVaultTimeout:
                    if (policy.Enabled)
                    {
-                       var singleOrg = await _policyRepository.GetByOrganizationIdTypeAsync(org.Id, PolicyType.SingleOrg);
-                       if (singleOrg?.Enabled != true)
-                       {
-                           throw new BadRequestException("Single Organization policy not enabled.");
-                       }
+                        await RequiredBySingleOrgAsync(org);
                    }
                    break;
             }
@@ -143,6 +123,43 @@ namespace Bit.Core.Services
             policy.RevisionDate = now;
             await _policyRepository.UpsertAsync(policy);
             await _eventService.LogPolicyEventAsync(policy, Enums.EventType.Policy_Updated);
+        }
+
+        private async Task RequiredBySingleOrgAsync(Organization org)
+        {
+            var singleOrg = await _policyRepository.GetByOrganizationIdTypeAsync(org.Id, PolicyType.SingleOrg);
+            if (singleOrg?.Enabled != true)
+            {
+                throw new BadRequestException("Single Organization policy not enabled.");
+            }
+        }
+
+        private async Task RequiredBySsoAsync(Organization org)
+        {
+            var requireSso = await _policyRepository.GetByOrganizationIdTypeAsync(org.Id, PolicyType.RequireSso);
+            if (requireSso?.Enabled == true)
+            {
+                throw new BadRequestException("Single Sign-On Authentication policy is enabled.");
+            }
+        }
+
+        private async Task RequiredByKeyConnectorAsync(Organization org)
+        {
+
+            var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(org.Id);
+            if (ssoConfig?.GetData()?.UseKeyConnector == true)
+            {
+                throw new BadRequestException("Key Connector is enabled.");
+            }
+        }
+
+        private async Task RequiredByVaultTimeoutAsync(Organization org)
+        {
+            var vaultTimeout = await _policyRepository.GetByOrganizationIdTypeAsync(org.Id, PolicyType.MaximumVaultTimeout);
+            if (vaultTimeout?.Enabled == true)
+            {
+                throw new BadRequestException("Maximum Vault Timeout policy is enabled.");
+            }
         }
     }
 }

--- a/src/Core/Services/Implementations/PolicyService.cs
+++ b/src/Core/Services/Implementations/PolicyService.cs
@@ -71,7 +71,7 @@ namespace Bit.Core.Services
                         var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(org.Id);
                         if (ssoConfig?.GetData()?.UseKeyConnector == true)
                         {
-                            throw new BadRequestException("KeyConnector is enabled.");
+                            throw new BadRequestException("Key Connector is enabled.");
                         }
                     }
                     break;

--- a/src/Core/Services/Implementations/SsoConfigService.cs
+++ b/src/Core/Services/Implementations/SsoConfigService.cs
@@ -44,7 +44,7 @@ namespace Bit.Core.Services
             var oldConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(config.OrganizationId);
             if (oldConfig?.GetData()?.UseKeyConnector == true && !useKeyConnector)
             {
-                throw new BadRequestException("KeyConnector cannot be disabled at this moment.");
+                throw new BadRequestException("Key Connector cannot be disabled at this moment.");
             }
 
             await LogEventsAsync(config, oldConfig);
@@ -56,13 +56,13 @@ namespace Bit.Core.Services
             var singleOrgPolicy = await _policyRepository.GetByOrganizationIdTypeAsync(config.OrganizationId, PolicyType.SingleOrg);
             if (singleOrgPolicy is not { Enabled: true })
             {
-                throw new BadRequestException("KeyConnector requires the Single Organization policy to be enabled.");
+                throw new BadRequestException("Key Connector requires the Single Organization policy to be enabled.");
             }
 
             var ssoPolicy = await _policyRepository.GetByOrganizationIdTypeAsync(config.OrganizationId, PolicyType.RequireSso);
             if (ssoPolicy is not { Enabled: true })
             {
-                throw new BadRequestException("KeyConnector requires the Single Sign-On Authentication policy to be enabled.");
+                throw new BadRequestException("Key Connector requires the Single Sign-On Authentication policy to be enabled.");
             }
 
             if (!config.Enabled) {

--- a/src/Core/Services/Implementations/SsoConfigService.cs
+++ b/src/Core/Services/Implementations/SsoConfigService.cs
@@ -64,6 +64,10 @@ namespace Bit.Core.Services
             {
                 throw new BadRequestException("KeyConnector requires the Single Sign-On Authentication policy to be enabled.");
             }
+
+            if (!config.Enabled) {
+                throw new BadRequestException("You must enable SSO to use Key Connector.");
+            }
         }
 
         private async Task LogEventsAsync(SsoConfig config, SsoConfig oldConfig)

--- a/src/Core/Services/Implementations/SsoConfigService.cs
+++ b/src/Core/Services/Implementations/SsoConfigService.cs
@@ -53,10 +53,16 @@ namespace Bit.Core.Services
 
         private async Task VerifyDependenciesAsync(SsoConfig config)
         {
-            var policy = await _policyRepository.GetByOrganizationIdTypeAsync(config.OrganizationId, PolicyType.SingleOrg);
-            if (policy is not { Enabled: true })
+            var singleOrgPolicy = await _policyRepository.GetByOrganizationIdTypeAsync(config.OrganizationId, PolicyType.SingleOrg);
+            if (singleOrgPolicy is not { Enabled: true })
             {
-                throw new BadRequestException("KeyConnector requires Single Organization to be enabled.");
+                throw new BadRequestException("KeyConnector requires the Single Organization policy to be enabled.");
+            }
+
+            var ssoPolicy = await _policyRepository.GetByOrganizationIdTypeAsync(config.OrganizationId, PolicyType.RequireSso);
+            if (ssoPolicy is not { Enabled: true })
+            {
+                throw new BadRequestException("KeyConnector requires the Single Sign-On Authentication policy to be enabled.");
             }
         }
 

--- a/test/Core.Test/Services/PolicyServiceTests.cs
+++ b/test/Core.Test/Services/PolicyServiceTests.cs
@@ -153,7 +153,7 @@ namespace Bit.Core.Test.Services
                     Substitute.For<IOrganizationService>(),
                     Guid.NewGuid()));
 
-            Assert.Contains("KeyConnector is enabled.", badRequestException.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Key Connector is enabled.", badRequestException.Message, StringComparison.OrdinalIgnoreCase);
 
             await sutProvider.GetDependency<IPolicyRepository>()
                 .DidNotReceiveWithAnyArgs()

--- a/test/Core.Test/Services/PolicyServiceTests.cs
+++ b/test/Core.Test/Services/PolicyServiceTests.cs
@@ -126,12 +126,16 @@ namespace Bit.Core.Test.Services
                 .UpsertAsync(default);
         }
 
-        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
-        public async Task SaveAsync_SingleOrg_KeyConnectorEnabled_ThrowsBadRequest(
-            [PolicyFixtures.Policy(Enums.PolicyType.SingleOrg)] Core.Models.Table.Policy policy,
+        [Theory]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, Enums.PolicyType.SingleOrg)]
+        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, Enums.PolicyType.RequireSso)]
+        public async Task SaveAsync_PolicyRequiredByKeyConnector_DisablePolicy_ThrowsBadRequest(
+            Enums.PolicyType policyType,
+            Policy policy,
             SutProvider<PolicyService> sutProvider)
         {
             policy.Enabled = false;
+            policy.Type = policyType;
 
             SetupOrg(sutProvider, policy.OrganizationId, new Organization
             {

--- a/test/Core.Test/Services/SsoConfigServiceTests.cs
+++ b/test/Core.Test/Services/SsoConfigServiceTests.cs
@@ -100,7 +100,7 @@ namespace Bit.Core.Test.Services
             var exception = await Assert.ThrowsAsync<BadRequestException>(
                 () => sutProvider.Sut.SaveAsync(newSsoConfig));
 
-            Assert.Contains("KeyConnector cannot be disabled at this moment.", exception.Message);
+            Assert.Contains("Key Connector cannot be disabled at this moment.", exception.Message);
 
             await sutProvider.GetDependency<ISsoConfigRepository>().DidNotReceiveWithAnyArgs()
                 .UpsertAsync(default);
@@ -124,7 +124,7 @@ namespace Bit.Core.Test.Services
             var exception = await Assert.ThrowsAsync<BadRequestException>(
                 () => sutProvider.Sut.SaveAsync(ssoConfig));
 
-            Assert.Contains("KeyConnector requires Single Organization to be enabled.", exception.Message);
+            Assert.Contains("Key Connector requires the Single Organization policy to be enabled.", exception.Message);
 
             await sutProvider.GetDependency<ISsoConfigRepository>().DidNotReceiveWithAnyArgs()
                 .UpsertAsync(default);


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

* Require SSO policy to be enabled to use Key Connector - fixes https://app.asana.com/0/1200804338582616/1201357373510768/f
* Require SSO configuration to be enabled to use Key Connector - fixes https://app.asana.com/0/1200804338582616/1201355566830450/f
* Update tests

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **In all files** - fix wording of error messages, "Key Connector" instead of "KeyConnector", and minor wording on policy requirements to clarify that they are policies

* **src/Core/Services/Implementations/PolicyService.cs**
  * refactor: extract each dependency into its own private method to allow for re-use
  * block disabling SSO Policy if Key Connector is enabled
* **test/Core.Test/Services/PolicyServiceTests.cs** - test this new dependency. I've reworked one of the existing tests to use inline autodata, given that we only need to change the policyType being disabled.

* **src/Core/Services/Implementations/SsoConfigService.cs**
  * block enabling Key Connector if SSO Policy is disabled
  * block enabling Key Connector if SSO configuration is disabled
* **test/Core.Test/Services/SsoConfigServiceTests.cs** - add tests for the above


## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
