### PR TITLE
[SG-692] Block unknown devices from using passwordless auth

### DIFF
--- a/src/Api/Controllers/AuthRequestsController.cs
+++ b/src/Api/Controllers/AuthRequestsController.cs
@@ -89,9 +89,9 @@ public class AuthRequestsController : Controller
         {
             throw new BadRequestException("Device type not provided.");
         }
-        if (!_globalSettings.PasswordlessAuth.KnownDevicesOnly)
+        if (_globalSettings.PasswordlessAuth.KnownDevicesOnly)
         {
-            var d = await _deviceRepository.GetByIdentifierAsync(_currentContext.DeviceIdentifier);
+            var d = await _deviceRepository.GetByIdentifierAsync(model.DeviceIdentifier);
             if (d == null || d.UserId != user.Id)
             {
                 throw new NotFoundException();

--- a/src/Notifications/Startup.cs
+++ b/src/Notifications/Startup.cs
@@ -113,7 +113,7 @@ public class Startup
                 options.ApplicationMaxBufferSize = 2048;
                 options.TransportMaxBufferSize = 4096;
             });
-            endpoints.MapHub<AnonymousNotificationsHub>("/anonymousHub", options =>
+            endpoints.MapHub<AnonymousNotificationsHub>("/anonymous-hub", options =>
             {
                 options.ApplicationMaxBufferSize = 2048;
                 options.TransportMaxBufferSize = 4096;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The unknown device check is turned of in error. This commit flips the conditional, and uses the model provided DeviceId to check instead of relying on context, which doesn't work in this case because of anonymity.

I also renamed the anonymousHub endpoint to anonymous-hub. I think that change is small enough to include here. This does mean this PR has a circular dependency with https://github.com/bitwarden/clients/pull/3650/files


## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
