### PR TITLE
Add Collections to public/groups API endpoint

### DIFF
--- a/src/Api/Public/Controllers/GroupsController.cs
+++ b/src/Api/Public/Controllers/GroupsController.cs
@@ -81,15 +81,16 @@ namespace Bit.Api.Public.Controllers
         /// </summary>
         /// <remarks>
         /// Returns a list of your organization's groups.
-        /// Group objects listed in this call do not include information about their associated collections.
         /// </remarks>
         [HttpGet]
         [ProducesResponseType(typeof(ListResponseModel<GroupResponseModel>), (int)HttpStatusCode.OK)]
         public async Task<IActionResult> List()
         {
-            var groups = await _groupRepository.GetManyByOrganizationIdAsync(_currentContext.OrganizationId.Value);
-            // TODO: Get all CollectionGroup associations for the organization and marry them up here for the response.
-            var groupResponses = groups.Select(g => new GroupResponseModel(g, null));
+            var groupsWithCollections =
+                await _groupRepository.GetManyWithCollectionsByOrganizationIdAsync(_currentContext.OrganizationId.Value);
+
+            var groupResponses = groupsWithCollections
+                .Select(g => new GroupResponseModel(g.Item1, g.Item2));
             var response = new ListResponseModel<GroupResponseModel>(groupResponses);
             return new JsonResult(response);
         }

--- a/src/Core/Repositories/IGroupRepository.cs
+++ b/src/Core/Repositories/IGroupRepository.cs
@@ -10,6 +10,7 @@ namespace Bit.Core.Repositories
     {
         Task<Tuple<Group, ICollection<SelectionReadOnly>>> GetByIdWithCollectionsAsync(Guid id);
         Task<ICollection<Group>> GetManyByOrganizationIdAsync(Guid organizationId);
+        Task<ICollection<Tuple<Group, ICollection<SelectionReadOnly>>>> GetManyWithCollectionsByOrganizationIdAsync(Guid organizationId);
         Task<ICollection<Guid>> GetManyIdsByUserIdAsync(Guid organizationUserId);
         Task<ICollection<Guid>> GetManyUserIdsByIdAsync(Guid id);
         Task<ICollection<GroupUser>> GetManyGroupUsersByOrganizationIdAsync(Guid organizationId);

--- a/src/Infrastructure.EntityFramework/Repositories/GroupRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/GroupRepository.cs
@@ -88,6 +88,24 @@ namespace Bit.Infrastructure.EntityFramework.Repositories
             }
         }
 
+        public async Task<ICollection<Tuple<Core.Entities.Group, ICollection<SelectionReadOnly>>>>
+            GetManyWithCollectionsByOrganizationIdAsync(Guid organizationId)
+        {
+            using (var scope = ServiceScopeFactory.CreateScope())
+            {
+                var dbContext = GetDatabaseContext(scope);
+                var data = await (
+                    from g in dbContext.Groups
+                    join cg in dbContext.CollectionGroups
+                        on g.Id equals cg.GroupId into ps
+                    from p in ps.DefaultIfEmpty()
+                    where g.OrganizationId == organizationId
+                    select new { g, p.CollectionId, p.ReadOnly, p.HidePasswords }).ToListAsync();
+
+                return Mapper.Map<List<Tuple<Core.Entities.Group, ICollection<SelectionReadOnly>>>>(data);
+            }
+        }
+
         public async Task<ICollection<Core.Entities.GroupUser>> GetManyGroupUsersByOrganizationIdAsync(Guid organizationId)
         {
             using (var scope = ServiceScopeFactory.CreateScope())

--- a/src/Sql/Sql.sqlproj
+++ b/src/Sql/Sql.sqlproj
@@ -194,6 +194,7 @@
     <Build Include="dbo\Stored Procedures\Group_ReadById.sql" />
     <Build Include="dbo\Stored Procedures\Group_ReadByOrganizationId.sql" />
     <Build Include="dbo\Stored Procedures\Group_ReadWithCollectionsById.sql" />
+    <Build Include="dbo\Stored Procedures\Group_ReadWithCollectionsByOrganizationId.sql" />
     <Build Include="dbo\Stored Procedures\Group_Update.sql" />
     <Build Include="dbo\Stored Procedures\Group_UpdateWithCollections.sql" />
     <Build Include="dbo\Stored Procedures\GroupUser_Delete.sql" />

--- a/src/Sql/dbo/Stored Procedures/Group_ReadWithCollectionsByOrganizationId.sql
+++ b/src/Sql/dbo/Stored Procedures/Group_ReadWithCollectionsByOrganizationId.sql
@@ -1,0 +1,17 @@
+﻿CREATE PROCEDURE [dbo].[Group_ReadWithCollectionsByOrganizationId]
+    @OrganizationId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+    SELECT
+        G.*,
+        [CollectionId] [Id],
+        [ReadOnly],
+        [HidePasswords]
+    FROM
+        [dbo].[GroupView] G
+    LEFT JOIN
+        [dbo].[CollectionGroup] CG ON G.Id = CG.GroupId
+    WHERE
+        [OrganizationId] = @OrganizationId
+END

--- a/util/Migrator/DbScripts/2017-08-19_00_InitialSetup.sql
+++ b/util/Migrator/DbScripts/2017-08-19_00_InitialSetup.sql
@@ -1914,6 +1914,28 @@ BEGIN
         [GroupId] = @Id
 END
 GO
+PRINT N'Creating [dbo].[Group_ReadWithCollectionsByOrganizationId]...';
+
+
+GO
+CREATE PROCEDURE [dbo].[Group_ReadWithCollectionsByOrganizationId]
+    @OrganizationId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+    SELECT
+        G.*,
+        [CollectionId] [Id],
+        [ReadOnly],
+        [HidePasswords]
+    FROM
+        [dbo].[GroupView] G
+    LEFT JOIN
+        [dbo].[CollectionGroup] CG ON G.Id = CG.GroupId
+    WHERE
+        [OrganizationId] = @OrganizationId
+END
+GO
 PRINT N'Creating [dbo].[Group_Update]...';
 
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other


## Objective
Amend the group objects returned when calling the /public/groups API endpoint to also include information about their associated collections.
Resolves https://github.com/bitwarden/server/issues/852. Implementation is based on the discussion from https://github.com/bitwarden/server/pull/1455.


## Code changes
* **IGroupRepository.cs:** Added a new method which would return all the groups, each one paired with the list of it's associated collections.
* **Infrastructure.Dapper/Repositories/GroupRepository.cs:** Added the Dapper implementation for the new method.
* **Infrastructure.EntityFramework/Repositories/GroupRepository.cs:** Added the EF implementation for the new method.
* **GroupsController.cs:** Replace the call to repository from the /public/groups API endpoint with the newly added method and use both tuple items returned when building the response.
* **Group_ReadWithCollectionsByOrganizationId.sql:** Added a new stored procedure for the Dapper implementation.
* **2017-08-19_00_InitialSetup.sql:** Added the new stored procedure for migration purposes.
* **Sql.sqlproj:** Included the newly added stored procedure.


## Testing requirements
Verify that when sending a GET request to the public/groups API endpoint, the "collections" field of each returned group contains a list with it's associated collections.


## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [x] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
