### PR TITLE
[PS-1771] Added Atlassian global equivalent domain

### DIFF
--- a/src/Core/Enums/GlobalEquivalentDomainsType.cs
+++ b/src/Core/Enums/GlobalEquivalentDomainsType.cs
@@ -91,4 +91,5 @@ public enum GlobalEquivalentDomainsType : byte
     Ubisoft = 86,
     TransferWise = 87,
     TakeawayEU = 88,
+    Atlassian = 89,
 }

--- a/src/Core/Utilities/StaticStore.cs
+++ b/src/Core/Utilities/StaticStore.cs
@@ -100,6 +100,7 @@ public class StaticStore
         GlobalDomains.Add(GlobalEquivalentDomainsType.Ubisoft, new List<string> { "ubisoft.com", "ubi.com" });
         GlobalDomains.Add(GlobalEquivalentDomainsType.TransferWise, new List<string> { "transferwise.com", "wise.com" });
         GlobalDomains.Add(GlobalEquivalentDomainsType.TakeawayEU, new List<string> { "takeaway.com", "just-eat.dk", "just-eat.no", "just-eat.fr", "just-eat.ch", "lieferando.de", "lieferando.at", "thuisbezorgd.nl", "pyszne.pl" });
+        GlobalDomains.Add(GlobalEquivalentDomainsType.Atlassian, new List<string> { "atlassian.com", "bitbucket.org", "trello.com", "statuspage.io", "atlassian.net", "jira.com" });
         #endregion
 
         #region Plans


### PR DESCRIPTION
Hi, also see #2203 which was my original pull request that I accidentally closed (my apologies)

## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
I've added a global equivalent domain for Atlassian accounts, based on information gotten from the [Atlassian support page]( https://support.atlassian.com/atlassian-account/docs/what-is-an-atlassian-account)! 

This of course does not include services that have their pages on an Atlassian subdomain, for example [confluence.atlassian.com](https://confluence.atlassian.com).



## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **StaticStore.cs:** Added domains that use Atlassian's account system
* **GlobalEquivalentDomainsType.cs:** Updated enums to reflect other global equivalent domains

## Before you submit

<!-- (mark with an `X`) -->

```
- [X] I have checked for formatting errors (`dotnet format --verify-no-changes`) (required)
- [ ] If making database changes - I have also updated Entity Framework queries and/or migrations
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
```
