### PR TITLE
Null out sponsorship values when foreign key deleted

### DIFF
--- a/src/Core/Repositories/EntityFramework/OrganizationRepository.cs
+++ b/src/Core/Repositories/EntityFramework/OrganizationRepository.cs
@@ -107,10 +107,9 @@ namespace Bit.Core.Repositories.EntityFramework
                     .Where(os =>
                         os.SponsoringOrganizationId == organization.Id ||
                         os.SponsoredOrganizationId == organization.Id);
-                dbContext.RemoveRange(sponsorships.Where(os => os.CloudSponsor));
 
                 Guid? UpdatedOrgId(Guid? orgId) => orgId == organization.Id ? null : organization.Id;
-                foreach (var sponsorship in sponsorships.Where(os => !os.CloudSponsor))
+                foreach (var sponsorship in sponsorships)
                 {
                     sponsorship.SponsoredOrganizationId = UpdatedOrgId(sponsorship.SponsoredOrganizationId);
                     sponsorship.SponsoringOrganizationId = UpdatedOrgId(sponsorship.SponsoringOrganizationId);

--- a/src/Core/Repositories/EntityFramework/OrganizationUserRepository.cs
+++ b/src/Core/Repositories/EntityFramework/OrganizationUserRepository.cs
@@ -77,7 +77,11 @@ namespace Bit.Core.Repositories.EntityFramework
                 var sponsorships = dbContext.OrganizationSponsorships
                     .Where(os => os.SponsoringOrganizationUserId != default &&
                         os.SponsoringOrganizationUserId.Value == organizationUserId);
-                dbContext.RemoveRange(sponsorships);
+                foreach (var sponsorship in sponsorships)
+                {
+                    sponsorship.SponsoringOrganizationUserId = null;
+                }
+
                 dbContext.Remove(orgUser);
                 await dbContext.SaveChangesAsync();
             }
@@ -92,7 +96,11 @@ namespace Bit.Core.Repositories.EntityFramework
                 var sponsorships = dbContext.OrganizationSponsorships
                     .Where(os => os.SponsoringOrganizationUserId != default &&
                         organizationUserIds.Contains(os.SponsoringOrganizationUserId ?? default));
-                dbContext.RemoveRange(sponsorships);
+                foreach (var sponsorship in sponsorships)
+                {
+                    sponsorship.SponsoringOrganizationUserId = null;
+                }
+
                 dbContext.RemoveRange(entities);
                 await dbContext.SaveChangesAsync();
             }

--- a/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_OrganizationDeleted.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_OrganizationDeleted.sql
@@ -9,23 +9,13 @@ BEGIN
     SET
         [SponsoringOrganizationId] = NULL
     WHERE
-        [SponsoringOrganizationId] = @OrganizationId AND
-        [CloudSponsor] = 0
+        [SponsoringOrganizationId] = @OrganizationId
 
     UPDATE
         [dbo].[OrganizationSponsorship]
     SET
         [SponsoredOrganizationId] = NULL
     WHERE
-        [SponsoredOrganizationId] = @OrganizationId AND
-        [CloudSponsor] = 0
-
-    DELETE
-    FROM
-        [dbo].[OrganizationSponsorship]
-    WHERE
-        [CloudSponsor] = 1 AND
-        ([SponsoredOrganizationId] = @OrganizationId OR
-         [SponsoringOrganizationId] = @OrganizationId)
+        [SponsoredOrganizationId] = @OrganizationId
 END
 GO

--- a/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_OrganizationUserDeleted.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_OrganizationUserDeleted.sql
@@ -4,9 +4,12 @@ AS
 BEGIN
     SET NOCOUNT ON
 
-    DELETE
+    UPDATE
+        OS
+    SET
+        [SponsoringOrganizationUserId] = NULL
     FROM
-        [dbo].[OrganizationSponsorship]
+        [dbo].[OrganizationSponsorship] OS
     WHERE
         [SponsoringOrganizationUserId] = @OrganizationUserId
 END

--- a/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_OrganizationUsersDeleted.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationSponsorship_OrganizationUsersDeleted.sql
@@ -4,22 +4,13 @@ AS
 BEGIN
     SET NOCOUNT ON
 
-    DECLARE @BatchSize AS INT;
-    SET @BatchSize = 100;
-
-    WHILE @BatchSize > 0
-        BEGIN
-        BEGIN TRANSACTION OrganizationSponsorship_DeleteOUs
-
-        DELETE TOP(@BatchSize) OS
-        FROM
-            [dbo].[OrganizationSponsorship] OS
-        INNER JOIN
-            @SponsoringOrganizationUserIds I ON I.Id = OS.SponsoringOrganizationUserId
-
-        SET @BatchSize = @@ROWCOUNT
-
-        COMMIT TRANSACTION OrganizationSponsorship_DeleteOUs
-    END
+    UPDATE
+        OS
+    SET
+        [SponsoringOrganizationUserId] = NULL
+    FROM
+        [dbo].[OrganizationSponsorship] OS
+    INNER JOIN
+        @SponsoringOrganizationUserIds I ON I.Id = OS.SponsoringOrganizationUserId
 END
 GO

--- a/util/Migrator/DbScripts/2021-11-23_00_NullOrganizationSponsorshipOnFkDelete.sql
+++ b/util/Migrator/DbScripts/2021-11-23_00_NullOrganizationSponsorshipOnFkDelete.sql
@@ -1,0 +1,86 @@
+-- OrganizationSponsorship_OrganizationDeleted
+IF OBJECT_ID('[dbo].[OrganizationSponsorship_OrganizationDeleted]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationSponsorship_OrganizationDeleted]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_OrganizationDeleted]
+    @OrganizationId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    UPDATE
+        [dbo].[OrganizationSponsorship]
+    SET
+        [SponsoringOrganizationId] = NULL
+    WHERE
+        [SponsoringOrganizationId] = @OrganizationId AND
+        [CloudSponsor] = 0
+
+    UPDATE
+        [dbo].[OrganizationSponsorship]
+    SET
+        [SponsoredOrganizationId] = NULL
+    WHERE
+        [SponsoredOrganizationId] = @OrganizationId AND
+        [CloudSponsor] = 0
+
+    DELETE
+    FROM
+        [dbo].[OrganizationSponsorship]
+    WHERE
+        [CloudSponsor] = 1 AND
+        ([SponsoredOrganizationId] = @OrganizationId OR
+         [SponsoringOrganizationId] = @OrganizationId)
+END
+GO
+
+-- OrganizationSponsorship_OrganizationUserDeleted
+IF OBJECT_ID('[dbo].[OrganizationSponsorship_OrganizationUserDeleted]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationSponsorship_OrganizationUserDeleted]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_OrganizationUserDeleted]
+    @OrganizationUserId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    UPDATE
+        OS
+    SET
+        [SponsoringOrganizationUserId] = NULL
+    FROM
+        [dbo].[OrganizationSponsorship] OS
+    WHERE
+        [SponsoringOrganizationUserId] = @OrganizationUserId
+END
+GO
+
+-- OrganizationSponsorship_OrganizationUsersDeleted
+IF OBJECT_ID('[dbo].[OrganizationSponsorship_OrganizationUsersDeleted]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationSponsorship_OrganizationUsersDeleted]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_OrganizationUsersDeleted]
+    @SponsoringOrganizationUserIds [dbo].[GuidIdArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    UPDATE
+        OS
+    SET
+        [SponsoringOrganizationUserId] = NULL
+    FROM
+        [dbo].[OrganizationSponsorship] OS
+    INNER JOIN
+        @SponsoringOrganizationUserIds I ON I.Id = OS.SponsoringOrganizationUserId
+END
+GO


### PR DESCRIPTION
Fixes https://app.asana.com/0/1169444489336079/1201418714239822/f

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
This allows us to maintain record of sponsorships up until they are explicitly removed. Fixes issues where removing sponsorships from organizations with invalid sponsorships would error

### Migration
Updated Organization Delete and OrganizationUser deletes to update associated sponsorships to null.

### EF
Updated Oragnization Delete and OrganizationUser Delete queries to null out associated sponsorships

## Testing requirements
Validate that Removing Organizations or OrganizationUsers that sponsor a family org does not make the family org unable to remove sponsorship. Note: we are not proactively updating sponsorship plans, just updating our copies of sponsorship info so we can validate successfully when it's invoice time.


## Before you submit
- [x] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
