### PR TITLE
Facilitate backup filename suffix. esp. for manual backups

### DIFF
--- a/util/MsSql/backup-db.sh
+++ b/util/MsSql/backup-db.sh
@@ -12,12 +12,13 @@ do
 
   # Backup timestamp
   export now=$(date +%Y%m%d_%H%M%S)
+  export BACKUP_FILENAME="${now}${BACKUP_FILENAME_SUFFIX}"
 
   # Do a new backup
   /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -i /backup-db.sql
 
   # Delete backup files older than 30 days
-  grep -B1 "BACKUP DATABASE successfully" /var/opt/mssql/log/errorlog | grep -q _$now.BAK &&
+  grep -B1 "BACKUP DATABASE successfully" /var/opt/mssql/log/errorlog | grep -q _${BACKUP_FILENAME}.BAK &&
   find /etc/bitwarden/mssql/backups/ -mindepth 1 -type f -name '*.BAK' -mtime +32 -delete
 
   # Break if called manually (without loop option)

--- a/util/MsSql/backup-db.sql
+++ b/util/MsSql/backup-db.sql
@@ -7,10 +7,10 @@ DECLARE @DatabaseNameSafe varchar(100)
 SET @DatabaseNameSafe = 'vault'
 
 DECLARE @BackupFile varchar(100)
-SET @BackupFile = '/etc/bitwarden/mssql/backups/' + @DatabaseNameSafe + '_FULL_$(now).BAK'
+SET @BackupFile = '/etc/bitwarden/mssql/backups/' + @DatabaseNameSafe + '_FULL_$(BACKUP_FILENAME).BAK'
 
 DECLARE @BackupName varchar(100)
-SET @BackupName = @DatabaseName + ' full backup for $(now)'
+SET @BackupName = @DatabaseName + ' full backup for $(BACKUP_FILENAME)'
 
 DECLARE @BackupCommand NVARCHAR(1000)
 SET @BackupCommand = 'BACKUP DATABASE [' + @DatabaseName + '] TO DISK = ''' + @BackupFile + ''' WITH INIT, NAME= ''' + @BackupName + ''', NOSKIP, NOFORMAT'


### PR DESCRIPTION
Helps when executing backups manually, like so:
`docker exec -ti -e BACKUP_FILENAME_SUFFIX='_PreUpdate' bitwarden-mssql /backup-db.sh`