### PR TITLE
Fix null error in SSO existing user flow

### DIFF
--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -447,7 +447,7 @@ namespace Bit.Sso.Controllers
             if (existingUser != null)
             {
                 if (existingUser.UsesKeyConnector && orgUser == null ||
-                    orgUser.Status == OrganizationUserStatusType.Invited)
+                    orgUser?.Status == OrganizationUserStatusType.Invited)
                 {
                     throw new Exception(_i18nService.T("UserAlreadyExistsKeyConnector"));
                 }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix the following error, which occurs when an existing account joins an Org via SSO.

```
info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
      Executed endpoint 'Bit.Sso.Controllers.AccountController.ExternalCallback (Sso)'
fail: Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware[1]
      An unhandled exception has occurred while executing the request.
      System.NullReferenceException: Object reference not set to an instance of an object.
         at Bit.Sso.Controllers.AccountController.AutoProvisionUserAsync(String provider, String providerUserId, IEnumerable`1 claims, String userIdentifier, SsoConfigurationData config) in /Users/thomasrittson/Projects/server/bitwarden_license/src/Sso/Controllers/AccountController.cs:line 449
```

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* Add null check in existing user flow. An "existing user" is only an existing Bitwarden user, not an existing `orgUser` for that organization.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

Make sure that the error cannot be reproduced:
* create an account that is not part of an organization
* sign in via SSO using the same email as the existing account
Expected result: no error, you can log into your vault and you move into the "accepted" state with the org.

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
