### PR TITLE
made the get plans endpoint anonymous

### DIFF
--- a/src/Api/Controllers/PlansController.cs
+++ b/src/Api/Controllers/PlansController.cs
@@ -17,6 +17,7 @@ namespace Bit.Api.Controllers
         }
 
         [HttpGet("")]
+        [AllowAnonymous]
         public ListResponseModel<PlanResponseModel> Get()
         {
             var data = StaticStore.Plans;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This change was made in relation to the trial initiation feature. The current implementation of the GET `plans` needs a user to be authorized before it can be called and this would not be necessary for the trial initiation feature. 



## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Api/Controllers/PlansController.cs:** Added `AllowAnonymous` which would allow the endpoint to be called without having an authenticated user.

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
