### PR TITLE
Remove falsely added Microsoft.Azure.Storage.Blobs

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -33,7 +33,6 @@
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.7" />
     <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.3" />
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="5.0.9" />


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With https://github.com/bitwarden/server/pull/1732 I migrated `Microsoft.Azure.Storage.Blobs` to `Azure.Storage.Blobs` but with https://github.com/bitwarden/server/pull/1759 it got falsely added again.

## Code changes
* **src/Core/Core.csproj:** Uninstalled `Microsoft.Azure.Storage.Blobs`

## Testing requirements
No testing needed, as dependency is not referenced anywhere.

## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
