### PR TITLE
[EC-388] Enforce organization policies when restoring user (pick to rc)

### DIFF
--- a/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
+++ b/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
@@ -193,7 +193,7 @@ namespace Bit.Scim.Controllers.v2
 
             if (model.Active && orgUser.Status == OrganizationUserStatusType.Deactivated)
             {
-                await _organizationService.ActivateUserAsync(orgUser, null);
+                await _organizationService.ActivateUserAsync(orgUser, null, _userService);
             }
             else if (!model.Active && orgUser.Status != OrganizationUserStatusType.Deactivated)
             {
@@ -229,7 +229,7 @@ namespace Bit.Scim.Controllers.v2
                     var active = activeProperty.GetBoolean();
                     if (active && orgUser.Status == OrganizationUserStatusType.Deactivated)
                     {
-                        await _organizationService.ActivateUserAsync(orgUser, null);
+                        await _organizationService.ActivateUserAsync(orgUser, null, _userService);
                         operationHandled = true;
                     }
                     else if (!active && orgUser.Status != OrganizationUserStatusType.Deactivated)

--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -391,14 +391,14 @@ namespace Bit.Api.Controllers
         [HttpPut("{id}/activate")]
         public async Task Activate(Guid orgId, Guid id)
         {
-            await ActivateOrDeactivateUserAsync(orgId, id, _organizationService.ActivateUserAsync);
+            await ActivateOrDeactivateUserAsync(orgId, id, (orgUser, userId) => _organizationService.ActivateUserAsync(orgUser, userId, _userService));
         }
 
         [HttpPatch("activate")]
         [HttpPut("activate")]
         public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkActivate(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
         {
-            return await ActivateOrDeactivateUsersAsync(orgId, model, _organizationService.ActivateUsersAsync);
+            return await ActivateOrDeactivateUsersAsync(orgId, model, (orgId, orgUserIds, restoringUserId) => _organizationService.ActivateUsersAsync(orgId, orgUserIds, restoringUserId, _userService));
         }
 
         private async Task ActivateOrDeactivateUserAsync(

--- a/src/Core/Services/IOrganizationService.cs
+++ b/src/Core/Services/IOrganizationService.cs
@@ -61,8 +61,8 @@ namespace Bit.Core.Services
         Task DeactivateUserAsync(OrganizationUser organizationUser, Guid? disablingUserId);
         Task<List<Tuple<OrganizationUser, string>>> DeactivateUsersAsync(Guid organizationId,
             IEnumerable<Guid> organizationUserIds, Guid? disablingUserId);
-        Task ActivateUserAsync(OrganizationUser organizationUser, Guid? enablingUserId);
+        Task ActivateUserAsync(OrganizationUser organizationUser, Guid? enablingUserId, IUserService userService);
         Task<List<Tuple<OrganizationUser, string>>> ActivateUsersAsync(Guid organizationId,
-            IEnumerable<Guid> organizationUserIds, Guid? enablingUserId);
+            IEnumerable<Guid> organizationUserIds, Guid? enablingUserId, IUserService userService);
     }
 }

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -2300,7 +2300,7 @@ namespace Bit.Core.Services
             return result;
         }
 
-        public async Task ActivateUserAsync(OrganizationUser organizationUser, Guid? enablingUserId)
+        public async Task ActivateUserAsync(OrganizationUser organizationUser, Guid? enablingUserId, IUserService userService)
         {
             if (organizationUser.Status != OrganizationUserStatusType.Deactivated)
             {
@@ -2318,6 +2318,8 @@ namespace Bit.Core.Services
                 throw new BadRequestException("Only owners can restore other owners.");
             }
 
+            await CheckPoliciesBeforeRestoreAsync(organizationUser, userService);
+
             var status = GetPriorActiveOrganizationUserStatusType(organizationUser);
 
             await _organizationUserRepository.ActivateAsync(organizationUser.Id, status);
@@ -2326,7 +2328,7 @@ namespace Bit.Core.Services
         }
 
         public async Task<List<Tuple<OrganizationUser, string>>> ActivateUsersAsync(Guid organizationId,
-            IEnumerable<Guid> organizationUserIds, Guid? enablingUserId)
+            IEnumerable<Guid> organizationUserIds, Guid? enablingUserId, IUserService userService)
         {
             var orgUsers = await _organizationUserRepository.GetManyAsync(organizationUserIds);
             var filteredUsers = orgUsers.Where(u => u.OrganizationId == organizationId)
@@ -2363,6 +2365,8 @@ namespace Bit.Core.Services
                     {
                         throw new BadRequestException("Only owners can restore other owners.");
                     }
+                    
+                    await CheckPoliciesBeforeRestoreAsync(organizationUser, userService);
 
                     var status = GetPriorActiveOrganizationUserStatusType(organizationUser);
 
@@ -2379,6 +2383,53 @@ namespace Bit.Core.Services
             }
 
             return result;
+        }
+
+        private async Task CheckPoliciesBeforeRestoreAsync(OrganizationUser orgUser, IUserService userService)
+        {
+            // An invited OrganizationUser isn't linked with a user account yet, so these checks are irrelevant
+            // The user will be subject to the same checks when they try to accept the invite
+            if (GetPriorActiveOrganizationUserStatusType(orgUser) == OrganizationUserStatusType.Invited)
+            {
+                return;
+            }
+            
+            var userId = orgUser.UserId.Value;
+            
+            // Enforce Single Organization Policy of organization user is being restored to
+            var allOrgUsers = await _organizationUserRepository.GetManyByUserAsync(userId);
+            var hasOtherOrgs = allOrgUsers.Any(ou => ou.OrganizationId != orgUser.OrganizationId);
+            var singleOrgPoliciesApplyingToRevokedUsers = await _policyRepository.GetManyByTypeApplicableToUserIdAsync(userId,
+                PolicyType.SingleOrg, OrganizationUserStatusType.Revoked);
+            var singleOrgPolicyApplies = singleOrgPoliciesApplyingToRevokedUsers.Any(p => p.OrganizationId == orgUser.OrganizationId);
+
+            if (hasOtherOrgs && singleOrgPolicyApplies)
+            {
+                throw new BadRequestException("You cannot restore this user until " +
+                    "they leave or remove all other organizations.");
+            }
+
+            // Enforce Single Organization Policy of other organizations user is a member of
+            var singleOrgPolicyCount = await _policyRepository.GetCountByTypeApplicableToUserIdAsync(userId,
+                PolicyType.SingleOrg);
+            if (singleOrgPolicyCount > 0)
+            {
+                throw new BadRequestException("You cannot restore this user because they are a member of " +
+                    "another organization which forbids it");
+            }
+
+            // Enforce Two Factor Authentication Policy of organization user is trying to join
+            var user = await _userRepository.GetByIdAsync(userId);
+            if (!await userService.TwoFactorIsEnabledAsync(user))
+            {
+                var invitedTwoFactorPolicies = await _policyRepository.GetManyByTypeApplicableToUserIdAsync(userId,
+                    PolicyType.TwoFactorAuthentication, OrganizationUserStatusType.Invited);
+                if (invitedTwoFactorPolicies.Any(p => p.OrganizationId == orgUser.OrganizationId))
+                {
+                    throw new BadRequestException("You cannot restore this user until they enable " +
+                        "two-step login on their user account.");
+                }
+            }
         }
 
         static OrganizationUserStatusType GetPriorActiveOrganizationUserStatusType(OrganizationUser organizationUser)

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -2365,7 +2365,7 @@ namespace Bit.Core.Services
                     {
                         throw new BadRequestException("Only owners can restore other owners.");
                     }
-                    
+
                     await CheckPoliciesBeforeRestoreAsync(organizationUser, userService);
 
                     var status = GetPriorActiveOrganizationUserStatusType(organizationUser);
@@ -2393,9 +2393,9 @@ namespace Bit.Core.Services
             {
                 return;
             }
-            
+
             var userId = orgUser.UserId.Value;
-            
+
             // Enforce Single Organization Policy of organization user is being restored to
             var allOrgUsers = await _organizationUserRepository.GetManyByUserAsync(userId);
             var hasOtherOrgs = allOrgUsers.Any(ou => ou.OrganizationId != orgUser.OrganizationId);

--- a/src/Sql/dbo/Stored Procedures/Policy_CountByTypeApplicableToUser.sql
+++ b/src/Sql/dbo/Stored Procedures/Policy_CountByTypeApplicableToUser.sql
@@ -1,7 +1,7 @@
 CREATE PROCEDURE [dbo].[Policy_CountByTypeApplicableToUser]
     @UserId UNIQUEIDENTIFIER,
     @PolicyType TINYINT,
-    @MinimumStatus TINYINT
+    @MinimumStatus SMALLINT
 AS
 BEGIN
     SET NOCOUNT ON

--- a/src/Sql/dbo/Stored Procedures/Policy_ReadByTypeApplicableToUser.sql
+++ b/src/Sql/dbo/Stored Procedures/Policy_ReadByTypeApplicableToUser.sql
@@ -1,7 +1,7 @@
 CREATE PROCEDURE [dbo].[Policy_ReadByTypeApplicableToUser]
     @UserId UNIQUEIDENTIFIER,
     @PolicyType TINYINT,
-    @MinimumStatus TINYINT
+    @MinimumStatus SMALLINT
 AS
 BEGIN
     SET NOCOUNT ON

--- a/util/Migrator/DbScripts/2022-07-28_00_CheckPoliciesOnRestore.sql
+++ b/util/Migrator/DbScripts/2022-07-28_00_CheckPoliciesOnRestore.sql
@@ -1,3 +1,53 @@
+-- 2022-06-08_00_DeactivatedUserStatus changed UserStatus from TINYINT to SMALLINT but these sprocs were missed
+
+-- Policy_ReadByTypeApplicableToUser
+IF OBJECT_ID('[dbo].[Policy_ReadByTypeApplicableToUser]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Policy_ReadByTypeApplicableToUser]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Policy_ReadByTypeApplicableToUser]
+    @UserId UNIQUEIDENTIFIER,
+    @PolicyType TINYINT,
+    @MinimumStatus SMALLINT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+SELECT *
+FROM [dbo].[PolicyApplicableToUser](@UserId, @PolicyType, @MinimumStatus)
+END
+GO
+
+-- Policy_CountByTypeApplicableToUser
+IF OBJECT_ID('[dbo].[Policy_CountByTypeApplicableToUser]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[Policy_CountByTypeApplicableToUser]
+END
+GO
+
+CREATE PROCEDURE [dbo].[Policy_CountByTypeApplicableToUser]
+    @UserId UNIQUEIDENTIFIER,
+    @PolicyType TINYINT,
+    @MinimumStatus SMALLINT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+SELECT COUNT(1)
+FROM [dbo].[PolicyApplicableToUser](@UserId, @PolicyType, @MinimumStatus)
+END
+GO
+
+-- We need to update this function because we now have OrganizationUserStatusTypes that are less than zero,
+-- and Deactivated/Revoked users may or may not be associated with a UserId
+IF OBJECT_ID('[dbo].[PolicyApplicableToUser]') IS NOT NULL
+BEGIN
+    DROP FUNCTION [dbo].[PolicyApplicableToUser]
+END
+GO
+
 CREATE FUNCTION [dbo].[PolicyApplicableToUser]
 (
     @UserId UNIQUEIDENTIFIER,
@@ -43,3 +93,4 @@ WHERE
         OR COALESCE(JSON_VALUE(OU.[Permissions], '$.managePolicies'), 'false') = 'false'
     )
     AND PUPO.[UserId] IS NULL   -- Not a provider
+GO


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This picks the commits in https://github.com/bitwarden/server/pull/2152 to `rc`. That PR is not approved yet and should be reviewed/approved first. Any changes made there will have to be reflected on this branch as well.

The reason I did this now is because `server/rc` does not have the refactor that updated code conventions to `revoke/restore`. It still uses `deactivate/activate` wording, so there were some merge conflicts when picking commits from `master`. The diff should be briefly reviewed and compared to https://github.com/bitwarden/server/pull/2152 before merging.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
