### PR TITLE
[EC-392] Add error message if revoked user tries to accept invite

### DIFF
--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1376,6 +1376,11 @@ public class OrganizationService : IOrganizationService
     private async Task<OrganizationUser> AcceptUserAsync(OrganizationUser orgUser, User user,
         IUserService userService)
     {
+        if (orgUser.Status == OrganizationUserStatusType.Revoked)
+        {
+            throw new BadRequestException("Your organization access has been revoked.");
+        }
+
         if (orgUser.Status != OrganizationUserStatusType.Invited)
         {
             throw new BadRequestException("Already accepted.");


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Show an accurate error message to a revoked user who tries to accept an invite. Currently they will receive an "Invite already accepted" message.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/Services/Implementations/OrganizationService.cs** - add a check for revoked status with error message.

Here's how it looks to the end user:

![Screen Shot 2022-09-06 at 12 23 43 pm](https://user-images.githubusercontent.com/31796059/188536295-242358cb-8fbc-445c-8472-f2d077589e95.png)

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
