### PR TITLE
Turn off migration service for EF

### DIFF
--- a/src/Admin/Startup.cs
+++ b/src/Admin/Startup.cs
@@ -6,6 +6,7 @@ using Bit.Core.Utilities;
 using Bit.SharedWeb.Utilities;
 using Microsoft.AspNetCore.Identity;
 using Stripe;
+using Bit.Core.Enums;
 
 #if !OSS
 using Bit.Commercial.Core.Utilities;
@@ -83,7 +84,10 @@ public class Startup
         services.AddHostedService<Jobs.JobsHostedService>();
         if (globalSettings.SelfHosted)
         {
-            services.AddHostedService<HostedServices.DatabaseMigrationHostedService>();
+            if (globalSettings.SelectedDatabaseProvider == SupportedDatabaseProviders.SqlServer)
+            {
+                services.AddHostedService<HostedServices.DatabaseMigrationHostedService>();
+            }
         }
         else
         {

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace Bit.Core.Settings;
+﻿using Bit.Core.Enums;
+
+namespace Bit.Core.Settings;
 
 public class GlobalSettings : IGlobalSettings
 {
@@ -42,6 +44,23 @@ public class GlobalSettings : IGlobalSettings
     public virtual IInstallationSettings Installation { get; set; } = new InstallationSettings();
     public virtual IBaseServiceUriSettings BaseServiceUri { get; set; }
     public virtual string DatabaseProvider { get; set; }
+    public SupportedDatabaseProviders SelectedDatabaseProvider
+    {
+        get
+        {
+            switch ((DatabaseProvider ?? "").ToLowerInvariant())
+            {
+                case "postgres":
+                case "postgresql":
+                    return SupportedDatabaseProviders.Postgres;
+                case "mysql":
+                case "mariadb":
+                    return SupportedDatabaseProviders.MySql;
+                default:
+                    return SupportedDatabaseProviders.SqlServer;
+            }
+        }
+    }
     public virtual SqlSettings SqlServer { get; set; } = new SqlSettings();
     public virtual SqlSettings PostgreSql { get; set; } = new SqlSettings();
     public virtual SqlSettings MySql { get; set; } = new SqlSettings();

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -51,23 +51,16 @@ public static class ServiceCollectionExtensions
         var selectedDatabaseProvider = globalSettings.DatabaseProvider;
         var provider = SupportedDatabaseProviders.SqlServer;
         var connectionString = string.Empty;
-        if (!string.IsNullOrWhiteSpace(selectedDatabaseProvider))
+        switch (globalSettings.SelectedDatabaseProvider)
         {
-            switch (selectedDatabaseProvider.ToLowerInvariant())
-            {
-                case "postgres":
-                case "postgresql":
-                    provider = SupportedDatabaseProviders.Postgres;
-                    connectionString = globalSettings.PostgreSql.ConnectionString;
-                    break;
-                case "mysql":
-                case "mariadb":
-                    provider = SupportedDatabaseProviders.MySql;
-                    connectionString = globalSettings.MySql.ConnectionString;
-                    break;
-                default:
-                    break;
-            }
+            case SupportedDatabaseProviders.Postgres:
+                connectionString = globalSettings.PostgreSql.ConnectionString;
+                break;
+            case SupportedDatabaseProviders.MySql:
+                connectionString = globalSettings.MySql.ConnectionString;
+                break;
+            default:
+                break;
         }
 
         var useEf = (provider != SupportedDatabaseProviders.SqlServer);


### PR DESCRIPTION
Admin was crashing when using EF due to starting the migrator hosted job.

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Do not activate migrator job for EF-backed db providers

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)

# TODO
Need to find a way to test
