### PR TITLE
[PS-206] Enforce enterprise policies against users the first time they are enabled

### DIFF
--- a/src/Core/Services/Implementations/PolicyService.cs
+++ b/src/Core/Services/Implementations/PolicyService.cs
@@ -84,7 +84,8 @@ namespace Bit.Core.Services
             {
                 policy.CreationDate = now;
             }
-            else if (policy.Enabled)
+
+            if (policy.Enabled)
             {
                 var currentPolicy = await _policyRepository.GetByIdAsync(policy.Id);
                 if (!currentPolicy?.Enabled ?? true)
@@ -95,7 +96,7 @@ namespace Bit.Core.Services
                         ou.Status != Enums.OrganizationUserStatusType.Invited &&
                         ou.Type != Enums.OrganizationUserType.Owner && ou.Type != Enums.OrganizationUserType.Admin &&
                         ou.UserId != savingUserId);
-                    switch (currentPolicy.Type)
+                    switch (policy.Type)
                     {
                         case Enums.PolicyType.TwoFactorAuthentication:
                             foreach (var orgUser in removableOrgUsers)


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The first time Single Org and 2FA policies are enabled, they won't kick any noncompliant users. If you toggle them off and back on, they'll then start working as expected.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/Services/Implementations/PolicyService.cs**
  * make policy enforcement (i.e. user removal checks) apply to new `Policy` objects as well - for some reason this was being skipped by the `if/else if` structure
  * use the type of the policy being saved, rather than the type of the existing policy, for the `switch` statement. This lets the same logic work for new policies as well. And where there is an existing policy, it should be the same type anyway (a saved policy model never changes type).

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

* confirm bug is fixed - check both Single Org and 2FA policies
* regression test for situation where the org has enabled these policies before

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
