### PR TITLE
Resolve being unable to configure duo (System.Text.Json)

### DIFF
--- a/src/Core/Utilities/DuoApi.cs
+++ b/src/Core/Utilities/DuoApi.cs
@@ -175,22 +175,21 @@ namespace Bit.Core.Utilities.Duo
             var res = ApiCall(method, path, parameters, timeout, out var statusCode);
             try
             {
+                // TODO: We should deserialize this into our own DTO and not work on dictionaries.
                 var dict = JsonSerializer.Deserialize<Dictionary<string, object>>(res);
-                if (dict["stat"] as string == "OK")
+                if (dict["stat"].ToString() == "OK")
                 {
-                    return dict["response"] as T;
+                    return JsonSerializer.Deserialize<T>(dict["response"].ToString());
                 }
-                else
+
+                var check = ToNullableInt(dict["code"].ToString());
+                var code = check.GetValueOrDefault(0);
+                var messageDetail = string.Empty;
+                if (dict.ContainsKey("message_detail"))
                 {
-                    var check = dict["code"] as int?;
-                    var code = check.GetValueOrDefault(0);
-                    var messageDetail = string.Empty;
-                    if (dict.ContainsKey("message_detail"))
-                    {
-                        messageDetail = dict["message_detail"] as string;
-                    }
-                    throw new ApiException(code, (int)statusCode, dict["message"] as string, messageDetail);
+                    messageDetail = dict["message_detail"].ToString();
                 }
+                throw new ApiException(code, (int)statusCode, dict["message"].ToString(), messageDetail);
             }
             catch (ApiException)
             {
@@ -200,6 +199,16 @@ namespace Bit.Core.Utilities.Duo
             {
                 throw new BadResponseException((int)statusCode, e);
             }
+        }
+
+        private int? ToNullableInt(string s)
+        {
+            int i;
+            if (int.TryParse(s, out i))
+            {
+                return i;
+            }
+            return null;
         }
 
         private string HmacSign(string data)


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
With the migration to system.text.json in #1803 it seems we never tested the DuoApi implementation. There were a few trailing changes needed to make it compatible with System.Text.Json.

I've added a tech debt item to tackle using a proper DTO for the responses as the Dictionary handling feels hacky.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

Verify we can add & modify DUO both personal and for orgs.


## Before you submit
- [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
