### PR TITLE
Feature/add key-connector version to self-hosted scripts

### DIFF
--- a/scripts/bitwarden.ps1
+++ b/scripts/bitwarden.ps1
@@ -28,6 +28,7 @@ $githubBaseUrl = "https://raw.githubusercontent.com/bitwarden/server/master"
 # Please do not create pull requests modifying the version numbers.
 $coreVersion = "1.45.2"
 $webVersion = "2.25.0"
+$keyConnectorVersion = "1.0.0"
 
 # Functions
 
@@ -115,36 +116,36 @@ if ($install) {
     Test-Output-Dir-Not-Exists
     New-Item -ItemType directory -Path $output -ErrorAction Ignore | Out-Null
     Get-Run-File
-    Invoke-Expression "& `"$scriptsDir\run.ps1`" -install -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion"
+    Invoke-Expression "& `"$scriptsDir\run.ps1`" -install -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion -keyConnectorVersion $keyConnectorVersion"
 }
 elseif ($start -Or $restart) {
     Test-Output-Dir-Exists
-    Invoke-Expression "& `"$scriptsDir\run.ps1`" -restart -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion"
+    Invoke-Expression "& `"$scriptsDir\run.ps1`" -restart -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion -keyConnectorVersion $keyConnectorVersion"
 }
 elseif ($update) {
     Test-Output-Dir-Exists
     Get-Run-File
-    Invoke-Expression "& `"$scriptsDir\run.ps1`" -update -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion"
+    Invoke-Expression "& `"$scriptsDir\run.ps1`" -update -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion -keyConnectorVersion $keyConnectorVersion"
 }
 elseif ($rebuild) {
     Test-Output-Dir-Exists
-    Invoke-Expression "& `"$scriptsDir\run.ps1`" -rebuild -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion"
+    Invoke-Expression "& `"$scriptsDir\run.ps1`" -rebuild -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion -keyConnectorVersion $keyConnectorVersion"
 }
 elseif ($updateconf) {
     Test-Output-Dir-Exists
-    Invoke-Expression "& `"$scriptsDir\run.ps1`" -updateconf -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion"
+    Invoke-Expression "& `"$scriptsDir\run.ps1`" -updateconf -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion -keyConnectorVersion $keyConnectorVersion"
 }
 elseif ($updatedb) {
     Test-Output-Dir-Exists
-    Invoke-Expression "& `"$scriptsDir\run.ps1`" -updatedb -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion"
+    Invoke-Expression "& `"$scriptsDir\run.ps1`" -updatedb -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion -keyConnectorVersion $keyConnectorVersion"
 }
 elseif ($stop) {
     Test-Output-Dir-Exists
-    Invoke-Expression "& `"$scriptsDir\run.ps1`" -stop -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion"
+    Invoke-Expression "& `"$scriptsDir\run.ps1`" -stop -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion -keyConnectorVersion $keyConnectorVersion"
 }
 elseif ($renewcert) {
     Test-Output-Dir-Exists
-    Invoke-Expression "& `"$scriptsDir\run.ps1`" -renewcert -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion"
+    Invoke-Expression "& `"$scriptsDir\run.ps1`" -renewcert -outputDir `"$output`" -coreVersion $coreVersion -webVersion $webVersion -keyConnectorVersion $keyConnectorVersion"
 }
 elseif ($updaterun) {
     Test-Output-Dir-Exists

--- a/scripts/bitwarden.sh
+++ b/scripts/bitwarden.sh
@@ -36,6 +36,7 @@ GITHUB_BASE_URL="https://raw.githubusercontent.com/bitwarden/server/master"
 # Please do not create pull requests modifying the version numbers.
 COREVERSION="1.45.2"
 WEBVERSION="2.25.0"
+KEYCONNECTORVERSION="1.0.0"
 
 echo "bitwarden.sh version $COREVERSION"
 docker --version
@@ -110,36 +111,36 @@ case $1 in
         checkOutputDirNotExists
         mkdir -p $OUTPUT
         downloadRunFile
-        $SCRIPTS_DIR/run.sh install $OUTPUT $COREVERSION $WEBVERSION
+        $SCRIPTS_DIR/run.sh install $OUTPUT $COREVERSION $WEBVERSION $KEYCONNECTORVERSION
         ;;
     "start" | "restart")
         checkOutputDirExists
-        $SCRIPTS_DIR/run.sh restart $OUTPUT $COREVERSION $WEBVERSION
+        $SCRIPTS_DIR/run.sh restart $OUTPUT $COREVERSION $WEBVERSION $KEYCONNECTORVERSION
         ;;
     "update")
         checkOutputDirExists
         downloadRunFile
-        $SCRIPTS_DIR/run.sh update $OUTPUT $COREVERSION $WEBVERSION
+        $SCRIPTS_DIR/run.sh update $OUTPUT $COREVERSION $WEBVERSION $KEYCONNECTORVERSION
         ;;
     "rebuild")
         checkOutputDirExists
-        $SCRIPTS_DIR/run.sh rebuild $OUTPUT $COREVERSION $WEBVERSION
+        $SCRIPTS_DIR/run.sh rebuild $OUTPUT $COREVERSION $WEBVERSION $KEYCONNECTORVERSION
         ;;
     "updateconf")
         checkOutputDirExists
-        $SCRIPTS_DIR/run.sh updateconf $OUTPUT $COREVERSION $WEBVERSION
+        $SCRIPTS_DIR/run.sh updateconf $OUTPUT $COREVERSION $WEBVERSION $KEYCONNECTORVERSION
         ;;
     "updatedb")
         checkOutputDirExists
-        $SCRIPTS_DIR/run.sh updatedb $OUTPUT $COREVERSION $WEBVERSION
+        $SCRIPTS_DIR/run.sh updatedb $OUTPUT $COREVERSION $WEBVERSION $KEYCONNECTORVERSION
         ;;
     "stop")
         checkOutputDirExists
-        $SCRIPTS_DIR/run.sh stop $OUTPUT $COREVERSION $WEBVERSION
+        $SCRIPTS_DIR/run.sh stop $OUTPUT $COREVERSION $WEBVERSION $KEYCONNECTORVERSION
         ;;
     "renewcert")
         checkOutputDirExists
-        $SCRIPTS_DIR/run.sh renewcert $OUTPUT $COREVERSION $WEBVERSION
+        $SCRIPTS_DIR/run.sh renewcert $OUTPUT $COREVERSION $WEBVERSION $KEYCONNECTORVERSION
         ;;
     "updaterun")
         checkOutputDirExists

--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -2,6 +2,7 @@ param (
     [string]$outputDir = "../.",
     [string]$coreVersion = "latest",
     [string]$webVersion = "latest",
+    [string]$keyConnectorVersion = "latest",
     [switch] $install,
     [switch] $start,
     [switch] $restart,
@@ -80,7 +81,7 @@ function Install() {
     Pull-Setup
     docker run -it --rm --name setup -v ${outputDir}:/bitwarden bitwarden/setup:$coreVersion `
         dotnet Setup.dll -install 1 -domain ${domain} -letsencrypt ${letsEncrypt} `
-        -os win -corev $coreVersion -webv $webVersion -q $setupQuiet -dbname "$database"
+        -os win -corev $coreVersion -webv $webVersion -keyconnectorv $keyConnectorVersion -q $setupQuiet -dbname "$database"
 }
 
 function Docker-Compose-Up {
@@ -168,7 +169,8 @@ function Update-Database {
     $mssqlId = docker-compose ps -q mssql
     docker run -it --rm --name setup --network container:$mssqlId `
         -v ${outputDir}:/bitwarden bitwarden/setup:$coreVersion `
-        dotnet Setup.dll -update 1 -db 1 -os win -corev $coreVersion -webv $webVersion -q $setupQuiet
+        dotnet Setup.dll -update 1 -db 1 -os win -corev $coreVersion -webv $webVersion `
+        -keyconnectorv $keyConnectorVersion -q $setupQuiet
     Write-Line "Database update complete"
 }
 
@@ -177,13 +179,15 @@ function Update([switch] $withpull) {
         Pull-Setup
     }
     docker run -it --rm --name setup -v ${outputDir}:/bitwarden bitwarden/setup:$coreVersion `
-        dotnet Setup.dll -update 1 -os win -corev $coreVersion -webv $webVersion -q $setupQuiet
+        dotnet Setup.dll -update 1 -os win -corev $coreVersion -webv $webVersion `
+        -keyconnectorv $keyConnectorVersion -q $setupQuiet
 }
 
 function Print-Environment {
     Pull-Setup
     docker run -it --rm --name setup -v ${outputDir}:/bitwarden bitwarden/setup:$coreVersion `
-        dotnet Setup.dll -printenv 1 -os win -corev $coreVersion -webv $webVersion -q $setupQuiet
+        dotnet Setup.dll -printenv 1 -os win -corev $coreVersion -webv $webVersion `
+        -keyconnectorv $keyConnectorVersion -q $setupQuiet
 }
 
 function Restart {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -190,9 +190,10 @@ function updateDatabase() {
 function updatebw() {
     CORE_ID=$(docker-compose ps -q admin)
     WEB_ID=$(docker-compose ps -q web)
+    KEYCONNECTOR_ID=$(docker-compose ps -q key-connector)
     if docker inspect --format='{{.Config.Image}}:' $CORE_ID | grep -F ":$COREVERSION:" | grep -q ":[0-9.]*:$" &&
        docker inspect --format='{{.Config.Image}}:' $WEB_ID | grep -F ":$WEBVERSION:" | grep -q ":[0-9.]*:$" &&
-       docker inspect --format='{{.Config.Image}}:' $WEB_ID | grep -F ":$KEYCONNECTORVERSION:" | grep -q ":[0-9.]*:$" &&
+       docker inspect --format='{{.Config.Image}}:' $KEYCONNECTOR_ID | grep -F ":$KEYCONNECTORVERSION:" | grep -q ":[0-9.]*:$"
     then
         echo "Update not needed"
         exit

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -26,6 +26,12 @@ then
     WEBVERSION=$4
 fi
 
+KEYCONNECTORVERSION="latest"
+if [ $# -gt 4 ]
+then
+    KEYCONNECTORVERSION=$5
+fi
+
 OS="lin"
 [ "$(uname)" == "Darwin" ] && OS="mac"
 ENV_DIR="$OUTPUT_DIR/env"
@@ -89,7 +95,7 @@ function install() {
     docker run -it --rm --name setup -v $OUTPUT_DIR:/bitwarden \
         --env-file $ENV_DIR/uid.env bitwarden/setup:$COREVERSION \
         dotnet Setup.dll -install 1 -domain $DOMAIN -letsencrypt $LETS_ENCRYPT -os $OS \
-        -corev $COREVERSION -webv $WEBVERSION -dbname "$DATABASE"
+        -corev $COREVERSION -webv $WEBVERSION -dbname "$DATABASE" -keyconnectorv $KEYCONNECTORVERSION
 }
 
 function dockerComposeUp() {
@@ -177,7 +183,7 @@ function updateDatabase() {
     MSSQL_ID=$(docker-compose ps -q mssql)
     docker run -i --rm --name setup --network container:$MSSQL_ID \
         -v $OUTPUT_DIR:/bitwarden --env-file $ENV_DIR/uid.env bitwarden/setup:$COREVERSION \
-        dotnet Setup.dll -update 1 -db 1 -os $OS -corev $COREVERSION -webv $WEBVERSION
+        dotnet Setup.dll -update 1 -db 1 -os $OS -corev $COREVERSION -webv $WEBVERSION -keyconnectorv $KEYCONNECTORVERSION
     echo "Database update complete"
 }
 
@@ -185,7 +191,8 @@ function updatebw() {
     CORE_ID=$(docker-compose ps -q admin)
     WEB_ID=$(docker-compose ps -q web)
     if docker inspect --format='{{.Config.Image}}:' $CORE_ID | grep -F ":$COREVERSION:" | grep -q ":[0-9.]*:$" &&
-       docker inspect --format='{{.Config.Image}}:' $WEB_ID | grep -F ":$WEBVERSION:" | grep -q ":[0-9.]*:$"
+       docker inspect --format='{{.Config.Image}}:' $WEB_ID | grep -F ":$WEBVERSION:" | grep -q ":[0-9.]*:$" &&
+       docker inspect --format='{{.Config.Image}}:' $WEB_ID | grep -F ":$KEYCONNECTORVERSION:" | grep -q ":[0-9.]*:$" &&
     then
         echo "Update not needed"
         exit
@@ -205,14 +212,14 @@ function update() {
     fi
     docker run -i --rm --name setup -v $OUTPUT_DIR:/bitwarden \
         --env-file $ENV_DIR/uid.env bitwarden/setup:$COREVERSION \
-        dotnet Setup.dll -update 1 -os $OS -corev $COREVERSION -webv $WEBVERSION
+        dotnet Setup.dll -update 1 -os $OS -corev $COREVERSION -webv $WEBVERSION -keyconnectorv $KEYCONNECTORVERSION
 }
 
 function printEnvironment() {
     pullSetup
     docker run -i --rm --name setup -v $OUTPUT_DIR:/bitwarden \
         --env-file $ENV_DIR/uid.env bitwarden/setup:$COREVERSION \
-        dotnet Setup.dll -printenv 1 -os $OS -corev $COREVERSION -webv $WEBVERSION
+        dotnet Setup.dll -printenv 1 -os $OS -corev $COREVERSION -webv $WEBVERSION -keyconnectorv $KEYCONNECTORVERSION
 }
 
 function restart() {

--- a/util/Setup/Context.cs
+++ b/util/Setup/Context.cs
@@ -18,6 +18,7 @@ namespace Bit.Setup
         public string HostOS { get; set; } = "win";
         public string CoreVersion { get; set; } = "latest";
         public string WebVersion { get; set; } = "latest";
+        public string KeyConnectorVersion { get; set; } = "latest";
         public Installation Install { get; set; } = new Installation();
         public Configuration Config { get; set; } = new Configuration();
 

--- a/util/Setup/DockerComposeBuilder.cs
+++ b/util/Setup/DockerComposeBuilder.cs
@@ -61,6 +61,10 @@ namespace Bit.Setup
                 {
                     WebVersion = context.WebVersion;
                 }
+                if (!string.IsNullOrWhiteSpace(context.KeyConnectorVersion))
+                {
+                    KeyConnectorVersion = context.KeyConnectorVersion;
+                }
             }
 
             public string ComposeVersion { get; set; } = "3";
@@ -71,6 +75,7 @@ namespace Bit.Setup
             public bool HasPort => !string.IsNullOrWhiteSpace(HttpPort) || !string.IsNullOrWhiteSpace(HttpsPort);
             public string CoreVersion { get; set; } = "latest";
             public string WebVersion { get; set; } = "latest";
+            public string KeyConnectorVersion { get; set; } = "latest";
         }
     }
 }

--- a/util/Setup/Program.cs
+++ b/util/Setup/Program.cs
@@ -38,6 +38,10 @@ namespace Bit.Setup
             {
                 _context.WebVersion = _context.Parameters["webv"];
             }
+            if (_context.Parameters.ContainsKey("keyconnectorv"))
+            {
+                _context.KeyConnectorVersion = _context.Parameters["keyconnectorv"];
+            }
             if (_context.Parameters.ContainsKey("stub"))
             {
                 _context.Stub = _context.Parameters["stub"] == "true" ||

--- a/util/Setup/Templates/DockerCompose.hbs
+++ b/util/Setup/Templates/DockerCompose.hbs
@@ -197,7 +197,7 @@ services:
 
 {{#if EnableKeyConnector}}
   key-connector:
-    image: bitwarden/key-connector:latest
+    image: bitwarden/key-connector:{{{KeyConnectorVersion}}}
     container_name: bitwarden-key-connector
     restart: always
     volumes:


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Adding the ability to set the version of the key-connector container. This allows users of the self-hosted scripts to manage their upgrade path when new versions of the key-connector are released. 


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **scripts/bitwarden.ps1:** Added keyConnectorVersion as a variable and argument for commands.
* **scripts/run.ps1:** Added keyConnectorVersion as an acceptable argument.
* **scripts/bitwarden.sh:** Added KEYCONNECTORVERSION as a variable and argument for commands.
* **scripts/run.sh:** Added KEYCONNECTORVERSION as an acceptable argument.
* **util/Setup/Context.cs:** Add KeyConnectorVersion argument, set to latest by default.
* **util/Setup/DockerComposeBuilder.cs:** Set KeyConnectorVersion to value of context.
* **util/Setup/Program.cs: ** Set the context for KeyConnectorVersion from value of keyconnectorv argument.
* **util/Setup/Templates/DockerCompose.hbs:** Moved from `latest` to a template variable for key-connector version.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
This needs standard self-hosted setup testing. The expectation is that after enabling key-connector in the config and running an `update` then the docker-compose configuration will use the key-connector version as a tag instead of `latest` UNLESS no key-connector version is specified. 

### Requirements
- git
- docker
- docker-compose
- dotnet 5.0

### Install & Dev/Test Setup
#### Clean install

1. Set up a clean install of the `dev` self-host server

####  Build new Setup image

1. clone `server` repo
2. `git switch feature/add-keyconnector-version`
3. `cd server/util/Setup`
4. `./build.sh && docker build -t bitwarden/setup:dev .`

#### Edit scripts to use new Setup image
With the current way we are releasing the self host installation scripts, we need to make some modifications so that we don't pull the latest released `bitwarden/setup:dev` image. These are the original self-host install scripts and not their respective counterparts in the newly cloned `server` project.

1. edit bitwarden.sh
  a. change COREVERSION to latest
  b. add a return to the top of the downloadRunFile function
    ```
    function downloadRunFile() {
      return
      ...
    }
    ```
2. edit bwdata/scripts/run.sh
  a. add a return line to the pullSetup function
    ```
    function pullSetup() {
      return
      ...
    }
    ```

#### Update installation and enable key connector

1. run a `./bitwarden.sh update`
2. in the `bwdata/config.yml` file, enable the key connector by setting the `enable_key_connector` to `true`
3. run a `./bitwarden.sh update`
4. Validate that the `docker-compose.yml` file contains entries for key-connector with a version tag.



## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
