### PR TITLE
Improve SSO Config validation

### DIFF
--- a/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
+++ b/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
@@ -311,8 +311,8 @@ namespace Bit.Core.Business.Sso
                     NameClaimType = JwtClaimTypes.Name,
                     RoleClaimType = JwtClaimTypes.Role,
                 },
-                CallbackPath = config.BuildCallbackPath(),
-                SignedOutCallbackPath = config.BuildSignedOutCallbackPath(),
+                CallbackPath = SsoConfigurationData.BuildCallbackPath(),
+                SignedOutCallbackPath = SsoConfigurationData.BuildSignedOutCallbackPath(),
                 MetadataAddress = config.MetadataAddress,
                 // Prevents URLs that go beyond 1024 characters which may break for some servers
                 AuthenticationMethod = config.RedirectBehavior,
@@ -356,7 +356,7 @@ namespace Bit.Core.Business.Sso
             }
 
             var spEntityId = new Sustainsys.Saml2.Metadata.EntityId(
-                config.BuildSaml2ModulePath(_globalSettings.BaseServiceUri.Sso));
+                SsoConfigurationData.BuildSaml2ModulePath(_globalSettings.BaseServiceUri.Sso));
             bool? allowCreate = null;
             if (config.SpNameIdFormat != Saml2NameIdFormat.Transient)
             {
@@ -365,7 +365,7 @@ namespace Bit.Core.Business.Sso
             var spOptions = new SPOptions
             {
                 EntityId = spEntityId,
-                ModulePath = config.BuildSaml2ModulePath(null, name),
+                ModulePath = SsoConfigurationData.BuildSaml2ModulePath(null, name),
                 NameIdPolicy = new Saml2NameIdPolicy(allowCreate, GetNameIdFormat(config.SpNameIdFormat)),
                 WantAssertionsSigned = config.SpWantAssertionsSigned,
                 AuthenticateRequestSigningBehavior = GetSigningBehavior(config.SpSigningBehavior),

--- a/src/Api/Models/Response/OrganizationSsoResponseModel.cs
+++ b/src/Api/Models/Response/OrganizationSsoResponseModel.cs
@@ -15,12 +15,8 @@ namespace Bit.Api.Models.Response
                 Enabled = config.Enabled;
                 Data = config.GetData();
             }
-            else
-            {
-                Data = new SsoConfigurationData();
-            }
 
-            Urls = new SsoUrls(organization.Id.ToString(), Data, globalSettings);
+            Urls = new SsoUrls(organization.Id.ToString(), globalSettings);
         }
 
         public bool Enabled { get; set; }
@@ -30,13 +26,13 @@ namespace Bit.Api.Models.Response
 
     public class SsoUrls
     {
-        public SsoUrls(string organizationId, SsoConfigurationData configurationData, GlobalSettings globalSettings)
+        public SsoUrls(string organizationId, GlobalSettings globalSettings)
         {
-            CallbackPath = configurationData.BuildCallbackPath(globalSettings.BaseServiceUri.Sso);
-            SignedOutCallbackPath = configurationData.BuildSignedOutCallbackPath(globalSettings.BaseServiceUri.Sso);
-            SpEntityId = configurationData.BuildSaml2ModulePath(globalSettings.BaseServiceUri.Sso);
-            SpMetadataUrl = configurationData.BuildSaml2MetadataUrl(globalSettings.BaseServiceUri.Sso, organizationId);
-            SpAcsUrl = configurationData.BuildSaml2AcsUrl(globalSettings.BaseServiceUri.Sso, organizationId);
+            CallbackPath = SsoConfigurationData.BuildCallbackPath(globalSettings.BaseServiceUri.Sso);
+            SignedOutCallbackPath = SsoConfigurationData.BuildSignedOutCallbackPath(globalSettings.BaseServiceUri.Sso);
+            SpEntityId = SsoConfigurationData.BuildSaml2ModulePath(globalSettings.BaseServiceUri.Sso);
+            SpMetadataUrl = SsoConfigurationData.BuildSaml2MetadataUrl(globalSettings.BaseServiceUri.Sso, organizationId);
+            SpAcsUrl = SsoConfigurationData.BuildSaml2AcsUrl(globalSettings.BaseServiceUri.Sso, organizationId);
         }
 
         public string CallbackPath { get; set; }

--- a/src/Core/Models/Data/SsoConfigurationData.cs
+++ b/src/Core/Models/Data/SsoConfigurationData.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json;
 using Bit.Core.Enums;
-using Bit.Core.Sso;
 using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 
@@ -11,9 +9,9 @@ namespace Bit.Core.Models.Data
 {
     public class SsoConfigurationData
     {
-        private const string _oidcSigninPath = "/oidc-signin";
-        private const string _oidcSignedOutPath = "/oidc-signedout";
-        private const string _saml2ModulePath = "/saml2";
+        private static string _oidcSigninPath = "/oidc-signin";
+        private static string _oidcSignedOutPath = "/oidc-signedout";
+        private static string _saml2ModulePath = "/saml2";
 
         public static SsoConfigurationData Deserialize(string data)
         {
@@ -35,7 +33,7 @@ namespace Bit.Core.Models.Data
         public string ClientId { get; set; }
         public string ClientSecret { get; set; }
         public string MetadataAddress { get; set; }
-        public OpenIdConnectRedirectBehavior RedirectBehavior { get; set; } = OpenIdConnectRedirectBehavior.FormPost;
+        public OpenIdConnectRedirectBehavior RedirectBehavior { get; set; }
         public bool GetClaimsFromUserInfoEndpoint { get; set; }
         public string AdditionalScopes { get; set; }
         public string AdditionalUserIdClaimTypes { get; set; }
@@ -49,43 +47,43 @@ namespace Bit.Core.Models.Data
         public string IdpSingleSignOnServiceUrl { get; set; }
         public string IdpSingleLogoutServiceUrl { get; set; }
         public string IdpX509PublicCert { get; set; }
-        public Saml2BindingType IdpBindingType { get; set; } = Saml2BindingType.HttpRedirect;
+        public Saml2BindingType IdpBindingType { get; set; }
         public bool IdpAllowUnsolicitedAuthnResponse { get; set; }
         public string IdpArtifactResolutionServiceUrl { get; set; }
         public bool IdpDisableOutboundLogoutRequests { get; set; }
-        public string IdpOutboundSigningAlgorithm { get; set; } = SamlSigningAlgorithms.Sha256;
+        public string IdpOutboundSigningAlgorithm { get; set; }
         public bool IdpWantAuthnRequestsSigned { get; set; }
 
         // SAML2 SP
-        public Saml2NameIdFormat SpNameIdFormat { get; set; } = Saml2NameIdFormat.Persistent;
-        public string SpOutboundSigningAlgorithm { get; set; } = SamlSigningAlgorithms.Sha256;
-        public Saml2SigningBehavior SpSigningBehavior { get; set; } = Saml2SigningBehavior.IfIdpWantAuthnRequestsSigned;
+        public Saml2NameIdFormat SpNameIdFormat { get; set; }
+        public string SpOutboundSigningAlgorithm { get; set; }
+        public Saml2SigningBehavior SpSigningBehavior { get; set; }
         public bool SpWantAssertionsSigned { get; set; }
         public bool SpValidateCertificates { get; set; }
-        public string SpMinIncomingSigningAlgorithm { get; set; } = SamlSigningAlgorithms.Sha256;
+        public string SpMinIncomingSigningAlgorithm { get; set; }
 
-        public string BuildCallbackPath(string ssoUri = null)
+        public static string BuildCallbackPath(string ssoUri = null)
         {
             return BuildSsoUrl(_oidcSigninPath, ssoUri);
         }
 
-        public string BuildSignedOutCallbackPath(string ssoUri = null)
+        public static string BuildSignedOutCallbackPath(string ssoUri = null)
         {
             return BuildSsoUrl(_oidcSignedOutPath, ssoUri);
         }
 
-        public string BuildSaml2ModulePath(string ssoUri = null, string scheme = null)
+        public static string BuildSaml2ModulePath(string ssoUri = null, string scheme = null)
         {
             return string.Concat(BuildSsoUrl(_saml2ModulePath, ssoUri),
                 string.IsNullOrWhiteSpace(scheme) ? string.Empty : $"/{scheme}");
         }
 
-        public string BuildSaml2AcsUrl(string ssoUri = null, string scheme = null)
+        public static string BuildSaml2AcsUrl(string ssoUri = null, string scheme = null)
         {
             return string.Concat(BuildSaml2ModulePath(ssoUri, scheme), "/Acs");
         }
 
-        public string BuildSaml2MetadataUrl(string ssoUri = null, string scheme = null)
+        public static string BuildSaml2MetadataUrl(string ssoUri = null, string scheme = null)
         {
             return BuildSaml2ModulePath(ssoUri, scheme);
         }
@@ -114,7 +112,7 @@ namespace Bit.Core.Models.Data
             .Select(c => c.Trim()) ??
             Array.Empty<string>();
 
-        private string BuildSsoUrl(string relativePath, string ssoUri)
+        private static string BuildSsoUrl(string relativePath, string ssoUri)
         {
             if (string.IsNullOrWhiteSpace(ssoUri) ||
                 !Uri.IsWellFormedUriString(ssoUri, UriKind.Absolute))


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Further changes required for https://github.com/bitwarden/web/pull/1332.
As discussed [here](https://github.com/bitwarden/jslib/pull/572#discussion_r781885797), we now set the SSO configuration defaults in the client-side form, instead of constructing an empty `SsoConfigurationData` class with defaults and sending it to the client. This PR removes the server-side defaults to avoid confusion about where they're set.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Api/Models/Response/OrganizationSsoResponseModel.cs** - leave the `Data` property null instead of constructing an object with default values.
* **src/Core/Models/Data/SsoConfigurationData.cs** - convert all the Url building methods to `static` methods. This is required now that we may not have an `SsoConfigurationData` instance in some cases. They actually didn't use any instantiated class properties, so this is more accurate anyway.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

See main ticket

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
