### PR TITLE
Expose collection name in public api.

### DIFF
--- a/src/Api/Models/Public/Response/CollectionResponseModel.cs
+++ b/src/Api/Models/Public/Response/CollectionResponseModel.cs
@@ -21,6 +21,7 @@ namespace Bit.Api.Models.Public.Response
 
             Id = collection.Id;
             ExternalId = collection.ExternalId;
+            Name = collection.Name;
             Groups = groups?.Select(c => new AssociationWithPermissionsResponseModel(c));
         }
 
@@ -36,6 +37,10 @@ namespace Bit.Api.Models.Public.Response
         /// <example>539a36c5-e0d2-4cf9-979e-51ecf5cf6593</example>
         [Required]
         public Guid Id { get; set; }
+        /// <summary>
+        /// The collections name.
+        /// </summary>
+        public string Name { get; set; }
         /// <summary>
         /// The associated groups that this collection is assigned to.
         /// </summary>


### PR DESCRIPTION
## Type of change

Return collection name in public api.

## Objective

I was just using the public api to find out which of my users are assigned to which collections. And then I had to stop because when the api returns no readable collection names, its not possible.