### PR TITLE
Fix OneLogin Import

### DIFF
--- a/src/Api/Models/Public/Request/OrganizationImportRequestModel.cs
+++ b/src/Api/Models/Public/Request/OrganizationImportRequestModel.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 using Bit.Core.Entities;
 using Bit.Core.Models.Business;
+using Bit.Core.Utilities;
 
 namespace Bit.Api.Models.Public.Request
 {
@@ -41,10 +43,12 @@ namespace Bit.Api.Models.Public.Request
             /// <example>external_id_123456</example>
             [Required]
             [StringLength(300)]
+            [JsonConverter(typeof(PermissiveStringConverter))]
             public string ExternalId { get; set; }
             /// <summary>
             /// The associated external ids for members in this group.
             /// </summary>
+            [JsonConverter(typeof(PermissiveStringEnumerableConverter))]
             public IEnumerable<string> MemberExternalIds { get; set; }
 
             public ImportedGroup ToImportedGroup(Guid organizationId)
@@ -79,6 +83,7 @@ namespace Bit.Api.Models.Public.Request
             /// <example>external_id_123456</example>
             [Required]
             [StringLength(300)]
+            [JsonConverter(typeof(PermissiveStringConverter))]
             public string ExternalId { get; set; }
             /// <summary>
             /// Determines if this member should be removed from the organization during import.

--- a/src/Core/Utilities/JsonHelpers.cs
+++ b/src/Core/Utilities/JsonHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using NS = Newtonsoft.Json;
@@ -127,6 +128,65 @@ namespace Bit.Core.Utilities
             }
 
             writer.WriteStringValue(CoreHelpers.ToEpocMilliseconds(value.Value).ToString());
+        }
+    }
+
+    /// <summary>
+    /// Allows reading a string from a number or string, should only be used on string properties
+    /// </summary>
+    public class PermissiveStringConverter : JsonConverter<string>
+    {
+        internal static PermissiveStringConverter Instance = new();
+
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return reader.TokenType switch
+            {
+                JsonTokenType.String => reader.GetString(),
+                JsonTokenType.Number => reader.GetInt64().ToString(),
+                JsonTokenType.Null => null,
+                _ => throw new JsonException($"Unsupported TokenType: {reader.TokenType}"),
+            };
+        }
+
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value);
+        }
+    }
+
+    /// <summary>
+    /// Allows reading a string from a number or string, should only be used on string properties
+    /// </summary>
+    public class PermissiveStringEnumerableConverter : JsonConverter<IEnumerable<string>>
+    {
+        public override IEnumerable<string> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartArray)
+            {
+                throw new JsonException("Should only be used on a JSON Array");
+            }
+
+            var stringList = new List<string>();
+
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+            {
+                stringList.Add(PermissiveStringConverter.Instance.Read(ref reader, typeof(string), options));
+            }
+
+            return stringList;
+        }
+
+        public override void Write(Utf8JsonWriter writer, IEnumerable<string> value, JsonSerializerOptions options)
+        {
+            writer.WriteStartArray();
+
+            foreach (var str in value)
+            {
+                PermissiveStringConverter.Instance.Write(writer, str, options);
+            }
+
+            writer.WriteEndArray();
         }
     }
 }

--- a/test/Core.Test/Utilities/PermissiveStringConverterTests.cs
+++ b/test/Core.Test/Utilities/PermissiveStringConverterTests.cs
@@ -18,7 +18,7 @@ namespace Bit.Core.Test.Utilities
         private const string boolJson = "{ \"StringProp\": true, \"EnumerableStringProp\": [ false, 1.2]}";
         private const string objectJsonOne = "{ \"StringProp\": { \"Message\": \"Hi\"}, \"EnumerableStringProp\": []}";
         private const string objectJsonTwo = "{ \"StringProp\": \"Hi\", \"EnumerableStringProp\": {}}";
-        private readonly string bigNumbersJson = 
+        private readonly string bigNumbersJson =
         "{ \"StringProp\":" + decimal.MinValue + ", \"EnumerableStringProp\": [" + ulong.MaxValue + ", " + long.MinValue + "]}";
 
         [Theory]

--- a/test/Core.Test/Utilities/PermissiveStringConverterTests.cs
+++ b/test/Core.Test/Utilities/PermissiveStringConverterTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/test/Core.Test/Utilities/PermissiveStringConverterTests.cs
+++ b/test/Core.Test/Utilities/PermissiveStringConverterTests.cs
@@ -49,7 +49,8 @@ namespace Bit.Core.Test.Utilities
 
             var jsonElement = JsonDocument.Parse(json).RootElement;
 
-            AssertHelper.AssertJsonProperty(jsonElement, "StringProp", JsonValueKind.String);
+            var stringProp = AssertHelper.AssertJsonProperty(jsonElement, "StringProp", JsonValueKind.String);
+            Assert.Equal("1", stringProp.GetString());
             var list = AssertHelper.AssertJsonProperty(jsonElement, "EnumerableStringProp", JsonValueKind.Array);
             Assert.Equal(2, list.GetArrayLength());
             var firstElement = list[0];

--- a/test/Core.Test/Utilities/PermissiveStringConverterTests.cs
+++ b/test/Core.Test/Utilities/PermissiveStringConverterTests.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Bit.Core.Utilities;
+using Bit.Test.Common.Helpers;
+using Xunit;
+
+namespace Bit.Core.Test.Utilities
+{
+    public class PermissiveStringConverterTests
+    {
+        private const string numberJson = "{ \"StringProp\": 1, \"EnumerableStringProp\": [ 2, 3 ]}";
+        private const string stringJson = "{ \"StringProp\": \"1\", \"EnumerableStringProp\": [ \"2\", \"3\" ]}";
+        private const string nullJson = "{ \"StringProp\": null, \"EnumerableStringProp\": [] }";
+
+        [Theory]
+        [InlineData(numberJson)]
+        [InlineData(stringJson)]
+        public void Read_Success(string json)
+        {
+            var obj = JsonSerializer.Deserialize<TestObject>(json);
+            Assert.Equal("1", obj.StringProp);
+            Assert.Equal(2, obj.EnumerableStringProp.Count());
+            Assert.Equal("2", obj.EnumerableStringProp.ElementAt(0));
+            Assert.Equal("3", obj.EnumerableStringProp.ElementAt(1));
+        }
+
+        [Fact]
+        public void Read_NullJson_Success()
+        {
+            var obj = JsonSerializer.Deserialize<TestObject>(nullJson);
+            Assert.Null(obj.StringProp);
+            Assert.Empty(obj.EnumerableStringProp);
+        }
+
+        [Fact]
+        public void Write_Success()
+        {
+            var json = JsonSerializer.Serialize(new TestObject
+            {
+                StringProp = "1",
+                EnumerableStringProp = new List<string>
+                {
+                    "2",
+                    "3",
+                },
+            });
+
+            var jsonElement = JsonDocument.Parse(json).RootElement;
+
+            AssertHelper.AssertJsonProperty(jsonElement, "StringProp", JsonValueKind.String);
+            var list = AssertHelper.AssertJsonProperty(jsonElement, "EnumerableStringProp", JsonValueKind.Array);
+            Assert.Equal(2, list.GetArrayLength());
+            var firstElement = list[0];
+            Assert.Equal(JsonValueKind.String, firstElement.ValueKind);
+            Assert.Equal("2", firstElement.GetString());
+            var secondElement = list[1];
+            Assert.Equal(JsonValueKind.String, secondElement.ValueKind);
+            Assert.Equal("3", secondElement.GetString());
+        }
+    }
+
+    public class TestObject
+    {
+        [JsonConverter(typeof(PermissiveStringConverter))]
+        public string StringProp { get; set; }
+
+        [JsonConverter(typeof(PermissiveStringEnumerableConverter))]
+        public IEnumerable<string> EnumerableStringProp { get; set; }
+    }
+}


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Asana Task: https://app.asana.com/0/1169444489336079/1201920783866411/f

Regression from #1753, Newtonsoft was more permissive about allowing numbers to be serialized into strings. This adds two converters that emulate that behavior when added `string` and `IEnumerable<string>` properties. 


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **OrganizationImportRequestModel.cs:** Added the JSON converters that will allow reading from numbers as well.
* **JsonHelpers.cs:** Added two converters for reading a string as a number as well as one that does the same for a list of strings.
* **PermissiveStringConverterTests.cs:** Tests for the converters.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Check that OneLogin is able to sync it's directory with Bitwarden.


## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
