### PR TITLE
Email verification for new devices

### DIFF
--- a/src/Core/Entities/User.cs
+++ b/src/Core/Entities/User.cs
@@ -139,6 +139,11 @@ namespace Bit.Core.Entities
             _twoFactorProviders = providers;
         }
 
+        public void ClearTwoFactorProviders()
+        {
+            SetTwoFactorProviders(new Dictionary<TwoFactorProviderType, TwoFactorProvider>());
+        }
+
         public TwoFactorProvider GetTwoFactorProvider(TwoFactorProviderType provider)
         {
             var providers = GetTwoFactorProviders();

--- a/src/Core/IdentityServer/BaseRequestValidator.cs
+++ b/src/Core/IdentityServer/BaseRequestValidator.cs
@@ -94,19 +94,24 @@ namespace Bit.Core.IdentityServer
                 return;
             }
 
-            var twoFactorRequirement = await RequiresTwoFactorAsync(user, request.GrantType);
-            if (twoFactorRequirement.Item1)
+            var (isTwoFactorRequired, requires2FABecauseNewDevice, twoFactorOrganization) = await RequiresTwoFactorAsync(user, request);
+            if (isTwoFactorRequired)
             {
                 // Just defaulting it
                 var twoFactorProviderType = TwoFactorProviderType.Authenticator;
                 if (!twoFactorRequest || !Enum.TryParse(twoFactorProvider, out twoFactorProviderType))
                 {
-                    await BuildTwoFactorResultAsync(user, twoFactorRequirement.Item2, context);
+                    await BuildTwoFactorResultAsync(user, twoFactorOrganization, context, requires2FABecauseNewDevice);
                     return;
                 }
 
-                var verified = await VerifyTwoFactor(user, twoFactorRequirement.Item2,
-                    twoFactorProviderType, twoFactorToken);
+                BeforeVerifyTwoFactor(user, twoFactorProviderType, requires2FABecauseNewDevice);
+
+                var verified = await VerifyTwoFactor(user, twoFactorOrganization,
+                    twoFactorProviderType, twoFactorToken, requires2FABecauseNewDevice);
+
+                AfterVerifyTwoFactor(user, twoFactorProviderType, requires2FABecauseNewDevice);
+
                 if (!verified && twoFactorProviderType != TwoFactorProviderType.Remember)
                 {
                     await UpdateFailedAuthDetailsAsync(user, true, unknownDevice);
@@ -117,7 +122,7 @@ namespace Bit.Core.IdentityServer
                 {
                     // Delay for brute force.
                     await Task.Delay(2000);
-                    await BuildTwoFactorResultAsync(user, twoFactorRequirement.Item2, context);
+                    await BuildTwoFactorResultAsync(user, twoFactorOrganization, context, requires2FABecauseNewDevice);
                     return;
                 }
             }
@@ -188,7 +193,7 @@ namespace Bit.Core.IdentityServer
             await SetSuccessResult(context, user, claims, customResponse);
         }
 
-        protected async Task BuildTwoFactorResultAsync(User user, Organization organization, T context)
+        protected async Task BuildTwoFactorResultAsync(User user, Organization organization, T context, bool requires2FABecauseNewDevice)
         {
             var providerKeys = new List<byte>();
             var providers = new Dictionary<string, Dictionary<string, object>>();
@@ -213,8 +218,23 @@ namespace Bit.Core.IdentityServer
 
             if (!enabledProviders.Any())
             {
-                await BuildErrorResultAsync("No two-step providers enabled.", false, context, user);
-                return;
+                if (!requires2FABecauseNewDevice)
+                {
+                    await BuildErrorResultAsync("No two-step providers enabled.", false, context, user);
+                    return;
+                }
+
+                var emailProvider = new TwoFactorProvider
+                {
+                    MetaData = new Dictionary<string, object> { ["Email"] = user.Email.ToLowerInvariant() },
+                    Enabled = true
+                };
+                enabledProviders.Add(new KeyValuePair<TwoFactorProviderType, TwoFactorProvider>(
+                    TwoFactorProviderType.Email, emailProvider));
+                user.SetTwoFactorProviders(new Dictionary<TwoFactorProviderType, TwoFactorProvider>
+                {
+                    [TwoFactorProviderType.Email] = emailProvider
+                });
             }
 
             foreach (var provider in enabledProviders)
@@ -234,7 +254,7 @@ namespace Bit.Core.IdentityServer
             if (enabledProviders.Count() == 1 && enabledProviders.First().Key == TwoFactorProviderType.Email)
             {
                 // Send email now if this is their only 2FA method
-                await _userService.SendTwoFactorEmailAsync(user);
+                await _userService.SendTwoFactorEmailAsync(user, requires2FABecauseNewDevice);
             }
         }
 
@@ -270,12 +290,12 @@ namespace Bit.Core.IdentityServer
 
         protected abstract void SetErrorResult(T context, Dictionary<string, object> customResponse);
 
-        private async Task<Tuple<bool, Organization>> RequiresTwoFactorAsync(User user, string grantType)
+        private async Task<Tuple<bool, bool, Organization>> RequiresTwoFactorAsync(User user, ValidatedTokenRequest request)
         {
-            if (grantType == "client_credentials")
+            if (request.GrantType == "client_credentials")
             {
                 // Do not require MFA for api key logins
-                return new Tuple<bool, Organization>(false, null);
+                return new Tuple<bool, bool, Organization>(false, false, null);
             }
 
             var individualRequired = _userManager.SupportsUserTwoFactor &&
@@ -297,7 +317,15 @@ namespace Bit.Core.IdentityServer
                 }
             }
 
-            return new Tuple<bool, Organization>(individualRequired || firstEnabledOrg != null, firstEnabledOrg);
+            var requires2FA = individualRequired || firstEnabledOrg != null;
+            var requires2FABecauseNewDevice = !requires2FA
+                                              && user.EmailVerified
+                                              && request.GrantType != "authorization_code"
+                                              && await IsNewDeviceAndNotTheFirstOneAsync(user, request);
+
+            requires2FA = requires2FA || requires2FABecauseNewDevice;
+
+            return new Tuple<bool, bool, Organization>(requires2FA, requires2FABecauseNewDevice, firstEnabledOrg);
         }
 
         private async Task<bool> IsValidAuthTypeAsync(User user, string grantType)
@@ -373,6 +401,33 @@ namespace Bit.Core.IdentityServer
                 Type = type,
                 PushToken = string.IsNullOrWhiteSpace(devicePushToken) ? null : devicePushToken
             };
+        }
+
+        private void BeforeVerifyTwoFactor(User user, TwoFactorProviderType type, bool requires2FABecauseNewDevice)
+        {
+            if (type == TwoFactorProviderType.Email
+                &&
+                requires2FABecauseNewDevice)
+            {
+                user.SetTwoFactorProviders(new Dictionary<TwoFactorProviderType, TwoFactorProvider>
+                {
+                    [TwoFactorProviderType.Email] = new TwoFactorProvider
+                    {
+                        MetaData = new Dictionary<string, object> { ["Email"] = user.Email.ToLowerInvariant() },
+                        Enabled = true
+                    }
+                });
+            }
+        }
+
+        private void AfterVerifyTwoFactor(User user, TwoFactorProviderType type, bool requires2FABecauseNewDevice)
+        {
+            if (type == TwoFactorProviderType.Email
+                &&
+                requires2FABecauseNewDevice)
+            {
+                user.ClearTwoFactorProviders();
+            }
         }
 
         private async Task<bool> VerifyTwoFactor(User user, Organization organization, TwoFactorProviderType type,
@@ -480,6 +535,23 @@ namespace Bit.Core.IdentityServer
 
             return await _deviceRepository.GetByIdentifierAsync(GetDeviceFromRequest(request).Identifier, user.Id);
         }
+
+        protected async Task<bool> IsNewDeviceAndNotTheFirstOneAsync(User user, ValidatedTokenRequest request)
+        {
+            if (user == null)
+            {
+                return default;
+            }
+
+            var devices = await _deviceRepository.GetManyByUserIdAsync(user.Id);
+            if (!devices.Any())
+            {
+                return false;
+            }
+
+            return !devices.Any(d => d.Identifier == GetDeviceFromRequest(request)?.Identifier);
+        }
+
         private async Task<Device> SaveDeviceAsync(User user, ValidatedTokenRequest request)
         {
             var device = GetDeviceFromRequest(request);

--- a/src/Core/IdentityServer/BaseRequestValidator.cs
+++ b/src/Core/IdentityServer/BaseRequestValidator.cs
@@ -108,7 +108,7 @@ namespace Bit.Core.IdentityServer
                 BeforeVerifyTwoFactor(user, twoFactorProviderType, requires2FABecauseNewDevice);
 
                 var verified = await VerifyTwoFactor(user, twoFactorOrganization,
-                    twoFactorProviderType, twoFactorToken, requires2FABecauseNewDevice);
+                    twoFactorProviderType, twoFactorToken);
 
                 AfterVerifyTwoFactor(user, twoFactorProviderType, requires2FABecauseNewDevice);
 

--- a/src/Core/MailTemplates/Handlebars/NewDeviceLoginTwoFactorEmail.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/NewDeviceLoginTwoFactorEmail.html.hbs
@@ -1,0 +1,19 @@
+﻿{{#>FullHtmlLayout}}
+<table width="100%" cellpadding="0" cellspacing="0" style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;" valign="top">
+            Your two-step verification code is: <b style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">{{Token}}</b>
+        </td>
+    </tr>
+    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;" valign="top">
+            Use this code to complete logging in with Bitwarden.
+        </td>
+    </tr>
+    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        <td class="content-block last" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0; -webkit-text-size-adjust: none;" valign="top">
+            This email was sent because you are logging in from a device we don’t recognize. If you did not request this code, you may want to <a target="_blank" clicktracking=off href="https://bitwarden.com/help/master-password/#change-master-password" style="-webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; box-sizing: border-box; color: #175DDC; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 25px; margin: 0; text-decoration: underline;">change your master password</a>. You can view our tips for selecting a secure master password <a target="_blank" clicktracking=off href="https://bitwarden.com/blog/picking-the-right-password-for-your-password-manager/" style="-webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; box-sizing: border-box; color: #175DDC; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 25px; margin: 0; text-decoration: underline;">here</a>.
+        </td>
+    </tr>
+</table>
+{{/FullHtmlLayout}}

--- a/src/Core/MailTemplates/Handlebars/NewDeviceLoginTwoFactorEmail.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/NewDeviceLoginTwoFactorEmail.text.hbs
@@ -1,0 +1,7 @@
+﻿{{#>BasicTextLayout}}
+Your two-step verification code is: {{Token}}
+
+Use this code to complete logging in with Bitwarden.
+
+This email was sent because you are logging in from a device we don’t recognize. If you did not request this code, you may want to change your master password (https://bitwarden.com/help/master-password/#change-master-password). You can view our tips for selecting a secure master password here (https://bitwarden.com/blog/picking-the-right-password-for-your-password-manager/).
+{{/BasicTextLayout}}

--- a/src/Core/Services/IMailService.cs
+++ b/src/Core/Services/IMailService.cs
@@ -16,6 +16,7 @@ namespace Bit.Core.Services
         Task SendChangeEmailAlreadyExistsEmailAsync(string fromEmail, string toEmail);
         Task SendChangeEmailEmailAsync(string newEmailAddress, string token);
         Task SendTwoFactorEmailAsync(string email, string token);
+        Task SendNewDeviceLoginTwoFactorEmailAsync(string email, string token);
         Task SendNoMasterPasswordHintEmailAsync(string email);
         Task SendMasterPasswordHintEmailAsync(string email, string hint);
         Task SendOrganizationInviteEmailAsync(string organizationName, bool orgCanSponsor, OrganizationUser orgUser, ExpiringToken token);

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -22,7 +22,7 @@ namespace Bit.Core.Services
         Task<IdentityResult> RegisterUserAsync(User user, string masterPassword, string token, Guid? orgUserId);
         Task<IdentityResult> RegisterUserAsync(User user);
         Task SendMasterPasswordHintAsync(string email);
-        Task SendTwoFactorEmailAsync(User user);
+        Task SendTwoFactorEmailAsync(User user, bool isBecauseNewDeviceLogin = false);
         Task<bool> VerifyTwoFactorEmailAsync(User user, string token);
         Task<CredentialCreateOptions> StartWebAuthnRegistrationAsync(User user);
         Task<bool> DeleteWebAuthnKeyAsync(User user, int id);

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -119,6 +119,21 @@ namespace Bit.Core.Services
             await _mailDeliveryService.SendEmailAsync(message);
         }
 
+        public async Task SendNewDeviceLoginTwoFactorEmailAsync(string email, string token)
+        {
+            var message = CreateDefaultMessage("New Device Login Verification Code", email);
+            var model = new EmailTokenViewModel
+            {
+                Token = token,
+                WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
+                SiteName = _globalSettings.SiteName
+            };
+            await AddMessageContentAsync(message, "NewDeviceLoginTwoFactorEmail", model);
+            message.MetaData.Add("SendGridBypassListManagement", true);
+            message.Category = "TwoFactorEmail";
+            await _mailDeliveryService.SendEmailAsync(message);
+        }
+
         public async Task SendMasterPasswordHintEmailAsync(string email, string hint)
         {
             var message = CreateDefaultMessage("Your Master Password Hint", email);

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -346,7 +346,7 @@ namespace Bit.Core.Services
             await _mailService.SendMasterPasswordHintEmailAsync(email, user.MasterPasswordHint);
         }
 
-        public async Task SendTwoFactorEmailAsync(User user)
+        public async Task SendTwoFactorEmailAsync(User user, bool isBecauseNewDeviceLogin = false)
         {
             var provider = user.GetTwoFactorProvider(TwoFactorProviderType.Email);
             if (provider == null || provider.MetaData == null || !provider.MetaData.ContainsKey("Email"))
@@ -357,7 +357,15 @@ namespace Bit.Core.Services
             var email = ((string)provider.MetaData["Email"]).ToLowerInvariant();
             var token = await base.GenerateUserTokenAsync(user, TokenOptions.DefaultEmailProvider,
                 "2faEmail:" + email);
-            await _mailService.SendTwoFactorEmailAsync(email, token);
+
+            if (isBecauseNewDeviceLogin)
+            {
+                await _mailService.SendNewDeviceLoginTwoFactorEmailAsync(email, token);
+            }
+            else
+            {
+                await _mailService.SendTwoFactorEmailAsync(email, token);
+            }
         }
 
         public async Task<bool> VerifyTwoFactorEmailAsync(User user, string token)

--- a/src/Core/Services/NoopImplementations/NoopMailService.cs
+++ b/src/Core/Services/NoopImplementations/NoopMailService.cs
@@ -75,6 +75,11 @@ namespace Bit.Core.Services
             return Task.FromResult(0);
         }
 
+        public Task SendNewDeviceLoginTwoFactorEmailAsync(string email, string token)
+        {
+            return Task.CompletedTask;
+        }
+
         public Task SendWelcomeEmailAsync(User user)
         {
             return Task.FromResult(0);


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Given: a user does not have 2FA set up AND the user is not logging in with SSO
When: the user logs in on a new device AND this is not the first device the user has logged in on
Then: required Email 2FA

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **User.cs:** Added method to clear 2FA
* **BaseRequestValidator:** Added logic to require and send email 2FA when there is a login on a new device that is not SSO and has no 2FA configured.
* **NewDeviceLoginTwoFactorEmail.text.hbs:** Added text template for the new email
* **NewDeviceLoginTwoFactorEmail.html.hbs:** Added html template for the new email
* **HandlebarsMailService:** Added method to send the new email with the email 2FA for new device's login
* **UserService:** Added logic to send the correct 2FA email depending on if that is because of a new device's login or of a configured email 2FA
* **UserServiceTests:** Added unit tests for the new logic on `SendTwoFactorEmailAsync`

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Test that on users that don't have SSO and don't have any 2FA set up, when login in new devices a 2FA is required and an email is received with the 2FA token and explaining why they are receiving that.
This shouldn't happen if the user has any 2FA set up or if they are login in with SSO.

## Additional notes
Maybe it'd be a good idea to refactor the `TwoFactorProvider` set up to be done in some other object like a factory or a static method (or extension method) that builds the provider given the type and some additional arguments. On what I did I just copied the Email `KeyValuePair<TwoFactorProviderType, TwoFactorProvider>` as I saw it was done on other parts just not to refactor the other parts and tackle that all at once with some planning beforehand given that it may break core stuff.

## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [X] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [X] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
