### PR TITLE
Add attachments check before moving ciphers to a free org

### DIFF
--- a/src/Core/Services/Implementations/CipherService.cs
+++ b/src/Core/Services/Implementations/CipherService.cs
@@ -502,7 +502,7 @@ namespace Bit.Core.Services
 
             try
             {
-                await ValidateCipherCanBeShared(cipher, sharingUserId, organizationId, attachments, lastKnownRevisionDate);
+                await ValidateCipherCanBeShared(cipher, sharingUserId, organizationId, lastKnownRevisionDate);
 
                 // Sproc will not save this UserId on the cipher. It is used limit scope of the collectionIds.
                 cipher.UserId = sharingUserId;
@@ -569,8 +569,7 @@ namespace Bit.Core.Services
             var cipherIds = new List<Guid>();
             foreach (var (cipher, lastKnownRevisionDate) in cipherInfos)
             {
-                var attachments = cipher.GetAttachments();
-                await ValidateCipherCanBeShared(cipher, sharingUserId, organizationId, attachments, lastKnownRevisionDate);
+                await ValidateCipherCanBeShared(cipher, sharingUserId, organizationId, lastKnownRevisionDate);
 
                 cipher.UserId = null;
                 cipher.OrganizationId = organizationId;
@@ -962,7 +961,6 @@ namespace Bit.Core.Services
             Cipher cipher,
             Guid sharingUserId,
             Guid organizationId,
-            Dictionary<string, CipherAttachment.MetaData> attachments,
             DateTime? lastKnownRevisionDate)
         {
             if (cipher.Id == default(Guid))
@@ -980,6 +978,7 @@ namespace Bit.Core.Services
                 throw new BadRequestException("One or more ciphers do not belong to you.");
             }
 
+            var attachments = cipher.GetAttachments();
             var hasAttachments = attachments?.Any() ?? false;
             var org = await _organizationRepository.GetByIdAsync(organizationId);
 

--- a/src/Core/Services/Implementations/CipherService.cs
+++ b/src/Core/Services/Implementations/CipherService.cs
@@ -612,6 +612,15 @@ namespace Bit.Core.Services
                     throw new BadRequestException("One or more ciphers do not belong to you.");
                 }
 
+                var attachments = cipher.GetAttachments();
+                var hasAttachments = attachments?.Any() ?? false;
+                var org = await _organizationRepository.GetByIdAsync(organizationId);
+
+                if (hasAttachments && !org.MaxStorageGb.HasValue)
+                {
+                    throw new BadRequestException("This organization cannot use attachments.");
+                }
+
                 ValidateCipherLastKnownRevisionDateAsync(cipher, lastKnownRevisionDate);
 
                 cipher.UserId = null;

--- a/test/Core.Test/Services/CipherServiceTests.cs
+++ b/test/Core.Test/Services/CipherServiceTests.cs
@@ -55,6 +55,13 @@ namespace Bit.Core.Test.Services
         public async Task ShareManyAsync_WrongRevisionDate_Throws(SutProvider<CipherService> sutProvider,
             IEnumerable<Cipher> ciphers, Guid organizationId, List<Guid> collectionIds)
         {
+            sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organizationId)
+                .Returns(new Organization
+                {
+                    PlanType = Enums.PlanType.EnterpriseAnnually,
+                    MaxStorageGb = 100
+                });
+
             var cipherInfos = ciphers.Select(c => (c, (DateTime?)c.RevisionDate.AddDays(-1)));
 
             var exception = await Assert.ThrowsAsync<BadRequestException>(
@@ -108,6 +115,13 @@ namespace Bit.Core.Test.Services
         public async Task ShareManyAsync_CorrectRevisionDate_Passes(string revisionDateString,
             SutProvider<CipherService> sutProvider, IEnumerable<Cipher> ciphers, Organization organization, List<Guid> collectionIds)
         {
+            sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id)
+                .Returns(new Organization
+                {
+                    PlanType = Enums.PlanType.EnterpriseAnnually,
+                    MaxStorageGb = 100
+                });
+
             var cipherInfos = ciphers.Select(c => (c,
                 string.IsNullOrEmpty(revisionDateString) ? null : (DateTime?)c.RevisionDate));
             var sharingUserId = ciphers.First().UserId.Value;

--- a/test/Core.Test/Services/CipherServiceTests.cs
+++ b/test/Core.Test/Services/CipherServiceTests.cs
@@ -157,5 +157,51 @@ namespace Bit.Core.Test.Services
                 Assert.Equal(revisionDate, cipher.RevisionDate);
             }
         }
+
+        [Theory]
+        [InlineUserCipherAutoData]
+        public async Task ShareManyAsync_FreeOrgWithAttachment_Throws(SutProvider<CipherService> sutProvider,
+            IEnumerable<Cipher> ciphers, Guid organizationId, List<Guid> collectionIds)
+        {
+            sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organizationId).Returns(new Organization
+            {
+                PlanType = Enums.PlanType.Free
+            });
+            ciphers.FirstOrDefault().Attachments =
+                "{\"attachment1\":{\"Size\":\"250\",\"FileName\":\"superCoolFile\","
+                + "\"Key\":\"superCoolFile\",\"ContainerName\":\"testContainer\",\"Validated\":false}}";
+
+            var cipherInfos = ciphers.Select(c => (c,
+               (DateTime?)c.RevisionDate));
+            var sharingUserId = ciphers.First().UserId.Value;
+
+            var exception = await Assert.ThrowsAsync<BadRequestException>(
+                () => sutProvider.Sut.ShareManyAsync(cipherInfos, organizationId, collectionIds, sharingUserId));
+            Assert.Contains("This organization cannot use attachments", exception.Message);
+        }
+
+        [Theory]
+        [InlineUserCipherAutoData]
+        public async Task ShareManyAsync_PaidOrgWithAttachment_Passes(SutProvider<CipherService> sutProvider,
+            IEnumerable<Cipher> ciphers, Guid organizationId, List<Guid> collectionIds)
+        {
+            sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organizationId)
+                .Returns(new Organization
+                {
+                    PlanType = Enums.PlanType.EnterpriseAnnually,
+                    MaxStorageGb = 100
+                });
+            ciphers.FirstOrDefault().Attachments =
+                "{\"attachment1\":{\"Size\":\"250\",\"FileName\":\"superCoolFile\","
+                + "\"Key\":\"superCoolFile\",\"ContainerName\":\"testContainer\",\"Validated\":false}}";
+
+            var cipherInfos = ciphers.Select(c => (c,
+               (DateTime?)c.RevisionDate));
+            var sharingUserId = ciphers.First().UserId.Value;
+
+            await sutProvider.Sut.ShareManyAsync(cipherInfos, organizationId, collectionIds, sharingUserId);
+            await sutProvider.GetDependency<ICipherRepository>().Received(1).UpdateCiphersAsync(sharingUserId,
+                Arg.Is<IEnumerable<Cipher>>(arg => arg.Except(ciphers).IsNullOrEmpty()));
+        }
     }
 }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fix issue where moving items with attachments from a paid user to a free org would render the attachment(s) inaccessible.
https://app.asana.com/0/1201211497354246/1201864568498139


## Code changes

* **src/Core/Services/Implementations/CipherService.cs:** Add check to ShareManyAsync method that mimics the one from ShareAsync to throw an error if there are attachments and the item is getting moved to a free org.
* **test/Core.Test/Services/CipherServiceTests.cs:** Add tests

## Testing requirements
Ensure that sharing multiple items to a free org fails if there are attachments on any of the items.


## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
