### PR TITLE
Allow for utilization of  readonly db connection

### DIFF
--- a/src/Infrastructure.Dapper/Repositories/UserRepository.cs
+++ b/src/Infrastructure.Dapper/Repositories/UserRepository.cs
@@ -109,7 +109,7 @@ namespace Bit.Infrastructure.Dapper.Repositories
 
         public async Task<DateTime> GetAccountRevisionDateAsync(Guid id)
         {
-            using (var connection = new SqlConnection(ConnectionString))
+            using (var connection = new SqlConnection(ReadOnlyConnectionString))
             {
                 var results = await connection.QueryAsync<DateTime>(
                     $"[{Schema}].[{Table}_ReadAccountRevisionDateById]",


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective
This PR allows the use of a read only connection string for GetAccountRevisionDateAsync

## Code changes
**-/src/Infrastructure.Dapper/Repositories/UserRepository.cs:** changed ConnectionString to ReadOnlyConnectionString

## Testing requirements
- Ensure we could use the ReadOnlyConnectionString
- Verify that the fallback mechanism works as expected


## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [x] This change has particular **deployment requirements** (notify the DevOps team)
