### PR TITLE
[feat] Allow CS to perform bulk actions on Stripe subscriptions from the Admin portal

### DIFF
--- a/src/Admin/Models/StripeSubscriptionsModel.cs
+++ b/src/Admin/Models/StripeSubscriptionsModel.cs
@@ -1,0 +1,42 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.Models.BitStripe;
+
+namespace Bit.Admin.Models
+{
+    public class StripeSubscriptionRowModel
+    {
+        public Stripe.Subscription Subscription { get; set; }
+        public bool Selected { get; set; }
+
+        public StripeSubscriptionRowModel() { }
+        public StripeSubscriptionRowModel(Stripe.Subscription subscription)
+        {
+            Subscription = subscription;
+        }
+    }
+
+    public enum StripeSubscriptionsAction
+    {
+        Search,
+        PreviousPage,
+        NextPage,
+        Export,
+        BulkCancel
+    }
+
+    public class StripeSubscriptionsModel : IValidatableObject
+    {
+        public List<StripeSubscriptionRowModel> Items { get; set; }
+        public StripeSubscriptionsAction Action { get; set; } = StripeSubscriptionsAction.Search;
+        public string Message { get; set; }
+        public List<Stripe.Price> Prices { get; set; }
+        public StripeSubscriptionListOptions Filter { get; set; } = new StripeSubscriptionListOptions();
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (Action == StripeSubscriptionsAction.BulkCancel && Filter.Status != "unpaid")
+            {
+                yield return new ValidationResult("Bulk cancel is currently only supported for unpaid subscriptions");
+            }
+        }
+    }
+}

--- a/src/Admin/Views/Shared/_Layout.cshtml
+++ b/src/Admin/Views/Shared/_Layout.cshtml
@@ -66,6 +66,9 @@
                                     <a class="dropdown-item" asp-controller="Tools" asp-action="TaxRate">
                                         Manage Tax Rates
                                     </a>
+                                    <a class="dropdown-item" asp-controller="Tools" asp-action="StripeSubscriptions">
+                                        Manage Stripe Subscriptions
+                                    </a>
                                 </div>
                             </li>
                             <li class="nav-item" active-controller="Logs">

--- a/src/Admin/Views/Tools/StripeSubscriptions.cshtml
+++ b/src/Admin/Views/Tools/StripeSubscriptions.cshtml
@@ -1,0 +1,265 @@
+@model StripeSubscriptionsModel
+@{
+    ViewData["Title"] = "Stripe Subscriptions";
+}
+
+@section Scripts {
+    <script>
+        function onRowSelect(selectingPage = false) {
+            var checkboxes = document.getElementsByClassName('row-check');
+            var checkedCheckboxCount = 0;
+            var bulkActions = document.getElementById('bulkActions');
+
+            var selectPage = document.getElementById('selectPage');
+            for(var i = 0; i < checkboxes.length; i++){
+                if((checkboxes[i].checked && !selectingPage) || selectingPage && selectPage.checked) {
+                    checkboxes[i].checked = true;
+                    checkedCheckboxCount += 1;
+                } else {
+                    checkboxes[i].checked = false;
+                }
+            }
+
+            if(checkedCheckboxCount > 0) {
+                bulkActions.classList.remove("d-none");
+            } else {
+                bulkActions.classList.add("d-none");
+            }
+
+            var selectPage = document.getElementById('selectPage');
+            var selectAll = document.getElementById('selectAll');
+            if (checkedCheckboxCount == checkboxes.length) {
+                selectPage.checked = true;
+                selectAll.classList.remove("d-none");
+
+                var selectAllElement = document.getElementById('selectAllElement');
+                selectAllElement.classList.remove('d-none');
+
+                var selectedAllConfirmation = document.getElementById('selectedAllConfirmation');
+                selectedAllConfirmation.classList.add('d-none');
+            } else {
+                selectPage.checked = false;
+                selectAll.classList.add("d-none");
+                var selectAllInput = document.getElementById('selectAllInput');
+                selectAllInput.checked = false;
+            }
+        }
+
+        function onSelectAll() {
+            var selectAllInput = document.getElementById('selectAllInput');
+            selectAllInput.checked = true;
+
+            var selectAllElement = document.getElementById('selectAllElement');
+            selectAllElement.classList.add('d-none');
+
+            var selectedAllConfirmation = document.getElementById('selectedAllConfirmation');
+            selectedAllConfirmation.classList.remove('d-none');
+        }
+
+        function exportSelectedSubscriptions() {
+            var selectAll = document.getElementById('selectAll');
+            var httpRequest = new XMLHttpRequest();
+            httpRequest.open('POST');
+            httpRequest.send();
+        }
+
+        function cancelSelectedSubscriptions() {
+
+        }
+    </script>
+}
+
+<h2>Manage Stripe Subscriptions</h2>
+@if (!string.IsNullOrWhiteSpace(Model.Message))
+{
+    <div class="alert alert-success"></div>
+}
+        <form method="post">
+        <div asp-validation-summary="All" class="alert alert-danger"></div>
+        <div class="row">
+            <div class="col-6">
+                <label asp-for="Filter.Status">Status</label>
+                <select asp-for="Filter.Status" name="filter.Status" class="form-control mr-2">
+                    <option asp-selected="Model.Filter.Status == null" value="all">All</option>
+                    <option asp-selected='Model.Filter.Status == "active"' value="active">Active</option>
+                    <option asp-selected='Model.Filter.Status == "unpaid"' value="unpaid">Unpaid</option>
+                </select>
+            </div>
+            <div class="col-6">
+                <label asp-for="Filter.CurrentPeriodEnd">Current Period End</label>
+                <div class="input-group">
+                    <div class="input-group-append">
+                        <div class="input-group-text">
+                            <span class="mr-1">
+                                <input type="radio" class="mr-1" asp-for="Filter.CurrentPeriodEndRange" name="filter.CurrentPeriodEndRange" value="lt">Before
+                            </span>
+                            <input type="radio" asp-for="Filter.CurrentPeriodEndRange" name="filter.CurrentPeriodEndRange" value="gt">After
+                        </div>
+                    </div>
+                    @{
+                        var date = @Model.Filter.CurrentPeriodEndDate.HasValue ? @Model.Filter.CurrentPeriodEndDate.Value.ToString("yyyy-MM-dd") : string.Empty;
+                        <input type="date" class="form-control" asp-for="Filter.CurrentPeriodEndDate" name="filter.CurrentPeriodEndDate" value="@date">
+                    }
+                </div>
+            </div>
+        </div>
+        <div class="row mt-2">
+            <div class="col-6">
+                <label asp-for="Filter.Price">Price ID</label>
+                <select asp-for="Filter.Price" name="filter.Price" class="form-control mr-2">
+                    <option asp-selected="Model.Filter.Price == null" value="@null">All</option>
+                    @foreach (var price in Model.Prices)
+                    {<option asp-selected='@Model.Filter.Price == @price.Id' value="@price.Id">@price.Id</option>}
+                </select>
+            </div>
+        </div>
+        <div class="row col-12 d-flex justify-content-end my-3">
+                <button type="submit" class="btn btn-primary" title="Search" name="action" asp-for="Action" value="@StripeSubscriptionsAction.Search"><i class="fa fa-search"></i> Search</button>
+        </div>
+    <hr/>
+    <input type="checkbox" class="d-none" asp-for="Filter.SelectAll" name="filter.SelectAll" id="selectAllInput" asp-for="Model.Filter.SelectAll">
+    <div class="text-center row d-flex justify-content-center">
+        <div id="selectAll" class="d-none col-8"> 
+            All @Model.Items.Count subscriptions on this page are selected.<br/>
+            <button type="button" id="selectAllElement" class="btn btn-link p-0 pb-1" onclick="onSelectAll()">Click here to select all subscriptions for this search.</button>
+            <span id="selectedAllConfirmation" class="d-none text-muted">✔ All subscriptions for this search are selected.</span><br/>
+            <div class="alert alert-warning" role="alert">Please be aware that bulk operations may take several minutes to complete.</div>
+        </div>
+    </div>
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead>
+                <tr>
+                     <th>
+                        <div class="form-check form-check-inline">
+                            <input id="selectPage" class="form-check-input" type="checkbox" onchange="onRowSelect(true)">
+                        </div>
+                    </th>
+                    <th>Id</th>
+                    <th>Customer Email</th>
+                    <th>Status</th>
+                    <th>Product</th>
+                    <th>Current Period End</th>
+                </tr>
+            </thead>
+            <tbody>
+                @if(!Model.Items.Any())
+                {
+                    <tr>
+                        <td colspan="6">No results to list.</td>
+                    </tr>
+                }
+                else
+                {
+                    @for(var i = 0; i < Model.Items.Count; i++)
+                    {
+                        <tr>
+                            <td>
+                                <input type="hidden" asp-for="@Model.Items[i].Subscription.Id" value="@Model.Items[i].Subscription.Id">
+                                <input type="hidden" asp-for="@Model.Items[i].Subscription.Status" value="@Model.Items[i].Subscription.Status">
+                                <input type="hidden" asp-for="@Model.Items[i].Subscription.CurrentPeriodEnd" value="@Model.Items[i].Subscription.CurrentPeriodEnd">
+                                <input type="hidden" asp-for="@Model.Items[i].Subscription.Customer.Email" value="@Model.Items[i].Subscription.Customer.Email">
+                                <input type="hidden" asp-for="@Model.Items[i].Subscription.LatestInvoice.Status" value="@Model.Items[i].Subscription.LatestInvoice.Status">
+                                <input type="hidden" asp-for="@Model.Items[i].Subscription.LatestInvoice.Id" value="@Model.Items[i].Subscription.LatestInvoice.Id">
+
+                                @for(var j = 0; j < Model.Items[i].Subscription.Items.Data.Count; j++)
+                                {
+                                    <input 
+                                        type="hidden"
+                                        asp-for="@Model.Items[i].Subscription.Items.Data[j].Plan.Id"
+                                        value="@Model.Items[i].Subscription.Items.Data[j].Plan.Id"
+                                    >
+                                }
+                                <div class="form-check">
+                                    <input class="form-check-input row-check" onchange="onRowSelect()" asp-for="@Model.Items[i].Selected">
+                                </div>
+                            </td>
+                            <td>
+                                @Model.Items[i].Subscription.Id
+                            </td>
+                            <td>
+                                @Model.Items[i].Subscription.Customer?.Email
+                            </td>
+                            <td>
+                                @Model.Items[i].Subscription.Status
+                            </td>
+                            <td>
+                                @string.Join(",", Model.Items[i].Subscription.Items.Data.Select(product => product.Plan.Id).ToArray())
+                            </td>
+                            <td>
+                                @Model.Items[i].Subscription.CurrentPeriodEnd.ToShortDateString()
+                            </td>
+                        </tr>
+                    }
+                }
+            </tbody>
+        </table>
+    </div>
+    <nav class="d-inline-flex">
+        <ul class="pagination">
+            @if(!string.IsNullOrWhiteSpace(Model.Filter.EndingBefore))
+            {
+                <input type="hidden" asp-for="@Model.Filter.EndingBefore" value="@Model.Filter.EndingBefore">
+                <li class="page-item">
+                    <button 
+                    type="submit"
+                    class="page-link"
+                    name="action"
+                    asp-for="Action"
+                    value="@StripeSubscriptionsAction.PreviousPage"
+                    >
+                        Previous
+                    </button>
+                </li>
+            }
+            else
+            {
+                <li class="page-item disabled">
+                    <a class="page-link" href="#" tabindex="-1">Previous</a>
+                </li>
+            }
+            @if(!string.IsNullOrWhiteSpace(Model.Filter.StartingAfter))
+            {
+                <input type="hidden" asp-for="@Model.Filter.StartingAfter" value="@Model.Filter.StartingAfter">
+                <li class="page-item">
+                    <button class="page-link"
+                    type="submit"
+                    name="action"
+                    asp-for="Action"
+                    value="@StripeSubscriptionsAction.NextPage"
+                    >
+                        Next
+                    </button>
+                </li>
+            }
+            else
+            {
+                <li class="page-item disabled">
+                    <a class="page-link" href="#" tabindex="-1">Next</a>
+                </li>
+            }
+        </ul>
+        <span id="bulkActions" class="d-none ml-2">
+            <span class="d-inline-flex">
+                <button 
+                    type="submit"
+                    class="btn btn-primary mr-1"
+                    name="action"
+                    asp-for="Action"
+                    value="@StripeSubscriptionsAction.Export"
+                >
+                    Export 
+                </button>
+                <button 
+                    type="submit"
+                    class="btn btn-danger"
+                    name="action"
+                    asp-for="Action"
+                    value="@StripeSubscriptionsAction.BulkCancel"
+                    >
+                    Bulk Cancel
+                </button>
+            </span>
+        </span>
+    </nav>
+    </form>

--- a/src/Api/Models/Request/Accounts/UpdateProfileRequestModel.cs
+++ b/src/Api/Models/Request/Accounts/UpdateProfileRequestModel.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.Entities;
 
 namespace Bit.Api.Models.Request.Accounts

--- a/src/Core/Models/Stripe/StripeSubscriptionListOptions.cs
+++ b/src/Core/Models/Stripe/StripeSubscriptionListOptions.cs
@@ -1,0 +1,41 @@
+﻿namespace Bit.Core.Models.BitStripe
+{
+    // Stripe's SubscriptionListOptions model has a complex input for date filters.
+    // It expects a dictionary, and has lots of validation rules around what can have a value and what can't.
+    // To simplify this a bit we are extending Stripe's model and using our own date inputs, and building the dictionary they expect JiT.
+    // ___
+    // Our model also facilitates selecting all elements in a list, which is unsupported by Stripe's model.
+    public class StripeSubscriptionListOptions : Stripe.SubscriptionListOptions
+    {
+        public DateTime? CurrentPeriodEndDate { get; set; }
+        public string CurrentPeriodEndRange { get; set; } = "lt";
+        public bool SelectAll { get; set; }
+        public new Stripe.DateRangeOptions CurrentPeriodEnd
+        {
+            get
+            {
+                return CurrentPeriodEndDate.HasValue ?
+                    new Stripe.DateRangeOptions()
+                    {
+                        LessThan = CurrentPeriodEndRange == "lt" ? CurrentPeriodEndDate : null,
+                        GreaterThan = CurrentPeriodEndRange == "gt" ? CurrentPeriodEndDate : null
+                    } :
+                    null;
+            }
+        }
+
+        public Stripe.SubscriptionListOptions ToStripeApiOptions()
+        {
+            var stripeApiOptions = (Stripe.SubscriptionListOptions)this;
+            if (CurrentPeriodEndDate.HasValue)
+            {
+                stripeApiOptions.CurrentPeriodEnd = new Stripe.DateRangeOptions()
+                {
+                    LessThan = CurrentPeriodEndRange == "lt" ? CurrentPeriodEndDate : null,
+                    GreaterThan = CurrentPeriodEndRange == "gt" ? CurrentPeriodEndDate : null
+                };
+            }
+            return stripeApiOptions;
+        }
+    }
+}

--- a/src/Core/Services/IStripeAdapter.cs
+++ b/src/Core/Services/IStripeAdapter.cs
@@ -1,4 +1,6 @@
-﻿namespace Bit.Core.Services
+﻿using Bit.Core.Models.BitStripe;
+
+namespace Bit.Core.Services
 {
     public interface IStripeAdapter
     {
@@ -8,8 +10,9 @@
         Task<Stripe.Customer> CustomerDeleteAsync(string id);
         Task<Stripe.Subscription> SubscriptionCreateAsync(Stripe.SubscriptionCreateOptions subscriptionCreateOptions);
         Task<Stripe.Subscription> SubscriptionGetAsync(string id, Stripe.SubscriptionGetOptions options = null);
+        Task<List<Stripe.Subscription>> SubscriptionListAsync(StripeSubscriptionListOptions subscriptionSearchOptions);
         Task<Stripe.Subscription> SubscriptionUpdateAsync(string id, Stripe.SubscriptionUpdateOptions options = null);
-        Task<Stripe.Subscription> SubscriptionCancelAsync(string Id, Stripe.SubscriptionCancelOptions options);
+        Task<Stripe.Subscription> SubscriptionCancelAsync(string Id, Stripe.SubscriptionCancelOptions options = null);
         Task<Stripe.Invoice> InvoiceUpcomingAsync(Stripe.UpcomingInvoiceOptions options);
         Task<Stripe.Invoice> InvoiceGetAsync(string id, Stripe.InvoiceGetOptions options);
         Task<Stripe.StripeList<Stripe.Invoice>> InvoiceListAsync(Stripe.InvoiceListOptions options);
@@ -31,5 +34,6 @@
         Task<Stripe.Card> CardDeleteAsync(string customerId, string cardId, Stripe.CardDeleteOptions options = null);
         Task<Stripe.BankAccount> BankAccountCreateAsync(string customerId, Stripe.BankAccountCreateOptions options = null);
         Task<Stripe.BankAccount> BankAccountDeleteAsync(string customerId, string bankAccount, Stripe.BankAccountDeleteOptions options = null);
+        Task<Stripe.StripeList<Stripe.Price>> PriceListAsync(Stripe.PriceListOptions options = null);
     }
 }


### PR DESCRIPTION
https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-404

## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
CS needs to bulk cancel many subscriptions in Stripe and void their open invoices based on subscription status, product type, and invoice due date. The current need is to cancel all unpaid premium subscriptions, and all unpaid org subscriptions with a variable due date.

## Code changes
1. Create a table view of Stripe Subscriptions and add it to the Tools menu (this is only visible for the Cloud build, not SH)
2. Allow for filtering of the Stripe Subscriptions table by subscription status, due date, and product type. This requires getting Prices from the Stripe API in addition to the subscriptions.
3. Allow rows in the Stripe Subscriptions view to be selected, or for the entire result set of a list to be selected.
4. Facilitate exporting selected rows in the Stripe Subscriptions view to a json file, or cancelling them if the filter is set to "unpaid".

## Screenshots
![Screen Shot 2022-07-12 at 12 56 39 PM](https://user-images.githubusercontent.com/15897251/178551741-133b3afd-a62f-45f5-b06a-69e260264e5a.png)


## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
