### PR TITLE
Use the correct policy enum type

### DIFF
--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -182,10 +182,10 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            var masterPasswordPolicy = await _policyRepository.GetByOrganizationIdTypeAsync<ResetPasswordDataModel>(orgId, PolicyType.MasterPassword);
+            var masterPasswordPolicy = await _policyRepository.GetByOrganizationIdTypeAsync(orgId, PolicyType.ResetPassword);
             var useMasterPasswordPolicy = masterPasswordPolicy != null &&
                 masterPasswordPolicy.Enabled &&
-                masterPasswordPolicy.DataModel.AutoEnrollEnabled;
+                masterPasswordPolicy.GetDataModel<ResetPasswordDataModel>().AutoEnrollEnabled;
 
             if (useMasterPasswordPolicy &&
                 string.IsNullOrWhiteSpace(model.ResetPasswordKey))

--- a/src/Core/Entities/Policy.cs
+++ b/src/Core/Entities/Policy.cs
@@ -30,13 +30,4 @@ namespace Bit.Core.Entities
             Data = CoreHelpers.ClassToJsonData(dataModel);
         }
     }
-
-    public class Policy<T> : Policy where T : IPolicyDataModel, new()
-    {
-        public T DataModel
-        {
-            get => GetDataModel<T>();
-            set => SetDataModel(value);
-        }
-    }
 }

--- a/src/Core/Repositories/IPolicyRepository.cs
+++ b/src/Core/Repositories/IPolicyRepository.cs
@@ -10,7 +10,6 @@ namespace Bit.Core.Repositories
     public interface IPolicyRepository : IRepository<Policy, Guid>
     {
         Task<Policy> GetByOrganizationIdTypeAsync(Guid organizationId, PolicyType type);
-        Task<Policy<T>> GetByOrganizationIdTypeAsync<T>(Guid organizationId, PolicyType type) where T : IPolicyDataModel, new();
         Task<ICollection<Policy>> GetManyByOrganizationIdAsync(Guid organizationId);
         Task<ICollection<Policy>> GetManyByUserIdAsync(Guid userId);
         Task<ICollection<Policy>> GetManyByTypeApplicableToUserIdAsync(Guid userId, PolicyType policyType,

--- a/src/Infrastructure.Dapper/Repositories/PolicyRepository.cs
+++ b/src/Infrastructure.Dapper/Repositories/PolicyRepository.cs
@@ -23,8 +23,6 @@ namespace Bit.Infrastructure.Dapper.Repositories
             : base(connectionString, readOnlyConnectionString)
         { }
 
-        public async Task<Policy<T>> GetByOrganizationIdTypeAsync<T>(Guid organizationId, PolicyType type) where T : IPolicyDataModel, new() =>
-            (Policy<T>)await GetByOrganizationIdTypeAsync(organizationId, type);
         public async Task<Policy> GetByOrganizationIdTypeAsync(Guid organizationId, PolicyType type)
         {
             using (var connection = new SqlConnection(ConnectionString))

--- a/src/Infrastructure.EntityFramework/Repositories/PolicyRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/PolicyRepository.cs
@@ -19,8 +19,6 @@ namespace Bit.Infrastructure.EntityFramework.Repositories
             : base(serviceScopeFactory, mapper, (DatabaseContext context) => context.Policies)
         { }
 
-        public async Task<Core.Entities.Policy<T>> GetByOrganizationIdTypeAsync<T>(Guid organizationId, PolicyType type) where T : IPolicyDataModel, new() =>
-            (Core.Entities.Policy<T>)await GetByOrganizationIdTypeAsync(organizationId, type);
         public async Task<Core.Entities.Policy> GetByOrganizationIdTypeAsync(Guid organizationId, PolicyType type)
         {
             using (var scope = ServiceScopeFactory.CreateScope())

--- a/test/Api.Test/Controllers/OrganizationUsersControllerTests.cs
+++ b/test/Api.Test/Controllers/OrganizationUsersControllerTests.cs
@@ -7,6 +7,7 @@ using Bit.Core.Entities;
 using Bit.Core.Models.Data.Organizations.Policies;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
+using Bit.Core.Utilities;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
@@ -48,14 +49,14 @@ namespace Bit.Api.Test.Controllers
         public async Task Accept_RequireMasterPasswordReset(Guid orgId, Guid orgUserId,
             OrganizationUserAcceptRequestModel model, User user, SutProvider<OrganizationUsersController> sutProvider)
         {
-            var policy = new Policy<ResetPasswordDataModel>
+            var policy = new Policy
             {
                 Enabled = true,
-                DataModel = new ResetPasswordDataModel { AutoEnrollEnabled = true, },
+                Data = CoreHelpers.ClassToJsonData(new ResetPasswordDataModel { AutoEnrollEnabled = true, }),
             };
             sutProvider.GetDependency<IUserService>().GetUserByPrincipalAsync(default).ReturnsForAnyArgs(user);
-            sutProvider.GetDependency<IPolicyRepository>().GetByOrganizationIdTypeAsync<ResetPasswordDataModel>(orgId,
-                Core.Enums.PolicyType.MasterPassword).Returns(policy);
+            sutProvider.GetDependency<IPolicyRepository>().GetByOrganizationIdTypeAsync(orgId,
+                Core.Enums.PolicyType.ResetPassword).Returns(policy);
 
             await sutProvider.Sut.Accept(orgId, orgUserId, model);
 

--- a/test/Core.Test/AutoFixture/PolicyFixtures.cs
+++ b/test/Core.Test/AutoFixture/PolicyFixtures.cs
@@ -30,16 +30,6 @@ namespace Bit.Core.Test.AutoFixture.PolicyFixtures
                 .With(o => o.OrganizationId, Guid.NewGuid())
                 .With(o => o.Type, Type)
                 .With(o => o.Enabled, true));
-            fixture.Customize<Policy<ResetPasswordDataModel>>(composer => composer
-                .With(o => o.Data, JsonSerializer.Serialize(fixture.Create<ResetPasswordDataModel>()))
-                .With(o => o.OrganizationId, Guid.NewGuid())
-                .With(o => o.Type, Type)
-                .With(o => o.Enabled, true));
-            fixture.Customize<Policy<SendOptionsPolicyData>>(composer => composer
-                .With(o => o.Data, JsonSerializer.Serialize(fixture.Create<ResetPasswordDataModel>()))
-                .With(o => o.OrganizationId, Guid.NewGuid())
-                .With(o => o.Type, Type)
-                .With(o => o.Enabled, true));
         }
     }
 

--- a/test/Core.Test/Services/PolicyServiceTests.cs
+++ b/test/Core.Test/Services/PolicyServiceTests.cs
@@ -203,7 +203,7 @@ namespace Bit.Core.Test.Services
 
         [Theory, BitAutoData]
         public async Task SaveAsync_NewPolicy_Created(
-            [PolicyFixtures.Policy(PolicyType.MasterPassword)] Policy policy, SutProvider<PolicyService> sutProvider)
+            [PolicyFixtures.Policy(PolicyType.ResetPassword)] Policy policy, SutProvider<PolicyService> sutProvider)
         {
             policy.Id = default;
 


### PR DESCRIPTION
## Type of change (mark with an `X`)

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Another fix for enroll password reset. I was using the wrong policy enum type. This also revealed that explicit conversion between non-generics and generics wasn't working properly, so I scraped that idea and start using the `getDataModel` methods to parse out policy data.