### PR TITLE
Remove (mark with an X) from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
-## Type of change (mark with an `X`)
+## Type of change
+
+<!-- (mark with an `X`) -->
 
 ```
 - [ ] Bug fix
@@ -19,7 +21,9 @@
 
 * **file.ext:** Description of what was changed and why
 
-## Before you submit (mark with an `X`)
+## Before you submit
+
+<!-- (mark with an `X`) -->
 
 ```
 - [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)


### PR DESCRIPTION
## Type of change (mark with an `X`)

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Moves the `(mark with an X)` to be a comment.

## Before you submit (mark with an `X`)

```
- [ ] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
