### PR TITLE
[EC-315] Record user IP and device type for OrgUser and ProviderUser events

### DIFF
--- a/src/Core/Services/Implementations/EventService.cs
+++ b/src/Core/Services/Implementations/EventService.cs
@@ -210,7 +210,7 @@ namespace Bit.Core.Services
                     continue;
                 }
 
-                eventMessages.Add(new EventMessage
+                eventMessages.Add(new EventMessage(_currentContext)
                 {
                     OrganizationId = organizationUser.OrganizationId,
                     UserId = organizationUser.UserId,
@@ -259,7 +259,7 @@ namespace Bit.Core.Services
                 {
                     continue;
                 }
-                eventMessages.Add(new EventMessage
+                eventMessages.Add(new EventMessage(_currentContext)
                 {
                     ProviderId = providerUser.ProviderId,
                     UserId = providerUser.UserId,

--- a/test/Common/Helpers/AssertHelper.cs
+++ b/test/Common/Helpers/AssertHelper.cs
@@ -64,6 +64,28 @@ namespace Bit.Test.Common.Helpers
         public static Expression<Predicate<T>> AssertPropertyEqual<T>(T expected, params string[] excludedPropertyStrings) =>
             (T actual) => AssertPropertyEqualPredicate(expected, excludedPropertyStrings)(actual);
 
+        private static Predicate<IEnumerable<T>> AssertPropertyEqualPredicate<T>(IEnumerable<T> expected, params string[] excludedPropertyStrings) => (actual) =>
+        {
+            // IEnumerable.Zip doesn't account for different lengths, we need to check this ourselves
+            if (actual.Count() != expected.Count())
+            {
+                throw new Exception(string.Concat($"Actual IEnumerable does not have the expected length.\n",
+                $"Expected: {expected.Count()}\n",
+                $"Actual: {actual.Count()}"));
+            }
+
+            var elements = expected.Zip(actual);
+            foreach (var (expectedEl, actualEl) in elements)
+            {
+                AssertPropertyEqual(expectedEl, actualEl, excludedPropertyStrings);
+            }
+
+            return true;
+        };
+
+        public static Expression<Predicate<IEnumerable<T>>> AssertPropertyEqual<T>(IEnumerable<T> expected, params string[] excludedPropertyStrings) =>
+            (actual) => AssertPropertyEqualPredicate(expected, excludedPropertyStrings)(actual);
+
         private static Predicate<T> AssertEqualExpectedPredicate<T>(T expected) => (actual) =>
         {
             Assert.Equal(expected, actual);

--- a/test/Core.Test/Services/EventServiceTests.cs
+++ b/test/Core.Test/Services/EventServiceTests.cs
@@ -1,7 +1,9 @@
 ﻿using Bit.Core.Context;
 using Bit.Core.Entities;
+using Bit.Core.Entities.Provider;
 using Bit.Core.Enums;
 using Bit.Core.Models.Data;
+using Bit.Core.Models.Data.Organizations;
 using Bit.Core.Services;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
@@ -35,6 +37,73 @@ namespace Bit.Core.Test.Services
                 e.OrganizationId == organization.Id &&
                 e.Type == eventType &&
                 e.InstallationId == installationId));
+        }
+
+        [Theory, BitAutoData]
+        public async Task LogOrganizationUserEvent_LogsRequiredInfo(OrganizationUser orgUser, EventType eventType, DateTime date,
+            Guid actingUserId, Guid providerId, string ipAddress, DeviceType deviceType, SutProvider<EventService> sutProvider)
+        {
+            var orgAbilities = new Dictionary<Guid, OrganizationAbility>()
+            {
+                {orgUser.OrganizationId, new OrganizationAbility() { UseEvents = true, Enabled = true } }
+            };
+            sutProvider.GetDependency<IApplicationCacheService>().GetOrganizationAbilitiesAsync().Returns(orgAbilities);
+            sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
+            sutProvider.GetDependency<ICurrentContext>().IpAddress.Returns(ipAddress);
+            sutProvider.GetDependency<ICurrentContext>().DeviceType.Returns(deviceType);
+            sutProvider.GetDependency<ICurrentContext>().ProviderIdForOrg(Arg.Any<Guid>()).Returns(providerId);
+
+            await sutProvider.Sut.LogOrganizationUserEventAsync(orgUser, eventType, date);
+
+            var expected = new List<IEvent>() {
+                new EventMessage()
+                {
+                    IpAddress = ipAddress,
+                    DeviceType = deviceType,
+                    OrganizationId = orgUser.OrganizationId,
+                    UserId = orgUser.UserId,
+                    OrganizationUserId = orgUser.Id,
+                    ProviderId = providerId,
+                    Type = eventType,
+                    ActingUserId = actingUserId,
+                    Date = date
+                }
+            };
+
+            await sutProvider.GetDependency<IEventWriteService>().Received(1).CreateManyAsync(Arg.Is(AssertHelper.AssertPropertyEqual<IEvent>(expected, new[] { "IdempotencyId" })));
+        }
+
+        [Theory, BitAutoData]
+        public async Task LogProviderUserEvent_LogsRequiredInfo(ProviderUser providerUser, EventType eventType, DateTime date,
+            Guid actingUserId, Guid providerId, string ipAddress, DeviceType deviceType, SutProvider<EventService> sutProvider)
+        {
+            var providerAbilities = new Dictionary<Guid, ProviderAbility>()
+            {
+                {providerUser.ProviderId, new ProviderAbility() { UseEvents = true, Enabled = true } }
+            };
+            sutProvider.GetDependency<IApplicationCacheService>().GetProviderAbilitiesAsync().Returns(providerAbilities);
+            sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
+            sutProvider.GetDependency<ICurrentContext>().IpAddress.Returns(ipAddress);
+            sutProvider.GetDependency<ICurrentContext>().DeviceType.Returns(deviceType);
+            sutProvider.GetDependency<ICurrentContext>().ProviderIdForOrg(Arg.Any<Guid>()).Returns(providerId);
+
+            await sutProvider.Sut.LogProviderUserEventAsync(providerUser, eventType, date);
+
+            var expected = new List<IEvent>() {
+                new EventMessage()
+                {
+                    IpAddress = ipAddress,
+                    DeviceType = deviceType,
+                    ProviderId = providerUser.ProviderId,
+                    UserId = providerUser.UserId,
+                    ProviderUserId = providerUser.Id,
+                    Type = eventType,
+                    ActingUserId = actingUserId,
+                    Date = date
+                }
+            };
+
+            await sutProvider.GetDependency<IEventWriteService>().Received(1).CreateManyAsync(Arg.Is(AssertHelper.AssertPropertyEqual<IEvent>(expected, new[] { "IdempotencyId" })));
         }
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix: 

> If an Owner edits a user, and then checks the Event Log for that Edit User event, hovering over the column for the Bitwarden client and IP address always shows: "Unknown, "

I also noticed that ProviderUser events have the same defect.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/Services/Implementations/EventService.cs** - use the right constructor that takes `_currentContext`. This will get and save the IP address and device type.
* **test/Core.Test/Services/EventServiceTests.cs** - add tests to make sure the expected info is saved
* **test/Common/Helpers/AssertHelper.cs** - add a new assert helper which will compare 2 `IEnumerables` to make sure their contents are equal in the `AssertPropertyEqual` sense. This was required because `EventWriteService` is called with a list of events to write, we need some way to call `AssertPropertyEqual` on the individual elements of the list. This seemed the easiest and most generalizable pattern to achieve this.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [x] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
