### PR TITLE
[SG-378] Fix null collectionIds after live-syncing a cipher

### DIFF
--- a/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
+++ b/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
@@ -70,6 +70,7 @@ namespace Bit.Core.Services
                     UserId = cipher.UserId,
                     OrganizationId = cipher.OrganizationId,
                     RevisionDate = cipher.RevisionDate,
+                    CollectionIds = collectionIds,
                 };
 
                 await SendPayloadToUserAsync(cipher.UserId.Value, type, message, true);

--- a/src/Core/Services/Implementations/NotificationsApiPushNotificationService.cs
+++ b/src/Core/Services/Implementations/NotificationsApiPushNotificationService.cs
@@ -71,6 +71,7 @@ namespace Bit.Core.Services
                     Id = cipher.Id,
                     UserId = cipher.UserId,
                     RevisionDate = cipher.RevisionDate,
+                    CollectionIds = collectionIds,
                 };
 
                 await SendMessageAsync(type, message, true);


### PR DESCRIPTION
## Type of change (mark with an `X`)

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Fix organizational vault items disappearing from the Collection filter when they are edited, and return only when the client is synced.
[SG-378](https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-378)



## Code changes

* **src/Core/Services/Implementations/NotificationHubPushNotificationService.cs:** Add collectionIds to SyncCipherPushNotification object
* **src/Core/Services/Implementations/NotificationsApiPushNotificationService.cs:** Add collectionIds to SyncCipherPushNotification object

**NOTE** I have not tested this locally as there is not an easy way to, this is likely the issue though.

## Before you submit (mark with an `X`)

```
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
