### PR TITLE
[fix] Address QA found defects for the Stripe Subscriptions admin tool

### DIFF
--- a/src/Admin/Controllers/ToolsController.cs
+++ b/src/Admin/Controllers/ToolsController.cs
@@ -485,11 +485,11 @@ namespace Bit.Admin.Controllers
             }
             else
             {
-                if (model.Action == StripeSubscriptionsAction.PreviousPage)
+                if (model.Action == StripeSubscriptionsAction.PreviousPage || model.Action == StripeSubscriptionsAction.Search)
                 {
                     model.Filter.StartingAfter = null;
                 }
-                if (model.Action == StripeSubscriptionsAction.NextPage)
+                if (model.Action == StripeSubscriptionsAction.NextPage || model.Action == StripeSubscriptionsAction.Search)
                 {
                     model.Filter.EndingBefore = null;
                 }

--- a/src/Admin/Controllers/ToolsController.cs
+++ b/src/Admin/Controllers/ToolsController.cs
@@ -453,6 +453,7 @@ namespace Bit.Admin.Controllers
             {
                 Items = subscriptions.Select(s => new StripeSubscriptionRowModel(s)).ToList(),
                 Prices = (await _stripeAdapter.PriceListAsync(new Stripe.PriceListOptions() { Limit = 100 })).Data,
+                TestClocks = await _stripeAdapter.TestClockListAsync(),
                 Filter = options
             };
             return View(model);
@@ -464,6 +465,7 @@ namespace Bit.Admin.Controllers
             if (!ModelState.IsValid)
             {
                 model.Prices = (await _stripeAdapter.PriceListAsync(new Stripe.PriceListOptions() { Limit = 100 })).Data;
+                model.TestClocks = await _stripeAdapter.TestClockListAsync();
                 return View(model);
             }
 

--- a/src/Admin/Models/StripeSubscriptionsModel.cs
+++ b/src/Admin/Models/StripeSubscriptionsModel.cs
@@ -30,6 +30,7 @@ namespace Bit.Admin.Models
         public StripeSubscriptionsAction Action { get; set; } = StripeSubscriptionsAction.Search;
         public string Message { get; set; }
         public List<Stripe.Price> Prices { get; set; }
+        public List<Stripe.TestHelpers.TestClock> TestClocks { get; set; }
         public StripeSubscriptionListOptions Filter { get; set; } = new StripeSubscriptionListOptions();
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {

--- a/src/Admin/Views/Tools/StripeSubscriptions.cshtml
+++ b/src/Admin/Views/Tools/StripeSubscriptions.cshtml
@@ -112,6 +112,14 @@
                     {<option asp-selected='@Model.Filter.Price == @price.Id' value="@price.Id">@price.Id</option>}
                 </select>
             </div>
+            <div class="col-6">
+                <label asp-for="Filter.TestClock">Test Clock</label>
+                <select asp-for="Filter.TestClock" name="filter.TestClock" class="form-control mr-2">
+                    <option asp-selected="Model.Filter.TestClock == null" value="@null">All</option>
+                    @foreach (var clock in Model.TestClocks)
+                    {<option asp-selected='@Model.Filter.TestClock == @clock.Id' value="@clock.Id">@clock.Name</option>}
+                </select>
+            </div>
         </div>
         <div class="row col-12 d-flex justify-content-end my-3">
                 <button type="submit" class="btn btn-primary" title="Search" name="action" asp-for="Action" value="@StripeSubscriptionsAction.Search"><i class="fa fa-search"></i> Search</button>

--- a/src/Core/Models/Stripe/StripeSubscriptionListOptions.cs
+++ b/src/Core/Models/Stripe/StripeSubscriptionListOptions.cs
@@ -27,6 +27,13 @@
         public Stripe.SubscriptionListOptions ToStripeApiOptions()
         {
             var stripeApiOptions = (Stripe.SubscriptionListOptions)this;
+
+            if (SelectAll)
+            {
+                stripeApiOptions.EndingBefore = null;
+                stripeApiOptions.StartingAfter = null;
+            }
+
             if (CurrentPeriodEndDate.HasValue)
             {
                 stripeApiOptions.CurrentPeriodEnd = new Stripe.DateRangeOptions()
@@ -35,6 +42,7 @@
                     GreaterThan = CurrentPeriodEndRange == "gt" ? CurrentPeriodEndDate : null
                 };
             }
+
             return stripeApiOptions;
         }
     }

--- a/src/Core/Services/IStripeAdapter.cs
+++ b/src/Core/Services/IStripeAdapter.cs
@@ -35,5 +35,6 @@ namespace Bit.Core.Services
         Task<Stripe.BankAccount> BankAccountCreateAsync(string customerId, Stripe.BankAccountCreateOptions options = null);
         Task<Stripe.BankAccount> BankAccountDeleteAsync(string customerId, string bankAccount, Stripe.BankAccountDeleteOptions options = null);
         Task<Stripe.StripeList<Stripe.Price>> PriceListAsync(Stripe.PriceListOptions options = null);
+        Task<List<Stripe.TestHelpers.TestClock>> TestClockListAsync();
     }
 }

--- a/src/Core/Services/Implementations/StripeAdapter.cs
+++ b/src/Core/Services/Implementations/StripeAdapter.cs
@@ -15,6 +15,7 @@ namespace Bit.Core.Services
         private readonly Stripe.CardService _cardService;
         private readonly Stripe.BankAccountService _bankAccountService;
         private readonly Stripe.PriceService _priceService;
+        private readonly Stripe.TestHelpers.TestClockService _testClockService;
 
         public StripeAdapter()
         {
@@ -29,6 +30,7 @@ namespace Bit.Core.Services
             _cardService = new Stripe.CardService();
             _bankAccountService = new Stripe.BankAccountService();
             _priceService = new Stripe.PriceService();
+            _testClockService = new Stripe.TestHelpers.TestClockService();
         }
 
         public Task<Stripe.Customer> CustomerCreateAsync(Stripe.CustomerCreateOptions options)
@@ -197,6 +199,20 @@ namespace Bit.Core.Services
         public async Task<Stripe.StripeList<Stripe.Price>> PriceListAsync(Stripe.PriceListOptions options = null)
         {
             return await _priceService.ListAsync(options);
+        }
+
+        public async Task<List<Stripe.TestHelpers.TestClock>> TestClockListAsync()
+        {
+            var items = new List<Stripe.TestHelpers.TestClock>();
+            var options = new Stripe.TestHelpers.TestClockListOptions()
+            {
+                Limit = 100
+            };
+            await foreach (var i in _testClockService.ListAutoPagingAsync(options))
+            {
+                items.Add(i);
+            }
+            return items;
         }
     }
 }


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/SG-404?atlOrigin=eyJpIjoiZTEzZmU3ZDMzM2U1NGRjNDk0ZWY5N2EyNTg5MzQxODEiLCJwIjoiaiJ9

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Address defects found on the Stripe Subscription admin tool during QA.

## Code changes
Each commit addresses a specific defect:

* [[fix] Clear the page on Stripe Subscription search change](https://github.com/bitwarden/server/commit/2b9d247930caf02c0419c6a8c4829b8d579af708)
Addresses [[SG-466]](https://bitwarden.atlassian.net/browse/SG-466) which describes an error throwing when changing the search filter on any page > 1. I fixed this by nulling out the pagination properties when the form action is a search.

* [[fix] Ensure page is null when selecting all Stripe Subscriptions for…](https://github.com/bitwarden/server/commit/5bf822fa734b99a855ce9f5dfe5a5d69464f4b2d)
Addresses [[SG-470]](https://bitwarden.atlassian.net/browse/SG-470) which describes the export function not including the current page. Similar to the first fix, this one was because we were leaving pagination properties around on the view model even though SelectAll is supposed to bypass pagination. I fixed this by nulling out pagination properties if `SelectAll` is true for a search.

* [[feat] Allow Stripe Subscriptions to be filtered by a test clock](https://github.com/bitwarden/server/commit/bf125d29bd6a7c733af1017d25f43adf1275fb27)
Addresses [[SG-481]](https://bitwarden.atlassian.net/browse/SG-481) which describes an issue QA is having testing this functionality because Stripe's subscription list API excludes records created in a test clock by default. This is the the main way QA tests subscription aging in Stripe. I addresses this by adding a form input for test clocks.

## Screenshots
![Screen Shot 2022-07-26 at 10 39 46 AM](https://user-images.githubusercontent.com/15897251/181035785-ca8d70ae-b726-4e22-8a99-4c4a3e0f3b5f.png)

## Before you submit

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```


[SG-466]: https://bitwarden.atlassian.net/browse/SG-466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SG-470]: https://bitwarden.atlassian.net/browse/SG-470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ