### PR TITLE
[EC-584] Removed ListResponseModel from OrganizationExportResponseModel

### DIFF
--- a/src/Api/Controllers/OrganizationExportController.cs
+++ b/src/Api/Controllers/OrganizationExportController.cs
@@ -39,25 +39,10 @@ public class OrganizationExportController : Controller
 
         var result = new OrganizationExportResponseModel
         {
-            Collections = GetOrganizationCollectionsResponse(orgCollections),
-            Ciphers = GetOrganizationCiphersResponse(orgCiphers, collectionCiphersGroupDict)
+            Collections = orgCollections.Select(c => new CollectionResponseModel(c)),
+            Ciphers = orgCiphers.Select(c => new CipherMiniDetailsResponseModel(c, _globalSettings, collectionCiphersGroupDict, c.OrganizationUseTotp))
         };
 
         return result;
-    }
-
-    private ListResponseModel<CollectionResponseModel> GetOrganizationCollectionsResponse(IEnumerable<Collection> orgCollections)
-    {
-        var collections = orgCollections.Select(c => new CollectionResponseModel(c));
-        return new ListResponseModel<CollectionResponseModel>(collections);
-    }
-
-    private ListResponseModel<CipherMiniDetailsResponseModel> GetOrganizationCiphersResponse(IEnumerable<CipherOrganizationDetails> orgCiphers,
-        Dictionary<Guid, IGrouping<Guid, CollectionCipher>> collectionCiphersGroupDict)
-    {
-        var responses = orgCiphers.Select(c => new CipherMiniDetailsResponseModel(c, _globalSettings,
-            collectionCiphersGroupDict, c.OrganizationUseTotp));
-
-        return new ListResponseModel<CipherMiniDetailsResponseModel>(responses);
     }
 }

--- a/src/Api/Controllers/OrganizationExportController.cs
+++ b/src/Api/Controllers/OrganizationExportController.cs
@@ -41,8 +41,8 @@ public class OrganizationExportController : Controller
         IEnumerable<Collection> orgCollections = await _collectionService.GetOrganizationCollections(organizationId);
         (IEnumerable<CipherOrganizationDetails> orgCiphers, Dictionary<Guid, IGrouping<Guid, CollectionCipher>> collectionCiphersGroupDict) = await _cipherService.GetOrganizationCiphers(userId, organizationId);
 
-        // Backward compatibility with versions 2022.9.0 and 2022.10.0 that use ListResponseModel
-        if (new[] { "2022.9.0", "2022.10.0" }.Contains(_currentContext.ClientVersion))
+        // Backward compatibility with versions between 2022.9.0 and 2022.11.0 that use ListResponseModel
+        if (_currentContext.ClientVersion >= new Version("2022.9.0") && _currentContext.ClientVersion < new Version("2022.11.0"))
         {
             var organizationExportListResponseModel = new OrganizationExportListResponseModel
             {

--- a/src/Api/Controllers/OrganizationExportController.cs
+++ b/src/Api/Controllers/OrganizationExportController.cs
@@ -41,8 +41,8 @@ public class OrganizationExportController : Controller
         IEnumerable<Collection> orgCollections = await _collectionService.GetOrganizationCollections(organizationId);
         (IEnumerable<CipherOrganizationDetails> orgCiphers, Dictionary<Guid, IGrouping<Guid, CollectionCipher>> collectionCiphersGroupDict) = await _cipherService.GetOrganizationCiphers(userId, organizationId);
 
-        // Backward compatibility
-        if (_currentContext.ClientVersion == "2022.9.0")
+        // Backward compatibility with versions 2022.9.0 and 2022.10.0 that use ListResponseModel
+        if (new[] { "2022.9.0", "2022.10.0" }.Contains(_currentContext.ClientVersion))
         {
             var organizationExportListResponseModel = new OrganizationExportListResponseModel
             {

--- a/src/Api/Controllers/OrganizationExportController.cs
+++ b/src/Api/Controllers/OrganizationExportController.cs
@@ -41,8 +41,8 @@ public class OrganizationExportController : Controller
         IEnumerable<Collection> orgCollections = await _collectionService.GetOrganizationCollections(organizationId);
         (IEnumerable<CipherOrganizationDetails> orgCiphers, Dictionary<Guid, IGrouping<Guid, CollectionCipher>> collectionCiphersGroupDict) = await _cipherService.GetOrganizationCiphers(userId, organizationId);
 
-        // Backward compatibility with versions between 2022.9.0 and 2022.11.0 that use ListResponseModel
-        if (_currentContext.ClientVersion >= new Version("2022.9.0") && _currentContext.ClientVersion < new Version("2022.11.0"))
+        // Backward compatibility with versions before 2022.11.0 that use ListResponseModel
+        if (_currentContext.ClientVersion < new Version("2022.11.0"))
         {
             var organizationExportListResponseModel = new OrganizationExportListResponseModel
             {

--- a/src/Api/Models/Response/OrganizationExportResponseModel.cs
+++ b/src/Api/Models/Response/OrganizationExportResponseModel.cs
@@ -14,7 +14,7 @@ public class OrganizationExportResponseModel : ResponseModel
 }
 
 [Obsolete("This version is for backwards compatibility for client version 2022.9.0")]
-public class ListResponseOrganizationExportResponseModel
+public class OrganizationExportListResponseModel
 {
     public ListResponseModel<CollectionResponseModel> Collections { get; set; }
 

--- a/src/Api/Models/Response/OrganizationExportResponseModel.cs
+++ b/src/Api/Models/Response/OrganizationExportResponseModel.cs
@@ -1,12 +1,14 @@
-﻿namespace Bit.Api.Models.Response;
+﻿using Bit.Core.Models.Api;
 
-public class OrganizationExportResponseModel
+namespace Bit.Api.Models.Response;
+
+public class OrganizationExportResponseModel : ResponseModel
 {
-    public OrganizationExportResponseModel()
+    public OrganizationExportResponseModel() : base("organizationExport")
     {
     }
 
-    public ListResponseModel<CollectionResponseModel> Collections { get; set; }
+    public IEnumerable<CollectionResponseModel> Collections { get; set; }
 
-    public ListResponseModel<CipherMiniDetailsResponseModel> Ciphers { get; set; }
+    public IEnumerable<CipherMiniDetailsResponseModel> Ciphers { get; set; }
 }

--- a/src/Api/Models/Response/OrganizationExportResponseModel.cs
+++ b/src/Api/Models/Response/OrganizationExportResponseModel.cs
@@ -12,3 +12,11 @@ public class OrganizationExportResponseModel : ResponseModel
 
     public IEnumerable<CipherMiniDetailsResponseModel> Ciphers { get; set; }
 }
+
+[Obsolete("This version is for backwards compatibility for client version 2022.9.0")]
+public class ListResponseOrganizationExportResponseModel
+{
+    public ListResponseModel<CollectionResponseModel> Collections { get; set; }
+
+    public ListResponseModel<CipherMiniDetailsResponseModel> Ciphers { get; set; }
+}

--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -32,7 +32,7 @@ public class CurrentContext : ICurrentContext
     public virtual bool MaybeBot { get; set; }
     public virtual int? BotScore { get; set; }
     public virtual string ClientId { get; set; }
-    public virtual string ClientVersion { get; set; }
+    public virtual Version ClientVersion { get; set; }
 
     public CurrentContext(IProviderUserRepository providerUserRepository)
     {
@@ -84,7 +84,7 @@ public class CurrentContext : ICurrentContext
 
         if (httpContext.Request.Headers.ContainsKey("Bitwarden-Client-Version"))
         {
-            ClientVersion = httpContext.Request.Headers["Bitwarden-Client-Version"];
+            ClientVersion = new Version(httpContext.Request.Headers["Bitwarden-Client-Version"]);
         }
     }
 

--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -32,6 +32,7 @@ public class CurrentContext : ICurrentContext
     public virtual bool MaybeBot { get; set; }
     public virtual int? BotScore { get; set; }
     public virtual string ClientId { get; set; }
+    public virtual string ClientVersion { get; set; }
 
     public CurrentContext(IProviderUserRepository providerUserRepository)
     {
@@ -79,6 +80,11 @@ public class CurrentContext : ICurrentContext
         if (httpContext.Request.Headers.ContainsKey("X-Cf-Maybe-Bot"))
         {
             MaybeBot = httpContext.Request.Headers["X-Cf-Maybe-Bot"] == "1";
+        }
+
+        if (httpContext.Request.Headers.ContainsKey("Bitwarden-Client-Version"))
+        {
+            ClientVersion = httpContext.Request.Headers["Bitwarden-Client-Version"];
         }
     }
 

--- a/src/Core/Context/ICurrentContext.cs
+++ b/src/Core/Context/ICurrentContext.cs
@@ -22,6 +22,7 @@ public interface ICurrentContext
     bool MaybeBot { get; set; }
     int? BotScore { get; set; }
     string ClientId { get; set; }
+    string ClientVersion { get; set; }
     Task BuildAsync(HttpContext httpContext, GlobalSettings globalSettings);
     Task BuildAsync(ClaimsPrincipal user, GlobalSettings globalSettings);
 

--- a/src/Core/Context/ICurrentContext.cs
+++ b/src/Core/Context/ICurrentContext.cs
@@ -22,7 +22,7 @@ public interface ICurrentContext
     bool MaybeBot { get; set; }
     int? BotScore { get; set; }
     string ClientId { get; set; }
-    string ClientVersion { get; set; }
+    Version ClientVersion { get; set; }
     Task BuildAsync(HttpContext httpContext, GlobalSettings globalSettings);
     Task BuildAsync(ClaimsPrincipal user, GlobalSettings globalSettings);
 


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
There is an issue on exporting an organization vault where the nested data from the API response was not being parsed.
These changes revert the behavior back to what it was to previously before the unintended change by removing the wrap with ListResponseModel.


## Code changes

Related client changes on [this PR](https://github.com/bitwarden/clients/pull/3641).

* **src/Api/Controllers/OrganizationExportController.cs:** Removed the creation of ListResponseModels
* **src/Api/Models/Response/OrganizationExportResponseModel.cs:** Removed the ListResponseModel wrap from the properties

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
