### PR TITLE
choose other emails when primary not available

### DIFF
--- a/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
+++ b/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
@@ -135,6 +135,11 @@ namespace Bit.Scim.Controllers.v2
                         email = model.UserName?.ToLowerInvariant();
                         break;
                     default:
+                        email = model.WorkEmail?.ToLowerInvariant();
+                        if (string.IsNullOrWhiteSpace(email))
+                        {
+                            email = model.Emails?.FirstOrDefault()?.Value?.ToLowerInvariant();
+                        }
                         break;
                 }
             }

--- a/bitwarden_license/src/Scim/Models/BaseScimUserModel.cs
+++ b/bitwarden_license/src/Scim/Models/BaseScimUserModel.cs
@@ -16,6 +16,7 @@ namespace Bit.Scim.Models
         public NameModel Name { get; set; }
         public List<EmailModel> Emails { get; set; }
         public string PrimaryEmail => Emails?.FirstOrDefault(e => e.Primary)?.Value;
+        public string WorkEmail => Emails?.FirstOrDefault(e => e.Type == "work")?.Value;
         public string DisplayName { get; set; }
         public bool Active { get; set; }
         public List<string> Groups { get; set; }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Some configurations with IdP might not send a primary email. This change adds some logic to choose an email of type "work", or finally fall back to just using the first email in the list.

https://bitwarden.atlassian.net/browse/EC-446

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **base scim user model:** Added a computer property for work email.
* **user controller:** Added logic to use alternate email when primary not provided.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
