### PR TITLE
Change setup validation to use a dto

### DIFF
--- a/util/Setup/Program.cs
+++ b/util/Setup/Program.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Globalization;
 using System.Net.Http;
-using System.Text.Json;
+using System.Net.Http.Json;
 using Bit.Migrator;
 
 namespace Bit.Setup
@@ -272,10 +272,8 @@ namespace Bit.Setup
                     return false;
                 }
 
-                var resultString = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-                using var jsonDocument = JsonSerializer.Deserialize<JsonDocument>(resultString);
-                var root = jsonDocument.RootElement;
-                if (!root.GetProperty("Enabled").GetBoolean())
+                var result = response.Content.ReadFromJsonAsync<InstallationValidationResponseModel>().GetAwaiter().GetResult();
+                if (!result.Enabled)
                 {
                     Console.WriteLine("Installation id has been disabled.");
                     return false;
@@ -325,6 +323,11 @@ namespace Bit.Setup
 
                 _context.Parameters.Add(_context.Args[i].Substring(1), _context.Args[i + 1]);
             }
+        }
+
+        class InstallationValidationResponseModel
+        {
+            public bool Enabled { get; init; }
         }
     }
 }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Changes the setup application to use a DTO for the response from the bitwarden server. This ensures we use the System.Text.Json Web defaults https://docs.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializerdefaults?view=net-6.0#system-text-json-jsonserializerdefaults-web which are case-insensitive. It's also nicer than using JsonDocument.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

Verify setup works against prod. (Would be nice to verify it correctly checks Disabled)

## Before you submit
- [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
