### PR TITLE
Migrate deprecated Microsoft.Azure.EventGrid to Azure.Messaging.EventGrid

### DIFF
--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -28,10 +28,10 @@
   </Choose>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.7.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.9" />
     <PackageReference Include="NewRelic.Agent" Version="8.41.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-    <PackageReference Include="Microsoft.Azure.EventGrid" Version="3.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -14,7 +14,7 @@ using System.Collections.Generic;
 using Bit.Core.Models.Table;
 using Bit.Core.Settings;
 using Core.Models.Data;
-using Microsoft.Azure.EventGrid.Models;
+using Azure.Messaging.EventGrid;
 using Bit.Core.Models.Data;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;

--- a/src/Api/Controllers/SendsController.cs
+++ b/src/Api/Controllers/SendsController.cs
@@ -12,7 +12,7 @@ using Bit.Core.Settings;
 using Bit.Core.Models.Api.Response;
 using Bit.Core.Enums;
 using Bit.Core.Context;
-using Microsoft.Azure.EventGrid.Models;
+using Azure.Messaging.EventGrid;
 using Bit.Api.Utilities;
 using System.Collections.Generic;
 using Bit.Core.Models.Table;

--- a/src/Api/Utilities/ApiHelpers.cs
+++ b/src/Api/Utilities/ApiHelpers.cs
@@ -1,4 +1,4 @@
-using Bit.Core.Utilities;
+﻿using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Azure.Messaging.EventGrid;
@@ -61,23 +61,19 @@ namespace Bit.Api.Utilities
             {
                 if (eventGridEvent.TryGetSystemEventData(out object systemEvent))
                 {
-                    switch (systemEvent)
+                    if (systemEvent is SubscriptionValidationEventData eventData)
                     {
-                        case SubscriptionValidationEventData subscriptionValidated:
-                            // Might want to enable additional validation: subject, topic etc.
+                        // Might want to enable additional validation: subject, topic etc.
+                        var responseData = new SubscriptionValidationResponse()
+                        {
+                            ValidationResponse = eventData.ValidationCode
+                        };
 
-                            var responseData = new SubscriptionValidationResponse()
-                            {
-                                ValidationResponse = subscriptionValidated.ValidationCode
-                            };
-
-                            return new OkObjectResult(responseData);
-                            break;
-                        default:
-                            break;
+                        return new OkObjectResult(responseData);
                     }
                 }
-                else if (eventTypeHandlers.ContainsKey(eventGridEvent.EventType))
+
+                if (eventTypeHandlers.ContainsKey(eventGridEvent.EventType))
                 {
                     await eventTypeHandlers[eventGridEvent.EventType](eventGridEvent);
                 }

--- a/src/Api/Utilities/ApiHelpers.cs
+++ b/src/Api/Utilities/ApiHelpers.cs
@@ -1,4 +1,4 @@
-﻿using Bit.Core.Utilities;
+using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Azure.Messaging.EventGrid;
@@ -55,7 +55,8 @@ namespace Bit.Api.Utilities
             }
 
             var response = string.Empty;
-            var eventGridEvents = EventGridEvent.ParseMany(BinaryData.FromStream(request.Body));
+            var requestData = await BinaryData.FromStreamAsync(request.Body);
+            var eventGridEvents = EventGridEvent.ParseMany(requestData);
             foreach (var eventGridEvent in eventGridEvents)
             {
                 if (eventGridEvent.TryGetSystemEventData(out object systemEvent))


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Since Microsoft decided to deprecate `Microsoft.Azure.EventGrid` (V3) in favor of `Azure.Messaging.EventGrid` (V4) this PR migrates this dependency.

Tested this locally with connection to Azure Test Account and webhook calling ngrok to verify file sizes.

## Code changes
* **src/Api/Api.csproj:** Remove packageReference for `Microsoft.Azure.EventGrid` and install `Azure.Messaging.EventGrid` as replacement
* **src/Api/Controllers/CiphersController.cs:** Replace using of `Microsoft.Azure.EventGrid.Models` with `Azure.Messaging.EventGrid`
* **src/Api/Controllers/SendsController.cs:** Replace using of `Microsoft.Azure.EventGrid.Models` with `Azure.Messaging.EventGrid`
* **src/Api/Utilities/ApiHelper.cs:** 
    * Replace using of `Microsoft.Azure.EventGrid.Models` with `Azure.Messaging.EventGrid`
    * Add using `Azure.Messaging.EventGrid.SystemEvents`
    * Remove reading and checking if requestBody is empty and returning earlf if that is the case
    * Use `EventGridEvent.ParseMany` to read the requestBody and retrieve the `eventGridEvents`
    * Check for `SubscriptionValidationEventData` and if not present, check and use other eventHandlers 

## Testing requirements
Regression testing of Cipher attachments and Send functionality

## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
