### PR TITLE
[EC-388] Enforce organization policies when restoring user

### DIFF
--- a/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
+++ b/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
@@ -193,7 +193,7 @@ namespace Bit.Scim.Controllers.v2
 
             if (model.Active && orgUser.Status == OrganizationUserStatusType.Revoked)
             {
-                await _organizationService.RestoreUserAsync(orgUser, null);
+                await _organizationService.RestoreUserAsync(orgUser, null, _userService);
             }
             else if (!model.Active && orgUser.Status != OrganizationUserStatusType.Revoked)
             {
@@ -229,7 +229,7 @@ namespace Bit.Scim.Controllers.v2
                     var active = activeProperty.GetBoolean();
                     if (active && orgUser.Status == OrganizationUserStatusType.Revoked)
                     {
-                        await _organizationService.RestoreUserAsync(orgUser, null);
+                        await _organizationService.RestoreUserAsync(orgUser, null, _userService);
                         operationHandled = true;
                     }
                     else if (!active && orgUser.Status != OrganizationUserStatusType.Revoked)

--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -423,14 +423,14 @@ namespace Bit.Api.Controllers
         [HttpPut("{id}/restore")]
         public async Task RestoreAsync(Guid orgId, Guid id)
         {
-            await RestoreOrRevokeUserAsync(orgId, id, _organizationService.RestoreUserAsync);
+            await RestoreOrRevokeUserAsync(orgId, id, (orgUser, userId) => _organizationService.RestoreUserAsync(orgUser, userId, _userService));
         }
 
         [HttpPatch("restore")]
         [HttpPut("restore")]
         public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkRestoreAsync(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
         {
-            return await RestoreOrRevokeUsersAsync(orgId, model, _organizationService.RestoreUsersAsync);
+            return await RestoreOrRevokeUsersAsync(orgId, model, (orgId, orgUserIds, restoringUserId ) => _organizationService.RestoreUsersAsync(orgId, orgUserIds, restoringUserId, _userService));
         }
 
         private async Task RestoreOrRevokeUserAsync(

--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -430,7 +430,7 @@ namespace Bit.Api.Controllers
         [HttpPut("restore")]
         public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkRestoreAsync(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
         {
-            return await RestoreOrRevokeUsersAsync(orgId, model, (orgId, orgUserIds, restoringUserId ) => _organizationService.RestoreUsersAsync(orgId, orgUserIds, restoringUserId, _userService));
+            return await RestoreOrRevokeUsersAsync(orgId, model, (orgId, orgUserIds, restoringUserId) => _organizationService.RestoreUsersAsync(orgId, orgUserIds, restoringUserId, _userService));
         }
 
         private async Task RestoreOrRevokeUserAsync(

--- a/src/Core/Services/IOrganizationService.cs
+++ b/src/Core/Services/IOrganizationService.cs
@@ -61,8 +61,8 @@ namespace Bit.Core.Services
         Task RevokeUserAsync(OrganizationUser organizationUser, Guid? revokingUserId);
         Task<List<Tuple<OrganizationUser, string>>> RevokeUsersAsync(Guid organizationId,
             IEnumerable<Guid> organizationUserIds, Guid? revokingUserId);
-        Task RestoreUserAsync(OrganizationUser organizationUser, Guid? restoringUserId);
+        Task RestoreUserAsync(OrganizationUser organizationUser, Guid? restoringUserId, IUserService userService);
         Task<List<Tuple<OrganizationUser, string>>> RestoreUsersAsync(Guid organizationId,
-            IEnumerable<Guid> organizationUserIds, Guid? restoringUserId);
+            IEnumerable<Guid> organizationUserIds, Guid? restoringUserId, IUserService userService);
     }
 }

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -2365,7 +2365,7 @@ namespace Bit.Core.Services
                     {
                         throw new BadRequestException("Only owners can restore other owners.");
                     }
-                    
+
                     await CheckPoliciesBeforeRestoreAsync(organizationUser, userService);
 
                     var status = GetPriorActiveOrganizationUserStatusType(organizationUser);
@@ -2393,9 +2393,9 @@ namespace Bit.Core.Services
             {
                 return;
             }
-            
+
             var userId = orgUser.UserId.Value;
-            
+
             // Enforce Single Organization Policy of organization user is being restored to
             var allOrgUsers = await _organizationUserRepository.GetManyByUserAsync(userId);
             var hasOtherOrgs = allOrgUsers.Any(ou => ou.OrganizationId != orgUser.OrganizationId);

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -2300,7 +2300,7 @@ namespace Bit.Core.Services
             return result;
         }
 
-        public async Task RestoreUserAsync(OrganizationUser organizationUser, Guid? restoringUserId)
+        public async Task RestoreUserAsync(OrganizationUser organizationUser, Guid? restoringUserId, IUserService userService)
         {
             if (organizationUser.Status != OrganizationUserStatusType.Revoked)
             {
@@ -2318,6 +2318,8 @@ namespace Bit.Core.Services
                 throw new BadRequestException("Only owners can restore other owners.");
             }
 
+            await CheckPoliciesBeforeRestoreAsync(organizationUser, userService);
+
             var status = GetPriorActiveOrganizationUserStatusType(organizationUser);
 
             await _organizationUserRepository.RestoreAsync(organizationUser.Id, status);
@@ -2326,7 +2328,7 @@ namespace Bit.Core.Services
         }
 
         public async Task<List<Tuple<OrganizationUser, string>>> RestoreUsersAsync(Guid organizationId,
-            IEnumerable<Guid> organizationUserIds, Guid? restoringUserId)
+            IEnumerable<Guid> organizationUserIds, Guid? restoringUserId, IUserService userService)
         {
             var orgUsers = await _organizationUserRepository.GetManyAsync(organizationUserIds);
             var filteredUsers = orgUsers.Where(u => u.OrganizationId == organizationId)
@@ -2363,6 +2365,8 @@ namespace Bit.Core.Services
                     {
                         throw new BadRequestException("Only owners can restore other owners.");
                     }
+                    
+                    await CheckPoliciesBeforeRestoreAsync(organizationUser, userService);
 
                     var status = GetPriorActiveOrganizationUserStatusType(organizationUser);
 
@@ -2379,6 +2383,53 @@ namespace Bit.Core.Services
             }
 
             return result;
+        }
+
+        private async Task CheckPoliciesBeforeRestoreAsync(OrganizationUser orgUser, IUserService userService)
+        {
+            // An invited OrganizationUser isn't linked with a user account yet, so these checks are irrelevant
+            // The user will be subject to the same checks when they try to accept the invite
+            if (GetPriorActiveOrganizationUserStatusType(orgUser) == OrganizationUserStatusType.Invited)
+            {
+                return;
+            }
+            
+            var userId = orgUser.UserId.Value;
+            
+            // Enforce Single Organization Policy of organization user is being restored to
+            var allOrgUsers = await _organizationUserRepository.GetManyByUserAsync(userId);
+            var hasOtherOrgs = allOrgUsers.Any(ou => ou.OrganizationId != orgUser.OrganizationId);
+            var singleOrgPoliciesApplyingToRevokedUsers = await _policyRepository.GetManyByTypeApplicableToUserIdAsync(userId,
+                PolicyType.SingleOrg, OrganizationUserStatusType.Revoked);
+            var singleOrgPolicyApplies = singleOrgPoliciesApplyingToRevokedUsers.Any(p => p.OrganizationId == orgUser.OrganizationId);
+
+            if (hasOtherOrgs && singleOrgPolicyApplies)
+            {
+                throw new BadRequestException("You cannot restore this user until " +
+                    "they leave or remove all other organizations.");
+            }
+
+            // Enforce Single Organization Policy of other organizations user is a member of
+            var singleOrgPolicyCount = await _policyRepository.GetCountByTypeApplicableToUserIdAsync(userId,
+                PolicyType.SingleOrg);
+            if (singleOrgPolicyCount > 0)
+            {
+                throw new BadRequestException("You cannot restore this user because they are a member of " +
+                    "another organization which forbids it");
+            }
+
+            // Enforce Two Factor Authentication Policy of organization user is trying to join
+            var user = await _userRepository.GetByIdAsync(userId);
+            if (!await userService.TwoFactorIsEnabledAsync(user))
+            {
+                var invitedTwoFactorPolicies = await _policyRepository.GetManyByTypeApplicableToUserIdAsync(userId,
+                    PolicyType.TwoFactorAuthentication, OrganizationUserStatusType.Invited);
+                if (invitedTwoFactorPolicies.Any(p => p.OrganizationId == orgUser.OrganizationId))
+                {
+                    throw new BadRequestException("You cannot restore this user until they enable " +
+                        "two-step login on their user account.");
+                }
+            }
         }
 
         static OrganizationUserStatusType GetPriorActiveOrganizationUserStatusType(OrganizationUser organizationUser)

--- a/src/Sql/dbo/Functions/PolicyApplicableToUser.sql
+++ b/src/Sql/dbo/Functions/PolicyApplicableToUser.sql
@@ -25,12 +25,11 @@ LEFT JOIN
 WHERE
     (
         (
-            OU.[UserId] IS NOT NULL     -- OrgUsers who have accepted their invite and are linked to a UserId
+            OU.[Status] != 0     -- OrgUsers who have accepted their invite and are linked to a UserId
             AND OU.[UserId] = @UserId 
         )
         OR (
-            OU.[Email] IS NOT NULL      -- OrgUsers who have not accepted their invite are not linked to a UserId yet, 
-                                        -- so we have to look up their email. This includes invited but revoked orgUsers
+            OU.[Status] = 0     -- 'Invited' OrgUsers are not linked to a UserId yet, so we have to look up their email
             AND OU.[Email] IN (SELECT U.Email FROM [dbo].[UserView] U WHERE U.Id = @UserId)
         )
     )

--- a/src/Sql/dbo/Stored Procedures/Policy_CountByTypeApplicableToUser.sql
+++ b/src/Sql/dbo/Stored Procedures/Policy_CountByTypeApplicableToUser.sql
@@ -1,7 +1,7 @@
 CREATE PROCEDURE [dbo].[Policy_CountByTypeApplicableToUser]
     @UserId UNIQUEIDENTIFIER,
     @PolicyType TINYINT,
-    @MinimumStatus TINYINT
+    @MinimumStatus SMALLINT
 AS
 BEGIN
     SET NOCOUNT ON

--- a/src/Sql/dbo/Stored Procedures/Policy_ReadByTypeApplicableToUser.sql
+++ b/src/Sql/dbo/Stored Procedures/Policy_ReadByTypeApplicableToUser.sql
@@ -1,7 +1,7 @@
 CREATE PROCEDURE [dbo].[Policy_ReadByTypeApplicableToUser]
     @UserId UNIQUEIDENTIFIER,
     @PolicyType TINYINT,
-    @MinimumStatus TINYINT
+    @MinimumStatus SMALLINT
 AS
 BEGIN
     SET NOCOUNT ON

--- a/util/Migrator/DbScripts/2022-07-28_00_CheckPoliciesOnRestore.sql
+++ b/util/Migrator/DbScripts/2022-07-28_00_CheckPoliciesOnRestore.sql
@@ -92,4 +92,4 @@ WHERE
    OR COALESCE(JSON_VALUE(OU.[Permissions], '$.managePolicies'), 'false') = 'false'
     )
   AND PUPO.[UserId] IS NULL   -- Not a provider
-    GO
+GO

--- a/util/Migrator/DbScripts/2022-07-28_00_CheckPoliciesOnRestore.sql
+++ b/util/Migrator/DbScripts/2022-07-28_00_CheckPoliciesOnRestore.sql
@@ -75,22 +75,21 @@ LEFT JOIN
 WHERE
     (
         (
-            OU.[UserId] IS NOT NULL     -- OrgUsers who have accepted their invite and are linked to a UserId
+            OU.[Status] != 0     -- OrgUsers who have accepted their invite and are linked to a UserId
             AND OU.[UserId] = @UserId 
         )
         OR (
-            OU.[Email] IS NOT NULL      -- OrgUsers who have not accepted their invite are not linked to a UserId yet, 
-                                        -- so we have to look up their email. This includes invited but revoked orgUsers
+            OU.[Status] = 0     -- 'Invited' OrgUsers are not linked to a UserId yet, so we have to look up their email
             AND OU.[Email] IN (SELECT U.Email FROM [dbo].[UserView] U WHERE U.Id = @UserId)
-        )
     )
-    AND P.[Type] = @PolicyType
-    AND P.[Enabled] = 1
-    AND OU.[Status] >= @MinimumStatus
-    AND OU.[Type] >= 2              -- Not an owner (0) or admin (1)
-    AND (                           -- Can't manage policies
-        OU.[Permissions] IS NULL
-        OR COALESCE(JSON_VALUE(OU.[Permissions], '$.managePolicies'), 'false') = 'false'
     )
-    AND PUPO.[UserId] IS NULL   -- Not a provider
-GO
+  AND P.[Type] = @PolicyType
+  AND P.[Enabled] = 1
+  AND OU.[Status] >= @MinimumStatus
+  AND OU.[Type] >= 2              -- Not an owner (0) or admin (1)
+  AND (                           -- Can't manage policies
+    OU.[Permissions] IS NULL
+   OR COALESCE(JSON_VALUE(OU.[Permissions], '$.managePolicies'), 'false') = 'false'
+    )
+  AND PUPO.[UserId] IS NULL   -- Not a provider
+    GO

--- a/util/Migrator/DbScripts/2022-07-28_00_CheckPoliciesOnRestore.sql
+++ b/util/Migrator/DbScripts/2022-07-28_00_CheckPoliciesOnRestore.sql
@@ -89,7 +89,7 @@ WHERE
   AND OU.[Type] >= 2              -- Not an owner (0) or admin (1)
   AND (                           -- Can't manage policies
     OU.[Permissions] IS NULL
-   OR COALESCE(JSON_VALUE(OU.[Permissions], '$.managePolicies'), 'false') = 'false'
+    OR COALESCE(JSON_VALUE(OU.[Permissions], '$.managePolicies'), 'false') = 'false'
     )
   AND PUPO.[UserId] IS NULL   -- Not a provider
 GO

--- a/util/Migrator/DbScripts/2022-07-28_00_CheckPoliciesOnRestore.sql
+++ b/util/Migrator/DbScripts/2022-07-28_00_CheckPoliciesOnRestore.sql
@@ -1,3 +1,53 @@
+-- 2022-06-08_00_DeactivatedUserStatus changed UserStatus from TINYINT to SMALLINT but these sprocs were missed
+
+-- Policy_ReadByTypeApplicableToUser
+IF OBJECT_ID('[dbo].[Policy_ReadByTypeApplicableToUser]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Policy_ReadByTypeApplicableToUser]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Policy_ReadByTypeApplicableToUser]
+    @UserId UNIQUEIDENTIFIER,
+    @PolicyType TINYINT,
+    @MinimumStatus SMALLINT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+SELECT *
+FROM [dbo].[PolicyApplicableToUser](@UserId, @PolicyType, @MinimumStatus)
+END
+GO
+
+-- Policy_CountByTypeApplicableToUser
+IF OBJECT_ID('[dbo].[Policy_CountByTypeApplicableToUser]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Policy_CountByTypeApplicableToUser]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Policy_CountByTypeApplicableToUser]
+    @UserId UNIQUEIDENTIFIER,
+    @PolicyType TINYINT,
+    @MinimumStatus SMALLINT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+SELECT COUNT(1)
+FROM [dbo].[PolicyApplicableToUser](@UserId, @PolicyType, @MinimumStatus)
+END
+GO
+
+-- We need to update this function because we now have OrganizationUserStatusTypes that are less than zero,
+-- and Deactivated/Revoked users may or may not be associated with a UserId
+IF OBJECT_ID('[dbo].[PolicyApplicableToUser]') IS NOT NULL
+BEGIN
+    DROP FUNCTION [dbo].[PolicyApplicableToUser]
+END
+GO
+
 CREATE FUNCTION [dbo].[PolicyApplicableToUser]
 (
     @UserId UNIQUEIDENTIFIER,
@@ -43,3 +93,4 @@ WHERE
         OR COALESCE(JSON_VALUE(OU.[Permissions], '$.managePolicies'), 'false') = 'false'
     )
     AND PUPO.[UserId] IS NULL   -- Not a provider
+GO


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Revoked users are not subject to organization policies (that happened automagically from existing code), but we weren't re-enforcing/checking those policies when restoring them. See EC-388 for more info.

Add policy checks to the "restore" logic, similar to the checks that are in the "accept invite" logic.

~This will be picked to rc.~ It's too late to pick to rc, I suggest it's included in the hotfix that turns on scim.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

**src/Core/Services/Implementations/OrganizationService.cs**
* add `CheckPoliciesBeforeRestoreAsync`. This is largely copy/pasted from the `AcceptUser` method, with some tweaks to the logic (to query revoked users instead of invited) and error message wording. I have created a tech debt ticket to refactor and reduce this code duplication (EC-393) but we're very close to the release, so I don't want to do this now.
* call this method where required
* note that we need to pass in `UserService`, presumably because it's a circular dependency - again can be tackled in the follow-up tech debt ticket

**bitwarden_license/src/Scim/Controllers/v2/UsersController.cs** - update call to pass in `userService`

**src/Api/Controllers/OrganizationUsersController.cs** - update call to pass in `userService`. Use a lambda to keep interfaces the same.

**src/Sql/dbo/Stored Procedures/Policy_CountByTypeApplicableToUser.sql** and **src/Sql/dbo/Stored Procedures/Policy_ReadByTypeApplicableToUser.sql** - the `OrganizationUserStatus` is now stored in a `SMALLINT`, not a `TINYINT`. This should've been updated but was missed

**src/Sql/dbo/Functions/PolicyApplicableToUser.sql** - previously, this function used the `Invited` status to indicate that we had to match the OrgUser & User by email address, and any other status to indicate we could match them by UserId. Now we can have a Revoked user, which could be in either state, so we need to look beneath this abstraction and check the columns directly.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
