### PR TITLE
captcha scores

### DIFF
--- a/src/Core/IdentityServer/BaseRequestValidator.cs
+++ b/src/Core/IdentityServer/BaseRequestValidator.cs
@@ -92,9 +92,12 @@ namespace Bit.Core.IdentityServer
 
             var valid = await ValidateContextAsync(context, validatorContext);
             var user = validatorContext.User;
-            if (!valid || isBot)
+            if (!valid)
             {
                 await UpdateFailedAuthDetailsAsync(user, false, !validatorContext.KnownDevice);
+            }
+            if (!valid || isBot)
+            {
                 await BuildErrorResultAsync("Username or password is incorrect. Try again.", false, context, user);
                 return;
             }

--- a/src/Core/IdentityServer/CustomTokenRequestValidator.cs
+++ b/src/Core/IdentityServer/CustomTokenRequestValidator.cs
@@ -62,15 +62,20 @@ namespace Bit.Core.IdentityServer
             {
                 return;
             }
-            await ValidateAsync(context, context.Result.ValidatedRequest);
+            await ValidateAsync(context, context.Result.ValidatedRequest,
+                new CustomValidatorRequestContext { KnownDevice = true });
         }
 
-        protected async override Task<(User, bool)> ValidateContextAsync(CustomTokenRequestValidationContext context)
+        protected async override Task<bool> ValidateContextAsync(CustomTokenRequestValidationContext context,
+            CustomValidatorRequestContext validatorContext)
         {
             var email = context.Result.ValidatedRequest.Subject?.GetDisplayName()
                 ?? context.Result.ValidatedRequest.ClientClaims?.FirstOrDefault(claim => claim.Type == JwtClaimTypes.Email)?.Value;
-            var user = string.IsNullOrWhiteSpace(email) ? null : await _userManager.FindByEmailAsync(email);
-            return (user, user != null);
+            if (!string.IsNullOrWhiteSpace(email))
+            {
+                validatorContext.User = await _userManager.FindByEmailAsync(email);
+            }
+            return validatorContext.User != null;
         }
 
         protected override async Task SetSuccessResult(CustomTokenRequestValidationContext context, User user,

--- a/src/Core/IdentityServer/CustomValidatorRequestContext.cs
+++ b/src/Core/IdentityServer/CustomValidatorRequestContext.cs
@@ -1,0 +1,12 @@
+﻿using Bit.Core.Entities;
+using Bit.Core.Models.Business;
+
+namespace Bit.Core.IdentityServer
+{
+    public class CustomValidatorRequestContext
+    {
+        public User User { get; set; }
+        public bool KnownDevice { get; set; }
+        public CaptchaResponse CaptchaResponse { get; set; }
+    }
+}

--- a/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
+++ b/src/Core/IdentityServer/ResourceOwnerPasswordValidator.cs
@@ -59,25 +59,31 @@ namespace Bit.Core.IdentityServer
                 return;
             }
 
-            string bypassToken = null;
             var user = await _userManager.FindByEmailAsync(context.UserName.ToLowerInvariant());
-            var unknownDevice = !await KnownDeviceAsync(user, context.Request);
-            if (unknownDevice && _captchaValidationService.RequireCaptchaValidation(_currentContext, user?.FailedLoginCount ?? 0))
+            var validatorContext = new CustomValidatorRequestContext
+            {
+                User = user,
+                KnownDevice = await KnownDeviceAsync(user, context.Request)
+            };
+            string bypassToken = null;
+            if (!validatorContext.KnownDevice &&
+                _captchaValidationService.RequireCaptchaValidation(_currentContext, user))
             {
                 var captchaResponse = context.Request.Raw["captchaResponse"]?.ToString();
 
                 if (string.IsNullOrWhiteSpace(captchaResponse))
                 {
                     context.Result = new GrantValidationResult(TokenRequestErrors.InvalidGrant, "Captcha required.",
-                        new Dictionary<string, object> {
+                        new Dictionary<string, object>
+                        {
                             { _captchaValidationService.SiteKeyResponseKeyName, _captchaValidationService.SiteKey },
                         });
                     return;
                 }
 
-                var captchaValid = _captchaValidationService.ValidateCaptchaBypassToken(captchaResponse, user) ||
-                    await _captchaValidationService.ValidateCaptchaResponseAsync(captchaResponse, _currentContext.IpAddress);
-                if (!captchaValid)
+                validatorContext.CaptchaResponse = await _captchaValidationService.ValidateCaptchaResponseAsync(
+                    captchaResponse, _currentContext.IpAddress, null);
+                if (!validatorContext.CaptchaResponse.Success)
                 {
                     await BuildErrorResultAsync("Captcha is invalid. Please refresh and try again", false, context, null);
                     return;
@@ -85,27 +91,27 @@ namespace Bit.Core.IdentityServer
                 bypassToken = _captchaValidationService.GenerateCaptchaBypassToken(user);
             }
 
-            await ValidateAsync(context, context.Request, unknownDevice);
+            await ValidateAsync(context, context.Request, validatorContext);
             if (context.Result.CustomResponse != null && bypassToken != null)
             {
                 context.Result.CustomResponse["CaptchaBypassToken"] = bypassToken;
             }
         }
 
-        protected async override Task<(User, bool)> ValidateContextAsync(ResourceOwnerPasswordValidationContext context)
+        protected async override Task<bool> ValidateContextAsync(ResourceOwnerPasswordValidationContext context,
+            CustomValidatorRequestContext validatorContext)
         {
-            if (string.IsNullOrWhiteSpace(context.UserName))
+            if (string.IsNullOrWhiteSpace(context.UserName) || validatorContext.User == null)
             {
-                return (null, false);
+                return false;
             }
 
-            var user = await _userManager.FindByEmailAsync(context.UserName.ToLowerInvariant());
-            if (user == null || !await _userService.CheckPasswordAsync(user, context.Password))
+            if (!await _userService.CheckPasswordAsync(validatorContext.User, context.Password))
             {
-                return (user, false);
+                return false;
             }
 
-            return (user, true);
+            return true;
         }
 
         protected override Task SetSuccessResult(ResourceOwnerPasswordValidationContext context, User user,

--- a/src/Core/Models/Business/CaptchaResponse.cs
+++ b/src/Core/Models/Business/CaptchaResponse.cs
@@ -1,0 +1,9 @@
+﻿namespace Bit.Core.Models.Business
+{
+    public class CaptchaResponse
+    {
+        public bool Success { get; set; }
+        public bool MaybeBot { get; set; }
+        public bool IsBot { get; set; }
+    }
+}

--- a/src/Core/Services/ICaptchaValidationService.cs
+++ b/src/Core/Services/ICaptchaValidationService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Bit.Core.Context;
 using Bit.Core.Entities;
+using Bit.Core.Models.Business;
 
 namespace Bit.Core.Services
 {
@@ -8,10 +9,9 @@ namespace Bit.Core.Services
     {
         string SiteKey { get; }
         string SiteKeyResponseKeyName { get; }
-        bool RequireCaptchaValidation(ICurrentContext currentContext, int failedLoginCount = 0);
-        Task<bool> ValidateCaptchaResponseAsync(string captchResponse, string clientIpAddress);
+        bool RequireCaptchaValidation(ICurrentContext currentContext, User user = null);
+        Task<CaptchaResponse> ValidateCaptchaResponseAsync(string captchResponse, string clientIpAddress,
+            User user = null);
         string GenerateCaptchaBypassToken(User user);
-        bool ValidateCaptchaBypassToken(string encryptedToken, User user);
-        bool ValidateFailedAuthEmailConditions(bool unknownDevice, int failedLoginCount);
     }
 }

--- a/src/Core/Services/Implementations/HCaptchaValidationService.cs
+++ b/src/Core/Services/Implementations/HCaptchaValidationService.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Bit.Core.Context;
 using Bit.Core.Entities;
+using Bit.Core.Models.Business;
 using Bit.Core.Models.Business.Tokenables;
 using Bit.Core.Settings;
 using Bit.Core.Tokens;
@@ -37,14 +39,19 @@ namespace Bit.Core.Services
 
         public string GenerateCaptchaBypassToken(User user) => _tokenizer.Protect(new HCaptchaTokenable(user));
 
-        public bool ValidateCaptchaBypassToken(string bypassToken, User user) =>
-            TokenIsApiKey(bypassToken, user) || TokenIsCaptchaBypassToken(bypassToken, user);
-
-        public async Task<bool> ValidateCaptchaResponseAsync(string captchaResponse, string clientIpAddress)
+        public async Task<CaptchaResponse> ValidateCaptchaResponseAsync(string captchaResponse, string clientIpAddress,
+            User user = null)
         {
+            var response = new CaptchaResponse { Success = false };
             if (string.IsNullOrWhiteSpace(captchaResponse))
             {
-                return false;
+                return response;
+            }
+
+            if (user != null && ValidateCaptchaBypassToken(captchaResponse, user))
+            {
+                response.Success = true;
+                return response;
             }
 
             var httpClient = _httpClientFactory.CreateClient("HCaptchaValidationService");
@@ -70,39 +77,60 @@ namespace Bit.Core.Services
             catch (Exception e)
             {
                 _logger.LogError(11389, e, "Unable to verify with HCaptcha.");
-                return false;
+                return response;
             }
 
             if (!responseMessage.IsSuccessStatusCode)
             {
-                return false;
+                return response;
             }
 
-            using var jsonDocument = await responseMessage.Content.ReadFromJsonAsync<JsonDocument>();
-            var root = jsonDocument.RootElement;
-            return root.GetProperty("success").GetBoolean();
+            using var hcaptchResponse = await responseMessage.Content.ReadFromJsonAsync<HCpatchaResponse>();
+            response.Success = hcaptchResponse.Success;
+            var score = hcaptchResponse.Score.GetValueOrDefault();
+            response.MaybeBot = score >= _globalSettings.Captcha.MaybeBotScoreThreshold;
+            response.IsBot = score >= _globalSettings.Captcha.IsBotScoreThreshold;
+            return response;
         }
 
-        public bool RequireCaptchaValidation(ICurrentContext currentContext, int failedLoginCount = 0)
+        public bool RequireCaptchaValidation(ICurrentContext currentContext, User user = null)
         {
+            if (user == null)
+            {
+                return currentContext.IsBot || _globalSettings.Captcha.ForceCaptchaRequired;
+            }
+
             var failedLoginCeiling = _globalSettings.Captcha.MaximumFailedLoginAttempts;
+            var failedLoginCount = user?.FailedLoginCount ?? 0;
+            var cloudEmailUnverified = !_globalSettings.SelfHosted && !user.EmailVerified;
             return currentContext.IsBot ||
                    _globalSettings.Captcha.ForceCaptchaRequired ||
+                   cloudEmailUnverified ||
                    failedLoginCeiling > 0 && failedLoginCount >= failedLoginCeiling;
         }
 
-        public bool ValidateFailedAuthEmailConditions(bool unknownDevice, int failedLoginCount)
-        {
-            var failedLoginCeiling = _globalSettings.Captcha.MaximumFailedLoginAttempts;
-            return unknownDevice && failedLoginCeiling > 0 && failedLoginCount == failedLoginCeiling;
-        }
-
-        private static bool TokenIsApiKey(string bypassToken, User user) =>
+        private static bool TokenIsValidApiKey(string bypassToken, User user) =>
             !string.IsNullOrWhiteSpace(bypassToken) && user != null && user.ApiKey == bypassToken;
-        private bool TokenIsCaptchaBypassToken(string encryptedToken, User user)
+
+        private bool TokenIsValidCaptchaBypassToken(string encryptedToken, User user)
         {
             return _tokenizer.TryUnprotect(encryptedToken, out var data) &&
                 data.Valid && data.TokenIsValid(user);
+        }
+
+        private bool ValidateCaptchaBypassToken(string bypassToken, User user) =>
+            TokenIsValidApiKey(bypassToken, user) || TokenIsValidCaptchaBypassToken(bypassToken, user);
+
+        public class HCpatchaResponse : IDisposable
+        {
+            [JsonPropertyName("success")]
+            public bool Success { get; set; }
+            [JsonPropertyName("score")]
+            public double? Score { get; set; }
+            [JsonPropertyName("score_reason")]
+            public string ScoreReason { get; set; }
+
+            public void Dispose() { }
         }
     }
 }

--- a/src/Core/Services/Implementations/HCaptchaValidationService.cs
+++ b/src/Core/Services/Implementations/HCaptchaValidationService.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Json;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Bit.Core.Context;
@@ -85,7 +84,7 @@ namespace Bit.Core.Services
                 return response;
             }
 
-            using var hcaptchResponse = await responseMessage.Content.ReadFromJsonAsync<HCpatchaResponse>();
+            using var hcaptchResponse = await responseMessage.Content.ReadFromJsonAsync<HCaptchaResponse>();
             response.Success = hcaptchResponse.Success;
             var score = hcaptchResponse.Score.GetValueOrDefault();
             response.MaybeBot = score >= _globalSettings.Captcha.MaybeBotScoreThreshold;
@@ -121,14 +120,14 @@ namespace Bit.Core.Services
         private bool ValidateCaptchaBypassToken(string bypassToken, User user) =>
             TokenIsValidApiKey(bypassToken, user) || TokenIsValidCaptchaBypassToken(bypassToken, user);
 
-        public class HCpatchaResponse : IDisposable
+        public class HCaptchaResponse : IDisposable
         {
             [JsonPropertyName("success")]
             public bool Success { get; set; }
             [JsonPropertyName("score")]
             public double? Score { get; set; }
             [JsonPropertyName("score_reason")]
-            public string ScoreReason { get; set; }
+            public List<string> ScoreReason { get; set; }
 
             public void Dispose() { }
         }

--- a/src/Core/Services/Implementations/HCaptchaValidationService.cs
+++ b/src/Core/Services/Implementations/HCaptchaValidationService.cs
@@ -84,9 +84,9 @@ namespace Bit.Core.Services
                 return response;
             }
 
-            using var hcaptchResponse = await responseMessage.Content.ReadFromJsonAsync<HCaptchaResponse>();
-            response.Success = hcaptchResponse.Success;
-            var score = hcaptchResponse.Score.GetValueOrDefault();
+            using var hcaptchaResponse = await responseMessage.Content.ReadFromJsonAsync<HCaptchaResponse>();
+            response.Success = hcaptchaResponse.Success;
+            var score = hcaptchaResponse.Score.GetValueOrDefault();
             response.MaybeBot = score >= _globalSettings.Captcha.MaybeBotScoreThreshold;
             response.IsBot = score >= _globalSettings.Captcha.IsBotScoreThreshold;
             return response;

--- a/src/Core/Services/NoopImplementations/NoopCaptchaValidationService.cs
+++ b/src/Core/Services/NoopImplementations/NoopCaptchaValidationService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Bit.Core.Context;
 using Bit.Core.Entities;
+using Bit.Core.Models.Business;
 
 namespace Bit.Core.Services
 {
@@ -8,13 +9,12 @@ namespace Bit.Core.Services
     {
         public string SiteKeyResponseKeyName => null;
         public string SiteKey => null;
-        public bool RequireCaptchaValidation(ICurrentContext currentContext, int failedLoginCount = 0) => false;
-        public bool ValidateFailedAuthEmailConditions(bool unknownDevice, int failedLoginCount) => false;
+        public bool RequireCaptchaValidation(ICurrentContext currentContext, User user = null) => false;
         public string GenerateCaptchaBypassToken(User user) => "";
-        public bool ValidateCaptchaBypassToken(string encryptedToken, User user) => false;
-        public Task<bool> ValidateCaptchaResponseAsync(string captchResponse, string clientIpAddress)
+        public Task<CaptchaResponse> ValidateCaptchaResponseAsync(string captchaResponse, string clientIpAddress,
+            User user = null)
         {
-            return Task.FromResult(true);
+            return Task.FromResult(new CaptchaResponse { Success = true });
         }
     }
 }

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -469,6 +469,8 @@ namespace Bit.Core.Settings
             public string HCaptchaSecretKey { get; set; }
             public string HCaptchaSiteKey { get; set; }
             public int MaximumFailedLoginAttempts { get; set; }
+            public double MaybeBotScoreThreshold { get; set; } = double.MaxValue;
+            public double IsBotScoreThreshold { get; set; } = double.MaxValue;
         }
 
         public class StripeSettings

--- a/src/Core/Utilities/CaptchaProtectedAttribute.cs
+++ b/src/Core/Utilities/CaptchaProtectedAttribute.cs
@@ -16,7 +16,7 @@ namespace Bit.Core.Utilities
             var currentContext = context.HttpContext.RequestServices.GetRequiredService<ICurrentContext>();
             var captchaValidationService = context.HttpContext.RequestServices.GetRequiredService<ICaptchaValidationService>();
 
-            if (captchaValidationService.RequireCaptchaValidation(currentContext))
+            if (captchaValidationService.RequireCaptchaValidation(currentContext, null))
             {
                 var captchaResponse = (context.ActionArguments[ModelParameterName] as ICaptchaProtectedModel)?.CaptchaResponse;
 
@@ -25,9 +25,9 @@ namespace Bit.Core.Utilities
                     throw new BadRequestException(captchaValidationService.SiteKeyResponseKeyName, captchaValidationService.SiteKey);
                 }
 
-                var captchaValid = captchaValidationService.ValidateCaptchaResponseAsync(captchaResponse,
-                    currentContext.IpAddress).GetAwaiter().GetResult();
-                if (!captchaValid)
+                var captchaValidationResponse = captchaValidationService.ValidateCaptchaResponseAsync(captchaResponse,
+                    currentContext.IpAddress, null).GetAwaiter().GetResult();
+                if (!captchaValidationResponse.Success)
                 {
                     throw new BadRequestException("Captcha is invalid. Please refresh and try again");
                 }

--- a/src/Core/Utilities/CaptchaProtectedAttribute.cs
+++ b/src/Core/Utilities/CaptchaProtectedAttribute.cs
@@ -27,7 +27,7 @@ namespace Bit.Core.Utilities
 
                 var captchaValidationResponse = captchaValidationService.ValidateCaptchaResponseAsync(captchaResponse,
                     currentContext.IpAddress, null).GetAwaiter().GetResult();
-                if (!captchaValidationResponse.Success)
+                if (!captchaValidationResponse.Success || captchaValidationResponse.IsBot)
                 {
                     throw new BadRequestException("Captcha is invalid. Please refresh and try again");
                 }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Implement captcha scores.

While I was in here, I also took the opportunity to cleanup some things related to captcha's existing implementation with identity validators and optimize parameter passing and database lookups with a context class.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **hcaptcha validation service:** Expanded response to include scoring. Made `ValidateCaptchaBypassToken` private and moved out `ValidateFailedAuthEmailConditions` to the validator class.
* **global settings:** Add score thresholds
* **CustomValidatorRequestContext:** Added to reduce parameters being passed validator functions around reduce lookups to database. Looking at the rest of the code, I feel like we might could extend the use of this more to optimize database lookups during authentication by preserving some context between function calls.
* **base request validator:** Moved `ValidateFailedAuthEmailConditions` here since it was the only place it was being used. Applied `CustomValidatorRequestContext` and `CaptchaResponse` scoring.
* **resource owner request validator:** React to changes in base class
* **custom token request validator:** React to changes in base class

## Testing requirements
Regression testing of authentication. 

Note to QA: See me for more "offline discussion" on properly testing this.

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [x] This change has particular **deployment requirements** (notify the DevOps team)
