### PR TITLE
[Key Connector] Disable EA Takeover

### DIFF
--- a/test/Core.Test/Services/EmergencyAccessServiceTests.cs
+++ b/test/Core.Test/Services/EmergencyAccessServiceTests.cs
@@ -1,0 +1,117 @@
+﻿using Bit.Core.Exceptions;
+using Bit.Core.Models.Table;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Bit.Core.Test.AutoFixture.Attributes;
+using Bit.Core.Test.AutoFixture;
+using NSubstitute;
+using System.Threading.Tasks;
+using System;
+using Xunit;
+
+namespace Bit.Core.Test.Services
+{
+    public class EmergencyAccessServiceTests
+    {
+        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
+        public async Task InviteAsync_UserWithKeyConnectorCannotUseTakeover(
+            SutProvider<EmergencyAccessService> sutProvider, User invitingUser, string email, int waitTime)
+        {
+            invitingUser.UsesKeyConnector = true;
+            sutProvider.GetDependency<IUserService>().CanAccessPremium(invitingUser).Returns(true);
+
+            var exception = await Assert.ThrowsAsync<BadRequestException>(
+                () => sutProvider.Sut.InviteAsync(invitingUser, email, Enums.EmergencyAccessType.Takeover, waitTime));
+
+            Assert.Contains("You cannot use Emergency Access Takeover because you are using Key Connector", exception.Message);
+            await sutProvider.GetDependency<IEmergencyAccessRepository>().DidNotReceiveWithAnyArgs().CreateAsync(default);
+        }
+
+        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
+        public async Task ConfirmUserAsync_UserWithKeyConnectorCannotUseTakeover(
+            SutProvider<EmergencyAccessService> sutProvider, User confirmingUser, string key)
+        {
+            confirmingUser.UsesKeyConnector = true;
+            var emergencyAccess = new EmergencyAccess
+            {
+                Status = Enums.EmergencyAccessStatusType.Accepted,
+                GrantorId = confirmingUser.Id,
+                Type = Enums.EmergencyAccessType.Takeover,
+            };
+
+            sutProvider.GetDependency<IUserRepository>().GetByIdAsync(confirmingUser.Id).Returns(confirmingUser);
+            sutProvider.GetDependency<IEmergencyAccessRepository>().GetByIdAsync(Arg.Any<Guid>()).Returns(emergencyAccess);
+
+            var exception = await Assert.ThrowsAsync<BadRequestException>(
+                () => sutProvider.Sut.ConfirmUserAsync(new Guid(), key, confirmingUser.Id));
+
+            Assert.Contains("You cannot use Emergency Access Takeover because you are using Key Connector", exception.Message);
+            await sutProvider.GetDependency<IEmergencyAccessRepository>().DidNotReceiveWithAnyArgs().ReplaceAsync(default);
+        }
+
+        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
+        public async Task SaveAsync_UserWithKeyConnectorCannotUseTakeover(
+            SutProvider<EmergencyAccessService> sutProvider, User savingUser)
+        {
+            savingUser.UsesKeyConnector = true;
+            var emergencyAccess = new EmergencyAccess
+            {
+                Type = Enums.EmergencyAccessType.Takeover,
+                GrantorId = savingUser.Id,
+            };
+
+            sutProvider.GetDependency<IUserService>().GetUserByIdAsync(savingUser.Id).Returns(savingUser);
+           
+            var exception = await Assert.ThrowsAsync<BadRequestException>(
+                () => sutProvider.Sut.SaveAsync(emergencyAccess, savingUser.Id));
+
+            Assert.Contains("You cannot use Emergency Access Takeover because you are using Key Connector", exception.Message);
+            await sutProvider.GetDependency<IEmergencyAccessRepository>().DidNotReceiveWithAnyArgs().ReplaceAsync(default);
+        }
+
+        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
+        public async Task InitiateAsync_UserWithKeyConnectorCannotUseTakeover(
+            SutProvider<EmergencyAccessService> sutProvider, User initiatingUser, User grantor)
+        {
+            grantor.UsesKeyConnector = true;
+            var emergencyAccess = new EmergencyAccess
+            {
+                Status = Enums.EmergencyAccessStatusType.Confirmed,
+                GranteeId = initiatingUser.Id,
+                GrantorId = grantor.Id,
+                Type = Enums.EmergencyAccessType.Takeover,
+            };
+
+            sutProvider.GetDependency<IEmergencyAccessRepository>().GetByIdAsync(Arg.Any<Guid>()).Returns(emergencyAccess);
+            sutProvider.GetDependency<IUserRepository>().GetByIdAsync(grantor.Id).Returns(grantor);
+
+            var exception = await Assert.ThrowsAsync<BadRequestException>(
+                () => sutProvider.Sut.InitiateAsync(new Guid(), initiatingUser));
+
+            Assert.Contains("You cannot takeover an account that is using Key Connector", exception.Message);
+            await sutProvider.GetDependency<IEmergencyAccessRepository>().DidNotReceiveWithAnyArgs().ReplaceAsync(default);
+        }
+
+        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
+        public async Task TakeoverAsync_UserWithKeyConnectorCannotUseTakeover(
+            SutProvider<EmergencyAccessService> sutProvider, User requestingUser, User grantor)
+        {
+            grantor.UsesKeyConnector = true;
+            var emergencyAccess = new EmergencyAccess
+            {
+                GrantorId = grantor.Id,
+                GranteeId = requestingUser.Id,
+                Status = Enums.EmergencyAccessStatusType.RecoveryApproved,
+                Type = Enums.EmergencyAccessType.Takeover,
+            };
+
+            sutProvider.GetDependency<IEmergencyAccessRepository>().GetByIdAsync(Arg.Any<Guid>()).Returns(emergencyAccess);
+            sutProvider.GetDependency<IUserRepository>().GetByIdAsync(grantor.Id).Returns(grantor);
+
+            var exception = await Assert.ThrowsAsync<BadRequestException>(
+                () => sutProvider.Sut.TakeoverAsync(new Guid(), requestingUser));
+
+            Assert.Contains("You cannot takeover an account that is using Key Connector", exception.Message);
+        }
+    }
+}


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Disable Emergency Access Takeover if the grantor is using Key Connector.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/Services/Implementations/EmergencyAccessService.cs** - add checks at key touchpoints for Emergency Access:
  * creating an invite
  * editing/saving an invite
  * confirming a grantee
  * requesting takeover access
  * takeover

This may be excessive, but we don't know what Emergency Access invites a user may have saved, or what state they're in, at the time they convert to Key Connector. We also want to make sure that if we've bricked an existing EA configuration, we let the relevant person know as soon as possible (e.g. don't make them wait until the end of the 7 days).

I did not block the following, generally because they seem like minor touchpoints which will be shortly followed by one of the above anyway:
* accepting an invite (as grantee)
* approving a takeover request (I'm open to arguments that this should be blocked to give immediate feedback to the grantor, but I haven't done it for now)
* handle timed out requests
* re-sending invites

Add unit tests.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

Confirm that the above actions are blocked when the grantor is using Key Connector. They're all unit tested so I think it would be reasonable to only test a few in the interests of time (given that there's probably a high set up/tear down time with each manual test).

## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
