### PR TITLE
[SG-167] Base Passwordless API

### DIFF
--- a/src/Api/Controllers/AuthRequestsController.cs
+++ b/src/Api/Controllers/AuthRequestsController.cs
@@ -1,0 +1,138 @@
+﻿using Bit.Api.Models.Request;
+using Bit.Api.Models.Response;
+using Bit.Core.Context;
+using Bit.Core.Entities;
+using Bit.Core.Exceptions;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bit.Api.Controllers
+{
+    [Route("auth-requests")]
+    [Authorize("Application")]
+    public class AuthRequestsController : Controller
+    {
+        private readonly IUserRepository _userRepository;
+        private readonly IDeviceRepository _deviceRepository;
+        private readonly IUserService _userService;
+        private readonly IAuthRequestRepository _authRequestRepository;
+        private readonly ICurrentContext _currentContext;
+        private readonly IPushNotificationService _pushNotificationService;
+
+        public AuthRequestsController(
+            IUserRepository userRepository,
+            IDeviceRepository deviceRepository,
+            IUserService userService,
+            IAuthRequestRepository authRequestRepository,
+            ICurrentContext currentContext,
+            IPushNotificationService pushNotificationService)
+        {
+            _userRepository = userRepository;
+            _deviceRepository = deviceRepository;
+            _userService = userService;
+            _authRequestRepository = authRequestRepository;
+            _currentContext = currentContext;
+            _pushNotificationService = pushNotificationService;
+        }
+
+        [HttpGet("{id}")]
+        public async Task<AuthRequestResponseModel> Get(string id)
+        {
+            var userId = _userService.GetProperUserId(User).Value;
+            var authRequest = await _authRequestRepository.GetByIdAsync(new Guid(id));
+            if (authRequest == null || authRequest.UserId != userId)
+            {
+                throw new NotFoundException();
+            }
+
+            return new AuthRequestResponseModel(authRequest);
+        }
+
+        [HttpGet("{id}/response")]
+        [AllowAnonymous]
+        public async Task<AuthRequestResponseModel> GetResponse(string id, [FromQuery] string code)
+        {
+            var authRequest = await _authRequestRepository.GetByIdAsync(new Guid(id));
+            if (authRequest == null || code != authRequest.AccessCode)
+            {
+                throw new NotFoundException();
+            }
+
+            if (authRequest.isSpent())
+            {
+                throw new NotFoundException();
+            }
+
+            return new AuthRequestResponseModel(authRequest);
+        }
+
+        [HttpPost("")]
+        [AllowAnonymous]
+        public async Task<AuthRequestResponseModel> Post([FromBody] AuthRequestCreateRequestModel model)
+        {
+            var user = await _userRepository.GetByEmailAsync(model.Email);
+            if (user == null)
+            {
+                throw new NotFoundException();
+            }
+            if (!_currentContext.DeviceType.HasValue)
+            {
+                throw new BadRequestException("Device type not provided.");
+            }
+            var authRequest = new AuthRequest
+            {
+                RequestDeviceIdentifier = model.DeviceIdentifier,
+                RequestDeviceType = _currentContext.DeviceType.Value,
+                RequestIpAddress = _currentContext.IpAddress,
+                AccessCode = model.AccessCode,
+                PublicKey = model.PublicKey,
+                UserId = user.Id,
+                Type = model.Type.Value,
+                RequestFingerprint = model.FingerprintPhrase
+            };
+            await _authRequestRepository.CreateAsync(authRequest);
+            await _pushNotificationService.PushAuthRequestAsync(authRequest);
+            return new AuthRequestResponseModel(authRequest);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<AuthRequestResponseModel> Put(string id, [FromBody] AuthRequestUpdateRequestModel model)
+        {
+            var userId = _userService.GetProperUserId(User).Value;
+            var authRequest = await _authRequestRepository.GetByIdAsync(new Guid(id));
+            if (authRequest == null || authRequest.UserId != userId)
+            {
+                throw new NotFoundException();
+            }
+
+            if (authRequest.isSpent())
+            {
+                throw new NotFoundException();
+            }
+
+            var device = await _deviceRepository.GetByIdentifierAsync(model.DeviceIdentifier);
+            if (device == null)
+            {
+                throw new BadRequestException("Invalid device.");
+            }
+
+            if (!model.RequestApproved)
+            {
+                authRequest.FailedLoginAttempts++;
+            }
+            else
+            {
+                authRequest.Key = model.Key;
+                authRequest.MasterPasswordHash = model.MasterPasswordHash;
+                authRequest.ResponseDeviceId = device.Id;
+                authRequest.ResponseDate = DateTime.UtcNow;
+            }
+
+            await _authRequestRepository.ReplaceAsync(authRequest);
+            await _pushNotificationService.PushAuthRequestResponseAsync(authRequest);
+            return new AuthRequestResponseModel(authRequest);
+        }
+    }
+}

--- a/src/Api/Models/Request/AuthRequestRequestModel.cs
+++ b/src/Api/Models/Request/AuthRequestRequestModel.cs
@@ -1,0 +1,33 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.Enums;
+using Newtonsoft.Json;
+
+namespace Bit.Api.Models.Request
+{
+    public class AuthRequestCreateRequestModel
+    {
+        [Required]
+        public string Email { get; set; }
+        [Required]
+        public string PublicKey { get; set; }
+        [Required]
+        public string DeviceIdentifier { get; set; }
+        [Required]
+        [StringLength(25)]
+        public string AccessCode { get; set; }
+        [Required]
+        public AuthRequestType? Type { get; set; }
+        [Required]
+        public string FingerprintPhrase { get; set; }
+    }
+
+    public class AuthRequestUpdateRequestModel
+    {
+        public string Key { get; set; }
+        public string MasterPasswordHash { get; set; }
+        [Required]
+        public string DeviceIdentifier { get; set; }
+        [Required]
+        public bool RequestApproved { get; set; }
+    }
+}

--- a/src/Api/Models/Response/AuthRequestResponseModel.cs
+++ b/src/Api/Models/Response/AuthRequestResponseModel.cs
@@ -1,0 +1,37 @@
+﻿using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Models.Api;
+
+namespace Bit.Api.Models.Response
+{
+    public class AuthRequestResponseModel : ResponseModel
+    {
+        public AuthRequestResponseModel(AuthRequest authRequest, string obj = "auth-request")
+            : base(obj)
+        {
+            if (authRequest == null)
+            {
+                throw new ArgumentNullException(nameof(authRequest));
+            }
+
+            Id = authRequest.Id.ToString();
+            PublicKey = authRequest.PublicKey;
+            RequestDeviceType = authRequest.RequestDeviceType;
+            RequestIpAddress = authRequest.RequestIpAddress;
+            Key = authRequest.Key;
+            MasterPasswordHash = authRequest.MasterPasswordHash;
+            CreationDate = authRequest.CreationDate;
+            RequestApproved = !string.IsNullOrWhiteSpace(Key) &&
+                (authRequest.Type == AuthRequestType.Unlock || !string.IsNullOrWhiteSpace(MasterPasswordHash));
+        }
+
+        public string Id { get; set; }
+        public string PublicKey { get; set; }
+        public DeviceType RequestDeviceType { get; set; }
+        public string RequestIpAddress { get; set; }
+        public string Key { get; set; }
+        public string MasterPasswordHash { get; set; }
+        public DateTime CreationDate { get; set; }
+        public bool RequestApproved { get; set; }
+    }
+}

--- a/src/Core/Entities/AuthRequest.cs
+++ b/src/Core/Entities/AuthRequest.cs
@@ -19,12 +19,21 @@ namespace Bit.Core.Entities
         public DateTime CreationDate { get; internal set; } = DateTime.UtcNow;
         public DateTime? ResponseDate { get; set; }
         public DateTime? AuthenticationDate { get; set; }
-        public DateTime ExpirationDate { get; internal set; } = DateTime.UtcNow.AddMinutes(15);
         public int FailedLoginAttempts { get; set; } = 0;
 
         public void SetNewId()
         {
             Id = CoreHelpers.GenerateComb();
+        }
+
+        public bool isSpent()
+        {
+            return ResponseDate.HasValue || AuthenticationDate.HasValue || getExpirationDate() < DateTime.UtcNow;
+        }
+
+        public DateTime getExpirationDate()
+        {
+            return CreationDate.AddMinutes(15);
         }
     }
 }

--- a/src/Core/Enums/PushType.cs
+++ b/src/Core/Enums/PushType.cs
@@ -20,5 +20,8 @@
         SyncSendCreate = 12,
         SyncSendUpdate = 13,
         SyncSendDelete = 14,
+
+        AuthRequest = 15,
+        AuthRequestResponse = 16,
     }
 }

--- a/src/Core/IdentityServer/BaseRequestValidator.cs
+++ b/src/Core/IdentityServer/BaseRequestValidator.cs
@@ -108,6 +108,9 @@ namespace Bit.Core.IdentityServer
             {
                 // Just defaulting it
                 var twoFactorProviderType = TwoFactorProviderType.Authenticator;
+
+                // If 2FA is required but either this isn't a 2FA request or it is but it's the wrong type, return a response to the client
+                // indicating that 2FA is required.
                 if (!twoFactorRequest || !Enum.TryParse(twoFactorProvider, out twoFactorProviderType))
                 {
                     await BuildTwoFactorResultAsync(user, twoFactorOrganization, context, requires2FABecauseNewDevice);

--- a/src/Core/Models/PushNotification.cs
+++ b/src/Core/Models/PushNotification.cs
@@ -44,4 +44,10 @@ namespace Bit.Core.Models
         public Guid UserId { get; set; }
         public DateTime RevisionDate { get; set; }
     }
+
+    public class AuthRequestPushNotification
+    {
+        public Guid UserId { get; set; }
+        public Guid Id { get; set; }
+    }
 }

--- a/src/Core/Services/IPushNotificationService.cs
+++ b/src/Core/Services/IPushNotificationService.cs
@@ -19,6 +19,8 @@ namespace Bit.Core.Services
         Task PushSyncSendCreateAsync(Send send);
         Task PushSyncSendUpdateAsync(Send send);
         Task PushSyncSendDeleteAsync(Send send);
+        Task PushAuthRequestAsync(AuthRequest authRequest);
+        Task PushAuthRequestResponseAsync(AuthRequest authRequest);
         Task SendPayloadToUserAsync(string userId, PushType type, object payload, string identifier, string deviceId = null);
         Task SendPayloadToOrganizationAsync(string orgId, PushType type, object payload, string identifier,
             string deviceId = null);

--- a/src/Core/Services/Implementations/AzureQueuePushNotificationService.cs
+++ b/src/Core/Services/Implementations/AzureQueuePushNotificationService.cs
@@ -160,6 +160,27 @@ namespace Bit.Core.Services
             }
         }
 
+        public async Task PushAuthRequestAsync(AuthRequest authRequest)
+        {
+            await PushAuthRequestAsync(authRequest, PushType.AuthRequest);
+        }
+
+        public async Task PushAuthRequestResponseAsync(AuthRequest authRequest)
+        {
+            await PushAuthRequestAsync(authRequest, PushType.AuthRequestResponse);
+        }
+
+        private async Task PushAuthRequestAsync(AuthRequest authRequest, PushType type)
+        {
+            var message = new AuthRequestPushNotification
+            {
+                Id = authRequest.Id,
+                UserId = authRequest.UserId
+            };
+
+            await SendMessageAsync(type, message, true);
+        }
+
         private async Task SendMessageAsync<T>(PushType type, T payload, bool excludeCurrentContext)
         {
             var contextId = GetContextIdentifier(excludeCurrentContext);

--- a/src/Core/Services/Implementations/MultiServicePushNotificationService.cs
+++ b/src/Core/Services/Implementations/MultiServicePushNotificationService.cs
@@ -139,6 +139,18 @@ namespace Bit.Core.Services
             return Task.FromResult(0);
         }
 
+        public Task PushAuthRequestAsync(AuthRequest authRequest)
+        {
+            PushToServices((s) => s.PushAuthRequestAsync(authRequest));
+            return Task.FromResult(0);
+        }
+
+        public Task PushAuthRequestResponseAsync(AuthRequest authRequest)
+        {
+            PushToServices((s) => s.PushAuthRequestResponseAsync(authRequest));
+            return Task.FromResult(0);
+        }
+
         public Task SendPayloadToUserAsync(string userId, PushType type, object payload, string identifier,
             string deviceId = null)
         {

--- a/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
+++ b/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
@@ -167,6 +167,27 @@ namespace Bit.Core.Services
             }
         }
 
+        public async Task PushAuthRequestAsync(AuthRequest authRequest)
+        {
+            await PushAuthRequestAsync(authRequest, PushType.AuthRequest);
+        }
+
+        public async Task PushAuthRequestResponseAsync(AuthRequest authRequest)
+        {
+            await PushAuthRequestAsync(authRequest, PushType.AuthRequestResponse);
+        }
+
+        private async Task PushAuthRequestAsync(AuthRequest authRequest, PushType type)
+        {
+            var message = new AuthRequestPushNotification
+            {
+                Id = authRequest.Id,
+                UserId = authRequest.UserId
+            };
+
+            await SendPayloadToUserAsync(authRequest.UserId, type, message, true);
+        }
+
         private async Task SendPayloadToUserAsync(Guid userId, PushType type, object payload, bool excludeCurrentContext)
         {
             await SendPayloadToUserAsync(userId.ToString(), type, payload, GetContextIdentifier(excludeCurrentContext));

--- a/src/Core/Services/Implementations/NotificationsApiPushNotificationService.cs
+++ b/src/Core/Services/Implementations/NotificationsApiPushNotificationService.cs
@@ -167,6 +167,27 @@ namespace Bit.Core.Services
             }
         }
 
+        public async Task PushAuthRequestAsync(AuthRequest authRequest)
+        {
+            await PushAuthRequestAsync(authRequest, PushType.AuthRequest);
+        }
+
+        public async Task PushAuthRequestResponseAsync(AuthRequest authRequest)
+        {
+            await PushAuthRequestAsync(authRequest, PushType.AuthRequestResponse);
+        }
+
+        private async Task PushAuthRequestAsync(AuthRequest authRequest, PushType type)
+        {
+            var message = new AuthRequestPushNotification
+            {
+                Id = authRequest.Id,
+                UserId = authRequest.UserId
+            };
+
+            await SendMessageAsync(type, message, true);
+        }
+
         private async Task SendMessageAsync<T>(PushType type, T payload, bool excludeCurrentContext)
         {
             var contextId = GetContextIdentifier(excludeCurrentContext);

--- a/src/Core/Services/Implementations/RelayPushNotificationService.cs
+++ b/src/Core/Services/Implementations/RelayPushNotificationService.cs
@@ -167,6 +167,27 @@ namespace Bit.Core.Services
             }
         }
 
+        public async Task PushAuthRequestAsync(AuthRequest authRequest)
+        {
+            await PushAuthRequestAsync(authRequest, PushType.AuthRequest);
+        }
+
+        public async Task PushAuthRequestResponseAsync(AuthRequest authRequest)
+        {
+            await PushAuthRequestAsync(authRequest, PushType.AuthRequestResponse);
+        }
+
+        private async Task PushAuthRequestAsync(AuthRequest authRequest, PushType type)
+        {
+            var message = new AuthRequestPushNotification
+            {
+                Id = authRequest.Id,
+                UserId = authRequest.UserId
+            };
+
+            await SendPayloadToUserAsync(authRequest.UserId, type, message, true);
+        }
+
         private async Task SendPayloadToUserAsync(Guid userId, PushType type, object payload, bool excludeCurrentContext)
         {
             var request = new PushSendRequestModel

--- a/src/Core/Services/NoopImplementations/NoopPushNotificationService.cs
+++ b/src/Core/Services/NoopImplementations/NoopPushNotificationService.cs
@@ -75,6 +75,16 @@ namespace Bit.Core.Services
             return Task.FromResult(0);
         }
 
+        public Task PushAuthRequestAsync(AuthRequest authRequest)
+        {
+            return Task.FromResult(0);
+        }
+
+        public Task PushAuthRequestResponseAsync(AuthRequest authRequest)
+        {
+            return Task.FromResult(0);
+        }
+
         public Task SendPayloadToOrganizationAsync(string orgId, PushType type, object payload, string identifier,
             string deviceId = null)
         {

--- a/src/Infrastructure.Dapper/DapperServiceCollectionExtensions.cs
+++ b/src/Infrastructure.Dapper/DapperServiceCollectionExtensions.cs
@@ -34,6 +34,7 @@ namespace Bit.Infrastructure.Dapper
             services.AddSingleton<IUserRepository, UserRepository>();
             services.AddSingleton<IOrganizationApiKeyRepository, OrganizationApiKeyRepository>();
             services.AddSingleton<IOrganizationConnectionRepository, OrganizationConnectionRepository>();
+            services.AddSingleton<IAuthRequestRepository, AuthRequestRepository>();
 
             if (selfHosted)
             {

--- a/src/Notifications/HubHelpers.cs
+++ b/src/Notifications/HubHelpers.cs
@@ -61,6 +61,14 @@ namespace Bit.Notifications
                     await hubContext.Clients.User(sendNotification.Payload.UserId.ToString())
                         .SendAsync("ReceiveMessage", sendNotification, cancellationToken);
                     break;
+                case PushType.AuthRequest:
+                case PushType.AuthRequestResponse:
+                    var authRequestNotification =
+                        JsonSerializer.Deserialize<PushNotificationData<AuthRequestPushNotification>>(
+                                notificationJson);
+                    await hubContext.Clients.User(authRequestNotification.Payload.UserId.ToString())
+                        .SendAsync("ReceiveMessage", authRequestNotification, cancellationToken);
+                    break;
                 default:
                     break;
             }

--- a/src/Sql/dbo/Stored Procedures/AuthRequest_Create.sql
+++ b/src/Sql/dbo/Stored Procedures/AuthRequest_Create.sql
@@ -12,7 +12,6 @@
     @Key VARCHAR(MAX),
     @MasterPasswordHash VARCHAR(MAX),
     @CreationDate DATETIME2(7),
-    @ExpirationDate DATETIME2(7),
     @ResponseDate DATETIME2(7),
     @AuthenticationDate DATETIME2(7),
     @FailedLoginAttempts TINYINT
@@ -35,7 +34,6 @@ BEGIN
         [Key],
         [MasterPasswordHash],
         [CreationDate],
-        [ExpirationDate],
         [ResponseDate],
         [AuthenticationDate],
         [FailedLoginAttempts]
@@ -55,7 +53,6 @@ BEGIN
         @Key,
         @MasterPasswordHash,
         @CreationDate,
-        @ExpirationDate,
         @ResponseDate,
         @AuthenticationDate,
         @FailedLoginAttempts

--- a/src/Sql/dbo/Tables/AuthRequest.sql
+++ b/src/Sql/dbo/Tables/AuthRequest.sql
@@ -12,7 +12,6 @@
     [Key]                       VARCHAR(MAX)     NULL,
     [MasterPasswordHash]        VARCHAR(MAX)     NULL,
     [CreationDate]              DATETIME2 (7)    NOT NULL,
-    [ExpirationDate]            DATETIME2 (7)    NOT NULL,
     [ResponseDate]              DATETIME2 (7)    NULL,
     [AuthenticationDate]        DATETIME2 (7)    NULL,
     [FailedLoginAttempts]       TINYINT          NOT NULL,

--- a/util/Migrator/DbScripts/2022-08-08_00_AuthRequestInit.sql
+++ b/util/Migrator/DbScripts/2022-08-08_00_AuthRequestInit.sql
@@ -20,7 +20,6 @@ CREATE TABLE [dbo].[AuthRequest] (
     [Key]                       VARCHAR(MAX)     NULL,
     [MasterPasswordHash]        VARCHAR(MAX)     NULL,
     [CreationDate]              DATETIME2 (7)    NOT NULL,
-    [ExpirationDate]            DATETIME2 (7)    NOT NULL,
     [ResponseDate]              DATETIME2 (7)    NULL,
     [AuthenticationDate]        DATETIME2 (7)    NULL,
     [FailedLoginAttempts]       TINYINT          NOT NULL,
@@ -67,7 +66,6 @@ CREATE PROCEDURE [dbo].[AuthRequest_Create]
     @Key VARCHAR(MAX),
     @MasterPasswordHash VARCHAR(MAX),
     @CreationDate DATETIME2(7),
-    @ExpirationDate DATETIME2(7),
     @ResponseDate DATETIME2(7),
     @AuthenticationDate DATETIME2(7),
     @FailedLoginAttempts TINYINT
@@ -90,7 +88,6 @@ BEGIN
         [Key],
         [MasterPasswordHash],
         [CreationDate],
-        [ExpirationDate],
         [ResponseDate],
         [AuthenticationDate],
         [FailedLoginAttempts]
@@ -110,7 +107,6 @@ BEGIN
         @Key,
         @MasterPasswordHash,
         @CreationDate,
-        @ExpirationDate,
         @ResponseDate,
         @AuthenticationDate,
         @FailedLoginAttempts


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Provide a base api to talk to + notificatons for clients as part of ongoing passwordless work.

This is mostly the same contents as https://github.com/bitwarden/server/tree/authreq, which Kyle authored. Some changes to the model and controller were made based on updated requirements of the feature. More updates are on the way, but this should provide all the basic functionality needed for developing clients.

## Code changes
* Expose an API for creating, responding to, and polling an `AuthRequest`.
* Provide notification support for `AuthRequest` changes
* Adds a contextual comment to the BaseRequestValidator.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
