### PR TITLE
Families for enterprise/add sponsorship prevalidate

### DIFF
--- a/src/Api/Controllers/OrganizationSponsorshipsController.cs
+++ b/src/Api/Controllers/OrganizationSponsorshipsController.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Bit.Core.Context;
-using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Api;
 using Bit.Core.Models.Api.Request;
@@ -67,11 +65,18 @@ namespace Bit.Api.Controllers
                 (await CurrentUser).Email);
         }
 
+        [HttpPost("validate-token")]
+        [SelfHosted(NotSelfHostedOnly = true)]
+        public async Task<bool> ValidateSponsorshipToken([FromQuery] string sponsorshipToken)
+        {
+            return await _organizationsSponsorshipService.ValidateRedemptionTokenAsync(sponsorshipToken, (await CurrentUser).Email);
+        }
+
         [HttpPost("redeem")]
         [SelfHosted(NotSelfHostedOnly = true)]
         public async Task RedeemSponsorship([FromQuery] string sponsorshipToken, [FromBody] OrganizationSponsorshipRedeemRequestModel model)
         {
-            if (!await _organizationsSponsorshipService.ValidateRedemptionTokenAsync(sponsorshipToken))
+            if (!await _organizationsSponsorshipService.ValidateRedemptionTokenAsync(sponsorshipToken, (await CurrentUser).Email))
             {
                 throw new BadRequestException("Failed to parse sponsorship token.");
             }

--- a/src/Api/Controllers/OrganizationSponsorshipsController.cs
+++ b/src/Api/Controllers/OrganizationSponsorshipsController.cs
@@ -67,7 +67,7 @@ namespace Bit.Api.Controllers
 
         [HttpPost("validate-token")]
         [SelfHosted(NotSelfHostedOnly = true)]
-        public async Task<bool> ValidateSponsorshipToken([FromQuery] string sponsorshipToken)
+        public async Task<bool> PreValidateSponsorshipToken([FromQuery] string sponsorshipToken)
         {
             return await _organizationsSponsorshipService.ValidateRedemptionTokenAsync(sponsorshipToken, (await CurrentUser).Email);
         }

--- a/src/Core/Services/IOrganizationSponsorshipService.cs
+++ b/src/Core/Services/IOrganizationSponsorshipService.cs
@@ -7,7 +7,7 @@ namespace Bit.Core.Services
 {
     public interface IOrganizationSponsorshipService
     {
-        Task<bool> ValidateRedemptionTokenAsync(string encryptedToken);
+        Task<bool> ValidateRedemptionTokenAsync(string encryptedToken, string currentUserEmail);
         Task OfferSponsorshipAsync(Organization sponsoringOrg, OrganizationUser sponsoringOrgUser,
             PlanSponsorshipType sponsorshipType, string sponsoredEmail, string friendlyName, string sponsoringUserEmail);
         Task ResendSponsorshipOfferAsync(Organization sponsoringOrg, OrganizationUser sponsoringOrgUser,

--- a/src/Core/Services/Implementations/OrganizationSponsorshipService.cs
+++ b/src/Core/Services/Implementations/OrganizationSponsorshipService.cs
@@ -37,9 +37,9 @@ namespace Bit.Core.Services
             _dataProtector = dataProtectionProvider.CreateProtector("OrganizationSponsorshipServiceDataProtector");
         }
 
-        public async Task<bool> ValidateRedemptionTokenAsync(string encryptedToken, string currentUserEmail)
+        public async Task<bool> ValidateRedemptionTokenAsync(string encryptedToken, string sponsoredUserEmail)
         {
-            if (!encryptedToken.StartsWith(TokenClearTextPrefix) || currentUserEmail == null)
+            if (!encryptedToken.StartsWith(TokenClearTextPrefix) || sponsoredUserEmail == null)
             {
                 return false;
             }
@@ -63,7 +63,7 @@ namespace Bit.Core.Services
                 var sponsorship = await _organizationSponsorshipRepository.GetByIdAsync(sponsorshipId);
                 if (sponsorship == null ||
                     sponsorship.PlanSponsorshipType != sponsorshipType ||
-                    sponsorship.OfferedToEmail != currentUserEmail)
+                    sponsorship.OfferedToEmail != sponsoredUserEmail)
                 {
                     return false;
                 }

--- a/src/Core/Services/Implementations/OrganizationSponsorshipService.cs
+++ b/src/Core/Services/Implementations/OrganizationSponsorshipService.cs
@@ -37,9 +37,9 @@ namespace Bit.Core.Services
             _dataProtector = dataProtectionProvider.CreateProtector("OrganizationSponsorshipServiceDataProtector");
         }
 
-        public async Task<bool> ValidateRedemptionTokenAsync(string encryptedToken)
+        public async Task<bool> ValidateRedemptionTokenAsync(string encryptedToken, string currentUserEmail)
         {
-            if (!encryptedToken.StartsWith(TokenClearTextPrefix))
+            if (!encryptedToken.StartsWith(TokenClearTextPrefix) || currentUserEmail == null)
             {
                 return false;
             }
@@ -61,7 +61,9 @@ namespace Bit.Core.Services
                 }
 
                 var sponsorship = await _organizationSponsorshipRepository.GetByIdAsync(sponsorshipId);
-                if (sponsorship == null || sponsorship.PlanSponsorshipType != sponsorshipType)
+                if (sponsorship == null ||
+                    sponsorship.PlanSponsorshipType != sponsorshipType ||
+                    sponsorship.OfferedToEmail != currentUserEmail)
                 {
                     return false;
                 }

--- a/test/Api.Test/Controllers/OrganizationSponsorshipsControllerTests.cs
+++ b/test/Api.Test/Controllers/OrganizationSponsorshipsControllerTests.cs
@@ -39,10 +39,10 @@ namespace Bit.Api.Test.Controllers
 
         [Theory]
         [BitAutoData]
-        public async Task RedeemSponsorship_BadToken_ThrowsBadRequest(string sponsorshipToken,
+        public async Task RedeemSponsorship_BadToken_ThrowsBadRequest(string sponsorshipToken, string userEmail,
             OrganizationSponsorshipRedeemRequestModel model, SutProvider<OrganizationSponsorshipsController> sutProvider)
         {
-            sutProvider.GetDependency<IOrganizationSponsorshipService>().ValidateRedemptionTokenAsync(sponsorshipToken)
+            sutProvider.GetDependency<IOrganizationSponsorshipService>().ValidateRedemptionTokenAsync(sponsorshipToken, userEmail)
                 .Returns(false);
 
             var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
@@ -56,10 +56,10 @@ namespace Bit.Api.Test.Controllers
 
         [Theory]
         [BitAutoData]
-        public async Task RedeemSponsorship_NotSponsoredOrgOwner_ThrowsBadRequest(string sponsorshipToken,
+        public async Task RedeemSponsorship_NotSponsoredOrgOwner_ThrowsBadRequest(string sponsorshipToken, string userEmail,
             OrganizationSponsorshipRedeemRequestModel model, SutProvider<OrganizationSponsorshipsController> sutProvider)
         {
-            sutProvider.GetDependency<IOrganizationSponsorshipService>().ValidateRedemptionTokenAsync(sponsorshipToken)
+            sutProvider.GetDependency<IOrganizationSponsorshipService>().ValidateRedemptionTokenAsync(sponsorshipToken, userEmail)
                 .Returns(true);
             sutProvider.GetDependency<ICurrentContext>().OrganizationOwner(model.SponsoredOrganizationId).Returns(false);
 

--- a/test/Api.Test/Controllers/OrganizationSponsorshipsControllerTests.cs
+++ b/test/Api.Test/Controllers/OrganizationSponsorshipsControllerTests.cs
@@ -39,11 +39,14 @@ namespace Bit.Api.Test.Controllers
 
         [Theory]
         [BitAutoData]
-        public async Task RedeemSponsorship_BadToken_ThrowsBadRequest(string sponsorshipToken, string userEmail,
+        public async Task RedeemSponsorship_BadToken_ThrowsBadRequest(string sponsorshipToken, User user,
             OrganizationSponsorshipRedeemRequestModel model, SutProvider<OrganizationSponsorshipsController> sutProvider)
         {
-            sutProvider.GetDependency<IOrganizationSponsorshipService>().ValidateRedemptionTokenAsync(sponsorshipToken, userEmail)
-                .Returns(false);
+            sutProvider.GetDependency<ICurrentContext>().UserId.Returns(user.Id);
+            sutProvider.GetDependency<IUserService>().GetUserByIdAsync(user.Id)
+                .Returns(user);
+            sutProvider.GetDependency<IOrganizationSponsorshipService>().ValidateRedemptionTokenAsync(sponsorshipToken,
+                user.Email).Returns(false);
 
             var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
                 sutProvider.Sut.RedeemSponsorship(sponsorshipToken, model));
@@ -56,11 +59,14 @@ namespace Bit.Api.Test.Controllers
 
         [Theory]
         [BitAutoData]
-        public async Task RedeemSponsorship_NotSponsoredOrgOwner_ThrowsBadRequest(string sponsorshipToken, string userEmail,
+        public async Task RedeemSponsorship_NotSponsoredOrgOwner_ThrowsBadRequest(string sponsorshipToken, User user,
             OrganizationSponsorshipRedeemRequestModel model, SutProvider<OrganizationSponsorshipsController> sutProvider)
         {
-            sutProvider.GetDependency<IOrganizationSponsorshipService>().ValidateRedemptionTokenAsync(sponsorshipToken, userEmail)
-                .Returns(true);
+            sutProvider.GetDependency<ICurrentContext>().UserId.Returns(user.Id);
+            sutProvider.GetDependency<IUserService>().GetUserByIdAsync(user.Id)
+                .Returns(user);
+            sutProvider.GetDependency<IOrganizationSponsorshipService>().ValidateRedemptionTokenAsync(sponsorshipToken,
+                user.Email).Returns(true);
             sutProvider.GetDependency<ICurrentContext>().OrganizationOwner(model.SponsoredOrganizationId).Returns(false);
 
             var exception = await Assert.ThrowsAsync<BadRequestException>(() =>

--- a/test/Api.Test/Controllers/OrganizationSponsorshipsControllerTests.cs
+++ b/test/Api.Test/Controllers/OrganizationSponsorshipsControllerTests.cs
@@ -74,6 +74,21 @@ namespace Bit.Api.Test.Controllers
 
         [Theory]
         [BitAutoData]
+        public async Task PreValidateSponsorshipToken_ValidatesToken_Success(string sponsorshipToken, User user,
+            SutProvider<OrganizationSponsorshipsController> sutProvider)
+        {
+            sutProvider.GetDependency<ICurrentContext>().UserId.Returns(user.Id);
+            sutProvider.GetDependency<IUserService>().GetUserByIdAsync(user.Id)
+                .Returns(user);
+
+            await sutProvider.Sut.PreValidateSponsorshipToken(sponsorshipToken);
+
+            await sutProvider.GetDependency<IOrganizationSponsorshipService>().Received(1)
+                .ValidateRedemptionTokenAsync(sponsorshipToken, user.Email);
+        }
+
+        [Theory]
+        [BitAutoData]
         public async Task RevokeSponsorship_WrongSponsoringUser_ThrowsBadRequest(OrganizationUser sponsoringOrgUser,
             Guid currentUserId, SutProvider<OrganizationSponsorshipsController> sutProvider)
         {


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Add sponsorship pre-validate endpoint which returns whether the provided token is valid or not.


## Testing requirements
None, test via web PR


## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
