### PR TITLE
Add usesKeyConnector to organizationUserUserDetailsResponseModel

### DIFF
--- a/src/Core/Models/Api/Response/OrganizationUserResponseModel.cs
+++ b/src/Core/Models/Api/Response/OrganizationUserResponseModel.cs
@@ -41,6 +41,7 @@ namespace Bit.Core.Models.Api
             AccessAll = organizationUser.AccessAll;
             Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(organizationUser.Permissions);
             ResetPasswordEnrolled = !string.IsNullOrEmpty(organizationUser.ResetPasswordKey);
+            UsesKeyConnector = organizationUser.UsesKeyConnector;
         }
 
         public string Id { get; set; }
@@ -50,6 +51,7 @@ namespace Bit.Core.Models.Api
         public bool AccessAll { get; set; }
         public Permissions Permissions { get; set; }
         public bool ResetPasswordEnrolled { get; set; }
+        public bool UsesKeyConnector { get; set; }
     }
 
     public class OrganizationUserDetailsResponseModel : OrganizationUserResponseModel


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add `UsesKeyConnector` to `OrganizationUserUserDetailsResponseModel` since we need it available in the web vault.

Resolves: https://app.asana.com/0/1201363553288890/1201385116854988
Related: https://github.com/bitwarden/web/pull/1307

## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
