### PR TITLE
Allow disabling key connector if no user is enrolled

### DIFF
--- a/src/Core/Services/Implementations/SsoConfigService.cs
+++ b/src/Core/Services/Implementations/SsoConfigService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
@@ -12,17 +13,20 @@ namespace Bit.Core.Services
         private readonly ISsoConfigRepository _ssoConfigRepository;
         private readonly IPolicyRepository _policyRepository;
         private readonly IOrganizationRepository _organizationRepository;
+        private readonly IOrganizationUserRepository _organizationUserRepository;
         private readonly IEventService _eventService;
 
         public SsoConfigService(
             ISsoConfigRepository ssoConfigRepository,
             IPolicyRepository policyRepository,
             IOrganizationRepository organizationRepository,
+            IOrganizationUserRepository organizationUserRepository,
             IEventService eventService)
         {
             _ssoConfigRepository = ssoConfigRepository;
             _policyRepository = policyRepository;
             _organizationRepository = organizationRepository;
+            _organizationUserRepository = organizationUserRepository;
             _eventService = eventService;
         }
 
@@ -42,13 +46,21 @@ namespace Bit.Core.Services
             }
 
             var oldConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(config.OrganizationId);
-            if (oldConfig?.GetData()?.UseKeyConnector == true && !useKeyConnector)
+            var disabledKeyConnector = oldConfig?.GetData()?.UseKeyConnector == true && !useKeyConnector;
+            if (disabledKeyConnector && await UserHasKeyConnectorEnabledAsync(config.OrganizationId))
             {
-                throw new BadRequestException("KeyConnector cannot be disabled at this moment.");
+                throw new BadRequestException("Key Connector cannot be disabled at this moment.");
             }
 
             await LogEventsAsync(config, oldConfig);
             await _ssoConfigRepository.UpsertAsync(config);
+        }
+
+        private async Task<bool> UserHasKeyConnectorEnabledAsync(Guid organizationId)
+        {
+            var userDetails =
+                await _organizationUserRepository.GetManyDetailsByOrganizationAsync(organizationId);
+            return userDetails.Any(u => u.UsesKeyConnector);
         }
 
         private async Task VerifyDependenciesAsync(SsoConfig config)

--- a/src/Core/Services/Implementations/SsoConfigService.cs
+++ b/src/Core/Services/Implementations/SsoConfigService.cs
@@ -47,7 +47,7 @@ namespace Bit.Core.Services
 
             var oldConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(config.OrganizationId);
             var disabledKeyConnector = oldConfig?.GetData()?.UseKeyConnector == true && !useKeyConnector;
-            if (disabledKeyConnector && await UserHasKeyConnectorEnabledAsync(config.OrganizationId))
+            if (disabledKeyConnector && await AnyOrgUserHasKeyConnectorEnabledAsync(config.OrganizationId))
             {
                 throw new BadRequestException("Key Connector cannot be disabled at this moment.");
             }
@@ -56,7 +56,7 @@ namespace Bit.Core.Services
             await _ssoConfigRepository.UpsertAsync(config);
         }
 
-        private async Task<bool> UserHasKeyConnectorEnabledAsync(Guid organizationId)
+        private async Task<bool> AnyOrgUserHasKeyConnectorEnabledAsync(Guid organizationId)
         {
             var userDetails =
                 await _organizationUserRepository.GetManyDetailsByOrganizationAsync(organizationId);

--- a/test/Core.Test/Services/SsoConfigServiceTests.cs
+++ b/test/Core.Test/Services/SsoConfigServiceTests.cs
@@ -100,9 +100,6 @@ namespace Bit.Core.Test.Services
             sutProvider.GetDependency<IOrganizationUserRepository>().GetManyDetailsByOrganizationAsync(orgId)
                 .Returns(new[] { new OrganizationUserUserDetails { UsesKeyConnector = true } });
 
-            sutProvider.GetDependency<IOrganizationUserRepository>().GetManyDetailsByOrganizationAsync(orgId)
-                .Returns(new[] { new OrganizationUserUserDetails { UsesKeyConnector = true } });
-
             var exception = await Assert.ThrowsAsync<BadRequestException>(
                 () => sutProvider.Sut.SaveAsync(newSsoConfig));
 

--- a/test/Core.Test/Services/SsoConfigServiceTests.cs
+++ b/test/Core.Test/Services/SsoConfigServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Bit.Core.Exceptions;
+using Bit.Core.Models.Data;
 using Bit.Core.Models.Table;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
@@ -96,14 +97,54 @@ namespace Bit.Core.Test.Services
             var ssoConfigRepository = sutProvider.GetDependency<ISsoConfigRepository>();
             ssoConfigRepository.GetByOrganizationIdAsync(orgId).Returns(oldSsoConfig);
             ssoConfigRepository.UpsertAsync(newSsoConfig).Returns(Task.CompletedTask);
+            sutProvider.GetDependency<IOrganizationUserRepository>().GetManyDetailsByOrganizationAsync(orgId)
+                .Returns(new[] { new OrganizationUserUserDetails { UsesKeyConnector = true } });
+
+            sutProvider.GetDependency<IOrganizationUserRepository>().GetManyDetailsByOrganizationAsync(orgId)
+                .Returns(new[] { new OrganizationUserUserDetails { UsesKeyConnector = true } });
 
             var exception = await Assert.ThrowsAsync<BadRequestException>(
                 () => sutProvider.Sut.SaveAsync(newSsoConfig));
 
-            Assert.Contains("KeyConnector cannot be disabled at this moment.", exception.Message);
+            Assert.Contains("Key Connector cannot be disabled at this moment.", exception.Message);
 
             await sutProvider.GetDependency<ISsoConfigRepository>().DidNotReceiveWithAnyArgs()
                 .UpsertAsync(default);
+        }
+
+        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
+        public async Task SaveAsync_AllowDisablingKeyConnectorNoUserUsing(SutProvider<SsoConfigService> sutProvider,
+            Guid orgId)
+        {
+            var utcNow = DateTime.UtcNow;
+
+            var oldSsoConfig = new SsoConfig
+            {
+                Id = 1,
+                Data = "{\"useKeyConnector\": true}",
+                Enabled = true,
+                OrganizationId = orgId,
+                CreationDate = utcNow.AddDays(-10),
+                RevisionDate = utcNow.AddDays(-10),
+            };
+
+            var newSsoConfig = new SsoConfig
+            {
+                Id = 1,
+                Data = "{}",
+                Enabled = true,
+                OrganizationId = orgId,
+                CreationDate = utcNow.AddDays(-10),
+                RevisionDate = utcNow,
+            };
+
+            var ssoConfigRepository = sutProvider.GetDependency<ISsoConfigRepository>();
+            ssoConfigRepository.GetByOrganizationIdAsync(orgId).Returns(oldSsoConfig);
+            ssoConfigRepository.UpsertAsync(newSsoConfig).Returns(Task.CompletedTask);
+            sutProvider.GetDependency<IOrganizationUserRepository>().GetManyDetailsByOrganizationAsync(orgId)
+                .Returns(new[] { new OrganizationUserUserDetails { UsesKeyConnector = false } });
+
+            await sutProvider.Sut.SaveAsync(newSsoConfig);
         }
 
         [Theory, CustomAutoData(typeof(SutProviderCustomization))]

--- a/test/Core.Test/Services/SsoConfigServiceTests.cs
+++ b/test/Core.Test/Services/SsoConfigServiceTests.cs
@@ -110,8 +110,8 @@ namespace Bit.Core.Test.Services
         }
 
         [Theory, CustomAutoData(typeof(SutProviderCustomization))]
-        public async Task SaveAsync_AllowDisablingKeyConnectorNoUserUsing(SutProvider<SsoConfigService> sutProvider,
-            Guid orgId)
+        public async Task SaveAsync_AllowDisablingKeyConnectorWhenNoUserIsUsingIt(
+            SutProvider<SsoConfigService> sutProvider, Guid orgId)
         {
             var utcNow = DateTime.UtcNow;
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Allows disabling of key connector as long as no organization user is enrolled.

Resolves https://app.asana.com/0/1201363553288890/1201363553288929

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

Verify key connector can be disabled if no user is enrolled, and verify it cannot if a user is enrolled.

## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
