### PR TITLE
[PS-299] Fix for displaying email address in email template Emergency Access Accepted

### DIFF
--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -604,7 +604,7 @@ namespace Bit.Core.Services
             var message = CreateDefaultMessage($"Accepted Emergency Access", email);
             var model = new EmergencyAccessAcceptedViewModel
             {
-                GranteeEmail = CoreHelpers.SanitizeForEmail(granteeEmail),
+                GranteeEmail = granteeEmail,
                 WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
                 SiteName = _globalSettings.SiteName
             };


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When setting up emergency access, the email received after the invitee accepts access does not include the “@” or “.” symbols. Instead, it displays “[at]” and “[dot]”. 

![image](https://user-images.githubusercontent.com/43214426/170289534-2b93022a-d704-406d-824f-4c8715bcbc65.png)

Expected: The email should display as `email.example+1@bitwarden.com`


## Code changes
Target file change:
/src/Core/Services/Implementations/HandlebarsMailService.cs
function SendEmergencyAccessAcceptedEmailAsync

Change:
Removed the function call CoreHelpers.SanitizeForEmail() on the granteeEmail variable. 

CoreHelpers.SanitizeForEmail() was performing:
- HTML encoding 
- modifying string content, which is what is causing the email address to be displayed in such a way

### HTML Encoding

By default, HTML encoding is provided by the Handlebars framework.
See https://handlebarsjs.com/guide/expressions.html#html-escaping

In some cases, Bitwarden overrides this default encoding, specifically when inserting URLs, this is denoted by using  the "triple-stash", {{{ in the .text.hbs email template file.

For the emergency access accepted email template, this override is not used.

Related PRs for historical references:
https://github.com/bitwarden/server/pull/1138
https://github.com/bitwarden/server/pull/1514

### Modifying String Content

As far as the string modifications/input sanitization, this specific email address, granteeEmail, is provided by the database not client input during the emergency access accepted operation. 

When the grantee email address is inserted into the database at the beginning of the emergency access process, the client provided email must pass the required StrictEmailAddress data annotation, at this point input sanitization is achieved.

https://github.com/bitwarden/server/blob/f235938c413b2d0b33d6e67180d5f9399be5541b/src/Api/Controllers/EmergencyAccessController.cs#L100-L105

https://github.com/bitwarden/server/blob/f235938c413b2d0b33d6e67180d5f9399be5541b/src/Api/Models/Request/EmergencyAccessRequstModels.cs#L8-L13


## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
