### PR TITLE
SCIM: case-insensitive op string comparisons

### DIFF
--- a/bitwarden_license/src/Scim/Controllers/v2/GroupsController.cs
+++ b/bitwarden_license/src/Scim/Controllers/v2/GroupsController.cs
@@ -163,11 +163,12 @@ namespace Bit.Scim.Controllers.v2
 
             var operationHandled = false;
 
-            var replaceOp = model.Operations?.FirstOrDefault(o => o.Op == "replace");
+            var replaceOp = model.Operations?.FirstOrDefault(o =>
+                o.Op?.ToLowerInvariant() == "replace");
             if (replaceOp != null)
             {
                 // Replace a list of members
-                if (replaceOp.Path == "members")
+                if (replaceOp.Path?.ToLowerInvariant() == "members")
                 {
                     var ids = GetOperationValueIds(replaceOp.Value);
                     await _groupRepository.UpdateUsersAsync(group.Id, ids);
@@ -184,7 +185,9 @@ namespace Bit.Scim.Controllers.v2
 
             // Add a single member
             var addMemberOp = model.Operations?.FirstOrDefault(
-                o => o.Op == "add" && !string.IsNullOrWhiteSpace(o.Path) && o.Path.StartsWith("members[value eq "));
+                o => o.Op?.ToLowerInvariant() == "add" &&
+                !string.IsNullOrWhiteSpace(o.Path) &&
+                o.Path.ToLowerInvariant().StartsWith("members[value eq "));
             if (addMemberOp != null)
             {
                 var addId = GetOperationPathId(addMemberOp.Path);
@@ -198,7 +201,9 @@ namespace Bit.Scim.Controllers.v2
             }
 
             // Add a list of members
-            var addMembersOp = model.Operations?.FirstOrDefault(o => o.Op == "add" && o.Path == "members");
+            var addMembersOp = model.Operations?.FirstOrDefault(o =>
+                o.Op?.ToLowerInvariant() == "add" &&
+                o.Path?.ToLowerInvariant() == "members");
             if (addMembersOp != null)
             {
                 var orgUserIds = (await _groupRepository.GetManyUserIdsByIdAsync(group.Id)).ToHashSet();
@@ -212,7 +217,9 @@ namespace Bit.Scim.Controllers.v2
 
             // Remove a single member
             var removeMemberOp = model.Operations?.FirstOrDefault(
-                o => o.Op == "remove" && !string.IsNullOrWhiteSpace(o.Path) && o.Path.StartsWith("members[value eq "));
+                o => o.Op?.ToLowerInvariant() == "remove" &&
+                !string.IsNullOrWhiteSpace(o.Path) &&
+                o.Path.ToLowerInvariant().StartsWith("members[value eq "));
             if (removeMemberOp != null)
             {
                 var removeId = GetOperationPathId(removeMemberOp.Path);
@@ -224,7 +231,9 @@ namespace Bit.Scim.Controllers.v2
             }
 
             // Remove a list of members
-            var removeMembersOp = model.Operations?.FirstOrDefault(o => o.Op == "remove" && o.Path == "members");
+            var removeMembersOp = model.Operations?.FirstOrDefault(o =>
+                o.Op?.ToLowerInvariant() == "remove" &&
+                o.Path?.ToLowerInvariant() == "members");
             if (removeMembersOp != null)
             {
                 var orgUserIds = (await _groupRepository.GetManyUserIdsByIdAsync(group.Id)).ToHashSet();

--- a/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
+++ b/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
@@ -220,7 +220,8 @@ namespace Bit.Scim.Controllers.v2
 
             var operationHandled = false;
 
-            var replaceOp = model.Operations?.FirstOrDefault(o => o.Op == "replace");
+            var replaceOp = model.Operations?.FirstOrDefault(o =>
+                o.Op?.ToLowerInvariant() == "replace");
             if (replaceOp != null)
             {
                 if (replaceOp.Value.TryGetProperty("active", out var activeProperty))


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Some providers, like Azure, will send SCIM operation strings capitalized. For example, `Add` vs `add`. This ensures that logic that relies on comparisons with these strings are case-insensitive. 

cc: @eliykat 


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **user controller:** Lowercase and string comparisons on operations.
* **group controller:** Lowercase and string comparisons on operations.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
