### PR TITLE
[Captcha] BUG Add null checks | Make ceiling default to zero

### DIFF
--- a/src/Core/IdentityServer/BaseRequestValidator.cs
+++ b/src/Core/IdentityServer/BaseRequestValidator.cs
@@ -515,7 +515,7 @@ namespace Bit.Core.IdentityServer
         private async Task ResetFailedAuthDetailsAsync(User user)
         {
             // Early escape if db hit not necessary
-            if (user.FailedLoginCount == 0)
+            if (user == null || user.FailedLoginCount == 0)
             {
                 return;
             }
@@ -527,6 +527,11 @@ namespace Bit.Core.IdentityServer
 
         private async Task UpdateFailedAuthDetailsAsync(User user, bool twoFactorInvalid, bool unknownDevice)
         {
+            if (user == null)
+            {
+                return;
+            }
+            
             var utcNow = DateTime.UtcNow;
             user.FailedLoginCount = ++user.FailedLoginCount;
             user.LastFailedLoginDate = user.RevisionDate = utcNow;

--- a/src/Core/IdentityServer/BaseRequestValidator.cs
+++ b/src/Core/IdentityServer/BaseRequestValidator.cs
@@ -531,7 +531,7 @@ namespace Bit.Core.IdentityServer
             {
                 return;
             }
-            
+
             var utcNow = DateTime.UtcNow;
             user.FailedLoginCount = ++user.FailedLoginCount;
             user.LastFailedLoginDate = user.RevisionDate = utcNow;

--- a/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
+++ b/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
@@ -62,7 +62,7 @@ namespace Bit.Core.IdentityServer
             string bypassToken = null;
             var user = await _userManager.FindByEmailAsync(context.UserName.ToLowerInvariant());
             var unknownDevice = !await KnownDeviceAsync(user, context.Request);
-            if (unknownDevice && _captchaValidationService.RequireCaptchaValidation(_currentContext, user.FailedLoginCount))
+            if (unknownDevice && _captchaValidationService.RequireCaptchaValidation(_currentContext, user?.FailedLoginCount ?? 0))
             {
                 var captchaResponse = context.Request.Raw["captchaResponse"]?.ToString();
 

--- a/src/Core/Services/ICaptchaValidationService.cs
+++ b/src/Core/Services/ICaptchaValidationService.cs
@@ -8,7 +8,7 @@ namespace Bit.Core.Services
     {
         string SiteKey { get; }
         string SiteKeyResponseKeyName { get; }
-        bool RequireCaptchaValidation(ICurrentContext currentContext, int? failedLoginCount = null);
+        bool RequireCaptchaValidation(ICurrentContext currentContext, int failedLoginCount = 0);
         Task<bool> ValidateCaptchaResponseAsync(string captchResponse, string clientIpAddress);
         string GenerateCaptchaBypassToken(User user);
         bool ValidateCaptchaBypassToken(string encryptedToken, User user);

--- a/src/Core/Services/Implementations/HCaptchaValidationService.cs
+++ b/src/Core/Services/Implementations/HCaptchaValidationService.cs
@@ -83,17 +83,17 @@ namespace Bit.Core.Services
             return root.GetProperty("success").GetBoolean();
         }
 
-        public bool RequireCaptchaValidation(ICurrentContext currentContext, int? failedLoginCount = null)
+        public bool RequireCaptchaValidation(ICurrentContext currentContext, int failedLoginCount = 0)
         {
-            var failedLoginCeiling = _globalSettings.Captcha.MaximumFailedLoginAttempts.GetValueOrDefault();
+            var failedLoginCeiling = _globalSettings.Captcha.MaximumFailedLoginAttempts;
             return currentContext.IsBot ||
                    _globalSettings.Captcha.ForceCaptchaRequired ||
-                   failedLoginCeiling > 0 && failedLoginCount.GetValueOrDefault() >= failedLoginCeiling;
+                   failedLoginCeiling > 0 && failedLoginCount >= failedLoginCeiling;
         }
 
         public bool ValidateFailedAuthEmailConditions(bool unknownDevice, int failedLoginCount)
         {
-            var failedLoginCeiling = _globalSettings.Captcha.MaximumFailedLoginAttempts.GetValueOrDefault();
+            var failedLoginCeiling = _globalSettings.Captcha.MaximumFailedLoginAttempts;
             return unknownDevice && failedLoginCeiling > 0 && failedLoginCount == failedLoginCeiling;
         }
 

--- a/src/Core/Services/NoopImplementations/NoopCaptchaValidationService.cs
+++ b/src/Core/Services/NoopImplementations/NoopCaptchaValidationService.cs
@@ -8,7 +8,7 @@ namespace Bit.Core.Services
     {
         public string SiteKeyResponseKeyName => null;
         public string SiteKey => null;
-        public bool RequireCaptchaValidation(ICurrentContext currentContext, int? failedLoginCount) => false;
+        public bool RequireCaptchaValidation(ICurrentContext currentContext, int failedLoginCount = 0) => false;
         public bool ValidateFailedAuthEmailConditions(bool unknownDevice, int failedLoginCount) => false;
         public string GenerateCaptchaBypassToken(User user) => "";
         public bool ValidateCaptchaBypassToken(string encryptedToken, User user) => false;

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -463,7 +463,7 @@ namespace Bit.Core.Settings
             public bool ForceCaptchaRequired { get; set; } = false;
             public string HCaptchaSecretKey { get; set; }
             public string HCaptchaSiteKey { get; set; }
-            public int? MaximumFailedLoginAttempts { get; set; }
+            public int MaximumFailedLoginAttempts { get; set; }
         }
 
         public class StripeSettings

--- a/src/Identity/appsettings.SelfHosted.json
+++ b/src/Identity/appsettings.SelfHosted.json
@@ -15,7 +15,7 @@
       "internalSso": null
     },
     "captcha": {
-      "maximumFailedLoginAttempts": null
+      "maximumFailedLoginAttempts": 0
     }
   }
 }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Need to account for a null `user` object throughout the login flow and captcha logging process

> Update `SelfHosted` override to use `0` instead of `null`

> Update `GlobalSettings -> Captcha -> MaximumFailedLoginAttempts` to default to `0`

## Code changes
* **BaseRequestValidator.cs**: Added null checks necessary for hitting the login flow without finding a known user
* **ResourceOwnerPasswordValidator.cs**: Add null coalesce for handling `null` user
* **Interface/Noop/HCaptchaValidationService.cs**: Updated default `LoginFailedCount` to default to `0`
* **GlobalSettings.cs**: Remove nullable int attribute
* **appSettings.SelfHosted.json**: Update override state from `null` to `0`

## Testing requirements
- After running self-hosted script, make sure your override env variable is being set properly and triggers captcha when expected (= or > ceiling value)
- Hit the login flow with a `null` user and make sure it fails gracefully 

## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
