### PR TITLE
Fix OrganizationConnection Update

### DIFF
--- a/test/Api.Test/Controllers/OrganizationConnectionsControllerTests.cs
+++ b/test/Api.Test/Controllers/OrganizationConnectionsControllerTests.cs
@@ -141,6 +141,10 @@ namespace Bit.Api.Test.Controllers
         [BitAutoData]
         public async Task UpdateConnection_RequiresOwnerPermissions(SutProvider<OrganizationConnectionsController> sutProvider)
         {
+            sutProvider.GetDependency<IOrganizationConnectionRepository>()
+                .GetByIdAsync(Arg.Any<Guid>())
+                .Returns(new OrganizationConnection());
+
             var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.UpdateConnection(default, null));
 
             Assert.Contains("Only the owner of an organization can update a connection.", exception.Message);
@@ -157,6 +161,10 @@ namespace Bit.Api.Test.Controllers
 
             sutProvider.GetDependency<ICurrentContext>().OrganizationOwner(typedModel.OrganizationId).Returns(true);
 
+            sutProvider.GetDependency<IOrganizationConnectionRepository>()
+                .GetByIdAsync(existing1.Id)
+                .Returns(existing1);
+
             sutProvider.GetDependency<IOrganizationConnectionRepository>().GetByOrganizationIdTypeAsync(typedModel.OrganizationId, type).Returns(new[] { existing1, existing2 });
 
             var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.UpdateConnection(existing1.Id, typedModel));
@@ -170,6 +178,10 @@ namespace Bit.Api.Test.Controllers
             OrganizationConnection updated,
             SutProvider<OrganizationConnectionsController> sutProvider)
         {
+            existing.SetConfig(new BillingSyncConfig
+            {
+                CloudOrganizationId = config.CloudOrganizationId,
+            });
             updated.Config = JsonSerializer.Serialize(config);
             updated.Id = existing.Id;
             var model = RequestModelFromEntity(updated);
@@ -177,6 +189,9 @@ namespace Bit.Api.Test.Controllers
             sutProvider.GetDependency<ICurrentContext>().OrganizationOwner(model.OrganizationId).Returns(true);
             sutProvider.GetDependency<IOrganizationConnectionRepository>().GetByOrganizationIdTypeAsync(model.OrganizationId, model.Type).Returns(new[] { existing });
             sutProvider.GetDependency<IUpdateOrganizationConnectionCommand>().UpdateAsync<BillingSyncConfig>(default).ReturnsForAnyArgs(updated);
+            sutProvider.GetDependency<IOrganizationConnectionRepository>()
+                .GetByIdAsync(existing.Id)
+                .Returns(existing);
 
             var expected = new OrganizationConnectionResponseModel(updated, typeof(BillingSyncConfig));
             var result = await sutProvider.Sut.UpdateConnection(existing.Id, model);
@@ -184,6 +199,13 @@ namespace Bit.Api.Test.Controllers
             AssertHelper.AssertPropertyEqual(expected, result);
             await sutProvider.GetDependency<IUpdateOrganizationConnectionCommand>().Received(1)
                 .UpdateAsync(Arg.Is(AssertHelper.AssertPropertyEqual(model.ToData(updated.Id))));
+        }
+
+        [Theory]
+        [BitAutoData]
+        public async Task UpdateConnection_DoesNotExist_ThrowsNotFound(SutProvider<OrganizationConnectionsController> sutProvider)
+        {
+            await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.UpdateConnection(Guid.NewGuid(), null));
         }
 
         [Theory]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When updating an `OrganizationConnection` the `CloudOrganizationId` was getting set to an empty guid. This will make it impossible for the billing sync to take place and the remediation was to delete and recreate it. If the billing sync token was saved multiple times it would have bad data.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Api/Controllers/OrganizationConnectionsController.cs:** Made the CloudOrganizationId section of the config readonly and copied the value from the existing connection on update.
* **test/Api.Test/Controllers/OrganizationConnectionsControllerTests.cs:** Fixed and added tests to validate that it is working as expected.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
