### PR TITLE
add proper URI validation to duo host

### DIFF
--- a/src/Api/Models/Request/TwoFactorRequestModels.cs
+++ b/src/Api/Models/Request/TwoFactorRequestModels.cs
@@ -105,7 +105,7 @@ namespace Bit.Api.Models.Request
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            if (!Host.StartsWith("api-") || (!Host.EndsWith(".duosecurity.com") && !Host.EndsWith(".duofederal.com")))
+            if (!Core.Utilities.Duo.DuoApi.ValidHost(Host))
             {
                 yield return new ValidationResult("Host is invalid.", new string[] { nameof(Host) });
             }

--- a/src/Core/Utilities/DuoApi.cs
+++ b/src/Core/Utilities/DuoApi.cs
@@ -35,6 +35,21 @@ namespace Bit.Core.Utilities.Duo
             _ikey = ikey;
             _skey = skey;
             _host = host;
+
+            if (!ValidHost(host))
+            {
+                throw new DuoException("Invalid Duo host configured.", new ArgumentException(nameof(host)));
+            }
+        }
+
+        public static bool ValidHost(string host)
+        {
+            if (Uri.TryCreate($"https://{host}", UriKind.Absolute, out var uri))
+            {
+                return uri.Host.StartsWith("api-") &&
+                    (uri.Host.EndsWith(".duosecurity.com") || uri.Host.EndsWith(".duofederal.com"));
+            }
+            return false;
         }
 
         public static string CanonicalizeParams(Dictionary<string, string> parameters)
@@ -245,6 +260,10 @@ namespace Bit.Core.Utilities.Duo
     public class DuoException : Exception
     {
         public int HttpStatus { get; private set; }
+
+        public DuoException(string message, Exception inner)
+            : base(message, inner)
+        { }
 
         public DuoException(int httpStatus, string message, Exception inner)
             : base(message, inner)


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Validate Duo host by constructing proper URI object and examining the Host property rather than parsing the inputted string directly.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **DuoApi:** Added ValidHost static helper to parse string host properly using .NET's Uri class. Also added validation to DuoApi constructor.
* **TwoFactorRequestModels.cs:** Use ValidHost helper from DuoApi

## Testing requirements
Ensure you can only configure properly formatted Duo Host values such as `api-something.duosecurity.com` and `api-something.duofederal.com`.


## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
