### PR TITLE
[EC-276] Admin with custom permission is unable to manage all collections

### DIFF
--- a/src/Core/Services/Implementations/CollectionService.cs
+++ b/src/Core/Services/Implementations/CollectionService.cs
@@ -124,7 +124,7 @@ namespace Bit.Core.Services
             }
 
             IEnumerable<Collection> orgCollections;
-            if (await _currentContext.OrganizationAdmin(organizationId) || await _currentContext.OrganizationCustom(organizationId))
+            if (await _currentContext.OrganizationAdmin(organizationId) || await _currentContext.ViewAllCollections(organizationId))
             {
                 // Admins, Owners, Providers and Custom (with collection management permissions) can access all items even if not assigned to them
                 orgCollections = await _collectionRepository.GetManyByOrganizationIdAsync(organizationId);

--- a/src/Core/Services/Implementations/CollectionService.cs
+++ b/src/Core/Services/Implementations/CollectionService.cs
@@ -124,9 +124,9 @@ namespace Bit.Core.Services
             }
 
             IEnumerable<Collection> orgCollections;
-            if (await _currentContext.OrganizationAdmin(organizationId))
+            if (await _currentContext.OrganizationAdmin(organizationId) || await _currentContext.OrganizationCustom(organizationId))
             {
-                // Admins, Owners and Providers can access all items even if not assigned to them
+                // Admins, Owners, Providers and Custom (with collection management permissions) can access all items even if not assigned to them
                 orgCollections = await _collectionRepository.GetManyByOrganizationIdAsync(organizationId);
             }
             else


### PR DESCRIPTION
## Type of change


```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Admin with custom “Manage all collections” permission should be able to manage all collections regardless of his access control.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/Services/Implementations/CollectionService.cs:** Added a check to see if the user has permissions to view all collections

## Before you submit


```
- [X] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
