### PR TITLE
Seek to origin of MemoryStream before use

### DIFF
--- a/src/Admin/Controllers/ToolsController.cs
+++ b/src/Admin/Controllers/ToolsController.cs
@@ -265,6 +265,7 @@ namespace Bit.Admin.Controllers
                     model.InstallationId.Value, model.Version);
                 var ms = new MemoryStream();
                 await JsonSerializer.SerializeAsync(ms, license, JsonHelpers.Indented);
+                ms.Seek(0, SeekOrigin.Begin);
                 return File(ms, "text/plain", "bitwarden_organization_license.json");
             }
             else if (user != null)
@@ -272,6 +273,7 @@ namespace Bit.Admin.Controllers
                 var license = await _userService.GenerateLicenseAsync(user, null, model.Version);
                 var ms = new MemoryStream();
                 await JsonSerializer.SerializeAsync(ms, license, JsonHelpers.Indented);
+                ms.Seek(0, SeekOrigin.Begin);
                 return File(ms, "text/plain", "bitwarden_premium_license.json");
             }
             else


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fix license generator

## Code changes
* **ToolsController**: MS's File helper doesn't seek to origin of the stream it's given because not all streams can seek. We need to reset to the origin prior to passing in.

## Testing requirements
Validate admin license generator produces a file



## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
