### PR TITLE
Add error handling to identity accounts controller

### DIFF
--- a/src/Identity/Controllers/AccountsController.cs
+++ b/src/Identity/Controllers/AccountsController.cs
@@ -8,12 +8,14 @@ using Bit.Core.Models.Data;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Utilities;
+using Bit.SharedWeb.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
 namespace Bit.Identity.Controllers
 {
     [Route("accounts")]
+    [ExceptionHandlerFilter]
     public class AccountsController : Controller
     {
         private readonly ILogger<AccountsController> _logger;

--- a/src/Identity/Startup.cs
+++ b/src/Identity/Startup.cs
@@ -58,7 +58,6 @@ namespace Bit.Identity
             services.AddMemoryCache();
 
             // Mvc
-            // MVC
             services.AddMvc(config =>
             {
                 config.Filters.Add(new ModelStateValidationFilterAttribute());

--- a/src/SharedWeb/Utilities/ExceptionHandlerFilterAttribute.cs
+++ b/src/SharedWeb/Utilities/ExceptionHandlerFilterAttribute.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using Bit.Core.Exceptions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+using Stripe;
+using InternalApi = Bit.Core.Models.Api;
+
+namespace Bit.SharedWeb.Utilities
+{
+    public class ExceptionHandlerFilterAttribute : ExceptionFilterAttribute
+    {
+        public ExceptionHandlerFilterAttribute()
+        {
+        }
+
+        public override void OnException(ExceptionContext context)
+        {
+            var errorMessage = "An error has occurred.";
+
+            var exception = context.Exception;
+            if (exception == null)
+            {
+                // Should never happen.
+                return;
+            }
+
+            InternalApi.ErrorResponseModel internalErrorModel = null;
+            if (exception is BadRequestException badRequestException)
+            {
+                context.HttpContext.Response.StatusCode = 400;
+                if (badRequestException.ModelState != null)
+                {
+                    internalErrorModel = new InternalApi.ErrorResponseModel(badRequestException.ModelState);
+                }
+                else
+                {
+                    errorMessage = badRequestException.Message;
+                }
+            }
+            else if (exception is GatewayException)
+            {
+                errorMessage = exception.Message;
+                context.HttpContext.Response.StatusCode = 400;
+            }
+            else if (exception is NotSupportedException && !string.IsNullOrWhiteSpace(exception.Message))
+            {
+                errorMessage = exception.Message;
+                context.HttpContext.Response.StatusCode = 400;
+            }
+            else if (exception is ApplicationException)
+            {
+                context.HttpContext.Response.StatusCode = 402;
+            }
+            else if (exception is NotFoundException)
+            {
+                errorMessage = "Resource not found.";
+                context.HttpContext.Response.StatusCode = 404;
+            }
+            else if (exception is SecurityTokenValidationException)
+            {
+                errorMessage = "Invalid token.";
+                context.HttpContext.Response.StatusCode = 403;
+            }
+            else if (exception is UnauthorizedAccessException)
+            {
+                errorMessage = "Unauthorized.";
+                context.HttpContext.Response.StatusCode = 401;
+            }
+            else
+            {
+                var logger = context.HttpContext.RequestServices.GetRequiredService<ILogger<ExceptionHandlerFilterAttribute>>();
+                logger.LogError(0, exception, exception.Message);
+                errorMessage = "An unhandled server error has occurred.";
+                context.HttpContext.Response.StatusCode = 500;
+            }
+
+            var errorModel = internalErrorModel ?? new InternalApi.ErrorResponseModel(errorMessage);
+            var env = context.HttpContext.RequestServices.GetRequiredService<IWebHostEnvironment>();
+            if (env.IsDevelopment())
+            {
+                errorModel.ExceptionMessage = exception.Message;
+                errorModel.ExceptionStackTrace = exception.StackTrace;
+                errorModel.InnerExceptionMessage = exception?.InnerException?.Message;
+            }
+            context.Result = new ObjectResult(errorModel);
+        }
+    }
+}


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
We moved prelogin and register endpoints to the identity service, but failed to realize that service lacks the same error handling as API. This copies that handling over to the new controller.

It's worth reworking how this filter works to we can dry up the implementation, but I'm going to add that as a tech debt item seeing as this is to fix a regression defect.

## Code changes
* **AcountsController**: use the filter
* **ExceptionHandlerFilterAttribute**: Copy over the filter used for API. Remove public api and stripe handling since we won't use that here.

## Testing requirements
Validate exceptions from identity account endpoint

This will be cherry picked into `rc`



## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
