### PR TITLE
Bumping the self-host versions

### DIFF
--- a/scripts/bitwarden.ps1
+++ b/scripts/bitwarden.ps1
@@ -26,7 +26,7 @@ $scriptsDir = "${output}\scripts"
 $githubBaseUrl = "https://raw.githubusercontent.com/bitwarden/server/master"
 
 # Please do not create pull requests modifying the version numbers.
-$coreVersion = "1.45.0"
+$coreVersion = "1.45.2"
 $webVersion = "2.25.0"
 
 # Functions

--- a/scripts/bitwarden.ps1
+++ b/scripts/bitwarden.ps1
@@ -26,8 +26,8 @@ $scriptsDir = "${output}\scripts"
 $githubBaseUrl = "https://raw.githubusercontent.com/bitwarden/server/master"
 
 # Please do not create pull requests modifying the version numbers.
-$coreVersion = "1.44.1"
-$webVersion = "2.24.2"
+$coreVersion = "1.45.0"
+$webVersion = "2.25.0"
 
 # Functions
 

--- a/scripts/bitwarden.sh
+++ b/scripts/bitwarden.sh
@@ -34,8 +34,8 @@ SCRIPTS_DIR="$OUTPUT/scripts"
 GITHUB_BASE_URL="https://raw.githubusercontent.com/bitwarden/server/master"
 
 # Please do not create pull requests modifying the version numbers.
-COREVERSION="1.44.1"
-WEBVERSION="2.24.2"
+COREVERSION="1.45.0"
+WEBVERSION="2.25.0"
 
 echo "bitwarden.sh version $COREVERSION"
 docker --version

--- a/scripts/bitwarden.sh
+++ b/scripts/bitwarden.sh
@@ -34,7 +34,7 @@ SCRIPTS_DIR="$OUTPUT/scripts"
 GITHUB_BASE_URL="https://raw.githubusercontent.com/bitwarden/server/master"
 
 # Please do not create pull requests modifying the version numbers.
-COREVERSION="1.45.0"
+COREVERSION="1.45.2"
 WEBVERSION="2.25.0"
 
 echo "bitwarden.sh version $COREVERSION"


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective
Bump the self-host version to the latest released.

## Code changes
* **./scripts/bitwarden.sh:** Bump server version 1.45.0 and web 2.25.0
* * **./scripts/bitwarden.ps1:** Bump server version 1.45.0 and web 2.25.0

## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
