### PR TITLE
[EC-484] Remove getBilling API

### DIFF
--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -621,22 +621,7 @@ public class AccountsController : Controller
             Success = result.Item1
         };
     }
-
-    [Obsolete("2022-04-01 Use separate Billing History/Payment APIs, left for backwards compatability with older clients")]
-    [HttpGet("billing")]
-    [SelfHosted(NotSelfHostedOnly = true)]
-    public async Task<BillingResponseModel> GetBilling()
-    {
-        var user = await _userService.GetUserByPrincipalAsync(User);
-        if (user == null)
-        {
-            throw new UnauthorizedAccessException();
-        }
-
-        var billingInfo = await _paymentService.GetBillingAsync(user);
-        return new BillingResponseModel(billingInfo);
-    }
-
+    
     [HttpGet("subscription")]
     public async Task<SubscriptionResponseModel> GetSubscription()
     {

--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -621,7 +621,7 @@ public class AccountsController : Controller
             Success = result.Item1
         };
     }
-    
+
     [HttpGet("subscription")]
     public async Task<SubscriptionResponseModel> GetSubscription()
     {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other


## Objective
> Remove obsolete `getBilling` API. This was only used by the `web` client and was relocated in `April 2022`

## Code changes
- **AccountsController.cs**: Removed `getBilling` API call.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
