### PR TITLE
Fix organization duo 2fa not working due to switch to System.Text.Json

### DIFF
--- a/src/Core/Identity/OrganizationDuoWebTokenProvider.cs
+++ b/src/Core/Identity/OrganizationDuoWebTokenProvider.cs
@@ -44,8 +44,8 @@ namespace Bit.Core.Identity
                 return Task.FromResult<string>(null);
             }
 
-            var signatureRequest = DuoWeb.SignRequest((string)provider.MetaData["IKey"],
-                (string)provider.MetaData["SKey"], _globalSettings.Duo.AKey, user.Email);
+            var signatureRequest = DuoWeb.SignRequest(provider.MetaData["IKey"].ToString(),
+                provider.MetaData["SKey"].ToString(), _globalSettings.Duo.AKey, user.Email);
             return Task.FromResult(signatureRequest);
         }
 

--- a/src/Core/Identity/OrganizationDuoWebTokenProvider.cs
+++ b/src/Core/Identity/OrganizationDuoWebTokenProvider.cs
@@ -62,8 +62,8 @@ namespace Bit.Core.Identity
                 return Task.FromResult(false);
             }
 
-            var response = DuoWeb.VerifyResponse((string)provider.MetaData["IKey"],
-                (string)provider.MetaData["SKey"], _globalSettings.Duo.AKey, token);
+            var response = DuoWeb.VerifyResponse(provider.MetaData["IKey"].ToString(),
+                provider.MetaData["SKey"].ToString(), _globalSettings.Duo.AKey, token);
 
             return Task.FromResult(response == user.Email);
         }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
I believe organization 2fa was changed to use System.Text.Json. However it behaves slightly different compared to newtonsoft and we can't cast a `JsonElement` to string, and instead need to use the `ToString` operation.

Note: Will be 🍒 ⛏️ to `rc`.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

Verify Organization based duo works.

## Before you submit
- [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
