### PR TITLE
[DEVOPS-862] Add protections around SQL migration modification changes

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Enforce Label
-        uses: yogevbd/enforce-label-action@8d1e1709b1011e6d90400a0e6cf7c0b77aa5efeb
+        uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024
         with:
           BANNED_LABELS: "hold"
           BANNED_LABELS_DESCRIPTION: "PRs on hold cannot be merged"

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -12,5 +12,5 @@ jobs:
       - name: Enforce Label
         uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024
         with:
-          BANNED_LABELS: "hold"
-          BANNED_LABELS_DESCRIPTION: "PRs on hold cannot be merged"
+          BANNED_LABELS: "hold, DB migrations changed"
+          BANNED_LABELS_DESCRIPTION: "PRs with ${bannedLabel.name} label cannot be merged"

--- a/.github/workflows/protect-files.yml
+++ b/.github/workflows/protect-files.yml
@@ -1,6 +1,6 @@
 # Runs if there are changes to the paths: list.
 # Starts a matrix job to check for modified files, then sets output based on the results.
-# The input decides if the label job is ran, adding a "HOLD" label to the PR.
+# The input decides if the label job is ran, adding a label to the PR.
 ---
 
 name: Protect Files
@@ -35,7 +35,7 @@ jobs:
       - name: Check for file changes
         id: check-changes
         run: |
-          MODIFIED_FILES=$(git diff --name-only --diff-filter=M origin/${GITHUB_BASE_REF})
+          MODIFIED_FILES=$(git diff --name-only --diff-filter=M ${GITHUB_BASE_REF})
 
           for file in $MODIFIED_FILES; do
             if [[ $file == *"${{ matrix.path }}"*]]; then
@@ -55,4 +55,4 @@ jobs:
       - name: Label PR
         uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
         with:
-          add-labels: "hold"
+          add-labels: "DB migrations changed"

--- a/.github/workflows/protect-files.yml
+++ b/.github/workflows/protect-files.yml
@@ -1,0 +1,39 @@
+---
+
+name: Protect Files
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+    paths: ["util/Migrator/DbScripts"]
+
+jobs:
+  changed-files:
+    name: Check for file changes
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - name: Database Scripts
+            path: util/Migrator/DbScripts
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+        with:
+          fetch-depth: 0
+
+      - name: Check for file changes
+        run: |
+          if [ -z "$(git diff --name-only HEAD)" ]; then
+            echo "No files changed"
+            exit 0
+          fi
+          echo "Files changed"
+          exit 1
+
+
+
+
+

--- a/.github/workflows/protect-files.yml
+++ b/.github/workflows/protect-files.yml
@@ -1,16 +1,24 @@
+# Runs if there are changes to the paths: list.
+# Starts a matrix job to check for modified files, then sets output based on the results.
+# The input decides if the label job is ran, adding a "HOLD" label to the PR.
 ---
 
 name: Protect Files
 
 on:
   pull_request:
-    types: [opened, edited, synchronize]
-    paths: ["util/Migrator/DbScripts"]
+    types: 
+      - opened
+      - synchronize
+    paths: 
+      - "util/Migrator/DbScripts"
 
 jobs:
   changed-files:
     name: Check for file changes
     runs-on: ubuntu-20.04
+    outputs:
+      changes: steps.check-changes.outputs.changes_detected
 
     strategy:
       fail-fast: true
@@ -18,22 +26,34 @@ jobs:
         include:
           - name: Database Scripts
             path: util/Migrator/DbScripts
+
     steps:
       - name: Checkout PR
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: 0
 
       - name: Check for file changes
+        id: check-changes
         run: |
-          if [ -z "$(git diff --name-only HEAD)" ]; then
-            echo "No files changed"
-            exit 0
-          fi
-          echo "Files changed"
-          exit 1
+          MODIFIED_FILES=$(git diff --name-only --diff-filter=M ${GITHUB_BASE_REF})
 
+          for file in $MODIFIED_FILES; do
+            if [[ $file == *"${{ matrix.path }}"*]]; then
+              echo "::set-output name=changes_detected::'true'"
+              break
+            else echo "::set-output name=changes_detected::'false'"
+            fi
+          done
 
-
-
-
+  label-pr:
+    name: Add label to pull request
+    runs-on: ubuntu-20.04
+    needs: 
+      - changed-files
+    if: contains(needs.changed-files.outputs.changes, "true") || job.changed-files.status == "failure"
+    steps:
+      - name: Label PR
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+        with:
+          add-labels: "hold"

--- a/.github/workflows/protect-files.yml
+++ b/.github/workflows/protect-files.yml
@@ -26,7 +26,6 @@ jobs:
         include:
           - name: Database Scripts
             path: util/Migrator/DbScripts
-
     steps:
       - name: Checkout PR
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -36,7 +35,7 @@ jobs:
       - name: Check for file changes
         id: check-changes
         run: |
-          MODIFIED_FILES=$(git diff --name-only --diff-filter=M ${GITHUB_BASE_REF})
+          MODIFIED_FILES=$(git diff --name-only --diff-filter=M origin/${GITHUB_BASE_REF})
 
           for file in $MODIFIED_FILES; do
             if [[ $file == *"${{ matrix.path }}"*]]; then

--- a/.github/workflows/protect-files.yml
+++ b/.github/workflows/protect-files.yml
@@ -26,6 +26,7 @@ jobs:
         include:
           - name: Database Scripts
             path: util/Migrator/DbScripts
+            label: "DB migrations changed"
     steps:
       - name: Checkout PR
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -55,4 +56,4 @@ jobs:
       - name: Label PR
         uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
         with:
-          add-labels: "DB migrations changed"
+          add-labels: ${{ matrix.label }}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
We want to create some visibility around PRs that modify our current SQL migration files. This workflow checks for modifications to existing migration files and, at this time, places a "DB migrations changed" label to the PR that had the file changes.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **.github/workflows/protect-files.yml:** Add workflow to check for modified changes in `util/Migrator/DbScripts`.
* **.github/workflows/enforce-labels.yml:** Updated action version for enforcing a label.

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
