### PR TITLE
[PS-671] Fix port number for vs profile Api-SelfHost

### DIFF
--- a/src/Api/Properties/launchSettings.json
+++ b/src/Api/Properties/launchSettings.json
@@ -26,7 +26,7 @@
     "Api-SelfHost": {
       "commandName": "Project",
       "launchBrowser": false,
-      "applicationUrl": "http://localhost:4000",
+      "applicationUrl": "http://localhost:4001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "developSelfHosted": "true"


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
It is expected that for local development, self-hosted server services will by default be +1 to the port number you typically expect a given service.

The objective of this PR is to set the expected port number for the Api-SelfHost Visual Studio launch profile to 4001.


## Code changes
src/Api/Properties/launchSettings.json

Setting Api-SelfHost launch profile to port 4001 to align with expectations. 

See the Visual Studio Code launch profile "API-SelfHost" for reference https://github.com/bitwarden/server/blob/dded4e7780644d04751113c1fa8bb5e9b6e268a0/.vscode/launch.json#L282


## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
