### PR TITLE
[EC-329] Update OrgUserDetailsView to include PlanType & sponsorship info

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/Queries/OrganizationUserOrganizationDetailsViewQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/OrganizationUserOrganizationDetailsViewQuery.cs
@@ -54,8 +54,11 @@ namespace Bit.Infrastructure.EntityFramework.Repositories.Queries
                 PrivateKey = x.o.PrivateKey,
                 ProviderId = x.p.Id,
                 ProviderName = x.p.Name,
-                FamilySponsorshipFriendlyName = x.os.FriendlyName,
                 SsoConfig = x.ss.Data,
+                FamilySponsorshipFriendlyName = x.os.FriendlyName,
+                FamilySponsorshipLastSyncDate = x.os.LastSyncDate,
+                FamilySponsorshipToDelete = x.os.ToDelete,
+                FamilySponsorshipValidUntil = x.os.ValidUntil
             });
         }
     }

--- a/util/Migrator/DbScripts/2022-07-15_00_FixOrgUserDetails.sql
+++ b/util/Migrator/DbScripts/2022-07-15_00_FixOrgUserDetails.sql
@@ -1,4 +1,11 @@
-﻿CREATE VIEW [dbo].[OrganizationUserOrganizationDetailsView]
+
+IF EXISTS(SELECT * FROM sys.views WHERE [Name] = 'OrganizationUserOrganizationDetailsView')
+    BEGIN
+        DROP VIEW [dbo].[OrganizationUserOrganizationDetailsView]
+    END
+GO
+
+CREATE VIEW [dbo].[OrganizationUserOrganizationDetailsView]
 AS
 SELECT
     OU.[UserId],
@@ -40,7 +47,7 @@ SELECT
     OS.[ValidUntil] FamilySponsorshipValidUntil
 FROM
     [dbo].[OrganizationUser] OU
-INNER JOIN
+LEFT JOIN
     [dbo].[Organization] O ON O.[Id] = OU.[OrganizationId]
 LEFT JOIN
     [dbo].[SsoUser] SU ON SU.[UserId] = OU.[UserId] AND SU.[OrganizationId] = OU.[OrganizationId]
@@ -52,3 +59,4 @@ LEFT JOIN
     [dbo].[SsoConfig] SS ON SS.[OrganizationId] = OU.[OrganizationId]
 LEFT JOIN
     [dbo].[OrganizationSponsorship] OS ON OS.[SponsoringOrganizationUserID] = OU.[Id]
+GO


### PR DESCRIPTION

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
During our work with Families for Enterprise, we forgot to update `OrganizationUserOrganizationDetailsView.sql` with the new properties we included in the migrations. I believe that during the SCIM work, we copied and used that sql file for the new migrations, understandably assuming that the sql would match the view currently in the database.

After these new migrations are applied to a database, the models lose the F4E information it needs and the client loses the ability to see the settings. These changes include the missed properties back in the sql file and adds a migration to fix the database.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->


* **src/Infrastructure.EntityFramework/Repositories/Queries/OrganizationUserOrganizationDetailsViewQuery.cs:** Include family sponsorship properties in the entity framework query
* **src/Sql/dbo/Views/OrganizationUserOrganizationDetailsView.sql:** Fix the sql file to include the missed properties
* **util/Migrator/DbScripts/2022-07-15_00_FixOrgUserDetails.sql:** Add a new migration file that includes both the SCIM work and the F4E properties we need.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [x] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
