### PR TITLE
[fix] Correct a typo in the event name of a stripe webhook

### DIFF
--- a/src/Billing/Constants/HandledStripeWebhook.cs
+++ b/src/Billing/Constants/HandledStripeWebhook.cs
@@ -3,7 +3,7 @@
     public static class HandledStripeWebhook
     {
         public static string SubscriptionDeleted => "customer.subscription.deleted";
-        public static string SubscriptionUpdated => "customer.subscriptions.updated";
+        public static string SubscriptionUpdated => "customer.subscription.updated";
         public static string UpcomingInvoice => "invoice.upcoming";
         public static string ChargeSucceeded => "charge.succeeded";
         public static string ChargeRefunded => "charge.refunded";


### PR DESCRIPTION
https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-134

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
There is a typo in one of the events on https://github.com/bitwarden/server/pull/2017.
The "subscription" event is listed as "subscriptions" for one instance.

Source: https://stripe.com/docs/billing/subscriptions/webhooks#events

## Code changes
Remove the s

## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
