### PR TITLE
EC-262 - add missing validation on deactivate

### DIFF
--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -2244,6 +2244,11 @@ namespace Bit.Core.Services
             {
                 try
                 {
+                    if (organizationUser.Status == OrganizationUserStatusType.Deactivated)
+                    {
+                        throw new BadRequestException("Already deactivated.");
+                    }
+
                     if (disablingUserId.HasValue && organizationUser.UserId == disablingUserId)
                     {
                         throw new BadRequestException("You cannot deactivate yourself.");


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Part of EC-263 review caught [this missing validation](https://github.com/bitwarden/clients/pull/2893/#pullrequestreview-1010005021), being corrected here.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **OrganizationService.cs:** Check when deactivating bulk users, if user is deactivated already, if so then `throw`.

## Before you submit

```
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
