### PR TITLE
[PS-630] Fix Master Password Hint Email template

### DIFF
--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -139,7 +139,7 @@ namespace Bit.Core.Services
             var message = CreateDefaultMessage("Your Master Password Hint", email);
             var model = new MasterPasswordHintViewModel
             {
-                Hint = CoreHelpers.SanitizeForEmail(hint),
+                Hint = CoreHelpers.SanitizeForEmail(hint, false),
                 WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
                 SiteName = _globalSettings.SiteName
             };


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fixing double HTML encoding on master password hint email.

For a master password hint example, "@£$%^*(*)_+{}"|<>?:"|`~.是是是不不"

The email displays unexpected characters.
![image](https://user-images.githubusercontent.com/43214426/170773779-eb88c8b9-ce9e-4a3f-bee1-98f0ebf74c42.png)


This is caused by the SantizeForEmail() function HTML encoding the string and the Handlebars.Net framework, encoding the string a second time.

See related for more information:
https://github.com/bitwarden/server/pull/1514
https://handlebarsjs.com/guide/expressions.html#html-escaping

## Code changes
/src/Core/Services/Implementations/HandlebarsMailsService.cs
SendMasterPasswordHintEmailAsync()

Setting HTML encoding to false, so the master password hint is only HTML encoded once by the Handlebars.Net framework.

## Notes 

To note, the SantizeForEmail() function will still perform input sanitization for certain special characters, for example:
@ -> [at]
. -> [dot]

This is to prevent injecting links into emails, and to keep high profile email clients like Gmail from being able to infer a link, since this is a free text user input field.

See related PR for similar work performed on emails containing OrganizationName:
https://github.com/bitwarden/server/pull/1478

## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
