### PR TITLE
[PS-284] Allow installation clients to not need a user.

### DIFF
--- a/src/Core/IdentityServer/CustomTokenRequestValidator.cs
+++ b/src/Core/IdentityServer/CustomTokenRequestValidator.cs
@@ -57,7 +57,7 @@ namespace Bit.Core.IdentityServer
         public async Task ValidateAsync(CustomTokenRequestValidationContext context)
         {
             string[] allowedGrantTypes = { "authorization_code", "client_credentials" };
-            if (!allowedGrantTypes.Contains(context.Result.ValidatedRequest.GrantType) 
+            if (!allowedGrantTypes.Contains(context.Result.ValidatedRequest.GrantType)
                 || context.Result.ValidatedRequest.ClientId.StartsWith("organization")
                 || context.Result.ValidatedRequest.ClientId.StartsWith("installation"))
             {

--- a/src/Core/IdentityServer/CustomTokenRequestValidator.cs
+++ b/src/Core/IdentityServer/CustomTokenRequestValidator.cs
@@ -57,8 +57,9 @@ namespace Bit.Core.IdentityServer
         public async Task ValidateAsync(CustomTokenRequestValidationContext context)
         {
             string[] allowedGrantTypes = { "authorization_code", "client_credentials" };
-            if (!allowedGrantTypes.Contains(context.Result.ValidatedRequest.GrantType) ||
-                context.Result.ValidatedRequest.ClientId.StartsWith("organization"))
+            if (!allowedGrantTypes.Contains(context.Result.ValidatedRequest.GrantType) 
+                || context.Result.ValidatedRequest.ClientId.StartsWith("organization")
+                || context.Result.ValidatedRequest.ClientId.StartsWith("installation"))
             {
                 return;
             }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

RelayPushNotificationService and RelayPushRegistrationService rely on being able to authenticate as an installation to function. This would enable that to work again.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/IdentityServer/CustomTokenRequestValidator.cs:** `organization` already opts out of the additional validation about `User` details. This makes it so that `installation` has the same opt out.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Validate that live syncing is working on self-hosted installs.


## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
  -  Tests for this change will be added in #1945 
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
