### PR TITLE
Fix/identity service model validation

### DIFF
--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -124,7 +124,7 @@ namespace Bit.Api
             services.AddCoreLocalizationServices();
 
 #if OSS
-                services.AddOosServices();
+            services.AddOosServices();
 #else
             services.AddCommCoreServices();
 #endif

--- a/src/Api/Utilities/ModelStateValidationFilterAttribute.cs
+++ b/src/Api/Utilities/ModelStateValidationFilterAttribute.cs
@@ -10,7 +10,7 @@ namespace Bit.Api.Utilities
     {
         private readonly bool _publicApi;
 
-        public ModelStateValidationFilterAttribute(bool publicApi) : base()
+        public ModelStateValidationFilterAttribute(bool publicApi)
         {
             _publicApi = publicApi;
         }

--- a/src/Api/Utilities/ModelStateValidationFilterAttribute.cs
+++ b/src/Api/Utilities/ModelStateValidationFilterAttribute.cs
@@ -6,33 +6,24 @@ using InternalApi = Bit.Core.Models.Api;
 
 namespace Bit.Api.Utilities
 {
-    public class ModelStateValidationFilterAttribute : ActionFilterAttribute
+    public class ModelStateValidationFilterAttribute : SharedWeb.Utilities.ModelStateValidationFilterAttribute
     {
         private readonly bool _publicApi;
 
-        public ModelStateValidationFilterAttribute(bool publicApi)
+        public ModelStateValidationFilterAttribute(bool publicApi) : base()
         {
             _publicApi = publicApi;
         }
 
-        public override void OnActionExecuting(ActionExecutingContext context)
+        protected override void OnModelStateInvalid(ActionExecutingContext context)
         {
-            var model = context.ActionArguments.FirstOrDefault(a => a.Key == "model");
-            if (model.Key == "model" && model.Value == null)
+            if (_publicApi)
             {
-                context.ModelState.AddModelError(string.Empty, "Body is empty.");
+                context.Result = new BadRequestObjectResult(new ErrorResponseModel(context.ModelState));
             }
-
-            if (!context.ModelState.IsValid)
+            else
             {
-                if (_publicApi)
-                {
-                    context.Result = new BadRequestObjectResult(new ErrorResponseModel(context.ModelState));
-                }
-                else
-                {
-                    context.Result = new BadRequestObjectResult(new InternalApi.ErrorResponseModel(context.ModelState));
-                }
+                context.Result = new BadRequestObjectResult(new InternalApi.ErrorResponseModel(context.ModelState));
             }
         }
     }

--- a/src/Identity/Controllers/AccountsController.cs
+++ b/src/Identity/Controllers/AccountsController.cs
@@ -30,7 +30,7 @@ namespace Bit.Identity.Controllers
             _userService = userService;
         }
 
-        // Moved from API, If you modify this endpoint, please update Identity as well.
+        // Moved from API, If you modify this endpoint, please update API as well.
         [HttpPost("register")]
         [CaptchaProtected]
         public async Task PostRegister([FromBody] RegisterRequestModel model)
@@ -51,7 +51,7 @@ namespace Bit.Identity.Controllers
             throw new BadRequestException(ModelState);
         }
 
-        // Moved from API, If you modify this endpoint, please update Identity as well.
+        // Moved from API, If you modify this endpoint, please update API as well.
         [HttpPost("prelogin")]
         public async Task<PreloginResponseModel> PostPrelogin([FromBody] PreloginRequestModel model)
         {

--- a/src/Identity/Startup.cs
+++ b/src/Identity/Startup.cs
@@ -58,7 +58,11 @@ namespace Bit.Identity
             services.AddMemoryCache();
 
             // Mvc
-            services.AddMvc();
+            // MVC
+            services.AddMvc(config =>
+            {
+                config.Filters.Add(new ModelStateValidationFilterAttribute());
+            });
 
             if (!globalSettings.SelfHosted)
             {

--- a/src/SharedWeb/Utilities/ModelStateValidationFilterAttribute.cs
+++ b/src/SharedWeb/Utilities/ModelStateValidationFilterAttribute.cs
@@ -1,0 +1,33 @@
+﻿using System.Linq;
+using Bit.Core.Models.Api;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Bit.SharedWeb.Utilities
+{
+    public class ModelStateValidationFilterAttribute : ActionFilterAttribute
+    {
+        public ModelStateValidationFilterAttribute()
+        {
+        }
+
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            var model = context.ActionArguments.FirstOrDefault(a => a.Key == "model");
+            if (model.Key == "model" && model.Value == null)
+            {
+                context.ModelState.AddModelError(string.Empty, "Body is empty.");
+            }
+
+            if (!context.ModelState.IsValid)
+            {
+                OnModelStateInvalid(context);
+            }
+        }
+
+        protected virtual void OnModelStateInvalid(ActionExecutingContext context)
+        {
+            context.Result = new BadRequestObjectResult(new ErrorResponseModel(context.ModelState));
+        }
+    }
+}


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Asana Task: https://app.asana.com/0/1200804338582616/1201754397034782/f

We moved `register` and `prelogin` endpoints out of API and into Indentity with #1807, but failed to mirror that change in the bitwarden/web project. However, we did update our internal deployment functions to point `api/prelogin` and `api/register` to the identity project. This resulted in different MVC options for dev vs QA/prod deployments.

This PR adds our `ModelState.IsValid` filter to Identity as well as API. Identity has no public interface so that logic remains in API.

## Code changes
* **api/startup & Identity/\*\*/accountsController**: Just some comment and format cleaning
* **api/ModelStateFilterAttribute**: Extract common code to base class and add template method override for handling invalid ModelStates differently in API
* **identity/startup**: Add in model state filter
* **SharedWeb/ModelStateFilterAttribute**: Extract common code this this base class. Default invalid behavior is throwing internalAPI error


## Testing requirements
Retest invalid model attributes (spaces in email registration, too long, missing data, etc.) Should fail as before.

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)

# RC
Note: This PR will be pulled into `rc` to fix a regression defect