### PR TITLE
parse user active path as string value

### DIFF
--- a/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
+++ b/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
@@ -232,7 +232,8 @@ namespace Bit.Scim.Controllers.v2
                     // Active from path
                     if (operation.Path?.ToLowerInvariant() == "active")
                     {
-                        var handled = await HandleActiveOperationAsync(orgUser, operation.Value.GetBoolean());
+                        var active = operation.Value.ToString()?.ToLowerInvariant();
+                        var handled = await HandleActiveOperationAsync(orgUser, active == "true");
                         if (!operationHandled)
                         {
                             operationHandled = handled;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
https://bitwarden.atlassian.net/browse/EC-448

Contrary to their documentation, Azure sends the `active` value flag as a string.

        {
            "op": "Replace",
            "path": "active",
            "value": "False"
        },

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **userscontroller.cs:** Parse active flag as a string vs boolean.

## Before you submit

<!-- (mark with an `X`) -->

```
- [x] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
