### PR TITLE
Dynamic naming and versioning of containers during deployment

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -111,6 +111,10 @@ function dockerComposePull() {
 }
 
 function dockerComposeFiles() {
+    set -a
+    [[ -e "${DOCKER_DIR}/.env" ]] && . "${DOCKER_DIR}/.env"
+    set +a
+
     if [ -f "${DOCKER_DIR}/docker-compose.override.yml" ]
     then
         export COMPOSE_FILE="$DOCKER_DIR/docker-compose.yml:$DOCKER_DIR/docker-compose.override.yml"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -19,12 +19,14 @@ if [ $# -gt 2 ]
 then
     COREVERSION=$3
 fi
+export COREVERSION
 
 WEBVERSION="latest"
 if [ $# -gt 3 ]
 then
     WEBVERSION=$4
 fi
+export WEBVERSION
 
 OS="lin"
 [ "$(uname)" == "Darwin" ] && OS="mac"

--- a/util/Setup/Templates/DockerCompose.hbs
+++ b/util/Setup/Templates/DockerCompose.hbs
@@ -17,8 +17,8 @@ version: '{{{ComposeVersion}}}'
 
 services:
   mssql:
-    image: bitwarden/mssql:{{{CoreVersion}}}
-    container_name: bitwarden-mssql
+    image: bitwarden/mssql:${COREVERSION}
+    container_name: ${COMPOSE_PROJECT_NAME:-bitwarden}-mssql
     restart: always
     stop_grace_period: 60s
     volumes:
@@ -35,8 +35,8 @@ services:
       - ../env/mssql.override.env
 
   web:
-    image: bitwarden/web:{{{WebVersion}}}
-    container_name: bitwarden-web
+    image: bitwarden/web:${WEBVERSION}
+    container_name: ${COMPOSE_PROJECT_NAME:-bitwarden}-web
     restart: always
     volumes:
       - ../web:/etc/bitwarden/web
@@ -45,8 +45,8 @@ services:
       - ../env/uid.env
 
   attachments:
-    image: bitwarden/attachments:{{{CoreVersion}}}
-    container_name: bitwarden-attachments
+    image: bitwarden/attachments:${COREVERSION}
+    container_name: ${COMPOSE_PROJECT_NAME:-bitwarden}-attachments
     restart: always
     volumes:
       - ../core/attachments:/etc/bitwarden/core/attachments
@@ -55,8 +55,8 @@ services:
       - ../env/uid.env
 
   api:
-    image: bitwarden/api:{{{CoreVersion}}}
-    container_name: bitwarden-api
+    image: bitwarden/api:${COREVERSION}
+    container_name: ${COMPOSE_PROJECT_NAME:-bitwarden}-api
     restart: always
     volumes:
       - ../core:/etc/bitwarden/core
@@ -71,8 +71,8 @@ services:
       - public
 
   identity:
-    image: bitwarden/identity:{{{CoreVersion}}}
-    container_name: bitwarden-identity
+    image: bitwarden/identity:${COREVERSION}
+    container_name: ${COMPOSE_PROJECT_NAME:-bitwarden}-identity
     restart: always
     volumes:
       - ../identity:/etc/bitwarden/identity
@@ -88,8 +88,8 @@ services:
       - public
 
   sso:
-    image: bitwarden/sso:{{{CoreVersion}}}
-    container_name: bitwarden-sso
+    image: bitwarden/sso:${COREVERSION}
+    container_name: ${COMPOSE_PROJECT_NAME:-bitwarden}-sso
     restart: always
     volumes:
       - ../identity:/etc/bitwarden/identity
@@ -105,8 +105,8 @@ services:
       - public
 
   admin:
-    image: bitwarden/admin:{{{CoreVersion}}}
-    container_name: bitwarden-admin
+    image: bitwarden/admin:${COREVERSION}
+    container_name: ${COMPOSE_PROJECT_NAME:-bitwarden}-admin
     restart: always
     depends_on:
       - mssql
@@ -123,8 +123,8 @@ services:
       - public
 
   icons:
-    image: bitwarden/icons:{{{CoreVersion}}}
-    container_name: bitwarden-icons
+    image: bitwarden/icons:${COREVERSION}
+    container_name: ${COMPOSE_PROJECT_NAME:-bitwarden}-icons
     restart: always
     volumes:
       - ../ca-certificates:/etc/bitwarden/ca-certificates
@@ -137,8 +137,8 @@ services:
       - public
 
   notifications:
-    image: bitwarden/notifications:{{{CoreVersion}}}
-    container_name: bitwarden-notifications
+    image: bitwarden/notifications:${COREVERSION}
+    container_name: ${COMPOSE_PROJECT_NAME:-bitwarden}-notifications
     restart: always
     volumes:
       - ../ca-certificates:/etc/bitwarden/ca-certificates
@@ -152,8 +152,8 @@ services:
       - public
 
   events:
-    image: bitwarden/events:{{{CoreVersion}}}
-    container_name: bitwarden-events
+    image: bitwarden/events:${COREVERSION}
+    container_name: ${COMPOSE_PROJECT_NAME:-bitwarden}-events
     restart: always
     volumes:
       - ../ca-certificates:/etc/bitwarden/ca-certificates
@@ -167,8 +167,8 @@ services:
       - public
 
   nginx:
-    image: bitwarden/nginx:{{{CoreVersion}}}
-    container_name: bitwarden-nginx
+    image: bitwarden/nginx:${COREVERSION}
+    container_name: ${COMPOSE_PROJECT_NAME:-bitwarden}-nginx
     restart: always
     depends_on:
       - web
@@ -198,7 +198,7 @@ services:
 {{#if EnableKeyConnector}}
   key-connector:
     image: bitwarden/key-connector:latest
-    container_name: bitwarden-key-connector
+    container_name: ${COMPOSE_PROJECT_NAME:-bitwarden}-key-connector
     restart: always
     volumes:
       - ../key-connector:/etc/bitwarden/key-connector


### PR DESCRIPTION
## Type of change
- [x] New feature development
- [x] Build/deploy pipeline (DevOps)
- [ ] Bug fix
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Follow up from an earlier pull request #1727 to complete this [feature request](https://community.bitwarden.com/t/appropriate-naming-of-bitwarden-docker-networks-and-containers/35341/2) (now Github contrinution).



## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
1. The `export` in `run.sh` will allow `docker-compose` to access the variables at runtime, as they're referenced in `docker-compose.yml`
2. Check #1727 to elaborate on L116 - L119 of `run.sh` below.
3. `${COMPOSE_PROJECT_NAME:-bitwarden}` instructs `docker-compose` to use the value of `COMPOSE_PROJECT_NAME` variable, otherwise, it defaults to 'bitwarden'.

This is helpful to easily create staging environments, the [feature request](https://community.bitwarden.com/t/appropriate-naming-of-bitwarden-docker-networks-and-containers/35341/2) (now Github contribution) shows an example:
![image](https://user-images.githubusercontent.com/298208/142775009-960e2d0a-622d-4397-a5f0-bec5f98eb4ba.png)


* **file.ext:** Description of what was changed and why

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Bitwarden seems to be using the service names for inter-container networking, example below:
https://github.com/bitwarden/server/blob/d3673cdc8513a0846694ae0aff6b205f42838c73/util/Setup/Templates/NginxConfig.hbs#L117-L131

Hence, this PR shouldn't affect that, as it only changes the `container_name`.


## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [x] This change has particular **deployment requirements** (notify the DevOps team)
