### PR TITLE
[PS-82] Check Send 2FA email for login for new devices

### DIFF
--- a/src/Api/Controllers/TwoFactorController.cs
+++ b/src/Api/Controllers/TwoFactorController.cs
@@ -289,7 +289,16 @@ namespace Bit.Api.Controllers
             {
                 if (await _userService.VerifySecretAsync(user, model.Secret))
                 {
-                    await _userService.SendTwoFactorEmailAsync(user);
+                    var isBecauseNewDeviceLogin = false;
+                    if (user.GetTwoFactorProvider(TwoFactorProviderType.Email) is null
+                        &&
+                        await _userService.Needs2FABecauseNewDeviceAsync(user, model.DeviceIdentifier, null))
+                    {
+                        model.ToUser(user);
+                        isBecauseNewDeviceLogin = true;
+                    }
+
+                    await _userService.SendTwoFactorEmailAsync(user, isBecauseNewDeviceLogin);
                     return;
                 }
             }

--- a/src/Api/Models/Request/TwoFactorRequestModels.cs
+++ b/src/Api/Models/Request/TwoFactorRequestModels.cs
@@ -203,6 +203,8 @@ namespace Bit.Api.Models.Request
         [StringLength(256)]
         public string Email { get; set; }
 
+        public string DeviceIdentifier { get; set; }
+
         public User ToUser(User extistingUser)
         {
             var providers = extistingUser.GetTwoFactorProviders();

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -78,5 +78,6 @@ namespace Bit.Core.Services
         Task SendOTPAsync(User user);
         Task<bool> VerifyOTPAsync(User user, string token);
         Task<bool> VerifySecretAsync(User user, string secret);
+        Task<bool> Needs2FABecauseNewDeviceAsync(User user, string deviceIdentifier, string grantType);
     }
 }

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -17,7 +17,9 @@ using Bit.Core.Utilities;
 using Fido2NetLib;
 using Fido2NetLib.Objects;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using File = System.IO.File;
@@ -51,6 +53,8 @@ namespace Bit.Core.Services
         private readonly GlobalSettings _globalSettings;
         private readonly IOrganizationService _organizationService;
         private readonly IProviderUserRepository _providerUserRepository;
+        private readonly IDeviceRepository _deviceRepository;
+        private readonly IWebHostEnvironment _environment;
 
         public UserService(
             IUserRepository userRepository,
@@ -79,7 +83,9 @@ namespace Bit.Core.Services
             ICurrentContext currentContext,
             GlobalSettings globalSettings,
             IOrganizationService organizationService,
-            IProviderUserRepository providerUserRepository)
+            IProviderUserRepository providerUserRepository,
+            IDeviceRepository deviceRepository,
+            IWebHostEnvironment environment)
             : base(
                   store,
                   optionsAccessor,
@@ -114,6 +120,8 @@ namespace Bit.Core.Services
             _globalSettings = globalSettings;
             _organizationService = organizationService;
             _providerUserRepository = providerUserRepository;
+            _deviceRepository = deviceRepository;
+            _environment = environment;
         }
 
         public Guid? GetProperUserId(ClaimsPrincipal principal)
@@ -1407,6 +1415,30 @@ namespace Bit.Core.Services
             return user.UsesKeyConnector
                 ? await VerifyOTPAsync(user, secret)
                 : await CheckPasswordAsync(user, secret);
+        }
+
+        public async Task<bool> Needs2FABecauseNewDeviceAsync(User user, string deviceIdentifier, string grantType)
+        {
+            return user.EmailVerified
+                   && grantType != "authorization_code"
+                   && !_environment.IsDevelopment()
+                   && await IsNewDeviceAndNotTheFirstOneAsync(user, deviceIdentifier);
+        }
+
+        private async Task<bool> IsNewDeviceAndNotTheFirstOneAsync(User user, string deviceIdentifier)
+        {
+            if (user == null)
+            {
+                return default;
+            }
+
+            var devices = await _deviceRepository.GetManyByUserIdAsync(user.Id);
+            if (!devices.Any())
+            {
+                return false;
+            }
+
+            return !devices.Any(d => d.Identifier == deviceIdentifier);
         }
     }
 }

--- a/test/Core.Test/Services/UserServiceTests.cs
+++ b/test/Core.Test/Services/UserServiceTests.cs
@@ -7,11 +7,14 @@ using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Models;
 using Bit.Core.Models.Business;
+using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using Bit.Test.Common.Helpers;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Hosting;
 using NSubstitute;
 using NSubstitute.ReceivedExtensions;
 using Xunit;
@@ -155,6 +158,113 @@ namespace Bit.Core.Test.Services
             });
 
             await Assert.ThrowsAsync<ArgumentNullException>("No email.", () => sutProvider.Sut.SendTwoFactorEmailAsync(user));
+        }
+
+        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
+        public async Task Needs2FABecauseNewDeviceAsync_ReturnsTrue(SutProvider<UserService> sutProvider, User user)
+        {
+            user.Id = Guid.NewGuid();
+            user.EmailVerified = true;
+            const string deviceIdToCheck = "7b01b586-b210-499f-8d52-0c3fdaa646fc";
+            const string deviceIdInRepo = "ea29126c-91b7-4cc4-8ce6-00105b37f64a";
+
+            sutProvider.GetDependency<IDeviceRepository>()
+                       .GetManyByUserIdAsync(user.Id)
+                       .Returns(Task.FromResult<ICollection<Device>>(new List<Device>
+                       {
+                            new Device { Identifier = deviceIdInRepo }
+                       }));
+
+            Assert.True(await sutProvider.Sut.Needs2FABecauseNewDeviceAsync(user, deviceIdToCheck, "password"));
+        }
+
+        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
+        public async Task Needs2FABecauseNewDeviceAsync_ReturnsFalse_When_GranType_Is_AuthorizationCode(SutProvider<UserService> sutProvider, User user)
+        {
+            user.Id = Guid.NewGuid();
+            user.EmailVerified = true;
+            const string deviceIdToCheck = "7b01b586-b210-499f-8d52-0c3fdaa646fc";
+            const string deviceIdInRepo = "ea29126c-91b7-4cc4-8ce6-00105b37f64a";
+
+            sutProvider.GetDependency<IDeviceRepository>()
+                       .GetManyByUserIdAsync(user.Id)
+                       .Returns(Task.FromResult<ICollection<Device>>(new List<Device>
+                       {
+                            new Device { Identifier = deviceIdInRepo }
+                       }));
+
+            Assert.False(await sutProvider.Sut.Needs2FABecauseNewDeviceAsync(user, deviceIdToCheck, "authorization_code"));
+        }
+
+        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
+        public async Task Needs2FABecauseNewDeviceAsync_ReturnsFalse_When_Email_Is_Not_Verified(SutProvider<UserService> sutProvider, User user)
+        {
+            user.Id = Guid.NewGuid();
+            user.EmailVerified = false;
+            const string deviceIdToCheck = "7b01b586-b210-499f-8d52-0c3fdaa646fc";
+            const string deviceIdInRepo = "ea29126c-91b7-4cc4-8ce6-00105b37f64a";
+
+            sutProvider.GetDependency<IDeviceRepository>()
+                       .GetManyByUserIdAsync(user.Id)
+                       .Returns(Task.FromResult<ICollection<Device>>(new List<Device>
+                       {
+                            new Device { Identifier = deviceIdInRepo }
+                       }));
+
+            Assert.False(await sutProvider.Sut.Needs2FABecauseNewDeviceAsync(user, deviceIdToCheck, "password"));
+        }
+
+        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
+        public async Task Needs2FABecauseNewDeviceAsync_ReturnsFalse_When_Is_The_First_Device(SutProvider<UserService> sutProvider, User user)
+        {
+            user.Id = Guid.NewGuid();
+            user.EmailVerified = true;
+            const string deviceIdToCheck = "7b01b586-b210-499f-8d52-0c3fdaa646fc";
+
+            sutProvider.GetDependency<IDeviceRepository>()
+                       .GetManyByUserIdAsync(user.Id)
+                       .Returns(Task.FromResult<ICollection<Device>>(new List<Device>()));
+
+            Assert.False(await sutProvider.Sut.Needs2FABecauseNewDeviceAsync(user, deviceIdToCheck, "password"));
+        }
+
+        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
+        public async Task Needs2FABecauseNewDeviceAsync_ReturnsFalse_When_DeviceId_Is_Already_In_Repo(SutProvider<UserService> sutProvider, User user)
+        {
+            user.Id = Guid.NewGuid();
+            user.EmailVerified = true;
+            const string deviceIdToCheck = "7b01b586-b210-499f-8d52-0c3fdaa646fc";
+
+            sutProvider.GetDependency<IDeviceRepository>()
+                       .GetManyByUserIdAsync(user.Id)
+                       .Returns(Task.FromResult<ICollection<Device>>(new List<Device>
+                       {
+                            new Device { Identifier = deviceIdToCheck }
+                       }));
+
+            Assert.False(await sutProvider.Sut.Needs2FABecauseNewDeviceAsync(user, deviceIdToCheck, "password"));
+        }
+
+        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
+        public async Task Needs2FABecauseNewDeviceAsync_ReturnsFalse_When_Environment_Is_Development(SutProvider<UserService> sutProvider, User user)
+        {
+            user.Id = Guid.NewGuid();
+            user.EmailVerified = true;
+            const string deviceIdToCheck = "7b01b586-b210-499f-8d52-0c3fdaa646fc";
+            const string deviceIdInRepo = "ea29126c-91b7-4cc4-8ce6-00105b37f64a";
+
+            sutProvider.GetDependency<IDeviceRepository>()
+                       .GetManyByUserIdAsync(user.Id)
+                       .Returns(Task.FromResult<ICollection<Device>>(new List<Device>
+                       {
+                            new Device { Identifier = deviceIdInRepo }
+                       }));
+
+            sutProvider.GetDependency<IWebHostEnvironment>()
+                       .EnvironmentName
+                       .Returns(Environments.Development);
+
+            Assert.False(await sutProvider.Sut.Needs2FABecauseNewDeviceAsync(user, deviceIdToCheck, "password"));
         }
     }
 }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When resending the code on login we need to check if it's a 2FA email because of a new device. This is fix and continuation of #1931 


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **TwoFactorControlller.cs:** Check whether the 2FA email to be sent is because of a new device
* **TwoFactorRequestModel:** Added `DeviceIdentifier`
* **UserService:** Moved logic to check whether it needs 2FA email because of new device login here to be shared from different part of the app and be more testable. Also disabled the feature in development environment because it's a little tedious when you're testing on several devices.
* **BaseRequestValidator:** Calls now the `userService` to check the logic if it needs 2FA email because of a new device login
* **UserServiceTests:** Added Tests for the logic if it needs 2FA email because of new device login.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
When logging in on a new device with email verified and being on the verification code view on any client (except CLI because it doesn't apply), on resending the verification code the user should receive the email correctly.


## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [X] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
