### PR TITLE
Allow Let's Encrypt random sleep on renewal to be disabled

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -154,8 +154,7 @@ function dockerPrune() {
 function preventLetsEncryptRandomSleepOnRenew() {
     if [ -f "${OUTPUT_DIR}/config.yml" ]
     then
-        grep -E "^lets_encrypt_no_random_sleep_on_renew: true" "${OUTPUT_DIR}/config.yml" 2>&1 >/dev/null
-        if [ "$?" -eq 0 ]
+        if grep -q -E "^lets_encrypt_no_random_sleep_on_renew: true" "${OUTPUT_DIR}/config.yml"
         then
             echo '--no-random-sleep-on-renew'
         fi

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -151,13 +151,24 @@ function dockerPrune() {
         --filter="label!=com.bitwarden.project=setup"
 }
 
+function preventLetsEncryptRandomSleepOnRenew() {
+    if [ -f "${OUTPUT_DIR}/config.yml" ]
+    then
+        grep -E "^lets_encrypt_no_random_sleep_on_renew: true" "${OUTPUT_DIR}/config.yml" 2>&1 >/dev/null
+        if [ "$?" -eq 0 ]
+        then
+            echo '--no-random-sleep-on-renew'
+        fi
+    fi
+}
+
 function updateLetsEncrypt() {
     if [ -d "${OUTPUT_DIR}/letsencrypt/live" ]
     then
         docker pull certbot/certbot
         docker run -i --rm --name certbot -p 443:443 -p 80:80 \
             -v $OUTPUT_DIR/letsencrypt:/etc/letsencrypt/ certbot/certbot \
-            renew --logs-dir /etc/letsencrypt/logs
+            renew $(preventLetsEncryptRandomSleepOnRenew) --logs-dir /etc/letsencrypt/logs
     fi
 }
 
@@ -167,7 +178,7 @@ function forceUpdateLetsEncrypt() {
         docker pull certbot/certbot
         docker run -i --rm --name certbot -p 443:443 -p 80:80 \
             -v $OUTPUT_DIR/letsencrypt:/etc/letsencrypt/ certbot/certbot \
-            renew --logs-dir /etc/letsencrypt/logs --force-renew
+            renew $(preventLetsEncryptRandomSleepOnRenew) --logs-dir /etc/letsencrypt/logs --force-renew
     fi
 }
 

--- a/util/Setup/Configuration.cs
+++ b/util/Setup/Configuration.cs
@@ -103,6 +103,9 @@ namespace Bit.Setup
         [Description("Enable Key Connector (https://bitwarden.com/help/article/deploy-key-connector)")]
         public bool EnableKeyConnector { get; set; } = false;
 
+        [Description("Disable random sleep when renewing a Let's Encrypt SSL certificate.")]
+        public bool LetsEncryptNoRandomSleepOnRenew { get; set; } = false;
+
         [YamlIgnore]
         public string Domain
         {


### PR DESCRIPTION
## Type of change
New feature development


## Objective
This allows for self-hosted Bitwarden administrators to define that certbot should not sleep randomly on renewals. This was previously reported in #415, but LE has since introduced the --no-random-sleep-on-renew flag to prevent the delay.

Prior PR #1261 for previous effort.

## Code changes
Updates `Setup` to be aware of the `lets_encrypt_no_random_sleep_on_renew` flag in the `config.yml`
