### PR TITLE
Update missed email template to new format

### DIFF
--- a/src/Core/MailTemplates/Handlebars/FamiliesForEnterprise/FamiliesForEnterpriseOfferNewAccount.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/FamiliesForEnterprise/FamiliesForEnterpriseOfferNewAccount.html.hbs
@@ -5,16 +5,19 @@
             A Bitwarden organization, {{SponsorOrgName}}, has sponsored a free Families subscription for you! To accept your complimentary subscription, you will need to create an account with this email address.
         </td>
     </tr>
+    <tr style="margin: 0; box-sizing: border-box;line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;" valign="top">
+            If you do not recognize this account, please ignore this message.
+            <br style="margin: 0; box-sizing: border-box; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;" />
+            <br style="margin: 0; box-sizing: border-box; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;" />
+        </td>
+    </tr>
     <tr style="margin: 0; box-sizing: border-box; line-height: 25px; -webkit-text-size-adjust: none;">
         <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none; text-align: center;" valign="top" align="center">
             <a href="{{{Url}}}" clicktracking=off target="_blank" style="color: #ffffff; text-decoration: none; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; background-color: #175DDC; border-color: #175DDC; border-style: solid; border-width: 10px 20px; margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
                 Create Account
             </a>
-        </td>
-    </tr>
-    <tr style="margin: 0; box-sizing: border-box;line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
-        <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;" valign="top">
-            If you do not recognize this account, please ignore this message.
+            <br style="margin: 0; box-sizing: border-box; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;" />
         </td>
     </tr>
 </table>

--- a/src/Core/MailTemplates/Handlebars/FamiliesForEnterprise/FamiliesForEnterpriseOfferNewAccount.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/FamiliesForEnterprise/FamiliesForEnterpriseOfferNewAccount.text.hbs
@@ -1,7 +1,8 @@
 {{#>BasicTextLayout}}
 A Bitwarden organization, {{SponsorOrgName}}, has sponsored a free Families subscription for you! To accept your complimentary subscription, you will need to create an account with this email address. Click the link below.
 
+If you do not recognize this account, please ignore this message.
+
 {{Url}}
 
-If you do not recognize this account, please ignore this message.
 {{/BasicTextLayout}}

--- a/test/Core.Test/Services/HandlebarsMailServiceTests.cs
+++ b/test/Core.Test/Services/HandlebarsMailServiceTests.cs
@@ -111,7 +111,8 @@ namespace Bit.Core.Test.Services
                 { ("familyUserEmail", typeof(string)), "test@bitwarden.com" },
                 { ("sponsorEmail", typeof(string)), "test@bitwarden.com" },
                 { ("familyOrgName", typeof(string)), "Test Org Name" },
-                { ("existingAccount", typeof(bool)), true },
+                // Swap existingAccount to true or false to generate different versions of the SendFamiliesForEnterpriseOfferEmailAsync emails.
+                { ("existingAccount", typeof(bool)), false },
                 { ("sponsorshipEndDate", typeof(DateTime)), DateTime.UtcNow.AddDays(1)},
                 { ("sponsorOrgName", typeof(string)), "Sponsor Test Org Name" },
                 { ("expirationDate", typeof(DateTime)), DateTime.Now.AddDays(3) },


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This is a follow-up to https://github.com/bitwarden/server/pull/2033.

For this specific template, needed to: 
- Add an additional margin above and below each call-to-action button
- For emails that include only the “ignore” warning below the call-to-action button move the warning up, so the button is the last item displayed

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

src/Core/MailTemplates/Handlebars/FamiliesForEnterprise/FamiliesForEnterpriseOfferNewAccount.html.hbs
- Moved the "ignore" warning above the call-to-action button
- Added a `<br>` above and below the call-to-action button

src/Core/MailTemplates/Handlebars/FamiliesForEnterprise/FamiliesForEnterpriseOfferNewAccount.text.hbs
- Reordered text to reflect moving the "ignore" warnings above call-to-action buttons

test/Core.Test/Services/HandlebarsMailServiceTests.cs
- Added comments in the code to explain how to generate the two different versions of the email. 

One version for when an account already exists was updated, however the version for when an account doesn't exist is what is being updated in this PR.

## Screenshots
![image](https://user-images.githubusercontent.com/43214426/177581989-3a79a32e-1ba7-463f-89e6-fd00517eb79e.png)

![image](https://user-images.githubusercontent.com/43214426/177582064-0dfea712-ed2c-4df8-bfc3-3e46db00e6e1.png)


## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
