### PR TITLE
[EC-293] Fix device verification get settings so the state is correct

### DIFF
--- a/src/Api/Controllers/TwoFactorController.cs
+++ b/src/Api/Controllers/TwoFactorController.cs
@@ -391,7 +391,8 @@ namespace Bit.Api.Controllers
                 return new DeviceVerificationResponseModel(false, false);
             }
 
-            return new DeviceVerificationResponseModel(_userService.CanEditDeviceVerificationSettings(user), user.UnknownDeviceVerificationEnabled);
+            var canUserEditDeviceVerificationSettings = _userService.CanEditDeviceVerificationSettings(user);
+            return new DeviceVerificationResponseModel(canUserEditDeviceVerificationSettings, canUserEditDeviceVerificationSettings && user.UnknownDeviceVerificationEnabled);
         }
 
         [HttpPut("device-verification-settings")]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix device verification `GetDeviceVerificationSettings` so that it returns the correct state when the global setting is off.

Context:
Currently, when the global setting is off the web is showing the Device Verification checkbox `On` for users given that that value is obtained directly from the `UnknownDeviceVerificationEnabled` column value of the `User` table. So, instead the checkbox should be off in that case. Therefore with this change the checkbox gets directly the value of the column only when they can edit the value, otherwise it will be off.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **TwoFactorController.cs:** Now it returns the correct state on `GetDeviceVerificationSettings`. When the user can't edit the device verification setting, then it should return false on `UnknownDeviceVerificationEnabled` parameter.

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
