### PR TITLE
[PS-1051] Delay user verification requirement on master password reset

### DIFF
--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -297,17 +297,17 @@ namespace Bit.Api.Controllers
                 throw new UnauthorizedAccessException();
             }
 
-            if (model.ResetPasswordKey != null && !await _userService.VerifySecretAsync(user, model.Secret))
-            {
-                await Task.Delay(2000);
-                throw new BadRequestException("MasterPasswordHash", "Invalid password.");
-            }
-            else
-            {
-                var callingUserId = user.Id;
+            // if (model.ResetPasswordKey != null && !await _userService.VerifySecretAsync(user, model.Secret))
+            // {
+            //     await Task.Delay(2000);
+            //     throw new BadRequestException("MasterPasswordHash", "Invalid password.");
+            // }
+            // else
+            // {
+            var callingUserId = user.Id;
                 await _organizationService.UpdateUserResetPasswordEnrollmentAsync(
                    new Guid(orgId), new Guid(userId), model.ResetPasswordKey, callingUserId);
-            }
+            // }
         }
 
         [HttpPut("{id}/reset-password")]

--- a/src/Api/Models/Request/Organizations/OrganizationUserRequestModels.cs
+++ b/src/Api/Models/Request/Organizations/OrganizationUserRequestModels.cs
@@ -95,7 +95,7 @@ namespace Bit.Api.Models.Request.Organizations
         public IEnumerable<string> GroupIds { get; set; }
     }
 
-    public class OrganizationUserResetPasswordEnrollmentRequestModel : SecretVerificationRequestModel
+    public class OrganizationUserResetPasswordEnrollmentRequestModel
     {
         public string ResetPasswordKey { get; set; }
     }


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Delay user verification requirement on master password reset. This is to give clients a chance to update to the new api requirements


## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
