### PR TITLE
Update OrganizationSponsorship valid until when updating org expirati…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,6 +40,7 @@
                 "Identity",
                 "Sso",
                 "Icons",
+                "Billing"
             ],
             "presentation": {
                 "hidden": false,
@@ -117,6 +118,28 @@
             "program": "${workspaceFolder}/src/Api/bin/Debug/net5.0/Api.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Api",
+            "stopAtEntry": false,
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
+            "name": "Billing",
+            "presentation": {
+                "hidden": false,
+                "group": "cloud",
+                "order": 10
+            },
+            "requireExactSource": true,
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "buildBilling",
+            "program": "${workspaceFolder}/src/Billing/bin/Debug/net5.0/Billing.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/Billing",
             "stopAtEntry": false,
             "env": {
                 "ASPNETCORE_ENVIRONMENT": "Development"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -90,6 +90,22 @@
             }
         },
         {
+            "label": "buildBilling",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/Billing/Billing.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
             "label": "clean",
             "type": "shell",
             "command": "dotnet clean",

--- a/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
+++ b/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ namespace Bit.Core.OrganizationFeatures
             services.AddScoped<IValidateRedemptionTokenCommand, ValidateRedemptionTokenCommand>();
             services.AddScoped<IValidateSponsorshipCommand, ValidateSponsorshipCommand>();
             services.AddScoped<IValidateBillingSyncKeyCommand, ValidateBillingSyncKeyCommand>();
+            services.AddScoped<IOrganizationSponsorshipRenewCommand, OrganizationSponsorshipRenewCommand>();
             services.AddScoped<ICloudSyncSponsorshipsCommand, CloudSyncSponsorshipsCommand>();
             services.AddScoped<ISelfHostedSyncSponsorshipsCommand, SelfHostedSyncSponsorshipsCommand>();
             services.AddScoped<ISelfHostedSyncSponsorshipsCommand, SelfHostedSyncSponsorshipsCommand>();

--- a/src/Core/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/Cloud/OrganizationSponsorshipRenewCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/Cloud/OrganizationSponsorshipRenewCommand.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+using Bit.Core.OrganizationFeatures.OrganizationSponsorships.FamiliesForEnterprise.Interfaces;
+using Bit.Core.Repositories;
+
+namespace Bit.Core.OrganizationFeatures.OrganizationSponsorships.FamiliesForEnterprise.Cloud
+{
+    public class OrganizationSponsorshipRenewCommand : IOrganizationSponsorshipRenewCommand
+    {
+        private readonly IOrganizationSponsorshipRepository _organizationSponsorshipRepository;
+
+        public OrganizationSponsorshipRenewCommand(IOrganizationSponsorshipRepository organizationSponsorshipRepository)
+        {
+            _organizationSponsorshipRepository = organizationSponsorshipRepository;
+        }
+
+        public async Task UpdateExpirationDateAsync(Guid organizationId, DateTime expireDate)
+        {
+            var sponsorship = await _organizationSponsorshipRepository.GetBySponsoredOrganizationIdAsync(organizationId);
+
+            if (sponsorship == null)
+            {
+                return;
+            }
+
+            sponsorship.ValidUntil = expireDate;
+            await _organizationSponsorshipRepository.UpsertAsync(sponsorship);
+        }
+    }
+}

--- a/src/Core/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/Cloud/OrganizationSponsorshipRenewCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/Cloud/OrganizationSponsorshipRenewCommand.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Bit.Core.OrganizationFeatures.OrganizationSponsorships.FamiliesForEnterprise.Interfaces;
 using Bit.Core.Repositories;

--- a/src/Core/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/Interfaces/IOrganizationSponsorshipRenewCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/Interfaces/IOrganizationSponsorshipRenewCommand.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 
 namespace Bit.Core.OrganizationFeatures.OrganizationSponsorships.FamiliesForEnterprise.Interfaces

--- a/src/Core/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/Interfaces/IOrganizationSponsorshipRenewCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/Interfaces/IOrganizationSponsorshipRenewCommand.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Bit.Core.OrganizationFeatures.OrganizationSponsorships.FamiliesForEnterprise.Interfaces
+{
+    public interface IOrganizationSponsorshipRenewCommand
+    {
+        Task UpdateExpirationDateAsync(Guid organizationId, DateTime expireDate);
+    }
+}

--- a/test/Core.Test/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/Cloud/OrganizationSponsorshipRenewCommandTests.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/Cloud/OrganizationSponsorshipRenewCommandTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Bit.Core.Entities;
 using Bit.Core.OrganizationFeatures.OrganizationSponsorships.FamiliesForEnterprise.Cloud;

--- a/test/Core.Test/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/Cloud/OrganizationSponsorshipRenewCommandTests.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/Cloud/OrganizationSponsorshipRenewCommandTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using Bit.Core.Entities;
+using Bit.Core.OrganizationFeatures.OrganizationSponsorships.FamiliesForEnterprise.Cloud;
+using Bit.Core.Repositories;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.OrganizationFeatures.OrganizationSponsorships.FamiliesForEnterprise.Cloud
+{
+    [SutProviderCustomize]
+    public class OrganizationSponsorshipRenewCommandTests
+    {
+        [Theory]
+        [BitAutoData]
+        public async Task UpdateExpirationDate_UpdatesValidUntil(OrganizationSponsorship sponsorship, DateTime expireDate,
+            SutProvider<OrganizationSponsorshipRenewCommand> sutProvider)
+        {
+            sutProvider.GetDependency<IOrganizationSponsorshipRepository>().GetBySponsoredOrganizationIdAsync(sponsorship.SponsoredOrganizationId.Value).Returns(sponsorship);
+
+            await sutProvider.Sut.UpdateExpirationDateAsync(sponsorship.SponsoredOrganizationId.Value, expireDate);
+
+            await sutProvider.GetDependency<IOrganizationSponsorshipRepository>().Received(1)
+                .UpsertAsync(sponsorship);
+        }
+    }
+}


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Update valid until when we update an organization's Expiration date. This is done whenever the subscription is updated.

## Testing requirements
Ensure validUntil date represents the correct date.



## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
