### PR TITLE
naming the docker-compose stack

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -101,7 +101,7 @@ function install() {
 function dockerComposeUp() {
     dockerComposeFiles
     dockerComposeVolumes
-    docker-compose up -d
+    docker-compose -p bitwarden up -d
 }
 
 function dockerComposeDown() {


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective
NAMING THE STACK
i use portainer and bitwarden.sh starts bitwarden's stack using docker-compose but without specifying a stack name
i made this little change by my side, what do you think about it ?
now it is good named in my portainer stack


## Code changes
adding "-p bitwarden" to the function dockerComposeUp line 104
