### PR TITLE
[SG-167] Build Notifications for Passwordless Auth 

### DIFF
--- a/src/Core/Entities/AuthRequest.cs
+++ b/src/Core/Entities/AuthRequest.cs
@@ -1,0 +1,41 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.Utilities;
+
+namespace Bit.Core.Entities;
+
+public class AuthRequest : ITableObject<Guid>
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public Enums.AuthRequestType Type { get; set; }
+    [MaxLength(50)]
+    public string RequestDeviceIdentifier { get; set; }
+    public Enums.DeviceType RequestDeviceType { get; set; }
+    [MaxLength(50)]
+    public string RequestIpAddress { get; set; }
+    public string RequestFingerprint { get; set; }
+    public Guid? ResponseDeviceId { get; set; }
+    [MaxLength(25)]
+    public string AccessCode { get; set; }
+    public string PublicKey { get; set; }
+    public string Key { get; set; }
+    public string MasterPasswordHash { get; set; }
+    public DateTime CreationDate { get; set; } = DateTime.UtcNow;
+    public DateTime? ResponseDate { get; set; }
+    public DateTime? AuthenticationDate { get; set; }
+
+    public void SetNewId()
+    {
+        Id = CoreHelpers.GenerateComb();
+    }
+
+    public bool isSpent()
+    {
+        return ResponseDate.HasValue || AuthenticationDate.HasValue || getExpirationDate() < DateTime.UtcNow;
+    }
+
+    public DateTime getExpirationDate()
+    {
+        return CreationDate.AddMinutes(15);
+    }
+}

--- a/src/Core/Enums/AuthRequestType.cs
+++ b/src/Core/Enums/AuthRequestType.cs
@@ -1,0 +1,7 @@
+﻿namespace Bit.Core.Enums;
+
+public enum AuthRequestType : byte
+{
+    AuthenticateAndUnlock = 0,
+    Unlock = 1
+}

--- a/src/Core/Enums/PushType.cs
+++ b/src/Core/Enums/PushType.cs
@@ -20,4 +20,7 @@ public enum PushType : byte
     SyncSendCreate = 12,
     SyncSendUpdate = 13,
     SyncSendDelete = 14,
+
+    AuthRequest = 15,
+    AuthRequestResponse = 16,
 }

--- a/src/Core/Models/PushNotification.cs
+++ b/src/Core/Models/PushNotification.cs
@@ -44,3 +44,9 @@ public class SyncSendPushNotification
     public Guid UserId { get; set; }
     public DateTime RevisionDate { get; set; }
 }
+
+public class AuthRequestPushNotification
+{
+    public Guid UserId { get; set; }
+    public Guid Id { get; set; }
+}

--- a/src/Core/Services/IPushNotificationService.cs
+++ b/src/Core/Services/IPushNotificationService.cs
@@ -19,6 +19,8 @@ public interface IPushNotificationService
     Task PushSyncSendCreateAsync(Send send);
     Task PushSyncSendUpdateAsync(Send send);
     Task PushSyncSendDeleteAsync(Send send);
+    Task PushAuthRequestAsync(AuthRequest authRequest);
+    Task PushAuthRequestResponseAsync(AuthRequest authRequest);
     Task SendPayloadToUserAsync(string userId, PushType type, object payload, string identifier, string deviceId = null);
     Task SendPayloadToOrganizationAsync(string orgId, PushType type, object payload, string identifier,
         string deviceId = null);

--- a/src/Core/Services/Implementations/AzureQueuePushNotificationService.cs
+++ b/src/Core/Services/Implementations/AzureQueuePushNotificationService.cs
@@ -160,6 +160,27 @@ public class AzureQueuePushNotificationService : IPushNotificationService
         }
     }
 
+    public async Task PushAuthRequestAsync(AuthRequest authRequest)
+    {
+        await PushAuthRequestAsync(authRequest, PushType.AuthRequest);
+    }
+
+    public async Task PushAuthRequestResponseAsync(AuthRequest authRequest)
+    {
+        await PushAuthRequestAsync(authRequest, PushType.AuthRequestResponse);
+    }
+
+    private async Task PushAuthRequestAsync(AuthRequest authRequest, PushType type)
+    {
+        var message = new AuthRequestPushNotification
+        {
+            Id = authRequest.Id,
+            UserId = authRequest.UserId
+        };
+
+        await SendMessageAsync(type, message, true);
+    }
+
     private async Task SendMessageAsync<T>(PushType type, T payload, bool excludeCurrentContext)
     {
         var contextId = GetContextIdentifier(excludeCurrentContext);

--- a/src/Core/Services/Implementations/MultiServicePushNotificationService.cs
+++ b/src/Core/Services/Implementations/MultiServicePushNotificationService.cs
@@ -139,6 +139,18 @@ public class MultiServicePushNotificationService : IPushNotificationService
         return Task.FromResult(0);
     }
 
+    public Task PushAuthRequestAsync(AuthRequest authRequest)
+    {
+        PushToServices((s) => s.PushAuthRequestAsync(authRequest));
+        return Task.FromResult(0);
+    }
+
+    public Task PushAuthRequestResponseAsync(AuthRequest authRequest)
+    {
+        PushToServices((s) => s.PushAuthRequestResponseAsync(authRequest));
+        return Task.FromResult(0);
+    }
+
     public Task SendPayloadToUserAsync(string userId, PushType type, object payload, string identifier,
         string deviceId = null)
     {

--- a/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
+++ b/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
@@ -167,6 +167,27 @@ public class NotificationHubPushNotificationService : IPushNotificationService
         }
     }
 
+    public async Task PushAuthRequestAsync(AuthRequest authRequest)
+    {
+        await PushAuthRequestAsync(authRequest, PushType.AuthRequest);
+    }
+
+    public async Task PushAuthRequestResponseAsync(AuthRequest authRequest)
+    {
+        await PushAuthRequestAsync(authRequest, PushType.AuthRequestResponse);
+    }
+
+    private async Task PushAuthRequestAsync(AuthRequest authRequest, PushType type)
+    {
+        var message = new AuthRequestPushNotification
+        {
+            Id = authRequest.Id,
+            UserId = authRequest.UserId
+        };
+
+        await SendPayloadToUserAsync(authRequest.UserId, type, message, true);
+    }
+
     private async Task SendPayloadToUserAsync(Guid userId, PushType type, object payload, bool excludeCurrentContext)
     {
         await SendPayloadToUserAsync(userId.ToString(), type, payload, GetContextIdentifier(excludeCurrentContext));

--- a/src/Core/Services/Implementations/NotificationsApiPushNotificationService.cs
+++ b/src/Core/Services/Implementations/NotificationsApiPushNotificationService.cs
@@ -152,6 +152,27 @@ public class NotificationsApiPushNotificationService : BaseIdentityClientService
         await PushSendAsync(send, PushType.SyncSendDelete);
     }
 
+    public async Task PushAuthRequestAsync(AuthRequest authRequest)
+    {
+        await PushAuthRequestAsync(authRequest, PushType.AuthRequest);
+    }
+
+    public async Task PushAuthRequestResponseAsync(AuthRequest authRequest)
+    {
+        await PushAuthRequestAsync(authRequest, PushType.AuthRequestResponse);
+    }
+
+    private async Task PushAuthRequestAsync(AuthRequest authRequest, PushType type)
+    {
+        var message = new AuthRequestPushNotification
+        {
+            Id = authRequest.Id,
+            UserId = authRequest.UserId
+        };
+
+        await SendMessageAsync(type, message, true);
+    }
+
     private async Task PushSendAsync(Send send, PushType type)
     {
         if (send.UserId.HasValue)

--- a/src/Core/Services/Implementations/RelayPushNotificationService.cs
+++ b/src/Core/Services/Implementations/RelayPushNotificationService.cs
@@ -167,6 +167,27 @@ public class RelayPushNotificationService : BaseIdentityClientService, IPushNoti
         }
     }
 
+    public async Task PushAuthRequestAsync(AuthRequest authRequest)
+    {
+        await PushAuthRequestAsync(authRequest, PushType.AuthRequest);
+    }
+
+    public async Task PushAuthRequestResponseAsync(AuthRequest authRequest)
+    {
+        await PushAuthRequestAsync(authRequest, PushType.AuthRequestResponse);
+    }
+
+    private async Task PushAuthRequestAsync(AuthRequest authRequest, PushType type)
+    {
+        var message = new AuthRequestPushNotification
+        {
+            Id = authRequest.Id,
+            UserId = authRequest.UserId
+        };
+
+        await SendPayloadToUserAsync(authRequest.UserId, type, message, true);
+    }
+
     private async Task SendPayloadToUserAsync(Guid userId, PushType type, object payload, bool excludeCurrentContext)
     {
         var request = new PushSendRequestModel

--- a/src/Core/Services/NoopImplementations/NoopPushNotificationService.cs
+++ b/src/Core/Services/NoopImplementations/NoopPushNotificationService.cs
@@ -75,6 +75,16 @@ public class NoopPushNotificationService : IPushNotificationService
         return Task.FromResult(0);
     }
 
+    public Task PushAuthRequestAsync(AuthRequest authRequest)
+    {
+        return Task.FromResult(0);
+    }
+
+    public Task PushAuthRequestResponseAsync(AuthRequest authRequest)
+    {
+        return Task.FromResult(0);
+    }
+
     public Task SendPayloadToOrganizationAsync(string orgId, PushType type, object payload, string identifier,
         string deviceId = null)
     {

--- a/src/Notifications/AnonymousNotificationsHub.cs
+++ b/src/Notifications/AnonymousNotificationsHub.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Bit.Notifications;
+
+[AllowAnonymous]
+public class AnonymousNotificationsHub : Microsoft.AspNetCore.SignalR.Hub, INotificationHub
+{
+    public override async Task OnConnectedAsync()
+    {
+        var httpContext = Context.GetHttpContext();
+        var token = httpContext.Request.Query["Token"].FirstOrDefault();
+        if (!string.IsNullOrWhiteSpace(token))
+        {
+            await Groups.AddToGroupAsync(Context.ConnectionId, token);
+        }
+        await base.OnConnectedAsync();
+    }
+}

--- a/src/Notifications/AzureQueueHostedService.cs
+++ b/src/Notifications/AzureQueueHostedService.cs
@@ -9,6 +9,7 @@ public class AzureQueueHostedService : IHostedService, IDisposable
 {
     private readonly ILogger _logger;
     private readonly IHubContext<NotificationsHub> _hubContext;
+    private readonly IHubContext<AnonymousNotificationsHub> _anonymousHubContext;
     private readonly GlobalSettings _globalSettings;
 
     private Task _executingTask;
@@ -18,11 +19,13 @@ public class AzureQueueHostedService : IHostedService, IDisposable
     public AzureQueueHostedService(
         ILogger<AzureQueueHostedService> logger,
         IHubContext<NotificationsHub> hubContext,
+        IHubContext<AnonymousNotificationsHub> anonymousHubContext,
         GlobalSettings globalSettings)
     {
         _logger = logger;
         _hubContext = hubContext;
         _globalSettings = globalSettings;
+        _anonymousHubContext = anonymousHubContext;
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -62,7 +65,7 @@ public class AzureQueueHostedService : IHostedService, IDisposable
                         try
                         {
                             await HubHelpers.SendNotificationToHubAsync(
-                                message.DecodeMessageText(), _hubContext, cancellationToken);
+                                message.DecodeMessageText(), _hubContext, _anonymousHubContext, cancellationToken);
                             await _queueClient.DeleteMessageAsync(message.MessageId, message.PopReceipt);
                         }
                         catch (Exception e)

--- a/src/Notifications/HubHelpers.cs
+++ b/src/Notifications/HubHelpers.cs
@@ -7,8 +7,11 @@ namespace Bit.Notifications;
 
 public static class HubHelpers
 {
-    public static async Task SendNotificationToHubAsync(string notificationJson,
-        IHubContext<NotificationsHub> hubContext, CancellationToken cancellationToken = default(CancellationToken))
+    public static async Task SendNotificationToHubAsync(
+        string notificationJson,
+        IHubContext<NotificationsHub> hubContext,
+        IHubContext<AnonymousNotificationsHub> anonymousHubContext = null,
+        CancellationToken cancellationToken = default(CancellationToken))
     {
         var notification = JsonSerializer.Deserialize<PushNotificationData<object>>(notificationJson);
         switch (notification.Type)
@@ -60,6 +63,20 @@ public static class HubHelpers
                             notificationJson);
                 await hubContext.Clients.User(sendNotification.Payload.UserId.ToString())
                     .SendAsync("ReceiveMessage", sendNotification, cancellationToken);
+                break;
+            case PushType.AuthRequest:
+                var authRequestNotification =
+                    JsonSerializer.Deserialize<PushNotificationData<AuthRequestPushNotification>>(
+                            notificationJson);
+                await hubContext.Clients.User(authRequestNotification.Payload.UserId.ToString())
+                    .SendAsync("ReceiveMessage", authRequestNotification, cancellationToken);
+                break;
+            case PushType.AuthRequestResponse:
+                var authRequestResponseNotification =
+                    JsonSerializer.Deserialize<PushNotificationData<AuthRequestPushNotification>>(
+                            notificationJson);
+                await anonymousHubContext.Clients.Group(authRequestResponseNotification.Payload.Id.ToString())
+                    .SendAsync("AuthRequestResponseRecieved", authRequestResponseNotification, cancellationToken);
                 break;
             default:
                 break;

--- a/src/Notifications/INotificationHub.cs
+++ b/src/Notifications/INotificationHub.cs
@@ -1,0 +1,7 @@
+﻿namespace Bit.Notifications;
+
+public interface INotificationHub
+{
+    Task OnConnectedAsync();
+    Task OnDisconnectedAsync(Exception exception);
+}

--- a/src/Notifications/Startup.cs
+++ b/src/Notifications/Startup.cs
@@ -110,8 +110,19 @@ public class Startup
         {
             endpoints.MapHub<NotificationsHub>("/hub", options =>
             {
-                options.ApplicationMaxBufferSize = 2048; // client => server messages are not even used
-                options.TransportMaxBufferSize = 4096;
+                var applicationMaxBufferSize = 2048; // client => server messages are not even used
+                var transportMaxBufferSize = 4096;
+                endpoints.MapHub<NotificationsHub>("/hub", options =>
+                {
+                    options.ApplicationMaxBufferSize = applicationMaxBufferSize;
+                    options.TransportMaxBufferSize = transportMaxBufferSize;
+                });
+                endpoints.MapHub<AnonymousNotificationsHub>("/anonymousHub", options =>
+                {
+                    options.ApplicationMaxBufferSize = applicationMaxBufferSize;
+                    options.TransportMaxBufferSize = transportMaxBufferSize;
+                });
+                endpoints.MapDefaultControllerRoute();
             });
             endpoints.MapDefaultControllerRoute();
         });


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->
https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-167

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
A major component of the upcoming passwordless authentication involves push notifications to and from the web vault and mobile app. Currently we are dealing with an issue with the notifications server, and are forced to deploy to QA cloud to do an e2e test of passwordless authentication with a local app and API. 

This PR adds the Passwordless entity (called `AuthRequest`) and the notifications that use it to master. Other server work for passwordless will be merged separately. 


## Code changes
This is more or less a typical entity and notification flow. I created a new model for the entity, and new methods on each notification service for sending `AuthRequestRequest` and `AuthRequestResponse` notifications. 

One peculiar thing is that the `AuthRequestResponse` notifications are handled with a new notification hub that is anonymous. This is because devices that are polling for passwordless responses are not authenticated.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
