### PR TITLE
Add alternative databases to development docker-compose

### DIFF
--- a/dev/.env.example
+++ b/dev/.env.example
@@ -3,3 +3,7 @@ COMPOSE_PROJECT_NAME=BitwardenServer
 # https://docs.microsoft.com/en-us/sql/relational-databases/security/password-policy?view=sql-server-ver15
 MSSQL_PASSWORD=SET_A_PASSWORD_HERE_123
 MAILCATCHER_PORT=1080
+
+# Alternative databases
+POSTGRES_PASSWORD=SET_A_PASSWORD_HERE_123
+MYSQL_ROOT_PASSWORD=SET_A_PASSWORD_HERE_123

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -39,5 +39,38 @@ services:
     profiles:
       - mail
 
+  postgres:
+    image: postgres:14
+    restart: always
+    ports: 
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: bw-vault
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres_dev_data:/var/lib/postgresql/data
+      - ./.data/postgres/config:/etc/postgresql
+      - ./.data/postgres/log:/var/log/postgresql
+    profiles:
+      - postgres
+
+  mysql:
+    image: mysql:8
+    container_name: bw-mysql
+    restart: always
+    ports: 
+      - "3306:3306"
+    command: --default-authentication-plugin=mysql_native_password
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: bw-vault
+    volumes:
+      - mysql_dev_data:/var/lib/mysql
+    profiles:
+      - mysql
+
 volumes:
   edgesql_dev_data:
+  postgres_dev_data:
+  mysql_dev_data:

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     ports: 
       - "5432:5432"
     environment:
-      POSTGRES_DB: bw-vault
+      POSTGRES_DB: vault_dev
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
@@ -64,7 +64,7 @@ services:
     command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      MYSQL_DATABASE: bw-vault
+      MYSQL_DATABASE: vault_dev
     volumes:
       - mysql_dev_data:/var/lib/mysql
     profiles:

--- a/dev/secrets.json.example
+++ b/dev/secrets.json.example
@@ -7,6 +7,12 @@
     "sqlServer": {
       "connectionString": "Server=localhost;Database=vault_dev;User Id=SA;Password=SET_A_PASSWORD_HERE_123;"
     },
+    "postgreSql": {
+      "connectionString": "Host=localhost;Username=postgres;Password=SET_A_PASSWORD_HERE_123;Database=vault_dev;Include Error Detail=true",
+    },
+    "mySql": {
+      "connectionString": "server=localhost;uid=root;pwd=SET_A_PASSWORD_HERE_123;database=vault_dev"
+    },
     "identityServer": {
       "certificateThumbprint": "<your Identity certificate thumbprint with no spaces>"
     },


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Adds Postgres and MySQL to the development docker-compose which can be used when developing for EF.

## Before you submit
- [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
