### PR TITLE
[EC-144] Fix stripe revert logic

### DIFF
--- a/src/Core/Models/Business/SubscriptionUpdate.cs
+++ b/src/Core/Models/Business/SubscriptionUpdate.cs
@@ -82,7 +82,7 @@ namespace Bit.Core.Models.Business
 
     public class StorageSubscriptionUpdate : SubscriptionUpdate
     {
-        private Nullable<long> _prevStorage;
+        private long? _prevStorage;
         private readonly string _plan;
         private readonly long? _additionalStorage;
         protected override List<string> PlanIds => new() { _plan };

--- a/src/Core/Models/Business/SubscriptionUpdate.cs
+++ b/src/Core/Models/Business/SubscriptionUpdate.cs
@@ -35,7 +35,6 @@ namespace Bit.Core.Models.Business
 
     public class SeatSubscriptionUpdate : SubscriptionUpdate
     {
-        private readonly Organization _organization;
         private readonly int _previousSeats;
         private readonly StaticStore.Plan _plan;
         private readonly long? _additionalSeats;
@@ -44,7 +43,6 @@ namespace Bit.Core.Models.Business
 
         public SeatSubscriptionUpdate(Organization organization, StaticStore.Plan plan, long? additionalSeats)
         {
-            _organization = organization;
             _plan = plan;
             _additionalSeats = additionalSeats;
             _previousSeats = organization.Seats ?? 0;

--- a/src/Core/Models/Business/SubscriptionUpdate.cs
+++ b/src/Core/Models/Business/SubscriptionUpdate.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Bit.Core.Entities;
 using Stripe;
@@ -35,15 +36,18 @@ namespace Bit.Core.Models.Business
     public class SeatSubscriptionUpdate : SubscriptionUpdate
     {
         private readonly Organization _organization;
+        private readonly int _previousSeats;
         private readonly StaticStore.Plan _plan;
         private readonly long? _additionalSeats;
         protected override List<string> PlanIds => new() { _plan.StripeSeatPlanId };
+
 
         public SeatSubscriptionUpdate(Organization organization, StaticStore.Plan plan, long? additionalSeats)
         {
             _organization = organization;
             _plan = plan;
             _additionalSeats = additionalSeats;
+            _previousSeats = organization.Seats ?? 0;
         }
 
         public override List<SubscriptionItemOptions> UpgradeItemsOptions(Subscription subscription)
@@ -63,6 +67,7 @@ namespace Bit.Core.Models.Business
 
         public override List<SubscriptionItemOptions> RevertItemsOptions(Subscription subscription)
         {
+
             var item = SubscriptionItem(subscription, PlanIds.Single());
             return new()
             {
@@ -70,8 +75,8 @@ namespace Bit.Core.Models.Business
                 {
                     Id = item?.Id,
                     Plan = PlanIds.Single(),
-                    Quantity = _organization.Seats,
-                    Deleted = item?.Id != null ? true : (bool?)null,
+                    Quantity = _previousSeats,
+                    Deleted = _previousSeats == 0 ? true : (bool?)null,
                 }
             };
         }
@@ -79,6 +84,7 @@ namespace Bit.Core.Models.Business
 
     public class StorageSubscriptionUpdate : SubscriptionUpdate
     {
+        private Nullable<long> _prevStorage;
         private readonly string _plan;
         private readonly long? _additionalStorage;
         protected override List<string> PlanIds => new() { _plan };
@@ -92,6 +98,7 @@ namespace Bit.Core.Models.Business
         public override List<SubscriptionItemOptions> UpgradeItemsOptions(Subscription subscription)
         {
             var item = SubscriptionItem(subscription, PlanIds.Single());
+            _prevStorage = item.Quantity;
             return new()
             {
                 new SubscriptionItemOptions
@@ -106,6 +113,11 @@ namespace Bit.Core.Models.Business
 
         public override List<SubscriptionItemOptions> RevertItemsOptions(Subscription subscription)
         {
+            if (!_prevStorage.HasValue)
+            {
+                throw new Exception("Unknown previous value, must first call UpgradeItemsOptions");
+            }
+
             var item = SubscriptionItem(subscription, PlanIds.Single());
             return new()
             {
@@ -113,8 +125,8 @@ namespace Bit.Core.Models.Business
                 {
                     Id = item?.Id,
                     Plan = _plan,
-                    Quantity = item?.Quantity ?? 0,
-                    Deleted = item?.Id != null ? true : (bool?)null,
+                    Quantity = _prevStorage.Value,
+                    Deleted = _prevStorage.Value == 0 ? true : (bool?)null,
                 }
             };
         }

--- a/src/Core/Models/Business/SubscriptionUpdate.cs
+++ b/src/Core/Models/Business/SubscriptionUpdate.cs
@@ -96,7 +96,7 @@ namespace Bit.Core.Models.Business
         public override List<SubscriptionItemOptions> UpgradeItemsOptions(Subscription subscription)
         {
             var item = SubscriptionItem(subscription, PlanIds.Single());
-            _prevStorage = item.Quantity;
+            _prevStorage = item?.Quantity ?? 0;
             return new()
             {
                 new SubscriptionItemOptions

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -791,25 +791,16 @@ namespace Bit.Core.Services
                 }
                 catch
                 {
-                    try
+                    // Need to revert the subscription
+                    await _stripeAdapter.SubscriptionUpdateAsync(sub.Id, new Stripe.SubscriptionUpdateOptions
                     {
-                        // Need to revert the subscription
-                        await _stripeAdapter.SubscriptionUpdateAsync(sub.Id, new Stripe.SubscriptionUpdateOptions
-                        {
-                            Items = subscriptionUpdate.RevertItemsOptions(sub),
-                            // This proration behavior prevents a false "credit" from
-                            //  being applied forward to the next month's invoice
-                            ProrationBehavior = "none",
-                            CollectionMethod = collectionMethod,
-                            DaysUntilDue = daysUntilDue,
-                        });
-                    }
-                    catch
-                    {
-                        // Revert can fail, so we need to throw no matter what
-                        throw;
-                    }
-
+                        Items = subscriptionUpdate.RevertItemsOptions(sub),
+                        // This proration behavior prevents a false "credit" from
+                        //  being applied forward to the next month's invoice
+                        ProrationBehavior = "none",
+                        CollectionMethod = collectionMethod,
+                        DaysUntilDue = daysUntilDue,
+                    });
                     throw;
                 }
             }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fixes an issue where reverting a subscription update would fail.

Props to @MGibson1 for pairing and supporting on this!!

## Code changes
* **src/Core/Models/Business/SubscriptionUpdate.cs:** 
  * Save previousSeats during a seat expansion subscription update to decide in case of a revert to either update the existing subscription item (Teams/Enterprise) or delete it.
  * Save previousStorage during a storage expansion subscription update to decide in case of a revert to either update the existing subscription item (storage-gb-XXX) or delete it.
* **src/Core/Services/Implementations/StripePaymentService.cs:** 
  * Adding a try catch around the Subscription-Update/-Revert as the revert previously threw but was swallowed

## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
