### PR TITLE
Fix logic to start and stop staging slots on App Services

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,13 @@ jobs:
           slot-name: "staging"
 
       - name: Start staging slot
-        run: az webapp start -n ${{ steps.retrieve-secrets.outputs.webapp-name }} -g bitwarden -s staging
+        run: |
+          if [[ "$SERVICE" = "Api" ]] || [[ "$SERVICE" = "Identity" ]]; then
+            RESOURCE_GROUP=bitwardenappservices
+          else
+            RESOURCE_GROUP=bitwarden
+          fi
+          az webapp start -n $WEBAPP_NAME -g $RESOURCE_GROUP -s staging
 
 
   release-docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,9 @@ jobs:
           slot-name: "staging"
 
       - name: Start staging slot
+        env:
+          SERVICE: ${{ matrix.name }}
+          WEBAPP_NAME: ${{ steps.retrieve-secrets.outputs.webapp-name }}
         run: |
           if [[ "$SERVICE" = "Api" ]] || [[ "$SERVICE" = "Identity" ]]; then
             RESOURCE_GROUP=bitwardenappservices

--- a/.github/workflows/stop-staging-slots.yml
+++ b/.github/workflows/stop-staging-slots.yml
@@ -48,4 +48,8 @@ jobs:
           echo "::set-output name=webapp-name::$webapp_name"
 
       - name: Stop staging slot
-        run: az webapp stop -n ${{ steps.retrieve-secrets.outputs.webapp-name }} -g bitwarden -s staging
+        env:
+          WEBAPP_NAME: ${{ steps.retrieve-secrets.outputs.webapp-name }}
+        run: |
+          RESOURCE_GROUP=$(az webapp list --query "[?name=='$WEBAPP_NAME'].resourceGroup" -o tsv)
+          az webapp stop -n $WEBAPP_NAME -g $RESOURCE_GROUP -s staging

--- a/.github/workflows/stop-staging-slots.yml
+++ b/.github/workflows/stop-staging-slots.yml
@@ -49,8 +49,12 @@ jobs:
 
       - name: Stop staging slot
         env:
+          SERVICE: ${{ matrix.name }}
           WEBAPP_NAME: ${{ steps.retrieve-secrets.outputs.webapp-name }}
         run: |
-          RESOURCE_GROUP=$(az webapp list --query "[?name=='${{ steps.retrieve-secrets.outputs.webapp-name }}'].resourceGroup" -o tsv)
-          az webapp list --query "[?name=='${{ steps.retrieve-secrets.outputs.webapp-name }}'].resourceGroup" -o tsv
+          if [[ "$SERVICE" = "Api" ]] || [[ "$SERVICE" = "Identity" ]]; then
+            RESOURCE_GROUP=bitwardenappservices
+          else
+            RESOURCE_GROUP=bitwarden
+          fi
           az webapp stop -n $WEBAPP_NAME -g $RESOURCE_GROUP -s staging

--- a/.github/workflows/stop-staging-slots.yml
+++ b/.github/workflows/stop-staging-slots.yml
@@ -52,4 +52,5 @@ jobs:
           WEBAPP_NAME: ${{ steps.retrieve-secrets.outputs.webapp-name }}
         run: |
           RESOURCE_GROUP=$(az webapp list --query "[?name=='$WEBAPP_NAME'].resourceGroup" -o tsv)
+          az webapp list --query "[?name=='$WEBAPP_NAME'].resourceGroup" -o tsv
           az webapp stop -n $WEBAPP_NAME -g $RESOURCE_GROUP -s staging

--- a/.github/workflows/stop-staging-slots.yml
+++ b/.github/workflows/stop-staging-slots.yml
@@ -51,6 +51,6 @@ jobs:
         env:
           WEBAPP_NAME: ${{ steps.retrieve-secrets.outputs.webapp-name }}
         run: |
-          RESOURCE_GROUP=$(az webapp list --query "[?name=='$WEBAPP_NAME'].resourceGroup" -o tsv)
-          az webapp list --query "[?name=='$WEBAPP_NAME'].resourceGroup" -o tsv
+          RESOURCE_GROUP=$(az webapp list --query "[?name=='${{ steps.retrieve-secrets.outputs.webapp-name }}'].resourceGroup" -o tsv)
+          az webapp list --query "[?name=='${{ steps.retrieve-secrets.outputs.webapp-name }}'].resourceGroup" -o tsv
           az webapp stop -n $WEBAPP_NAME -g $RESOURCE_GROUP -s staging


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR fixes the logic used to start and stop the staging slot on each of our App Services.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **.github/workflows/release.yml:** Updated the logic to start the staging slots.
* **.github/workflows/stop-staging-slots.yml:** Updated the logic to stop the staging slots.


## Before you submit
- [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
