### PR TITLE
[EC-529] fix: missing constructor DI assignment

### DIFF
--- a/src/Api/Controllers/CiphersController.cs
+++ b/src/Api/Controllers/CiphersController.cs
@@ -222,6 +222,12 @@ public class CiphersController : Controller
         var responses = orgCiphers.Select(c => new CipherMiniDetailsResponseModel(c, _globalSettings,
             collectionCiphersGroupDict, c.OrganizationUseTotp));
 
+        var providerId = await _currentContext.ProviderIdForOrg(orgIdGuid);
+        if (providerId.HasValue)
+        {
+            await _providerService.LogProviderAccessToOrganizationAsync(orgIdGuid);
+        }
+
         return new ListResponseModel<CipherMiniDetailsResponseModel>(responses);
     }
 

--- a/src/Core/Services/Implementations/CipherService.cs
+++ b/src/Core/Services/Implementations/CipherService.cs
@@ -47,7 +47,8 @@ public class CipherService : ICipherService
         IPolicyRepository policyRepository,
         GlobalSettings globalSettings,
         IReferenceEventService referenceEventService,
-        ICurrentContext currentContext)
+        ICurrentContext currentContext,
+        IProviderService providerService)
     {
         _cipherRepository = cipherRepository;
         _folderRepository = folderRepository;
@@ -63,6 +64,7 @@ public class CipherService : ICipherService
         _globalSettings = globalSettings;
         _referenceEventService = referenceEventService;
         _currentContext = currentContext;
+        _providerService = providerService;
     }
 
     public async Task SaveAsync(Cipher cipher, Guid savingUserId, DateTime? lastKnownRevisionDate,

--- a/src/Core/Services/Implementations/CipherService.cs
+++ b/src/Core/Services/Implementations/CipherService.cs
@@ -31,7 +31,6 @@ public class CipherService : ICipherService
     private const long _fileSizeLeeway = 1024L * 1024L; // 1MB 
     private readonly IReferenceEventService _referenceEventService;
     private readonly ICurrentContext _currentContext;
-    private readonly IProviderService _providerService;
 
     public CipherService(
         ICipherRepository cipherRepository,
@@ -47,8 +46,7 @@ public class CipherService : ICipherService
         IPolicyRepository policyRepository,
         GlobalSettings globalSettings,
         IReferenceEventService referenceEventService,
-        ICurrentContext currentContext,
-        IProviderService providerService)
+        ICurrentContext currentContext)
     {
         _cipherRepository = cipherRepository;
         _folderRepository = folderRepository;
@@ -64,7 +62,6 @@ public class CipherService : ICipherService
         _globalSettings = globalSettings;
         _referenceEventService = referenceEventService;
         _currentContext = currentContext;
-        _providerService = providerService;
     }
 
     public async Task SaveAsync(Cipher cipher, Guid savingUserId, DateTime? lastKnownRevisionDate,
@@ -877,12 +874,6 @@ public class CipherService : ICipherService
         var collectionCiphersGroupDict = collectionCiphers
             .Where(c => orgCipherIds.Contains(c.CipherId))
             .GroupBy(c => c.CipherId).ToDictionary(s => s.Key);
-
-        var providerId = await _currentContext.ProviderIdForOrg(organizationId);
-        if (providerId.HasValue)
-        {
-            await _providerService.LogProviderAccessToOrganizationAsync(organizationId);
-        }
 
         return (orgCiphers, collectionCiphersGroupDict);
     }

--- a/src/Identity/Startup.cs
+++ b/src/Identity/Startup.cs
@@ -144,6 +144,8 @@ public class Startup
             services.AddHostedService<Core.HostedServices.ApplicationCacheHostedService>();
         }
 
+        services.AddOosServices();
+
         // HttpClients
         services.AddHttpClient("InternalSso", client =>
         {

--- a/src/Identity/Startup.cs
+++ b/src/Identity/Startup.cs
@@ -144,8 +144,6 @@ public class Startup
             services.AddHostedService<Core.HostedServices.ApplicationCacheHostedService>();
         }
 
-        services.AddOosServices();
-
         // HttpClients
         services.AddHttpClient("InternalSso", client =>
         {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Server throws error when providers try to access an org vault that they are not a member of. Issue is caused when the server tries to log the access because a required dependency is not properly injected (assignment missing in constructor).

## Code changes
* **CipherService.cs:** Add missing statement

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
