### PR TITLE
consolidate subdirectories for persisted assets

### DIFF
--- a/docker-lite/Dockerfile
+++ b/docker-lite/Dockerfile
@@ -194,6 +194,7 @@ ENV globalSettings__baseServiceUri__internalIdentity="http://localhost:5005"
 ENV globalSettings__baseServiceUri__internalNotifications="http://localhost:5006"
 ENV globalSettings__baseServiceUri__internalSso="http://localhost:5007"
 ENV globalSettings__baseServiceUri__internalWeb="http://localhost:5008"
+ENV globalSettings__dataProtection__directory="/etc/bitwarden"
 EXPOSE 8080
 EXPOSE 8443
 
@@ -210,12 +211,8 @@ RUN apk add --update-cache \
 
 # Create required directories
 RUN mkdir -p /etc/bitwarden/core/attachments
-RUN mkdir -p /etc/bitwarden/core/aspnet-dataprotection
-RUN mkdir -p /etc/bitwarden/identity
 RUN mkdir -p /etc/bitwarden/logs
-RUN mkdir -p /etc/bitwarden/nginx
 RUN mkdir -p /etc/bitwarden/ssl
-RUN mkdir -p /etc/bitwarden/web
 
 # Copy all apps from dotnet-build stage
 WORKDIR /app

--- a/docker-lite/Dockerfile
+++ b/docker-lite/Dockerfile
@@ -195,6 +195,9 @@ ENV globalSettings__baseServiceUri__internalNotifications="http://localhost:5006
 ENV globalSettings__baseServiceUri__internalSso="http://localhost:5007"
 ENV globalSettings__baseServiceUri__internalWeb="http://localhost:5008"
 ENV globalSettings__dataProtection__directory="/etc/bitwarden"
+ENV globalSettings__identityServer__certificatePassword="default_cert_password"
+ENV globalSettings__attachment__baseDirectory="/etc/bitwarden/attachments"
+ENV globalSettings__send__baseDirectory="/etc/bitwarden/attachments/send"
 EXPOSE 8080
 EXPOSE 8443
 
@@ -210,7 +213,7 @@ RUN apk add --update-cache \
     && rm -rf /var/cache/apk/*
 
 # Create required directories
-RUN mkdir -p /etc/bitwarden/core/attachments
+RUN mkdir -p /etc/bitwarden/attachments
 RUN mkdir -p /etc/bitwarden/logs
 RUN mkdir -p /etc/bitwarden/ssl
 

--- a/docker-lite/entrypoint.sh
+++ b/docker-lite/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Generate Identity certificate
-if [ ! -f /etc/bitwarden/identity/identity.pfx ]; then
+if [ ! -f /etc/bitwarden/identity.pfx ]; then
   openssl req \
   -x509 \
   -newkey rsa:4096 \
@@ -14,7 +14,7 @@ if [ ! -f /etc/bitwarden/identity/identity.pfx ]; then
   
   openssl pkcs12 \
   -export \
-  -out /etc/bitwarden/identity/identity.pfx \
+  -out /etc/bitwarden/identity.pfx \
   -inkey /etc/bitwarden/identity/identity.key \
   -in /etc/bitwarden/identity/identity.crt \
   -passout pass:$globalSettings__identityServer__certificatePassword
@@ -23,8 +23,8 @@ if [ ! -f /etc/bitwarden/identity/identity.pfx ]; then
   rm /etc/bitwarden/identity/identity.key
 fi
 
-cp /etc/bitwarden/identity/identity.pfx /app/Identity/identity.pfx
-cp /etc/bitwarden/identity/identity.pfx /app/Sso/identity.pfx
+cp /etc/bitwarden/identity.pfx /app/Identity/identity.pfx
+cp /etc/bitwarden/identity.pfx /app/Sso/identity.pfx
 
 # Generate SSL certificates
 if [ -z "$(ls -A /etc/bitwarden/ssl)" ]; then
@@ -48,6 +48,6 @@ fi
 /usr/local/bin/confd -onetime -backend env
 
 # Set up Web app-id.json
-cp /etc/bitwarden/web/app-id.json /app/Web/app-id.json
+cp /etc/bitwarden/app-id.json /app/Web/app-id.json
 
 exec /usr/bin/supervisord

--- a/docker-lite/entrypoint.sh
+++ b/docker-lite/entrypoint.sh
@@ -7,20 +7,20 @@ if [ ! -f /etc/bitwarden/identity.pfx ]; then
   -newkey rsa:4096 \
   -sha256 \
   -nodes \
-  -keyout /etc/bitwarden/identity/identity.key \
-  -out /etc/bitwarden/identity/identity.crt \
+  -keyout /etc/bitwarden/identity.key \
+  -out /etc/bitwarden/identity.crt \
   -subj "/CN=Bitwarden IdentityServer" \
   -days 36500
   
   openssl pkcs12 \
   -export \
   -out /etc/bitwarden/identity.pfx \
-  -inkey /etc/bitwarden/identity/identity.key \
-  -in /etc/bitwarden/identity/identity.crt \
+  -inkey /etc/bitwarden/identity.key \
+  -in /etc/bitwarden/identity.crt \
   -passout pass:$globalSettings__identityServer__certificatePassword
   
-  rm /etc/bitwarden/identity/identity.crt
-  rm /etc/bitwarden/identity/identity.key
+  rm /etc/bitwarden/identity.crt
+  rm /etc/bitwarden/identity.key
 fi
 
 cp /etc/bitwarden/identity.pfx /app/Identity/identity.pfx

--- a/docker-lite/global-settings.env
+++ b/docker-lite/global-settings.env
@@ -11,7 +11,6 @@ adminSettings__admins="admin@example.com"
 globalSettings__disableUserRegistration=false
 globalSettings__installation__id=00000000-0000-0000-0000-000000000000
 globalSettings__installation__key=00000000000000000000
-globalSettings__identityServer__certificatePassword=super_strong_cert_password
 
 #################
 # SMTP Settings #

--- a/docker-lite/nginx/confd/nginx-config.toml
+++ b/docker-lite/nginx/confd/nginx-config.toml
@@ -1,6 +1,6 @@
 [template]
 src = "nginx-config.conf.tmpl"
-dest = "/etc/bitwarden/nginx/server.conf"
+dest = "/etc/nginx/bitwarden.conf"
 keys = [
   "BW_CA_ENABLE",
   "BW_CA_CERT",

--- a/docker-lite/nginx/nginx.conf
+++ b/docker-lite/nginx/nginx.conf
@@ -34,7 +34,7 @@ pid        /var/run/nginx/nginx.pid;
 http {
   # Include proxy and server configuration.
   include /etc/nginx/proxy.conf;
-  include /etc/bitwarden/nginx/server.conf;
+  include /etc/nginx/bitwarden.conf;
 
   # Hide nginx version information.
   server_tokens off;

--- a/docker-lite/supervisord.ini
+++ b/docker-lite/supervisord.ini
@@ -18,7 +18,7 @@ stdout_logfile=/var/log/bitwarden/api.log
 
 [program:attachments]
 autorestart=true
-command=/usr/bin/dotnet "Attachments.dll" "/contentRoot=/etc/bitwarden/core/attachments" "/webRoot=."
+command=/usr/bin/dotnet "Attachments.dll" "/contentRoot=/etc/bitwarden/attachments" "/webRoot=."
 directory=/app/Attachments
 environment=ASPNETCORE_URLS="http://+:5002"
 redirect_stderr=true


### PR DESCRIPTION
wanted to reduce the number of directories under /etc/bitwarden to make it cleaner on disk.

also created a default password for identity cert so we didn't need to ask user to set that as a required env variable