### PR TITLE
[EC-336] Fix invalid SCIM invites and SCIM log directory

### DIFF
--- a/util/Setup/Templates/DockerCompose.hbs
+++ b/util/Setup/Templates/DockerCompose.hbs
@@ -218,8 +218,9 @@ services:
     container_name: bitwarden-scim
     restart: always
     volumes:
+      - ../core:/etc/bitwarden/core
       - ../ca-certificates:/etc/bitwarden/ca-certificates
-      - ../logs/api:/etc/bitwarden/logs
+      - ../logs/scim:/etc/bitwarden/logs
     env_file:
       - global.env
       - ../env/uid.env


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Follow on from https://github.com/bitwarden/server/pull/2135. That fixed invalid SCIM invites in local dev instances, but QA's self-hosted instance continues to experience the issue.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **util/Setup/Templates/DockerCompose.hbs** - the scim container was not mounting the `core` directory, which is the default location for asp.net data protection data (see [the default GlobalSettings value](https://github.com/bitwarden/server/blob/d9e98a27c146fd0a93ce38d704fe4cd9efaece15/src/Core/Settings/GlobalSettings.cs#L334-L334), also confirmed by inspecting my local self-hosted deployment). I can't spot any other issues with the container or environment setup.
* also fix the log directory, looks like a copy/paste job from api which wasn't updated.

**This will be picked to rc**

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
