### PR TITLE
[BEEEP] Add explicit error message when uploading the wrong license type

### DIFF
--- a/src/Core/Enums/LicenseType.cs
+++ b/src/Core/Enums/LicenseType.cs
@@ -1,0 +1,8 @@
+﻿namespace Bit.Core.Enums
+{
+    public enum LicenseType : byte
+    {
+        User = 0,
+        Organization = 1,
+    }
+}

--- a/src/Core/Models/Business/OrganizationLicense.cs
+++ b/src/Core/Models/Business/OrganizationLicense.cs
@@ -21,6 +21,7 @@ namespace Bit.Core.Models.Business
             ILicensingService licenseService, int? version = null)
         {
             Version = version.GetValueOrDefault(CURRENT_LICENSE_FILE_VERSION); // TODO: Remember to change the constant
+            LicenseType = Enums.LicenseType.Organization;
             LicenseKey = org.LicenseKey;
             InstallationId = installationId;
             Id = org.Id;
@@ -121,9 +122,7 @@ namespace Bit.Core.Models.Business
         public DateTime? Refresh { get; set; }
         public DateTime? Expires { get; set; }
         public bool Trial { get; set; }
-        // Dummy field used for validating uploaded license isn't a UserLicense.
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public string Email { get; set; }
+        public LicenseType? LicenseType { get; set; }
         public string Hash { get; set; }
         public string Signature { get; set; }
         [JsonIgnore]

--- a/src/Core/Models/Business/OrganizationLicense.cs
+++ b/src/Core/Models/Business/OrganizationLicense.cs
@@ -122,6 +122,7 @@ namespace Bit.Core.Models.Business
         public DateTime? Expires { get; set; }
         public bool Trial { get; set; }
         // Dummy field used for validating uploaded license isn't a UserLicense.
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string Email { get; set; }
         public string Hash { get; set; }
         public string Signature { get; set; }

--- a/src/Core/Models/Business/OrganizationLicense.cs
+++ b/src/Core/Models/Business/OrganizationLicense.cs
@@ -121,6 +121,8 @@ namespace Bit.Core.Models.Business
         public DateTime? Refresh { get; set; }
         public DateTime? Expires { get; set; }
         public bool Trial { get; set; }
+        // Dummy field used for validating uploaded license isn't a UserLicense.
+        public string Email { get; set; }
         public string Hash { get; set; }
         public string Signature { get; set; }
         [JsonIgnore]

--- a/src/Core/Models/Business/UserLicense.cs
+++ b/src/Core/Models/Business/UserLicense.cs
@@ -66,6 +66,8 @@ namespace Bit.Core.Models.Business
         public DateTime? Refresh { get; set; }
         public DateTime? Expires { get; set; }
         public bool Trial { get; set; }
+        // Dummy field used for validating uploaded license isn't an OrganizationLicense.
+        public string Plan { get; set; }
         public string Hash { get; set; }
         public string Signature { get; set; }
         [JsonIgnore]

--- a/src/Core/Models/Business/UserLicense.cs
+++ b/src/Core/Models/Business/UserLicense.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json.Serialization;
 using Bit.Core.Entities;
+using Bit.Core.Enums;
 using Bit.Core.Services;
 
 namespace Bit.Core.Models.Business
@@ -18,6 +19,7 @@ namespace Bit.Core.Models.Business
         public UserLicense(User user, SubscriptionInfo subscriptionInfo, ILicensingService licenseService,
             int? version = null)
         {
+            LicenseType = Enums.LicenseType.User;
             LicenseKey = user.LicenseKey;
             Id = user.Id;
             Name = user.Name;
@@ -39,6 +41,7 @@ namespace Bit.Core.Models.Business
 
         public UserLicense(User user, ILicensingService licenseService, int? version = null)
         {
+            LicenseType = Enums.LicenseType.User;
             LicenseKey = user.LicenseKey;
             Id = user.Id;
             Name = user.Name;
@@ -66,9 +69,7 @@ namespace Bit.Core.Models.Business
         public DateTime? Refresh { get; set; }
         public DateTime? Expires { get; set; }
         public bool Trial { get; set; }
-        // Dummy field used for validating uploaded license isn't an OrganizationLicense.
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public string Plan { get; set; }
+        public LicenseType? LicenseType { get; set; }
         public string Hash { get; set; }
         public string Signature { get; set; }
         [JsonIgnore]

--- a/src/Core/Models/Business/UserLicense.cs
+++ b/src/Core/Models/Business/UserLicense.cs
@@ -67,6 +67,7 @@ namespace Bit.Core.Models.Business
         public DateTime? Expires { get; set; }
         public bool Trial { get; set; }
         // Dummy field used for validating uploaded license isn't an OrganizationLicense.
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string Plan { get; set; }
         public string Hash { get; set; }
         public string Signature { get; set; }

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -661,6 +661,12 @@ namespace Bit.Core.Services
             OrganizationLicense license, User owner, string ownerKey, string collectionName, string publicKey,
             string privateKey)
         {
+            if (license != null && !string.IsNullOrEmpty(license.Email))
+            {
+                throw new BadRequestException("Premium licenses cannot be applied to an organization. "
+                                              + "Upload this license from your personal account settings page.");
+            }
+
             if (license == null || !_licensingService.VerifyLicense(license))
             {
                 throw new BadRequestException("Invalid license.");
@@ -804,6 +810,12 @@ namespace Bit.Core.Services
             if (!_globalSettings.SelfHosted)
             {
                 throw new InvalidOperationException("Licenses require self hosting.");
+            }
+
+            if (license != null && !string.IsNullOrEmpty(license.Email))
+            {
+                throw new BadRequestException("Premium licenses cannot be applied to an organization. "
+                                              + "Upload this license from your personal account settings page.");
             }
 
             if (license == null || !_licensingService.VerifyLicense(license))

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -661,7 +661,7 @@ namespace Bit.Core.Services
             OrganizationLicense license, User owner, string ownerKey, string collectionName, string publicKey,
             string privateKey)
         {
-            if (license != null && !string.IsNullOrEmpty(license.Email))
+            if (license?.LicenseType != null && license.LicenseType != LicenseType.Organization)
             {
                 throw new BadRequestException("Premium licenses cannot be applied to an organization. "
                                               + "Upload this license from your personal account settings page.");
@@ -812,7 +812,7 @@ namespace Bit.Core.Services
                 throw new InvalidOperationException("Licenses require self hosting.");
             }
 
-            if (license != null && !string.IsNullOrEmpty(license.Email))
+            if (license?.LicenseType != null && license.LicenseType != LicenseType.Organization)
             {
                 throw new BadRequestException("Premium licenses cannot be applied to an organization. "
                                               + "Upload this license from your personal account settings page.");

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -1030,6 +1030,12 @@ namespace Bit.Core.Services
                 throw new InvalidOperationException("Licenses require self hosting.");
             }
 
+            if (license != null && !string.IsNullOrEmpty(license.Plan))
+            {
+                throw new BadRequestException("Organization licenses cannot be applied to a user. "
+                    + "Upload this license from the Org settings page.");
+            }
+
             if (license == null || !_licenseService.VerifyLicense(license))
             {
                 throw new BadRequestException("Invalid license.");

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -1030,7 +1030,7 @@ namespace Bit.Core.Services
                 throw new InvalidOperationException("Licenses require self hosting.");
             }
 
-            if (license != null && !string.IsNullOrEmpty(license.Plan))
+            if (license?.LicenseType != null && license.LicenseType != LicenseType.User)
             {
                 throw new BadRequestException("Organization licenses cannot be applied to a user. "
                     + "Upload this license from the Organization settings page.");

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -1033,7 +1033,7 @@ namespace Bit.Core.Services
             if (license != null && !string.IsNullOrEmpty(license.Plan))
             {
                 throw new BadRequestException("Organization licenses cannot be applied to a user. "
-                    + "Upload this license from the Org settings page.");
+                    + "Upload this license from the Organization settings page.");
             }
 
             if (license == null || !_licenseService.VerifyLicense(license))


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Adds an error message when the user uploads the wrong license type. I.e. uploading a premium license to an org, or an org license to their own account.

It works by adding a new field called `LicenseType` to each license. If the field is *not* null, and has the wrong type we reject it.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

Regression sweep around downloading & uploading licenses. Verify you cannot upload the wrong license type.

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
