### PR TITLE
PS-1027 - prevent encoding of the organization name in master passwor…

### DIFF
--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -413,7 +413,7 @@ namespace Bit.Core.Services
             var model = new AdminResetPasswordViewModel()
             {
                 UserName = GetUserIdentifier(email, userName),
-                OrgName = CoreHelpers.SanitizeForEmail(orgName),
+                OrgName = CoreHelpers.SanitizeForEmail(orgName, false),
             };
             await AddMessageContentAsync(message, "AdminResetPassword", model);
             message.Category = "AdminResetPassword";


### PR DESCRIPTION
…d reset email

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Apostrophes should be displayed as expected in an organization's name in the master password reset email.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->


Within the `SendAdminResetPasswordEmailAsync` function, added an argument `false` when calling `SanitizeForEmail` for the organization name. This prevents the organization name from being html encoded, which follows the pattern established in this PR: https://github.com/bitwarden/server/pull/1478

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
