### PR TITLE
[PS-165] Missing copy verification code

### DIFF
--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -224,12 +224,12 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
-            IEnumerable<Cipher> orgCiphers;
+            IEnumerable<CipherOrganizationDetails> orgCiphers;
             if (await _currentContext.OrganizationOwner(orgIdGuid))
             {
                 // User may be a Provider for the organization, in which case GetManyByUserIdAsync won't return any results
                 // But they have access to all organization ciphers, so we can safely get by orgId instead
-                orgCiphers = await _cipherRepository.GetManyByOrganizationIdAsync(orgIdGuid);
+                orgCiphers = await _cipherRepository.GetManyOrganizationDetailsByOrganizationIdAsync(orgIdGuid);
             }
             else
             {
@@ -243,10 +243,11 @@ namespace Bit.Api.Controllers
             var collectionCiphersGroupDict = collectionCiphers
                 .Where(c => orgCipherIds.Contains(c.CipherId))
                 .GroupBy(c => c.CipherId).ToDictionary(s => s.Key);
+            
 
-
-            var responses = orgCiphers.Select(c => new CipherMiniDetailsResponseModel(c, _globalSettings,
-                collectionCiphersGroupDict));
+            var responses = orgCiphers.Select(c => new CipherMiniDetailsResponseModel(c, _globalSettings, 
+                collectionCiphersGroupDict, c.OrganizationUseTotp));
+            
 
             var providerId = await _currentContext.ProviderIdForOrg(orgIdGuid);
             if (providerId.HasValue)

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -243,11 +243,11 @@ namespace Bit.Api.Controllers
             var collectionCiphersGroupDict = collectionCiphers
                 .Where(c => orgCipherIds.Contains(c.CipherId))
                 .GroupBy(c => c.CipherId).ToDictionary(s => s.Key);
-            
 
-            var responses = orgCiphers.Select(c => new CipherMiniDetailsResponseModel(c, _globalSettings, 
+
+            var responses = orgCiphers.Select(c => new CipherMiniDetailsResponseModel(c, _globalSettings,
                 collectionCiphersGroupDict, c.OrganizationUseTotp));
-            
+
 
             var providerId = await _currentContext.ProviderIdForOrg(orgIdGuid);
             if (providerId.HasValue)

--- a/src/Api/Models/Response/CipherResponseModel.cs
+++ b/src/Api/Models/Response/CipherResponseModel.cs
@@ -132,8 +132,8 @@ namespace Bit.Api.Models.Response
     public class CipherMiniDetailsResponseModel : CipherMiniResponseModel
     {
         public CipherMiniDetailsResponseModel(Cipher cipher, GlobalSettings globalSettings,
-            IDictionary<Guid, IGrouping<Guid, CollectionCipher>> collectionCiphers, string obj = "cipherMiniDetails")
-            : base(cipher, globalSettings, false, obj)
+            IDictionary<Guid, IGrouping<Guid, CollectionCipher>> collectionCiphers, bool orgUseTotp, string obj = "cipherMiniDetails")
+            : base(cipher, globalSettings, orgUseTotp, obj)
         {
             if (collectionCiphers?.ContainsKey(cipher.Id) ?? false)
             {

--- a/src/Core/Repositories/ICipherRepository.cs
+++ b/src/Core/Repositories/ICipherRepository.cs
@@ -11,6 +11,7 @@ namespace Bit.Core.Repositories
     {
         Task<CipherDetails> GetByIdAsync(Guid id, Guid userId);
         Task<CipherOrganizationDetails> GetOrganizationDetailsByIdAsync(Guid id);
+        Task<ICollection<CipherOrganizationDetails>> GetManyOrganizationDetailsByOrganizationIdAsync(Guid organizationId);
         Task<bool> GetCanEditByIdAsync(Guid userId, Guid cipherId);
         Task<ICollection<CipherDetails>> GetManyByUserIdAsync(Guid userId, bool withOrganizations = true);
         Task<ICollection<Cipher>> GetManyByOrganizationIdAsync(Guid organizationId);

--- a/src/Infrastructure.Dapper/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.Dapper/Repositories/CipherRepository.cs
@@ -50,6 +50,20 @@ namespace Bit.Infrastructure.Dapper.Repositories
             }
         }
 
+        public async Task<ICollection<CipherOrganizationDetails>> GetManyOrganizationDetailsByOrganizationIdAsync(
+            Guid organizationId)
+        {
+            using (var connection = new SqlConnection(ConnectionString))
+            {
+                var results = await connection.QueryAsync<CipherOrganizationDetails>(
+                    $"[{Schema}].[CipherOrganizationDetails_ReadByOrganizationId]",
+                    new { OrganizationId = organizationId },
+                    commandType: CommandType.StoredProcedure);
+
+                return results.ToList();
+            }
+        }
+
         public async Task<bool> GetCanEditByIdAsync(Guid userId, Guid cipherId)
         {
             using (var connection = new SqlConnection(ConnectionString))

--- a/src/Infrastructure.EntityFramework/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CipherRepository.cs
@@ -259,6 +259,18 @@ namespace Bit.Infrastructure.EntityFramework.Repositories
             }
         }
 
+        public async Task<ICollection<CipherOrganizationDetails>> GetManyOrganizationDetailsByOrganizationIdAsync(
+            Guid organizationId)
+        {
+            using (var scope = ServiceScopeFactory.CreateScope())
+            {
+                var dbContext = GetDatabaseContext(scope);
+                var query = new CipherOrganizationDetailsReadByIdQuery(organizationId);
+                var data = await query.Run(dbContext).ToListAsync();
+                return data;
+            }
+        }
+
         public async Task<bool> GetCanEditByIdAsync(Guid userId, Guid cipherId)
         {
             using (var scope = ServiceScopeFactory.CreateScope())

--- a/src/Infrastructure.EntityFramework/Repositories/Queries/CipherOrganizationDetailsReadByOrgizationIdQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/CipherOrganizationDetailsReadByOrgizationIdQuery.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Linq;
+using Core.Models.Data;
+
+namespace Bit.Infrastructure.EntityFramework.Repositories.Queries
+{
+    public class CipherOrganizationDetailsReadByOrgizationIdQuery : IQuery<CipherOrganizationDetails>
+    {
+        private readonly Guid _organizationId;
+
+        public CipherOrganizationDetailsReadByOrgizationIdQuery(Guid organizationId)
+        {
+            _organizationId = organizationId;
+        }
+        public virtual IQueryable<CipherOrganizationDetails> Run(DatabaseContext dbContext)
+        {
+            var query = from c in dbContext.Ciphers
+                join o in dbContext.Organizations
+                    on c.OrganizationId equals o.Id into o_g
+                from o in o_g.DefaultIfEmpty()
+                where c.OrganizationId == _organizationId
+                select new CipherOrganizationDetails
+                {
+                    Id = c.Id,
+                    UserId = c.UserId,
+                    OrganizationId = c.OrganizationId,
+                    Type = c.Type,
+                    Data = c.Data,
+                    Favorites = c.Favorites,
+                    Folders = c.Folders,
+                    Attachments = c.Attachments,
+                    CreationDate = c.CreationDate,
+                    RevisionDate = c.RevisionDate,
+                    DeletedDate = c.DeletedDate,
+                    OrganizationUseTotp = o.UseTotp,
+                };
+            return query;
+        }
+    }
+}

--- a/src/Infrastructure.EntityFramework/Repositories/Queries/CipherOrganizationDetailsReadByOrgizationIdQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/CipherOrganizationDetailsReadByOrgizationIdQuery.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using Core.Models.Data;
 
@@ -15,25 +15,25 @@ namespace Bit.Infrastructure.EntityFramework.Repositories.Queries
         public virtual IQueryable<CipherOrganizationDetails> Run(DatabaseContext dbContext)
         {
             var query = from c in dbContext.Ciphers
-                join o in dbContext.Organizations
-                    on c.OrganizationId equals o.Id into o_g
-                from o in o_g.DefaultIfEmpty()
-                where c.OrganizationId == _organizationId
-                select new CipherOrganizationDetails
-                {
-                    Id = c.Id,
-                    UserId = c.UserId,
-                    OrganizationId = c.OrganizationId,
-                    Type = c.Type,
-                    Data = c.Data,
-                    Favorites = c.Favorites,
-                    Folders = c.Folders,
-                    Attachments = c.Attachments,
-                    CreationDate = c.CreationDate,
-                    RevisionDate = c.RevisionDate,
-                    DeletedDate = c.DeletedDate,
-                    OrganizationUseTotp = o.UseTotp,
-                };
+                        join o in dbContext.Organizations
+                            on c.OrganizationId equals o.Id into o_g
+                        from o in o_g.DefaultIfEmpty()
+                        where c.OrganizationId == _organizationId
+                        select new CipherOrganizationDetails
+                        {
+                            Id = c.Id,
+                            UserId = c.UserId,
+                            OrganizationId = c.OrganizationId,
+                            Type = c.Type,
+                            Data = c.Data,
+                            Favorites = c.Favorites,
+                            Folders = c.Folders,
+                            Attachments = c.Attachments,
+                            CreationDate = c.CreationDate,
+                            RevisionDate = c.RevisionDate,
+                            DeletedDate = c.DeletedDate,
+                            OrganizationUseTotp = o.UseTotp,
+                        };
             return query;
         }
     }

--- a/src/Sql/Sql.sqlproj
+++ b/src/Sql/Sql.sqlproj
@@ -390,5 +390,6 @@
     <Build Include="dbo\Stored Procedures\OrganizationConnection_ReadByOrganizationIdType.sql" />
     <Build Include="dbo\Views\OrganizationApiKeyView.sql" />
     <Build Include="dbo\Views\OrganizationConnectionView.sql" />
+    <Build Include="dbo\Stored Procedures\CipherOrganizationDetails_ReadByOrganizationId.sql" />
   </ItemGroup>
 </Project>

--- a/src/Sql/dbo/Stored Procedures/CipherOrganizationDetails_ReadByOrganizationId.sql
+++ b/src/Sql/dbo/Stored Procedures/CipherOrganizationDetails_ReadByOrganizationId.sql
@@ -1,0 +1,19 @@
+CREATE PROCEDURE [dbo].[CipherOrganizationDetails_ReadByOrganizationId]
+    @OrganizationId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        C.*,
+        CASE 
+            WHEN O.[UseTotp] = 1 THEN 1
+            ELSE 0
+        END [OrganizationUseTotp]
+    FROM
+        [dbo].[CipherView] C
+    LEFT JOIN
+        [dbo].[OrganizationView] O ON O.[Id] = C.[OrganizationId]
+    WHERE
+        C.[OrganizationId] = @OrganizationId 
+END


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Display the option `Copy Verification Code` for Admins and Owners of an organization. The option currently does not show up when the user is the admin or owner of the organization and this happens because `OrganizationUseTotp` is not set and always returns a `false` from the `organization-details` endpoint.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
- **src/Sql/dbo/Stored Procedures/CipherOrganizationDetails_ReadByOrganizationId.sql:** Created stored procedure to retrieve ciphers for organizations along with the `UseTotp` column.
- **src/Infrastructure.EntityFramework/Repositories/Queries/CipherOrganizationDetailsReadByOrgizationIdQuery.cs:** EF equivalent of script for retrieving organization details.
-  **src/Infrastructure.EntityFramework/Repositories/CipherRepository.cs:** `GetManyOrganizationDetailsByOrganizationIdAsync` repository method implementation that takes organizationId as parameter and makes call to EF query.
-  **src/Infrastructure.Dapper/Repositories/CipherRepository.cs:** Dapper implementation of `GetManyOrganizationDetailsByOrganizationIdAsync` method which calls the `CipherOrganizationDetails_ReadByOrganizationId` strored procedure used to retrieve organization details.
- **src/Core/Repositories/ICipherRepository.cs:** Added `GetManyOrganizationDetailsByOrganizationIdAsync` abstract method definition.
- **src/Api/Models/Response/CipherResponseModel.cs:** Replaced the hard coded false argument with `orgUseTotp` which can be set to whatever boolean value from the controller.
- **src/Api/Controllers/CiphersController.cs:** Replaced `GetManyByOrganizationIdAsync` call with `GetManyOrganizationDetailsByOrganizationIdAsync` which includes the `OrganizationUseTotp` property.

## Before you submit
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [X] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)

https://user-images.githubusercontent.com/13024008/171172208-d85004ee-cb7e-4137-9048-553f611f5856.mov
