### PR TITLE
Null org, org user ids, and friendly name to indicate invalid, unused sponsorship state

### DIFF
--- a/src/Core/Repositories/EntityFramework/OrganizationRepository.cs
+++ b/src/Core/Repositories/EntityFramework/OrganizationRepository.cs
@@ -113,6 +113,7 @@ namespace Bit.Core.Repositories.EntityFramework
                 {
                     sponsorship.SponsoredOrganizationId = UpdatedOrgId(sponsorship.SponsoredOrganizationId);
                     sponsorship.SponsoringOrganizationId = UpdatedOrgId(sponsorship.SponsoringOrganizationId);
+                    sponsorship.FriendlyName = null;
                 }
 
                 dbContext.Remove(orgEntity);

--- a/src/Core/Repositories/EntityFramework/OrganizationUserRepository.cs
+++ b/src/Core/Repositories/EntityFramework/OrganizationUserRepository.cs
@@ -80,6 +80,7 @@ namespace Bit.Core.Repositories.EntityFramework
                 foreach (var sponsorship in sponsorships)
                 {
                     sponsorship.SponsoringOrganizationUserId = null;
+                    sponsorship.FriendlyName = null;
                 }
 
                 dbContext.Remove(orgUser);
@@ -99,6 +100,7 @@ namespace Bit.Core.Repositories.EntityFramework
                 foreach (var sponsorship in sponsorships)
                 {
                     sponsorship.SponsoringOrganizationUserId = null;
+                    sponsorship.FriendlyName = null;
                 }
 
                 dbContext.RemoveRange(entities);

--- a/util/Migrator/DbScripts/2021-11-30_00_NullOrganizationSponsorshipOnOrgDelete.sql
+++ b/util/Migrator/DbScripts/2021-11-30_00_NullOrganizationSponsorshipOnOrgDelete.sql
@@ -1,0 +1,80 @@
+-- OrganizationSponsorship_OrganizationDeleted
+IF OBJECT_ID('[dbo].[OrganizationSponsorship_OrganizationDeleted]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationSponsorship_OrganizationDeleted]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_OrganizationDeleted]
+    @OrganizationId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    UPDATE
+        [dbo].[OrganizationSponsorship]
+    SET
+        [SponsoringOrganizationId] = NULL,
+        [FriendlyName] = NULL
+    WHERE
+        [SponsoringOrganizationId] = @OrganizationId
+
+    UPDATE
+        [dbo].[OrganizationSponsorship]
+    SET
+        [SponsoredOrganizationId] = NULL,
+        [FriendlyName] = NULL
+    WHERE
+        [SponsoredOrganizationId] = @OrganizationId
+END
+GO
+
+-- OrganizationSponsorship_OrganizationUserDeleted
+IF OBJECT_ID('[dbo].[OrganizationSponsorship_OrganizationUserDeleted]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationSponsorship_OrganizationUserDeleted]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_OrganizationUserDeleted]
+    @OrganizationUserId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    UPDATE
+        OS
+    SET
+        [SponsoringOrganizationUserId] = NULL,
+        [FriendlyName] = NULL
+    FROM
+        [dbo].[OrganizationSponsorship] OS
+    WHERE
+        [SponsoringOrganizationUserId] = @OrganizationUserId
+END
+GO
+
+-- OrganizationSponsorship_OrganizationUsersDeleted
+IF OBJECT_ID('[dbo].[OrganizationSponsorship_OrganizationUsersDeleted]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationSponsorship_OrganizationUsersDeleted]
+END
+GO
+
+CREATE PROCEDURE [dbo].[OrganizationSponsorship_OrganizationUsersDeleted]
+    @SponsoringOrganizationUserIds [dbo].[GuidIdArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    UPDATE
+        OS
+    SET
+        [SponsoringOrganizationUserId] = NULL,
+        [FriendlyName] = NULL
+    FROM
+        [dbo].[OrganizationSponsorship] OS
+    INNER JOIN
+        @SponsoringOrganizationUserIds I ON I.Id = OS.SponsoringOrganizationUserId
+END
+GO


### PR DESCRIPTION
Asana Ticket: https://app.asana.com/0/1169444489336079/1201418714239822/f

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
1. I had just straight up forgotten to edit the org delete sproc to always null out identities rather than sometimes delete. We null these values to allow for better handling of states where the sponsorship is invalid, but the sponsored org doesn't yet know that and still has the sponsored Stripe plan.
2. `FriendlyName` is used as an indicator that a sponsorship has been used for an enterprise organization. If a sponsorship goes invalid, it should be nulled

## Testing requirements
Test deleting organizations and dropping org users still allow manual removal of sponsorship from families org.


## Before you submit
- [x] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
