### PR TITLE
[EC-284] Prevent duplicate organization invites

### DIFF
--- a/src/Api/Models/Request/Accounts/UpdateProfileRequestModel.cs
+++ b/src/Api/Models/Request/Accounts/UpdateProfileRequestModel.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.Entities;
 
 namespace Bit.Api.Models.Request.Accounts

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1135,7 +1135,8 @@ namespace Bit.Core.Services
             var events = new List<(OrganizationUser, EventType, DateTime?)>();
             foreach (var (invite, externalId) in invites)
             {
-                foreach (var email in invite.Emails)
+                // Prevent duplicate invitations
+                foreach (var email in invite.Emails.Distinct())
                 {
                     try
                     {

--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -196,6 +196,28 @@ namespace Bit.Core.Test.Services
         }
 
         [Theory]
+        [OrganizationInviteAutoData]
+        public async Task InviteUser_DuplicateEmails_PassesWithoutDuplicates(Organization organization, OrganizationUser invitor,
+                    [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.Owner)] OrganizationUser owner,
+            OrganizationUserInvite invite, SutProvider<OrganizationService> sutProvider)
+        {
+            invite.Emails = invite.Emails.Append(invite.Emails.First());
+
+            sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
+            sutProvider.GetDependency<ICurrentContext>().OrganizationOwner(organization.Id).Returns(true);
+            sutProvider.GetDependency<ICurrentContext>().ManageUsers(organization.Id).Returns(true);
+            var organizationUserRepository = sutProvider.GetDependency<IOrganizationUserRepository>();
+            organizationUserRepository.GetManyByOrganizationAsync(organization.Id, OrganizationUserType.Owner)
+                .Returns(new[] { owner });
+
+            await sutProvider.Sut.InviteUsersAsync(organization.Id, invitor.UserId, new (OrganizationUserInvite, string)[] { (invite, null) });
+
+            await sutProvider.GetDependency<IMailService>().Received(1)
+                .BulkSendOrganizationInviteEmailAsync(organization.Name,
+                    Arg.Is<IEnumerable<(OrganizationUser, ExpiringToken)>>(v => v.Count() == invite.Emails.Distinct().Count()));
+        }
+
+        [Theory]
         [OrganizationInviteAutoData(
             inviteeUserType: (int)OrganizationUserType.Admin,
             invitorUserType: (int)OrganizationUserType.Owner


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
We were previously allowing multiple organization invites for duplicate emails. This fix adds validation to make sure we're removing duplicates from the list of emails.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->


* **src/Core/Services/Implementations/OrganizationService.cs:** loop only through distinct emails
* **test/Core.Test/Services/OrganizationServiceTests.cs:** add test
* **src/Api/Models/Request/Accounts/UpdateProfileRequestModel.cs:** formatting

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
