### PR TITLE
[SM-68] Fix move interfaces to core

### DIFF
--- a/bitwarden_license/src/Commercial.Core/SecretManagerFeatures/SecretManagerCollectionExtensions.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretManagerFeatures/SecretManagerCollectionExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using Bit.Commercial.Core.SecretManagerFeatures.Secrets;
-using Bit.Commercial.Core.SecretManagerFeatures.Secrets.Interfaces;
+using Bit.Core.SecretManagerFeatures.Secrets.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Bit.Commercial.Core.SecretManagerFeatures

--- a/bitwarden_license/src/Commercial.Core/SecretManagerFeatures/Secrets/CreateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretManagerFeatures/Secrets/CreateSecretCommand.cs
@@ -1,6 +1,6 @@
-﻿using Bit.Commercial.Core.SecretManagerFeatures.Secrets.Interfaces;
-using Bit.Core.Entities;
+﻿using Bit.Core.Entities;
 using Bit.Core.Repositories;
+using Bit.Core.SecretManagerFeatures.Secrets.Interfaces;
 
 namespace Bit.Commercial.Core.SecretManagerFeatures.Secrets
 {

--- a/bitwarden_license/src/Commercial.Core/SecretManagerFeatures/Secrets/UpdateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretManagerFeatures/Secrets/UpdateSecretCommand.cs
@@ -1,7 +1,7 @@
-﻿using Bit.Commercial.Core.SecretManagerFeatures.Secrets.Interfaces;
-using Bit.Core.Entities;
+﻿using Bit.Core.Entities;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
+using Bit.Core.SecretManagerFeatures.Secrets.Interfaces;
 
 namespace Bit.Commercial.Core.SecretManagerFeatures.Secrets
 {

--- a/src/Api/Controllers/SecretsController.cs
+++ b/src/Api/Controllers/SecretsController.cs
@@ -2,9 +2,9 @@
 using Bit.Api.SecretManagerFeatures.Models.Request;
 using Bit.Api.SecretManagerFeatures.Models.Response;
 using Bit.Api.Utilities;
-using Bit.Commercial.Core.SecretManagerFeatures.Secrets.Interfaces;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
+using Bit.Core.SecretManagerFeatures.Secrets.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Bit.Api.Controllers

--- a/src/Core/SecretManagerFeatures/Secrets/Interfaces/ICreateSecretCommand.cs
+++ b/src/Core/SecretManagerFeatures/Secrets/Interfaces/ICreateSecretCommand.cs
@@ -1,6 +1,6 @@
 ﻿using Bit.Core.Entities;
 
-namespace Bit.Commercial.Core.SecretManagerFeatures.Secrets.Interfaces
+namespace Bit.Core.SecretManagerFeatures.Secrets.Interfaces
 {
     public interface ICreateSecretCommand
     {

--- a/src/Core/SecretManagerFeatures/Secrets/Interfaces/IUpdateSecretCommand.cs
+++ b/src/Core/SecretManagerFeatures/Secrets/Interfaces/IUpdateSecretCommand.cs
@@ -1,6 +1,6 @@
 ﻿using Bit.Core.Entities;
 
-namespace Bit.Commercial.Core.SecretManagerFeatures.Secrets.Interfaces
+namespace Bit.Core.SecretManagerFeatures.Secrets.Interfaces
 {
     public interface IUpdateSecretCommand
     {

--- a/test/Api.Test/Controllers/SecretsControllerTests.cs
+++ b/test/Api.Test/Controllers/SecretsControllerTests.cs
@@ -1,9 +1,9 @@
 ﻿using Bit.Api.Controllers;
 using Bit.Api.SecretManagerFeatures.Models.Request;
-using Bit.Commercial.Core.SecretManagerFeatures.Secrets.Interfaces;
 using Bit.Core.Entities;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
+using Bit.Core.SecretManagerFeatures.Secrets.Interfaces;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using Bit.Test.Common.Helpers;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR is to fix the open source build errors occurring due to interfaces not being in the Core project.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

src/Core/SecretManagerFeatures/Secrets/Interfaces/ICreateSecretCommand.cs
src/Core/SecretManagerFeatures/Secrets/Interfaces/IUpdateSecretCommand.cs

Moved interfaces to core and updated references. 

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
