### PR TITLE
Families for enterprise/fix new org sponsorship after deleted sponsored org

### DIFF
--- a/src/Core/Services/Implementations/OrganizationSponsorshipService.cs
+++ b/src/Core/Services/Implementations/OrganizationSponsorshipService.cs
@@ -98,7 +98,7 @@ namespace Bit.Core.Services
 
             var existingOrgSponsorship = await _organizationSponsorshipRepository
                 .GetBySponsoringOrganizationUserIdAsync(sponsoringOrgUser.Id);
-            if (existingOrgSponsorship != null)
+            if (existingOrgSponsorship != null && existingOrgSponsorship.SponsoredOrganizationId != null)
             {
                 throw new BadRequestException("Can only sponsor one organization per Organization User.");
             }

--- a/src/Core/Services/Implementations/OrganizationSponsorshipService.cs
+++ b/src/Core/Services/Implementations/OrganizationSponsorshipService.cs
@@ -98,7 +98,7 @@ namespace Bit.Core.Services
 
             var existingOrgSponsorship = await _organizationSponsorshipRepository
                 .GetBySponsoringOrganizationUserIdAsync(sponsoringOrgUser.Id);
-            if (existingOrgSponsorship != null && existingOrgSponsorship.SponsoredOrganizationId != null)
+            if (existingOrgSponsorship?.SponsoredOrganizationId != null)
             {
                 throw new BadRequestException("Can only sponsor one organization per Organization User.");
             }

--- a/src/Core/Services/Implementations/OrganizationSponsorshipService.cs
+++ b/src/Core/Services/Implementations/OrganizationSponsorshipService.cs
@@ -113,9 +113,15 @@ namespace Bit.Core.Services
                 CloudSponsor = true,
             };
 
+            if (existingOrgSponsorship != null)
+            {
+                // Replace existing invalid offer with our new sponsorship offer
+                sponsorship.Id = existingOrgSponsorship.Id;
+            }
+
             try
             {
-                sponsorship = await _organizationSponsorshipRepository.CreateAsync(sponsorship);
+                await _organizationSponsorshipRepository.UpsertAsync(sponsorship);
 
                 await SendSponsorshipOfferAsync(sponsorship, sponsoringUserEmail);
             }

--- a/test/Core.Test/Services/OrganizationSponsorshipServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationSponsorshipServiceTests.cs
@@ -139,7 +139,7 @@ namespace Bit.Core.Test.Services
             };
 
             await sutProvider.GetDependency<IOrganizationSponsorshipRepository>().Received(1)
-                .CreateAsync(Arg.Is<OrganizationSponsorship>(s => SponsorshipValidator(s, expectedSponsorship)));
+                .UpsertAsync(Arg.Is<OrganizationSponsorship>(s => SponsorshipValidator(s, expectedSponsorship)));
 
             await sutProvider.GetDependency<IMailService>().Received(1).
                 SendFamiliesForEnterpriseOfferEmailAsync(sponsoredEmail, email,
@@ -156,7 +156,7 @@ namespace Bit.Core.Test.Services
 
             var expectedException = new Exception();
             OrganizationSponsorship createdSponsorship = null;
-            sutProvider.GetDependency<IOrganizationSponsorshipRepository>().CreateAsync(default).ThrowsForAnyArgs(callInfo =>
+            sutProvider.GetDependency<IOrganizationSponsorshipRepository>().UpsertAsync(default).ThrowsForAnyArgs(callInfo =>
             {
                 createdSponsorship = callInfo.ArgAt<OrganizationSponsorship>(0);
                 createdSponsorship.Id = Guid.NewGuid();


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
We are no longer deleting sponsorships when organizations related to them are deleted. This was to allow for more fluid removal when evaluating the validity of a sponsorship at renewal time.

However, this breaks our logic for if a user is already sponsoring an organization, because we have hanging organization sponsorships in the event that a sponsored family is deleted. This change recognizes that a sponsorship is only used if the sponsored organization field is filled out.

If a sponsorship exists, we reuse this to avoid creating many instances of orphaned sponsorships.




## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
