### PR TITLE
SCIM: Associate users to group on PUT/POST

### DIFF
--- a/bitwarden_license/src/Scim/Controllers/v2/GroupsController.cs
+++ b/bitwarden_license/src/Scim/Controllers/v2/GroupsController.cs
@@ -319,10 +319,13 @@ namespace Bit.Scim.Controllers.v2
                     memberIds.Add(guidId);
                 }
             }
+
             if (!memberIds.Any() && skipIfEmpty)
             {
-                await _groupRepository.UpdateUsersAsync(group.Id, memberIds);
+                return;
             }
+
+            await _groupRepository.UpdateUsersAsync(group.Id, memberIds);
         }
     }
 }

--- a/bitwarden_license/src/Scim/Controllers/v2/GroupsController.cs
+++ b/bitwarden_license/src/Scim/Controllers/v2/GroupsController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using Bit.Core.Entities;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Scim.Context;
@@ -126,6 +127,7 @@ namespace Bit.Scim.Controllers.v2
 
             var group = model.ToGroup(organizationId);
             await _groupService.SaveAsync(group, null);
+            await UpdateGroupMembersAsync(group, model, true);
             var response = new ScimGroupResponseModel(group);
             return new CreatedResult(Url.Action(nameof(Get), new { group.OrganizationId, group.Id }), response);
         }
@@ -145,6 +147,7 @@ namespace Bit.Scim.Controllers.v2
 
             group.Name = model.DisplayName;
             await _groupService.SaveAsync(group);
+            await UpdateGroupMembersAsync(group, model, false);
             return new ObjectResult(new ScimGroupResponseModel(group));
         }
 
@@ -294,6 +297,32 @@ namespace Bit.Scim.Controllers.v2
                 return id;
             }
             return null;
+        }
+
+        private async Task UpdateGroupMembersAsync(Group group, ScimGroupRequestModel model, bool skipIfEmpty)
+        {
+            if (_scimContext.RequestScimProvider != Core.Enums.ScimProviderType.Okta)
+            {
+                return;
+            }
+
+            if (model.Members == null)
+            {
+                return;
+            }
+
+            var memberIds = new List<Guid>();
+            foreach (var id in model.Members.Select(i => i.Value))
+            {
+                if (Guid.TryParse(id, out var guidId))
+                {
+                    memberIds.Add(guidId);
+                }
+            }
+            if (!memberIds.Any() && skipIfEmpty)
+            {
+                await _groupRepository.UpdateUsersAsync(group.Id, memberIds);
+            }
         }
     }
 }

--- a/bitwarden_license/src/Scim/Models/ScimGroupRequestModel.cs
+++ b/bitwarden_license/src/Scim/Models/ScimGroupRequestModel.cs
@@ -19,5 +19,13 @@ namespace Bit.Scim.Models
                 OrganizationId = organizationId
             };
         }
+
+        public List<GroupMembersModel> Members { get; set; }
+
+        public class GroupMembersModel
+        {
+            public string Value { get; set; }
+            public string Display { get; set; }
+        }
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
It was discovered that Okta sends group membership relationships during the Group POST/PUT operations. Previously this was only handled on PATCH options.

cc: @eliykat @aj-bw @fschillingeriv 

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **group request model:** Extended model to include `members` array.
* **groups controller:** Added `UpdateGroupMembersAsync` method to be called by POST/PUT.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
