### PR TITLE
Hotfix/add logging to tokenables

### DIFF
--- a/src/Core/Utilities/LoggerFactoryExtensions.cs
+++ b/src/Core/Utilities/LoggerFactoryExtensions.cs
@@ -57,6 +57,7 @@ namespace Bit.Core.Utilities
             }
 
             var config = new LoggerConfiguration()
+                .MinimumLevel.Debug()
                 .Enrich.FromLogContext()
                 .Filter.ByIncludingOnly(inclusionPredicate);
 


### PR DESCRIPTION
Set serilog min level. This is further filtered by both our own filters and MS appsettings