### PR TITLE
Add logging to tokenables

### DIFF
--- a/bitwarden_license/src/Scim/Program.cs
+++ b/bitwarden_license/src/Scim/Program.cs
@@ -1,5 +1,4 @@
 ﻿using Bit.Core.Utilities;
-using Serilog.Events;
 
 namespace Bit.Scim;
 
@@ -13,7 +12,7 @@ public class Program
             {
                 webBuilder.UseStartup<Startup>();
                 webBuilder.ConfigureLogging((hostingContext, logging) =>
-                    logging.AddSerilog(hostingContext, e =>
+                    logging.AddSerilog(hostingContext, (e, globalSettings) =>
                     {
                         var context = e.Properties["SourceContext"].ToString();
 
@@ -24,7 +23,7 @@ public class Program
                             return false;
                         }
 
-                        return e.Level >= LogEventLevel.Warning;
+                        return e.Level >= globalSettings.MinLogLevel.ScimSettings.Default;
                     }));
             })
             .Build()

--- a/bitwarden_license/src/Sso/Program.cs
+++ b/bitwarden_license/src/Sso/Program.cs
@@ -15,7 +15,7 @@ public class Program
             {
                 webBuilder.UseStartup<Startup>();
                 webBuilder.ConfigureLogging((hostingContext, logging) =>
-                logging.AddSerilog(hostingContext, e =>
+                logging.AddSerilog(hostingContext, (e, globalSettings) =>
                 {
                     var context = e.Properties["SourceContext"].ToString();
                     if (e.Properties.ContainsKey("RequestPath") &&
@@ -24,7 +24,7 @@ public class Program
                     {
                         return false;
                     }
-                    return e.Level >= LogEventLevel.Error;
+                    return e.Level >= globalSettings.MinLogLevel.SsoSettings.Default;
                 }));
             })
             .Build()

--- a/bitwarden_license/src/Sso/Program.cs
+++ b/bitwarden_license/src/Sso/Program.cs
@@ -1,6 +1,5 @@
 ﻿using Bit.Core.Utilities;
 using Serilog;
-using Serilog.Events;
 
 namespace Bit.Sso;
 

--- a/src/Admin/Program.cs
+++ b/src/Admin/Program.cs
@@ -1,5 +1,4 @@
 ﻿using Bit.Core.Utilities;
-using Serilog.Events;
 
 namespace Bit.Admin;
 

--- a/src/Admin/Program.cs
+++ b/src/Admin/Program.cs
@@ -18,7 +18,7 @@ public class Program
                 });
                 webBuilder.UseStartup<Startup>();
                 webBuilder.ConfigureLogging((hostingContext, logging) =>
-                logging.AddSerilog(hostingContext, e =>
+                logging.AddSerilog(hostingContext, (e, globalSettings) =>
                 {
                     var context = e.Properties["SourceContext"].ToString();
                     if (e.Properties.ContainsKey("RequestPath") &&
@@ -27,7 +27,7 @@ public class Program
                     {
                         return false;
                     }
-                    return e.Level >= LogEventLevel.Error;
+                    return e.Level >= globalSettings.MinLogLevel.AdminSettings.Default;
                 }));
             })
             .Build()

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -16,7 +16,7 @@ public class Program
             {
                 webBuilder.UseStartup<Startup>();
                 webBuilder.ConfigureLogging((hostingContext, logging) =>
-                    logging.AddSerilog(hostingContext, e =>
+                    logging.AddSerilog(hostingContext, (e, globalSettings) =>
                     {
                         var context = e.Properties["SourceContext"].ToString();
                         if (e.Exception != null &&
@@ -26,19 +26,19 @@ public class Program
                             return false;
                         }
 
-                        if (e.Level == LogEventLevel.Information &&
+                        if (
                             context.Contains(typeof(IpRateLimitMiddleware).FullName))
                         {
-                            return true;
+                            return e.Level >= globalSettings.MinLogLevel.ApiSettings.IpRateLimit;
                         }
 
                         if (context.Contains("IdentityServer4.Validation.TokenValidator") ||
                             context.Contains("IdentityServer4.Validation.TokenRequestValidator"))
                         {
-                            return e.Level > LogEventLevel.Error;
+                            return e.Level >= globalSettings.MinLogLevel.ApiSettings.IdentityToken;
                         }
 
-                        return e.Level >= LogEventLevel.Error;
+                        return e.Level >= globalSettings.MinLogLevel.ApiSettings.Default;
                     }));
             })
             .Build()

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -1,7 +1,6 @@
 ﻿using AspNetCoreRateLimit;
 using Bit.Core.Utilities;
 using Microsoft.IdentityModel.Tokens;
-using Serilog.Events;
 
 namespace Bit.Api;
 

--- a/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
+++ b/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Bit.Core.Settings;
 using Bit.Core.Tokens;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Bit.Core.OrganizationFeatures;
 
@@ -70,7 +71,8 @@ public static class OrganizationServiceCollectionExtensions
             new DataProtectorTokenFactory<OrganizationSponsorshipOfferTokenable>(
                 OrganizationSponsorshipOfferTokenable.ClearTextPrefix,
                 OrganizationSponsorshipOfferTokenable.DataProtectorPurpose,
-                serviceProvider.GetDataProtectionProvider())
+                serviceProvider.GetDataProtectionProvider(),
+                serviceProvider.GetRequiredService<ILogger<DataProtectorTokenFactory<OrganizationSponsorshipOfferTokenable>>>())
         );
     }
 }

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace Bit.Core.Settings;
+﻿using Serilog.Events;
+
+namespace Bit.Core.Settings;
 
 public class GlobalSettings : IGlobalSettings
 {
@@ -58,6 +60,7 @@ public class GlobalSettings : IGlobalSettings
     public virtual DocumentDbSettings DocumentDb { get; set; } = new DocumentDbSettings();
     public virtual SentrySettings Sentry { get; set; } = new SentrySettings();
     public virtual SyslogSettings Syslog { get; set; } = new SyslogSettings();
+    public virtual ILogLevelSettings MinLogLevel { get; set; } = new LogLevelSettings();
     public virtual NotificationHubSettings NotificationHub { get; set; } = new NotificationHubSettings();
     public virtual YubicoSettings Yubico { get; set; } = new YubicoSettings();
     public virtual DuoSettings Duo { get; set; } = new DuoSettings();
@@ -519,4 +522,74 @@ public class GlobalSettings : IGlobalSettings
         public int SlidingWindowSeconds { get; set; } = 120;
     }
 
+    public class LogLevelSettings : ILogLevelSettings
+    {
+        public IBillingLogLevelSettings BillingSettings { get; set; } = new BillingLogLevelSettings();
+        public IApiLogLevelSettings ApiSettings { get; set; } = new ApiLogLevelSettings();
+        public IIdentityLogLevelSettings IdentitySettings { get; set; } = new IdentityLogLevelSettings();
+        public IScimLogLevelSettings ScimSettings { get; set; } = new ScimLogLevelSettings();
+        public ISsoLogLevelSettings SsoSettings { get; set; } = new SsoLogLevelSettings();
+        public IAdminLogLevelSettings AdminSettings { get; set; } = new AdminLogLevelSettings();
+        public IEventsLogLevelSettings EventsSettings { get; set; } = new EventsLogLevelSettings();
+        public IEventsProcessorLogLevelSettings EventsProcessorSettings { get; set; } = new EventsProcessorLogLevelSettings();
+        public IIconsLogLevelSettings IconsSettings { get; set; } = new IconsLogLevelSettings();
+        public INotificationsLogLevelSettings NotificationsSettings { get; set; } = new NotificationsLogLevelSettings();
+    }
+
+    public class BillingLogLevelSettings : IBillingLogLevelSettings
+    {
+        public LogEventLevel Default { get; set; } = LogEventLevel.Warning;
+        public LogEventLevel Jobs { get; set; } = LogEventLevel.Information;
+    }
+
+    public class ApiLogLevelSettings : IApiLogLevelSettings
+    {
+        public LogEventLevel Default { get; set; } = LogEventLevel.Error;
+        public LogEventLevel IdentityToken { get; set; } = LogEventLevel.Error;
+        public LogEventLevel IpRateLimit { get; set; } = LogEventLevel.Information;
+    }
+
+    public class IdentityLogLevelSettings : IIdentityLogLevelSettings
+    {
+        public LogEventLevel Default { get; set; } = LogEventLevel.Error;
+        public LogEventLevel IdentityToken { get; set; } = LogEventLevel.Fatal;
+        public LogEventLevel IpRateLimit { get; set; } = LogEventLevel.Information;
+    }
+
+    public class ScimLogLevelSettings : IScimLogLevelSettings
+    {
+        public LogEventLevel Default { get; set; } = LogEventLevel.Warning;
+    }
+
+    public class SsoLogLevelSettings : ISsoLogLevelSettings
+    {
+        public LogEventLevel Default { get; set; } = LogEventLevel.Error;
+    }
+
+    public class AdminLogLevelSettings : IAdminLogLevelSettings
+    {
+        public LogEventLevel Default { get; set; } = LogEventLevel.Error;
+    }
+
+    public class EventsLogLevelSettings : IEventsLogLevelSettings
+    {
+        public LogEventLevel Default { get; set; } = LogEventLevel.Error;
+        public LogEventLevel IdentityToken { get; set; } = LogEventLevel.Fatal;
+    }
+
+    public class EventsProcessorLogLevelSettings : IEventsProcessorLogLevelSettings
+    {
+        public LogEventLevel Default { get; set; } = LogEventLevel.Warning;
+    }
+
+    public class IconsLogLevelSettings : IIconsLogLevelSettings
+    {
+        public LogEventLevel Default { get; set; } = LogEventLevel.Error;
+    }
+
+    public class NotificationsLogLevelSettings : INotificationsLogLevelSettings
+    {
+        public LogEventLevel Default { get; set; } = LogEventLevel.Warning;
+        public LogEventLevel IdentityToken { get; set; } = LogEventLevel.Fatal;
+    }
 }

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -1,4 +1,4 @@
-﻿using Serilog.Events;
+﻿using Bit.Core.Settings.LogSettings;
 
 namespace Bit.Core.Settings;
 
@@ -520,76 +520,5 @@ public class GlobalSettings : IGlobalSettings
         /// TODO: Determine/discuss a suitable sliding window
         /// </summary>
         public int SlidingWindowSeconds { get; set; } = 120;
-    }
-
-    public class LogLevelSettings : ILogLevelSettings
-    {
-        public IBillingLogLevelSettings BillingSettings { get; set; } = new BillingLogLevelSettings();
-        public IApiLogLevelSettings ApiSettings { get; set; } = new ApiLogLevelSettings();
-        public IIdentityLogLevelSettings IdentitySettings { get; set; } = new IdentityLogLevelSettings();
-        public IScimLogLevelSettings ScimSettings { get; set; } = new ScimLogLevelSettings();
-        public ISsoLogLevelSettings SsoSettings { get; set; } = new SsoLogLevelSettings();
-        public IAdminLogLevelSettings AdminSettings { get; set; } = new AdminLogLevelSettings();
-        public IEventsLogLevelSettings EventsSettings { get; set; } = new EventsLogLevelSettings();
-        public IEventsProcessorLogLevelSettings EventsProcessorSettings { get; set; } = new EventsProcessorLogLevelSettings();
-        public IIconsLogLevelSettings IconsSettings { get; set; } = new IconsLogLevelSettings();
-        public INotificationsLogLevelSettings NotificationsSettings { get; set; } = new NotificationsLogLevelSettings();
-    }
-
-    public class BillingLogLevelSettings : IBillingLogLevelSettings
-    {
-        public LogEventLevel Default { get; set; } = LogEventLevel.Warning;
-        public LogEventLevel Jobs { get; set; } = LogEventLevel.Information;
-    }
-
-    public class ApiLogLevelSettings : IApiLogLevelSettings
-    {
-        public LogEventLevel Default { get; set; } = LogEventLevel.Error;
-        public LogEventLevel IdentityToken { get; set; } = LogEventLevel.Error;
-        public LogEventLevel IpRateLimit { get; set; } = LogEventLevel.Information;
-    }
-
-    public class IdentityLogLevelSettings : IIdentityLogLevelSettings
-    {
-        public LogEventLevel Default { get; set; } = LogEventLevel.Error;
-        public LogEventLevel IdentityToken { get; set; } = LogEventLevel.Fatal;
-        public LogEventLevel IpRateLimit { get; set; } = LogEventLevel.Information;
-    }
-
-    public class ScimLogLevelSettings : IScimLogLevelSettings
-    {
-        public LogEventLevel Default { get; set; } = LogEventLevel.Warning;
-    }
-
-    public class SsoLogLevelSettings : ISsoLogLevelSettings
-    {
-        public LogEventLevel Default { get; set; } = LogEventLevel.Error;
-    }
-
-    public class AdminLogLevelSettings : IAdminLogLevelSettings
-    {
-        public LogEventLevel Default { get; set; } = LogEventLevel.Error;
-    }
-
-    public class EventsLogLevelSettings : IEventsLogLevelSettings
-    {
-        public LogEventLevel Default { get; set; } = LogEventLevel.Error;
-        public LogEventLevel IdentityToken { get; set; } = LogEventLevel.Fatal;
-    }
-
-    public class EventsProcessorLogLevelSettings : IEventsProcessorLogLevelSettings
-    {
-        public LogEventLevel Default { get; set; } = LogEventLevel.Warning;
-    }
-
-    public class IconsLogLevelSettings : IIconsLogLevelSettings
-    {
-        public LogEventLevel Default { get; set; } = LogEventLevel.Error;
-    }
-
-    public class NotificationsLogLevelSettings : INotificationsLogLevelSettings
-    {
-        public LogEventLevel Default { get; set; } = LogEventLevel.Warning;
-        public LogEventLevel IdentityToken { get; set; } = LogEventLevel.Fatal;
     }
 }

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -1,4 +1,4 @@
-﻿using Bit.Core.Settings.LogSettings;
+﻿using Bit.Core.Settings.LoggingSettings;
 
 namespace Bit.Core.Settings;
 

--- a/src/Core/Settings/IGlobalSettings.cs
+++ b/src/Core/Settings/IGlobalSettings.cs
@@ -15,4 +15,5 @@ public interface IGlobalSettings
     IBaseServiceUriSettings BaseServiceUri { get; set; }
     ITwoFactorAuthSettings TwoFactorAuth { get; set; }
     ISsoSettings Sso { get; set; }
+    ILogLevelSettings MinLogLevel { get; set; }
 }

--- a/src/Core/Settings/ILogLevelSettings.cs
+++ b/src/Core/Settings/ILogLevelSettings.cs
@@ -1,0 +1,74 @@
+using Serilog.Events;
+
+namespace Bit.Core.Settings;
+
+public interface ILogLevelSettings
+{
+    IBillingLogLevelSettings BillingSettings { get; set; }
+    IApiLogLevelSettings ApiSettings { get; set; }
+    IIdentityLogLevelSettings IdentitySettings { get; set; }
+    IScimLogLevelSettings ScimSettings { get; set; }
+    ISsoLogLevelSettings SsoSettings { get; set; }
+    IAdminLogLevelSettings AdminSettings { get; set; }
+    IEventsLogLevelSettings EventsSettings { get; set; }
+    IEventsProcessorLogLevelSettings EventsProcessorSettings { get; set; }
+    IIconsLogLevelSettings IconsSettings { get; set; }
+    INotificationsLogLevelSettings NotificationsSettings { get; set; }
+}
+
+public interface IBillingLogLevelSettings
+{
+    LogEventLevel Default { get; set; }
+    LogEventLevel Jobs { get; set; }
+}
+
+public interface IApiLogLevelSettings
+{
+    LogEventLevel Default { get; set; }
+    LogEventLevel IdentityToken { get; set; }
+    LogEventLevel IpRateLimit { get; set; }
+}
+
+public interface IIdentityLogLevelSettings
+{
+    LogEventLevel Default { get; set; }
+    LogEventLevel IdentityToken { get; set; }
+    LogEventLevel IpRateLimit { get; set; }
+}
+
+public interface IScimLogLevelSettings
+{
+    LogEventLevel Default { get; set; }
+}
+
+public interface ISsoLogLevelSettings
+{
+    LogEventLevel Default { get; set; }
+}
+
+public interface IAdminLogLevelSettings
+{
+    LogEventLevel Default { get; set; }
+}
+
+public interface IEventsLogLevelSettings
+{
+    LogEventLevel Default { get; set; }
+    LogEventLevel IdentityToken { get; set; }
+}
+
+public interface IEventsProcessorLogLevelSettings
+{
+    LogEventLevel Default { get; set; }
+}
+
+public interface IIconsLogLevelSettings
+{
+    LogEventLevel Default { get; set; }
+}
+
+public interface INotificationsLogLevelSettings
+{
+    LogEventLevel Default { get; set; }
+    LogEventLevel IdentityToken { get; set; }
+}

--- a/src/Core/Settings/ILogLevelSettings.cs
+++ b/src/Core/Settings/ILogLevelSettings.cs
@@ -1,4 +1,4 @@
-using Serilog.Events;
+﻿using Serilog.Events;
 
 namespace Bit.Core.Settings;
 

--- a/src/Core/Settings/LoggingSettings/AdminLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/AdminLogLevelSettings.cs
@@ -1,0 +1,8 @@
+using Serilog.Events;
+
+namespace Bit.Core.Settings.LogSettings;
+
+public class AdminLogLevelSettings : IAdminLogLevelSettings
+{
+    public LogEventLevel Default { get; set; } = LogEventLevel.Error;
+}

--- a/src/Core/Settings/LoggingSettings/AdminLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/AdminLogLevelSettings.cs
@@ -1,4 +1,4 @@
-using Serilog.Events;
+﻿using Serilog.Events;
 
 namespace Bit.Core.Settings.LogSettings;
 

--- a/src/Core/Settings/LoggingSettings/AdminLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/AdminLogLevelSettings.cs
@@ -1,6 +1,6 @@
 ﻿using Serilog.Events;
 
-namespace Bit.Core.Settings.LogSettings;
+namespace Bit.Core.Settings.LoggingSettings;
 
 public class AdminLogLevelSettings : IAdminLogLevelSettings
 {

--- a/src/Core/Settings/LoggingSettings/ApiLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/ApiLogLevelSettings.cs
@@ -1,6 +1,6 @@
 ﻿using Serilog.Events;
 
-namespace Bit.Core.Settings.LogSettings;
+namespace Bit.Core.Settings.LoggingSettings;
 
 public class ApiLogLevelSettings : IApiLogLevelSettings
 {

--- a/src/Core/Settings/LoggingSettings/ApiLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/ApiLogLevelSettings.cs
@@ -1,0 +1,10 @@
+using Serilog.Events;
+
+namespace Bit.Core.Settings.LogSettings;
+
+public class ApiLogLevelSettings : IApiLogLevelSettings
+{
+    public LogEventLevel Default { get; set; } = LogEventLevel.Error;
+    public LogEventLevel IdentityToken { get; set; } = LogEventLevel.Fatal;
+    public LogEventLevel IpRateLimit { get; set; } = LogEventLevel.Information;
+}

--- a/src/Core/Settings/LoggingSettings/ApiLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/ApiLogLevelSettings.cs
@@ -1,4 +1,4 @@
-using Serilog.Events;
+﻿using Serilog.Events;
 
 namespace Bit.Core.Settings.LogSettings;
 

--- a/src/Core/Settings/LoggingSettings/BillingLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/BillingLogLevelSettings.cs
@@ -1,6 +1,6 @@
 ﻿using Serilog.Events;
 
-namespace Bit.Core.Settings.LogSettings;
+namespace Bit.Core.Settings.LoggingSettings;
 
 public class BillingLogLevelSettings : IBillingLogLevelSettings
 {

--- a/src/Core/Settings/LoggingSettings/BillingLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/BillingLogLevelSettings.cs
@@ -1,4 +1,4 @@
-using Serilog.Events;
+﻿using Serilog.Events;
 
 namespace Bit.Core.Settings.LogSettings;
 

--- a/src/Core/Settings/LoggingSettings/BillingLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/BillingLogLevelSettings.cs
@@ -1,0 +1,9 @@
+using Serilog.Events;
+
+namespace Bit.Core.Settings.LogSettings;
+
+public class BillingLogLevelSettings : IBillingLogLevelSettings
+{
+    public LogEventLevel Default { get; set; } = LogEventLevel.Warning;
+    public LogEventLevel Jobs { get; set; } = LogEventLevel.Information;
+}

--- a/src/Core/Settings/LoggingSettings/EventsLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/EventsLogLevelSettings.cs
@@ -1,4 +1,4 @@
-using Serilog.Events;
+﻿using Serilog.Events;
 
 namespace Bit.Core.Settings.LogSettings;
 

--- a/src/Core/Settings/LoggingSettings/EventsLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/EventsLogLevelSettings.cs
@@ -1,6 +1,6 @@
 ﻿using Serilog.Events;
 
-namespace Bit.Core.Settings.LogSettings;
+namespace Bit.Core.Settings.LoggingSettings;
 
 public class EventsLogLevelSettings : IEventsLogLevelSettings
 {

--- a/src/Core/Settings/LoggingSettings/EventsLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/EventsLogLevelSettings.cs
@@ -1,0 +1,9 @@
+using Serilog.Events;
+
+namespace Bit.Core.Settings.LogSettings;
+
+public class EventsLogLevelSettings : IEventsLogLevelSettings
+{
+    public LogEventLevel Default { get; set; } = LogEventLevel.Error;
+    public LogEventLevel IdentityToken { get; set; } = LogEventLevel.Fatal;
+}

--- a/src/Core/Settings/LoggingSettings/EventsProcessorLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/EventsProcessorLogLevelSettings.cs
@@ -1,0 +1,8 @@
+using Serilog.Events;
+
+namespace Bit.Core.Settings.LogSettings;
+
+public class EventsProcessorLogLevelSettings : IEventsProcessorLogLevelSettings
+{
+    public LogEventLevel Default { get; set; } = LogEventLevel.Warning;
+}

--- a/src/Core/Settings/LoggingSettings/EventsProcessorLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/EventsProcessorLogLevelSettings.cs
@@ -1,4 +1,4 @@
-using Serilog.Events;
+﻿using Serilog.Events;
 
 namespace Bit.Core.Settings.LogSettings;
 

--- a/src/Core/Settings/LoggingSettings/EventsProcessorLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/EventsProcessorLogLevelSettings.cs
@@ -1,6 +1,6 @@
 ﻿using Serilog.Events;
 
-namespace Bit.Core.Settings.LogSettings;
+namespace Bit.Core.Settings.LoggingSettings;
 
 public class EventsProcessorLogLevelSettings : IEventsProcessorLogLevelSettings
 {

--- a/src/Core/Settings/LoggingSettings/IconsLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/IconsLogLevelSettings.cs
@@ -1,6 +1,6 @@
 ﻿using Serilog.Events;
 
-namespace Bit.Core.Settings.LogSettings;
+namespace Bit.Core.Settings.LoggingSettings;
 
 public class IconsLogLevelSettings : IIconsLogLevelSettings
 {

--- a/src/Core/Settings/LoggingSettings/IconsLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/IconsLogLevelSettings.cs
@@ -1,4 +1,4 @@
-using Serilog.Events;
+﻿using Serilog.Events;
 
 namespace Bit.Core.Settings.LogSettings;
 

--- a/src/Core/Settings/LoggingSettings/IconsLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/IconsLogLevelSettings.cs
@@ -1,0 +1,8 @@
+using Serilog.Events;
+
+namespace Bit.Core.Settings.LogSettings;
+
+public class IconsLogLevelSettings : IIconsLogLevelSettings
+{
+    public LogEventLevel Default { get; set; } = LogEventLevel.Error;
+}

--- a/src/Core/Settings/LoggingSettings/IdentityLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/IdentityLogLevelSettings.cs
@@ -1,0 +1,10 @@
+using Serilog.Events;
+
+namespace Bit.Core.Settings.LogSettings;
+
+public class IdentityLogLevelSettings : IIdentityLogLevelSettings
+{
+    public LogEventLevel Default { get; set; } = LogEventLevel.Error;
+    public LogEventLevel IdentityToken { get; set; } = LogEventLevel.Fatal;
+    public LogEventLevel IpRateLimit { get; set; } = LogEventLevel.Information;
+}

--- a/src/Core/Settings/LoggingSettings/IdentityLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/IdentityLogLevelSettings.cs
@@ -1,6 +1,6 @@
 ﻿using Serilog.Events;
 
-namespace Bit.Core.Settings.LogSettings;
+namespace Bit.Core.Settings.LoggingSettings;
 
 public class IdentityLogLevelSettings : IIdentityLogLevelSettings
 {

--- a/src/Core/Settings/LoggingSettings/IdentityLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/IdentityLogLevelSettings.cs
@@ -1,4 +1,4 @@
-using Serilog.Events;
+﻿using Serilog.Events;
 
 namespace Bit.Core.Settings.LogSettings;
 

--- a/src/Core/Settings/LoggingSettings/LogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/LogLevelSettings.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace Bit.Core.Settings.LogSettings;
+namespace Bit.Core.Settings.LoggingSettings;
 
 public class LogLevelSettings : ILogLevelSettings
 {

--- a/src/Core/Settings/LoggingSettings/LogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/LogLevelSettings.cs
@@ -1,0 +1,16 @@
+
+namespace Bit.Core.Settings.LogSettings;
+
+public class LogLevelSettings : ILogLevelSettings
+{
+    public IBillingLogLevelSettings BillingSettings { get; set; } = new BillingLogLevelSettings();
+    public IApiLogLevelSettings ApiSettings { get; set; } = new ApiLogLevelSettings();
+    public IIdentityLogLevelSettings IdentitySettings { get; set; } = new IdentityLogLevelSettings();
+    public IScimLogLevelSettings ScimSettings { get; set; } = new ScimLogLevelSettings();
+    public ISsoLogLevelSettings SsoSettings { get; set; } = new SsoLogLevelSettings();
+    public IAdminLogLevelSettings AdminSettings { get; set; } = new AdminLogLevelSettings();
+    public IEventsLogLevelSettings EventsSettings { get; set; } = new EventsLogLevelSettings();
+    public IEventsProcessorLogLevelSettings EventsProcessorSettings { get; set; } = new EventsProcessorLogLevelSettings();
+    public IIconsLogLevelSettings IconsSettings { get; set; } = new IconsLogLevelSettings();
+    public INotificationsLogLevelSettings NotificationsSettings { get; set; } = new NotificationsLogLevelSettings();
+}

--- a/src/Core/Settings/LoggingSettings/LogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/LogLevelSettings.cs
@@ -1,4 +1,4 @@
-
+﻿
 namespace Bit.Core.Settings.LogSettings;
 
 public class LogLevelSettings : ILogLevelSettings

--- a/src/Core/Settings/LoggingSettings/NotificationsLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/NotificationsLogLevelSettings.cs
@@ -1,0 +1,9 @@
+using Serilog.Events;
+
+namespace Bit.Core.Settings.LogSettings;
+
+public class NotificationsLogLevelSettings : INotificationsLogLevelSettings
+{
+    public LogEventLevel Default { get; set; } = LogEventLevel.Warning;
+    public LogEventLevel IdentityToken { get; set; } = LogEventLevel.Fatal;
+}

--- a/src/Core/Settings/LoggingSettings/NotificationsLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/NotificationsLogLevelSettings.cs
@@ -1,4 +1,4 @@
-using Serilog.Events;
+﻿using Serilog.Events;
 
 namespace Bit.Core.Settings.LogSettings;
 

--- a/src/Core/Settings/LoggingSettings/NotificationsLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/NotificationsLogLevelSettings.cs
@@ -1,6 +1,6 @@
 ﻿using Serilog.Events;
 
-namespace Bit.Core.Settings.LogSettings;
+namespace Bit.Core.Settings.LoggingSettings;
 
 public class NotificationsLogLevelSettings : INotificationsLogLevelSettings
 {

--- a/src/Core/Settings/LoggingSettings/ScimLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/ScimLogLevelSettings.cs
@@ -1,4 +1,4 @@
-using Serilog.Events;
+﻿using Serilog.Events;
 
 namespace Bit.Core.Settings.LogSettings;
 

--- a/src/Core/Settings/LoggingSettings/ScimLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/ScimLogLevelSettings.cs
@@ -1,0 +1,8 @@
+using Serilog.Events;
+
+namespace Bit.Core.Settings.LogSettings;
+
+public class ScimLogLevelSettings : IScimLogLevelSettings
+{
+    public LogEventLevel Default { get; set; } = LogEventLevel.Warning;
+}

--- a/src/Core/Settings/LoggingSettings/ScimLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/ScimLogLevelSettings.cs
@@ -1,6 +1,6 @@
 ﻿using Serilog.Events;
 
-namespace Bit.Core.Settings.LogSettings;
+namespace Bit.Core.Settings.LoggingSettings;
 
 public class ScimLogLevelSettings : IScimLogLevelSettings
 {

--- a/src/Core/Settings/LoggingSettings/SsoLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/SsoLogLevelSettings.cs
@@ -1,0 +1,8 @@
+using Serilog.Events;
+
+namespace Bit.Core.Settings.LogSettings;
+
+public class SsoLogLevelSettings : ISsoLogLevelSettings
+{
+    public LogEventLevel Default { get; set; } = LogEventLevel.Error;
+}

--- a/src/Core/Settings/LoggingSettings/SsoLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/SsoLogLevelSettings.cs
@@ -1,4 +1,4 @@
-using Serilog.Events;
+﻿using Serilog.Events;
 
 namespace Bit.Core.Settings.LogSettings;
 

--- a/src/Core/Settings/LoggingSettings/SsoLogLevelSettings.cs
+++ b/src/Core/Settings/LoggingSettings/SsoLogLevelSettings.cs
@@ -1,6 +1,6 @@
 ﻿using Serilog.Events;
 
-namespace Bit.Core.Settings.LogSettings;
+namespace Bit.Core.Settings.LoggingSettings;
 
 public class SsoLogLevelSettings : ISsoLogLevelSettings
 {

--- a/src/Core/Tokens/DataProtectorTokenFactory.cs
+++ b/src/Core/Tokens/DataProtectorTokenFactory.cs
@@ -50,7 +50,7 @@ public class DataProtectorTokenFactory<T> : IDataProtectorTokenFactory<T> where 
         }
         catch (Exception ex)
         {
-            _logger.LogInformation(ex, "Failed to unprotect token: {0}", token);
+            _logger.LogInformation(ex, "Failed to unprotect token: {@0}", token);
             data = default;
             return false;
         }

--- a/src/Core/Tokens/DataProtectorTokenFactory.cs
+++ b/src/Core/Tokens/DataProtectorTokenFactory.cs
@@ -50,7 +50,7 @@ public class DataProtectorTokenFactory<T> : IDataProtectorTokenFactory<T> where 
         }
         catch (Exception ex)
         {
-            _logger.LogInformation(ex, "Failed to unprotect token: {@0}", token);
+            _logger.LogInformation(ex, "Failed to unprotect token: {rawToken}", token);
             data = default;
             return false;
         }

--- a/src/Core/Tokens/DataProtectorTokenFactory.cs
+++ b/src/Core/Tokens/DataProtectorTokenFactory.cs
@@ -48,8 +48,9 @@ public class DataProtectorTokenFactory<T> : IDataProtectorTokenFactory<T> where 
             data = Unprotect(token);
             return true;
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogInformation(ex, "Failed to unprotect token: {0}", token);
             data = default;
             return false;
         }

--- a/src/Core/Tokens/DataProtectorTokenFactory.cs
+++ b/src/Core/Tokens/DataProtectorTokenFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Logging;
 
 namespace Bit.Core.Tokens;
 
@@ -6,15 +7,17 @@ public class DataProtectorTokenFactory<T> : IDataProtectorTokenFactory<T> where 
 {
     private readonly IDataProtector _dataProtector;
     private readonly string _clearTextPrefix;
+    private readonly ILogger<DataProtectorTokenFactory<T>> _logger;
 
-    public DataProtectorTokenFactory(string clearTextPrefix, string purpose, IDataProtectionProvider dataProtectionProvider)
+    public DataProtectorTokenFactory(string clearTextPrefix, string purpose, IDataProtectionProvider dataProtectionProvider, ILogger<DataProtectorTokenFactory<T>> logger)
     {
         _dataProtector = dataProtectionProvider.CreateProtector(purpose);
         _clearTextPrefix = clearTextPrefix;
+        _logger = logger;
     }
 
     public string Protect(T data) =>
-        data.ToToken().ProtectWith(_dataProtector).WithPrefix(_clearTextPrefix).ToString();
+        data.ToToken().ProtectWith(_dataProtector, _logger).WithPrefix(_clearTextPrefix).ToString();
 
     /// <summary>
     /// Unprotect token
@@ -24,7 +27,7 @@ public class DataProtectorTokenFactory<T> : IDataProtectorTokenFactory<T> where 
     /// <returns>The parsed tokenable</returns>
     /// <exception>Throws CryptographicException if fails to unprotect</exception>
     public T Unprotect(string token) =>
-        Tokenable.FromToken<T>(new Token(token).RemovePrefix(_clearTextPrefix).UnprotectWith(_dataProtector).ToString());
+        Tokenable.FromToken<T>(new Token(token).RemovePrefix(_clearTextPrefix).UnprotectWith(_dataProtector, _logger).ToString());
 
     public bool TokenValid(string token)
     {

--- a/src/Core/Tokens/Token.cs
+++ b/src/Core/Tokens/Token.cs
@@ -30,7 +30,7 @@ public class Token
 
     public Token ProtectWith<T>(IDataProtector dataProtector, ILogger<T> logger)
     {
-        logger.LogDebug("Protecting token: {@0}", this);
+        logger.LogDebug("Protecting token: {token}", this);
         return new(dataProtector.Protect(ToString()));
     }
 
@@ -46,7 +46,7 @@ public class Token
             logger.LogInformation(e, "Failed to unprotect token: {token}", this);
             throw;
         }
-        logger.LogDebug("Unprotected token: {token} to {@decryptedToken}", this, unprotected);
+        logger.LogDebug("Unprotected token: {token} to {decryptedToken}", this, unprotected);
         return new(unprotected);
     }
 

--- a/src/Core/Tokens/Token.cs
+++ b/src/Core/Tokens/Token.cs
@@ -28,13 +28,13 @@ public class Token
     }
 
 
-    public Token ProtectWith<T>(IDataProtector dataProtector, ILogger<T> logger)
+    public Token ProtectWith(IDataProtector dataProtector, ILogger logger)
     {
         logger.LogDebug("Protecting token: {token}", this);
         return new(dataProtector.Protect(ToString()));
     }
 
-    public Token UnprotectWith<T>(IDataProtector dataProtector, ILogger<T> logger)
+    public Token UnprotectWith(IDataProtector dataProtector, ILogger logger)
     {
         var unprotected = "";
         try

--- a/src/Core/Tokens/Token.cs
+++ b/src/Core/Tokens/Token.cs
@@ -43,11 +43,11 @@ public class Token
         }
         catch (Exception e)
         {
-            logger.LogInformation(e, "Failed to unprotect token: {@0}", this);
+            logger.LogInformation(e, "Failed to unprotect token: {token}", this);
             throw;
         }
-        logger.LogDebug("Unprotected token: {@0} to {@1}", this, unprotected);
-        return new(dataProtector.Unprotect(ToString()));
+        logger.LogDebug("Unprotected token: {token} to {@decryptedToken}", this, unprotected);
+        return new(unprotected);
     }
 
     public override string ToString() => _token;

--- a/src/Core/Tokens/Token.cs
+++ b/src/Core/Tokens/Token.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.DataProtection;
+﻿using Amazon.Runtime.Internal.Util;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Logging;
 
 namespace Bit.Core.Tokens;
 
@@ -26,11 +28,28 @@ public class Token
         return new Token(_token[expectedPrefix.Length..]);
     }
 
-    public Token ProtectWith(IDataProtector dataProtector) =>
-        new(dataProtector.Protect(ToString()));
 
-    public Token UnprotectWith(IDataProtector dataProtector) =>
-        new(dataProtector.Unprotect(ToString()));
+    public Token ProtectWith<T>(IDataProtector dataProtector, ILogger<T> logger)
+    {
+        logger.LogDebug("Protecting token: {0}", this);
+        return new(dataProtector.Protect(ToString()));
+    }
+
+    public Token UnprotectWith<T>(IDataProtector dataProtector, ILogger<T> logger)
+    {
+        var unprotected = "";
+        try
+        {
+            unprotected = dataProtector.Unprotect(ToString());
+        }
+        catch (Exception e)
+        {
+            logger.LogInformation(e, "Failed to unprotect token: {0}", this);
+            throw;
+        }
+        logger.LogDebug("Unprotected token: {0} to {1}", this, unprotected);
+        return new(dataProtector.Unprotect(ToString()));
+    }
 
     public override string ToString() => _token;
 }

--- a/src/Core/Tokens/Token.cs
+++ b/src/Core/Tokens/Token.cs
@@ -1,5 +1,4 @@
-﻿using Amazon.Runtime.Internal.Util;
-using Microsoft.AspNetCore.DataProtection;
+﻿using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging;
 
 namespace Bit.Core.Tokens;

--- a/src/Core/Tokens/Token.cs
+++ b/src/Core/Tokens/Token.cs
@@ -30,7 +30,7 @@ public class Token
 
     public Token ProtectWith<T>(IDataProtector dataProtector, ILogger<T> logger)
     {
-        logger.LogDebug("Protecting token: {0}", this);
+        logger.LogDebug("Protecting token: {@0}", this);
         return new(dataProtector.Protect(ToString()));
     }
 
@@ -43,10 +43,10 @@ public class Token
         }
         catch (Exception e)
         {
-            logger.LogInformation(e, "Failed to unprotect token: {0}", this);
+            logger.LogInformation(e, "Failed to unprotect token: {@0}", this);
             throw;
         }
-        logger.LogDebug("Unprotected token: {0} to {1}", this, unprotected);
+        logger.LogDebug("Unprotected token: {@0} to {@1}", this, unprotected);
         return new(dataProtector.Unprotect(ToString()));
     }
 

--- a/src/Core/Utilities/LoggerFactoryExtensions.cs
+++ b/src/Core/Utilities/LoggerFactoryExtensions.cs
@@ -33,10 +33,10 @@ public static class LoggerFactoryExtensions
         WebHostBuilderContext context,
         Func<LogEvent, IGlobalSettings, bool> filter = null)
     {
-        // if (context.HostingEnvironment.IsDevelopment())
-        // {
-        //     return builder;
-        // }
+        if (context.HostingEnvironment.IsDevelopment())
+        {
+            return builder;
+        }
 
         var globalSettings = new GlobalSettings();
         ConfigurationBinder.Bind(context.Configuration.GetSection("GlobalSettings"), globalSettings);

--- a/src/Core/Utilities/LoggerFactoryExtensions.cs
+++ b/src/Core/Utilities/LoggerFactoryExtensions.cs
@@ -31,12 +31,15 @@ public static class LoggerFactoryExtensions
     public static ILoggingBuilder AddSerilog(
         this ILoggingBuilder builder,
         WebHostBuilderContext context,
-        Func<LogEvent, bool> filter = null)
+        Func<LogEvent, IGlobalSettings, bool> filter = null)
     {
-        if (context.HostingEnvironment.IsDevelopment())
-        {
-            return builder;
-        }
+        // if (context.HostingEnvironment.IsDevelopment())
+        // {
+        //     return builder;
+        // }
+
+        var globalSettings = new GlobalSettings();
+        ConfigurationBinder.Bind(context.Configuration.GetSection("GlobalSettings"), globalSettings);
 
         bool inclusionPredicate(LogEvent e)
         {
@@ -49,11 +52,8 @@ public static class LoggerFactoryExtensions
             {
                 return true;
             }
-            return filter(e);
+            return filter(e, globalSettings);
         }
-
-        var globalSettings = new GlobalSettings();
-        ConfigurationBinder.Bind(context.Configuration.GetSection("GlobalSettings"), globalSettings);
 
         var config = new LoggerConfiguration()
             .Enrich.FromLogContext()

--- a/src/Events/Program.cs
+++ b/src/Events/Program.cs
@@ -14,13 +14,13 @@ public class Program
             {
                 webBuilder.UseStartup<Startup>();
                 webBuilder.ConfigureLogging((hostingContext, logging) =>
-                    logging.AddSerilog(hostingContext, e =>
+                    logging.AddSerilog(hostingContext, (e, globalSettings) =>
                     {
                         var context = e.Properties["SourceContext"].ToString();
                         if (context.Contains("IdentityServer4.Validation.TokenValidator") ||
                             context.Contains("IdentityServer4.Validation.TokenRequestValidator"))
                         {
-                            return e.Level > LogEventLevel.Error;
+                            return e.Level >= globalSettings.MinLogLevel.EventsSettings.IdentityToken;
                         }
 
                         if (e.Properties.ContainsKey("RequestPath") &&
@@ -30,7 +30,7 @@ public class Program
                             return false;
                         }
 
-                        return e.Level >= LogEventLevel.Error;
+                        return e.Level >= globalSettings.MinLogLevel.EventsSettings.Default;
                     }));
             })
             .Build()

--- a/src/Events/Program.cs
+++ b/src/Events/Program.cs
@@ -1,5 +1,4 @@
 ﻿using Bit.Core.Utilities;
-using Serilog.Events;
 
 namespace Bit.Events;
 

--- a/src/EventsProcessor/Program.cs
+++ b/src/EventsProcessor/Program.cs
@@ -1,5 +1,4 @@
 ﻿using Bit.Core.Utilities;
-using Serilog.Events;
 
 namespace Bit.EventsProcessor;
 

--- a/src/EventsProcessor/Program.cs
+++ b/src/EventsProcessor/Program.cs
@@ -13,7 +13,7 @@ public class Program
             {
                 webBuilder.UseStartup<Startup>();
                 webBuilder.ConfigureLogging((hostingContext, logging) =>
-                    logging.AddSerilog(hostingContext, e => e.Level >= LogEventLevel.Warning));
+                    logging.AddSerilog(hostingContext, (e, globalSettings) => e.Level >= globalSettings.MinLogLevel.EventsProcessorSettings.Default));
             })
             .Build()
             .Run();

--- a/src/Icons/Program.cs
+++ b/src/Icons/Program.cs
@@ -13,7 +13,7 @@ public class Program
             {
                 webBuilder.UseStartup<Startup>();
                 webBuilder.ConfigureLogging((hostingContext, logging) =>
-                    logging.AddSerilog(hostingContext, e => e.Level >= LogEventLevel.Error));
+                    logging.AddSerilog(hostingContext, (e, globalSettings) => e.Level >= globalSettings.MinLogLevel.IconsSettings.Default));
             })
             .Build()
             .Run();

--- a/src/Icons/Program.cs
+++ b/src/Icons/Program.cs
@@ -1,5 +1,4 @@
 ﻿using Bit.Core.Utilities;
-using Serilog.Events;
 
 namespace Bit.Icons;
 

--- a/src/Identity/Program.cs
+++ b/src/Identity/Program.cs
@@ -1,6 +1,5 @@
 ﻿using AspNetCoreRateLimit;
 using Bit.Core.Utilities;
-using Serilog.Events;
 
 namespace Bit.Identity;
 

--- a/src/Identity/Program.cs
+++ b/src/Identity/Program.cs
@@ -22,22 +22,21 @@ public class Program
             {
                 webBuilder.UseStartup<Startup>();
                 webBuilder.ConfigureLogging((hostingContext, logging) =>
-                    logging.AddSerilog(hostingContext, e =>
+                    logging.AddSerilog(hostingContext, (e, globalSettings) =>
                     {
                         var context = e.Properties["SourceContext"].ToString();
-                        if (context.Contains(typeof(IpRateLimitMiddleware).FullName) &&
-                            e.Level == LogEventLevel.Information)
+                        if (context.Contains(typeof(IpRateLimitMiddleware).FullName))
                         {
-                            return true;
+                            return e.Level >= globalSettings.MinLogLevel.IdentitySettings.IpRateLimit;
                         }
 
                         if (context.Contains("IdentityServer4.Validation.TokenValidator") ||
                             context.Contains("IdentityServer4.Validation.TokenRequestValidator"))
                         {
-                            return e.Level > LogEventLevel.Error;
+                            return e.Level >= globalSettings.MinLogLevel.IdentitySettings.IdentityToken;
                         }
 
-                        return e.Level >= LogEventLevel.Error;
+                        return e.Level >= globalSettings.MinLogLevel.IdentitySettings.Default;
                     }));
             });
     }

--- a/src/Notifications/Program.cs
+++ b/src/Notifications/Program.cs
@@ -14,13 +14,13 @@ public class Program
             {
                 webBuilder.UseStartup<Startup>();
                 webBuilder.ConfigureLogging((hostingContext, logging) =>
-                    logging.AddSerilog(hostingContext, e =>
+                    logging.AddSerilog(hostingContext, (e, globalSettings) =>
                     {
                         var context = e.Properties["SourceContext"].ToString();
                         if (context.Contains("IdentityServer4.Validation.TokenValidator") ||
                             context.Contains("IdentityServer4.Validation.TokenRequestValidator"))
                         {
-                            return e.Level > LogEventLevel.Error;
+                            return e.Level >= globalSettings.MinLogLevel.NotificationsSettings.IdentityToken;
                         }
 
                         if (e.Level == LogEventLevel.Error &&
@@ -41,7 +41,7 @@ public class Program
                             return false;
                         }
 
-                        return e.Level >= LogEventLevel.Warning;
+                        return e.Level >= globalSettings.MinLogLevel.NotificationsSettings.Default;
                     }));
             })
             .Build()

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -35,6 +35,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Serilog.Context;
 using StackExchange.Redis;
@@ -116,19 +117,22 @@ public static class ServiceCollectionExtensions
             new DataProtectorTokenFactory<EmergencyAccessInviteTokenable>(
                 EmergencyAccessInviteTokenable.ClearTextPrefix,
                 EmergencyAccessInviteTokenable.DataProtectorPurpose,
-                serviceProvider.GetDataProtectionProvider())
+                serviceProvider.GetDataProtectionProvider(),
+                serviceProvider.GetRequiredService<ILogger<DataProtectorTokenFactory<EmergencyAccessInviteTokenable>>>())
         );
         services.AddSingleton<IDataProtectorTokenFactory<HCaptchaTokenable>>(serviceProvider =>
             new DataProtectorTokenFactory<HCaptchaTokenable>(
                 HCaptchaTokenable.ClearTextPrefix,
                 HCaptchaTokenable.DataProtectorPurpose,
-                serviceProvider.GetDataProtectionProvider())
+                serviceProvider.GetDataProtectionProvider(),
+                serviceProvider.GetRequiredService<ILogger<DataProtectorTokenFactory<HCaptchaTokenable>>>())
         );
         services.AddSingleton<IDataProtectorTokenFactory<SsoTokenable>>(serviceProvider =>
             new DataProtectorTokenFactory<SsoTokenable>(
                 SsoTokenable.ClearTextPrefix,
                 SsoTokenable.DataProtectorPurpose,
-                serviceProvider.GetDataProtectionProvider()));
+                serviceProvider.GetDataProtectionProvider(),
+                serviceProvider.GetRequiredService<ILogger<DataProtectorTokenFactory<SsoTokenable>>>()));
     }
 
     public static void AddDefaultServices(this IServiceCollection services, GlobalSettings globalSettings)


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other -- hotfix candidate for extra logging diagnostics
```

## Objective

We're experiencing token protection/unprotection issues for a new stepped onboarding flow. To continue diagnosis, we need insight into these protected strings.

We also want to be able to reduce these log levels without code changes, which is the reason for the GlobalSettings changes.

Log level defaults are matched to current values, and to increase level to a given are, you would set that config. For example, for this issue, we will need

```bash
globalSettings__minLogLevel__identitySettings__default=debug
```


## Code changes
- **Program.cs**: all of these changes are just redirecting to use globalSettings values.
- **OrganizationServiceCollectionExtension/ServiceCollectionExtensions**: add logger to data protector factories
- **LoggerFactoryExtensions**: Add globalSettings to the filter predicates.
- **Token**: Add logging to protect and unprotect
- **DataProtectorTokenFactory**: add logging to exceptions caught during unprotect.
- **settings/*.ts**: These are all the settings changes. Add interfaces for log level and defaults to GlobalSettings Object to match the current filter values.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
