### PR TITLE
[EC-160] Give Provider Users access to all org ciphers and collections

### DIFF
--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -236,7 +236,7 @@ namespace Bit.Api.Controllers
                 var ciphers = await _cipherRepository.GetManyByUserIdAsync(userId, true);
                 orgCiphers = ciphers.Where(c => c.OrganizationId == orgIdGuid);
             }
-            
+
             var orgCipherIds = orgCiphers.Select(c => c.Id);
 
             var collectionCiphers = await _collectionCipherRepository.GetManyByOrganizationIdAsync(orgIdGuid);

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -224,8 +224,19 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
-            var ciphers = await _cipherRepository.GetManyByUserIdAsync(userId, true);
-            var orgCiphers = ciphers.Where(c => c.OrganizationId == orgIdGuid);
+            IEnumerable<Cipher> orgCiphers;
+            if (await _currentContext.OrganizationOwner(orgIdGuid))
+            {
+                // User may be a Provider for the organization, in which case GetManyByUserIdAsync won't return any results
+                // But they have access to all organization ciphers, so we can safely get by orgId instead
+                orgCiphers = await _cipherRepository.GetManyByOrganizationIdAsync(orgIdGuid);
+            }
+            else
+            {
+                var ciphers = await _cipherRepository.GetManyByUserIdAsync(userId, true);
+                orgCiphers = ciphers.Where(c => c.OrganizationId == orgIdGuid);
+            }
+            
             var orgCipherIds = orgCiphers.Select(c => c.Id);
 
             var collectionCiphers = await _collectionCipherRepository.GetManyByOrganizationIdAsync(orgIdGuid);

--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -87,11 +87,11 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
-            // User may be a Provider for the organization, in which case GetManyByUserIdAsync won't return any results
-            // But they have access to all organization collections, so we can safely get by orgId instead
             IEnumerable<Collection> orgCollections;
             if (await _currentContext.OrganizationOwner(orgIdGuid))
             {
+                // User may be a Provider for the organization, in which case GetManyByUserIdAsync won't return any results
+                // But they have access to all organization collections, so we can safely get by orgId instead
                 orgCollections = await _collectionRepository.GetManyByOrganizationIdAsync(orgIdGuid);
             }
             else

--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -87,8 +87,19 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
-            var collections = await _collectionRepository.GetManyByUserIdAsync(_currentContext.UserId.Value);
-            var orgCollections = collections.Where(c => c.OrganizationId == orgIdGuid);
+            // User may be a Provider for the organization, in which case GetManyByUserIdAsync won't return any results
+            // But they have access to all organization collections, so we can safely get by orgId instead
+            IEnumerable<Collection> orgCollections;
+            if (await _currentContext.OrganizationOwner(orgIdGuid))
+            {
+                orgCollections = await _collectionRepository.GetManyByOrganizationIdAsync(orgIdGuid);
+            }
+            else
+            {
+                var collections = await _collectionRepository.GetManyByUserIdAsync(_currentContext.UserId.Value);
+                orgCollections = collections.Where(c => c.OrganizationId == orgIdGuid);
+            }
+
             var responses = orgCollections.Select(c => new CollectionResponseModel(c));
             return new ListResponseModel<CollectionResponseModel>(responses);
         }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix bug: Provider Users cannot see any ciphers or collections for orgs they manage.

Git blame: https://github.com/bitwarden/server/pull/1906

That PR changed the code to use `CipherRepository.GetManyByUserIdAsync` and `CollectionRepository.GetManyByUserIdAsync`. However, these methods do not take account of providers - they are purely based on `User` and `OrganizationUser` permissions. Therefore, if the user has access via a provider, they are not getting any results back from the database query.

**Note: this will be a hotfix** 

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Revert back to the old logic if the user is an Owner (which includes Provider Users). To me, this seems like the simplest and safest solution for a hotfix. And aside from that, I'm not sure we need to complicate the logic of the underlying SQL queries by adding providers to them, just for this case.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

* confirm that the bug is fixed
* check for regressions against the original bug and generally

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [x] This change has particular **deployment requirements** (notify the DevOps team)
