### PR TITLE
[Key Connector] Fix bug preventing user from leaving org

### DIFF
--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -385,9 +385,10 @@ namespace Bit.Api.Controllers
             }
 
             var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(orgGuidId);
-            if (ssoConfig?.GetData()?.KeyConnectorEnabled == true)
+            if (ssoConfig?.GetData()?.KeyConnectorEnabled == true &&
+                _currentContext.User.UsesKeyConnector)
             {
-                throw new BadRequestException("You cannot leave an Organization that is using Key Connector.");
+                throw new BadRequestException("You cannot leave this Organization because you are using its Key Connector.");
             }
 
             var userId = _userService.GetProperUserId(User);


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fixes QA feedback in https://app.asana.com/0/1200804338582616/1201362245089015/f.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* only prevent a user from leaving an org if both the org _and the user_ use Key Connector. This accounts for the different combinations of states:
  * org uses Key Connector but user doesn't and wishes to leave (the test case that failed)
  * the user uses Key Connector but wants to leave an unrelated org (unlikely due to the Single Org policy, but could theoretically happen if a user is promoted to owner/admin)
  * neither use Key Connector - fine
  * both use Key Connector - block
* add tests (happy and unhappy paths)

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

Confirm that the bug is fixed, regression testing on leaving an org.

## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
