### PR TITLE
[PS-7] change revert email copy and add ValidUntil to sponsorship

### DIFF
--- a/src/Core/MailTemplates/Handlebars/FamiliesForEnterprise/FamiliesForEnterpriseSponsorshipReverting.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/FamiliesForEnterprise/FamiliesForEnterpriseSponsorshipReverting.html.hbs
@@ -2,7 +2,7 @@
 <table width="100%" cellpadding="0" cellspacing="0" style="margin: 0; box-sizing: border-box; line-height: 25px; -webkit-text-size-adjust: none;">
     <tr style="margin: 0; box-sizing: border-box; line-height: 25px; -webkit-text-size-adjust: none;">
         <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;" valign="top">
-            Your Families for Enterprise sponsorship will revert back to your existing payment method at the end of the current billing cycle.
+            Your Families subscription will remain sponsored until {{ExpirationDate}}. To continue your plan, make sure you have a current payment method for the subscription. Review or update your payment method under Settings in your Families Organization.
         </td>
     </tr>
 </table>

--- a/src/Core/MailTemplates/Handlebars/FamiliesForEnterprise/FamiliesForEnterpriseSponsorshipReverting.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/FamiliesForEnterprise/FamiliesForEnterpriseSponsorshipReverting.text.hbs
@@ -1,3 +1,3 @@
 {{#>BasicTextLayout}}
-Your Families for Enterprise sponsorship will revert back to your existing payment method at the end of the current billing cycle.
+Your Families subscription will remain sponsored until {{Date}}. To continue your plan, make sure you have a current payment method for the subscription. Review or update your payment method under Settings in your Families Organization.
 {{/BasicTextLayout}}

--- a/src/Core/Models/Mail/FamiliesForEnterprise/FamiliesForEnterpriseSponsorshipRevertingViewModel.cs
+++ b/src/Core/Models/Mail/FamiliesForEnterprise/FamiliesForEnterpriseSponsorshipRevertingViewModel.cs
@@ -1,7 +1,9 @@
-﻿namespace Bit.Core.Models.Mail.FamiliesForEnterprise
+﻿using System;
+
+namespace Bit.Core.Models.Mail.FamiliesForEnterprise
 {
     public class FamiliesForEnterpriseSponsorshipRevertingViewModel : BaseMailModel
     {
-        public string OrganizationName { get; set; }
+        public DateTime ExpirationDate { get; set; }
     }
 }

--- a/src/Core/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/Cloud/ValidateSponsorshipCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/Cloud/ValidateSponsorshipCommand.cs
@@ -84,7 +84,7 @@ namespace Bit.Core.OrganizationFeatures.OrganizationSponsorships.FamiliesForEnte
                     {
                         await _mailService.SendFamiliesForEnterpriseSponsorshipRevertingEmailAsync(
                             sponsoredOrganization.BillingEmailAddress(),
-                            sponsorship.ValidUntil.GetValueOrDefault());
+                            sponsorship.ValidUntil ?? DateTime.UtcNow.AddDays(15));
                     }
                 }
                 catch (Exception e)

--- a/src/Core/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/Cloud/ValidateSponsorshipCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/Cloud/ValidateSponsorshipCommand.cs
@@ -80,9 +80,12 @@ namespace Bit.Core.OrganizationFeatures.OrganizationSponsorships.FamiliesForEnte
 
                 try
                 {
-                    await _mailService.SendFamiliesForEnterpriseSponsorshipRevertingEmailAsync(
-                        sponsoredOrganization.BillingEmailAddress(),
-                        sponsoredOrganization.Name);
+                    if (sponsorship != null)
+                    {
+                        await _mailService.SendFamiliesForEnterpriseSponsorshipRevertingEmailAsync(
+                            sponsoredOrganization.BillingEmailAddress(),
+                            sponsorship.ValidUntil.GetValueOrDefault());
+                    }
                 }
                 catch (Exception e)
                 {

--- a/src/Core/Services/IMailService.cs
+++ b/src/Core/Services/IMailService.cs
@@ -53,7 +53,7 @@ namespace Bit.Core.Services
         Task SendFamiliesForEnterpriseOfferEmailAsync(string sponsorOrgName, string email, bool existingAccount, string token);
         Task BulkSendFamiliesForEnterpriseOfferEmailAsync(string SponsorOrgName, IEnumerable<(string Email, bool ExistingAccount, string Token)> invites);
         Task SendFamiliesForEnterpriseRedeemedEmailsAsync(string familyUserEmail, string sponsorEmail);
-        Task SendFamiliesForEnterpriseSponsorshipRevertingEmailAsync(string email, string familyOrgName);
+        Task SendFamiliesForEnterpriseSponsorshipRevertingEmailAsync(string email, DateTime expirationDate);
         Task SendOTPEmailAsync(string email, string token);
         Task SendFailedLoginAttemptsEmailAsync(string email, DateTime utcNow, string ip);
         Task SendFailedTwoFactorAttemptsEmailAsync(string email, DateTime utcNow, string ip);

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -824,12 +824,12 @@ namespace Bit.Core.Services
             await _mailDeliveryService.SendEmailAsync(message);
         }
 
-        public async Task SendFamiliesForEnterpriseSponsorshipRevertingEmailAsync(string email, string familyOrgName)
+        public async Task SendFamiliesForEnterpriseSponsorshipRevertingEmailAsync(string email, DateTime expirationDate)
         {
-            var message = CreateDefaultMessage($"{familyOrgName} Organization Sponsorship Is No Longer Valid", email);
+            var message = CreateDefaultMessage("Your Families Sponsorship was Removed", email);
             var model = new FamiliesForEnterpriseSponsorshipRevertingViewModel
             {
-                OrganizationName = CoreHelpers.SanitizeForEmail(familyOrgName, false),
+                ExpirationDate = expirationDate,
             };
             await AddMessageContentAsync(message, "FamiliesForEnterprise.FamiliesForEnterpriseSponsorshipReverting", model);
             message.Category = "FamiliesForEnterpriseSponsorshipReverting";

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -204,6 +204,7 @@ namespace Bit.Core.Services
 
             var sub = await _stripeAdapter.SubscriptionGetAsync(org.GatewaySubscriptionId);
             org.ExpirationDate = sub.CurrentPeriodEnd;
+            sponsorship.ValidUntil = sub.CurrentPeriodEnd;
 
         }
 

--- a/src/Core/Services/NoopImplementations/NoopMailService.cs
+++ b/src/Core/Services/NoopImplementations/NoopMailService.cs
@@ -221,7 +221,7 @@ namespace Bit.Core.Services
             return Task.FromResult(0);
         }
 
-        public Task SendFamiliesForEnterpriseSponsorshipRevertingEmailAsync(string email, string familyOrgName)
+        public Task SendFamiliesForEnterpriseSponsorshipRevertingEmailAsync(string email, DateTime expirationDate)
         {
             return Task.FromResult(0);
         }

--- a/test/Core.Test/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/CancelSponsorshipCommandTestsBase.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/CancelSponsorshipCommandTestsBase.cs
@@ -16,8 +16,11 @@ namespace Bit.Core.Test.OrganizationFeatures.OrganizationSponsorships.FamiliesFo
             await sutProvider.GetDependency<IPaymentService>().Received(1)
                 .RemoveOrganizationSponsorshipAsync(sponsoredOrg, sponsorship);
             await sutProvider.GetDependency<IOrganizationRepository>().Received(1).UpsertAsync(sponsoredOrg);
-            await sutProvider.GetDependency<IMailService>().Received(1)
-                .SendFamiliesForEnterpriseSponsorshipRevertingEmailAsync(sponsoredOrg.BillingEmailAddress(), sponsoredOrg.Name);
+            if (sponsorship != null)
+            {
+                await sutProvider.GetDependency<IMailService>().Received(1)
+                    .SendFamiliesForEnterpriseSponsorshipRevertingEmailAsync(sponsoredOrg.BillingEmailAddress(), sponsorship.ValidUntil.GetValueOrDefault());
+            }
         }
 
         protected async Task AssertDeletedSponsorshipAsync<T>(OrganizationSponsorship sponsorship,


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Changed the copy for RevertSponsorship emails

Added the `ValidUntil` property to sponsorships whenever they are modified


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
- Check for correct email copy when invoice upcoming event is sent from stripe


## Before you submit
- [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
