### PR TITLE
[EC-588] Add secrets override for dev logging

### DIFF
--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -25,7 +25,7 @@ public class GlobalSettings : IGlobalSettings
         set => _logDirectory = value;
     }
     public virtual long? LogRollBySizeLimit { get; set; }
-    public virtual bool DevLogging { get; set; } = false;
+    public virtual bool EnableDevLogging { get; set; } = false;
     public virtual string LicenseDirectory
     {
         get => BuildDirectory(_licenseDirectory, "/core/licenses");

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -25,6 +25,7 @@ public class GlobalSettings : IGlobalSettings
         set => _logDirectory = value;
     }
     public virtual long? LogRollBySizeLimit { get; set; }
+    public virtual bool DevLogging { get; set; } = false;
     public virtual string LicenseDirectory
     {
         get => BuildDirectory(_licenseDirectory, "/core/licenses");

--- a/src/Core/Utilities/LoggerFactoryExtensions.cs
+++ b/src/Core/Utilities/LoggerFactoryExtensions.cs
@@ -40,7 +40,7 @@ public static class LoggerFactoryExtensions
         {
             return builder;
         }
-        
+
         bool inclusionPredicate(LogEvent e)
         {
             if (filter == null)

--- a/src/Core/Utilities/LoggerFactoryExtensions.cs
+++ b/src/Core/Utilities/LoggerFactoryExtensions.cs
@@ -20,7 +20,7 @@ public static class LoggerFactoryExtensions
         IHostApplicationLifetime applicationLifetime,
         GlobalSettings globalSettings)
     {
-        if (env.IsDevelopment())
+        if (env.IsDevelopment() && !globalSettings.DevLogging)
         {
             return;
         }
@@ -33,14 +33,14 @@ public static class LoggerFactoryExtensions
         WebHostBuilderContext context,
         Func<LogEvent, IGlobalSettings, bool> filter = null)
     {
-        if (context.HostingEnvironment.IsDevelopment())
-        {
-            return builder;
-        }
-
         var globalSettings = new GlobalSettings();
         ConfigurationBinder.Bind(context.Configuration.GetSection("GlobalSettings"), globalSettings);
 
+        if (context.HostingEnvironment.IsDevelopment() && !globalSettings.DevLogging)
+        {
+            return builder;
+        }
+        
         bool inclusionPredicate(LogEvent e)
         {
             if (filter == null)

--- a/src/Core/Utilities/LoggerFactoryExtensions.cs
+++ b/src/Core/Utilities/LoggerFactoryExtensions.cs
@@ -20,7 +20,7 @@ public static class LoggerFactoryExtensions
         IHostApplicationLifetime applicationLifetime,
         GlobalSettings globalSettings)
     {
-        if (env.IsDevelopment() && !globalSettings.DevLogging)
+        if (env.IsDevelopment() && !globalSettings.EnableDevLogging)
         {
             return;
         }
@@ -36,7 +36,7 @@ public static class LoggerFactoryExtensions
         var globalSettings = new GlobalSettings();
         ConfigurationBinder.Bind(context.Configuration.GetSection("GlobalSettings"), globalSettings);
 
-        if (context.HostingEnvironment.IsDevelopment() && !globalSettings.DevLogging)
+        if (context.HostingEnvironment.IsDevelopment() && !globalSettings.EnableDevLogging)
         {
             return builder;
         }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

We currently have to comment out code to enable logging to disk in dev environments. This PR adds a globalSettings switch to override this in a more convenient and discoverable way.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/Settings/GlobalSettings.cs** - add new override switch, default to `false` which is the current behaviour
* **src/Core/Utilities/LoggerFactoryExtensions.cs** - only return early if it's a dev environment _and_ dev logging is not enabled.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
