### PR TITLE
Setup should be aware of the Let's Encrypt no random sleep flag

### DIFF
--- a/util/Setup/Configuration.cs
+++ b/util/Setup/Configuration.cs
@@ -106,6 +106,9 @@ public class Configuration
     [Description("Enable SCIM")]
     public bool EnableScim { get; set; } = false;
 
+    [Description("Disable random sleep when renewing a Let's Encrypt SSL certificate.")]
+    public bool LetsEncryptNoRandomSleepOnRenew { get; set; } = false;
+
     [YamlIgnore]
     public string Domain
     {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Allow the self-host scripts to bypass Let's Encrypts random sleep when renewing certs.


## Code changes
Support `lets_encrypt_no_random_sleep_on_renew` in the configuration

Other PRs
* Replaces #1766 
* Supplements bitwarden/self-host#64

* **util/Setup/Configuration.cs:**  Added the `lets_encrypt_no_random_sleep_on_renew` flag for the configuration

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
