### PR TITLE
[EC-447] SCIM User delete endpoint is not deleting the user from the Bitwarden organization

### DIFF
--- a/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
+++ b/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
@@ -262,7 +262,7 @@ public class UsersController : Controller
     }
 
     [HttpDelete("{id}")]
-    public async Task<IActionResult> Delete(Guid organizationId, Guid id, [FromBody] ScimUserRequestModel model)
+    public async Task<IActionResult> Delete(Guid organizationId, Guid id)
     {
         var orgUser = await _organizationUserRepository.GetByIdAsync(id);
         if (orgUser == null || orgUser.OrganizationId != organizationId)


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
When a user was deleted from the IDP then the call that was made to the BItwarden SCIM API was returning an error '415 Unsupported Media Type' because it was expecting a body payload to be sent although it was not needed. The endpoint has been updated to not need a body payload.

## Code changes
* **bitwarden_license/src/Scim/Controllers/v2/UsersController.cs:** Removed the unneeded body payload from the DELETE endpoint.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
