### PR TITLE
Ignore case on AutoEnrollEnabled so it is deserialized properly

### DIFF
--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -185,7 +185,7 @@ namespace Bit.Api.Controllers
                 return new OrganizationAutoEnrollStatusResponseModel(organization.Id, false);
             }
 
-            var data = JsonSerializer.Deserialize<ResetPasswordDataModel>(resetPasswordPolicy.Data);
+            var data = JsonSerializer.Deserialize<ResetPasswordDataModel>(resetPasswordPolicy.Data, JsonHelpers.IgnoreCase);
             return new OrganizationAutoEnrollStatusResponseModel(organization.Id, data?.AutoEnrollEnabled ?? false);
         }
 

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1773,7 +1773,7 @@ namespace Bit.Core.Services
             // Block the user from withdrawal if auto enrollment is enabled
             if (resetPasswordKey == null && resetPasswordPolicy.Data != null)
             {
-                var data = JsonSerializer.Deserialize<ResetPasswordDataModel>(resetPasswordPolicy.Data);
+                var data = JsonSerializer.Deserialize<ResetPasswordDataModel>(resetPasswordPolicy.Data, JsonHelpers.IgnoreCase);
 
                 if (data?.AutoEnrollEnabled ?? false)
                 {


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fixes an issue where users signing up with SSO where not auto enrolled in Admin Password Reset
https://app.asana.com/0/1169444489336079/1201833276744587/f

The cause was the incorrect deserialization of the `autoEnrollEnabled` property because it is saved as lower camel case instead of came case. Pass a flag to the JsonSerializer to ignore the case.



## Code changes

* **src/Api/Controllers/OrganizationsController.cs:** Pass IgnoreCase setting to JsonSerializer for resetPasswordPolicy.
* **src/Core/Services/Implementations/OrganizationService.cs:** Noticed the same issue in this file as well, update it while I'm here.

## Testing requirements
Ensure users enrolling with SSO are auto enrolled into Admin Password Reset



## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
