### PR TITLE
[euvr] Separate Billing Payment/History APIs

### DIFF
--- a/src/Api/Controllers/AccountsBillingController.cs
+++ b/src/Api/Controllers/AccountsBillingController.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading.Tasks;
+using Bit.Api.Models.Response;
+using Bit.Core.Services;
+using Bit.Core.Utilities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bit.Api.Controllers
+{
+    [Route("accounts/billing")]
+    [Authorize("Application")]
+    public class AccountsBillingController : Controller
+    {
+        private readonly IPaymentService _paymentService;
+        private readonly IUserService _userService;
+
+        public AccountsBillingController(
+            IPaymentService paymentService,
+            IUserService userService)
+        {
+            _paymentService = paymentService;
+            _userService = userService;
+        }
+
+        [HttpGet("history")]
+        [SelfHosted(NotSelfHostedOnly = true)]
+        public async Task<BillingHistoryResponseModel> GetBillingHistory()
+        {
+            var user = await _userService.GetUserByPrincipalAsync(User);
+            if(user == null)
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            var billingInfo = await _paymentService.GetBillingHistoryAsync(user);
+            return new BillingHistoryResponseModel(billingInfo);
+        }
+
+        [HttpGet("payment-method")]
+        [SelfHosted(NotSelfHostedOnly = true)]
+        public async Task<BillingPaymentResponseModel> GetPaymentMethod()
+        {
+            var user = await _userService.GetUserByPrincipalAsync(User);
+            if(user == null)
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            var billingInfo = await _paymentService.GetBillingBalanceAndSourceAsync(user);
+            return new BillingPaymentResponseModel(billingInfo);
+        }
+    }
+}

--- a/src/Api/Controllers/AccountsBillingController.cs
+++ b/src/Api/Controllers/AccountsBillingController.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Bit.Api.Models.Response;
 using Bit.Core.Services;
@@ -28,7 +28,7 @@ namespace Bit.Api.Controllers
         public async Task<BillingHistoryResponseModel> GetBillingHistory()
         {
             var user = await _userService.GetUserByPrincipalAsync(User);
-            if(user == null)
+            if (user == null)
             {
                 throw new UnauthorizedAccessException();
             }
@@ -42,7 +42,7 @@ namespace Bit.Api.Controllers
         public async Task<BillingPaymentResponseModel> GetPaymentMethod()
         {
             var user = await _userService.GetUserByPrincipalAsync(User);
-            if(user == null)
+            if (user == null)
             {
                 throw new UnauthorizedAccessException();
             }

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -639,6 +639,34 @@ namespace Bit.Api.Controllers
             var billingInfo = await _paymentService.GetBillingAsync(user);
             return new BillingResponseModel(billingInfo);
         }
+        
+        [HttpGet("billing-history")]
+        [SelfHosted(NotSelfHostedOnly = true)]
+        public async Task<BillingHistoryResponseModel> GetBillingHistory()
+        {
+            var user = await _userService.GetUserByPrincipalAsync(User);
+            if (user == null)
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            var billingInfo = await _paymentService.GetBillingHistoryAsync(user);
+            return new BillingHistoryResponseModel(billingInfo);
+        }
+        
+        [HttpGet("billing-payment")]
+        [SelfHosted(NotSelfHostedOnly = true)]
+        public async Task<BillingPaymentResponseModel> GetPaymentMethod()
+        {
+            var user = await _userService.GetUserByPrincipalAsync(User);
+            if (user == null)
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            var billingInfo = await _paymentService.GetBillingBalanceAndSourceAsync(user);
+            return new BillingPaymentResponseModel(billingInfo);
+        }
 
         [HttpGet("subscription")]
         public async Task<SubscriptionResponseModel> GetSubscription()

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -639,7 +639,7 @@ namespace Bit.Api.Controllers
             var billingInfo = await _paymentService.GetBillingAsync(user);
             return new BillingResponseModel(billingInfo);
         }
-        
+
         [HttpGet("billing-history")]
         [SelfHosted(NotSelfHostedOnly = true)]
         public async Task<BillingHistoryResponseModel> GetBillingHistory()
@@ -653,7 +653,7 @@ namespace Bit.Api.Controllers
             var billingInfo = await _paymentService.GetBillingHistoryAsync(user);
             return new BillingHistoryResponseModel(billingInfo);
         }
-        
+
         [HttpGet("billing-payment")]
         [SelfHosted(NotSelfHostedOnly = true)]
         public async Task<BillingPaymentResponseModel> GetPaymentMethod()

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -640,7 +640,7 @@ namespace Bit.Api.Controllers
             var billingInfo = await _paymentService.GetBillingAsync(user);
             return new BillingResponseModel(billingInfo);
         }
-        
+
         [HttpGet("subscription")]
         public async Task<SubscriptionResponseModel> GetSubscription()
         {

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -626,6 +626,7 @@ namespace Bit.Api.Controllers
             };
         }
 
+        [Obsolete("2022-04-01 Use separate Billing History/Payment APIs, left for backwards compatability with older clients")]
         [HttpGet("billing")]
         [SelfHosted(NotSelfHostedOnly = true)]
         public async Task<BillingResponseModel> GetBilling()
@@ -639,35 +640,7 @@ namespace Bit.Api.Controllers
             var billingInfo = await _paymentService.GetBillingAsync(user);
             return new BillingResponseModel(billingInfo);
         }
-
-        [HttpGet("billing-history")]
-        [SelfHosted(NotSelfHostedOnly = true)]
-        public async Task<BillingHistoryResponseModel> GetBillingHistory()
-        {
-            var user = await _userService.GetUserByPrincipalAsync(User);
-            if (user == null)
-            {
-                throw new UnauthorizedAccessException();
-            }
-
-            var billingInfo = await _paymentService.GetBillingHistoryAsync(user);
-            return new BillingHistoryResponseModel(billingInfo);
-        }
-
-        [HttpGet("billing-payment")]
-        [SelfHosted(NotSelfHostedOnly = true)]
-        public async Task<BillingPaymentResponseModel> GetPaymentMethod()
-        {
-            var user = await _userService.GetUserByPrincipalAsync(User);
-            if (user == null)
-            {
-                throw new UnauthorizedAccessException();
-            }
-
-            var billingInfo = await _paymentService.GetBillingBalanceAndSourceAsync(user);
-            return new BillingPaymentResponseModel(billingInfo);
-        }
-
+        
         [HttpGet("subscription")]
         public async Task<SubscriptionResponseModel> GetSubscription()
         {

--- a/src/Api/Models/Response/BillingHistoryResponseModel.cs
+++ b/src/Api/Models/Response/BillingHistoryResponseModel.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Linq;
+using Bit.Core.Models.Api;
+using Bit.Core.Models.Business;
+
+namespace Bit.Api.Models.Response
+{
+    public class BillingHistoryResponseModel : ResponseModel
+    {
+        public BillingHistoryResponseModel(BillingInfo billing)
+            : base("billingHistory")
+        {
+            Transactions = billing.Transactions?.Select(t => new BillingTransaction(t));
+            Invoices = billing.Invoices?.Select(i => new BillingInvoice(i));
+        }
+        public IEnumerable<BillingInvoice> Invoices { get; set; }
+        public IEnumerable<BillingTransaction> Transactions { get; set; }
+    }
+}

--- a/src/Api/Models/Response/BillingHistoryResponseModel.cs
+++ b/src/Api/Models/Response/BillingHistoryResponseModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Bit.Core.Models.Api;
 using Bit.Core.Models.Business;

--- a/src/Api/Models/Response/BillingPaymentResponseModel.cs
+++ b/src/Api/Models/Response/BillingPaymentResponseModel.cs
@@ -1,4 +1,4 @@
-using Bit.Core.Models.Api;
+﻿using Bit.Core.Models.Api;
 using Bit.Core.Models.Business;
 
 namespace Bit.Api.Models.Response

--- a/src/Api/Models/Response/BillingPaymentResponseModel.cs
+++ b/src/Api/Models/Response/BillingPaymentResponseModel.cs
@@ -1,0 +1,18 @@
+using Bit.Core.Models.Api;
+using Bit.Core.Models.Business;
+
+namespace Bit.Api.Models.Response
+{
+    public class BillingPaymentResponseModel : ResponseModel
+    {
+        public BillingPaymentResponseModel(BillingInfo billing)
+            : base("billingPayment")
+        {
+            Balance = billing.Balance;
+            PaymentSource = billing.PaymentSource != null ? new BillingSource(billing.PaymentSource) : null;
+        }
+
+        public decimal Balance { get; set; }
+        public BillingSource PaymentSource { get; set; }
+    }
+}

--- a/src/Core/Services/IPaymentService.cs
+++ b/src/Core/Services/IPaymentService.cs
@@ -28,6 +28,8 @@ namespace Bit.Core.Services
             string paymentToken, bool allowInAppPurchases = false, TaxInfo taxInfo = null);
         Task<bool> CreditAccountAsync(ISubscriber subscriber, decimal creditAmount);
         Task<BillingInfo> GetBillingAsync(ISubscriber subscriber);
+        Task<BillingInfo> GetBillingHistoryAsync(ISubscriber subscriber);
+        Task<BillingInfo> GetBillingBalanceAndSourceAsync(ISubscriber subscriber);
         Task<SubscriptionInfo> GetSubscriptionAsync(ISubscriber subscriber);
         Task<TaxInfo> GetTaxInfoAsync(ISubscriber subscriber);
         Task SaveTaxInfoAsync(ISubscriber subscriber, TaxInfo taxInfo);

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -1459,24 +1459,24 @@ namespace Bit.Core.Services
 
             return billingInfo;
         }
-        
+
         public async Task<BillingInfo> GetBillingBalanceAndSourceAsync(ISubscriber subscriber)
         {
             var customer = await GetCustomerAsync(subscriber.GatewayCustomerId, true);
-            var billingInfo = new BillingInfo 
-            { 
+            var billingInfo = new BillingInfo
+            {
                 Balance = GetBillingBalance(customer),
                 PaymentSource = await GetBillingPaymentSourceAsync(customer)
             };
 
             return billingInfo;
         }
-        
+
         public async Task<BillingInfo> GetBillingHistoryAsync(ISubscriber subscriber)
         {
             var customer = await GetCustomerAsync(subscriber.GatewayCustomerId);
-            var billingInfo = new BillingInfo 
-            { 
+            var billingInfo = new BillingInfo
+            {
                 Transactions = await GetBillingTransactionsAsync(subscriber),
                 Invoices = await GetBillingInvoicesAsync(customer)
             };
@@ -1670,7 +1670,7 @@ namespace Bit.Core.Services
             {
                 return null;
             }
-            
+
             if (customer.Metadata?.ContainsKey("appleReceipt") ?? false)
             {
                 return new BillingInfo.BillingSource
@@ -1678,7 +1678,7 @@ namespace Bit.Core.Services
                     Type = PaymentMethodType.AppleInApp
                 };
             }
-            
+
             if (customer.Metadata?.ContainsKey("btCustomerId") ?? false)
             {
                 try
@@ -1693,19 +1693,19 @@ namespace Bit.Core.Services
                 }
                 catch (Braintree.Exceptions.NotFoundException) { }
             }
-            
+
             if (customer.InvoiceSettings?.DefaultPaymentMethod?.Type == "card")
             {
                 return new BillingInfo.BillingSource(
                     customer.InvoiceSettings.DefaultPaymentMethod);
             }
-            
+
             if (customer.DefaultSource != null &&
                 (customer.DefaultSource is Stripe.Card || customer.DefaultSource is Stripe.BankAccount))
             {
                 return new BillingInfo.BillingSource(customer.DefaultSource);
             }
-            
+
             var paymentMethod = GetLatestCardPaymentMethod(customer.Id);
             return paymentMethod != null ? new BillingInfo.BillingSource(paymentMethod) : null;
         }
@@ -1716,7 +1716,7 @@ namespace Bit.Core.Services
             {
                 return null;
             }
-            
+
             Stripe.Customer customer = null;
             try
             {
@@ -1733,7 +1733,7 @@ namespace Bit.Core.Services
 
             return customer;
         }
-        
+
         private async Task<IEnumerable<BillingInfo.BillingTransaction>> GetBillingTransactionsAsync(ISubscriber subscriber)
         {
             ICollection<Transaction> transactions = null;
@@ -1748,25 +1748,25 @@ namespace Bit.Core.Services
 
             return transactions?.OrderByDescending(i => i.CreationDate)
                 .Select(t => new BillingInfo.BillingTransaction(t));
-            
+
         }
-        
+
         private async Task<IEnumerable<BillingInfo.BillingInvoice>> GetBillingInvoicesAsync(Stripe.Customer customer)
         {
             if (customer == null)
             {
                 return null;
             }
-            
+
             var invoices = await _stripeAdapter.InvoiceListAsync(new Stripe.InvoiceListOptions
             {
                 Customer = customer.Id,
                 Limit = 50
             });
-                
+
             return invoices.Data.Where(i => i.Status != "void" && i.Status != "draft")
                 .OrderByDescending(i => i.Created).Select(i => new BillingInfo.BillingInvoice(i));
-            
+
         }
     }
 }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Because of changes to the UI structure for the `Settings -> Subscription` components, the `GetBilling` API needs to be separated in order to maintain components being self-contained for data.
> SG-19

## Code changes
- **AccountsController.cs**: Added `billing-history` and `billing-payment` API endpoints
- **BillingHistoryResponseModel.cs**: Created response model for housing `Invoices` and `Transactions`
- **BillingPaymentResponseModel.cs**: Created response model for housing `Balance` and `PaymentSource`
- **IPaymentService.cs**: Added new methods to interface: `GetBillingHistoryAsync` and `GetBillingBalanceAndSourceAsync`
- **StripePaymentService.cs**: Cleaned up existing `GetBillingAsync` method by breaking out different properties into functions that can be used independently. Created new methods `GetBillingHistoryAsync` and `GetBillingBalanceAndSourceAsync` for grabbing only the necessary information.

## Testing requirements
- Test new tabs available in `Settings -> Subscription`
- Test `Organization Settings -> Billing` as that will still use the `GetBilling` API that's in place (backwards-compat)

## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
