### PR TITLE
EC-198 Added feature flag for 2FA Email for new device login

### DIFF
--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -17,7 +17,6 @@ using Bit.Core.Utilities;
 using Fido2NetLib;
 using Fido2NetLib.Objects;
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -49,7 +48,7 @@ namespace Bit.Core.Services
         private readonly IReferenceEventService _referenceEventService;
         private readonly IFido2 _fido2;
         private readonly ICurrentContext _currentContext;
-        private readonly GlobalSettings _globalSettings;
+        private readonly IGlobalSettings _globalSettings;
         private readonly IOrganizationService _organizationService;
         private readonly IProviderUserRepository _providerUserRepository;
         private readonly IDeviceRepository _deviceRepository;
@@ -79,7 +78,7 @@ namespace Bit.Core.Services
             IReferenceEventService referenceEventService,
             IFido2 fido2,
             ICurrentContext currentContext,
-            GlobalSettings globalSettings,
+            IGlobalSettings globalSettings,
             IOrganizationService organizationService,
             IProviderUserRepository providerUserRepository,
             IDeviceRepository deviceRepository)

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -69,7 +69,7 @@ namespace Bit.Core.Settings
         public virtual AppleIapSettings AppleIap { get; set; } = new AppleIapSettings();
         public virtual SsoSettings Sso { get; set; } = new SsoSettings();
         public virtual StripeSettings Stripe { get; set; } = new StripeSettings();
-        public virtual TwoFactorAuthSettings TwoFactorAuth { get; set; } = new TwoFactorAuthSettings();
+        public virtual ITwoFactorAuthSettings TwoFactorAuth { get; set; } = new TwoFactorAuthSettings();
 
         public string BuildExternalUri(string explicitValue, string name)
         {
@@ -482,7 +482,7 @@ namespace Bit.Core.Settings
             public int MaxNetworkRetries { get; set; } = 2;
         }
 
-        public class TwoFactorAuthSettings
+        public class TwoFactorAuthSettings : ITwoFactorAuthSettings
         {
             public bool EmailOnNewDeviceLogin { get; set; } = true;
         }

--- a/src/Core/Settings/IGlobalSettings.cs
+++ b/src/Core/Settings/IGlobalSettings.cs
@@ -1,6 +1,4 @@
-﻿using static Bit.Core.Settings.GlobalSettings;
-
-namespace Bit.Core.Settings
+﻿namespace Bit.Core.Settings
 {
     public interface IGlobalSettings
     {
@@ -10,9 +8,11 @@ namespace Bit.Core.Settings
         string LicenseDirectory { get; set; }
         string LicenseCertificatePassword { get; set; }
         int OrganizationInviteExpirationHours { get; set; }
+        bool DisableUserRegistration { get; set; }
         IInstallationSettings Installation { get; set; }
         IFileStorageSettings Attachment { get; set; }
         IConnectionStringSettings Storage { get; set; }
         IBaseServiceUriSettings BaseServiceUri { get; set; }
+        ITwoFactorAuthSettings TwoFactorAuth { get; set; }
     }
 }

--- a/src/Core/Settings/ITwoFactorAuthSettings.cs
+++ b/src/Core/Settings/ITwoFactorAuthSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace Bit.Core.Settings
+{
+    public interface ITwoFactorAuthSettings
+    {
+        bool EmailOnNewDeviceLogin { get; set; }
+    }
+}

--- a/test/Core.Test/Services/UserServiceTests.cs
+++ b/test/Core.Test/Services/UserServiceTests.cs
@@ -36,8 +36,8 @@ namespace Bit.Core.Test.Services
             user.EmailVerified = true;
             user.Email = userLicense.Email;
 
-            sutProvider.GetDependency<Settings.GlobalSettings>().SelfHosted = true;
-            sutProvider.GetDependency<Settings.GlobalSettings>().LicenseDirectory = tempDir.Directory;
+            sutProvider.GetDependency<Settings.IGlobalSettings>().SelfHosted = true;
+            sutProvider.GetDependency<Settings.IGlobalSettings>().LicenseDirectory = tempDir.Directory;
             sutProvider.GetDependency<ILicensingService>()
                 .VerifyLicense(userLicense)
                 .Returns(true);
@@ -173,10 +173,8 @@ namespace Bit.Core.Test.Services
                             new Device { Identifier = deviceIdInRepo }
                        }));
 
-            sutProvider.GetDependency<Settings.GlobalSettings>().TwoFactorAuth = new Settings.GlobalSettings.TwoFactorAuthSettings
-            {
-                EmailOnNewDeviceLogin = true
-            };
+
+            sutProvider.GetDependency<Settings.IGlobalSettings>().TwoFactorAuth.EmailOnNewDeviceLogin.Returns(true);
 
             Assert.True(await sutProvider.Sut.Needs2FABecauseNewDeviceAsync(user, deviceIdToCheck, "password"));
         }
@@ -263,10 +261,7 @@ namespace Bit.Core.Test.Services
                             new Device { Identifier = deviceIdInRepo }
                        }));
 
-            sutProvider.GetDependency<Settings.GlobalSettings>().TwoFactorAuth = new Settings.GlobalSettings.TwoFactorAuthSettings
-            {
-                EmailOnNewDeviceLogin = false
-            };
+            sutProvider.GetDependency<Settings.IGlobalSettings>().TwoFactorAuth.EmailOnNewDeviceLogin.Returns(false);
 
             Assert.False(await sutProvider.Sut.Needs2FABecauseNewDeviceAsync(user, deviceIdToCheck, "password"));
         }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add feature flag for 2FA Email for new device login so we can disable the need to ask for 2FA email on new device logins by configuration.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **GlobalSettings:** Added TwoFactorAuth -> EmailOnNewDeviceLogin to enable/disable 2FA Email for new device logins
* **UserService.cs:** Added Global Settings -> TwoFactorAuth -> EmailOnNewDeviceLogin check and reordered the checks so that it doesn't check for stuff when the feature is off. Also removed the dev environment check given that now we can rely on global settings flag.
* **UserServiceTests.cs** Added tests for the new global settings' check and removed the ones for environment check.

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
