### PR TITLE
[EC-235] Give Admins (and above) access to all items

### DIFF
--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -225,9 +225,9 @@ namespace Bit.Api.Controllers
             }
 
             IEnumerable<Cipher> orgCiphers;
-            // Admins, Owners and Providers can access all items even if not assigned to them
             if (await _currentContext.OrganizationAdmin(orgIdGuid))
             {
+                // Admins, Owners and Providers can access all items even if not assigned to them
                 orgCiphers = await _cipherRepository.GetManyByOrganizationIdAsync(orgIdGuid);
             }
             else

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -225,10 +225,9 @@ namespace Bit.Api.Controllers
             }
 
             IEnumerable<Cipher> orgCiphers;
-            if (await _currentContext.OrganizationOwner(orgIdGuid))
+            // Admins, Owners and Providers can access all items even if not assigned to them
+            if (await _currentContext.OrganizationAdmin(orgIdGuid))
             {
-                // User may be a Provider for the organization, in which case GetManyByUserIdAsync won't return any results
-                // But they have access to all organization ciphers, so we can safely get by orgId instead
                 orgCiphers = await _cipherRepository.GetManyByOrganizationIdAsync(orgIdGuid);
             }
             else

--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -88,10 +88,9 @@ namespace Bit.Api.Controllers
             }
 
             IEnumerable<Collection> orgCollections;
-            if (await _currentContext.OrganizationOwner(orgIdGuid))
+            // Admins, Owners and Providers can access all items even if not assigned to them
+            if (await _currentContext.OrganizationAdmin(orgIdGuid))
             {
-                // User may be a Provider for the organization, in which case GetManyByUserIdAsync won't return any results
-                // But they have access to all organization collections, so we can safely get by orgId instead
                 orgCollections = await _collectionRepository.GetManyByOrganizationIdAsync(orgIdGuid);
             }
             else

--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -89,8 +89,8 @@ namespace Bit.Api.Controllers
 
             IEnumerable<Collection> orgCollections;
             if (await _currentContext.OrganizationAdmin(orgIdGuid))
-            // Admins, Owners and Providers can access all items even if not assigned to them
             {
+                // Admins, Owners and Providers can access all items even if not assigned to them
                 orgCollections = await _collectionRepository.GetManyByOrganizationIdAsync(orgIdGuid);
             }
             else

--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -88,8 +88,8 @@ namespace Bit.Api.Controllers
             }
 
             IEnumerable<Collection> orgCollections;
-            // Admins, Owners and Providers can access all items even if not assigned to them
             if (await _currentContext.OrganizationAdmin(orgIdGuid))
+            // Admins, Owners and Providers can access all items even if not assigned to them
             {
                 orgCollections = await _collectionRepository.GetManyByOrganizationIdAsync(orgIdGuid);
             }


### PR DESCRIPTION
## Type of change (mark with an `X`)

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix an issue where admins cannot see collections that they create.

This is the same issue as https://github.com/bitwarden/server/pull/1959, I just didn't cast the net wide enough. Instead of just checking for Owners (and implicitly Providers), we should also check for Admins - as they also have access to all items.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* change `_currentContext.organizationOwner` to `_currentContext.organizationAdmin` (which implicitly includes owners and providers as well)
* make comment more succinct

## Before you submit (mark with an `X`)

```
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
