### PR TITLE
[PS-616] [PS-795] Fix/auto enroll master password reset without user verification

### DIFF
--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -12,7 +12,7 @@ using Bit.Core.Context;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Business;
-using Bit.Core.Models.Data;
+using Bit.Core.Models.Data.Organizations.Policies;
 using Bit.Core.OrganizationFeatures.OrganizationApiKeys.Interfaces;
 using Bit.Core.Repositories;
 using Bit.Core.Services;

--- a/src/Api/Models/Request/Organizations/OrganizationUserRequestModels.cs
+++ b/src/Api/Models/Request/Organizations/OrganizationUserRequestModels.cs
@@ -40,6 +40,8 @@ namespace Bit.Api.Models.Request.Organizations
     {
         [Required]
         public string Token { get; set; }
+        // Used to auto-enroll in master password reset
+        public string ResetPasswordKey { get; set; }
     }
 
     public class OrganizationUserConfirmRequestModel

--- a/src/Core/Entities/Policy.cs
+++ b/src/Core/Entities/Policy.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Text.Json;
 using Bit.Core.Enums;
 using Bit.Core.Models.Data.Organizations.Policies;
 using Bit.Core.Utilities;
@@ -20,14 +19,24 @@ namespace Bit.Core.Entities
         {
             Id = CoreHelpers.GenerateComb();
         }
+
+        public T GetDataModel<T>() where T : IPolicyDataModel, new()
+        {
+            return CoreHelpers.LoadClassFromJsonData<T>(Data);
+        }
+
+        public void SetDataModel<T>(T dataModel) where T : IPolicyDataModel, new()
+        {
+            Data = CoreHelpers.ClassToJsonData(dataModel);
+        }
     }
 
-    public class Policy<T> : Policy where T : IPolicyDataModel
+    public class Policy<T> : Policy where T : IPolicyDataModel, new()
     {
         public T DataModel
         {
-            get => JsonSerializer.Deserialize<T>(Data);
-            set => Data = JsonSerializer.Serialize(value);
+            get => GetDataModel<T>();
+            set => SetDataModel(value);
         }
     }
 }

--- a/src/Core/Entities/Policy.cs
+++ b/src/Core/Entities/Policy.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Text.Json;
 using Bit.Core.Enums;
+using Bit.Core.Models.Data.Organizations.Policies;
 using Bit.Core.Utilities;
 
 namespace Bit.Core.Entities
@@ -17,6 +19,15 @@ namespace Bit.Core.Entities
         public void SetNewId()
         {
             Id = CoreHelpers.GenerateComb();
+        }
+    }
+
+    public class Policy<T> : Policy where T : IPolicyDataModel
+    {
+        public T DataModel
+        {
+            get => JsonSerializer.Deserialize<T>(Data);
+            set => Data = JsonSerializer.Serialize(value);
         }
     }
 }

--- a/src/Core/Models/Data/Organizations/Policies/IPolicyDataModel.cs
+++ b/src/Core/Models/Data/Organizations/Policies/IPolicyDataModel.cs
@@ -1,4 +1,4 @@
-namespace Bit.Core.Models.Data.Organizations.Policies
+﻿namespace Bit.Core.Models.Data.Organizations.Policies
 {
     public interface IPolicyDataModel
     {

--- a/src/Core/Models/Data/Organizations/Policies/IPolicyDataModel.cs
+++ b/src/Core/Models/Data/Organizations/Policies/IPolicyDataModel.cs
@@ -1,0 +1,6 @@
+namespace Bit.Core.Models.Data.Organizations.Policies
+{
+    public interface IPolicyDataModel
+    {
+    }
+}

--- a/src/Core/Models/Data/Organizations/Policies/ResetPasswordDataModel.cs
+++ b/src/Core/Models/Data/Organizations/Policies/ResetPasswordDataModel.cs
@@ -1,8 +1,8 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace Bit.Core.Models.Data
+namespace Bit.Core.Models.Data.Organizations.Policies
 {
-    public class ResetPasswordDataModel
+    public class ResetPasswordDataModel : IPolicyDataModel
     {
         [Display(Name = "ResetPasswordAutoEnrollCheckbox")]
         public bool AutoEnrollEnabled { get; set; }

--- a/src/Core/Models/Data/Organizations/Policies/SendOptionsPolicyData.cs
+++ b/src/Core/Models/Data/Organizations/Policies/SendOptionsPolicyData.cs
@@ -1,8 +1,8 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace Bit.Core.Models.Data
+namespace Bit.Core.Models.Data.Organizations.Policies
 {
-    public class SendOptionsPolicyData
+    public class SendOptionsPolicyData : IPolicyDataModel
     {
         [Display(Name = "DisableHideEmail")]
         public bool DisableHideEmail { get; set; }

--- a/src/Core/Repositories/IPolicyRepository.cs
+++ b/src/Core/Repositories/IPolicyRepository.cs
@@ -10,7 +10,7 @@ namespace Bit.Core.Repositories
     public interface IPolicyRepository : IRepository<Policy, Guid>
     {
         Task<Policy> GetByOrganizationIdTypeAsync(Guid organizationId, PolicyType type);
-        Task<Policy<T>> GetByOrganizationIdTypeAsync<T>(Guid organizationId, PolicyType type) where T : IPolicyDataModel;
+        Task<Policy<T>> GetByOrganizationIdTypeAsync<T>(Guid organizationId, PolicyType type) where T : IPolicyDataModel, new();
         Task<ICollection<Policy>> GetManyByOrganizationIdAsync(Guid organizationId);
         Task<ICollection<Policy>> GetManyByUserIdAsync(Guid userId);
         Task<ICollection<Policy>> GetManyByTypeApplicableToUserIdAsync(Guid userId, PolicyType policyType,

--- a/src/Core/Repositories/IPolicyRepository.cs
+++ b/src/Core/Repositories/IPolicyRepository.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
+using Bit.Core.Models.Data.Organizations.Policies;
 
 namespace Bit.Core.Repositories
 {
     public interface IPolicyRepository : IRepository<Policy, Guid>
     {
         Task<Policy> GetByOrganizationIdTypeAsync(Guid organizationId, PolicyType type);
+        Task<Policy<T>> GetByOrganizationIdTypeAsync<T>(Guid organizationId, PolicyType type) where T : IPolicyDataModel;
         Task<ICollection<Policy>> GetManyByOrganizationIdAsync(Guid organizationId);
         Task<ICollection<Policy>> GetManyByUserIdAsync(Guid userId);
         Task<ICollection<Policy>> GetManyByTypeApplicableToUserIdAsync(Guid userId, PolicyType policyType,

--- a/src/Core/Services/IOrganizationService.cs
+++ b/src/Core/Services/IOrganizationService.cs
@@ -51,7 +51,7 @@ namespace Bit.Core.Services
         Task<List<Tuple<OrganizationUser, string>>> DeleteUsersAsync(Guid organizationId,
             IEnumerable<Guid> organizationUserIds, Guid? deletingUserId);
         Task UpdateUserGroupsAsync(OrganizationUser organizationUser, IEnumerable<Guid> groupIds, Guid? loggedInUserId);
-        Task UpdateUserResetPasswordEnrollmentAsync(Guid organizationId, Guid organizationUserId, string resetPasswordKey, Guid? callingUserId);
+        Task UpdateUserResetPasswordEnrollmentAsync(Guid organizationId, Guid userId, string resetPasswordKey, Guid? callingUserId);
         Task<OrganizationLicense> GenerateLicenseAsync(Guid organizationId, Guid installationId);
         Task<OrganizationLicense> GenerateLicenseAsync(Organization organization, Guid installationId,
             int? version = null);

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -1751,10 +1751,10 @@ namespace Bit.Core.Services
                 EventType.OrganizationUser_UpdatedGroups);
         }
 
-        public async Task UpdateUserResetPasswordEnrollmentAsync(Guid organizationId, Guid organizationUserId, string resetPasswordKey, Guid? callingUserId)
+        public async Task UpdateUserResetPasswordEnrollmentAsync(Guid organizationId, Guid userId, string resetPasswordKey, Guid? callingUserId)
         {
             // Org User must be the same as the calling user and the organization ID associated with the user must match passed org ID
-            var orgUser = await _organizationUserRepository.GetByOrganizationAsync(organizationId, organizationUserId);
+            var orgUser = await _organizationUserRepository.GetByOrganizationAsync(organizationId, userId);
             if (!callingUserId.HasValue || orgUser == null || orgUser.UserId != callingUserId.Value ||
                 orgUser.OrganizationId != organizationId)
             {

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -10,6 +10,7 @@ using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Business;
 using Bit.Core.Models.Data;
+using Bit.Core.Models.Data.Organizations.Policies;
 using Bit.Core.Repositories;
 using Bit.Core.Settings;
 using Bit.Core.Utilities;

--- a/src/Core/Services/Implementations/PolicyService.cs
+++ b/src/Core/Services/Implementations/PolicyService.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Bit.Core.Entities;

--- a/src/Core/Services/Implementations/SendService.cs
+++ b/src/Core/Services/Implementations/SendService.cs
@@ -292,14 +292,9 @@ namespace Bit.Core.Services
             if (send.HideEmail.GetValueOrDefault())
             {
                 var sendOptionsPolicies = await _policyRepository.GetManyByTypeApplicableToUserIdAsync(userId.Value, PolicyType.SendOptions);
-                foreach (var policy in sendOptionsPolicies)
+                if (sendOptionsPolicies.Any(p => p.GetDataModel<SendOptionsPolicyData>()?.DisableHideEmail ?? false))
                 {
-                    var data = CoreHelpers.LoadClassFromJsonData<SendOptionsPolicyData>(policy.Data);
-                    if (data?.DisableHideEmail ?? false)
-                    {
-                        throw new BadRequestException("Due to an Enterprise Policy, you are not allowed to hide your email address from recipients when creating or editing a Send.");
-                    }
-
+                    throw new BadRequestException("Due to an Enterprise Policy, you are not allowed to hide your email address from recipients when creating or editing a Send.");
                 }
             }
         }

--- a/src/Core/Services/Implementations/SendService.cs
+++ b/src/Core/Services/Implementations/SendService.cs
@@ -9,6 +9,7 @@ using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Business;
 using Bit.Core.Models.Data;
+using Bit.Core.Models.Data.Organizations.Policies;
 using Bit.Core.Repositories;
 using Bit.Core.Settings;
 using Bit.Core.Utilities;

--- a/src/Infrastructure.Dapper/Repositories/PolicyRepository.cs
+++ b/src/Infrastructure.Dapper/Repositories/PolicyRepository.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
+using Bit.Core.Models.Data.Organizations.Policies;
 using Bit.Core.Repositories;
 using Bit.Core.Settings;
 using Dapper;
@@ -21,6 +22,9 @@ namespace Bit.Infrastructure.Dapper.Repositories
         public PolicyRepository(string connectionString, string readOnlyConnectionString)
             : base(connectionString, readOnlyConnectionString)
         { }
+
+        public async Task<Policy<T>> GetByOrganizationIdTypeAsync<T>(Guid organizationId, PolicyType type) where T : IPolicyDataModel =>
+            (Policy<T>)await GetByOrganizationIdTypeAsync(organizationId, type);
         public async Task<Policy> GetByOrganizationIdTypeAsync(Guid organizationId, PolicyType type)
         {
             using (var connection = new SqlConnection(ConnectionString))

--- a/src/Infrastructure.Dapper/Repositories/PolicyRepository.cs
+++ b/src/Infrastructure.Dapper/Repositories/PolicyRepository.cs
@@ -23,7 +23,7 @@ namespace Bit.Infrastructure.Dapper.Repositories
             : base(connectionString, readOnlyConnectionString)
         { }
 
-        public async Task<Policy<T>> GetByOrganizationIdTypeAsync<T>(Guid organizationId, PolicyType type) where T : IPolicyDataModel =>
+        public async Task<Policy<T>> GetByOrganizationIdTypeAsync<T>(Guid organizationId, PolicyType type) where T : IPolicyDataModel, new() =>
             (Policy<T>)await GetByOrganizationIdTypeAsync(organizationId, type);
         public async Task<Policy> GetByOrganizationIdTypeAsync(Guid organizationId, PolicyType type)
         {

--- a/src/Infrastructure.EntityFramework/Repositories/PolicyRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/PolicyRepository.cs
@@ -19,7 +19,7 @@ namespace Bit.Infrastructure.EntityFramework.Repositories
             : base(serviceScopeFactory, mapper, (DatabaseContext context) => context.Policies)
         { }
 
-        public async Task<Core.Entities.Policy<T>> GetByOrganizationIdTypeAsync<T>(Guid organizationId, PolicyType type) where T : IPolicyDataModel =>
+        public async Task<Core.Entities.Policy<T>> GetByOrganizationIdTypeAsync<T>(Guid organizationId, PolicyType type) where T : IPolicyDataModel, new() =>
             (Core.Entities.Policy<T>)await GetByOrganizationIdTypeAsync(organizationId, type);
         public async Task<Core.Entities.Policy> GetByOrganizationIdTypeAsync(Guid organizationId, PolicyType type)
         {

--- a/src/Infrastructure.EntityFramework/Repositories/PolicyRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/PolicyRepository.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
 using Bit.Core.Enums;
+using Bit.Core.Models.Data.Organizations.Policies;
 using Bit.Core.Repositories;
 using Bit.Infrastructure.EntityFramework.Models;
 using Bit.Infrastructure.EntityFramework.Repositories.Queries;
@@ -18,6 +19,8 @@ namespace Bit.Infrastructure.EntityFramework.Repositories
             : base(serviceScopeFactory, mapper, (DatabaseContext context) => context.Policies)
         { }
 
+        public async Task<Core.Entities.Policy<T>> GetByOrganizationIdTypeAsync<T>(Guid organizationId, PolicyType type) where T : IPolicyDataModel =>
+            (Core.Entities.Policy<T>)await GetByOrganizationIdTypeAsync(organizationId, type);
         public async Task<Core.Entities.Policy> GetByOrganizationIdTypeAsync(Guid organizationId, PolicyType type)
         {
             using (var scope = ServiceScopeFactory.CreateScope())

--- a/test/Api.Test/Controllers/OrganizationUsersControllerTests.cs
+++ b/test/Api.Test/Controllers/OrganizationUsersControllerTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading.Tasks;
+using Bit.Api.Controllers;
+using Bit.Api.Models.Request.Organizations;
+using Bit.Api.Test.AutoFixture.Attributes;
+using Bit.Core.Entities;
+using Bit.Core.Models.Data.Organizations.Policies;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Api.Test.Controllers
+{
+    [ControllerCustomize(typeof(OrganizationUsersController))]
+    [SutProviderCustomize]
+    public class OrganizationUsersControllerTests
+    {
+        [Theory]
+        [BitAutoData]
+        public async Task Accept_RequiresKnownUser(Guid orgId, Guid orgUserId, OrganizationUserAcceptRequestModel model,
+            SutProvider<OrganizationUsersController> sutProvider)
+        {
+            sutProvider.GetDependency<IUserService>().GetUserByPrincipalAsync(default).ReturnsForAnyArgs((User)null);
+
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(() => sutProvider.Sut.Accept(orgId, orgUserId, model));
+        }
+
+        [Theory]
+        [BitAutoData]
+        public async Task Accept_NoMasterPasswordReset(Guid orgId, Guid orgUserId,
+            OrganizationUserAcceptRequestModel model, User user, SutProvider<OrganizationUsersController> sutProvider)
+        {
+            sutProvider.GetDependency<IUserService>().GetUserByPrincipalAsync(default).ReturnsForAnyArgs(user);
+
+            await sutProvider.Sut.Accept(orgId, orgUserId, model);
+
+            await sutProvider.GetDependency<IOrganizationService>().Received(1)
+                .AcceptUserAsync(orgUserId, user, model.Token, sutProvider.GetDependency<IUserService>());
+            await sutProvider.GetDependency<IOrganizationService>().DidNotReceiveWithAnyArgs()
+                .UpdateUserResetPasswordEnrollmentAsync(default, default, default, default);
+        }
+
+        [Theory]
+        [BitAutoData]
+        public async Task Accept_RequireMasterPasswordReset(Guid orgId, Guid orgUserId,
+            OrganizationUserAcceptRequestModel model, User user, SutProvider<OrganizationUsersController> sutProvider)
+        {
+            var policy = new Policy<ResetPasswordDataModel>
+            {
+                Enabled = true,
+                DataModel = new ResetPasswordDataModel { AutoEnrollEnabled = true, },
+            };
+            sutProvider.GetDependency<IUserService>().GetUserByPrincipalAsync(default).ReturnsForAnyArgs(user);
+            sutProvider.GetDependency<IPolicyRepository>().GetByOrganizationIdTypeAsync<ResetPasswordDataModel>(orgId,
+                Core.Enums.PolicyType.MasterPassword).Returns(policy);
+
+            await sutProvider.Sut.Accept(orgId, orgUserId, model);
+
+            await sutProvider.GetDependency<IOrganizationService>().Received(1)
+                .AcceptUserAsync(orgUserId, user, model.Token, sutProvider.GetDependency<IUserService>());
+            await sutProvider.GetDependency<IOrganizationService>().Received(1)
+                .UpdateUserResetPasswordEnrollmentAsync(orgId, user.Id, model.ResetPasswordKey, user.Id);
+        }
+    }
+}

--- a/test/Api.Test/Controllers/OrganizationUsersControllerTests.cs
+++ b/test/Api.Test/Controllers/OrganizationUsersControllerTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Bit.Api.Controllers;
 using Bit.Api.Models.Request.Organizations;

--- a/test/Core.Test/AutoFixture/PolicyFixtures.cs
+++ b/test/Core.Test/AutoFixture/PolicyFixtures.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Reflection;
+using System.Text.Json;
 using AutoFixture;
 using AutoFixture.Kernel;
 using AutoFixture.Xunit2;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
+using Bit.Core.Models.Data.Organizations.Policies;
 using Bit.Core.Test.AutoFixture.EntityFrameworkRepositoryFixtures;
 using Bit.Core.Test.AutoFixture.OrganizationFixtures;
 using Bit.Infrastructure.EntityFramework.Repositories;
@@ -25,6 +27,16 @@ namespace Bit.Core.Test.AutoFixture.PolicyFixtures
         public void Customize(IFixture fixture)
         {
             fixture.Customize<Policy>(composer => composer
+                .With(o => o.OrganizationId, Guid.NewGuid())
+                .With(o => o.Type, Type)
+                .With(o => o.Enabled, true));
+            fixture.Customize<Policy<ResetPasswordDataModel>>(composer => composer
+                .With(o => o.Data, JsonSerializer.Serialize(fixture.Create<ResetPasswordDataModel>()))
+                .With(o => o.OrganizationId, Guid.NewGuid())
+                .With(o => o.Type, Type)
+                .With(o => o.Enabled, true));
+            fixture.Customize<Policy<SendOptionsPolicyData>>(composer => composer
+                .With(o => o.Data, JsonSerializer.Serialize(fixture.Create<ResetPasswordDataModel>()))
                 .With(o => o.OrganizationId, Guid.NewGuid())
                 .With(o => o.Type, Type)
                 .With(o => o.Enabled, true));

--- a/test/Core.Test/Services/PolicyServiceTests.cs
+++ b/test/Core.Test/Services/PolicyServiceTests.cs
@@ -15,10 +15,12 @@ using PolicyFixtures = Bit.Core.Test.AutoFixture.PolicyFixtures;
 
 namespace Bit.Core.Test.Services
 {
+    [SutProviderCustomize]
     public class PolicyServiceTests
     {
-        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
-        public async Task SaveAsync_OrganizationDoesNotExist_ThrowsBadRequest([PolicyFixtures.Policy(PolicyType.DisableSend)] Policy policy, SutProvider<PolicyService> sutProvider)
+        [Theory, BitAutoData]
+        public async Task SaveAsync_OrganizationDoesNotExist_ThrowsBadRequest(
+            [PolicyFixtures.Policy(PolicyType.DisableSend)] Policy policy, SutProvider<PolicyService> sutProvider)
         {
             SetupOrg(sutProvider, policy.OrganizationId, null);
 
@@ -39,8 +41,9 @@ namespace Bit.Core.Test.Services
                 .LogPolicyEventAsync(default, default, default);
         }
 
-        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
-        public async Task SaveAsync_OrganizationCannotUsePolicies_ThrowsBadRequest([PolicyFixtures.Policy(PolicyType.DisableSend)] Policy policy, SutProvider<PolicyService> sutProvider)
+        [Theory, BitAutoData]
+        public async Task SaveAsync_OrganizationCannotUsePolicies_ThrowsBadRequest(
+            [PolicyFixtures.Policy(PolicyType.DisableSend)] Policy policy, SutProvider<PolicyService> sutProvider)
         {
             var orgId = Guid.NewGuid();
 
@@ -66,8 +69,9 @@ namespace Bit.Core.Test.Services
                 .LogPolicyEventAsync(default, default, default);
         }
 
-        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
-        public async Task SaveAsync_SingleOrg_RequireSsoEnabled_ThrowsBadRequest([PolicyFixtures.Policy(PolicyType.SingleOrg)] Policy policy, SutProvider<PolicyService> sutProvider)
+        [Theory, BitAutoData]
+        public async Task SaveAsync_SingleOrg_RequireSsoEnabled_ThrowsBadRequest(
+            [PolicyFixtures.Policy(PolicyType.SingleOrg)] Policy policy, SutProvider<PolicyService> sutProvider)
         {
             policy.Enabled = false;
 
@@ -98,7 +102,7 @@ namespace Bit.Core.Test.Services
                 .LogPolicyEventAsync(default, default, default);
         }
 
-        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
+        [Theory, BitAutoData]
         public async Task SaveAsync_SingleOrg_VaultTimeoutEnabled_ThrowsBadRequest([PolicyFixtures.Policy(Enums.PolicyType.SingleOrg)] Policy policy, SutProvider<PolicyService> sutProvider)
         {
             policy.Enabled = false;
@@ -127,8 +131,8 @@ namespace Bit.Core.Test.Services
         }
 
         [Theory]
-        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, Enums.PolicyType.SingleOrg)]
-        [InlineCustomAutoData(new[] { typeof(SutProviderCustomization) }, Enums.PolicyType.RequireSso)]
+        [BitAutoData(PolicyType.SingleOrg)]
+        [BitAutoData(PolicyType.RequireSso)]
         public async Task SaveAsync_PolicyRequiredByKeyConnector_DisablePolicy_ThrowsBadRequest(
             Enums.PolicyType policyType,
             Policy policy,
@@ -164,8 +168,9 @@ namespace Bit.Core.Test.Services
                 .UpsertAsync(default);
         }
 
-        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
-        public async Task SaveAsync_RequireSsoPolicy_NotEnabled_ThrowsBadRequestAsync([PolicyFixtures.Policy(Enums.PolicyType.RequireSso)] Policy policy, SutProvider<PolicyService> sutProvider)
+        [Theory, BitAutoData]
+        public async Task SaveAsync_RequireSsoPolicy_NotEnabled_ThrowsBadRequestAsync(
+            [PolicyFixtures.Policy(Enums.PolicyType.RequireSso)] Policy policy, SutProvider<PolicyService> sutProvider)
         {
             policy.Enabled = true;
 
@@ -196,8 +201,9 @@ namespace Bit.Core.Test.Services
                 .LogPolicyEventAsync(default, default, default);
         }
 
-        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
-        public async Task SaveAsync_NewPolicy_Created([PolicyFixtures.Policy(PolicyType.MasterPassword)] Policy policy, SutProvider<PolicyService> sutProvider)
+        [Theory, BitAutoData]
+        public async Task SaveAsync_NewPolicy_Created(
+            [PolicyFixtures.Policy(PolicyType.MasterPassword)] Policy policy, SutProvider<PolicyService> sutProvider)
         {
             policy.Id = default;
 
@@ -221,8 +227,9 @@ namespace Bit.Core.Test.Services
             Assert.True(policy.RevisionDate - utcNow < TimeSpan.FromSeconds(1));
         }
 
-        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
-        public async Task SaveAsync_VaultTimeoutPolicy_NotEnabled_ThrowsBadRequestAsync([PolicyFixtures.Policy(Enums.PolicyType.MaximumVaultTimeout)] Policy policy, SutProvider<PolicyService> sutProvider)
+        [Theory, BitAutoData]
+        public async Task SaveAsync_VaultTimeoutPolicy_NotEnabled_ThrowsBadRequestAsync(
+            [PolicyFixtures.Policy(PolicyType.MaximumVaultTimeout)] Policy policy, SutProvider<PolicyService> sutProvider)
         {
             policy.Enabled = true;
 
@@ -253,8 +260,9 @@ namespace Bit.Core.Test.Services
                 .LogPolicyEventAsync(default, default, default);
         }
 
-        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
-        public async Task SaveAsync_ExistingPolicy_UpdateTwoFactor([PolicyFixtures.Policy(PolicyType.TwoFactorAuthentication)] Policy policy, SutProvider<PolicyService> sutProvider)
+        [Theory, BitAutoData]
+        public async Task SaveAsync_ExistingPolicy_UpdateTwoFactor(
+            [PolicyFixtures.Policy(PolicyType.TwoFactorAuthentication)] Policy policy, SutProvider<PolicyService> sutProvider)
         {
             // If the policy that this is updating isn't enabled then do some work now that the current one is enabled
 
@@ -322,8 +330,9 @@ namespace Bit.Core.Test.Services
             Assert.True(policy.RevisionDate - utcNow < TimeSpan.FromSeconds(1));
         }
 
-        [Theory, CustomAutoData(typeof(SutProviderCustomization))]
-        public async Task SaveAsync_ExistingPolicy_UpdateSingleOrg([PolicyFixtures.Policy(PolicyType.TwoFactorAuthentication)] Policy policy, SutProvider<PolicyService> sutProvider)
+        [Theory, BitAutoData]
+        public async Task SaveAsync_ExistingPolicy_UpdateSingleOrg(
+            [PolicyFixtures.Policy(PolicyType.TwoFactorAuthentication)] Policy policy, SutProvider<PolicyService> sutProvider)
         {
             // If the policy that this is updating isn't enabled then do some work now that the current one is enabled
 

--- a/test/Core.Test/Services/SendServiceTests.cs
+++ b/test/Core.Test/Services/SendServiceTests.cs
@@ -7,6 +7,7 @@ using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Data;
+using Bit.Core.Models.Data.Organizations.Policies;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Test.AutoFixture.SendFixtures;


### PR DESCRIPTION
## Type of change (mark with an `X`)

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Add Master Password Reset enrollment to the accept invitation request directly. This allows us to keep the existing user flow separate and truly enforce that auto enrollment is for new org users only.

A bit of work was done to separate policy data models from other data models both in directories and with a common interface to facilitate the new `Policy<T>` generic class, which automatically deserializes the data model for you.

## Code changes
* **OrganizationUsersController**: Require a reset password token on accept if policies dictate.
* **OrganizationsController/**: Namespace changes to match directory structure changes
* **OrganizationUserAcceptRequestModel**: Add ResetPasswordKey to accept request, Only used if MPR auto enroll is enabled.
* **Policy/IPolicyDataModel/ResetPasswordDataModel/SendOptionsDataModel**: Add serializer/deserializer directly to model and add Generic class. The data models are the only two usages of policy data at the moment.
* **IPolicyRepository/PolicyRepository/EntityFrameworkPolicyRepository**: Add Generic Policy overload to relevant sproc call. Since the only new property is backed by another property, there is no need to actually DO anything, just cast it directly.
* **IOrganizationService/OrganizationService**: This parameter was confusingly named, you need a **User**Id here, not an OragnizationUserId.


### Tests

Test are added for meaningful controller changes and fixtures for Policies are updated to include the Generic types.

## Before you submit (mark with an `X`)

```
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
