### PR TITLE
Log swallowed HttpRequestExceptions

### DIFF
--- a/bitwarden_license/src/Sso/appsettings.Development.json
+++ b/bitwarden_license/src/Sso/appsettings.Development.json
@@ -11,7 +11,7 @@
       "internalAdmin": "http://localhost:62911",
       "internalIdentity": "http://localhost:33656",
       "internalApi": "http://localhost:4000",
-      "internalVault": "http://localhost:4001",
+      "internalVault": "https://localhost:8080",
       "internalSso": "http://localhost:51822"
     },
     "events": {

--- a/src/Admin/Controllers/HomeController.cs
+++ b/src/Admin/Controllers/HomeController.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Bit.Admin.Models;
 using Bit.Core.Settings;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
@@ -66,6 +67,7 @@ namespace Bit.Admin.Controllers
             catch (HttpRequestException e)
             {
                 _logger.LogError(e, $"Error encountered while sending GET request to {requestUri}");
+                return new JsonResult("HttpRequestException occurred, additional info in the logs") { StatusCode = StatusCodes.Status500InternalServerError };
             }
 
             return new JsonResult("-");
@@ -87,6 +89,7 @@ namespace Bit.Admin.Controllers
             catch (HttpRequestException e)
             {
                 _logger.LogError(e, $"Error encountered while sending GET request to {requestUri}");
+                return new JsonResult("HttpRequestException occurred, additional info in the logs") { StatusCode = StatusCodes.Status500InternalServerError };
             }
 
             return new JsonResult("-");

--- a/src/Admin/Controllers/HomeController.cs
+++ b/src/Admin/Controllers/HomeController.cs
@@ -67,7 +67,7 @@ namespace Bit.Admin.Controllers
             catch (HttpRequestException e)
             {
                 _logger.LogError(e, $"Error encountered while sending GET request to {requestUri}");
-                return new JsonResult("HttpRequestException occurred, additional info in the logs") { StatusCode = StatusCodes.Status500InternalServerError };
+                return new JsonResult("Unable to fetch latest version") { StatusCode = StatusCodes.Status500InternalServerError };
             }
 
             return new JsonResult("-");
@@ -89,7 +89,7 @@ namespace Bit.Admin.Controllers
             catch (HttpRequestException e)
             {
                 _logger.LogError(e, $"Error encountered while sending GET request to {requestUri}");
-                return new JsonResult("HttpRequestException occurred, additional info in the logs") { StatusCode = StatusCodes.Status500InternalServerError };
+                return new JsonResult("Unable to fetch installed version") { StatusCode = StatusCodes.Status500InternalServerError };
             }
 
             return new JsonResult("-");

--- a/src/Admin/Controllers/HomeController.cs
+++ b/src/Admin/Controllers/HomeController.cs
@@ -7,17 +7,20 @@ using Bit.Admin.Models;
 using Bit.Core.Settings;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace Bit.Admin.Controllers
 {
     public class HomeController : Controller
     {
         private readonly GlobalSettings _globalSettings;
-        private HttpClient _httpClient = new HttpClient();
+        private readonly HttpClient _httpClient = new HttpClient();
+        private readonly ILogger<HomeController> _logger;
 
-        public HomeController(GlobalSettings globalSettings)
+        public HomeController(GlobalSettings globalSettings, ILogger<HomeController> logger)
         {
             _globalSettings = globalSettings;
+            _logger = logger;
         }
 
         [Authorize]
@@ -40,10 +43,10 @@ namespace Bit.Admin.Controllers
 
         public async Task<IActionResult> GetLatestDockerHubVersion(string repository, CancellationToken cancellationToken)
         {
+            var requestUri = $"https://hub.docker.com/v2/repositories/bitwarden/{repository}/tags/";
             try
             {
-                var response = await _httpClient.GetAsync(
-                $"https://hub.docker.com/v2/repositories/bitwarden/{repository}/tags/", cancellationToken);
+                var response = await _httpClient.GetAsync(requestUri, cancellationToken);
                 if (response.IsSuccessStatusCode)
                 {
                     using var jsonDocument = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(cancellationToken), cancellationToken: cancellationToken);
@@ -60,17 +63,20 @@ namespace Bit.Admin.Controllers
                     }
                 }
             }
-            catch (HttpRequestException) { }
+            catch (HttpRequestException e)
+            {
+                _logger.LogError(e, $"Error encountered while sending GET request to {requestUri}");
+            }
 
             return new JsonResult("-");
         }
 
         public async Task<IActionResult> GetInstalledWebVersion(CancellationToken cancellationToken)
         {
+            var requestUri = $"{_globalSettings.BaseServiceUri.InternalVault}/version.json";
             try
             {
-                var response = await _httpClient.GetAsync(
-                    $"{_globalSettings.BaseServiceUri.InternalVault}/version.json", cancellationToken);
+                var response = await _httpClient.GetAsync(requestUri, cancellationToken);
                 if (response.IsSuccessStatusCode)
                 {
                     using var jsonDocument = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(cancellationToken), cancellationToken: cancellationToken);
@@ -78,7 +84,10 @@ namespace Bit.Admin.Controllers
                     return new JsonResult(root.GetProperty("version").GetString());
                 }
             }
-            catch (HttpRequestException) { }
+            catch (HttpRequestException e)
+            {
+                _logger.LogError(e, $"Error encountered while sending GET request to {requestUri}");
+            }
 
             return new JsonResult("-");
         }

--- a/src/Admin/appsettings.Development.json
+++ b/src/Admin/appsettings.Development.json
@@ -11,7 +11,7 @@
       "internalAdmin": "http://localhost:62911",
       "internalIdentity": "http://localhost:33656",
       "internalApi": "http://localhost:4000",
-      "internalVault": "http://localhost:4001",
+      "internalVault": "https://localhost:8080",
       "internalSso": "http://localhost:51822"
     },
     "mail": {

--- a/src/Api/appsettings.Development.json
+++ b/src/Api/appsettings.Development.json
@@ -11,7 +11,7 @@
       "internalAdmin": "http://localhost:62911",
       "internalIdentity": "http://localhost:33656",
       "internalApi": "http://localhost:4000",
-      "internalVault": "http://localhost:4001",
+      "internalVault": "https://localhost:8080",
       "internalSso": "http://localhost:51822"
     },
     "mail": {

--- a/src/Billing/appsettings.Development.json
+++ b/src/Billing/appsettings.Development.json
@@ -11,7 +11,7 @@
       "internalAdmin": "http://localhost:62911",
       "internalIdentity": "http://localhost:33656",
       "internalApi": "http://localhost:4000",
-      "internalVault": "http://localhost:4001",
+      "internalVault": "https://localhost:8080",
       "internalSso": "http://localhost:51822"
     },
     "mail": {

--- a/src/Events/appsettings.Development.json
+++ b/src/Events/appsettings.Development.json
@@ -11,7 +11,7 @@
       "internalAdmin": "http://localhost:62911",
       "internalIdentity": "http://localhost:33656",
       "internalApi": "http://localhost:4000",
-      "internalVault": "http://localhost:4001",
+      "internalVault": "https://localhost:8080",
       "internalSso": "http://localhost:51822"
     },
     "events": {

--- a/src/Identity/appsettings.Development.json
+++ b/src/Identity/appsettings.Development.json
@@ -11,7 +11,7 @@
       "internalAdmin": "http://localhost:62911",
       "internalIdentity": "http://localhost:33656",
       "internalApi": "http://localhost:4000",
-      "internalVault": "http://localhost:4001",
+      "internalVault": "https://localhost:8080",
       "internalSso": "http://localhost:51822"
     },
     "attachment": {

--- a/src/Notifications/appsettings.Development.json
+++ b/src/Notifications/appsettings.Development.json
@@ -11,7 +11,7 @@
       "internalAdmin": "http://localhost:62911",
       "internalIdentity": "http://localhost:33656",
       "internalApi": "http://localhost:4000",
-      "internalVault": "http://localhost:4001",
+      "internalVault": "https://localhost:8080",
       "internalSso": "http://localhost:51822"
     },
     "notifications": {


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
This PR addresses the issue raised in https://github.com/bitwarden/server/issues/1093. Since the HttpRequestExceptions was swallowed, users couldn't figure out what went wrong. By logging the issue, further investigations can now be made, to identify the culprit.

Additionally, the commit updates the internal web vault URLs used in Development mode, as they were using http and an outdated port number which is no longer used.


## Code changes
* **Admin/Controllers/HomeController.cs:** Added a logger which is injected through the constructor and used when an HttpRequestException is thrown to reveal what went wrong when sending the GET request to the specified Uri.
* **appsettings.Development.json:** Updated this file in every project to point to the correct URL of the web vault.

## Testing requirements
Verify that the errors that occur when sending a request to dockerhub or the web vault for retrieving the product version by accessing the Home page of the Bitwarden Admin Portal are successfully logged.


## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
