### PR TITLE
add some european takeaway domains to global domains

### DIFF
--- a/src/Core/Enums/GlobalEquivalentDomainsType.cs
+++ b/src/Core/Enums/GlobalEquivalentDomainsType.cs
@@ -90,5 +90,6 @@
         Proton = 85,
         Ubisoft = 86,
         TransferWise = 87,
+        TakeawayEU = 88,
     }
 }

--- a/src/Core/Utilities/StaticStore.cs
+++ b/src/Core/Utilities/StaticStore.cs
@@ -101,6 +101,7 @@ namespace Bit.Core.Utilities
             GlobalDomains.Add(GlobalEquivalentDomainsType.Proton, new List<string> { "protonmail.com", "protonvpn.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.Ubisoft, new List<string> { "ubisoft.com", "ubi.com" });
             GlobalDomains.Add(GlobalEquivalentDomainsType.TransferWise, new List<string> { "transferwise.com", "wise.com" });
+            GlobalDomains.Add(GlobalEquivalentDomainsType.TakeawayEU, new List<string> { "takeaway.com", "just-eat.dk", "just-eat.no", "just-eat.fr", "just-eat.ch", "lieferando.de", "lieferando.at", "thuisbezorgd.nl", "pyszne.pl" });
             #endregion
 
             #region Plans


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add domains owned by Just Eat Takeaway.com that share the account database. This is unique to just _some_ of the european domains, seemingly related to the origin of the services (company merging/acquiring) - looks like it's about services originally created by Takeaway.com (e.g. I can freely log in to Thuisbezorgd.nl, Lieferando.de or Just-Eat.dk with an account created on Pyszne.pl).

Full list of Just Eat Takeaway.com domains: https://en.wikipedia.org/wiki/Just_Eat_Takeaway#Local_brands

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->



## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->



## Before you submit
- [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
