### PR TITLE
Parse enqueued mail message model to object

### DIFF
--- a/src/Core/Models/Mail/IMailQueueMessage.cs
+++ b/src/Core/Models/Mail/IMailQueueMessage.cs
@@ -9,6 +9,6 @@ namespace Bit.Core.Models.Mail
         IEnumerable<string> BccEmails { get; set; }
         string Category { get; set; }
         string TemplateName { get; set; }
-        object Model { get; set; }
+        dynamic Model { get; set; }
     }
 }

--- a/src/Core/Models/Mail/MailQueueMessage.cs
+++ b/src/Core/Models/Mail/MailQueueMessage.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace Bit.Core.Models.Mail
 {
@@ -9,7 +11,21 @@ namespace Bit.Core.Models.Mail
         public IEnumerable<string> BccEmails { get; set; }
         public string Category { get; set; }
         public string TemplateName { get; set; }
-        public object Model { get; set; }
+        private object _model;
+        public object Model
+        {
+            get
+            {
+                if (_model?.GetType() == typeof(JObject))
+                {
+                    return (_model as JObject).ToObject(ModelType);
+                }
+                return _model;
+            }
+
+            set => _model = value;
+        }
+        public Type ModelType { get; set; }
 
         public MailQueueMessage() { }
 
@@ -21,6 +37,7 @@ namespace Bit.Core.Models.Mail
             Category = string.IsNullOrEmpty(message.Category) ? templateName : message.Category;
             TemplateName = templateName;
             Model = model;
+            ModelType = model.GetType();
         }
     }
 }

--- a/src/Core/Models/Mail/MailQueueMessage.cs
+++ b/src/Core/Models/Mail/MailQueueMessage.cs
@@ -1,6 +1,6 @@
-using System;
 using System.Collections.Generic;
-using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
+using Bit.Core.Utilities;
 
 namespace Bit.Core.Models.Mail
 {
@@ -11,25 +11,12 @@ namespace Bit.Core.Models.Mail
         public IEnumerable<string> BccEmails { get; set; }
         public string Category { get; set; }
         public string TemplateName { get; set; }
-        private object _model;
-        public object Model
-        {
-            get
-            {
-                if (_model?.GetType() == typeof(JObject))
-                {
-                    return (_model as JObject).ToObject(ModelType);
-                }
-                return _model;
-            }
-
-            set => _model = value;
-        }
-        public Type ModelType { get; set; }
+        [JsonConverter(typeof(ExpandoObjectJsonConverter))]
+        public dynamic Model { get; set; }
 
         public MailQueueMessage() { }
 
-        public MailQueueMessage(MailMessage message, string templateName, object model)
+        public MailQueueMessage(MailMessage message, string templateName, dynamic model)
         {
             Subject = message.Subject;
             ToEmails = message.ToEmails;
@@ -37,7 +24,6 @@ namespace Bit.Core.Models.Mail
             Category = string.IsNullOrEmpty(message.Category) ? templateName : message.Category;
             TemplateName = templateName;
             Model = model;
-            ModelType = model.GetType();
         }
     }
 }

--- a/src/Core/Utilities/ExpandoObjectJsonConverter.cs
+++ b/src/Core/Utilities/ExpandoObjectJsonConverter.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Dynamic;
+using Newtonsoft.Json;
+
+namespace Bit.Core.Utilities
+{
+    public class ExpandoObjectJsonConverter : JsonConverter
+    {
+        public override bool CanWrite => false;
+        public override bool CanConvert(Type objectType) => true;
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return serializer.Deserialize<ExpandoObject>(reader);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Potentially related to: https://app.asana.com/0/1169444489336079/1201460937687186/f

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The model of an MailQueueMessage is of type object to enable enqueuing of any message. However, this means the we are not able to parse a serialized json object back into the original object. Provide the model type to enable this deserialization.

## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
