### PR TITLE
[EC-247] Add columns to provider portal clients table

### DIFF
--- a/src/Api/Models/Response/Providers/ProviderOrganizationResponseModel.cs
+++ b/src/Api/Models/Response/Providers/ProviderOrganizationResponseModel.cs
@@ -38,6 +38,9 @@ namespace Bit.Api.Models.Response.Providers
             Settings = providerOrganization.Settings;
             CreationDate = providerOrganization.CreationDate;
             RevisionDate = providerOrganization.RevisionDate;
+            UserCount = providerOrganization.UserCount;
+            Seats = providerOrganization.Seats;
+            Plan = providerOrganization.Plan;
         }
 
         public Guid Id { get; set; }
@@ -47,6 +50,9 @@ namespace Bit.Api.Models.Response.Providers
         public string Settings { get; set; }
         public DateTime CreationDate { get; set; }
         public DateTime RevisionDate { get; set; }
+        public int? UserCount { get; set; }
+        public int? Seats { get; set; }
+        public string Plan { get; set; }
     }
 
     public class ProviderOrganizationOrganizationDetailsResponseModel : ProviderOrganizationResponseModel

--- a/src/Core/Models/Data/Provider/ProviderOrganizationOrganizationDetails.cs
+++ b/src/Core/Models/Data/Provider/ProviderOrganizationOrganizationDetails.cs
@@ -10,5 +10,8 @@
         public string Settings { get; set; }
         public DateTime CreationDate { get; set; }
         public DateTime RevisionDate { get; set; }
+        public int UserCount { get; set; }
+        public int? Seats { get; set; }
+        public string Plan { get; set; }
     }
 }

--- a/src/Infrastructure.EntityFramework/Repositories/Queries/ProviderOrganizationOrganizationDetailsReadByProviderIdQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/ProviderOrganizationOrganizationDetailsReadByProviderIdQuery.cs
@@ -15,6 +15,8 @@ namespace Bit.Infrastructure.EntityFramework.Repositories.Queries
             var query = from po in dbContext.ProviderOrganizations
                         join o in dbContext.Organizations
                             on po.OrganizationId equals o.Id
+                        join ou in dbContext.OrganizationUsers
+                            on po.OrganizationId equals ou.OrganizationId
                         where po.ProviderId == _providerId
                         select new { po, o };
             return query.Select(x => new ProviderOrganizationOrganizationDetails()
@@ -27,6 +29,9 @@ namespace Bit.Infrastructure.EntityFramework.Repositories.Queries
                 Settings = x.po.Settings,
                 CreationDate = x.po.CreationDate,
                 RevisionDate = x.po.RevisionDate,
+                UserCount = x.o.OrganizationUsers.Count,
+                Seats = x.o.Seats,
+                Plan = x.o.Plan
             });
         }
     }

--- a/src/Infrastructure.EntityFramework/Repositories/Queries/ProviderOrganizationOrganizationDetailsReadByProviderIdQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/ProviderOrganizationOrganizationDetailsReadByProviderIdQuery.cs
@@ -29,7 +29,7 @@ namespace Bit.Infrastructure.EntityFramework.Repositories.Queries
                 Settings = x.po.Settings,
                 CreationDate = x.po.CreationDate,
                 RevisionDate = x.po.RevisionDate,
-                UserCount = x.o.OrganizationUsers.Count,
+                UserCount = x.o.OrganizationUsers.Count(ou => ou.Status == Core.Enums.OrganizationUserStatusType.Confirmed),
                 Seats = x.o.Seats,
                 Plan = x.o.Plan
             });

--- a/util/Migrator/DbScripts/2022-07-20_00_ProviderOrganizationListDetails.sql
+++ b/util/Migrator/DbScripts/2022-07-20_00_ProviderOrganizationListDetails.sql
@@ -10,7 +10,7 @@ SELECT
     PO.[Settings],
     PO.[CreationDate],
     PO.[RevisionDate],
-    (SELECT COUNT(1) FROM [dbo].[OrganizationUser] OU WHERE OU.OrganizationId = PO.OrganizationId) UserCount,
+    (SELECT COUNT(1) FROM [dbo].[OrganizationUser] OU WHERE OU.OrganizationId = PO.OrganizationId AND OU.Status = 2) UserCount,
     O.Seats Seats,
     O.[Plan]
 FROM

--- a/util/Migrator/DbScripts/2022-07-20_00_ProviderOrganizationListDetails.sql
+++ b/util/Migrator/DbScripts/2022-07-20_00_ProviderOrganizationListDetails.sql
@@ -1,0 +1,20 @@
+-- Add columns 'UserCount', 'Seats' and 'Plan'
+CREATE OR ALTER VIEW [dbo].[ProviderOrganizationOrganizationDetailsView]
+AS
+SELECT
+    PO.[Id],
+    PO.[ProviderId],
+    PO.[OrganizationId],
+    O.[Name] OrganizationName,
+    PO.[Key],
+    PO.[Settings],
+    PO.[CreationDate],
+    PO.[RevisionDate],
+    (SELECT COUNT(1) FROM [dbo].[OrganizationUser] OU WHERE OU.OrganizationId = PO.OrganizationId) UserCount,
+    O.Seats Seats,
+    O.[Plan]
+FROM
+    [dbo].[ProviderOrganization] PO
+LEFT JOIN
+    [dbo].[Organization] O ON O.[Id] = PO.[OrganizationId]
+GO


### PR DESCRIPTION
## Type of change


```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

Add the number of users, total number of seats, and the plan columns to the client table within the Provider Portal.


## Code changes

* **src/Api/Models/Response/Providers/ProviderOrganizationResponseModel.cs:** Added properties to display values for "UserCount", "Seats" and "Plan"
* **src/Core/Models/Data/Provider/ProviderOrganizationOrganizationDetails.cs:** Added properties "UserCount", "Seats" and "Plan" to map query values
* **src/Infrastructure.EntityFramework/Repositories/Queries/ProviderOrganizationOrganizationDetailsReadByProviderIdQuery.cs:** Updated EF query to get values for the new columns
* **util/Migrator/DbScripts/2022-07-20_00_ProviderOrganizationListDetails.sql:** Added a new migration to update the view [dbo].[ProviderOrganizationOrganizationDetailsView] to include the new columns

## Before you submit


```
- [X] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [X] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
