### PR TITLE
Handle null user in captch tokenable

### DIFF
--- a/src/Core/Models/Business/Tokenables/HCaptchaTokenable.cs
+++ b/src/Core/Models/Business/Tokenables/HCaptchaTokenable.cs
@@ -24,12 +24,17 @@ namespace Bit.Core.Models.Business.Tokenables
 
         public HCaptchaTokenable(User user) : this()
         {
-            Id = user.Id;
-            Email = user.Email;
+            Id = user?.Id ?? default;
+            Email = user?.Email;
         }
 
         public bool TokenIsValid(User user)
         {
+            if (Id == default || Email == default || user == null)
+            {
+                return false;
+            }
+
             return Id == user.Id &&
             Email.Equals(user.Email, StringComparison.InvariantCultureIgnoreCase);
         }

--- a/test/Core.Test/Models/Business/Tokenables/HCaptchaTokenableTests.cs
+++ b/test/Core.Test/Models/Business/Tokenables/HCaptchaTokenableTests.cs
@@ -3,12 +3,44 @@ using AutoFixture.Xunit2;
 using Bit.Core.Entities;
 using Bit.Core.Models.Business.Tokenables;
 using Bit.Core.Tokens;
+using Bit.Test.Common.AutoFixture.Attributes;
 using Xunit;
 
 namespace Bit.Core.Test.Models.Business.Tokenables
 {
     public class HCaptchaTokenableTests
     {
+        [Fact]
+        public void CanHandleNullUser()
+        {
+            var token = new HCaptchaTokenable(null);
+
+            Assert.Equal(default, token.Id);
+            Assert.Equal(default, token.Email);
+        }
+
+        [Fact]
+        public void TokenWithNullUserIsInvalid()
+        {
+            var token = new HCaptchaTokenable(null)
+            {
+                ExpirationDate = DateTime.UtcNow + TimeSpan.FromDays(1)
+            };
+
+            Assert.False(token.Valid);
+        }
+
+        [Theory, BitAutoData]
+        public void TokenValidityCheckNullUserIsFalse(User user)
+        {
+            var token = new HCaptchaTokenable(user)
+            {
+                ExpirationDate = DateTime.UtcNow + TimeSpan.FromDays(1)
+            };
+
+            Assert.False(token.TokenIsValid(null));
+        }
+
         [Theory, AutoData]
         public void CanUpdateExpirationToNonStandard(User user)
         {

--- a/test/Core.Test/Models/Business/Tokenables/HCaptchaTokenableTests.cs
+++ b/test/Core.Test/Models/Business/Tokenables/HCaptchaTokenableTests.cs
@@ -31,7 +31,7 @@ namespace Bit.Core.Test.Models.Business.Tokenables
         }
 
         [Theory, BitAutoData]
-        public void TokenValidityCheckNullUserIsFalse(User user)
+        public void TokenValidityCheckNullUserIdIsInvalid(User user)
         {
             var token = new HCaptchaTokenable(user)
             {


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Handle captcha token properly for unknown user



## Code changes
* **hcaptchaTokenable**: produce a token populated by defaults if user is null. These tokens are never valid and validating against a `null` user is never valid.

## Testing requirements
We can trigger this state by settings captcha required to true and attempting to auth as an unknown user.

We should trigger no errors on server and fail with username or password incorrect.

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
