### PR TITLE
Add CreationDate to CipherResponse

### DIFF
--- a/src/Api/Models/Response/CipherResponseModel.cs
+++ b/src/Api/Models/Response/CipherResponseModel.cs
@@ -60,6 +60,7 @@ namespace Bit.Api.Models.Response
             OrganizationId = cipher.OrganizationId?.ToString();
             Attachments = AttachmentResponseModel.FromCipher(cipher, globalSettings);
             OrganizationUseTotp = orgUseTotp;
+            CreationDate = cipher.CreationDate;
             DeletedDate = cipher.DeletedDate;
             Reprompt = cipher.Reprompt.GetValueOrDefault(CipherRepromptType.None);
         }
@@ -79,6 +80,7 @@ namespace Bit.Api.Models.Response
         public IEnumerable<AttachmentResponseModel> Attachments { get; set; }
         public bool OrganizationUseTotp { get; set; }
         public DateTime RevisionDate { get; set; }
+        public DateTime CreationDate { get; set; }
         public DateTime? DeletedDate { get; set; }
         public CipherRepromptType Reprompt { get; set; }
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Includes CreationDate in CipherResponse so the data is included in API responses.

Screenshot:
<img width="544" alt="image" src="https://user-images.githubusercontent.com/42774874/180803978-59cff430-a0b6-4904-bdfd-124b70e23221.png">
Network response from `GET | https://localhost:8080/api/sync?excludeDomains=true` now returns `creationDate`.




## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Api/Models/Response/CipherResponseModel.cs:** Added `cipher.CreationDate`

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [NA] If making database changes - I have also updated Entity Framework queries and/or migrations
- [NA] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [NA] This change requires a **documentation update** (notify the documentation team)
- [NA] This change has particular **deployment requirements** (notify the DevOps team)
```
