### PR TITLE
[PS-794] Fix password reset email templates email format

### DIFF
--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -40,6 +40,20 @@ namespace Bit.Core.Services
             _mailEnqueuingService = mailEnqueuingService;
         }
 
+        private static string GetUserIdentifier(string email, string userName)
+        {
+            string identifier;
+            if (string.IsNullOrEmpty(userName))
+            {
+                identifier = email;
+            }
+            else
+            {
+                identifier = CoreHelpers.SanitizeForEmail(userName, false);
+            }
+            return identifier;
+        }
+
         public async Task SendVerifyEmailEmailAsync(string email, Guid userId, string token)
         {
             var message = CreateDefaultMessage("Verify Your Email", email);
@@ -416,20 +430,9 @@ namespace Bit.Core.Services
         public async Task SendAdminResetPasswordEmailAsync(string email, string userName, string orgName)
         {
             var message = CreateDefaultMessage("Master Password Has Been Changed", email);
-
-            string name;
-            if (string.IsNullOrEmpty(userName))
-            {
-                name = email;
-            }
-            else
-            {
-                name = CoreHelpers.SanitizeForEmail(userName, false);
-            }
-
             var model = new AdminResetPasswordViewModel()
             {
-                UserName = name,
+                UserName = GetUserIdentifier(email, userName),
                 OrgName = CoreHelpers.SanitizeForEmail(orgName),
             };
             await AddMessageContentAsync(message, "AdminResetPassword", model);
@@ -775,20 +778,9 @@ namespace Bit.Core.Services
         public async Task SendUpdatedTempPasswordEmailAsync(string email, string userName)
         {
             var message = CreateDefaultMessage("Master Password Has Been Changed", email);
-
-            string name;
-            if (string.IsNullOrEmpty(userName))
-            {
-                name = email;
-            }
-            else
-            {
-                name = CoreHelpers.SanitizeForEmail(userName, false);
-            }
-
             var model = new UpdateTempPasswordViewModel()
             {
-                UserName = name
+                UserName = GetUserIdentifier(email, userName)
             };
             await AddMessageContentAsync(message, "UpdatedTempPassword", model);
             message.Category = "UpdatedTempPassword";

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -416,9 +416,20 @@ namespace Bit.Core.Services
         public async Task SendAdminResetPasswordEmailAsync(string email, string userName, string orgName)
         {
             var message = CreateDefaultMessage("Master Password Has Been Changed", email);
+
+            string name;
+            if (string.IsNullOrEmpty(userName))
+            {
+                name = email;
+            }
+            else
+            {
+                name = CoreHelpers.SanitizeForEmail(userName, false);
+            }
+
             var model = new AdminResetPasswordViewModel()
             {
-                UserName = CoreHelpers.SanitizeForEmail(userName),
+                UserName = name,
                 OrgName = CoreHelpers.SanitizeForEmail(orgName),
             };
             await AddMessageContentAsync(message, "AdminResetPassword", model);
@@ -764,9 +775,20 @@ namespace Bit.Core.Services
         public async Task SendUpdatedTempPasswordEmailAsync(string email, string userName)
         {
             var message = CreateDefaultMessage("Master Password Has Been Changed", email);
+
+            string name;
+            if (string.IsNullOrEmpty(userName))
+            {
+                name = email;
+            }
+            else
+            {
+                name = CoreHelpers.SanitizeForEmail(userName, false);
+            }
+
             var model = new UpdateTempPasswordViewModel()
             {
-                UserName = CoreHelpers.SanitizeForEmail(userName)
+                UserName = name
             };
             await AddMessageContentAsync(message, "UpdatedTempPassword", model);
             message.Category = "UpdatedTempPassword";

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -40,20 +40,6 @@ namespace Bit.Core.Services
             _mailEnqueuingService = mailEnqueuingService;
         }
 
-        private static string GetUserIdentifier(string email, string userName)
-        {
-            string identifier;
-            if (string.IsNullOrEmpty(userName))
-            {
-                identifier = email;
-            }
-            else
-            {
-                identifier = CoreHelpers.SanitizeForEmail(userName, false);
-            }
-            return identifier;
-        }
-
         public async Task SendVerifyEmailEmailAsync(string email, Guid userId, string token)
         {
             var message = CreateDefaultMessage("Verify Your Email", email);
@@ -899,6 +885,11 @@ namespace Bit.Core.Services
             await AddMessageContentAsync(message, "FailedTwoFactorAttempts", model);
             message.Category = "FailedTwoFactorAttempts";
             await _mailDeliveryService.SendEmailAsync(message);
+        }
+
+        private static string GetUserIdentifier(string email, string userName)
+        {
+            return string.IsNullOrEmpty(userName) ? email : CoreHelpers.SanitizeForEmail(userName, false);
         }
     }
 }

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -794,7 +794,7 @@ namespace Bit.Core.Services
             user.ForcePasswordReset = true;
 
             await _userRepository.ReplaceAsync(user);
-            await _mailService.SendAdminResetPasswordEmailAsync(user.Email, user.Name ?? user.Email, org.Name);
+            await _mailService.SendAdminResetPasswordEmailAsync(user.Email, user.Name, org.Name);
             await _eventService.LogOrganizationUserEventAsync(orgUser, EventType.OrganizationUser_AdminResetPassword);
             await _pushService.PushLogOutAsync(user.Id);
 
@@ -820,7 +820,7 @@ namespace Bit.Core.Services
             user.MasterPasswordHint = hint;
 
             await _userRepository.ReplaceAsync(user);
-            await _mailService.SendUpdatedTempPasswordEmailAsync(user.Email, user.Name ?? user.Email);
+            await _mailService.SendUpdatedTempPasswordEmailAsync(user.Email, user.Name);
             await _eventService.LogUserEventAsync(user.Id, EventType.User_UpdatedTempPassword);
             await _pushService.PushLogOutAsync(user.Id);
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The purpose of this PR is to fix email address displaying for the email templates UpdatedTempPassword and AdminResetPassword. 

For both templates, if the user being targeted does not have a username the email templates default to using the user's email address. 

When the email address is used, the `@` and `.` characters are translated into `[at]` and `[dot]` respectively in the email sent.

## Screenshots
![image](https://user-images.githubusercontent.com/43214426/174836260-f8d3b85b-47a4-4331-8575-888add3f3d40.png)

![image](https://user-images.githubusercontent.com/43214426/174836601-c3a7bea1-e41a-4879-a747-a0247a1f2054.png)

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

### src/Core/Services/Implementations/UserService.cs

Removed the null-coalescing operators `??` from the send email calls, as we need to perform different actions in the template based on using the email address or username.

### src/Core/Services/Implementations/HandlebarsMailService.cs

Moved null check and added the empty string check into each send email function.

If we are using the email address as an identifier, we don't need the SanitizeForEmail() call as this is what causes the string modification which is the root cause of the bug.

For using the username as the identifier, added passing the false flag for HTML encoding as the value is being double HTML encoded. 
The handlerbars framework automatically HTML encodes values and SanitizeForEmail() also HTML encodes the value without the false flag. 
This double HTML encoding has caused issues in other templates. 

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
