### PR TITLE
[Bug] Skip WebAuthn 2fa event logs during login flow

### DIFF
--- a/src/Core/Identity/WebAuthnTokenProvider.cs
+++ b/src/Core/Identity/WebAuthnTokenProvider.cs
@@ -77,7 +77,7 @@ namespace Bit.Core.Identity
             var providers = user.GetTwoFactorProviders();
             providers[TwoFactorProviderType.WebAuthn] = provider;
             user.SetTwoFactorProviders(providers);
-            await userService.UpdateTwoFactorProviderAsync(user, TwoFactorProviderType.WebAuthn);
+            await userService.UpdateTwoFactorProviderAsync(user, TwoFactorProviderType.WebAuthn, true, false);
 
             return options.ToJson();
         }
@@ -123,7 +123,7 @@ namespace Bit.Core.Identity
             var providers = user.GetTwoFactorProviders();
             providers[TwoFactorProviderType.WebAuthn].MetaData[webAuthCred.Item1] = webAuthCred.Item2;
             user.SetTwoFactorProviders(providers);
-            await userService.UpdateTwoFactorProviderAsync(user, TwoFactorProviderType.WebAuthn);
+            await userService.UpdateTwoFactorProviderAsync(user, TwoFactorProviderType.WebAuthn, true, false);
 
             return res.Status == "ok";
         }

--- a/src/Core/Identity/WebAuthnTokenProvider.cs
+++ b/src/Core/Identity/WebAuthnTokenProvider.cs
@@ -77,7 +77,7 @@ namespace Bit.Core.Identity
             var providers = user.GetTwoFactorProviders();
             providers[TwoFactorProviderType.WebAuthn] = provider;
             user.SetTwoFactorProviders(providers);
-            await userService.UpdateTwoFactorProviderAsync(user, TwoFactorProviderType.WebAuthn, true, false);
+            await userService.UpdateTwoFactorProviderAsync(user, TwoFactorProviderType.WebAuthn, logEvent: false);
 
             return options.ToJson();
         }
@@ -123,7 +123,7 @@ namespace Bit.Core.Identity
             var providers = user.GetTwoFactorProviders();
             providers[TwoFactorProviderType.WebAuthn].MetaData[webAuthCred.Item1] = webAuthCred.Item2;
             user.SetTwoFactorProviders(providers);
-            await userService.UpdateTwoFactorProviderAsync(user, TwoFactorProviderType.WebAuthn, true, false);
+            await userService.UpdateTwoFactorProviderAsync(user, TwoFactorProviderType.WebAuthn, logEvent: false);
 
             return res.Status == "ok";
         }

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -43,7 +43,7 @@ namespace Bit.Core.Services
         Task<IdentityResult> UpdateKeyAsync(User user, string masterPassword, string key, string privateKey,
             IEnumerable<Cipher> ciphers, IEnumerable<Folder> folders, IEnumerable<Send> sends);
         Task<IdentityResult> RefreshSecurityStampAsync(User user, string masterPasswordHash);
-        Task UpdateTwoFactorProviderAsync(User user, TwoFactorProviderType type, bool setEnabled = true);
+        Task UpdateTwoFactorProviderAsync(User user, TwoFactorProviderType type, bool setEnabled = true, bool logEvent = true);
         Task DisableTwoFactorProviderAsync(User user, TwoFactorProviderType type,
             IOrganizationService organizationService);
         Task<bool> RecoverTwoFactorAsync(string email, string masterPassword, string recoveryCode,

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -877,7 +877,7 @@ namespace Bit.Core.Services
             await SaveUserAsync(user);
             if (logEvent)
             {
-                await _eventService.LogUserEventAsync(user.Id, EventType.User_Updated2fa); 
+                await _eventService.LogUserEventAsync(user.Id, EventType.User_Updated2fa);
             }
         }
 

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -871,11 +871,14 @@ namespace Bit.Core.Services
             return IdentityResult.Failed(_identityErrorDescriber.PasswordMismatch());
         }
 
-        public async Task UpdateTwoFactorProviderAsync(User user, TwoFactorProviderType type, bool setEnabled = true)
+        public async Task UpdateTwoFactorProviderAsync(User user, TwoFactorProviderType type, bool setEnabled = true, bool logEvent = true)
         {
             SetTwoFactorProvider(user, type, setEnabled);
             await SaveUserAsync(user);
-            await _eventService.LogUserEventAsync(user.Id, EventType.User_Updated2fa);
+            if (logEvent)
+            {
+                await _eventService.LogUserEventAsync(user.Id, EventType.User_Updated2fa); 
+            }
         }
 
         public async Task DisableTwoFactorProviderAsync(User user, TwoFactorProviderType type,


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Fix the issue where doing a standard login flow with 2fa (specifically WebAuthn) enabled would have multiple `Enabled/updated two-step login` event messages.
> [Web - 1178](https://github.com/bitwarden/web/issues/1178)
> EC-91

## Code changes
- **WebAuthnTokenProvider.cs**: Updated methods to pass parameter for skipping log events 
- **UserService.cs**: Updated method to handle default boolean for logging user event for updating/enabling 2fa

## Testing requirements
- Make sure changes properly suppress the event logs with a WebAuthn 2fa login flow

## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
