### PR TITLE
[PS-1470] Remove `Batch`

### DIFF
--- a/src/Core/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/SelfHosted/SelfHostedSyncSponsorshipsCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/SelfHosted/SelfHostedSyncSponsorshipsCommand.cs
@@ -8,7 +8,6 @@ using Bit.Core.OrganizationFeatures.OrganizationSponsorships.FamiliesForEnterpri
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Settings;
-using Bit.Core.Utilities;
 using Microsoft.Extensions.Logging;
 
 namespace Bit.Core.OrganizationFeatures.OrganizationSponsorships.FamiliesForEnterprise.SelfHosted;
@@ -71,7 +70,7 @@ public class SelfHostedSyncSponsorshipsCommand : BaseIdentityClientService, ISel
         }
         var syncedSponsorships = new List<OrganizationSponsorshipData>();
 
-        foreach (var orgSponsorshipsBatch in CoreHelpers.Batch(organizationSponsorshipsDict.Values, 1000))
+        foreach (var orgSponsorshipsBatch in organizationSponsorshipsDict.Values.Chunk(1000))
         {
             var response = await SendAsync<OrganizationSponsorshipSyncRequestModel, OrganizationSponsorshipSyncResponseModel>(HttpMethod.Post, "organization/sponsorship/sync", new OrganizationSponsorshipSyncRequestModel
             {

--- a/src/Core/Services/Implementations/CipherService.cs
+++ b/src/Core/Services/Implementations/CipherService.cs
@@ -403,7 +403,7 @@ public class CipherService : ICipherService
 
         var events = deletingCiphers.Select(c =>
             new Tuple<Cipher, EventType, DateTime?>(c, EventType.Cipher_Deleted, null));
-        foreach (var eventsBatch in events.Batch(100))
+        foreach (var eventsBatch in events.Chunk(100))
         {
             await _eventService.LogCipherEventsAsync(eventsBatch);
         }
@@ -574,7 +574,7 @@ public class CipherService : ICipherService
 
         var events = cipherInfos.Select(c =>
             new Tuple<Cipher, EventType, DateTime?>(c.cipher, EventType.Cipher_Shared, null));
-        foreach (var eventsBatch in events.Batch(100))
+        foreach (var eventsBatch in events.Chunk(100))
         {
             await _eventService.LogCipherEventsAsync(eventsBatch);
         }
@@ -791,7 +791,7 @@ public class CipherService : ICipherService
 
         var events = deletingCiphers.Select(c =>
             new Tuple<Cipher, EventType, DateTime?>(c, EventType.Cipher_SoftDeleted, null));
-        foreach (var eventsBatch in events.Batch(100))
+        foreach (var eventsBatch in events.Chunk(100))
         {
             await _eventService.LogCipherEventsAsync(eventsBatch);
         }
@@ -840,7 +840,7 @@ public class CipherService : ICipherService
             c.DeletedDate = null;
             return new Tuple<Cipher, EventType, DateTime?>(c, EventType.Cipher_Restored, null);
         });
-        foreach (var eventsBatch in events.Batch(100))
+        foreach (var eventsBatch in events.Chunk(100))
         {
             await _eventService.LogCipherEventsAsync(eventsBatch);
         }

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -70,32 +70,6 @@ public static class CoreHelpers
         return new Guid(guidArray);
     }
 
-    public static IEnumerable<IEnumerable<T>> Batch<T>(this IEnumerable<T> source, int size)
-    {
-        T[] bucket = null;
-        var count = 0;
-        foreach (var item in source)
-        {
-            if (bucket == null)
-            {
-                bucket = new T[size];
-            }
-            bucket[count++] = item;
-            if (count != size)
-            {
-                continue;
-            }
-            yield return bucket.Select(x => x);
-            bucket = null;
-            count = 0;
-        }
-        // Return the last bucket with all remaining elements
-        if (bucket != null && count > 0)
-        {
-            yield return bucket.Take(count);
-        }
-    }
-
     public static string CleanCertificateThumbprint(string thumbprint)
     {
         // Clean possible garbage characters from thumbprint copy/paste

--- a/src/Events/Controllers/CollectController.cs
+++ b/src/Events/Controllers/CollectController.cs
@@ -3,7 +3,6 @@ using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
-using Bit.Core.Utilities;
 using Bit.Events.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -95,7 +94,7 @@ public class CollectController : Controller
         }
         if (cipherEvents.Any())
         {
-            foreach (var eventsBatch in cipherEvents.Batch(50))
+            foreach (var eventsBatch in cipherEvents.Chunk(50))
             {
                 await _eventService.LogCipherEventsAsync(eventsBatch);
             }

--- a/test/Core.Test/Utilities/CoreHelpersTests.cs
+++ b/test/Core.Test/Utilities/CoreHelpersTests.cs
@@ -70,31 +70,6 @@ public class CoreHelpersTests
         Assert.Equal(expectedComb, comb);
     }
 
-    [Theory]
-    [InlineData(2, 5, new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 })]
-    [InlineData(2, 3, new[] { 1, 2, 3, 4, 5 })]
-    [InlineData(2, 1, new[] { 1, 2 })]
-    [InlineData(1, 1, new[] { 1 })]
-    [InlineData(2, 2, new[] { 1, 2, 3 })]
-    public void Batch_Success(int batchSize, int totalBatches, int[] collection)
-    {
-        // Arrange
-        var remainder = collection.Length % batchSize;
-
-        // Act
-        var batches = collection.Batch(batchSize);
-
-        // Assert
-        Assert.Equal(totalBatches, batches.Count());
-
-        foreach (var batch in batches.Take(totalBatches - 1))
-        {
-            Assert.Equal(batchSize, batch.Count());
-        }
-
-        Assert.Equal(batches.Last().Count(), remainder == 0 ? batchSize : remainder);
-    }
-
     /*
     [Fact]
     public void ToGuidIdArrayTVP_Success()


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
In .NET 6 a `Chunk` method was introduced ([docs](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.chunk?view=net-6.0)|[source](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Linq/src/System/Linq/Chunk.cs)) that has the exact same idea as our existing `Batch` method. This removes our implementation in favor of the built in one.

The `Chunk` implementation does differ from our implementation because it returns `IEnumerable<T[]>` instead of ours returning `IEnumerable<IEnumerable<T>>` but since an array is a superset of `IEnumerable<T>` it is totally fine. We should even get a little bit of a perf benefit from it.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/Utilities/CoreHelpers.cs:** Delete `Batch` method.
* **test/Core.Test/Utilities/CoreHelpersTests.cs:** I deleted the tests we had around our batch method but did plug in it to use Chunk first and our tests worked fine.
* Switch to using `Chunk` in all places we used `Batch`

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
