### PR TITLE
[SG-378] Get and send collectionIds when a cipher is updated

### DIFF
--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -179,6 +179,7 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
+            var collectionIds = (await _collectionCipherRepository.GetManyByUserIdCipherIdAsync(userId, new Guid(id))).Select(c => c.CollectionId).ToList();
             var modelOrgId = string.IsNullOrWhiteSpace(model.OrganizationId) ?
                 (Guid?)null : new Guid(model.OrganizationId);
             if (cipher.OrganizationId != modelOrgId)
@@ -187,7 +188,7 @@ namespace Bit.Api.Controllers
                     "then try again.");
             }
 
-            await _cipherService.SaveDetailsAsync(model.ToCipherDetails(cipher), userId, model.LastKnownRevisionDate);
+            await _cipherService.SaveDetailsAsync(model.ToCipherDetails(cipher), userId, model.LastKnownRevisionDate, collectionIds);
 
             var response = new CipherResponseModel(cipher, _globalSettings);
             return response;
@@ -205,9 +206,10 @@ namespace Bit.Api.Controllers
                 throw new NotFoundException();
             }
 
+            var collectionIds = (await _collectionCipherRepository.GetManyByUserIdCipherIdAsync(userId, new Guid(id))).Select(c => c.CollectionId).ToList();
             // object cannot be a descendant of CipherDetails, so let's clone it.
             var cipherClone = model.ToCipher(cipher).Clone();
-            await _cipherService.SaveAsync(cipherClone, userId, model.LastKnownRevisionDate, null, true, false);
+            await _cipherService.SaveAsync(cipherClone, userId, model.LastKnownRevisionDate, collectionIds, true, false);
 
             var response = new CipherMiniResponseModel(cipherClone, _globalSettings, cipher.OrganizationUseTotp);
             return response;

--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -170,16 +170,16 @@ namespace Bit.Api.Controllers
 
         [HttpPut("{id}")]
         [HttpPost("{id}")]
-        public async Task<CipherResponseModel> Put(string id, [FromBody] CipherRequestModel model)
+        public async Task<CipherResponseModel> Put(Guid id, [FromBody] CipherRequestModel model)
         {
             var userId = _userService.GetProperUserId(User).Value;
-            var cipher = await _cipherRepository.GetByIdAsync(new Guid(id), userId);
+            var cipher = await _cipherRepository.GetByIdAsync(id, userId);
             if (cipher == null)
             {
                 throw new NotFoundException();
             }
 
-            var collectionIds = (await _collectionCipherRepository.GetManyByUserIdCipherIdAsync(userId, new Guid(id))).Select(c => c.CollectionId).ToList();
+            var collectionIds = (await _collectionCipherRepository.GetManyByUserIdCipherIdAsync(userId, id)).Select(c => c.CollectionId).ToList();
             var modelOrgId = string.IsNullOrWhiteSpace(model.OrganizationId) ?
                 (Guid?)null : new Guid(model.OrganizationId);
             if (cipher.OrganizationId != modelOrgId)
@@ -196,17 +196,17 @@ namespace Bit.Api.Controllers
 
         [HttpPut("{id}/admin")]
         [HttpPost("{id}/admin")]
-        public async Task<CipherMiniResponseModel> PutAdmin(string id, [FromBody] CipherRequestModel model)
+        public async Task<CipherMiniResponseModel> PutAdmin(Guid id, [FromBody] CipherRequestModel model)
         {
             var userId = _userService.GetProperUserId(User).Value;
-            var cipher = await _cipherRepository.GetOrganizationDetailsByIdAsync(new Guid(id));
+            var cipher = await _cipherRepository.GetOrganizationDetailsByIdAsync(id);
             if (cipher == null || !cipher.OrganizationId.HasValue ||
                 !await _currentContext.EditAnyCollection(cipher.OrganizationId.Value))
             {
                 throw new NotFoundException();
             }
 
-            var collectionIds = (await _collectionCipherRepository.GetManyByUserIdCipherIdAsync(userId, new Guid(id))).Select(c => c.CollectionId).ToList();
+            var collectionIds = (await _collectionCipherRepository.GetManyByUserIdCipherIdAsync(userId, id)).Select(c => c.CollectionId).ToList();
             // object cannot be a descendant of CipherDetails, so let's clone it.
             var cipherClone = model.ToCipher(cipher).Clone();
             await _cipherService.SaveAsync(cipherClone, userId, model.LastKnownRevisionDate, collectionIds, true, false);

--- a/src/Core/Services/Implementations/CipherService.cs
+++ b/src/Core/Services/Implementations/CipherService.cs
@@ -98,17 +98,13 @@ namespace Bit.Core.Services
             }
             else
             {
-                if (collectionIds != null)
-                {
-                    throw new ArgumentException("Cannot create cipher with collection ids at the same time.");
-                }
                 ValidateCipherLastKnownRevisionDateAsync(cipher, lastKnownRevisionDate);
                 cipher.RevisionDate = DateTime.UtcNow;
                 await _cipherRepository.ReplaceAsync(cipher);
                 await _eventService.LogCipherEventAsync(cipher, Enums.EventType.Cipher_Updated);
 
                 // push
-                await _pushService.PushSyncCipherUpdateAsync(cipher, null);
+                await _pushService.PushSyncCipherUpdateAsync(cipher, collectionIds);
             }
         }
 
@@ -156,17 +152,13 @@ namespace Bit.Core.Services
             }
             else
             {
-                if (collectionIds != null)
-                {
-                    throw new ArgumentException("Cannot create cipher with collection ids at the same time.");
-                }
                 ValidateCipherLastKnownRevisionDateAsync(cipher, lastKnownRevisionDate);
                 cipher.RevisionDate = DateTime.UtcNow;
                 await _cipherRepository.ReplaceAsync(cipher);
                 await _eventService.LogCipherEventAsync(cipher, Enums.EventType.Cipher_Updated);
 
                 // push
-                await _pushService.PushSyncCipherUpdateAsync(cipher, null);
+                await _pushService.PushSyncCipherUpdateAsync(cipher, collectionIds);
             }
         }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Fix organizational vault items disappearing from the Collection filter when they are edited, and return only when the client is synced.
[SG-378](https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-378)

I think I got half of the fix in [this PR](https://github.com/bitwarden/server/pull/2057), but some more changes needed to be done.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Api/Controllers/CiphersController.cs:** Get the collectionIds for a cipher in `Put` and `PutAdmin` and send them to `SaveDetailsAsync()`
* **src/Core/Services/Implementations/CipherService.cs:** Send the collectionIds to `PushSyncCipherUpdateAsync()`. The argument exceptions in place haven't been touched in 4 years, and I don't think they apply anymore. You can in fact create a cipher with collectionIds.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
