### PR TITLE
[SG-617] [SG-697] [SG-686] Fix various minor passwordless bugs

### DIFF
--- a/src/Api/Controllers/AuthRequestsController.cs
+++ b/src/Api/Controllers/AuthRequestsController.cs
@@ -94,7 +94,7 @@ public class AuthRequestsController : Controller
             var devices = await _deviceRepository.GetManyByUserIdAsync(user.Id);
             if (devices == null || !devices.Any(d => d.Identifier == model.DeviceIdentifier))
             {
-                throw new NotFoundException();
+                throw new BadRequestException("Login with device is only available on devices that have been previously logged in.");
             }
         }
 

--- a/src/Api/Controllers/AuthRequestsController.cs
+++ b/src/Api/Controllers/AuthRequestsController.cs
@@ -46,7 +46,7 @@ public class AuthRequestsController : Controller
     {
         var userId = _userService.GetProperUserId(User).Value;
         var authRequests = await _authRequestRepository.GetManyByUserIdAsync(userId);
-        var responses = authRequests.Select(a => new AuthRequestResponseModel(a, _globalSettings.SelfHosted)).ToList();
+        var responses = authRequests.Select(a => new AuthRequestResponseModel(a, _globalSettings)).ToList();
         return new ListResponseModel<AuthRequestResponseModel>(responses);
     }
 
@@ -60,7 +60,7 @@ public class AuthRequestsController : Controller
             throw new NotFoundException();
         }
 
-        return new AuthRequestResponseModel(authRequest, _globalSettings.SelfHosted);
+        return new AuthRequestResponseModel(authRequest, _globalSettings);
     }
 
     [HttpGet("{id}/response")]
@@ -73,7 +73,7 @@ public class AuthRequestsController : Controller
             throw new NotFoundException();
         }
 
-        return new AuthRequestResponseModel(authRequest, _globalSettings.SelfHosted);
+        return new AuthRequestResponseModel(authRequest, _globalSettings);
     }
 
     [HttpPost("")]
@@ -111,7 +111,8 @@ public class AuthRequestsController : Controller
         };
         authRequest = await _authRequestRepository.CreateAsync(authRequest);
         await _pushNotificationService.PushAuthRequestAsync(authRequest);
-        return new AuthRequestResponseModel(authRequest, _globalSettings.SelfHosted);
+        var r = new AuthRequestResponseModel(authRequest, _globalSettings);
+        return r;
     }
 
     [HttpPut("{id}")]
@@ -140,6 +141,6 @@ public class AuthRequestsController : Controller
             await _pushNotificationService.PushAuthRequestResponseAsync(authRequest);
         }
 
-        return new AuthRequestResponseModel(authRequest, _globalSettings.SelfHosted);
+        return new AuthRequestResponseModel(authRequest, _globalSettings);
     }
 }

--- a/src/Api/Controllers/AuthRequestsController.cs
+++ b/src/Api/Controllers/AuthRequestsController.cs
@@ -137,9 +137,9 @@ public class AuthRequestsController : Controller
             authRequest.ResponseDeviceId = device.Id;
             authRequest.ResponseDate = DateTime.UtcNow;
             await _authRequestRepository.ReplaceAsync(authRequest);
+            await _pushNotificationService.PushAuthRequestResponseAsync(authRequest);
         }
 
-        await _pushNotificationService.PushAuthRequestResponseAsync(authRequest);
         return new AuthRequestResponseModel(authRequest, _globalSettings.SelfHosted);
     }
 }

--- a/src/Api/Models/Response/AuthRequestResponseModel.cs
+++ b/src/Api/Models/Response/AuthRequestResponseModel.cs
@@ -3,12 +3,13 @@ using System.Reflection;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Models.Api;
+using Bit.Core.Settings;
 
 namespace Bit.Api.Models.Response;
 
 public class AuthRequestResponseModel : ResponseModel
 {
-    public AuthRequestResponseModel(AuthRequest authRequest, bool isSelfHosted, string obj = "auth-request")
+    public AuthRequestResponseModel(AuthRequest authRequest, IGlobalSettings globalSettings, string obj = "auth-request")
         : base(obj)
     {
         if (authRequest == null)
@@ -27,7 +28,7 @@ public class AuthRequestResponseModel : ResponseModel
         CreationDate = authRequest.CreationDate;
         RequestApproved = !string.IsNullOrWhiteSpace(Key) &&
             (authRequest.Type == AuthRequestType.Unlock || !string.IsNullOrWhiteSpace(MasterPasswordHash));
-        Origin = Origin = isSelfHosted ? "SelfHosted" : "bitwarden.com";
+        Origin = globalSettings.SelfHosted ? globalSettings.BaseServiceUri.Vault : "bitwarden.com";
     }
 
     public string Id { get; set; }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
This PR addresses several small passwordless bugs found during QA. This PR will be cherry-picked to rc. Issues addressed are:

1. Currently the web vault is informed if an auth request is denied. We don't want any trace of denied requests making it back to callers as this is a security concern.
2. Failing the known device check returns a 404 without a useful error message. We eventually want to block this from being possible to attempt in UIs, but until then we need a descriptive error.
3. Selfhosted installs aren't receiving their URL in the auth request, it just reads "SelfHosted"


## Code changes
Each commit references an issue mentioned above. All are small changes.

1. Pass the full `GlobalSettings` object to the `AuthRequestResponse` constructor so it has access to self hosted URLs.
2. Set `AuthRequestResponse().Origin` to the self hosted instance's vault URL
3. Only send push notifications on responded AuthRequests if the request was approved
4. Add an error message to the known devices check.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
