### PR TITLE
[SG-698] Updated authrequestId to allow null value from client

### DIFF
--- a/src/Api/Controllers/TwoFactorController.cs
+++ b/src/Api/Controllers/TwoFactorController.cs
@@ -293,7 +293,7 @@ public class TwoFactorController : Controller
             if (!string.IsNullOrEmpty(model.AuthRequestAccessCode))
             {
                 if (await _verifyAuthRequestCommand
-                        .VerifyAuthRequestAsync(model.AuthRequestId, model.AuthRequestAccessCode))
+                        .VerifyAuthRequestAsync(new Guid(model.AuthRequestId), model.AuthRequestAccessCode))
                 {
                     var isBecauseNewDeviceLogin = await IsNewDeviceLoginAsync(user, model);
 

--- a/src/Api/Models/Request/TwoFactorRequestModels.cs
+++ b/src/Api/Models/Request/TwoFactorRequestModels.cs
@@ -204,7 +204,7 @@ public class TwoFactorEmailRequestModel : SecretVerificationRequestModel
 
     public string DeviceIdentifier { get; set; }
 
-    public Guid AuthRequestId { get; set; }
+    public string AuthRequestId { get; set; }
 
     public User ToUser(User extistingUser)
     {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This [PR](https://github.com/bitwarden/server/pull/2346) was created to allow 2FA to send emails for `passwordless`; while that fix would work, it created a bug for authentication using `passwords`. `AuthRequestId` was given a `Guid` data type, meaning null values could not be passed from the client and in the case of authenticating with passwords, `null` is passed as a value for that field.


## Code changes
Updated `AuthRequestId` data type to `string`.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
