### PR TITLE
Re-evaluate lock files to ensure they match project dependencies

### DIFF
--- a/bitwarden_license/src/Scim/packages.lock.json
+++ b/bitwarden_license/src/Scim/packages.lock.json
@@ -22,6 +22,15 @@
           "Newtonsoft.Json": "13.0.1"
         }
       },
+      "AspNetCoreRateLimit.Redis": {
+        "type": "Transitive",
+        "resolved": "1.0.1",
+        "contentHash": "CsSGy/7SXt6iBOKg0xCvsRjb/ZHshbtr2Of1MHc912L2sLnZqadUrTboyXZC+ZlgEBeJ14GyjPTu8ZyfEhGUnw==",
+        "dependencies": {
+          "AspNetCoreRateLimit": "4.0.2",
+          "StackExchange.Redis": "2.5.43"
+        }
+      },
       "AutoMapper": {
         "type": "Transitive",
         "resolved": "11.0.0",
@@ -588,14 +597,14 @@
           "Microsoft.Extensions.Primitives": "6.0.0"
         }
       },
-      "Microsoft.Extensions.Caching.Redis": {
+      "Microsoft.Extensions.Caching.StackExchangeRedis": {
         "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "cb21miiGDVjlNl8TRBKIi7OEFdlKuV8d4ZoYqFOhKdZhzo7Sv+b8Puy3NLW3y/g+UDclt7FTh+Za7ykurtaVMQ==",
+        "resolved": "6.0.6",
+        "contentHash": "bdVQpYm1hcHf0pyAypMjtDw3HjWQJ89UzloyyF1OBs56QlgA1naM498tP2Vjlho5vVRALMGPYzdRKCen8koubw==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Options": "2.2.0",
-          "StackExchange.Redis.StrongName": "1.2.6"
+          "Microsoft.Extensions.Caching.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Options": "6.0.0",
+          "StackExchange.Redis": "2.2.4"
         }
       },
       "Microsoft.Extensions.Configuration": {
@@ -841,8 +850,8 @@
       },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
-        "resolved": "2.1.2",
-        "contentHash": "mOJy3M0UN+LUG21dLGMxaWZEP6xYpQEpLuvuEQBaownaX4YuhH6NmNUlN9si+vNkAS6dwJ//N1O4DmLf2CikVg=="
+        "resolved": "5.0.0",
+        "contentHash": "VyPlqzH2wavqquTcYpkIIAQ6WdenuKoFN0BdYBbCWsclXacSOHNQn66Gt4z5NBqEYW0FAPm5rlvki9ZiCij5xQ=="
       },
       "Microsoft.NETCore.Targets": {
         "type": "Transitive",
@@ -946,11 +955,11 @@
       },
       "Microsoft.Win32.Registry": {
         "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "KSrRMb5vNi0CWSGG1++id2ZOs/1QhRqROt+qgbEAdQuGjGrFcl4AOl4/exGPUYz2wUnU42nvJqon1T3U0kPXLA==",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg==",
         "dependencies": {
-          "System.Security.AccessControl": "4.7.0",
-          "System.Security.Principal.Windows": "4.7.0"
+          "System.Security.AccessControl": "5.0.0",
+          "System.Security.Principal.Windows": "5.0.0"
         }
       },
       "Microsoft.Win32.SystemEvents": {
@@ -1060,6 +1069,14 @@
         "type": "Transitive",
         "resolved": "1.2.2",
         "contentHash": "2hrZfkbzeWJ3tNXXt/1beg4IY+nS4F3gIfh4NVFvW0f6Pj51hGpiJ4prBz7Dmrr4ZYrA96rTERVGieZ4xYm7jA=="
+      },
+      "Pipelines.Sockets.Unofficial": {
+        "type": "Transitive",
+        "resolved": "2.2.2",
+        "contentHash": "Bhk0FWxH1paI+18zr1g5cTL+ebeuDcBCR+rRFO+fKEhretgjs7MF2Mc1P64FGLecWp4zKCUOPzngBNrqVyY7Zg==",
+        "dependencies": {
+          "System.IO.Pipelines": "5.0.1"
+        }
       },
       "Pomelo.EntityFrameworkCore.MySql": {
         "type": "Transitive",
@@ -1398,34 +1415,13 @@
           "Serilog.Sinks.PeriodicBatching": "2.3.0"
         }
       },
-      "StackExchange.Redis.StrongName": {
+      "StackExchange.Redis": {
         "type": "Transitive",
-        "resolved": "1.2.6",
-        "contentHash": "UFmT1/JYu1PLiRwkyvEPVHk/tVTJa8Ka2rb9yzidzDoQARvhBVRpaWUeaP81373v54jupDBvAoGHGl0EY/HphQ==",
+        "resolved": "2.5.43",
+        "contentHash": "YQ38jVbX1b5mBi6lizESou+NpV6QZpeo6ofRR6qeuqJ8ePOmhcwhje3nDTNIGEkfPSK0sLuF6pR5rtFyq2F46g==",
         "dependencies": {
-          "NETStandard.Library": "1.6.1",
-          "System.Collections": "4.3.0",
-          "System.Collections.Concurrent": "4.3.0",
-          "System.Collections.NonGeneric": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.IO.Compression": "4.3.0",
-          "System.IO.FileSystem": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Net.NameResolution": "4.3.0",
-          "System.Net.Security": "4.3.0",
-          "System.Net.Sockets": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.0",
-          "System.Text.RegularExpressions": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Threading.Thread": "4.3.0",
-          "System.Threading.ThreadPool": "4.3.0",
-          "System.Threading.Timer": "4.3.0"
+          "Pipelines.Sockets.Unofficial": "2.2.2",
+          "System.Diagnostics.PerformanceCounter": "5.0.0"
         }
       },
       "starkbank-ecdsa": {
@@ -1492,15 +1488,15 @@
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "prtjIEMhGUnQq6RnPEYLpFt8AtLbp9yq2zxOSrY7KJJZrw25Fi97IzBqY7iqssbM61Ek5b8f3MG/sG1N2sN5KA==",
+        "resolved": "4.0.1",
+        "contentHash": "hMxFT2RhhlffyCdKLDXjx8WEC5JfCvNozAZxCablAuFRH74SCV4AgzE8yJCh/73bFnEoZgJ9MJmkjQ0dJmnKqA==",
         "dependencies": {
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0"
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
         }
       },
       "System.Collections.Specialized": {
@@ -1665,6 +1661,17 @@
         "contentHash": "frQDfv0rl209cKm1lnwTgFPzNigy2EKk1BS3uAvHvlBVKe5cymGyHO+Sj+NLv5VF/AhHsqPIUUwya5oV4CHMUw==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Diagnostics.PerformanceCounter": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "kcQWWtGVC3MWMNXdMDWfrmIlFZZ2OdoeT6pSNVRtk9+Sa7jwdPiMlNwb0ZQcS7NRlT92pCfmjRtkSWUW3RAKwg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "5.0.0",
+          "Microsoft.Win32.Registry": "5.0.0",
+          "System.Configuration.ConfigurationManager": "5.0.0",
+          "System.Security.Principal.Windows": "5.0.0"
         }
       },
       "System.Diagnostics.Process": {
@@ -1892,6 +1899,11 @@
         "resolved": "6.0.0",
         "contentHash": "Rfm2jYCaUeGysFEZjDe7j1R4x6Z6BzumS/vUT5a1AA/AWJuGX71PoGB0RmpyX3VmrGqVnAwtfMn39OHR8Y/5+g=="
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "5.0.1",
+        "contentHash": "qEePWsaq9LoEEIqhbGe6D5J8c9IqQOUuTzzV6wn1POlfdLkJliZY3OlB0j0f17uMWlqZYjH7txj+2YbyrIA8Yg=="
+      },
       "System.Linq": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1992,23 +2004,23 @@
       },
       "System.Net.NameResolution": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "AFYl08R7MrsrEjqpQWTZWBadqXyTzNDaWpMqyxhb0d6sGhV6xMDKueuBXlLL30gz+DIRY6MpdgnHWlCh5wmq9w==",
+        "resolved": "4.0.0",
+        "contentHash": "JdqRdM1Qym3YehqdKIi5LHrpypP4JMfxKQSNCJ2z4WawkG0il+N3XfNeJOxll2XrTnG7WgYYPoeiu/KOwg0DQw==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Net.Primitives": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Security.Principal.Windows": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0",
-          "runtime.native.System": "4.3.0"
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.Net.Primitives": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Security.Principal.Windows": "4.0.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "runtime.native.System": "4.0.0"
         }
       },
       "System.Net.NetworkInformation": {
@@ -2589,8 +2601,8 @@
       },
       "System.Security.Principal.Windows": {
         "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "ojD0PX0XhneCsUbAZVKdb7h/70vyYMDYs85lwEI+LngEONe/17A0cFaRFqZU+sOEidcVswYWikYOQ9PPfjlbtQ=="
+        "resolved": "5.0.0",
+        "contentHash": "t0MGLukB5WAVU9bO3MGzvlGnyJPgUlcwerXn1kzBRjwLKixT96XV0Uza41W49gVd8zEMFu9vQEFlv0IOrytICA=="
       },
       "System.Security.SecureString": {
         "type": "Transitive",
@@ -2866,6 +2878,7 @@
           "AWSSDK.SQS": "3.7.2.47",
           "AWSSDK.SimpleEmail": "3.7.0.150",
           "AspNetCoreRateLimit": "4.0.2",
+          "AspNetCoreRateLimit.Redis": "1.0.1",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "1.2.1",
           "Azure.Storage.Blobs": "12.11.0",
           "Azure.Storage.Queues": "12.9.0",
@@ -2880,7 +2893,7 @@
           "Microsoft.Azure.Cosmos.Table": "1.0.8",
           "Microsoft.Azure.NotificationHubs": "4.1.0",
           "Microsoft.Azure.ServiceBus": "5.2.0",
-          "Microsoft.Extensions.Caching.Redis": "2.2.0",
+          "Microsoft.Extensions.Caching.StackExchangeRedis": "6.0.6",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "6.0.1",
           "Microsoft.Extensions.Configuration.UserSecrets": "6.0.1",
           "Microsoft.Extensions.Identity.Stores": "6.0.4",
@@ -2901,7 +2914,7 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -2910,7 +2923,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -2920,9 +2933,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/bitwarden_license/src/Sso/packages.lock.json
+++ b/bitwarden_license/src/Sso/packages.lock.json
@@ -2775,7 +2775,7 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -2784,7 +2784,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -2794,9 +2794,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/bitwarden_license/test/CmmCore.Test/packages.lock.json
+++ b/bitwarden_license/test/CmmCore.Test/packages.lock.json
@@ -2880,25 +2880,25 @@
         "type": "Project",
         "dependencies": {
           "Azure.Messaging.EventGrid": "4.10.0",
-          "CommCore": "2022.6.0",
-          "Core": "2022.6.0",
-          "SharedWeb": "2022.6.0",
+          "CommCore": "2022.6.2",
+          "Core": "2022.6.2",
+          "SharedWeb": "2022.6.2",
           "Swashbuckle.AspNetCore": "6.3.1"
         }
       },
       "commcore": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0"
+          "Core": "2022.6.2"
         }
       },
       "common": {
         "type": "Project",
         "dependencies": {
-          "Api": "2022.6.0",
+          "Api": "2022.6.2",
           "AutoFixture.AutoNSubstitute": "4.17.0",
           "AutoFixture.Xunit2": "4.17.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Kralizek.AutoFixture.Extensions.MockHttp": "1.2.0",
           "Microsoft.NET.Test.Sdk": "17.1.0",
           "NSubstitute": "4.3.0",
@@ -2947,11 +2947,11 @@
       "core.test": {
         "type": "Project",
         "dependencies": {
-          "Api": "2022.6.0",
+          "Api": "2022.6.2",
           "AutoFixture.AutoNSubstitute": "4.17.0",
           "AutoFixture.Xunit2": "4.17.0",
-          "Common": "2022.6.0",
-          "Core": "2022.6.0",
+          "Common": "2022.6.2",
+          "Core": "2022.6.2",
           "Kralizek.AutoFixture.Extensions.MockHttp": "1.2.0",
           "Microsoft.NET.Test.Sdk": "17.1.0",
           "Moq": "4.17.2",
@@ -2962,7 +2962,7 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -2971,7 +2971,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -2981,9 +2981,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/src/Admin/packages.lock.json
+++ b/src/Admin/packages.lock.json
@@ -3148,7 +3148,7 @@
       "commcore": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0"
+          "Core": "2022.6.2"
         }
       },
       "core": {
@@ -3193,7 +3193,7 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -3202,7 +3202,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -3212,7 +3212,7 @@
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.Extensions.Logging": "6.0.0",
           "dbup-sqlserver": "4.5.0"
         }
@@ -3220,9 +3220,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/src/Api/packages.lock.json
+++ b/src/Api/packages.lock.json
@@ -2648,7 +2648,7 @@
       "commcore": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0"
+          "Core": "2022.6.2"
         }
       },
       "core": {
@@ -2693,7 +2693,7 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -2702,7 +2702,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -2712,9 +2712,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/src/Billing/packages.lock.json
+++ b/src/Billing/packages.lock.json
@@ -3164,7 +3164,7 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -3173,7 +3173,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -3183,9 +3183,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/src/Events/packages.lock.json
+++ b/src/Events/packages.lock.json
@@ -2633,7 +2633,7 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -2642,7 +2642,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -2652,9 +2652,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/src/EventsProcessor/packages.lock.json
+++ b/src/EventsProcessor/packages.lock.json
@@ -2633,7 +2633,7 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -2642,7 +2642,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -2652,9 +2652,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/src/Icons/packages.lock.json
+++ b/src/Icons/packages.lock.json
@@ -2651,7 +2651,7 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -2660,7 +2660,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -2670,9 +2670,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/src/Identity/packages.lock.json
+++ b/src/Identity/packages.lock.json
@@ -2655,7 +2655,7 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -2664,7 +2664,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -2674,9 +2674,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/src/Notifications/packages.lock.json
+++ b/src/Notifications/packages.lock.json
@@ -2683,7 +2683,7 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -2692,7 +2692,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -2702,9 +2702,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/src/SharedWeb/packages.lock.json
+++ b/src/SharedWeb/packages.lock.json
@@ -2633,7 +2633,7 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -2642,7 +2642,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",

--- a/test/Api.Test/packages.lock.json
+++ b/test/Api.Test/packages.lock.json
@@ -2873,25 +2873,25 @@
         "type": "Project",
         "dependencies": {
           "Azure.Messaging.EventGrid": "4.10.0",
-          "CommCore": "2022.6.0",
-          "Core": "2022.6.0",
-          "SharedWeb": "2022.6.0",
+          "CommCore": "2022.6.2",
+          "Core": "2022.6.2",
+          "SharedWeb": "2022.6.2",
           "Swashbuckle.AspNetCore": "6.3.1"
         }
       },
       "commcore": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0"
+          "Core": "2022.6.2"
         }
       },
       "common": {
         "type": "Project",
         "dependencies": {
-          "Api": "2022.6.0",
+          "Api": "2022.6.2",
           "AutoFixture.AutoNSubstitute": "4.17.0",
           "AutoFixture.Xunit2": "4.17.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Kralizek.AutoFixture.Extensions.MockHttp": "1.2.0",
           "Microsoft.NET.Test.Sdk": "17.1.0",
           "NSubstitute": "4.3.0",
@@ -2940,7 +2940,7 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -2949,7 +2949,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -2959,9 +2959,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/test/Billing.Test/packages.lock.json
+++ b/test/Billing.Test/packages.lock.json
@@ -3393,33 +3393,33 @@
         "type": "Project",
         "dependencies": {
           "Azure.Messaging.EventGrid": "4.10.0",
-          "CommCore": "2022.6.0",
-          "Core": "2022.6.0",
-          "SharedWeb": "2022.6.0",
+          "CommCore": "2022.6.2",
+          "Core": "2022.6.2",
+          "SharedWeb": "2022.6.2",
           "Swashbuckle.AspNetCore": "6.3.1"
         }
       },
       "billing": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.VisualStudio.Web.CodeGeneration.Design": "6.0.3",
-          "SharedWeb": "2022.6.0"
+          "SharedWeb": "2022.6.2"
         }
       },
       "commcore": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0"
+          "Core": "2022.6.2"
         }
       },
       "common": {
         "type": "Project",
         "dependencies": {
-          "Api": "2022.6.0",
+          "Api": "2022.6.2",
           "AutoFixture.AutoNSubstitute": "4.17.0",
           "AutoFixture.Xunit2": "4.17.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Kralizek.AutoFixture.Extensions.MockHttp": "1.2.0",
           "Microsoft.NET.Test.Sdk": "17.1.0",
           "NSubstitute": "4.3.0",
@@ -3468,7 +3468,7 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -3477,7 +3477,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -3487,9 +3487,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/test/Common/packages.lock.json
+++ b/test/Common/packages.lock.json
@@ -2869,16 +2869,16 @@
         "type": "Project",
         "dependencies": {
           "Azure.Messaging.EventGrid": "4.10.0",
-          "CommCore": "2022.6.0",
-          "Core": "2022.6.0",
-          "SharedWeb": "2022.6.0",
+          "CommCore": "2022.6.2",
+          "Core": "2022.6.2",
+          "SharedWeb": "2022.6.2",
           "Swashbuckle.AspNetCore": "6.3.1"
         }
       },
       "commcore": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0"
+          "Core": "2022.6.2"
         }
       },
       "core": {
@@ -2923,7 +2923,7 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -2932,7 +2932,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -2942,9 +2942,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/test/Core.Test/packages.lock.json
+++ b/test/Core.Test/packages.lock.json
@@ -2885,25 +2885,25 @@
         "type": "Project",
         "dependencies": {
           "Azure.Messaging.EventGrid": "4.10.0",
-          "CommCore": "2022.6.0",
-          "Core": "2022.6.0",
-          "SharedWeb": "2022.6.0",
+          "CommCore": "2022.6.2",
+          "Core": "2022.6.2",
+          "SharedWeb": "2022.6.2",
           "Swashbuckle.AspNetCore": "6.3.1"
         }
       },
       "commcore": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0"
+          "Core": "2022.6.2"
         }
       },
       "common": {
         "type": "Project",
         "dependencies": {
-          "Api": "2022.6.0",
+          "Api": "2022.6.2",
           "AutoFixture.AutoNSubstitute": "4.17.0",
           "AutoFixture.Xunit2": "4.17.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Kralizek.AutoFixture.Extensions.MockHttp": "1.2.0",
           "Microsoft.NET.Test.Sdk": "17.1.0",
           "NSubstitute": "4.3.0",
@@ -2952,7 +2952,7 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -2961,7 +2961,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -2971,9 +2971,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/test/Icons.Test/packages.lock.json
+++ b/test/Icons.Test/packages.lock.json
@@ -2827,14 +2827,14 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "0.16.1",
-          "Core": "2022.6.0",
-          "SharedWeb": "2022.6.0"
+          "Core": "2022.6.2",
+          "SharedWeb": "2022.6.2"
         }
       },
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -2843,7 +2843,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -2853,9 +2853,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/test/Identity.IntegrationTest/packages.lock.json
+++ b/test/Identity.IntegrationTest/packages.lock.json
@@ -3010,25 +3010,25 @@
         "type": "Project",
         "dependencies": {
           "Azure.Messaging.EventGrid": "4.10.0",
-          "CommCore": "2022.6.0",
-          "Core": "2022.6.0",
-          "SharedWeb": "2022.6.0",
+          "CommCore": "2022.6.2",
+          "Core": "2022.6.2",
+          "SharedWeb": "2022.6.2",
           "Swashbuckle.AspNetCore": "6.3.1"
         }
       },
       "commcore": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0"
+          "Core": "2022.6.2"
         }
       },
       "common": {
         "type": "Project",
         "dependencies": {
-          "Api": "2022.6.0",
+          "Api": "2022.6.2",
           "AutoFixture.AutoNSubstitute": "4.17.0",
           "AutoFixture.Xunit2": "4.17.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Kralizek.AutoFixture.Extensions.MockHttp": "1.2.0",
           "Microsoft.NET.Test.Sdk": "17.1.0",
           "NSubstitute": "4.3.0",
@@ -3077,15 +3077,15 @@
       "identity": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "SharedWeb": "2022.6.0",
+          "Core": "2022.6.2",
+          "SharedWeb": "2022.6.2",
           "Swashbuckle.AspNetCore.SwaggerGen": "6.3.1"
         }
       },
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -3094,7 +3094,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -3104,8 +3104,8 @@
       "integrationtestcommon": {
         "type": "Project",
         "dependencies": {
-          "Common": "2022.6.0",
-          "Identity": "2022.6.0",
+          "Common": "2022.6.2",
+          "Identity": "2022.6.2",
           "Microsoft.AspNetCore.Mvc.Testing": "6.0.5",
           "Microsoft.EntityFrameworkCore.InMemory": "6.0.5",
           "Microsoft.Extensions.Configuration": "6.0.1"
@@ -3114,9 +3114,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/test/Identity.Test/packages.lock.json
+++ b/test/Identity.Test/packages.lock.json
@@ -2873,25 +2873,25 @@
         "type": "Project",
         "dependencies": {
           "Azure.Messaging.EventGrid": "4.10.0",
-          "CommCore": "2022.6.0",
-          "Core": "2022.6.0",
-          "SharedWeb": "2022.6.0",
+          "CommCore": "2022.6.2",
+          "Core": "2022.6.2",
+          "SharedWeb": "2022.6.2",
           "Swashbuckle.AspNetCore": "6.3.1"
         }
       },
       "commcore": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0"
+          "Core": "2022.6.2"
         }
       },
       "common": {
         "type": "Project",
         "dependencies": {
-          "Api": "2022.6.0",
+          "Api": "2022.6.2",
           "AutoFixture.AutoNSubstitute": "4.17.0",
           "AutoFixture.Xunit2": "4.17.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Kralizek.AutoFixture.Extensions.MockHttp": "1.2.0",
           "Microsoft.NET.Test.Sdk": "17.1.0",
           "NSubstitute": "4.3.0",
@@ -2940,15 +2940,15 @@
       "identity": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "SharedWeb": "2022.6.0",
+          "Core": "2022.6.2",
+          "SharedWeb": "2022.6.2",
           "Swashbuckle.AspNetCore.SwaggerGen": "6.3.1"
         }
       },
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -2957,7 +2957,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -2967,9 +2967,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/test/IntegrationTestCommon/packages.lock.json
+++ b/test/IntegrationTestCommon/packages.lock.json
@@ -2996,25 +2996,25 @@
         "type": "Project",
         "dependencies": {
           "Azure.Messaging.EventGrid": "4.10.0",
-          "CommCore": "2022.6.0",
-          "Core": "2022.6.0",
-          "SharedWeb": "2022.6.0",
+          "CommCore": "2022.6.2",
+          "Core": "2022.6.2",
+          "SharedWeb": "2022.6.2",
           "Swashbuckle.AspNetCore": "6.3.1"
         }
       },
       "commcore": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0"
+          "Core": "2022.6.2"
         }
       },
       "common": {
         "type": "Project",
         "dependencies": {
-          "Api": "2022.6.0",
+          "Api": "2022.6.2",
           "AutoFixture.AutoNSubstitute": "4.17.0",
           "AutoFixture.Xunit2": "4.17.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Kralizek.AutoFixture.Extensions.MockHttp": "1.2.0",
           "Microsoft.NET.Test.Sdk": "17.1.0",
           "NSubstitute": "4.3.0",
@@ -3063,15 +3063,15 @@
       "identity": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "SharedWeb": "2022.6.0",
+          "Core": "2022.6.2",
+          "SharedWeb": "2022.6.2",
           "Swashbuckle.AspNetCore.SwaggerGen": "6.3.1"
         }
       },
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -3080,7 +3080,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -3090,9 +3090,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/util/MySqlMigrations/packages.lock.json
+++ b/util/MySqlMigrations/packages.lock.json
@@ -2662,16 +2662,16 @@
         "type": "Project",
         "dependencies": {
           "Azure.Messaging.EventGrid": "4.10.0",
-          "CommCore": "2022.6.0",
-          "Core": "2022.6.0",
-          "SharedWeb": "2022.6.0",
+          "CommCore": "2022.6.2",
+          "Core": "2022.6.2",
+          "SharedWeb": "2022.6.2",
           "Swashbuckle.AspNetCore": "6.3.1"
         }
       },
       "commcore": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0"
+          "Core": "2022.6.2"
         }
       },
       "core": {
@@ -2716,7 +2716,7 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -2725,7 +2725,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -2735,9 +2735,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/util/PostgresMigrations/packages.lock.json
+++ b/util/PostgresMigrations/packages.lock.json
@@ -2662,16 +2662,16 @@
         "type": "Project",
         "dependencies": {
           "Azure.Messaging.EventGrid": "4.10.0",
-          "CommCore": "2022.6.0",
-          "Core": "2022.6.0",
-          "SharedWeb": "2022.6.0",
+          "CommCore": "2022.6.2",
+          "Core": "2022.6.2",
+          "SharedWeb": "2022.6.2",
           "Swashbuckle.AspNetCore": "6.3.1"
         }
       },
       "commcore": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0"
+          "Core": "2022.6.2"
         }
       },
       "core": {
@@ -2716,7 +2716,7 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Dapper": "2.0.123",
           "System.Data.SqlClient": "4.8.3"
         }
@@ -2725,7 +2725,7 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "11.0.0",
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.EntityFrameworkCore.Relational": "6.0.4",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "6.0.4",
           "Pomelo.EntityFrameworkCore.MySql": "6.0.1",
@@ -2735,9 +2735,9 @@
       "sharedweb": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
-          "Infrastructure.Dapper": "2022.6.0",
-          "Infrastructure.EntityFramework": "2022.6.0"
+          "Core": "2022.6.2",
+          "Infrastructure.Dapper": "2022.6.2",
+          "Infrastructure.EntityFramework": "2022.6.2"
         }
       }
     }

--- a/util/Setup/packages.lock.json
+++ b/util/Setup/packages.lock.json
@@ -2558,7 +2558,7 @@
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "2022.6.0",
+          "Core": "2022.6.2",
           "Microsoft.Extensions.Logging": "6.0.0",
           "dbup-sqlserver": "4.5.0"
         }


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Package lock files didn't merge properly with PS-93, and they need to be re-evaluated with the latest project dependencies using `nuget restore --force-evaluate`


## Code changes

* **/\*\*/packages.lock.json:** Updated using `nuget restore --force-evaluate` to be in sync with project dependencies

## Before you submit

```
- [X] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
