### PR TITLE
Determine self hosted from global settings

### DIFF
--- a/src/Core/MailTemplates/Handlebars/OrganizationUserInvited.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/OrganizationUserInvited.html.hbs
@@ -16,8 +16,14 @@
         <td class="content-block last" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0; -webkit-text-size-adjust: none; text-align: center;" valign="top" align="center">
             If you do not wish to join this organization, you can safely ignore this email.
             {{#if OrganizationCanSponsor}}
-            <br />
-            <b style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">Did you know?</b> Members of {{OrganizationName}} receive a complimentary Families subscription. Learn more at the following link: https://bitwarden.com/help/article/families-for-enterprise/
+            <p style="margin-top:10px">
+                <b
+                    style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+                    Did you know?
+                </b>
+                Members of {{OrganizationName}} receive a complimentary Families subscription. Learn more at the
+                following link: https://bitwarden.com/help/article/families-for-enterprise/
+            </p>
             {{/if}}
         </td>
     </tr>

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1278,10 +1278,10 @@ namespace Bit.Core.Services
         }
 
 
-        private static bool CheckOrganizationCanSponsor(Organization organization)
+        private bool CheckOrganizationCanSponsor(Organization organization)
         {
             return StaticStore.GetPlan(organization.PlanType).Product == ProductType.Enterprise
-                && !organization.SelfHost;
+                && !_globalSettings.SelfHosted;
         }
 
         public async Task<OrganizationUser> AcceptUserAsync(Guid organizationUserId, User user, string token,


### PR DESCRIPTION
Partial fix for: https://app.asana.com/0/1169444489336079/1201466971009140/f

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
We are using the wrong property to determine if an organization is on a self hosted environment, this correct that bug.

I'm also inserting a little vertical space between the promo info and the main body of this message.

## Screenshot
![image](https://user-images.githubusercontent.com/18214891/144658847-4fa09189-b759-4f1d-8a0e-6f31f2a93907.png)



## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
