### PR TITLE
Limit migrations to only once

### DIFF
--- a/util/Migrator/DbScripts/2022-03-01_00_AddApiKeysTable.sql
+++ b/util/Migrator/DbScripts/2022-03-01_00_AddApiKeysTable.sql
@@ -201,6 +201,7 @@ BEGIN
             0 AS [Type], -- 0 represents 'Default' type
             [RevisionDate]
         FROM [dbo].[Organization]
+        WHERE NOT EXISTS(SELECT [Id] FROM [dbo].[OrganizationApiKey] [ApiKey] WHERE [ApiKey].[OrganizationId] = [OrganizationId] AND [ApiKey].[Type] = 0)
 
     PRINT N'Dropping old column'
     ALTER TABLE


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
QA Deploy runs all migrations each and every time and since the `ApiKey` column was added later this section of the migration runs each and every time. This will make it smart to not migrate new default api keys to the new table if one already exists.

PS-582

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **util/Migrator/DbScripts/2022-03-01_00_AddApiKeysTable.sql:** Only select items from `[dbo].[Organization]` that don't already have a default type organization api key in the `[dbo].[OrganizationApiKey]` table.

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
