### PR TITLE
Add logic for starting staging slot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,9 @@ jobs:
           package: ./${{ matrix.name }}.zip
           slot-name: "staging"
 
+      - name: Start staging slot
+        run: az webapp start -n ${{ steps.retrieve-secrets.outputs.webapp-name }} -g bitwarden -s staging
+
 
   release-docker:
     name: Build Docker images


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add logic to the `release` workflow to start the Web App staging slots after deploying to them.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **.github/workflows/release.yml:** Added step to `deploy` job that uses the Azure CLI to start the Web App staging slot.


## Before you submit
- [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
