### PR TITLE
[SG-656] Update API endpoint to use RegisterResponseModel

### DIFF
--- a/src/Api/Controllers/AccountsController.cs
+++ b/src/Api/Controllers/AccountsController.cs
@@ -35,6 +35,7 @@ public class AccountsController : Controller
     private readonly IUserService _userService;
     private readonly ISendRepository _sendRepository;
     private readonly ISendService _sendService;
+    private readonly ICaptchaValidationService _captchaValidationService;
 
     public AccountsController(
         GlobalSettings globalSettings,
@@ -47,7 +48,8 @@ public class AccountsController : Controller
         IUserRepository userRepository,
         IUserService userService,
         ISendRepository sendRepository,
-        ISendService sendService)
+        ISendService sendService,
+        ICaptchaValidationService captchaValidationService)
     {
         _cipherRepository = cipherRepository;
         _folderRepository = folderRepository;
@@ -60,11 +62,13 @@ public class AccountsController : Controller
         _userService = userService;
         _sendRepository = sendRepository;
         _sendService = sendService;
+        _captchaValidationService = captchaValidationService;
     }
 
     #region DEPRECATED (Moved to Identity Service)
 
-    [Obsolete("2022-01-12 Moved to Identity, left for backwards compatability with older clients")]
+    // This method is still used by self hosted intalls
+    [Obsolete("2022-01-12 Moved to Identity, left for backwards compatability with older clients.")]
     [HttpPost("prelogin")]
     [AllowAnonymous]
     public async Task<PreloginResponseModel> PostPrelogin([FromBody] PreloginRequestModel model)
@@ -81,17 +85,20 @@ public class AccountsController : Controller
         return new PreloginResponseModel(kdfInformation);
     }
 
-    [Obsolete("2022-01-12 Moved to Identity, left for backwards compatability with older clients")]
+    // This method is still used by self hosted intalls
+    [Obsolete("2022-01-12 Moved to Identity, left for backwards compatability with older clients.")]
     [HttpPost("register")]
     [AllowAnonymous]
     [CaptchaProtected]
-    public async Task PostRegister([FromBody] RegisterRequestModel model)
+    public async Task<RegisterResponseModel> PostRegister([FromBody] RegisterRequestModel model)
     {
-        var result = await _userService.RegisterUserAsync(model.ToUser(), model.MasterPasswordHash,
+        var user = model.ToUser();
+        var result = await _userService.RegisterUserAsync(user, model.MasterPasswordHash,
             model.Token, model.OrganizationUserId);
         if (result.Succeeded)
         {
-            return;
+            var captchaBypassToken = _captchaValidationService.GenerateCaptchaBypassToken(user);
+            return new RegisterResponseModel(captchaBypassToken);
         }
 
         foreach (var error in result.Errors.Where(e => e.Code != "DuplicateUserName"))

--- a/src/Core/Models/Api/Response/Accounts/ICaptchaProtectedResponseModel.cs
+++ b/src/Core/Models/Api/Response/Accounts/ICaptchaProtectedResponseModel.cs
@@ -1,0 +1,6 @@
+﻿namespace Bit.Core.Models.Api.Response.Accounts;
+
+public interface ICaptchaProtectedResponseModel
+{
+    public string CaptchaBypassToken { get; set; }
+}

--- a/src/Core/Models/Api/Response/Accounts/RegisterResponseModel.cs
+++ b/src/Core/Models/Api/Response/Accounts/RegisterResponseModel.cs
@@ -1,6 +1,4 @@
-﻿using Bit.Core.Models.Api;
-
-namespace Bit.Identity.Models;
+﻿namespace Bit.Core.Models.Api.Response.Accounts;
 
 public class RegisterResponseModel : ResponseModel, ICaptchaProtectedResponseModel
 {

--- a/src/Identity/Controllers/AccountsController.cs
+++ b/src/Identity/Controllers/AccountsController.cs
@@ -6,7 +6,6 @@ using Bit.Core.Models.Data;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Utilities;
-using Bit.Identity.Models;
 using Bit.SharedWeb.Utilities;
 using Microsoft.AspNetCore.Mvc;
 
@@ -33,7 +32,7 @@ public class AccountsController : Controller
         _captchaValidationService = captchaValidationService;
     }
 
-    // Moved from API, If you modify this endpoint, please update API as well.
+    // Moved from API, If you modify this endpoint, please update API as well. Self hosted installs still use the API endpoints.
     [HttpPost("register")]
     [CaptchaProtected]
     public async Task<RegisterResponseModel> PostRegister([FromBody] RegisterRequestModel model)
@@ -56,7 +55,7 @@ public class AccountsController : Controller
         throw new BadRequestException(ModelState);
     }
 
-    // Moved from API, If you modify this endpoint, please update API as well.
+    // Moved from API, If you modify this endpoint, please update API as well. Self hosted installs still use the API endpoints.
     [HttpPost("prelogin")]
     public async Task<PreloginResponseModel> PostPrelogin([FromBody] PreloginRequestModel model)
     {

--- a/src/Identity/Models/ICaptchaProtectedResponseModel.cs
+++ b/src/Identity/Models/ICaptchaProtectedResponseModel.cs
@@ -1,4 +1,0 @@
-﻿public interface ICaptchaProtectedResponseModel
-{
-    public string CaptchaBypassToken { get; set; }
-}

--- a/test/Api.Test/Controllers/AccountsControllerTests.cs
+++ b/test/Api.Test/Controllers/AccountsControllerTests.cs
@@ -30,6 +30,7 @@ public class AccountsControllerTests : IDisposable
     private readonly ISendRepository _sendRepository;
     private readonly ISendService _sendService;
     private readonly IProviderUserRepository _providerUserRepository;
+    private readonly ICaptchaValidationService _captchaValidationService;
 
     public AccountsControllerTests()
     {
@@ -44,6 +45,7 @@ public class AccountsControllerTests : IDisposable
         _globalSettings = new GlobalSettings();
         _sendRepository = Substitute.For<ISendRepository>();
         _sendService = Substitute.For<ISendService>();
+        _captchaValidationService = Substitute.For<ICaptchaValidationService>();
         _sut = new AccountsController(
             _globalSettings,
             _cipherRepository,
@@ -55,7 +57,8 @@ public class AccountsControllerTests : IDisposable
             _userRepository,
             _userService,
             _sendRepository,
-            _sendService
+            _sendService,
+            _captchaValidationService
         );
     }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
On https://github.com/bitwarden/server/pull/2278 I updated the Identity `register` endpoint to return a model, but I did not update the API `register` endpoint. This was because I was concerned they changes wouldn't be backwards compatible with old clients.

Turns out there is a bigger reason to update both register endpoints: those endpoints are still used by all self hosted servers.  To keep self hosted registrations working I've updated the API `register` endpoint with the new changes. The changes are still backwards compatible with old clients because old clients will have marked the register endpoint as not having a response and will not try to parse one.

## Code changes
* Move the `RegisterResponseModel` classes to `Core` to be used by API and Identity
* Copied the Identity `register` endpoint changes to the API `register` endpoint
* Append the comments in this area to mention that self hosted installs still don't use the Identity endpoint
* Add necessary dependencies to tests

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
