### PR TITLE
[ENG-71]  Updated release workflows with cleanup recommended by Vince

### DIFF
--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -95,16 +95,10 @@ jobs:
         id: deployment
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
+          initial-status: 'in_progress'
           environment: 'Server ${{ matrix.name }} - QA'
           task: 'deploy'
           description: 'Deploy from ${{ env.branch_name }} branch'
-
-      - name: Update ${{ matrix.name }} deployment status to In Progress
-        uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'in_progress'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
       - name: Download latest ${{ matrix.name }} asset from ${{ env.branch_name }}
         uses: bitwarden/gh-actions/download-artifacts@c1fa8e09871a860862d6bbe36184b06d2c7e35a8
@@ -155,7 +149,7 @@ jobs:
             --resource-group $AZURE_RESOURCE_GROUP
 
       - name: Update ${{ matrix.name }} deployment status to Success
-        if: success()
+        if: ${{ success() }}
         uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
@@ -163,7 +157,7 @@ jobs:
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
       - name: Update ${{ matrix.name }} deployment status to Failure
-        if: failure()
+        if: ${{ failure() }}
         uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,16 +80,10 @@ jobs:
         id: deployment
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
+          initial-status: 'in_progress'
           environment: 'Server ${{ matrix.name }} - Production'
           task: 'deploy'
           description: 'Deploy from ${{ needs.setup.outputs.branch-name }} branch'
-
-      - name: Update ${{ matrix.name }} deployment status to In Progress
-        uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          state: 'in_progress'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
       - name: Download latest Release ${{ matrix.name }} asset
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
@@ -156,7 +150,7 @@ jobs:
           az webapp start -n $WEBAPP_NAME -g $RESOURCE_GROUP -s staging
 
       - name: Update ${{ matrix.name }} deployment status to Success
-        if: success()
+        if: ${{ success() }}
         uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
@@ -164,7 +158,7 @@ jobs:
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
       - name: Update ${{ matrix.name }} deployment status to Failure
-        if: failure()
+        if: ${{ failure() }}
         uses: chrnorm/deployment-status@07b3930847f65e71c9c6802ff5a402f6dfb46b86
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
@vgrassia recommended some cleanup changes to the workflows in mobile and directory-connector repos. I'm making the same changes here for consistency.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

[.github/workflows/qa-deploy.yml](https://github.com/bitwarden/server/compare/ENG-71-deployment-job-updates?expand=1#diff-34fe8ffe807a379adfe93e3714b9531422bd502198d508f6d55793780678145f): Removed redundant job step and initialized the status to `in_progress` instead.  Added explicit expression syntax on `if` condition.
[.github/workflows/release.yml](https://github.com/bitwarden/server/compare/ENG-71-deployment-job-updates?expand=1#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34): Removed redundant job step and initialized the status to `in_progress` instead.  Added explicit expression syntax on `if` condition.

## Before you submit

<!-- (mark with an `X`) -->

```
- [ ] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
```