### PR TITLE
[EC-177 EC-178] Add uid.env to key-connector compose config

### DIFF
--- a/util/Setup/Templates/DockerCompose.hbs
+++ b/util/Setup/Templates/DockerCompose.hbs
@@ -205,6 +205,7 @@ services:
       - ../ca-certificates:/etc/bitwarden/ca-certificates
       - ../logs/key-connector:/etc/bitwarden/logs
     env_file:
+      - ../env/uid.env
       - ../env/key-connector.override.env
     networks:
       - default


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Key Connector does not include `uid.env` in its environment configuration. This means that the uid of the user inside the container is not set properly, and it causes errors when accessing mounted files.

This brings KC into line with the configuration of other containers.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

As above

## Before you submit
- [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
