### PR TITLE
[EC-335] Add migration script to rebuild OrganizationView

### DIFF
--- a/util/Migrator/DbScripts/2022-07-19_00_FixUseScimFlag.sql
+++ b/util/Migrator/DbScripts/2022-07-19_00_FixUseScimFlag.sql
@@ -1,0 +1,13 @@
+-- Recreate OrganizationView so that it includes the UseScim column
+IF OBJECT_ID('[dbo].[OrganizationView]') IS NOT NULL 
+BEGIN
+    DROP VIEW [dbo].[OrganizationView]
+END 
+GO
+
+CREATE VIEW [dbo].[OrganizationView]
+AS
+SELECT
+    *
+FROM
+    [dbo].[Organization]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

When trying to test the SCIM connection from the IdP end, I get the following error from the SCIM project:

```
info: Bit.Scim.Utilities.ApiKeyAuthenticationHandler[7]
      ScimApiKey was not authenticated. Failure message: Invalid parameters
```

My Organization has the `UseScim` flag set to `1`, but the `OrganizationView` table hasn't been rebuilt since that column was added. It seems that under the hood, views are hard-coded to return the columns present at the time the view was created. It doesn't get this value, so it defaults to `false` on the data model.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **util/Migrator/DbScripts/2022-07-19_00_FixUseScimFlag.sql** - delete and recreate the `OrganizationView`.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
