### PR TITLE
[Key Connector] Update error message for leaving org

### DIFF
--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -388,7 +388,7 @@ namespace Bit.Api.Controllers
             if (ssoConfig?.GetData()?.KeyConnectorEnabled == true &&
                 _currentContext.User.UsesKeyConnector)
             {
-                throw new BadRequestException("You cannot leave this Organization because you are using its Key Connector.");
+                throw new BadRequestException("Your organization's Single Sign-On settings prevent you from leaving.");
             }
 
             var userId = _userService.GetProperUserId(User);

--- a/test/Api.Test/Controllers/OrganizationsControllerTests.cs
+++ b/test/Api.Test/Controllers/OrganizationsControllerTests.cs
@@ -78,7 +78,7 @@ namespace Bit.Api.Test.Controllers
             var exception = await Assert.ThrowsAsync<BadRequestException>(
                 () => _sut.Leave(orgId.ToString()));
 
-            Assert.Contains("You cannot leave this Organization because you are using its Key Connector.",
+            Assert.Contains("Your organization's Single Sign-On settings prevent you from leaving.",
                 exception.Message);
 
             await _organizationService.DidNotReceiveWithAnyArgs().DeleteUserAsync(default, default);


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

If a user who is using Key Connector tries to leave the organization, change the error message to:

> Your organization's Single Sign-On settings prevent you from leaving.

This will be displayed in a red error toast.

## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
