### PR TITLE
[SG-686] Correctly format AuthRequestResponse.Origin

### DIFF
--- a/src/Api/Controllers/AuthRequestsController.cs
+++ b/src/Api/Controllers/AuthRequestsController.cs
@@ -46,7 +46,7 @@ public class AuthRequestsController : Controller
     {
         var userId = _userService.GetProperUserId(User).Value;
         var authRequests = await _authRequestRepository.GetManyByUserIdAsync(userId);
-        var responses = authRequests.Select(a => new AuthRequestResponseModel(a, _globalSettings)).ToList();
+        var responses = authRequests.Select(a => new AuthRequestResponseModel(a, _globalSettings.BaseServiceUri.Vault)).ToList();
         return new ListResponseModel<AuthRequestResponseModel>(responses);
     }
 
@@ -60,7 +60,7 @@ public class AuthRequestsController : Controller
             throw new NotFoundException();
         }
 
-        return new AuthRequestResponseModel(authRequest, _globalSettings);
+        return new AuthRequestResponseModel(authRequest, _globalSettings.BaseServiceUri.Vault);
     }
 
     [HttpGet("{id}/response")]
@@ -73,7 +73,7 @@ public class AuthRequestsController : Controller
             throw new NotFoundException();
         }
 
-        return new AuthRequestResponseModel(authRequest, _globalSettings);
+        return new AuthRequestResponseModel(authRequest, _globalSettings.BaseServiceUri.Vault);
     }
 
     [HttpPost("")]
@@ -111,7 +111,7 @@ public class AuthRequestsController : Controller
         };
         authRequest = await _authRequestRepository.CreateAsync(authRequest);
         await _pushNotificationService.PushAuthRequestAsync(authRequest);
-        var r = new AuthRequestResponseModel(authRequest, _globalSettings);
+        var r = new AuthRequestResponseModel(authRequest, _globalSettings.BaseServiceUri.Vault);
         return r;
     }
 
@@ -141,6 +141,6 @@ public class AuthRequestsController : Controller
             await _pushNotificationService.PushAuthRequestResponseAsync(authRequest);
         }
 
-        return new AuthRequestResponseModel(authRequest, _globalSettings);
+        return new AuthRequestResponseModel(authRequest, _globalSettings.BaseServiceUri.Vault);
     }
 }

--- a/src/Api/Models/Response/AuthRequestResponseModel.cs
+++ b/src/Api/Models/Response/AuthRequestResponseModel.cs
@@ -27,7 +27,7 @@ public class AuthRequestResponseModel : ResponseModel
         CreationDate = authRequest.CreationDate;
         RequestApproved = !string.IsNullOrWhiteSpace(Key) &&
             (authRequest.Type == AuthRequestType.Unlock || !string.IsNullOrWhiteSpace(MasterPasswordHash));
-        Origin = vaultUri;
+        Origin = new Uri(vaultUri).Host;
     }
 
     public string Id { get; set; }

--- a/src/Api/Models/Response/AuthRequestResponseModel.cs
+++ b/src/Api/Models/Response/AuthRequestResponseModel.cs
@@ -3,13 +3,12 @@ using System.Reflection;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Models.Api;
-using Bit.Core.Settings;
 
 namespace Bit.Api.Models.Response;
 
 public class AuthRequestResponseModel : ResponseModel
 {
-    public AuthRequestResponseModel(AuthRequest authRequest, IGlobalSettings globalSettings, string obj = "auth-request")
+    public AuthRequestResponseModel(AuthRequest authRequest, string vaultUri, string obj = "auth-request")
         : base(obj)
     {
         if (authRequest == null)
@@ -28,7 +27,7 @@ public class AuthRequestResponseModel : ResponseModel
         CreationDate = authRequest.CreationDate;
         RequestApproved = !string.IsNullOrWhiteSpace(Key) &&
             (authRequest.Type == AuthRequestType.Unlock || !string.IsNullOrWhiteSpace(MasterPasswordHash));
-        Origin = globalSettings.SelfHosted ? globalSettings.BaseServiceUri.Vault : "bitwarden.com";
+        Origin = vaultUri;
     }
 
     public string Id { get; set; }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
On https://github.com/bitwarden/server/pull/2320/commits/0c0a399793b903f6c76c216a02257845509b5679 I started sending the server's vault url as the `Origin` property for self hosted installs, but I left the hardcoded value of `'bitwarden.com`' for cloud installs. This leaves out QA cloud. 

There is also a missed requirement here in that I've was sending the full URL, but the spec only wants the host name.


## Code changes
- Just send the `vaultUri` instead of the full `GlobalSettings` object to the `AuthRequestResponse` constructor. We don't need the whole object now because there is no self hosted condition.
- Always use the `vaultUri` as the `origin` property value returned to clients
- Format `origin` to just be the host of the uri

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
