### PR TITLE
Return error object on captcha required

### DIFF
--- a/src/Core/Utilities/CaptchaProtectedAttribute.cs
+++ b/src/Core/Utilities/CaptchaProtectedAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using Bit.Core.Context;
-using Bit.Core.Exceptions;
 using Bit.Core.Models.Api;
 using Bit.Core.Services;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -22,14 +22,18 @@ namespace Bit.Core.Utilities
 
                 if (string.IsNullOrWhiteSpace(captchaResponse))
                 {
-                    throw new BadRequestException(captchaValidationService.SiteKeyResponseKeyName, captchaValidationService.SiteKey);
+                    context.HttpContext.Response.StatusCode = 400;
+                    context.Result = new ObjectResult(new ErrorResponseModel(captchaValidationService.SiteKeyResponseKeyName, captchaValidationService.SiteKey));
+                    return;
                 }
 
                 var captchaValid = captchaValidationService.ValidateCaptchaResponseAsync(captchaResponse,
                     currentContext.IpAddress).GetAwaiter().GetResult();
                 if (!captchaValid)
                 {
-                    throw new BadRequestException("Captcha is invalid. Please refresh and try again");
+                    context.HttpContext.Response.StatusCode = 400;
+                    context.Result = new ObjectResult(new ErrorResponseModel("Captcha is invalid. Please refresh and try again"));
+                    return;
                 }
             }
         }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
We are currently throwing on captcha for API endpoints, but we should be returning an error object for processing through the clients. This PR correct this behavior



## Code changes
* **CaptchaProtectedAttribute**: Return a 400 with a CaptchRequired error object on missing/invalid captcha

## Testing requirements
Validate that `register` endpoint no longer causes an error message in clients.



## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
