### PR TITLE
[EC-336] Fix invalid user invites when invited via SCIM

### DIFF
--- a/bitwarden_license/src/Scim/Startup.cs
+++ b/bitwarden_license/src/Scim/Startup.cs
@@ -31,7 +31,7 @@ namespace Bit.Scim
             // Settings
             var globalSettings = services.AddGlobalSettingsServices(Configuration, Environment);
             services.Configure<ScimSettings>(Configuration.GetSection("ScimSettings"));
-            
+
             // Data Protection
             services.AddCustomDataProtectionServices(Environment, globalSettings);
 

--- a/bitwarden_license/src/Scim/Startup.cs
+++ b/bitwarden_license/src/Scim/Startup.cs
@@ -31,6 +31,9 @@ namespace Bit.Scim
             // Settings
             var globalSettings = services.AddGlobalSettingsServices(Configuration, Environment);
             services.Configure<ScimSettings>(Configuration.GetSection("ScimSettings"));
+            
+            // Data Protection
+            services.AddCustomDataProtectionServices(Environment, globalSettings);
 
             // Stripe Billing
             StripeConfiguration.ApiKey = globalSettings.Stripe.ApiKey;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix:
> When successfully sending an invite from an IdP ( JumpCloud in my testing ), I am getting a red error toast on first log in to an account saying invalid token

This is because the Data Protection service in the SCIM project was not configured to use the local data protection keys. So the token was being generated with different parameters to when it was being checked in the Api project.

**This will be picked to rc**

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **bitwarden_license/src/Scim/Startup.cs** - add data protection configuration. [This is a copy + paste from the API project.](https://github.com/bitwarden/server/blob/7bb1003beaab7b36d279dc89ecfe731c8db667ba/src/Api/Startup.cs#L47-L49)

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
