### PR TITLE
fix cipher attachment saving on EF repos

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/BaseEntityFrameworkRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/BaseEntityFrameworkRepository.cs
@@ -124,8 +124,8 @@ public abstract class BaseEntityFrameworkRepository
                     !string.IsNullOrWhiteSpace(e.Attachments))
                 .Select(e => e.Attachments)
                 .ToListAsync();
-            var storage = attachments.Sum(e => JsonDocument.Parse(e)?.RootElement.EnumerateArray()
-                .Sum(p => p.GetProperty("Size").GetInt64()) ?? 0);
+            var storage = attachments.Sum(e => JsonDocument.Parse(e)?.RootElement.EnumerateObject()
+                .Sum(p => p.Value.GetProperty("Size").GetInt64()) ?? 0);
             var organization = new Organization
             {
                 Id = organizationId,
@@ -152,8 +152,8 @@ public abstract class BaseEntityFrameworkRepository
                     !string.IsNullOrWhiteSpace(e.Attachments))
                 .Select(e => e.Attachments)
                 .ToListAsync();
-            var storage = attachments.Sum(e => JsonDocument.Parse(e)?.RootElement.EnumerateArray()
-                .Sum(p => p.GetProperty("Size").GetInt64()) ?? 0);
+            var storage = attachments.Sum(e => JsonDocument.Parse(e)?.RootElement.EnumerateObject()
+                .Sum(p => p.Value.GetProperty("Size").GetInt64()) ?? 0);
             var user = new Models.User
             {
                 Id = userId,

--- a/src/Infrastructure.EntityFramework/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CipherRepository.cs
@@ -549,9 +549,11 @@ public class CipherRepository : Repository<Core.Entities.Cipher, Cipher, Guid>, 
         {
             var dbContext = GetDatabaseContext(scope);
             var cipher = await dbContext.Ciphers.FindAsync(attachment.Id);
-            var attachmentsJson = string.IsNullOrWhiteSpace(cipher.Attachments) ? new JObject() : JObject.Parse(cipher.Attachments);
-            attachmentsJson.Add(attachment.AttachmentId, attachment.AttachmentData);
-            cipher.Attachments = JsonConvert.SerializeObject(attachmentsJson);
+            var attachments = string.IsNullOrWhiteSpace(cipher.Attachments) ?
+                new Dictionary<string, CipherAttachment.MetaData>() :
+                JsonConvert.DeserializeObject<Dictionary<string, CipherAttachment.MetaData>>(cipher.Attachments);
+            attachments.Add(attachment.AttachmentId, JsonConvert.DeserializeObject<CipherAttachment.MetaData>(attachment.AttachmentData));
+            cipher.Attachments = JsonConvert.SerializeObject(attachments);
             await dbContext.SaveChangesAsync();
 
             if (attachment.OrganizationId.HasValue)


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Cipher attachments were being saved as the wrong data structure (`Dict<string, string>`) compared to the SQL server implementation (`Dict<string, object>`). This change fixes that and stores them as the proper Dictionary data structure.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CipherRepository.cs:** Use proper Dictionary data structure for attachments.
* **BaseEntityFrameworkRepository.cs:** Fix calculations of storage size to match the data structure.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
