### PR TITLE
Fix Stripe object lock timeouts

### DIFF
--- a/bitwarden_license/src/Sso/Startup.cs
+++ b/bitwarden_license/src/Sso/Startup.cs
@@ -36,7 +36,7 @@ namespace Bit.Sso
             var globalSettings = services.AddGlobalSettingsServices(Configuration);
 
             // Stripe Billing
-            StripeConfiguration.ApiKey = globalSettings.Stripe.StripeApiKey;
+            StripeConfiguration.ApiKey = globalSettings.Stripe.ApiKey;
             StripeConfiguration.MaxNetworkRetries = globalSettings.Stripe.MaxNetworkRetries;
 
             // Data Protection

--- a/bitwarden_license/src/Sso/Startup.cs
+++ b/bitwarden_license/src/Sso/Startup.cs
@@ -36,7 +36,8 @@ namespace Bit.Sso
             var globalSettings = services.AddGlobalSettingsServices(Configuration);
 
             // Stripe Billing
-            StripeConfiguration.ApiKey = globalSettings.StripeApiKey;
+            StripeConfiguration.ApiKey = globalSettings.Stripe.StripeApiKey;
+            StripeConfiguration.MaxNetworkRetries = globalSettings.Stripe.MaxNetworkRetries;
 
             // Data Protection
             services.AddCustomDataProtectionServices(Environment, globalSettings);

--- a/bitwarden_license/src/Sso/appsettings.json
+++ b/bitwarden_license/src/Sso/appsettings.json
@@ -4,7 +4,7 @@
     "siteName": "Bitwarden",
     "projectName": "SSO",
     "stripe": {
-      "stripeApiKey": "SECRET"
+      "apiKey": "SECRET"
     },
     "oidcIdentityClientKey": "SECRET",
     "sqlServer": {

--- a/bitwarden_license/src/Sso/appsettings.json
+++ b/bitwarden_license/src/Sso/appsettings.json
@@ -3,7 +3,9 @@
     "selfHosted": false,
     "siteName": "Bitwarden",
     "projectName": "SSO",
-    "stripeApiKey": "SECRET",
+    "stripe": {
+      "stripeApiKey": "SECRET"
+    },
     "oidcIdentityClientKey": "SECRET",
     "sqlServer": {
       "connectionString": "SECRET"

--- a/src/Admin/Startup.cs
+++ b/src/Admin/Startup.cs
@@ -44,7 +44,8 @@ namespace Bit.Admin
             services.AddCustomDataProtectionServices(Environment, globalSettings);
 
             // Stripe Billing
-            StripeConfiguration.ApiKey = globalSettings.StripeApiKey;
+            StripeConfiguration.ApiKey = globalSettings.Stripe.StripeApiKey;
+            StripeConfiguration.MaxNetworkRetries = globalSettings.Stripe.MaxNetworkRetries;
 
             // Repositories
             services.AddSqlServerRepositories(globalSettings);

--- a/src/Admin/Startup.cs
+++ b/src/Admin/Startup.cs
@@ -44,7 +44,7 @@ namespace Bit.Admin
             services.AddCustomDataProtectionServices(Environment, globalSettings);
 
             // Stripe Billing
-            StripeConfiguration.ApiKey = globalSettings.Stripe.StripeApiKey;
+            StripeConfiguration.ApiKey = globalSettings.Stripe.ApiKey;
             StripeConfiguration.MaxNetworkRetries = globalSettings.Stripe.MaxNetworkRetries;
 
             // Repositories

--- a/src/Admin/appsettings.json
+++ b/src/Admin/appsettings.json
@@ -3,7 +3,9 @@
     "selfHosted": false,
     "siteName": "Bitwarden",
     "projectName": "Admin",
-    "stripeApiKey": "SECRET",
+    "stripe": {
+      "stripeApiKey": "SECRET"
+    },
     "sqlServer": {
       "connectionString": "SECRET"
     },

--- a/src/Admin/appsettings.json
+++ b/src/Admin/appsettings.json
@@ -4,7 +4,7 @@
     "siteName": "Bitwarden",
     "projectName": "Admin",
     "stripe": {
-      "stripeApiKey": "SECRET"
+      "apiKey": "SECRET"
     },
     "sqlServer": {
       "connectionString": "SECRET"

--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -61,7 +61,8 @@ namespace Bit.Api
             }
 
             // Stripe Billing
-            StripeConfiguration.ApiKey = globalSettings.StripeApiKey;
+            StripeConfiguration.ApiKey = globalSettings.Stripe.StripeApiKey;
+            StripeConfiguration.MaxNetworkRetries = globalSettings.Stripe.MaxNetworkRetries;
 
             // Repositories
             services.AddSqlServerRepositories(globalSettings);

--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -61,7 +61,7 @@ namespace Bit.Api
             }
 
             // Stripe Billing
-            StripeConfiguration.ApiKey = globalSettings.Stripe.StripeApiKey;
+            StripeConfiguration.ApiKey = globalSettings.Stripe.ApiKey;
             StripeConfiguration.MaxNetworkRetries = globalSettings.Stripe.MaxNetworkRetries;
 
             // Repositories

--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -3,7 +3,9 @@
     "selfHosted": false,
     "siteName": "Bitwarden",
     "projectName": "Api",
-    "stripeApiKey": "SECRET",
+    "stripe": {
+      "stripeApiKey": "SECRET"
+    },
     "sqlServer": {
       "connectionString": "SECRET"
     },

--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -4,7 +4,7 @@
     "siteName": "Bitwarden",
     "projectName": "Api",
     "stripe": {
-      "stripeApiKey": "SECRET"
+      "apiKey": "SECRET"
     },
     "sqlServer": {
       "connectionString": "SECRET"

--- a/src/Billing/Startup.cs
+++ b/src/Billing/Startup.cs
@@ -35,7 +35,8 @@ namespace Bit.Billing
             services.Configure<BillingSettings>(Configuration.GetSection("BillingSettings"));
 
             // Stripe Billing
-            StripeConfiguration.ApiKey = globalSettings.StripeApiKey;
+            StripeConfiguration.ApiKey = globalSettings.Stripe.StripeApiKey;
+            StripeConfiguration.MaxNetworkRetries = globalSettings.Stripe.MaxNetworkRetries;
 
             // Repositories
             services.AddSqlServerRepositories(globalSettings);

--- a/src/Billing/Startup.cs
+++ b/src/Billing/Startup.cs
@@ -35,7 +35,7 @@ namespace Bit.Billing
             services.Configure<BillingSettings>(Configuration.GetSection("BillingSettings"));
 
             // Stripe Billing
-            StripeConfiguration.ApiKey = globalSettings.Stripe.StripeApiKey;
+            StripeConfiguration.ApiKey = globalSettings.Stripe.ApiKey;
             StripeConfiguration.MaxNetworkRetries = globalSettings.Stripe.MaxNetworkRetries;
 
             // Repositories

--- a/src/Billing/appsettings.json
+++ b/src/Billing/appsettings.json
@@ -3,7 +3,9 @@
     "selfHosted": false,
     "siteName": "Bitwarden",
     "projectName": "Billing",
-    "stripeApiKey": "SECRET",
+    "stripe": {
+      "stripeApiKey": "SECRET"
+    },
     "sqlServer": {
       "connectionString": "SECRET"
     },

--- a/src/Billing/appsettings.json
+++ b/src/Billing/appsettings.json
@@ -4,7 +4,7 @@
     "siteName": "Bitwarden",
     "projectName": "Billing",
     "stripe": {
-      "stripeApiKey": "SECRET"
+      "apiKey": "SECRET"
     },
     "sqlServer": {
       "connectionString": "SECRET"

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -468,7 +468,7 @@ namespace Bit.Core.Settings
 
         public class StripeSettings
         {
-            public string StripeApiKey { get; set; }
+            public string ApiKey { get; set; }
             public int MaxNetworkRetries { get; set; } = 2;
         }
     }

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -18,7 +18,6 @@ namespace Bit.Core.Settings
         public bool SelfHosted { get; set; }
         public virtual string KnownProxies { get; set; }
         public virtual string SiteName { get; set; }
-        public virtual string StripeApiKey { get; set; }
         public virtual string ProjectName { get; set; }
         public virtual string LogDirectory
         {
@@ -68,6 +67,7 @@ namespace Bit.Core.Settings
         public virtual ServiceBusSettings ServiceBus { get; set; } = new ServiceBusSettings();
         public virtual AppleIapSettings AppleIap { get; set; } = new AppleIapSettings();
         public virtual SsoSettings Sso { get; set; } = new SsoSettings();
+        public virtual StripeSettings Stripe { get; set; } = new StripeSettings();
 
         public string BuildExternalUri(string explicitValue, string name)
         {
@@ -464,6 +464,12 @@ namespace Bit.Core.Settings
             public bool ForceCaptchaRequired { get; set; } = false;
             public string HCaptchaSecretKey { get; set; }
             public string HCaptchaSiteKey { get; set; }
+        }
+
+        public class StripeSettings
+        {
+            public string StripeApiKey { get; set; }
+            public int MaxNetworkRetries { get; set; } = 2;
         }
     }
 }

--- a/src/Identity/appsettings.json
+++ b/src/Identity/appsettings.json
@@ -4,7 +4,7 @@
     "siteName": "Bitwarden",
     "projectName": "Identity",
     "stripe": {
-      "stripeApiKey": "SECRET"
+      "apiKey": "SECRET"
     },
     "oidcIdentityClientKey": "SECRET",
     "sqlServer": {

--- a/src/Identity/appsettings.json
+++ b/src/Identity/appsettings.json
@@ -3,7 +3,9 @@
     "selfHosted": false,
     "siteName": "Bitwarden",
     "projectName": "Identity",
-    "stripeApiKey": "SECRET",
+    "stripe": {
+      "stripeApiKey": "SECRET"
+    },
     "oidcIdentityClientKey": "SECRET",
     "sqlServer": {
       "connectionString": "SECRET"


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix a Stripe error that may be preventing users from updating CC details:

> This object cannot be accessed right now because another API request or Stripe process is currently accessing it. If you see this error intermittently, retry the request. If you see this error frequently and are making multiple concurrent requests to a single object, make your requests serially or at a lower rate.

This is an [object lock timeout](https://stripe.com/docs/rate-limits#object-lock-timeouts) error and Stripe recommends fixing it by:
1. setting a `MaxNetworkRetries` value, so that we retry a couple of times before throwing an error
2. avoiding multiple concurrent requests against the same object

This change implements (1) as a first try at fixing the issue. It defaults to 0 so at the moment we're not doing this at all.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* now that we have multiple Stripe configuration options, move `globalSettings.stripeApiKey` into `globalSettings.stripe.apiKey`
* add `globalSettings.stripe.maxNetworkRetries` and set it to a (hopefully) smart default of 2 (but this gives us flexibility to configure it without changing code). I wasn't sure whether to set defaults here or in `appsettings.json`, but I can see there are some other defaults here, and I didn't want to risk assigning a null/undefined value. Any other guidance here is welcome though.
* update `appsettings.json` to have this new structure
* set `StripeConfiguration.MaxNetworkRetries` in the startup services

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

We were never able to reproduce the original error reliably, so we'll be relying on user feedback for that.

QA should make sure that there are no regressions on Stripe payments and operations. Especially because we've changed the location of the api key, which is fairly critical.

Note that the user secrets for QA and Cloud instances will need to be updated to match the new structure.

## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [x] This change has particular **deployment requirements** (notify the DevOps team) @joseph-flinn please see above
