### PR TITLE
Make optional ssoConfig fields nullable

### DIFF
--- a/src/Core/Models/Api/Request/Organizations/OrganizationSsoRequestModel.cs
+++ b/src/Core/Models/Api/Request/Organizations/OrganizationSsoRequestModel.cs
@@ -51,7 +51,7 @@ namespace Bit.Core.Models.Api
         public string ClientSecret { get; set; }
         public string MetadataAddress { get; set; }
         public OpenIdConnectRedirectBehavior RedirectBehavior { get; set; }
-        public bool GetClaimsFromUserInfoEndpoint { get; set; }
+        public bool? GetClaimsFromUserInfoEndpoint { get; set; }
         public string AdditionalScopes { get; set; }
         public string AdditionalUserIdClaimTypes { get; set; }
         public string AdditionalEmailClaimTypes { get; set; }
@@ -63,8 +63,8 @@ namespace Bit.Core.Models.Api
         public Saml2NameIdFormat SpNameIdFormat { get; set; }
         public string SpOutboundSigningAlgorithm { get; set; }
         public Saml2SigningBehavior SpSigningBehavior { get; set; }
-        public bool SpWantAssertionsSigned { get; set; }
-        public bool SpValidateCertificates { get; set; }
+        public bool? SpWantAssertionsSigned { get; set; }
+        public bool? SpValidateCertificates { get; set; }
         public string SpMinIncomingSigningAlgorithm { get; set; }
 
         // SAML2 IDP
@@ -75,9 +75,9 @@ namespace Bit.Core.Models.Api
         public string IdpArtifactResolutionServiceUrl { get; set; }
         public string IdpX509PublicCert { get; set; }
         public string IdpOutboundSigningAlgorithm { get; set; }
-        public bool IdpAllowUnsolicitedAuthnResponse { get; set; }
-        public bool IdpDisableOutboundLogoutRequests { get; set; }
-        public bool IdpWantAuthnRequestsSigned { get; set; }
+        public bool? IdpAllowUnsolicitedAuthnResponse { get; set; }
+        public bool? IdpDisableOutboundLogoutRequests { get; set; }
+        public bool? IdpWantAuthnRequestsSigned { get; set; }
 
         public IEnumerable<ValidationResult> Validate(ValidationContext context)
         {
@@ -184,7 +184,7 @@ namespace Bit.Core.Models.Api
                 ClientId = ClientId,
                 ClientSecret = ClientSecret,
                 MetadataAddress = MetadataAddress,
-                GetClaimsFromUserInfoEndpoint = GetClaimsFromUserInfoEndpoint,
+                GetClaimsFromUserInfoEndpoint = GetClaimsFromUserInfoEndpoint.GetValueOrDefault(),
                 RedirectBehavior = RedirectBehavior,
                 IdpEntityId = IdpEntityId,
                 IdpBindingType = IdpBindingType,
@@ -193,14 +193,14 @@ namespace Bit.Core.Models.Api
                 IdpArtifactResolutionServiceUrl = IdpArtifactResolutionServiceUrl,
                 IdpX509PublicCert = StripPemCertificateElements(IdpX509PublicCert),
                 IdpOutboundSigningAlgorithm = IdpOutboundSigningAlgorithm,
-                IdpAllowUnsolicitedAuthnResponse = IdpAllowUnsolicitedAuthnResponse,
-                IdpDisableOutboundLogoutRequests = IdpDisableOutboundLogoutRequests,
-                IdpWantAuthnRequestsSigned = IdpWantAuthnRequestsSigned,
+                IdpAllowUnsolicitedAuthnResponse = IdpAllowUnsolicitedAuthnResponse.GetValueOrDefault(),
+                IdpDisableOutboundLogoutRequests = IdpDisableOutboundLogoutRequests.GetValueOrDefault(),
+                IdpWantAuthnRequestsSigned = IdpWantAuthnRequestsSigned.GetValueOrDefault(),
                 SpNameIdFormat = SpNameIdFormat,
                 SpOutboundSigningAlgorithm = SpOutboundSigningAlgorithm ?? SamlSigningAlgorithms.Sha256,
                 SpSigningBehavior = SpSigningBehavior,
-                SpWantAssertionsSigned = SpWantAssertionsSigned,
-                SpValidateCertificates = SpValidateCertificates,
+                SpWantAssertionsSigned = SpWantAssertionsSigned.GetValueOrDefault(),
+                SpValidateCertificates = SpValidateCertificates.GetValueOrDefault(),
                 SpMinIncomingSigningAlgorithm = SpMinIncomingSigningAlgorithm,
                 AdditionalScopes = AdditionalScopes,
                 AdditionalUserIdClaimTypes = AdditionalUserIdClaimTypes,


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Required to support https://github.com/bitwarden/web/pull/1332. Because we disable the inactive SSO fields (e.g. disable SAML if configuring OpenId), that field data is not sent to the server. This is a slight change in behaviour, as previously you could save both an OpenId and SAML configuration and switch between them. However, after discussing with Jordan, we were unable to identify a use case for this. I assume it's probably an unintended side-effect of using template forms.

Most types are nullable by default, we just need to make the `bool`s nullable and then call `getValueOrDefault()` when mapping it over to the data model.

## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
