### PR TITLE
[SG-656] Send a captcha bypass token back from the register endpoint

### DIFF
--- a/src/Identity/Controllers/AccountsController.cs
+++ b/src/Identity/Controllers/AccountsController.cs
@@ -6,6 +6,7 @@ using Bit.Core.Models.Data;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Utilities;
+using Bit.Identity.Models;
 using Bit.SharedWeb.Utilities;
 using Microsoft.AspNetCore.Mvc;
 
@@ -18,27 +19,32 @@ public class AccountsController : Controller
     private readonly ILogger<AccountsController> _logger;
     private readonly IUserRepository _userRepository;
     private readonly IUserService _userService;
+    private readonly ICaptchaValidationService _captchaValidationService;
 
     public AccountsController(
         ILogger<AccountsController> logger,
         IUserRepository userRepository,
-        IUserService userService)
+        IUserService userService,
+        ICaptchaValidationService captchaValidationService)
     {
         _logger = logger;
         _userRepository = userRepository;
         _userService = userService;
+        _captchaValidationService = captchaValidationService;
     }
 
     // Moved from API, If you modify this endpoint, please update API as well.
     [HttpPost("register")]
     [CaptchaProtected]
-    public async Task PostRegister([FromBody] RegisterRequestModel model)
+    public async Task<RegisterResponseModel> PostRegister([FromBody] RegisterRequestModel model)
     {
         var result = await _userService.RegisterUserAsync(model.ToUser(), model.MasterPasswordHash,
             model.Token, model.OrganizationUserId);
         if (result.Succeeded)
         {
-            return;
+            var user = await _userRepository.GetByEmailAsync(model.Email);
+            var captchaBypassToken = _captchaValidationService.GenerateCaptchaBypassToken(user);
+            return new RegisterResponseModel(captchaBypassToken);
         }
 
         foreach (var error in result.Errors.Where(e => e.Code != "DuplicateUserName"))

--- a/src/Identity/Controllers/AccountsController.cs
+++ b/src/Identity/Controllers/AccountsController.cs
@@ -38,11 +38,11 @@ public class AccountsController : Controller
     [CaptchaProtected]
     public async Task<RegisterResponseModel> PostRegister([FromBody] RegisterRequestModel model)
     {
-        var result = await _userService.RegisterUserAsync(model.ToUser(), model.MasterPasswordHash,
+        var user = model.ToUser();
+        var result = await _userService.RegisterUserAsync(user, model.MasterPasswordHash,
             model.Token, model.OrganizationUserId);
         if (result.Succeeded)
         {
-            var user = await _userRepository.GetByEmailAsync(model.Email);
             var captchaBypassToken = _captchaValidationService.GenerateCaptchaBypassToken(user);
             return new RegisterResponseModel(captchaBypassToken);
         }

--- a/src/Identity/Models/ICaptchaProtectedResponseModel.cs
+++ b/src/Identity/Models/ICaptchaProtectedResponseModel.cs
@@ -1,0 +1,4 @@
+﻿public interface ICaptchaProtectedResponseModel
+{
+    public string CaptchaBypassToken { get; set; }
+}

--- a/src/Identity/Models/RegisterResponseModel.cs
+++ b/src/Identity/Models/RegisterResponseModel.cs
@@ -1,0 +1,14 @@
+﻿using Bit.Core.Models.Api;
+
+namespace Bit.Identity.Models;
+
+public class RegisterResponseModel : ResponseModel
+{
+    public RegisterResponseModel(string captchaBypassToken)
+        : base("register")
+    {
+        CaptchaBypassToken = captchaBypassToken;
+    }
+
+    public string CaptchaBypassToken { get; set; }
+}

--- a/src/Identity/Models/RegisterResponseModel.cs
+++ b/src/Identity/Models/RegisterResponseModel.cs
@@ -2,7 +2,7 @@
 
 namespace Bit.Identity.Models;
 
-public class RegisterResponseModel : ResponseModel
+public class RegisterResponseModel : ResponseModel, ICaptchaProtectedResponseModel
 {
     public RegisterResponseModel(string captchaBypassToken)
         : base("register")

--- a/test/Identity.Test/Controllers/AccountsControllerTests.cs
+++ b/test/Identity.Test/Controllers/AccountsControllerTests.cs
@@ -20,16 +20,19 @@ public class AccountsControllerTests : IDisposable
     private readonly ILogger<AccountsController> _logger;
     private readonly IUserRepository _userRepository;
     private readonly IUserService _userService;
+    private readonly ICaptchaValidationService _captchaValidationService;
 
     public AccountsControllerTests()
     {
         _logger = Substitute.For<ILogger<AccountsController>>();
         _userRepository = Substitute.For<IUserRepository>();
         _userService = Substitute.For<IUserService>();
+        _captchaValidationService = Substitute.For<ICaptchaValidationService>();
         _sut = new AccountsController(
             _logger,
             _userRepository,
-            _userService
+            _userService,
+            _captchaValidationService
         );
     }
 


### PR DESCRIPTION
https://bitwarden.atlassian.net/jira/software/c/projects/SG/boards/71?modal=detail&selectedIssue=SG-656

This will be part of a cloud server hotfix.

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The trial initiation flow has a registration step that automatically does a login in the background. This has Captcha problems, namely that it can spawn two captchas in a row - one during registration and one during login. This is not ideal UX, so we've added a bypass token that returns from the registration endpoint that can be used to skip the next captcha.

https://github.com/bitwarden/clients/pull/3531 depends on this change.

## Code changes
- Create a model to encapsulate a `RegistrationResponse`
- Generate a user `CaptchaBypassToken` after a successful registration that we return to caller.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
