### PR TITLE
[PS-658] Fix initial database creation in run_migrations.sh

### DIFF
--- a/dev/helpers/mssql/run_migrations.sh
+++ b/dev/helpers/mssql/run_migrations.sh
@@ -36,11 +36,16 @@ END;
 IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = 'migrations_$DATABASE')
 BEGIN
   CREATE DATABASE migrations_$DATABASE;
-  CREATE TABLE [migrations_$DATABASE].[dbo].[migrations] (
+END;
+
+GO
+IF OBJECT_ID('[migrations_$DATABASE].[dbo].[migrations]') IS NULL
+BEGIN
+    CREATE TABLE [migrations_$DATABASE].[dbo].[migrations] (
       [Id]                   INT IDENTITY(1,1) PRIMARY KEY,
       [Filename]             NVARCHAR(MAX) NOT NULL,
       [CreationDate]         DATETIME2 (7)    NULL,
-  );
+    );
 END;"
 
 /opt/mssql-tools/bin/sqlcmd -S $SERVER -d master -U $USER -P $PASSWD -I -Q "$QUERY"


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When running migrate.ps1 on a new database for local development, errors output in the terminal "login failed" and no new databases are created. 

The objective of this PR is to fix initial database creation via migrate.ps1 for setting up a new local developer environment.

## Code changes

/dev/helpers/run_migrations.sh

The databases are not being created due to the database creation and table creation SQL statements being in the same batch in /dev/helpers/run_migrations.sh. 

This code update separates out the database creation and table creation between a GO statement, so both databases and the table are properly created.

## Screenshots
An example, attempting to execute SQL block in question. 

![image](https://user-images.githubusercontent.com/43214426/169860376-86a34c95-d919-424d-a26d-f473b050f362.png)



## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
