### PR TITLE
[PS-626] Send Org Name in Cloud Sponsorship Invite

### DIFF
--- a/src/Api/Controllers/OrganizationSponsorshipsController.cs
+++ b/src/Api/Controllers/OrganizationSponsorshipsController.cs
@@ -70,11 +70,13 @@ namespace Bit.Api.Controllers
         [SelfHosted(NotSelfHostedOnly = true)]
         public async Task CreateSponsorship(Guid sponsoringOrgId, [FromBody] OrganizationSponsorshipCreateRequestModel model)
         {
+            var sponsoringOrg = await _organizationRepository.GetByIdAsync(sponsoringOrgId);
+
             var sponsorship = await _createSponsorshipCommand.CreateSponsorshipAsync(
-                await _organizationRepository.GetByIdAsync(sponsoringOrgId),
+                sponsoringOrg,
                 await _organizationUserRepository.GetByOrganizationAsync(sponsoringOrgId, _currentContext.UserId ?? default),
                 model.PlanSponsorshipType, model.SponsoredEmail, model.FriendlyName);
-            await _sendSponsorshipOfferCommand.SendSponsorshipOfferAsync(sponsorship, (await CurrentUser).Email);
+            await _sendSponsorshipOfferCommand.SendSponsorshipOfferAsync(sponsorship, sponsoringOrg.Name);
         }
 
         [Authorize("Application")]


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fixes cloud sponsorship email to act the same as the self-hosted sponsorship email invite.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Api/Controllers/OrganizationSponsorshipsController.cs:** Get sponsoring org separately so that its value can be used to send the email with the sponsoring org name.  

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
