### PR TITLE
Fix null error when leaving organization

### DIFF
--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -384,15 +384,17 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
+            var user = await _userService.GetUserByPrincipalAsync(User);
+
             var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(orgGuidId);
             if (ssoConfig?.GetData()?.KeyConnectorEnabled == true &&
-                _currentContext.User.UsesKeyConnector)
+                user.UsesKeyConnector)
             {
                 throw new BadRequestException("Your organization's Single Sign-On settings prevent you from leaving.");
             }
 
-            var userId = _userService.GetProperUserId(User);
-            await _organizationService.DeleteUserAsync(orgGuidId, userId.Value);
+            
+            await _organizationService.DeleteUserAsync(orgGuidId, user.Id);
         }
 
         [HttpDelete("{id}")]

--- a/test/Api.Test/Controllers/OrganizationsControllerTests.cs
+++ b/test/Api.Test/Controllers/OrganizationsControllerTests.cs
@@ -72,8 +72,7 @@ namespace Bit.Api.Test.Controllers
 
             _currentContext.OrganizationUser(orgId).Returns(true);
             _ssoConfigRepository.GetByOrganizationIdAsync(orgId).Returns(ssoConfig);
-            _userService.GetProperUserId(Arg.Any<ClaimsPrincipal>()).Returns(user.Id);
-            _currentContext.User.Returns(user);
+            _userService.GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
 
             var exception = await Assert.ThrowsAsync<BadRequestException>(
                 () => _sut.Leave(orgId.ToString()));
@@ -106,8 +105,7 @@ namespace Bit.Api.Test.Controllers
 
             _currentContext.OrganizationUser(orgId).Returns(true);
             _ssoConfigRepository.GetByOrganizationIdAsync(orgId).Returns(ssoConfig);
-            _userService.GetProperUserId(Arg.Any<ClaimsPrincipal>()).Returns(user.Id);
-            _currentContext.User.Returns(user);
+            _userService.GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
 
             await _organizationService.DeleteUserAsync(orgId, user.Id);
             await _organizationService.Received(1).DeleteUserAsync(orgId, user.Id);


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix null error when a user tries to leave an organization.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Api/Controllers/OrganizationsController.cs** - `_currentContext.User` is null in this situation, use `userService.GetByPrincipalAsync` instead. I've tested and confirm this returns a value.
* update tests

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

Check that users can successfully leave an org.

## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
