### PR TITLE
[SM-207] API for listing service accounts by organization

### DIFF
--- a/src/Api/Controllers/ServiceAccountsController.cs
+++ b/src/Api/Controllers/ServiceAccountsController.cs
@@ -1,0 +1,27 @@
+﻿using Bit.Api.Models.Response;
+using Bit.Api.SecretManagerFeatures.Models.Response;
+using Bit.Api.Utilities;
+using Bit.Core.Repositories;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bit.Api.Controllers
+{
+    [SecretsManager]
+    public class ServiceAccountsController : Controller
+    {
+        private readonly IServiceAccountRepository _serviceAccountRepository;
+
+        public ServiceAccountsController(IServiceAccountRepository serviceAccountRepository)
+        {
+            _serviceAccountRepository = serviceAccountRepository;
+        }
+
+        [HttpGet("organizations/{organizationId}/service-accounts")]
+        public async Task<ListResponseModel<ServiceAccountResponseModel>> GetServiceAccountsByOrganizationAsync([FromRoute] Guid organizationId)
+        {
+            var serviceAccounts = await _serviceAccountRepository.GetManyByOrganizationIdAsync(organizationId);
+            var responses = serviceAccounts.Select(serviceAccount => new ServiceAccountResponseModel(serviceAccount));
+            return new ListResponseModel<ServiceAccountResponseModel>(responses);
+        }
+    }
+}

--- a/src/Api/SecretManagerFeatures/Models/Response/ServiceAccountResponseModel.cs
+++ b/src/Api/SecretManagerFeatures/Models/Response/ServiceAccountResponseModel.cs
@@ -1,0 +1,34 @@
+﻿using Bit.Core.Entities;
+using Bit.Core.Models.Api;
+
+namespace Bit.Api.SecretManagerFeatures.Models.Response
+{
+    public class ServiceAccountResponseModel : ResponseModel
+    {
+        public ServiceAccountResponseModel(ServiceAccount serviceAccount, string obj = "serviceAccount")
+            : base(obj)
+        {
+            if (serviceAccount == null)
+            {
+                throw new ArgumentNullException(nameof(serviceAccount));
+            }
+
+            Id = serviceAccount.Id.ToString();
+            OrganizationId = serviceAccount.OrganizationId.ToString();
+            Name = serviceAccount.Name;
+            CreationDate = serviceAccount.CreationDate;
+            RevisionDate = serviceAccount.RevisionDate;
+        }
+
+        public string Id { get; set; }
+
+        public string OrganizationId { get; set; }
+
+        public string Name { get; set; }
+
+        public DateTime CreationDate { get; set; }
+
+        public DateTime RevisionDate { get; set; }
+    }
+}
+

--- a/test/Api.Test/Controllers/ServiceAccountsControllerTests.cs
+++ b/test/Api.Test/Controllers/ServiceAccountsControllerTests.cs
@@ -1,0 +1,41 @@
+﻿using Bit.Api.Controllers;
+using Bit.Core.Entities;
+using Bit.Core.Repositories;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Bit.Test.Common.Helpers;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Api.Test.Controllers
+{
+    [ControllerCustomize(typeof(ServiceAccountsController))]
+    [SutProviderCustomize]
+    [JsonDocumentCustomize]
+    public class ServiceAccountsControllerTests
+    {
+        [Theory]
+        [BitAutoData]
+        public async void GetServiceAccountsByOrganization_ReturnsEmptyList(SutProvider<ServiceAccountsController> sutProvider, Guid id)
+        {
+            var result = await sutProvider.Sut.GetServiceAccountsByOrganizationAsync(id);
+
+            await sutProvider.GetDependency<IServiceAccountRepository>().Received(1)
+                         .GetManyByOrganizationIdAsync(Arg.Is(AssertHelper.AssertPropertyEqual(id)));
+
+            Assert.Empty(result.Data);
+        }
+
+        [Theory]
+        [BitAutoData]
+        public async void GetServiceAccountsByOrganization_Success(SutProvider<ServiceAccountsController> sutProvider, ServiceAccount resultServiceAccount)
+        {
+            sutProvider.GetDependency<IServiceAccountRepository>().GetManyByOrganizationIdAsync(default).ReturnsForAnyArgs(new List<ServiceAccount>() { resultServiceAccount });
+
+            var result = await sutProvider.Sut.GetServiceAccountsByOrganizationAsync(resultServiceAccount.OrganizationId);
+
+            await sutProvider.GetDependency<IServiceAccountRepository>().Received(1)
+                         .GetManyByOrganizationIdAsync(Arg.Is(AssertHelper.AssertPropertyEqual(resultServiceAccount.OrganizationId)));
+        }
+    }
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The purpose of this PR is to add an endpoint to the API to fetch all service accounts for an organization.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- src/Api/Controllers/ServiceAccountsController.cs

New controller for service accounts with a GET endpoint for fetching service accounts by organization

- src/Api/SecretManagerFeatures/Models/Response/ServiceAccountResponseModel.cs

Response model for returning a service account model

- test/Api.Test/Controllers/ServiceAccountsControllerTests.cs

Unit tests for the new controller and endpoint

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
