### PR TITLE
Fix iOS Push Notification template

### DIFF
--- a/src/Core/Services/Implementations/NotificationHubPushRegistrationService.cs
+++ b/src/Core/Services/Implementations/NotificationHubPushRegistrationService.cs
@@ -65,7 +65,7 @@ namespace Bit.Core.Services
                     break;
                 case DeviceType.iOS:
                     payloadTemplate = "{\"data\":{\"type\":\"#(type)\",\"payload\":\"$(payload)\"}," +
-                        "\"aps\":{\"alert\":null,\"badge\":null,\"content-available\":1}}";
+                        "\"aps\":{\"content-available\":1}}";
                     messageTemplate = "{\"data\":{\"type\":\"#(type)\"}," +
                         "\"aps\":{\"alert\":\"$(message)\",\"badge\":null,\"content-available\":1}}";
                     badgeMessageTemplate = "{\"data\":{\"type\":\"#(type)\"}," +


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix payload template for iOS silent push notification. As stated [here](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification) for `content-available` key.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **NotificationHubPushRegistrationService.cs:** Removed `alert`, and `badge` keys from `aps` so that `content-available` works as expected.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
This needs to work alongside with the [mobile PR](https://github.com/bitwarden/mobile/pull/1708), so testing is in that PR

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
