### PR TITLE
Fix json only serializing base properties

### DIFF
--- a/src/Api/Models/Request/SendRequestModel.cs
+++ b/src/Api/Models/Request/SendRequestModel.cs
@@ -71,7 +71,8 @@ namespace Bit.Api.Models.Request
                     existingSend.Data = JsonSerializer.Serialize(fileData, JsonHelpers.IgnoreWritingNull);
                     break;
                 case SendType.Text:
-                    existingSend.Data = JsonSerializer.Serialize(ToSendData(), JsonHelpers.IgnoreWritingNull);
+                    var sendData = ToSendData();
+                    existingSend.Data = JsonSerializer.Serialize(sendData, sendData.GetType(), JsonHelpers.IgnoreWritingNull);
                     break;
                 default:
                     throw new ArgumentException("Unsupported type: " + nameof(Type) + ".");

--- a/test/Api.Test/Models/Request/SendRequestModelTests.cs
+++ b/test/Api.Test/Models/Request/SendRequestModelTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text.Json;
 using Bit.Api.Models;
 using Bit.Api.Models.Request;

--- a/test/Api.Test/Models/Request/SendRequestModelTests.cs
+++ b/test/Api.Test/Models/Request/SendRequestModelTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Text.Json;
+using Bit.Api.Models;
+using Bit.Api.Models.Request;
+using Bit.Core.Enums;
+using Bit.Core.Services;
+using Bit.Test.Common.Helpers;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Api.Test.Models.Request
+{
+    public class SendRequestModelTests
+    {
+        [Fact]
+        public void ToSend_Text_Success()
+        {
+            var deletionDate = DateTime.UtcNow.AddDays(5);
+            var sendRequest = new SendRequestModel
+            {
+                DeletionDate = deletionDate,
+                Disabled = false,
+                ExpirationDate = null,
+                HideEmail = false,
+                Key = "encrypted_key",
+                MaxAccessCount = null,
+                Name = "encrypted_name",
+                Notes = null,
+                Password = "Password",
+                Text = new SendTextModel()
+                {
+                    Hidden = false,
+                    Text = "encrypted_text"
+                },
+                Type = SendType.Text,
+            };
+
+            var sendService = Substitute.For<ISendService>();
+            sendService.HashPassword(Arg.Any<string>())
+                .Returns((info) => $"hashed_{(string)info[0]}");
+
+            var send = sendRequest.ToSend(Guid.NewGuid(), sendService);
+
+            Assert.Equal(deletionDate, send.DeletionDate);
+            Assert.False(send.Disabled);
+            Assert.Null(send.ExpirationDate);
+            Assert.False(send.HideEmail);
+            Assert.Equal("encrypted_key", send.Key);
+            Assert.Equal("hashed_Password", send.Password);
+
+            using var jsonDocument = JsonDocument.Parse(send.Data);
+            var root = jsonDocument.RootElement;
+            var text = AssertHelper.AssertJsonProperty(root, "Text", JsonValueKind.String).GetString();
+            Assert.Equal("encrypted_text", text);
+            AssertHelper.AssertJsonProperty(root, "Hidden", JsonValueKind.False);
+            Assert.False(root.TryGetProperty("Notes", out var _));
+            var name = AssertHelper.AssertJsonProperty(root, "Name", JsonValueKind.String).GetString();
+            Assert.Equal("encrypted_name", name);
+        }
+    }
+}


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This bug fixes a regression from #1803, STJ handles polymorphism differently. Without telling it the type of the object it actually is it was getting the type at compile time and it thought it was just a `SendData` which means it was not serializing and saving the `Text` and `Hidden` properties. 


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **SendRequestModel.cs:** I instructed the serializer to gather the type at runtime so that it doesn't miss any properties. I could have also changed the return type of `ToSendData` to be `SendTextData` instead of the inherited class `SendData`. Both are viable changes. 
* **SendRequestModelTests:** I added a test to verify that this doesn't happen again.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Verify that creating/saving a text send saves the text and hidden properties that you set.


## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
