### PR TITLE
respect allowanonymous on scim auth

### DIFF
--- a/bitwarden_license/src/Scim/Controllers/InfoController.cs
+++ b/bitwarden_license/src/Scim/Controllers/InfoController.cs
@@ -1,8 +1,10 @@
 ﻿using Bit.Core.Utilities;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Bit.Scim.Controllers
 {
+    [AllowAnonymous]
     public class InfoController : Controller
     {
         [HttpGet("~/alive")]

--- a/bitwarden_license/src/Scim/Utilities/ApiKeyAuthenticationHandler.cs
+++ b/bitwarden_license/src/Scim/Utilities/ApiKeyAuthenticationHandler.cs
@@ -5,6 +5,7 @@ using Bit.Core.Repositories;
 using Bit.Scim.Context;
 using IdentityModel;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Options;
 
 namespace Bit.Scim.Utilities
@@ -32,6 +33,12 @@ namespace Bit.Scim.Utilities
 
         protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
         {
+            var endpoint = Context.GetEndpoint();
+            if (endpoint?.Metadata?.GetMetadata<IAllowAnonymous>() != null)
+            {
+                return AuthenticateResult.NoResult();
+            }
+
             if (!_scimContext.OrganizationId.HasValue || _scimContext.Organization == null)
             {
                 Logger.LogWarning("No organization.");


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Stop execution of custom authorization handler when `AllowAnonymous` attribute it used. This will stop spamming the logs about "no organization found" when calling alive endpoints.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **ApiKeyAuthenticationHandler.cs:** Look for `AllowAnonymous` attribute on endpoint and return early.
* **InfoController.cs** Add `AllowAnonymous` to controller endpoints.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
