### PR TITLE
[SG-689] Use a user-based known device check

### DIFF
--- a/src/Api/Controllers/AuthRequestsController.cs
+++ b/src/Api/Controllers/AuthRequestsController.cs
@@ -91,8 +91,8 @@ public class AuthRequestsController : Controller
         }
         if (_globalSettings.PasswordlessAuth.KnownDevicesOnly)
         {
-            var d = await _deviceRepository.GetByIdentifierAsync(model.DeviceIdentifier);
-            if (d == null || d.UserId != user.Id)
+            var devices = await _deviceRepository.GetManyByUserIdAsync(user.Id);
+            if (devices == null || !devices.Any(d => d.Identifier == model.DeviceIdentifier))
             {
                 throw new NotFoundException();
             }


### PR DESCRIPTION
This will be cherry picked to rc for passwordless testing.

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The passwordless implemented involves a known device check. We make sure the device identifier guid is valid for the given userId. This isn't working all the time and sometimes returns 404s for devices that are known and match the user. This commit stabilizes this functionality.

## Code changes
The issue here was that we were doing a device identifier first check for determining a match. We were looking for the given device identifier, and we return the first result found for it. This doesn't work for devices that have been used on multiple accounts - as the first returned record may be for a different account than the one being authorized.

I've changed this to be a user-first check that gets all devices for the requested userId, and checks to see if the device identifier is found in their devices list. 

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
