### PR TITLE
Pay 0 cost invoices that have not been paid

### DIFF
--- a/src/Core/Services/IStripeAdapter.cs
+++ b/src/Core/Services/IStripeAdapter.cs
@@ -19,7 +19,7 @@ namespace Bit.Core.Services
         Task<Stripe.Invoice> InvoiceUpdateAsync(string id, Stripe.InvoiceUpdateOptions options);
         Task<Stripe.Invoice> InvoiceFinalizeInvoiceAsync(string id, Stripe.InvoiceFinalizeOptions options);
         Task<Stripe.Invoice> InvoiceSendInvoiceAsync(string id, Stripe.InvoiceSendOptions options);
-        Task<Stripe.Invoice> InvoicePayAsync(string id, Stripe.InvoicePayOptions options);
+        Task<Stripe.Invoice> InvoicePayAsync(string id, Stripe.InvoicePayOptions options = null);
         Task<Stripe.Invoice> InvoiceDeleteAsync(string id, Stripe.InvoiceDeleteOptions options = null);
         Task<Stripe.Invoice> InvoiceVoidInvoiceAsync(string id, Stripe.InvoiceVoidOptions options = null);
         IEnumerable<Stripe.PaymentMethod> PaymentMethodListAutoPaging(Stripe.PaymentMethodListOptions options);

--- a/src/Core/Services/Implementations/StripeAdapter.cs
+++ b/src/Core/Services/Implementations/StripeAdapter.cs
@@ -101,7 +101,7 @@ namespace Bit.Core.Services
             return _invoiceService.SendInvoiceAsync(id, options);
         }
 
-        public Task<Stripe.Invoice> InvoicePayAsync(string id, Stripe.InvoicePayOptions options)
+        public Task<Stripe.Invoice> InvoicePayAsync(string id, Stripe.InvoicePayOptions options = null)
         {
             return _invoiceService.PayAsync(id, options);
         }

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -801,6 +801,12 @@ namespace Bit.Core.Services
                     throw;
                 }
             }
+            else if (!invoice.Paid)
+            {
+                // Pay invoice with no charge to customer this completes the invoice immediately without waiting the scheduled 1h
+                invoice = await _stripeAdapter.InvoicePayAsync(subResponse.LatestInvoiceId);
+                paymentIntentClientSecret = null;
+            }
 
             // Change back the subscription collection method and/or days until due
             if (collectionMethod != "send_invoice" || daysUntilDue == null)


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1169444489336079/1201443143244987/f

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Invoices with no cost to the customer are currently ignored and allowed to finish through Stripe's automated 1h scheduled completion. This creates potentially weird timelines where fast instances of reimbursement and charging can create instances of paying for services while a balance _should_ exist on the account.

Families for Enterprise surfaces this bug through being able to sign up for a sponsorship, which can award a balance for unused family plan time, then immediately revoke the sponsorship, which charges for the remaining time again.

This detects those kinds of invoices and pays them immediately rather than waiting the 1h maturation period.

## Code changes
* **StripeAdapter:** InvoicePayOptions are not required for Stripe API or this usage of the invoice pay method
* **StripePaymentService**: If a zero cost invoice has not yet been paid, we just immediately pay it and set the client secret to null, since no secret could exist for this balance award event.

## Testing requirements
Set up a sponsorship and immediately remove it. The families org should be charged only once in real dollars (multiple invoices will exist, but the charged amount should be 0).


## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
