### PR TITLE
Fix/f4e multiple sponsorships

### DIFF
--- a/src/Api/Controllers/OrganizationSponsorshipsController.cs
+++ b/src/Api/Controllers/OrganizationSponsorshipsController.cs
@@ -68,14 +68,16 @@ namespace Bit.Api.Controllers
         [SelfHosted(NotSelfHostedOnly = true)]
         public async Task<bool> PreValidateSponsorshipToken([FromQuery] string sponsorshipToken)
         {
-            return await _organizationsSponsorshipService.ValidateRedemptionTokenAsync(sponsorshipToken, (await CurrentUser).Email);
+            return (await _organizationsSponsorshipService.ValidateRedemptionTokenAsync(sponsorshipToken, (await CurrentUser).Email)).valid;
         }
 
         [HttpPost("redeem")]
         [SelfHosted(NotSelfHostedOnly = true)]
         public async Task RedeemSponsorship([FromQuery] string sponsorshipToken, [FromBody] OrganizationSponsorshipRedeemRequestModel model)
         {
-            if (!await _organizationsSponsorshipService.ValidateRedemptionTokenAsync(sponsorshipToken, (await CurrentUser).Email))
+            var (valid, sponsorship) = await _organizationsSponsorshipService.ValidateRedemptionTokenAsync(sponsorshipToken, (await CurrentUser).Email);
+
+            if (!valid)
             {
                 throw new BadRequestException("Failed to parse sponsorship token.");
             }
@@ -86,8 +88,7 @@ namespace Bit.Api.Controllers
             }
 
             await _organizationsSponsorshipService.SetUpSponsorshipAsync(
-                await _organizationSponsorshipRepository
-                    .GetByOfferedToEmailAsync((await CurrentUser).Email),
+                sponsorship,
                 // Check org to sponsor's product type
                 await _organizationRepository.GetByIdAsync(model.SponsoredOrganizationId));
         }

--- a/src/Core/Repositories/IOrganizationSponsorshipRepository.cs
+++ b/src/Core/Repositories/IOrganizationSponsorshipRepository.cs
@@ -10,6 +10,5 @@ namespace Bit.Core.Repositories
     {
         Task<OrganizationSponsorship> GetBySponsoringOrganizationUserIdAsync(Guid sponsoringOrganizationUserId);
         Task<OrganizationSponsorship> GetBySponsoredOrganizationIdAsync(Guid sponsoredOrganizationId);
-        Task<OrganizationSponsorship> GetByOfferedToEmailAsync(string email);
     }
 }

--- a/src/Core/Services/IOrganizationSponsorshipService.cs
+++ b/src/Core/Services/IOrganizationSponsorshipService.cs
@@ -7,7 +7,7 @@ namespace Bit.Core.Services
 {
     public interface IOrganizationSponsorshipService
     {
-        Task<bool> ValidateRedemptionTokenAsync(string encryptedToken, string currentUserEmail);
+        Task<(bool valid, OrganizationSponsorship sponsorship)> ValidateRedemptionTokenAsync(string encryptedToken, string currentUserEmail);
         Task OfferSponsorshipAsync(Organization sponsoringOrg, OrganizationUser sponsoringOrgUser,
             PlanSponsorshipType sponsorshipType, string sponsoredEmail, string friendlyName, string sponsoringUserEmail);
         Task ResendSponsorshipOfferAsync(Organization sponsoringOrg, OrganizationUser sponsoringOrgUser,

--- a/src/Core/Services/Implementations/OrganizationSponsorshipService.cs
+++ b/src/Core/Services/Implementations/OrganizationSponsorshipService.cs
@@ -37,11 +37,11 @@ namespace Bit.Core.Services
             _dataProtector = dataProtectionProvider.CreateProtector("OrganizationSponsorshipServiceDataProtector");
         }
 
-        public async Task<bool> ValidateRedemptionTokenAsync(string encryptedToken, string sponsoredUserEmail)
+        public async Task<(bool valid, OrganizationSponsorship sponsorship)> ValidateRedemptionTokenAsync(string encryptedToken, string sponsoredUserEmail)
         {
             if (!encryptedToken.StartsWith(TokenClearTextPrefix) || sponsoredUserEmail == null)
             {
-                return false;
+                return (false, null);
             }
 
             var decryptedToken = _dataProtector.Unprotect(encryptedToken[TokenClearTextPrefix.Length..]);
@@ -49,7 +49,7 @@ namespace Bit.Core.Services
 
             if (dataParts.Length != 3)
             {
-                return false;
+                return (false, null);
             }
 
             if (dataParts[0].Equals(FamiliesForEnterpriseTokenName))
@@ -57,7 +57,7 @@ namespace Bit.Core.Services
                 if (!Guid.TryParse(dataParts[1], out Guid sponsorshipId) ||
                     !Enum.TryParse<PlanSponsorshipType>(dataParts[2], true, out var sponsorshipType))
                 {
-                    return false;
+                    return (false, null);
                 }
 
                 var sponsorship = await _organizationSponsorshipRepository.GetByIdAsync(sponsorshipId);
@@ -65,13 +65,13 @@ namespace Bit.Core.Services
                     sponsorship.PlanSponsorshipType != sponsorshipType ||
                     sponsorship.OfferedToEmail != sponsoredUserEmail)
                 {
-                    return false;
+                    return (false, sponsorship);
                 }
 
-                return true;
+                return (true, sponsorship);
             }
 
-            return false;
+            return (false, null);
         }
 
         private string RedemptionToken(Guid sponsorshipId, PlanSponsorshipType sponsorshipType) =>

--- a/src/Infrastructure.Dapper/Repositories/OrganizationSponsorshipRepository.cs
+++ b/src/Infrastructure.Dapper/Repositories/OrganizationSponsorshipRepository.cs
@@ -48,21 +48,5 @@ namespace Bit.Infrastructure.Dapper.Repositories
                 return results.SingleOrDefault();
             }
         }
-
-        public async Task<OrganizationSponsorship> GetByOfferedToEmailAsync(string offeredToEmail)
-        {
-            using (var connection = new SqlConnection(ConnectionString))
-            {
-                var results = await connection.QueryAsync<OrganizationSponsorship>(
-                    "[dbo].[OrganizationSponsorship_ReadByOfferedToEmail]",
-                    new
-                    {
-                        OfferedToEmail = offeredToEmail
-                    },
-                    commandType: CommandType.StoredProcedure);
-
-                return results.SingleOrDefault();
-            }
-        }
     }
 }

--- a/test/Api.Test/Controllers/OrganizationSponsorshipsControllerTests.cs
+++ b/test/Api.Test/Controllers/OrganizationSponsorshipsControllerTests.cs
@@ -45,7 +45,7 @@ namespace Bit.Api.Test.Controllers
             sutProvider.GetDependency<IUserService>().GetUserByIdAsync(user.Id)
                 .Returns(user);
             sutProvider.GetDependency<IOrganizationSponsorshipService>().ValidateRedemptionTokenAsync(sponsorshipToken,
-                user.Email).Returns(false);
+                user.Email).Returns((false, null));
 
             var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
                 sutProvider.Sut.RedeemSponsorship(sponsorshipToken, model));
@@ -58,14 +58,14 @@ namespace Bit.Api.Test.Controllers
 
         [Theory]
         [BitAutoData]
-        public async Task RedeemSponsorship_NotSponsoredOrgOwner_ThrowsBadRequest(string sponsorshipToken, User user,
+        public async Task RedeemSponsorship_NotSponsoredOrgOwner_ThrowsBadRequest(string sponsorshipToken, User user, OrganizationSponsorship sponsorship,
             OrganizationSponsorshipRedeemRequestModel model, SutProvider<OrganizationSponsorshipsController> sutProvider)
         {
             sutProvider.GetDependency<ICurrentContext>().UserId.Returns(user.Id);
             sutProvider.GetDependency<IUserService>().GetUserByIdAsync(user.Id)
                 .Returns(user);
             sutProvider.GetDependency<IOrganizationSponsorshipService>().ValidateRedemptionTokenAsync(sponsorshipToken,
-                user.Email).Returns(true);
+                user.Email).Returns((true, sponsorship));
             sutProvider.GetDependency<ICurrentContext>().OrganizationOwner(model.SponsoredOrganizationId).Returns(false);
 
             var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
@@ -79,12 +79,32 @@ namespace Bit.Api.Test.Controllers
 
         [Theory]
         [BitAutoData]
-        public async Task PreValidateSponsorshipToken_ValidatesToken_Success(string sponsorshipToken, User user,
+        public async Task RedeemSponsorship_NotSponsoredOrgOwner_Success(string sponsorshipToken, User user, OrganizationSponsorship sponsorship, Organization sponsoringOrganization,
+            OrganizationSponsorshipRedeemRequestModel model, SutProvider<OrganizationSponsorshipsController> sutProvider)
+        {
+            sutProvider.GetDependency<ICurrentContext>().UserId.Returns(user.Id);
+            sutProvider.GetDependency<IUserService>().GetUserByIdAsync(user.Id)
+                .Returns(user);
+            sutProvider.GetDependency<IOrganizationSponsorshipService>().ValidateRedemptionTokenAsync(sponsorshipToken,
+                user.Email).Returns((true, sponsorship));
+            sutProvider.GetDependency<ICurrentContext>().OrganizationOwner(model.SponsoredOrganizationId).Returns(true);
+            sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(model.SponsoredOrganizationId).Returns(sponsoringOrganization);
+
+            await sutProvider.Sut.RedeemSponsorship(sponsorshipToken, model);
+
+            await sutProvider.GetDependency<IOrganizationSponsorshipService>().Received(1)
+                .SetUpSponsorshipAsync(sponsorship, sponsoringOrganization);
+        }
+
+        [Theory]
+        [BitAutoData]
+        public async Task PreValidateSponsorshipToken_ValidatesToken_Success(string sponsorshipToken, User user, OrganizationSponsorship sponsorship,
             SutProvider<OrganizationSponsorshipsController> sutProvider)
         {
             sutProvider.GetDependency<ICurrentContext>().UserId.Returns(user.Id);
             sutProvider.GetDependency<IUserService>().GetUserByIdAsync(user.Id)
                 .Returns(user);
+            sutProvider.GetDependency<IOrganizationSponsorshipService>().ValidateRedemptionTokenAsync(sponsorshipToken, user.Email).Returns((true, sponsorship));
 
             await sutProvider.Sut.PreValidateSponsorshipToken(sponsorshipToken);
 

--- a/test/Api.Test/Controllers/OrganizationSponsorshipsControllerTests.cs
+++ b/test/Api.Test/Controllers/OrganizationSponsorshipsControllerTests.cs
@@ -58,8 +58,9 @@ namespace Bit.Api.Test.Controllers
 
         [Theory]
         [BitAutoData]
-        public async Task RedeemSponsorship_NotSponsoredOrgOwner_ThrowsBadRequest(string sponsorshipToken, User user, OrganizationSponsorship sponsorship,
-            OrganizationSponsorshipRedeemRequestModel model, SutProvider<OrganizationSponsorshipsController> sutProvider)
+        public async Task RedeemSponsorship_NotSponsoredOrgOwner_ThrowsBadRequest(string sponsorshipToken, User user,
+            OrganizationSponsorship sponsorship, OrganizationSponsorshipRedeemRequestModel model,
+            SutProvider<OrganizationSponsorshipsController> sutProvider)
         {
             sutProvider.GetDependency<ICurrentContext>().UserId.Returns(user.Id);
             sutProvider.GetDependency<IUserService>().GetUserByIdAsync(user.Id)
@@ -79,7 +80,8 @@ namespace Bit.Api.Test.Controllers
 
         [Theory]
         [BitAutoData]
-        public async Task RedeemSponsorship_NotSponsoredOrgOwner_Success(string sponsorshipToken, User user, OrganizationSponsorship sponsorship, Organization sponsoringOrganization,
+        public async Task RedeemSponsorship_NotSponsoredOrgOwner_Success(string sponsorshipToken, User user,
+            OrganizationSponsorship sponsorship, Organization sponsoringOrganization,
             OrganizationSponsorshipRedeemRequestModel model, SutProvider<OrganizationSponsorshipsController> sutProvider)
         {
             sutProvider.GetDependency<ICurrentContext>().UserId.Returns(user.Id);
@@ -98,13 +100,14 @@ namespace Bit.Api.Test.Controllers
 
         [Theory]
         [BitAutoData]
-        public async Task PreValidateSponsorshipToken_ValidatesToken_Success(string sponsorshipToken, User user, OrganizationSponsorship sponsorship,
-            SutProvider<OrganizationSponsorshipsController> sutProvider)
+        public async Task PreValidateSponsorshipToken_ValidatesToken_Success(string sponsorshipToken, User user,
+            OrganizationSponsorship sponsorship, SutProvider<OrganizationSponsorshipsController> sutProvider)
         {
             sutProvider.GetDependency<ICurrentContext>().UserId.Returns(user.Id);
             sutProvider.GetDependency<IUserService>().GetUserByIdAsync(user.Id)
                 .Returns(user);
-            sutProvider.GetDependency<IOrganizationSponsorshipService>().ValidateRedemptionTokenAsync(sponsorshipToken, user.Email).Returns((true, sponsorship));
+            sutProvider.GetDependency<IOrganizationSponsorshipService>()
+                .ValidateRedemptionTokenAsync(sponsorshipToken, user.Email).Returns((true, sponsorship));
 
             await sutProvider.Sut.PreValidateSponsorshipToken(sponsorshipToken);
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Asana Task: https://app.asana.com/0/1169444489336079/1201757504282853/f
Attempting to Redeem a family org sponsorship while having multiple offers results in an error. This is due to the `GetByOfferedToEmailAsync` returning with a `SingleOrDefault`. Instead, we're using the token to grab the exact sponsorship offer redeemed and using that to set up sponsorship.


## Code changes
* **OrganizationSponsorshipController:** Use new returned sponsorship from token validation for setup
* **OrganizationSponsorshipRespository**: Remove `GetByOfferedToEmailAsync` since it's no longer used and likely problematic in design anyway
* **OrganizationSponsorshipService**: Return the `OrganizationSponsorship` used to validate the provided token.
* **OrganizationSponsorshipServiceTests**: Update tests with new return value and improve tests.


## Testing requirements
Validate fix of issue from Asana task. Reproduction instructions are in Asana.



## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
