### PR TITLE
[SG 475] Fix error thrown when changing payment method

### DIFF
--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -1372,18 +1372,20 @@ namespace Bit.Core.Services
                         }
                     }
 
-                    foreach (var source in customer.Sources.Where(s => s.Id != defaultSourceId))
+                    if (customer.Sources != null)
                     {
-                        if (source is Stripe.BankAccount)
+                        foreach (var source in customer.Sources.Where(s => s.Id != defaultSourceId))
                         {
-                            await _stripeAdapter.BankAccountDeleteAsync(customer.Id, source.Id);
-                        }
-                        else if (source is Stripe.Card)
-                        {
-                            await _stripeAdapter.CardDeleteAsync(customer.Id, source.Id);
+                            if (source is Stripe.BankAccount)
+                            {
+                                await _stripeAdapter.BankAccountDeleteAsync(customer.Id, source.Id);
+                            }
+                            else if (source is Stripe.Card)
+                            {
+                                await _stripeAdapter.CardDeleteAsync(customer.Id, source.Id);
+                            }
                         }
                     }
-
                     var cardPaymentMethods = _stripeAdapter.PaymentMethodListAutoPaging(new Stripe.PaymentMethodListOptions
                     {
                         Customer = customer.Id,

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -1187,7 +1187,9 @@ namespace Bit.Core.Services
 
             if (!string.IsNullOrWhiteSpace(subscriber.GatewayCustomerId))
             {
-                customer = await _stripeAdapter.CustomerGetAsync(subscriber.GatewayCustomerId);
+                var options = new Stripe.CustomerGetOptions();
+                options.AddExpand("sources");
+                customer = await _stripeAdapter.CustomerGetAsync(subscriber.GatewayCustomerId, options);
                 if (customer.Metadata?.Any() ?? false)
                 {
                     stripeCustomerMetadata = customer.Metadata;
@@ -1386,6 +1388,7 @@ namespace Bit.Core.Services
                             }
                         }
                     }
+
                     var cardPaymentMethods = _stripeAdapter.PaymentMethodListAutoPaging(new Stripe.PaymentMethodListOptions
                     {
                         Customer = customer.Id,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Fix error being thrown when changing a payment method. This will be cherry picked to `rc`


## Code changes


* **src/Core/Services/Implementations/StripePaymentService.cs:** 
    -  Add option to expand a customer's sources. According to the Stripe API, you need to pass this or else sources will not be returned. Not sure why this wasn't an issue before, but this fixes it. [docs link](https://stripe.com/docs/api/customers/object?lang=dotnet#customer_object-sources)
    - Add null check on sources. I could not find in the Stripe docs if sources will be returned as an empty list or null if they don't exist, I figured it was safer to keep this check in case it returns null.
## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
