### PR TITLE
Fix swapped launch settings default

### DIFF
--- a/src/Identity/Properties/launchSettings.json
+++ b/src/Identity/Properties/launchSettings.json
@@ -15,6 +15,14 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
+    "Identity": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:33656",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
     "Identity-SelfHost": {
       "commandName": "Project",
       "launchBrowser": false,
@@ -22,14 +30,6 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "developSelfHosted": "true"
-      }
-    },
-    "Identity": {
-      "commandName": "Project",
-      "launchBrowser": false,
-      "applicationUrl": "http://localhost:33656",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Default to cloud-type dev instance

## Code changes
The first run configuration is the default, all other configurations default to cloud-like instance, and we want to here as well.

## Testing requirements
None
