### PR TITLE
Check for ascii-only in entire local part of emails

### DIFF
--- a/src/Core/Utilities/StrictEmailAddressAttribute.cs
+++ b/src/Core/Utilities/StrictEmailAddressAttribute.cs
@@ -41,7 +41,7 @@ namespace Bit.Core.Utilities
             * Must end in a letter (including unicode)
             See the unit tests for examples of what is allowed.
             **/
-            var emailFormat = @"[\x00-\x7F]+@.+\.\p{L}+$";
+            var emailFormat = @"^[\x00-\x7F]+@.+\.\p{L}+$";
             if (!Regex.IsMatch(emailAddress, emailFormat))
             {
                 return false;

--- a/test/Core.Test/Utilities/StrictEmailAddressAttributeTests.cs
+++ b/test/Core.Test/Utilities/StrictEmailAddressAttributeTests.cs
@@ -45,7 +45,8 @@ namespace Bit.Core.Test.Utilities
         [InlineData("hellothere@.worldcom")]                // domain beginning with dot
         [InlineData("hellothere@worldcom.")]                // domain ending in dot
         [InlineData("hellothere@world.com-")]               // domain ending in hyphen
-        [InlineData("héllö@world.com")]                     // unicode in local-part
+        [InlineData("hellö@world.com")]                     // unicode at end of local-part
+        [InlineData("héllo@world.com")]                     // unicode in middle of local-part
         public void IsValid_ReturnsFalseWhenInvalid(string email)
         {
             var sut = new StrictEmailAddressAttribute();


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
We need to be sure to check the entirety of the email by specifying we check from beginning (`^`) to end (`$`).




## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
