### PR TITLE
[SM-63] Read UTC DateTimes from databases via EF and order by revision date

### DIFF
--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/Repositories/SecretRepository.cs
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/Repositories/SecretRepository.cs
@@ -34,6 +34,7 @@ namespace Bit.Commercial.Infrastructure.EntityFramework.Repositories
                 var dbContext = GetDatabaseContext(scope);
                 var secrets = await dbContext.Secret
                                         .Where(c => c.OrganizationId == organizationId && c.DeletedDate == null)
+                                        .OrderBy(c => c.RevisionDate)
                                         .ToListAsync();
                 return Mapper.Map<List<Core.Entities.Secret>>(secrets);
             }

--- a/src/Api/Controllers/SecretsController.cs
+++ b/src/Api/Controllers/SecretsController.cs
@@ -31,7 +31,7 @@ namespace Bit.Api.Controllers
             {
                 throw new NotFoundException();
             }
-            var responses = secrets.Select(secret => new SecretIdentifierResponseModel(secret));
+            var responses = secrets.OrderBy(secret => secret.RevisionDate).Select(secret => new SecretIdentifierResponseModel(secret));
             return new ListResponseModel<SecretIdentifierResponseModel>(responses);
         }
 

--- a/src/Api/Controllers/SecretsController.cs
+++ b/src/Api/Controllers/SecretsController.cs
@@ -31,7 +31,7 @@ namespace Bit.Api.Controllers
             {
                 throw new NotFoundException();
             }
-            var responses = secrets.OrderBy(secret => secret.RevisionDate).Select(secret => new SecretIdentifierResponseModel(secret));
+            var responses = secrets.Select(secret => new SecretIdentifierResponseModel(secret));
             return new ListResponseModel<SecretIdentifierResponseModel>(responses);
         }
 

--- a/src/Infrastructure.EntityFramework/Repositories/DatabaseContext.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/DatabaseContext.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Infrastructure.EntityFramework.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Bit.Infrastructure.EntityFramework.Repositories
 {
@@ -142,6 +143,30 @@ namespace Bit.Infrastructure.EntityFramework.Repositories
             eUser.ToTable(nameof(User));
             eOrganizationApiKey.ToTable(nameof(OrganizationApiKey));
             eOrganizationConnection.ToTable(nameof(OrganizationConnection));
+
+            ConfigureDateTimeUTCQueries(builder);
+        }
+
+        // Make sure this is called after configuring all the entities as it iterates through all setup entities.
+        private void ConfigureDateTimeUTCQueries(ModelBuilder builder)
+        {
+            foreach (var entityType in builder.Model.GetEntityTypes())
+            {
+                if (entityType.IsKeyless)
+                {
+                    continue;
+                }
+                foreach (var property in entityType.GetProperties())
+                {
+                    if (property.ClrType == typeof(DateTime) || property.ClrType == typeof(DateTime?))
+                    {
+                        property.SetValueConverter(
+                            new ValueConverter<DateTime, DateTime>(
+                                v => v,
+                                v => new DateTime(v.Ticks, DateTimeKind.Utc)));
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The purpose of this PR is to configure entity framework to read DateTime database model properties with the DateTimeKind set to UTC. Also, to order secrets by revision date in the `GetSecretsByOrganizationAsync` method.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

src/Api/Controllers/SecretsController.cs
Returning secrets list order by revision date.

src/Infrastructure.EntityFramework/Repositories/DatabaseContext.cs

Configuring entity framework for all database read operations that involve the CLR data type `DateTime` to set the `DateTimeKind` property to UTC. 

For databases using the DateTime data type, the `DateTimeKind` is not persisted to the database. By default, the kind returned in queries is unspecified, which can cause issues with conversions and serialization.

Configuring DateTimeKind to UTC for DateTime is what Bitwarden does for dapper already. 
https://github.com/bitwarden/server/blob/master/src/Infrastructure.Dapper/Repositories/DateTimeHandler.cs

Microsoft Entity Framework Docs on configuring DateTimeKind:
https://docs.microsoft.com/en-us/ef/core/modeling/value-conversions?tabs=data-annotations#specify-the-datetimekind-when-reading-dates

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
