### PR TITLE
CSA-6 Fix/remove artifact binding

### DIFF
--- a/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
+++ b/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
@@ -400,10 +400,6 @@ namespace Bit.Core.Business.Sso
             {
                 idp.SingleLogoutServiceUrl = new Uri(config.IdpSingleLogoutServiceUrl);
             }
-            if (!string.IsNullOrWhiteSpace(config.IdpArtifactResolutionServiceUrl))
-            {
-                idp.ArtifactResolutionServiceUrls.TryAdd(0, new Uri(config.IdpArtifactResolutionServiceUrl));
-            }
             if (!string.IsNullOrWhiteSpace(config.IdpOutboundSigningAlgorithm))
             {
                 idp.OutboundSigningAlgorithm = config.IdpOutboundSigningAlgorithm;
@@ -413,6 +409,7 @@ namespace Bit.Core.Business.Sso
                 var cert = CoreHelpers.Base64UrlDecode(config.IdpX509PublicCert);
                 idp.SigningKeys.AddConfiguredKey(new X509Certificate2(cert));
             }
+            idp.ArtifactResolutionServiceUrls.Clear();
             // This must happen last since it calls Validate() internally.
             idp.LoadMetadata = false;
 
@@ -461,7 +458,6 @@ namespace Bit.Core.Business.Sso
             {
                 Saml2BindingType.HttpRedirect => Sustainsys.Saml2.WebSso.Saml2BindingType.HttpRedirect,
                 Saml2BindingType.HttpPost => Sustainsys.Saml2.WebSso.Saml2BindingType.HttpPost,
-                Saml2BindingType.Artifact => Sustainsys.Saml2.WebSso.Saml2BindingType.Artifact,
                 _ => Sustainsys.Saml2.WebSso.Saml2BindingType.HttpPost,
             };
         }

--- a/bitwarden_license/src/Sso/Utilities/SsoAuthenticationMiddleware.cs
+++ b/bitwarden_license/src/Sso/Utilities/SsoAuthenticationMiddleware.cs
@@ -23,6 +23,12 @@ namespace Bit.Sso.Utilities
 
         public async Task Invoke(HttpContext context)
         {
+            if ((context.Request.Method == "GET" && context.Request.Query.ContainsKey("SAMLart"))
+                || (context.Request.Method == "POST" && context.Request.Form.ContainsKey("SAMLart")))
+            {
+                throw new Exception("SAMLart parameter detected. SAML Artifact binding is not allowed.");
+            }
+
             context.Features.Set<IAuthenticationFeature>(new AuthenticationFeature
             {
                 OriginalPath = context.Request.Path,

--- a/src/Api/Models/Request/Organizations/OrganizationSsoRequestModel.cs
+++ b/src/Api/Models/Request/Organizations/OrganizationSsoRequestModel.cs
@@ -72,6 +72,7 @@ namespace Bit.Api.Models.Request.Organizations
         public Saml2BindingType IdpBindingType { get; set; }
         public string IdpSingleSignOnServiceUrl { get; set; }
         public string IdpSingleLogoutServiceUrl { get; set; }
+        public string IdpArtifactResolutionServiceUrl { get => null; set { /*IGNORE*/ } }
         public string IdpX509PublicCert { get; set; }
         public string IdpOutboundSigningAlgorithm { get; set; }
         public bool? IdpAllowUnsolicitedAuthnResponse { get; set; }
@@ -177,6 +178,7 @@ namespace Bit.Api.Models.Request.Organizations
                 IdpBindingType = IdpBindingType,
                 IdpSingleSignOnServiceUrl = IdpSingleSignOnServiceUrl,
                 IdpSingleLogoutServiceUrl = IdpSingleLogoutServiceUrl,
+                IdpArtifactResolutionServiceUrl = null,
                 IdpX509PublicCert = StripPemCertificateElements(IdpX509PublicCert),
                 IdpOutboundSigningAlgorithm = IdpOutboundSigningAlgorithm,
                 IdpAllowUnsolicitedAuthnResponse = IdpAllowUnsolicitedAuthnResponse.GetValueOrDefault(),

--- a/src/Api/Models/Request/Organizations/OrganizationSsoRequestModel.cs
+++ b/src/Api/Models/Request/Organizations/OrganizationSsoRequestModel.cs
@@ -72,7 +72,6 @@ namespace Bit.Api.Models.Request.Organizations
         public Saml2BindingType IdpBindingType { get; set; }
         public string IdpSingleSignOnServiceUrl { get; set; }
         public string IdpSingleLogoutServiceUrl { get; set; }
-        public string IdpArtifactResolutionServiceUrl { get; set; }
         public string IdpX509PublicCert { get; set; }
         public string IdpOutboundSigningAlgorithm { get; set; }
         public bool? IdpAllowUnsolicitedAuthnResponse { get; set; }
@@ -111,12 +110,6 @@ namespace Bit.Api.Models.Request.Organizations
                         new[] { nameof(IdpEntityId) });
                 }
 
-                if (IdpBindingType == Saml2BindingType.Artifact && string.IsNullOrWhiteSpace(IdpArtifactResolutionServiceUrl))
-                {
-                    yield return new ValidationResult(i18nService.GetLocalizedHtmlString("Saml2BindingTypeValidationError"),
-                        new[] { nameof(IdpArtifactResolutionServiceUrl) });
-                }
-
                 if (!Uri.IsWellFormedUriString(IdpEntityId, UriKind.Absolute) && string.IsNullOrWhiteSpace(IdpSingleSignOnServiceUrl))
                 {
                     yield return new ValidationResult(i18nService.GetLocalizedHtmlString("IdpSingleSignOnServiceUrlValidationError"),
@@ -127,12 +120,6 @@ namespace Bit.Api.Models.Request.Organizations
                 {
                     yield return new ValidationResult(i18nService.GetLocalizedHtmlString("IdpSingleSignOnServiceUrlInvalid"),
                         new[] { nameof(IdpSingleSignOnServiceUrl) });
-                }
-
-                if (InvalidServiceUrl(IdpArtifactResolutionServiceUrl))
-                {
-                    yield return new ValidationResult(i18nService.GetLocalizedHtmlString("IdpArtifactResolutionServiceUrlInvalid"),
-                        new[] { nameof(IdpArtifactResolutionServiceUrl) });
                 }
 
                 if (InvalidServiceUrl(IdpSingleLogoutServiceUrl))
@@ -190,7 +177,6 @@ namespace Bit.Api.Models.Request.Organizations
                 IdpBindingType = IdpBindingType,
                 IdpSingleSignOnServiceUrl = IdpSingleSignOnServiceUrl,
                 IdpSingleLogoutServiceUrl = IdpSingleLogoutServiceUrl,
-                IdpArtifactResolutionServiceUrl = IdpArtifactResolutionServiceUrl,
                 IdpX509PublicCert = StripPemCertificateElements(IdpX509PublicCert),
                 IdpOutboundSigningAlgorithm = IdpOutboundSigningAlgorithm,
                 IdpAllowUnsolicitedAuthnResponse = IdpAllowUnsolicitedAuthnResponse.GetValueOrDefault(),

--- a/src/Core/Enums/Saml2BindingType.cs
+++ b/src/Core/Enums/Saml2BindingType.cs
@@ -4,6 +4,5 @@
     {
         HttpRedirect = 1,
         HttpPost = 2,
-        Artifact = 4
     }
 }

--- a/src/Core/Models/Data/SsoConfigurationData.cs
+++ b/src/Core/Models/Data/SsoConfigurationData.cs
@@ -51,7 +51,6 @@ namespace Bit.Core.Models.Data
         public string IdpX509PublicCert { get; set; }
         public Saml2BindingType IdpBindingType { get; set; } = Saml2BindingType.HttpRedirect;
         public bool IdpAllowUnsolicitedAuthnResponse { get; set; }
-        public string IdpArtifactResolutionServiceUrl { get; set; }
         public bool IdpDisableOutboundLogoutRequests { get; set; }
         public string IdpOutboundSigningAlgorithm { get; set; } = SamlSigningAlgorithms.Sha256;
         public bool IdpWantAuthnRequestsSigned { get; set; }

--- a/src/Core/Models/Data/SsoConfigurationData.cs
+++ b/src/Core/Models/Data/SsoConfigurationData.cs
@@ -51,6 +51,7 @@ namespace Bit.Core.Models.Data
         public string IdpX509PublicCert { get; set; }
         public Saml2BindingType IdpBindingType { get; set; } = Saml2BindingType.HttpRedirect;
         public bool IdpAllowUnsolicitedAuthnResponse { get; set; }
+        public string IdpArtifactResolutionServiceUrl { get => null; set { /*IGNORE*/ } }
         public bool IdpDisableOutboundLogoutRequests { get; set; }
         public string IdpOutboundSigningAlgorithm { get; set; } = SamlSigningAlgorithms.Sha256;
         public bool IdpWantAuthnRequestsSigned { get; set; }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Remove Artifact binding capabilities from Bitwarden's SSO service for now; they _may_ be added back in the future.
see: https://app.asana.com/0/1169444489336079/1201340159635915/f
see: CSA-6

## Code changes
* **Saml2BindingType.cs:** Remove the Artifact binding type from the enum
* **DynamicAuthenticationSchemeProvider.cs:** Force clear artifact resolution URLs and remove validation/creation of Artifact bindings
* **SsoAuthenticationMiddleware.cs:** Add validation to fail on request when it includes the `SAMLart` parameter. Dont' let the name fool you, this is not to stifle login creativity or self-expression through art, `SAMLart` is the artifact binding parameter itself and should not be allowed
* **OrganizationSsoRequestModel.cs:** Remove validation around artifact binding URL and ensure they're always null, ignore `set` operations against the model. This is to provide backwards compatibility against JSON requests and stored JSON to prevent serialization/deserialization errors and keep compatibility with older clients.

## Testing requirements
* Ensure SAML SSO (POST and Redirect bindings) still works. A simple login test with both should suffice.
* Ensure you can still configure SAML SSO via the web vault and the configuration saves and loads as expected
* Ensure you can still configure OpenID Connect SSO via the web vault and the configuration saves and loads as expected

## Documentation updates
cc: @fschillingeriv 
Because this removes the underlying functionality for the Artifact binding and associated Artifact Endpoint URL configuration in the UI when configuring SAML, this update will need to be made to the documentation when this goes live (likely in March release). A similar PR will remove this from the UI itself.

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [x] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
