### PR TITLE
Fix format of StripePaymentService tests

### DIFF
--- a/test/Core.Test/Services/StripePaymentServiceTests.cs
+++ b/test/Core.Test/Services/StripePaymentServiceTests.cs
@@ -151,7 +151,7 @@ namespace Bit.Core.Test.Services
             });
             sutProvider.GetDependency<ITaxRateRepository>().GetByLocationAsync(Arg.Is<TaxRate>(t =>
                     t.Country == taxInfo.BillingAddressCountry && t.PostalCode == taxInfo.BillingAddressPostalCode))
-                .Returns(new List<TaxRate>{ new() { Id = "T-1"}});
+                .Returns(new List<TaxRate> { new() { Id = "T-1" } });
 
             var result = await sutProvider.Sut.PurchaseOrganizationAsync(organization, PaymentMethodType.Card, paymentToken, plan, 0, 0, false, taxInfo);
 
@@ -363,14 +363,14 @@ namespace Bit.Core.Test.Services
             });
             stripeAdapter.InvoiceUpcomingAsync(default).ReturnsForAnyArgs(new Stripe.Invoice
             {
-                PaymentIntent = new Stripe.PaymentIntent {Status = "requires_payment_method",},
+                PaymentIntent = new Stripe.PaymentIntent { Status = "requires_payment_method", },
                 AmountDue = 0
             });
             stripeAdapter.SubscriptionCreateAsync(default).ReturnsForAnyArgs(new Stripe.Subscription { });
 
             var plan = StaticStore.Plans.First(p => p.Type == PlanType.EnterpriseAnnually);
             var result = await sutProvider.Sut.UpgradeFreeOrganizationAsync(organization, plan, 0, 0, false, taxInfo);
-            
+
             Assert.Null(result);
         }
     }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

In #1615 I forgot to run the format, and the PR was opened before the format tool was added.

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
