### PR TITLE
Revert TwoFactorProviders to be saved with numerical value

### DIFF
--- a/src/Core/Entities/User.cs
+++ b/src/Core/Entities/User.cs
@@ -133,7 +133,7 @@ namespace Bit.Core.Entities
         public void SetTwoFactorProviders(Dictionary<TwoFactorProviderType, TwoFactorProvider> providers)
         {
             // When replacing with system.text remember to remove the extra serialization in WebAuthnTokenProvider.
-            TwoFactorProviders = JsonHelpers.LegacySerialize(providers);
+            TwoFactorProviders = JsonHelpers.LegacySerialize(providers, JsonHelpers.LegacyEnumKeyResolver);
             _twoFactorProviders = providers;
         }
 

--- a/test/Core.Test/Models/Tables/UserTests.cs
+++ b/test/Core.Test/Models/Tables/UserTests.cs
@@ -72,12 +72,12 @@ namespace Bit.Core.Test.Models.Tables
             using var jsonDocument = JsonDocument.Parse(user.TwoFactorProviders);
             var root = jsonDocument.RootElement;
 
-            var webAuthn = AssertHelper.AssertJsonProperty(root, "WebAuthn", JsonValueKind.Object);
+            var webAuthn = AssertHelper.AssertJsonProperty(root, "7", JsonValueKind.Object);
             AssertHelper.AssertJsonProperty(webAuthn, "Enabled", JsonValueKind.True);
             var webMetaData = AssertHelper.AssertJsonProperty(webAuthn, "MetaData", JsonValueKind.Object);
             AssertHelper.AssertJsonProperty(webMetaData, "Item", JsonValueKind.String);
 
-            var email = AssertHelper.AssertJsonProperty(root, "Email", JsonValueKind.Object);
+            var email = AssertHelper.AssertJsonProperty(root, "1", JsonValueKind.Object);
             AssertHelper.AssertJsonProperty(email, "Enabled", JsonValueKind.False);
             var emailMetaData = AssertHelper.AssertJsonProperty(email, "MetaData", JsonValueKind.Object);
             AssertHelper.AssertJsonProperty(emailMetaData, "Email", JsonValueKind.String);


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
In the course of #1803 two factor providers began being saved with the full enum key name instead of it's numerical value. Nothing should be broken as Newtonsoft can read either but we should stick with the current expectation.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **User.cs:** Uses the JsonSerializerSettings with the EnumKeyResolver set as it's ContractResolver
* **JsonHelpers.cs:** Adds a settings with EnumKeyResolver, and delete the unneeded default settings.

This will be 🍒⛏️ 

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->



## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
