### PR TITLE
[SM-68] Add API endpoints for getting, creating, and editing secrets

### DIFF
--- a/bitwarden_license/src/Commercial.Core/SecretManagerFeatures/SecretManagerCollectionExtensions.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretManagerFeatures/SecretManagerCollectionExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Bit.Commercial.Core.SecretManagerFeatures.Secrets;
+using Bit.Commercial.Core.SecretManagerFeatures.Secrets.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bit.Commercial.Core.SecretManagerFeatures
+{
+    public static class SecretManagerCollectionExtensions
+    {
+        public static void AddSecretManagerServices(this IServiceCollection services)
+        {
+            services.AddScoped<ICreateSecretCommand, CreateSecretCommand>();
+            services.AddScoped<IUpdateSecretCommand, UpdateSecretCommand>();
+        }
+    }
+}
+

--- a/bitwarden_license/src/Commercial.Core/SecretManagerFeatures/Secrets/CreateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretManagerFeatures/Secrets/CreateSecretCommand.cs
@@ -1,0 +1,22 @@
+﻿using Bit.Commercial.Core.SecretManagerFeatures.Secrets.Interfaces;
+using Bit.Core.Entities;
+using Bit.Core.Repositories;
+
+namespace Bit.Commercial.Core.SecretManagerFeatures.Secrets
+{
+    public class CreateSecretCommand : ICreateSecretCommand
+    {
+        private readonly ISecretRepository _secretRepository;
+
+        public CreateSecretCommand(ISecretRepository secretRepository)
+        {
+            _secretRepository = secretRepository;
+        }
+
+        public async Task<Secret> CreateAsync(Secret secret)
+        {
+            return await _secretRepository.CreateAsync(secret);
+        }
+    }
+}
+

--- a/bitwarden_license/src/Commercial.Core/SecretManagerFeatures/Secrets/Interfaces/ICreateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretManagerFeatures/Secrets/Interfaces/ICreateSecretCommand.cs
@@ -1,0 +1,10 @@
+﻿using Bit.Core.Entities;
+
+namespace Bit.Commercial.Core.SecretManagerFeatures.Secrets.Interfaces
+{
+    public interface ICreateSecretCommand
+    {
+        Task<Secret> CreateAsync(Secret secret);
+    }
+}
+

--- a/bitwarden_license/src/Commercial.Core/SecretManagerFeatures/Secrets/Interfaces/IUpdateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretManagerFeatures/Secrets/Interfaces/IUpdateSecretCommand.cs
@@ -1,0 +1,10 @@
+﻿using Bit.Core.Entities;
+
+namespace Bit.Commercial.Core.SecretManagerFeatures.Secrets.Interfaces
+{
+    public interface IUpdateSecretCommand
+    {
+        Task<Secret> UpdateAsync(Secret secret);
+    }
+}
+

--- a/bitwarden_license/src/Commercial.Core/SecretManagerFeatures/Secrets/UpdateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretManagerFeatures/Secrets/UpdateSecretCommand.cs
@@ -18,7 +18,7 @@ namespace Bit.Commercial.Core.SecretManagerFeatures.Secrets
         {
             if (secret.Id == default(Guid))
             {
-                throw new Exception("Cannot update secret, secret does not exist.");
+                throw new BadRequestException("Cannot update secret, secret does not exist.");
             }
 
             var existingSecret = await _secretRepository.GetByIdAsync(secret.Id);

--- a/bitwarden_license/src/Commercial.Core/SecretManagerFeatures/Secrets/UpdateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretManagerFeatures/Secrets/UpdateSecretCommand.cs
@@ -1,0 +1,40 @@
+﻿using Bit.Commercial.Core.SecretManagerFeatures.Secrets.Interfaces;
+using Bit.Core.Entities;
+using Bit.Core.Exceptions;
+using Bit.Core.Repositories;
+
+namespace Bit.Commercial.Core.SecretManagerFeatures.Secrets
+{
+    public class UpdateSecretCommand : IUpdateSecretCommand
+    {
+        private readonly ISecretRepository _secretRepository;
+
+        public UpdateSecretCommand(ISecretRepository secretRepository)
+        {
+            _secretRepository = secretRepository;
+        }
+
+        public async Task<Secret> UpdateAsync(Secret secret)
+        {
+            if (secret.Id == default(Guid))
+            {
+                throw new Exception("Cannot update secret, secret does not exist.");
+            }
+
+            var existingSecret = await _secretRepository.GetByIdAsync(secret.Id);
+            if (existingSecret == null)
+            {
+                throw new NotFoundException();
+            }
+
+            secret.OrganizationId = existingSecret.OrganizationId;
+            secret.CreationDate = existingSecret.CreationDate;
+            secret.DeletedDate = existingSecret.DeletedDate;
+            secret.RevisionDate = DateTime.UtcNow;
+
+            await _secretRepository.ReplaceAsync(secret);
+            return secret;
+        }
+    }
+}
+

--- a/bitwarden_license/src/Commercial.Core/Utilities/ServiceCollectionExtensions.cs
+++ b/bitwarden_license/src/Commercial.Core/Utilities/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Commercial.Core.Services;
+﻿using Bit.Commercial.Core.SecretManagerFeatures;
+using Bit.Commercial.Core.Services;
 using Bit.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -9,6 +10,7 @@ namespace Bit.Commercial.Core.Utilities
         public static void AddCommCoreServices(this IServiceCollection services)
         {
             services.AddScoped<IProviderService, ProviderService>();
+            services.AddSecretManagerServices();
         }
     }
 }

--- a/bitwarden_license/test/Commercial.Core.Test/SecretManagerFeatures/Secrets/CreateSecretCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretManagerFeatures/Secrets/CreateSecretCommandTests.cs
@@ -1,0 +1,27 @@
+﻿using Bit.Commercial.Core.SecretManagerFeatures.Secrets;
+using Bit.Core.Entities;
+using Bit.Core.Repositories;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Bit.Test.Common.Helpers;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Commercial.Core.Test.SecretManagerFeatures.Secrets
+{
+    [SutProviderCustomize]
+    public class CreateSecretCommandTests
+    {
+        [Theory]
+        [BitAutoData]
+        public async Task CreateAsync_CallsCreate(Secret data,
+          SutProvider<CreateSecretCommand> sutProvider)
+        {
+            await sutProvider.Sut.CreateAsync(data);
+
+            await sutProvider.GetDependency<ISecretRepository>().Received(1)
+                .CreateAsync(Arg.Is(AssertHelper.AssertPropertyEqual(data)));
+        }
+    }
+}
+

--- a/bitwarden_license/test/Commercial.Core.Test/SecretManagerFeatures/Secrets/UpdateSecretCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretManagerFeatures/Secrets/UpdateSecretCommandTests.cs
@@ -1,0 +1,52 @@
+﻿using Bit.Commercial.Core.SecretManagerFeatures.Secrets;
+using Bit.Core.Entities;
+using Bit.Core.Exceptions;
+using Bit.Core.Repositories;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Bit.Test.Common.Helpers;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Commercial.Core.Test.SecretManagerFeatures.Secrets
+{
+    [SutProviderCustomize]
+    public class UpdateSecretCommandTests
+    {
+        [Theory]
+        [BitAutoData]
+        public async Task UpdateAsync_DefaultGuidId_ThrowsNotFound(Secret data,
+          SutProvider<UpdateSecretCommand> sutProvider)
+        {
+            data.Id = new Guid();
+
+            var exception = await Assert.ThrowsAsync<Exception>(() => sutProvider.Sut.UpdateAsync(data));
+
+            Assert.Contains("Cannot update secret, secret does not exist.", exception.Message);
+            await sutProvider.GetDependency<ISecretRepository>().DidNotReceiveWithAnyArgs().ReplaceAsync(default);
+        }
+
+        [Theory]
+        [BitAutoData]
+        public async Task UpdateAsync_SecretDoesNotExist_ThrowsNotFound(Secret data,
+          SutProvider<UpdateSecretCommand> sutProvider)
+        {
+            var exception = await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.UpdateAsync(data));
+
+            await sutProvider.GetDependency<ISecretRepository>().DidNotReceiveWithAnyArgs().ReplaceAsync(default);
+        }
+
+        [Theory]
+        [BitAutoData]
+        public async Task UpdateAsync_CallsReplaceAsync(Secret data,
+          SutProvider<UpdateSecretCommand> sutProvider)
+        {
+            sutProvider.GetDependency<ISecretRepository>().GetByIdAsync(data.Id).Returns(data);
+            await sutProvider.Sut.UpdateAsync(data);
+
+            await sutProvider.GetDependency<ISecretRepository>().Received(1)
+                .ReplaceAsync(Arg.Is(AssertHelper.AssertPropertyEqual(data)));
+        }
+    }
+}
+

--- a/bitwarden_license/test/Commercial.Core.Test/SecretManagerFeatures/Secrets/UpdateSecretCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretManagerFeatures/Secrets/UpdateSecretCommandTests.cs
@@ -19,7 +19,7 @@ namespace Bit.Commercial.Core.Test.SecretManagerFeatures.Secrets
         {
             data.Id = new Guid();
 
-            var exception = await Assert.ThrowsAsync<Exception>(() => sutProvider.Sut.UpdateAsync(data));
+            var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.UpdateAsync(data));
 
             Assert.Contains("Cannot update secret, secret does not exist.", exception.Message);
             await sutProvider.GetDependency<ISecretRepository>().DidNotReceiveWithAnyArgs().ReplaceAsync(default);
@@ -123,10 +123,8 @@ namespace Bit.Commercial.Core.Test.SecretManagerFeatures.Secrets
             var result = await sutProvider.Sut.UpdateAsync(secretUpdate);
 
             Assert.NotEqual(existingSecret.RevisionDate, result.RevisionDate);
-            Assert.True(result.RevisionDate < updatedRevisionDate);
-            Assert.True(DateTime.UtcNow.AddMinutes(-1) < result.RevisionDate);
+            AssertHelper.AssertRecent(result.RevisionDate);
         }
-
     }
 }
 

--- a/src/Api/Controllers/SecretsController.cs
+++ b/src/Api/Controllers/SecretsController.cs
@@ -1,6 +1,9 @@
 ﻿using Bit.Api.Models.Response;
+using Bit.Api.SecretManagerFeatures.Models.Request;
 using Bit.Api.SecretManagerFeatures.Models.Response;
 using Bit.Api.Utilities;
+using Bit.Commercial.Core.SecretManagerFeatures.Secrets.Interfaces;
+using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Microsoft.AspNetCore.Mvc;
 
@@ -10,18 +13,53 @@ namespace Bit.Api.Controllers
     public class SecretsController : Controller
     {
         private readonly ISecretRepository _secretRepository;
+        private readonly ICreateSecretCommand _createSecretCommand;
+        private readonly IUpdateSecretCommand _updateSecretCommand;
 
-        public SecretsController(ISecretRepository secretRepository)
+        public SecretsController(ISecretRepository secretRepository, ICreateSecretCommand createSecretCommand, IUpdateSecretCommand updateSecretCommand)
         {
             _secretRepository = secretRepository;
+            _createSecretCommand = createSecretCommand;
+            _updateSecretCommand = updateSecretCommand;
         }
 
-        [HttpGet("organizations/{orgId}/secrets")]
-        public async Task<ListResponseModel<SecretResponseModel>> GetAsync([FromRoute] Guid orgId)
+        [HttpGet("organizations/{organizationId}/secrets")]
+        public async Task<ListResponseModel<SecretIdentifierResponseModel>> GetSecretsByOrganizationAsync([FromRoute] Guid organizationId)
         {
-            var results = await _secretRepository.GetManyByOrganizationIdAsync(orgId);
-            var responses = results.Select(secret => new SecretResponseModel(secret));
-            return new ListResponseModel<SecretResponseModel>(responses);
+            var results = await _secretRepository.GetManyByOrganizationIdAsync(organizationId);
+            var responses = results.Select(secret => new SecretIdentifierResponseModel(secret));
+            return new ListResponseModel<SecretIdentifierResponseModel>(responses);
+        }
+
+
+        [HttpGet("secrets/{id}")]
+        public async Task<SecretResponseModel> GetSecretAsync([FromRoute] Guid id)
+        {
+            var secret = await _secretRepository.GetByIdAsync(id);
+            if (secret == null)
+            {
+                throw new NotFoundException();
+            }
+            return new SecretResponseModel(secret);
+        }
+
+        [HttpPost("organizations/{organizationId}/secrets")]
+        public async Task<SecretResponseModel> CreateSecretAsync([FromRoute] Guid organizationId, [FromBody] SecretCreateRequestModel createRequest)
+        {
+            if (organizationId != createRequest.OrganizationId)
+            {
+                throw new BadRequestException("Organization ID does not match.");
+            }
+
+            var result = await _createSecretCommand.CreateAsync(createRequest.ToSecret());
+            return new SecretResponseModel(result);
+        }
+
+        [HttpPut("secrets/{id}")]
+        public async Task<SecretResponseModel> UpdateSecretAsync([FromRoute] Guid id, [FromBody] SecretUpdateRequestModel updateRequest)
+        {
+            var result = await _updateSecretCommand.UpdateAsync(updateRequest.ToSecret(id));
+            return new SecretResponseModel(result);
         }
     }
 }

--- a/src/Api/Controllers/SecretsController.cs
+++ b/src/Api/Controllers/SecretsController.cs
@@ -26,8 +26,12 @@ namespace Bit.Api.Controllers
         [HttpGet("organizations/{organizationId}/secrets")]
         public async Task<ListResponseModel<SecretIdentifierResponseModel>> GetSecretsByOrganizationAsync([FromRoute] Guid organizationId)
         {
-            var results = await _secretRepository.GetManyByOrganizationIdAsync(organizationId);
-            var responses = results.Select(secret => new SecretIdentifierResponseModel(secret));
+            var secrets = await _secretRepository.GetManyByOrganizationIdAsync(organizationId);
+            if (secrets == null || !secrets.Any())
+            {
+                throw new NotFoundException();
+            }
+            var responses = secrets.Select(secret => new SecretIdentifierResponseModel(secret));
             return new ListResponseModel<SecretIdentifierResponseModel>(responses);
         }
 

--- a/src/Api/SecretManagerFeatures/Models/Request/SecretCreateRequestModel.cs
+++ b/src/Api/SecretManagerFeatures/Models/Request/SecretCreateRequestModel.cs
@@ -1,0 +1,44 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.Entities;
+using Bit.Core.Utilities;
+
+namespace Bit.Api.SecretManagerFeatures.Models.Request
+{
+    public class SecretCreateRequestModel : IValidatableObject
+    {
+        [Required]
+        public Guid OrganizationId { get; set; }
+
+        [Required]
+        [EncryptedString]
+        public string Key { get; set; }
+
+        [Required]
+        [EncryptedString]
+        public string Value { get; set; }
+
+        [EncryptedString]
+        public string Note { get; set; }
+
+        public Secret ToSecret()
+        {
+            return new Secret()
+            {
+                OrganizationId = this.OrganizationId,
+                Key = this.Key,
+                Value = this.Value,
+                Note = this.Note,
+                DeletedDate = null,
+            };
+        }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (OrganizationId == default(Guid))
+            {
+                yield return new ValidationResult("Organization ID is required.");
+            }
+        }
+    }
+}
+

--- a/src/Api/SecretManagerFeatures/Models/Request/SecretCreateRequestModel.cs
+++ b/src/Api/SecretManagerFeatures/Models/Request/SecretCreateRequestModel.cs
@@ -17,6 +17,7 @@ namespace Bit.Api.SecretManagerFeatures.Models.Request
         [EncryptedString]
         public string Value { get; set; }
 
+        [Required]
         [EncryptedString]
         public string Note { get; set; }
 

--- a/src/Api/SecretManagerFeatures/Models/Request/SecretUpdateRequestModel.cs
+++ b/src/Api/SecretManagerFeatures/Models/Request/SecretUpdateRequestModel.cs
@@ -1,0 +1,33 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.Entities;
+using Bit.Core.Utilities;
+
+namespace Bit.Api.SecretManagerFeatures.Models.Request
+{
+    public class SecretUpdateRequestModel
+    {
+        [Required]
+        [EncryptedString]
+        public string Key { get; set; }
+
+        [Required]
+        [EncryptedString]
+        public string Value { get; set; }
+
+        [EncryptedString]
+        public string Note { get; set; }
+
+        public Secret ToSecret(Guid id)
+        {
+            return new Secret()
+            {
+                Id = id,
+                Key = this.Key,
+                Value = this.Value,
+                Note = this.Note,
+                DeletedDate = null,
+            };
+        }
+    }
+}
+

--- a/src/Api/SecretManagerFeatures/Models/Request/SecretUpdateRequestModel.cs
+++ b/src/Api/SecretManagerFeatures/Models/Request/SecretUpdateRequestModel.cs
@@ -14,6 +14,7 @@ namespace Bit.Api.SecretManagerFeatures.Models.Request
         [EncryptedString]
         public string Value { get; set; }
 
+        [Required]
         [EncryptedString]
         public string Note { get; set; }
 

--- a/src/Api/SecretManagerFeatures/Models/Response/SecretIdentifierResponseModel.cs
+++ b/src/Api/SecretManagerFeatures/Models/Response/SecretIdentifierResponseModel.cs
@@ -3,9 +3,9 @@ using Bit.Core.Models.Api;
 
 namespace Bit.Api.SecretManagerFeatures.Models.Response
 {
-    public class SecretResponseModel : ResponseModel
+    public class SecretIdentifierResponseModel : ResponseModel
     {
-        public SecretResponseModel(Secret secret, string obj = "secret")
+        public SecretIdentifierResponseModel(Secret secret, string obj = "secret")
             : base(obj)
         {
             if (secret == null)
@@ -16,8 +16,6 @@ namespace Bit.Api.SecretManagerFeatures.Models.Response
             Id = secret.Id.ToString();
             OrganizationId = secret.OrganizationId.ToString();
             Key = secret.Key;
-            Value = secret.Value;
-            Note = secret.Note;
             CreationDate = secret.CreationDate;
             RevisionDate = secret.RevisionDate;
         }
@@ -27,10 +25,6 @@ namespace Bit.Api.SecretManagerFeatures.Models.Response
         public string OrganizationId { get; set; }
 
         public string Key { get; set; }
-
-        public string Value { get; set; }
-
-        public string Note { get; set; }
 
         public DateTime CreationDate { get; set; }
 

--- a/test/Api.Test/Controllers/SecretsControllerTests.cs
+++ b/test/Api.Test/Controllers/SecretsControllerTests.cs
@@ -1,0 +1,91 @@
+﻿using Bit.Api.Controllers;
+using Bit.Api.SecretManagerFeatures.Models.Request;
+using Bit.Commercial.Core.SecretManagerFeatures.Secrets.Interfaces;
+using Bit.Core.Entities;
+using Bit.Core.Exceptions;
+using Bit.Core.Repositories;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Bit.Test.Common.Helpers;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Api.Test.Controllers
+{
+    [ControllerCustomize(typeof(SecretsController))]
+    [SutProviderCustomize]
+    [JsonDocumentCustomize]
+    public class SecretsControllerTests
+    {
+        [Theory]
+        [BitAutoData]
+        public async void GetSecretsByOrganization_ThrowsNotFound(SutProvider<SecretsController> sutProvider)
+        {
+            var exception = await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.GetSecretsByOrganizationAsync(Guid.NewGuid()));
+        }
+
+        [Theory]
+        [BitAutoData]
+        public async void GetSecret_NotFound(SutProvider<SecretsController> sutProvider)
+        {
+            await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.GetSecretAsync(Guid.NewGuid()));
+        }
+
+        [Theory]
+        [BitAutoData]
+        public async void CreateSecret_MismatchedOrgId_Throws(SutProvider<SecretsController> sutProvider, SecretCreateRequestModel data)
+        {
+            var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.CreateSecretAsync(Guid.NewGuid(), data));
+            Assert.Contains("Organization ID does not match.", exception.Message);
+        }
+
+        [Theory]
+        [BitAutoData]
+        public async void GetSecret_Success(SutProvider<SecretsController> sutProvider, Secret resultSecret)
+        {
+            sutProvider.GetDependency<ISecretRepository>().GetByIdAsync(default).ReturnsForAnyArgs(resultSecret);
+
+            var result = await sutProvider.Sut.GetSecretAsync(resultSecret.Id);
+
+            await sutProvider.GetDependency<ISecretRepository>().Received(1)
+                         .GetByIdAsync(Arg.Is(AssertHelper.AssertPropertyEqual(resultSecret.Id)));
+        }
+
+        [Theory]
+        [BitAutoData]
+        public async void GetSecretsByOrganization_Success(SutProvider<SecretsController> sutProvider, Secret resultSecret)
+        {
+            sutProvider.GetDependency<ISecretRepository>().GetManyByOrganizationIdAsync(default).ReturnsForAnyArgs(new List<Secret>() { resultSecret });
+
+            var result = await sutProvider.Sut.GetSecretsByOrganizationAsync(resultSecret.OrganizationId);
+
+            await sutProvider.GetDependency<ISecretRepository>().Received(1)
+                         .GetManyByOrganizationIdAsync(Arg.Is(AssertHelper.AssertPropertyEqual(resultSecret.OrganizationId)));
+        }
+
+        [Theory]
+        [BitAutoData]
+        public async void CreateSecret_Success(SutProvider<SecretsController> sutProvider, SecretCreateRequestModel data)
+        {
+            var resultSecret = data.ToSecret();
+
+            sutProvider.GetDependency<ICreateSecretCommand>().CreateAsync(default).ReturnsForAnyArgs(resultSecret);
+
+            var result = await sutProvider.Sut.CreateSecretAsync(data.OrganizationId, data);
+            await sutProvider.GetDependency<ICreateSecretCommand>().Received(1)
+                         .CreateAsync(Arg.Any<Secret>());
+        }
+
+        [Theory]
+        [BitAutoData]
+        public async void UpdateSecret_Success(SutProvider<SecretsController> sutProvider, SecretUpdateRequestModel data, Guid secretId)
+        {
+            var resultSecret = data.ToSecret(secretId);
+            sutProvider.GetDependency<IUpdateSecretCommand>().UpdateAsync(default).ReturnsForAnyArgs(resultSecret);
+
+            var result = await sutProvider.Sut.UpdateSecretAsync(secretId, data);
+            await sutProvider.GetDependency<IUpdateSecretCommand>().Received(1)
+                         .UpdateAsync(Arg.Any<Secret>());
+        }
+    }
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The purpose of this PR is to add API endpoints for getting, creating, and editing secrets for the Secrets Manager project.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
```
bitwarden_license/src/Commercial.Core/SecretManagerFeatures/SecretManagerCollectionExtensions.cs
bitwarden_license/src/Commercial.Core/Utilities/ServiceCollectionExtensions.cs
```

Adding the newly created CreateSecretCommand & UpdateSecretCommand into dependency injection.

```
bitwarden_license/src/Commercial.Core/SecretManagerFeatures/Secrets/CreateSecretCommand.cs
bitwarden_license/src/Commercial.Core/SecretManagerFeatures/Secrets/Interfaces/ICreateSecretCommand.cs
```
Interface and implementation of the CreateSecretCommand used by the Api SecretsController.

```
bitwarden_license/src/Commercial.Core/SecretManagerFeatures/Secrets/Interfaces/IUpdateSecretCommand.cs
bitwarden_license/src/Commercial.Core/SecretManagerFeatures/Secrets/UpdateSecretCommand.cs
```
Interface and implementation of the UpdateSecretCommand used by the Api SecretsController.


```
bitwarden_license/test/Commercial.Core.Test/SecretManagerFeatures/Secrets/CreateSecretCommandTests.cs
bitwarden_license/test/Commercial.Core.Test/SecretManagerFeatures/Secrets/UpdateSecretCommandTests.cs
test/Api.Test/Controllers/SecretsControllerTests.cs
```
Unit tests for new features. 

```
src/Api/Controllers/SecretsController.cs
```
Adding in new Api endpoints required. 

Swapped listing endpoints to use the new SecretIdentifierResponseModel.

To note, this controller is still locked down for only local development via `[SecretsManager]` attribute.


```
src/Api/SecretManagerFeatures/Models/Request/SecretCreateRequestModel.cs
src/Api/SecretManagerFeatures/Models/Request/SecretUpdateRequestModel.cs
```
New models to represent the JSON payloads expected by the new Api endpoints.


```
src/Api/SecretManagerFeatures/Models/Response/SecretIdentifierResponseModel.cs
```
Response body model used for listing endpoints. 

```
src/Api/SecretManagerFeatures/Models/Response/SecretResponseModel.cs
```
Response body model updated to be used for single action endpoints (update, create, and GetById)



## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [X] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
