### PR TITLE
CSA-1 - adding master password authentication when enrolling in passw…

### DIFF
--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -271,8 +271,17 @@ namespace Bit.Api.Controllers
         [HttpPut("{userId}/reset-password-enrollment")]
         public async Task PutResetPasswordEnrollment(string orgId, string userId, [FromBody] OrganizationUserResetPasswordEnrollmentRequestModel model)
         {
+            var user = await _userService.GetUserByIdAsync(new Guid(userId));
+            var authenticated = await _userService.CheckPasswordAsync(user, model.MasterPasswordHash);
+
+            if (!authenticated)
+            {
+                throw new UnauthorizedAccessException("Invalid user name or password");
+            }
+
             var callingUserId = _userService.GetProperUserId(User);
-            await _organizationService.UpdateUserResetPasswordEnrollmentAsync(new Guid(orgId), new Guid(userId), model.ResetPasswordKey, callingUserId);
+            await _organizationService.UpdateUserResetPasswordEnrollmentAsync(
+                new Guid(orgId), new Guid(userId), model.ResetPasswordKey, callingUserId);
         }
 
         [HttpPut("{id}/reset-password")]

--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -279,7 +279,7 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException("Invalid user name or password");
             }
 
-            var callingUserId = _userService.GetProperUserId(User);
+            var callingUserId = user.Id;
             await _organizationService.UpdateUserResetPasswordEnrollmentAsync(
                 new Guid(orgId), new Guid(userId), model.ResetPasswordKey, callingUserId);
         }

--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -271,7 +271,7 @@ namespace Bit.Api.Controllers
         [HttpPut("{userId}/reset-password-enrollment")]
         public async Task PutResetPasswordEnrollment(string orgId, string userId, [FromBody] OrganizationUserResetPasswordEnrollmentRequestModel model)
         {
-            var user = await _userService.GetUserByIdAsync(new Guid(userId));
+            var user = await _userService.GetUserByPrincipalAsync(this.User);
             var authenticated = await _userService.CheckPasswordAsync(user, model.MasterPasswordHash);
 
             if (!authenticated)

--- a/src/Api/Models/Request/Organizations/OrganizationUserRequestModels.cs
+++ b/src/Api/Models/Request/Organizations/OrganizationUserRequestModels.cs
@@ -95,6 +95,7 @@ namespace Bit.Api.Models.Request.Organizations
     public class OrganizationUserResetPasswordEnrollmentRequestModel
     {
         public string ResetPasswordKey { get; set; }
+        public string MasterPasswordHash { get; set; }
     }
 
     public class OrganizationUserBulkRequestModel

--- a/src/Api/Models/Request/Organizations/OrganizationUserRequestModels.cs
+++ b/src/Api/Models/Request/Organizations/OrganizationUserRequestModels.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json;
+using Bit.Api.Models.Request.Accounts;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Models.Data;
@@ -92,10 +93,9 @@ namespace Bit.Api.Models.Request.Organizations
         public IEnumerable<string> GroupIds { get; set; }
     }
 
-    public class OrganizationUserResetPasswordEnrollmentRequestModel
+    public class OrganizationUserResetPasswordEnrollmentRequestModel : SecretVerificationRequestModel
     {
         public string ResetPasswordKey { get; set; }
-        public string MasterPasswordHash { get; set; }
     }
 
     public class OrganizationUserBulkRequestModel


### PR DESCRIPTION
…ord reset

## Type of change
- [ X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Adding master password authentication when enrolling in password reset



## Code changes

* **OrganizationUserRequestModel.cs:** Added master password hash property
* * **OrganizationUsersController.cs:** Added user password verification

## Testing requirements
Check that the user's master password is required to enroll in password reset



## Before you submit
- [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
