### PR TITLE
Send invites for both all collection and limited collection users

### DIFF
--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1191,7 +1191,8 @@ namespace Bit.Core.Services
                 }
 
                 await AutoAddSeatsAsync(organization, newSeatsRequired, prorationDate);
-                await SendInvitesAsync(orgUsers, organization);
+                // await SendInvitesAsync(orgUsers, organization);
+                await SendInvitesAsync(orgUsers.Concat(limitedCollectionOrgUsers.Select(u => u.Item1)), organization);
                 await _eventService.LogOrganizationUserEventsAsync(events);
 
                 await _referenceEventService.RaiseEventAsync(

--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -355,6 +355,10 @@ namespace Bit.Core.Test.Services
             currentContext.ManageUsers(organization.Id).Returns(true);
 
             await sutProvider.Sut.InviteUsersAsync(organization.Id, invitor.UserId, new (OrganizationUserInvite, string)[] { (invite, null) });
+
+            await sutProvider.GetDependency<IMailService>().Received(1)
+                .BulkSendOrganizationInviteEmailAsync(organization.Name, Arg.Any<bool>(),
+                    Arg.Is<IEnumerable<(OrganizationUser, ExpiringToken)>>(v => v.Count() == invite.Emails.Count()));
         }
 
         [Theory, CustomAutoData(typeof(SutProviderCustomization))]

--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -334,11 +334,16 @@ namespace Bit.Core.Test.Services
             inviteeUserType: (int)OrganizationUserType.User,
             invitorUserType: (int)OrganizationUserType.Custom
         )]
-        public async Task InviteUser_Passes(Organization organization, OrganizationUserInvite invite,
+        public async Task InviteUser_Passes(Organization organization, IEnumerable<(OrganizationUserInvite invite, string externalId)> invites,
             OrganizationUser invitor,
             [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.Owner)]OrganizationUser owner,
             SutProvider<OrganizationService> sutProvider)
         {
+            // Autofixture will add collections for all of the invites, remove the first and for all the rest set all access false
+            invites.First().invite.AccessAll = true;
+            invites.First().invite.Collections = null;
+            invites.Skip(1).ToList().ForEach(i => i.invite.AccessAll = false);
+
             invitor.Permissions = JsonSerializer.Serialize(new Permissions() { ManageUsers = true },
                 new JsonSerializerOptions
                 {
@@ -354,11 +359,11 @@ namespace Bit.Core.Test.Services
                 .Returns(new [] {owner});
             currentContext.ManageUsers(organization.Id).Returns(true);
 
-            await sutProvider.Sut.InviteUsersAsync(organization.Id, invitor.UserId, new (OrganizationUserInvite, string)[] { (invite, null) });
+            await sutProvider.Sut.InviteUsersAsync(organization.Id, invitor.UserId, invites);
 
             await sutProvider.GetDependency<IMailService>().Received(1)
                 .BulkSendOrganizationInviteEmailAsync(organization.Name, Arg.Any<bool>(),
-                    Arg.Is<IEnumerable<(OrganizationUser, ExpiringToken)>>(v => v.Count() == invite.Emails.Count()));
+                    Arg.Is<IEnumerable<(OrganizationUser, ExpiringToken)>>(v => v.Count() == invites.SelectMany(i => i.invite.Emails).Count()));
         }
 
         [Theory, CustomAutoData(typeof(SutProviderCustomization))]


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
We are only enqueuing invite emails for users invited to an organization without specified collections. Fix that.

## Code changes
Concat the lists of new general access orgUsers with new limited access org users. Send invites to all.

* **OrganizationService:** Fix the issue
* **OrganizationServiceTests:** Test the fix -- for a working invite, make sure we send out the expected number of emails

## Testing requirements
Please test organization invite sending both specifying no collections and limited collections.



## Before you submit
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [x] This change has particular **deployment requirements** (notify the DevOps team)

# Hotfix

@bitwarden/dept-devops This PR is being proposed for a hotfix release to fix the above issue.
