### PR TITLE
Test out non nullable settings value

### DIFF
--- a/src/Core/Services/ICaptchaValidationService.cs
+++ b/src/Core/Services/ICaptchaValidationService.cs
@@ -8,7 +8,7 @@ namespace Bit.Core.Services
     {
         string SiteKey { get; }
         string SiteKeyResponseKeyName { get; }
-        bool RequireCaptchaValidation(ICurrentContext currentContext, int? failedLoginCount = null);
+        bool RequireCaptchaValidation(ICurrentContext currentContext, int failedLoginCount = 0);
         Task<bool> ValidateCaptchaResponseAsync(string captchResponse, string clientIpAddress);
         string GenerateCaptchaBypassToken(User user);
         bool ValidateCaptchaBypassToken(string encryptedToken, User user);

--- a/src/Core/Services/Implementations/HCaptchaValidationService.cs
+++ b/src/Core/Services/Implementations/HCaptchaValidationService.cs
@@ -83,17 +83,17 @@ namespace Bit.Core.Services
             return root.GetProperty("success").GetBoolean();
         }
 
-        public bool RequireCaptchaValidation(ICurrentContext currentContext, int? failedLoginCount = null)
+        public bool RequireCaptchaValidation(ICurrentContext currentContext, int failedLoginCount = 0)
         {
-            var failedLoginCeiling = _globalSettings.Captcha.MaximumFailedLoginAttempts.GetValueOrDefault();
+            var failedLoginCeiling = _globalSettings.Captcha.MaximumFailedLoginAttempts;
             return currentContext.IsBot ||
                    _globalSettings.Captcha.ForceCaptchaRequired ||
-                   failedLoginCeiling > 0 && failedLoginCount.GetValueOrDefault() >= failedLoginCeiling;
+                   failedLoginCeiling > 0 && failedLoginCount >= failedLoginCeiling;
         }
 
         public bool ValidateFailedAuthEmailConditions(bool unknownDevice, int failedLoginCount)
         {
-            var failedLoginCeiling = _globalSettings.Captcha.MaximumFailedLoginAttempts.GetValueOrDefault();
+            var failedLoginCeiling = _globalSettings.Captcha.MaximumFailedLoginAttempts;
             return unknownDevice && failedLoginCeiling > 0 && failedLoginCount == failedLoginCeiling;
         }
 

--- a/src/Core/Services/NoopImplementations/NoopCaptchaValidationService.cs
+++ b/src/Core/Services/NoopImplementations/NoopCaptchaValidationService.cs
@@ -8,7 +8,7 @@ namespace Bit.Core.Services
     {
         public string SiteKeyResponseKeyName => null;
         public string SiteKey => null;
-        public bool RequireCaptchaValidation(ICurrentContext currentContext, int? failedLoginCount) => false;
+        public bool RequireCaptchaValidation(ICurrentContext currentContext, int failedLoginCount = 0) => false;
         public bool ValidateFailedAuthEmailConditions(bool unknownDevice, int failedLoginCount) => false;
         public string GenerateCaptchaBypassToken(User user) => "";
         public bool ValidateCaptchaBypassToken(string encryptedToken, User user) => false;

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -463,7 +463,7 @@ namespace Bit.Core.Settings
             public bool ForceCaptchaRequired { get; set; } = false;
             public string HCaptchaSecretKey { get; set; }
             public string HCaptchaSiteKey { get; set; }
-            public int? MaximumFailedLoginAttempts { get; set; }
+            public int MaximumFailedLoginAttempts { get; set; }
         }
 
         public class StripeSettings

--- a/src/Identity/appsettings.SelfHosted.json
+++ b/src/Identity/appsettings.SelfHosted.json
@@ -15,7 +15,7 @@
       "internalSso": null
     },
     "captcha": {
-      "maximumFailedLoginAttempts": null
+      "maximumFailedLoginAttempts": 0
     }
   }
 }


### PR DESCRIPTION
Setting is being overridden to null, despite env variable set to 1.
It's possible that arguments are overriding env var for unspecified
nullable int.

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->



## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->



## Before you submit
- [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
