### PR TITLE
Fix newtonsoft complaining about U2f keys

### DIFF
--- a/src/Core/Enums/TwoFactorProviderType.cs
+++ b/src/Core/Enums/TwoFactorProviderType.cs
@@ -6,7 +6,7 @@
         Email = 1,
         Duo = 2,
         YubiKey = 3,
-        // U2f = 4, // Deprecated
+        U2f = 4, // Deprecated
         Remember = 5,
         OrganizationDuo = 6,
         WebAuthn = 7,


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Resolves errors that occurs when the database has entries in the user table, column `TwoFactorProvider` with string keys, like `U2f` instead of the numeric value which we expect.

Note: Will be 🍒 ⛏️ to `rc`.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

Try to login to one of the affected accounts ...

## Before you submit
- [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
