### PR TITLE
handle patch commands with multiple operations and path values

### DIFF
--- a/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
+++ b/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
@@ -224,23 +224,29 @@ namespace Bit.Scim.Controllers.v2
             }
 
             var operationHandled = false;
-
-            var replaceOp = model.Operations?.FirstOrDefault(o =>
-                o.Op?.ToLowerInvariant() == "replace");
-            if (replaceOp != null)
+            foreach (var operation in model.Operations)
             {
-                if (replaceOp.Value.TryGetProperty("active", out var activeProperty))
+                // Replace operations
+                if (operation.Op?.ToLowerInvariant() == "replace")
                 {
-                    var active = activeProperty.GetBoolean();
-                    if (active && orgUser.Status == OrganizationUserStatusType.Revoked)
+                    // Active from path
+                    if (operation.Path?.ToLowerInvariant() == "active")
                     {
-                        await _organizationService.RestoreUserAsync(orgUser, null, _userService);
-                        operationHandled = true;
+                        var handled = await HandleActiveOperationAsync(orgUser, operation.Value.GetBoolean());
+                        if (!operationHandled)
+                        {
+                            operationHandled = handled;
+                        }
                     }
-                    else if (!active && orgUser.Status != OrganizationUserStatusType.Revoked)
+                    // Active from value object
+                    else if (string.IsNullOrWhiteSpace(operation.Path) &&
+                        operation.Value.TryGetProperty("active", out var activeProperty))
                     {
-                        await _organizationService.RevokeUserAsync(orgUser, null);
-                        operationHandled = true;
+                        var handled = await HandleActiveOperationAsync(orgUser, activeProperty.GetBoolean());
+                        if (!operationHandled)
+                        {
+                            operationHandled = handled;
+                        }
                     }
                 }
             }
@@ -268,6 +274,21 @@ namespace Bit.Scim.Controllers.v2
             }
             await _organizationService.DeleteUserAsync(organizationId, id, null);
             return new NoContentResult();
+        }
+
+        private async Task<bool> HandleActiveOperationAsync(Core.Entities.OrganizationUser orgUser, bool active)
+        {
+            if (active && orgUser.Status == OrganizationUserStatusType.Revoked)
+            {
+                await _organizationService.RestoreUserAsync(orgUser, null, _userService);
+                return true;
+            }
+            else if (!active && orgUser.Status != OrganizationUserStatusType.Revoked)
+            {
+                await _organizationService.RevokeUserAsync(orgUser, null);
+                return true;
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
https://bitwarden.atlassian.net/browse/EC-448

For patch requests, there could be multiple of the same operations. This change loops over them in a more encompassing way rather than looking at `FirstOrDefault` for each expected operation. The existing solution could skip operations if there are multiple operations of the same type in the patch request.

Additionally, Azure sends replace operations with path values for both group `displayName` changes and user `active` (disabling a user) changes. Updated replace operations to evaluate paths.

For example:

**Updating group name**

Azure

```
PATCH /Groups/fa2ce26709934589afc5 HTTP/1.1

{
    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
    "Operations": [{
        "op": "Replace",
        "path": "displayName",
        "value": "the name"
    }]
}
```

Others

```
PATCH /scim/v2/Groups/abf4dd94-a4c0-4f67-89c9-76b03340cb9b HTTP/1.1

{
    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
    "Operations": [{
        "op": "replace",
        "value": {
            "id": "abf4dd94-a4c0-4f67-89c9-76b03340cb9b",
            "displayName": "Test SCIMv2"
        }
    }]
}
```

**Disabling a user**

Azure

```
PATCH /Users/5171a35d82074e068ce2 HTTP/1.1

{
    "Operations": [
        {
            "op": "Replace",
            "path": "active",
            "value": false
        }
    ],
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:PatchOp"
    ]
}
```

Others

```
PATCH /scim/v2/Users/23a35c27-23d3-4c03-b4c5-6443c09e7173 HTTP/1.1

{
    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
    "Operations": [{
        "op": "replace",
        "value": {
            "active": false
        }
    }]
}
```

## Code changes

These look like more changes than there actually are. Basically I tucked much of the existing logic into a for loop, which causes a lot of line changes.

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **UsersController.cs:** Loop over operations. Handle path-based "user active" changes coming from Azure.
* **GroupsController.cs:** Loop over operations. Handle path-based "group display name" changes coming from Azure.


## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
