### PR TITLE
[PS-1280] small changes to icon fetching for self-hosted services

### DIFF
--- a/src/Icons/Models/IconResult.cs
+++ b/src/Icons/Models/IconResult.cs
@@ -44,7 +44,7 @@ namespace Bit.Icons.Models
 
             if (Priority == 0)
             {
-                Priority = 200;
+                Priority = 80;
             }
         }
 

--- a/src/Icons/Services/IconFetchingService.cs
+++ b/src/Icons/Services/IconFetchingService.cs
@@ -119,7 +119,7 @@ namespace Bit.Icons.Services
                     return null;
                 }
 
-                var baseUrl = "/";
+                var baseUrl = uri.ToString();
                 var baseUrlNode = document.QuerySelector("head base[href]");
                 if (baseUrlNode != null)
                 {
@@ -173,7 +173,7 @@ namespace Bit.Icons.Services
                 }
 
                 var iconResultTasks = new List<Task>();
-                foreach (var icon in icons.OrderBy(i => i.Priority).Take(10))
+                foreach (var icon in icons.OrderBy(i => i.Priority).Take(20))
                 {
                     Uri iconUri = null;
                     if (icon.Path.StartsWith("//") && Uri.TryCreate($"{GetScheme(uri)}://{icon.Path.Substring(2)}",


### PR DESCRIPTION
## Type of Change

Bug Fix

## Objective

The problematic website in question is Jellyfin. There were several issues preventing Bitwarden from retrieving a proper icon so I made changes to the relevent sections, but let me know if some of this needs to be removed.

## Code Changes

Priority: It seems like an icon link with no `sizes` property will get ranked higher than one with `sizes="256x256"` even though the latter has a confirmed size. I'm honestly not sure if this is true in practice, since the apple-touch-icon link was selected over the apple-touch-startup-image links for Jellyfin, despite the startup images having no size listed.

Base URL: This was the main issue and the only important change in this pull request. Bitwarden is checking for the `<base>` element which doesn't normally exist for self-hosted services. Jellyfin will send a `302` redirect to `/web/index.html` which was properly handled, but the resulting links were using `/` as the base URL which caused every single icon to fail. Not sure what the *best* solution is, but this pull request contains the quick solution I applied during testing.

Filtering: The favicon was ignored for Jellyfin only because it was near the end of the links in the head block and got filtered out by `icons.OrderBy(i => i.Priority).Take(10)` during the process. Not sure how helpful this will be in the future but I figured I would bring attention to the problem.

## Testing Requirements

Jellyfin has a [demo instance](https://demo.jellyfin.org) you can use to see this bug in action.