### PR TITLE
[SM-82] Add HttpController Attribute to protect secrets manager controllers during development

### DIFF
--- a/src/Api/Utilities/DevelopmentOnlyAttribute.cs
+++ b/src/Api/Utilities/DevelopmentOnlyAttribute.cs
@@ -4,19 +4,19 @@ using Microsoft.AspNetCore.Mvc.Filters;
 namespace Bit.Api.Utilities
 {
 
-        [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
-        public class DevelopmentOnlyAttribute : Attribute, IResourceFilter
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public class DevelopmentOnlyAttribute : Attribute, IResourceFilter
+    {
+        public void OnResourceExecuting(ResourceExecutingContext context)
         {
-            public void OnResourceExecuting(ResourceExecutingContext context)
+            var env = context.HttpContext.RequestServices.GetService<IHostEnvironment>();
+            if (!env.IsDevelopment())
             {
-                var env = context.HttpContext.RequestServices.GetService<IHostEnvironment>();
-                if (!env.IsDevelopment())
-                {
-                    context.Result = new NotFoundResult();
-                }
+                context.Result = new NotFoundResult();
             }
-
-            public void OnResourceExecuted(ResourceExecutedContext context) { }
         }
+
+        public void OnResourceExecuted(ResourceExecutedContext context) { }
+    }
 }
 

--- a/src/Api/Utilities/DevelopmentOnlyAttribute.cs
+++ b/src/Api/Utilities/DevelopmentOnlyAttribute.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Bit.Api.Utilities
+{
+
+        [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+        public class DevelopmentOnlyAttribute : Attribute, IResourceFilter
+        {
+            public void OnResourceExecuting(ResourceExecutingContext context)
+            {
+                var env = context.HttpContext.RequestServices.GetService<IHostEnvironment>();
+                if (!env.IsDevelopment())
+                {
+                    context.Result = new NotFoundResult();
+                }
+            }
+
+            public void OnResourceExecuted(ResourceExecutedContext context) { }
+        }
+}
+

--- a/src/Api/Utilities/SecretsManagerAttribute.cs
+++ b/src/Api/Utilities/SecretsManagerAttribute.cs
@@ -5,7 +5,7 @@ namespace Bit.Api.Utilities
 {
 
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
-    public class DevelopmentOnlyAttribute : Attribute, IResourceFilter
+    public class SecretsManagerAttribute : Attribute, IResourceFilter
     {
         public void OnResourceExecuting(ResourceExecutingContext context)
         {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The purpose of this PR is to create an attribute that can be used as a decorator for secrets manager controllers/methods that prevents code execution in non-developer environments. 


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

src/Api/Utilities/SecretsManagerAttribute.cs

The attribute class that prevents execution in non developer environments. 

When `!env.IsDevelopment()` HTTP status code 404 "Not Found" will be returned to the caller.

## Usage Examples

The attribute is intended to be used in two different ways.

On an entire controller:
### Example code
```
using Bit.Api.Utilities;
using Microsoft.AspNetCore.Mvc;

namespace Bit.Api.Controllers
{
    [ApiController]
    [Route("secrets")]
    [SecretsManager]
    public class SecretsController
    {
        [HttpGet(Name = "GetSecret")]
        public ActionResult<string> Get()
        {
            return "Secret";
        }
    }
}
```

Or on an individual method:
### Example code
```
using Bit.Api.Utilities;
using Microsoft.AspNetCore.Mvc;

namespace Bit.Api.Controllers
{
    [ApiController]
    [Route("secrets")]
    public class SecretsController
    {
        [HttpGet(Name = "GetSecret")]
        [SecretsManager]
        public ActionResult<string> Get()
        {
            return "Secret";
        }
    }
}
```

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
