### PR TITLE
Fix bitwarden typo in API URI

### DIFF
--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -437,7 +437,7 @@ namespace Bit.Core.Settings
             }
             public string ApiUri
             {
-                get => string.IsNullOrWhiteSpace(_apiUri) ? "https://api.biwarden.com" : _apiUri;
+                get => string.IsNullOrWhiteSpace(_apiUri) ? "https://api.bitwarden.com" : _apiUri;
                 set => _apiUri = value;
             }
         }


### PR DESCRIPTION
## Type of change (mark with an `X`)

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Noticed our logs when trying to do a billing sync were talking to the wrong URI:
```
System.Net.Http.HttpRequestException: Resource temporarily unavailable (api.biwarden.com:443)
Failed to send to https://api.biwarden.com/organization/sponsorship/sync.
```
I didn't have this config set locally so enabled me to find this typo
