### PR TITLE
[PS-899] Fix unawaited `Task`

### DIFF
--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -36,31 +36,29 @@ namespace Bit.Api.Controllers
         }
 
         [HttpGet("{id}")]
-        public async Task<CollectionResponseModel> Get(string orgId, string id)
+        public async Task<CollectionResponseModel> Get(Guid orgId, Guid id)
         {
             if (!await CanViewCollectionAsync(orgId, id))
             {
                 throw new NotFoundException();
             }
 
-            var collection = await GetCollectionAsync(new Guid(id), new Guid(orgId));
+            var collection = await GetCollectionAsync(id, orgId);
             return new CollectionResponseModel(collection);
         }
 
         [HttpGet("{id}/details")]
-        public async Task<CollectionGroupDetailsResponseModel> GetDetails(string orgId, string id)
+        public async Task<CollectionGroupDetailsResponseModel> GetDetails(Guid orgId, Guid id)
         {
-            var orgIdGuid = new Guid(orgId);
-            if (!await ViewAtLeastOneCollectionAsync(orgIdGuid) && !await _currentContext.ManageUsers(orgIdGuid))
+            if (!await ViewAtLeastOneCollectionAsync(orgId) && !await _currentContext.ManageUsers(orgId))
             {
                 throw new NotFoundException();
             }
 
-            var idGuid = new Guid(id);
-            if (await _currentContext.ViewAllCollections(orgIdGuid))
+            if (await _currentContext.ViewAllCollections(orgId))
             {
-                var collectionDetails = await _collectionRepository.GetByIdWithGroupsAsync(idGuid);
-                if (collectionDetails?.Item1 == null || collectionDetails.Item1.OrganizationId != orgIdGuid)
+                var collectionDetails = await _collectionRepository.GetByIdWithGroupsAsync(id);
+                if (collectionDetails?.Item1 == null || collectionDetails.Item1.OrganizationId != orgId)
                 {
                     throw new NotFoundException();
                 }
@@ -68,9 +66,9 @@ namespace Bit.Api.Controllers
             }
             else
             {
-                var collectionDetails = await _collectionRepository.GetByIdWithGroupsAsync(idGuid,
+                var collectionDetails = await _collectionRepository.GetByIdWithGroupsAsync(id,
                     _currentContext.UserId.Value);
-                if (collectionDetails?.Item1 == null || collectionDetails.Item1.OrganizationId != orgIdGuid)
+                if (collectionDetails?.Item1 == null || collectionDetails.Item1.OrganizationId != orgId)
                 {
                     throw new NotFoundException();
                 }
@@ -79,24 +77,23 @@ namespace Bit.Api.Controllers
         }
 
         [HttpGet("")]
-        public async Task<ListResponseModel<CollectionResponseModel>> Get(string orgId)
+        public async Task<ListResponseModel<CollectionResponseModel>> Get(Guid orgId)
         {
-            var orgIdGuid = new Guid(orgId);
-            if (!await _currentContext.ViewAllCollections(orgIdGuid) && !await _currentContext.ManageUsers(orgIdGuid))
+            if (!await _currentContext.ViewAllCollections(orgId) && !await _currentContext.ManageUsers(orgId))
             {
                 throw new NotFoundException();
             }
 
             IEnumerable<Collection> orgCollections;
-            if (await _currentContext.OrganizationAdmin(orgIdGuid))
+            if (await _currentContext.OrganizationAdmin(orgId))
             {
                 // Admins, Owners and Providers can access all items even if not assigned to them
-                orgCollections = await _collectionRepository.GetManyByOrganizationIdAsync(orgIdGuid);
+                orgCollections = await _collectionRepository.GetManyByOrganizationIdAsync(orgId);
             }
             else
             {
                 var collections = await _collectionRepository.GetManyByUserIdAsync(_currentContext.UserId.Value);
-                orgCollections = collections.Where(c => c.OrganizationId == orgIdGuid);
+                orgCollections = collections.Where(c => c.OrganizationId == orgId);
             }
 
             var responses = orgCollections.Select(c => new CollectionResponseModel(c));
@@ -113,28 +110,27 @@ namespace Bit.Api.Controllers
         }
 
         [HttpGet("{id}/users")]
-        public async Task<IEnumerable<SelectionReadOnlyResponseModel>> GetUsers(string orgId, string id)
+        public async Task<IEnumerable<SelectionReadOnlyResponseModel>> GetUsers(Guid orgId, Guid id)
         {
-            var collection = await GetCollectionAsync(new Guid(id), new Guid(orgId));
+            var collection = await GetCollectionAsync(id, orgId);
             var collectionUsers = await _collectionRepository.GetManyUsersByIdAsync(collection.Id);
             var responses = collectionUsers.Select(cu => new SelectionReadOnlyResponseModel(cu));
             return responses;
         }
 
         [HttpPost("")]
-        public async Task<CollectionResponseModel> Post(string orgId, [FromBody] CollectionRequestModel model)
+        public async Task<CollectionResponseModel> Post(Guid orgId, [FromBody] CollectionRequestModel model)
         {
-            var orgIdGuid = new Guid(orgId);
-            var collection = model.ToCollection(orgIdGuid);
+            var collection = model.ToCollection(orgId);
 
-            if (!await CanCreateCollection(orgIdGuid, collection.Id) &&
-                !await CanEditCollectionAsync(orgIdGuid, collection.Id))
+            if (!await CanCreateCollection(orgId, collection.Id) &&
+                !await CanEditCollectionAsync(orgId, collection.Id))
             {
                 throw new NotFoundException();
             }
 
-            var assignUserToCollection = !(await _currentContext.EditAnyCollection(orgIdGuid)) &&
-                await _currentContext.EditAssignedCollections(orgIdGuid);
+            var assignUserToCollection = !(await _currentContext.EditAnyCollection(orgId)) &&
+                await _currentContext.EditAssignedCollections(orgId);
 
             await _collectionService.SaveAsync(collection, model.Groups?.Select(g => g.ToSelectionReadOnly()),
                 assignUserToCollection ? _currentContext.UserId : null);
@@ -143,41 +139,41 @@ namespace Bit.Api.Controllers
 
         [HttpPut("{id}")]
         [HttpPost("{id}")]
-        public async Task<CollectionResponseModel> Put(string orgId, string id, [FromBody] CollectionRequestModel model)
+        public async Task<CollectionResponseModel> Put(Guid orgId, Guid id, [FromBody] CollectionRequestModel model)
         {
             if (!await CanEditCollectionAsync(orgId, id))
             {
                 throw new NotFoundException();
             }
 
-            var collection = await GetCollectionAsync(new Guid(id), new Guid(orgId));
+            var collection = await GetCollectionAsync(id, orgId);
             await _collectionService.SaveAsync(model.ToCollection(collection),
                 model.Groups?.Select(g => g.ToSelectionReadOnly()));
             return new CollectionResponseModel(collection);
         }
 
         [HttpPut("{id}/users")]
-        public async Task PutUsers(string orgId, string id, [FromBody] IEnumerable<SelectionReadOnlyRequestModel> model)
+        public async Task PutUsers(Guid orgId, Guid id, [FromBody] IEnumerable<SelectionReadOnlyRequestModel> model)
         {
             if (!await CanEditCollectionAsync(orgId, id))
             {
                 throw new NotFoundException();
             }
 
-            var collection = await GetCollectionAsync(new Guid(id), new Guid(orgId));
+            var collection = await GetCollectionAsync(id, orgId);
             await _collectionRepository.UpdateUsersAsync(collection.Id, model?.Select(g => g.ToSelectionReadOnly()));
         }
 
         [HttpDelete("{id}")]
         [HttpPost("{id}/delete")]
-        public async Task Delete(string orgId, string id)
+        public async Task Delete(Guid orgId, Guid id)
         {
             if (!await CanDeleteCollectionAsync(orgId, id))
             {
                 throw new NotFoundException();
             }
 
-            var collection = await GetCollectionAsync(new Guid(id), new Guid(orgId));
+            var collection = await GetCollectionAsync(id, orgId);
             await _collectionService.DeleteAsync(collection);
         }
 
@@ -220,8 +216,6 @@ namespace Bit.Api.Controllers
             return await _currentContext.CreateNewCollections(orgId);
         }
 
-        private async Task<bool> CanEditCollectionAsync(string orgId, string collectionId) =>
-            await CanEditCollectionAsync(new Guid(orgId), new Guid(collectionId));
         private async Task<bool> CanEditCollectionAsync(Guid orgId, Guid collectionId)
         {
             if (collectionId == default)
@@ -236,14 +230,13 @@ namespace Bit.Api.Controllers
 
             if (await _currentContext.EditAssignedCollections(orgId))
             {
-                return null != await _collectionRepository.GetByIdAsync(collectionId, _currentContext.UserId.Value);
+                var collectionDetails = await _collectionRepository.GetByIdAsync(collectionId, _currentContext.UserId.Value);
+                return collectionDetails != null;
             }
 
             return false;
         }
 
-        private async Task<bool> CanDeleteCollectionAsync(string orgId, string collectionId) =>
-            await CanDeleteCollectionAsync(new Guid(orgId), new Guid(collectionId));
         private async Task<bool> CanDeleteCollectionAsync(Guid orgId, Guid collectionId)
         {
             if (collectionId == default)
@@ -258,14 +251,13 @@ namespace Bit.Api.Controllers
 
             if (await _currentContext.DeleteAssignedCollections(orgId))
             {
-                return null != _collectionRepository.GetByIdAsync(collectionId, _currentContext.UserId.Value);
+                var collectionDetails = await _collectionRepository.GetByIdAsync(collectionId, _currentContext.UserId.Value);
+                return collectionDetails != null;
             }
 
             return false;
         }
 
-        private async Task<bool> CanViewCollectionAsync(string orgId, string collectionId) =>
-            await CanViewCollectionAsync(new Guid(orgId), new Guid(collectionId));
         private async Task<bool> CanViewCollectionAsync(Guid orgId, Guid collectionId)
         {
             if (collectionId == default)
@@ -280,7 +272,8 @@ namespace Bit.Api.Controllers
 
             if (await _currentContext.ViewAssignedCollections(orgId))
             {
-                return null != _collectionRepository.GetByIdAsync(collectionId, _currentContext.UserId.Value);
+                var collectionDetails = await _collectionRepository.GetByIdAsync(collectionId, _currentContext.UserId.Value);
+                return collectionDetails != null;
             }
 
             return false;

--- a/test/Api.Test/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.Test/Controllers/CollectionsControllerTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/test/Api.Test/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.Test/Controllers/CollectionsControllerTests.cs
@@ -18,7 +18,6 @@ using Xunit;
 
 namespace Bit.Api.Test.Controllers
 {
-
     [ControllerCustomize(typeof(CollectionsController))]
     [SutProviderCustomize]
     public class CollectionsControllerTests
@@ -71,8 +70,6 @@ namespace Bit.Api.Test.Controllers
                 });
 
             _ = await sutProvider.Sut.Put(orgId, collectionId, collectionRequest);
-
-
         }
 
         [Theory, BitAutoData]

--- a/test/Api.Test/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.Test/Controllers/CollectionsControllerTests.cs
@@ -89,10 +89,6 @@ namespace Bit.Api.Test.Controllers
                 .Returns(Task.FromResult<CollectionDetails>(null));
 
             _ = await Assert.ThrowsAsync<NotFoundException>(async () => await sutProvider.Sut.Put(orgId, collectionId, collectionRequest));
-
-            await sutProvider.GetDependency<ICollectionService>()
-                .Received(1)
-                .SaveAsync(Arg.Any<Collection>(), Arg.Any<IEnumerable<SelectionReadOnly>>(), null);
         }
     }
 }

--- a/test/Api.Test/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.Test/Controllers/CollectionsControllerTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Bit.Api.Controllers;
+using Bit.Api.Models.Request;
+using Bit.Api.Test.AutoFixture.Attributes;
+using Bit.Core.Context;
+using Bit.Core.Entities;
+using Bit.Core.Exceptions;
+using Bit.Core.Models.Data;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Api.Test.Controllers
+{
+
+    [ControllerCustomize(typeof(CollectionsController))]
+    [SutProviderCustomize]
+    public class CollectionsControllerTests
+    {
+        [Theory, BitAutoData]
+        public async Task Post_Success(Guid orgId, SutProvider<CollectionsController> sutProvider)
+        {
+            sutProvider.GetDependency<ICurrentContext>()
+                .CreateNewCollections(orgId)
+                .Returns(true);
+
+            sutProvider.GetDependency<ICurrentContext>()
+                .EditAnyCollection(orgId)
+                .Returns(false);
+
+            var collectionRequest = new CollectionRequestModel
+            {
+                Name = "encrypted_string",
+                ExternalId = "my_external_id"
+            };
+
+            _ = await sutProvider.Sut.Post(orgId, collectionRequest);
+
+            await sutProvider.GetDependency<ICollectionService>()
+                .Received(1)
+                .SaveAsync(Arg.Any<Collection>(), Arg.Any<IEnumerable<SelectionReadOnly>>(), null);
+        }
+
+        [Theory, BitAutoData]
+        public async Task Put_Success(Guid orgId, Guid collectionId, Guid userId, CollectionRequestModel collectionRequest,
+            SutProvider<CollectionsController> sutProvider)
+        {
+            sutProvider.GetDependency<ICurrentContext>()
+                .ViewAssignedCollections(orgId)
+                .Returns(true);
+
+            sutProvider.GetDependency<ICurrentContext>()
+                .EditAssignedCollections(orgId)
+                .Returns(true);
+
+            sutProvider.GetDependency<ICurrentContext>()
+                .UserId
+                .Returns(userId);
+
+            sutProvider.GetDependency<ICollectionRepository>()
+                .GetByIdAsync(collectionId, userId)
+                .Returns(new CollectionDetails
+                {
+                    OrganizationId = orgId,
+                });
+
+            _ = await sutProvider.Sut.Put(orgId, collectionId, collectionRequest);
+
+
+        }
+
+        [Theory, BitAutoData]
+        public async Task Put_CanNotEditAssignedCollection_ThrowsNotFound(Guid orgId, Guid collectionId, Guid userId, CollectionRequestModel collectionRequest,
+            SutProvider<CollectionsController> sutProvider)
+        {
+            sutProvider.GetDependency<ICurrentContext>()
+                .EditAssignedCollections(orgId)
+                .Returns(true);
+
+            sutProvider.GetDependency<ICurrentContext>()
+                .UserId
+                .Returns(userId);
+
+            sutProvider.GetDependency<ICollectionRepository>()
+                .GetByIdAsync(collectionId, userId)
+                .Returns(Task.FromResult<CollectionDetails>(null));
+
+            _ = await Assert.ThrowsAsync<NotFoundException>(async () => await sutProvider.Sut.Put(orgId, collectionId, collectionRequest));
+
+            await sutProvider.GetDependency<ICollectionService>()
+                .Received(1)
+                .SaveAsync(Arg.Any<Collection>(), Arg.Any<IEnumerable<SelectionReadOnly>>(), null);
+        }
+    }
+}


### PR DESCRIPTION
## Type of change (mark with an `X`)

```
- [x] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix a potential bug where are were not `await`ing some tasks and then ensuring they are not null. Since it wasn't awaited the `Task` would always be not null. 


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Api/Controllers/CollectionsController.cs:** Switch to await `GetByIdAsync` calls as well as move away from using Yoda conditions as I have not seen anywhere else in the code we do that. I also switched to using `Guid` directly in the parameters because it gives better error messages and makes it easier to unit test.

## Before you submit (mark with an `X`)

```
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
