### PR TITLE
[SG-169] Add arguements to AuthRequest_Update.sql

### DIFF
--- a/util/Migrator/DbScripts/2022-09-12_01_AuthRequestUpdate.sql
+++ b/util/Migrator/DbScripts/2022-09-12_01_AuthRequestUpdate.sql
@@ -1,4 +1,10 @@
-﻿CREATE PROCEDURE [dbo].[AuthRequest_Update]
+IF OBJECT_ID('[dbo].[AuthRequest_Update]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[AuthRequest_Update]
+END
+GO
+
+CREATE PROCEDURE [dbo].[AuthRequest_Update]
     @Id UNIQUEIDENTIFIER OUTPUT,
     @UserId UNIQUEIDENTIFIER,
     @Type SMALLINT, 
@@ -38,3 +44,4 @@ BEGIN
     WHERE
         [Id] = @Id
 END
+GO


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
In QA cloud responding to an auth request is throwing an error: Procedure or function AuthRequest_Update has too many arguments specified.

This PR addresses this error.

## Code changes
`AuthRequest_Update` previously only accepted specific arguments for updatable columns. Things like `RequestingUserId`, which should never change, were not included in the arguments list for the procedure. While technically true, this isn't the pattern we usually have for update procedures. `Send_Update.sql` is a good example, where the procedure accepts arguments for the entire table and it is up to callers to supply the full object that needs to be updated. 

This PR updates `AuthRequest_Update` to match this pattern, and adds a migration for that change. It seems like our base Dapper repo that handles generic updates like this expects the full object. This doesn't effect the Entity Framework implementation since that doesn't use stored procedures for updates.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
