### PR TITLE
Fix: Not sourcing the .env file when executing docker-compose

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -111,6 +111,10 @@ function dockerComposePull() {
 }
 
 function dockerComposeFiles() {
+    set -a
+    [[ -e "${DOCKER_DIR}/.env" ]] && . "${DOCKER_DIR}/.env"
+    set +a
+
     if [ -f "${DOCKER_DIR}/docker-compose.override.yml" ]
     then
         export COMPOSE_FILE="$DOCKER_DIR/docker-compose.yml:$DOCKER_DIR/docker-compose.override.yml"


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [x] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
As per [Docker Specs/Docs](https://docs.docker.com/compose/environment-variables/#the-env-file), the .env file in the same directory as docker-compose.yml should be used for defining variables used in the docker-compose files and to specify [Compose CLI environment variables](https://docs.docker.com/compose/reference/envvars/) like `COMPOSE_PROJECT_NAME`

This should also avoid the naming of networks with generic and confusing names like:
- docker_default
- docker_public

This commit should resolve the issue that has been raised both in Github and in the forum, some below:
https://community.bitwarden.com/t/appropriate-naming-of-bitwarden-docker-networks-and-containers/35341
https://community.bitwarden.com/t/docker-compose-project-name/15442

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why
`set -a`: "Each variable or function that is created or modified is given the export attribute and marked for export to the environment of subsequent commands."
"Using ‘+’ rather than ‘-’ causes these options to be turned off."
Source: [The Set Builtin](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html)



## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->



## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
