### PR TITLE
Added push notification logging

### DIFF
--- a/src/Core/Services/Implementations/MultiServicePushNotificationService.cs
+++ b/src/Core/Services/Implementations/MultiServicePushNotificationService.cs
@@ -44,7 +44,7 @@ public class MultiServicePushNotificationService : IPushNotificationService
             if (CoreHelpers.SettingHasValue(globalSettings.NotificationHub.ConnectionString))
             {
                 _services.Add(new NotificationHubPushNotificationService(installationDeviceRepository,
-                    globalSettings, httpContextAccessor));
+                    globalSettings, httpContextAccessor, hubLogger));
             }
             if (CoreHelpers.SettingHasValue(globalSettings.Notifications?.ConnectionString))
             {

--- a/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
+++ b/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
@@ -33,7 +33,7 @@ public class NotificationHubPushNotificationService : IPushNotificationService
         _client = NotificationHubClient.CreateClientFromConnectionString(
             _globalSettings.NotificationHub.ConnectionString,
             _globalSettings.NotificationHub.HubName,
-            _globalSettings.NotificationHub.EnableTestSend);
+            _globalSettings.NotificationHub.EnableLogging);
         _logger = logger;
     }
 
@@ -254,12 +254,7 @@ public class NotificationHubPushNotificationService : IPushNotificationService
                 { "type",  ((byte)type).ToString() },
                 { "payload", JsonSerializer.Serialize(payload) }
             }, tag);
-        if (outcome.Failure > 0)
-        {
-            _logger.LogError("Tracking ID: {id} | Failed to send {type} push notification to {count} devices with payload of {@payload}",
-                outcome.TrackingId, type, outcome.Failure, payload);
-        }
-        if (_globalSettings.NotificationHub.EnableTestSend)
+        if (_globalSettings.NotificationHub.EnableLogging)
         {
             _logger.LogInformation("Tracking ID: {id} | {type} push notification with {success} successes and {failure} failures with a payload of {@payload} and result of {@results}",
                 outcome.TrackingId, type, outcome.Success, outcome.Failure, payload, outcome.Results);

--- a/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
+++ b/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
@@ -9,6 +9,7 @@ using Bit.Core.Repositories;
 using Bit.Core.Settings;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.NotificationHubs;
+using Microsoft.Extensions.Logging;
 
 namespace Bit.Core.Services;
 
@@ -17,20 +18,23 @@ public class NotificationHubPushNotificationService : IPushNotificationService
     private readonly IInstallationDeviceRepository _installationDeviceRepository;
     private readonly GlobalSettings _globalSettings;
     private readonly IHttpContextAccessor _httpContextAccessor;
-
     private NotificationHubClient _client = null;
+    private ILogger _logger;
 
     public NotificationHubPushNotificationService(
         IInstallationDeviceRepository installationDeviceRepository,
         GlobalSettings globalSettings,
-        IHttpContextAccessor httpContextAccessor)
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<NotificationsApiPushNotificationService> logger)
     {
         _installationDeviceRepository = installationDeviceRepository;
         _globalSettings = globalSettings;
         _httpContextAccessor = httpContextAccessor;
         _client = NotificationHubClient.CreateClientFromConnectionString(
             _globalSettings.NotificationHub.ConnectionString,
-            _globalSettings.NotificationHub.HubName);
+            _globalSettings.NotificationHub.HubName,
+            _globalSettings.NotificationHub.EnableTestSend);
+        _logger = logger;
     }
 
     public async Task PushSyncCipherCreateAsync(Cipher cipher, IEnumerable<Guid> collectionIds)
@@ -244,12 +248,22 @@ public class NotificationHubPushNotificationService : IPushNotificationService
 
     private async Task SendPayloadAsync(string tag, PushType type, object payload)
     {
-        await _client.SendTemplateNotificationAsync(
+        var outcome = await _client.SendTemplateNotificationAsync(
             new Dictionary<string, string>
             {
                 { "type",  ((byte)type).ToString() },
                 { "payload", JsonSerializer.Serialize(payload) }
             }, tag);
+        if (outcome.Failure > 0)
+        {
+            _logger.LogError("Tracking ID: {id} | Failed to send {type} push notification to {count} devices with payload of {@payload}",
+                outcome.TrackingId, type, outcome.Failure, payload);
+        }
+        if (_globalSettings.NotificationHub.EnableTestSend)
+        {
+            _logger.LogInformation("Tracking ID: {id} | {type} push notification with {success} successes and {failure} failures with a payload of {@payload} and result of {@results}",
+                outcome.TrackingId, type, outcome.Success, outcome.Failure, payload, outcome.Results);
+        }
     }
 
     private string SanitizeTagInput(string input)

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -412,6 +412,7 @@ public class GlobalSettings : IGlobalSettings
             set => _connectionString = value.Trim('"');
         }
         public string HubName { get; set; }
+        public bool EnableTestSend { get; set; } = false;
     }
 
     public class YubicoSettings

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -412,7 +412,7 @@ public class GlobalSettings : IGlobalSettings
             set => _connectionString = value.Trim('"');
         }
         public string HubName { get; set; }
-        public bool EnableTestSend { get; set; } = false;
+        public bool EnableLogging { get; set; } = false;
     }
 
     public class YubicoSettings

--- a/test/Core.Test/Services/NotificationHubPushNotificationServiceTests.cs
+++ b/test/Core.Test/Services/NotificationHubPushNotificationServiceTests.cs
@@ -2,6 +2,7 @@
 using Bit.Core.Services;
 using Bit.Core.Settings;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
 
@@ -14,17 +15,20 @@ public class NotificationHubPushNotificationServiceTests
     private readonly IInstallationDeviceRepository _installationDeviceRepository;
     private readonly GlobalSettings _globalSettings;
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<NotificationsApiPushNotificationService> _logger;
 
     public NotificationHubPushNotificationServiceTests()
     {
         _installationDeviceRepository = Substitute.For<IInstallationDeviceRepository>();
         _globalSettings = new GlobalSettings();
         _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        _logger = Substitute.For<ILogger<NotificationsApiPushNotificationService>>();
 
         _sut = new NotificationHubPushNotificationService(
             _installationDeviceRepository,
             _globalSettings,
-            _httpContextAccessor
+            _httpContextAccessor,
+            _logger
         );
     }
 


### PR DESCRIPTION
## Type of change
```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Added flag-enabled logging to Azure Notification Hub push notifications.  This uses the `EnableTestSend` functionality on the Azure Notification Hub described [here](https://learn.microsoft.com/en-us/azure/notification-hubs/notification-hubs-push-notification-fixer#debug-failed-notifications-and-review-notification-outcome).

The logic is wrapped with a check against `NotificationHub.EnableLogging` in global settings, which defaults to `false`.

## Code changes

[src/Core/Services/Implementations/MultiServicePushNotificationService.cs](https://github.com/bitwarden/server/compare/master...feat/passwordless-push-notification-logging#diff-f8d0c6ddc3626f1cc981881004ceb0cf09c17419521c91fdb8899fcc2779cfa3): Passed logger in to `NotificationHubPushNotificationService`.
[src/Core/Services/Implementations/NotificationHubPushNotificationService.cs](https://github.com/bitwarden/server/compare/master...feat/passwordless-push-notification-logging#diff-745e85ca3e13e36c3245db9518b44dd94b41426e2161b891569dcc648f0d569e): Changed to handle result of the `SendTemplateNotificationAsync` and log if the `EnableLogging` property is set.
[src/Core/Settings/GlobalSettings.cs](https://github.com/bitwarden/server/compare/master...feat/passwordless-push-notification-logging#diff-5db3f085aa29787450e768b1180caec9666b5dc485e5551d50bbb6cf882a6db7): Added `EnableLogging` to the NotificationHub object, default to `false`.
[test/Core.Test/Services/NotificationHubPushNotificationServiceTests.cs](https://github.com/bitwarden/server/compare/master...feat/passwordless-push-notification-logging#diff-0d379b9320c3e6d8ad7d5b3e64f0e37e664f69af3b408c065cd246826a6f8d7a): Added logger to test.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
