### PR TITLE
Fix error if user is invited with access to all collections

### DIFF
--- a/src/Api/Models/Request/Organizations/OrganizationUserRequestModels.cs
+++ b/src/Api/Models/Request/Organizations/OrganizationUserRequestModels.cs
@@ -28,7 +28,7 @@ namespace Bit.Api.Models.Request.Organizations
                 Emails = Emails,
                 Type = Type,
                 AccessAll = AccessAll,
-                Collections = Collections.Select(c => c.ToSelectionReadOnly()),
+                Collections = Collections?.Select(c => c.ToSelectionReadOnly()),
                 Permissions = Permissions,
             };
         }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix an unhandled exception when a user is invited to an Organization with access to all collections.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Api/Models/Request/Organizations/OrganizationUserRequestModels.cs**: add null check, because this property is null if the user has access to all collections. There used to be a null check here but it got dropped in https://github.com/bitwarden/server/pull/1754 when the logic got moved.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

Confirm that the bug cannot be reproduced.

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
