### PR TITLE
EC-261 - Update OrganizationLicense for SCIM

### DIFF
--- a/src/Core/Models/Business/OrganizationLicense.cs
+++ b/src/Core/Models/Business/OrganizationLicense.cs
@@ -131,7 +131,7 @@ namespace Bit.Core.Models.Business
         /// <summary>
         /// Represents the current version of the license format. Should be updated whenever new fields are added.
         /// </summary>
-        private const int CURRENT_LICENSE_FILE_VERSION = 10;
+        private const int CURRENT_LICENSE_FILE_VERSION = 9;
         private bool ValidLicenseVersion
         {
             get => Version is >= 1 and <= 10;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
We try to maintain a reasonable timespan between bumping the version numbers. We've been on V8 for 8 months so bumping to 9 should be fine. I had previously and incorrectly set it to version 10.


## Code changes

* **src/Core/Models/Business/OrganizationLicense.cs:** Set license version to 9, not 10.

**This will require a cherry-pick to `rc`.**

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
