### PR TITLE
fix logic in some EF cipher queries

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/Queries/UserCipherDetailsQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/UserCipherDetailsQuery.cs
@@ -1,6 +1,6 @@
-﻿using Bit.Core.Enums;
+﻿using System.Text.Json;
+using Bit.Core.Enums;
 using Core.Models.Data;
-using Newtonsoft.Json.Linq;
 
 namespace Bit.Infrastructure.EntityFramework.Repositories.Queries;
 
@@ -59,13 +59,24 @@ public class UserCipherDetailsQuery : IQuery<CipherDetails>
             RevisionDate = c.RevisionDate,
             DeletedDate = c.DeletedDate,
             Favorite = _userId.HasValue && c.Favorites != null && c.Favorites.Contains($"\"{_userId}\":true"),
-            FolderId = _userId.HasValue && !string.IsNullOrWhiteSpace(c.Folders) ?
-                Guid.Parse(JObject.Parse(c.Folders)[_userId.Value.ToString()].Value<string>()) :
-                null,
+            FolderId = GetFolderId(_userId, c),
             Edit = true,
             ViewPassword = true,
             OrganizationUseTotp = false,
         });
         return union;
+    }
+
+    private static Guid? GetFolderId(Guid? userId, Models.Cipher cipher)
+    {
+        if (userId.HasValue && !string.IsNullOrWhiteSpace(cipher.Folders))
+        {
+            var folders = JsonSerializer.Deserialize<Dictionary<Guid, Guid>>(cipher.Folders);
+            if (folders.ContainsKey(userId.Value))
+            {
+                return folders[userId.Value];
+            }
+        }
+        return null;
     }
 }

--- a/src/Infrastructure.EntityFramework/Repositories/Queries/UserCipherDetailsQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/UserCipherDetailsQuery.cs
@@ -72,9 +72,9 @@ public class UserCipherDetailsQuery : IQuery<CipherDetails>
         if (userId.HasValue && !string.IsNullOrWhiteSpace(cipher.Folders))
         {
             var folders = JsonSerializer.Deserialize<Dictionary<Guid, Guid>>(cipher.Folders);
-            if (folders.ContainsKey(userId.Value))
+            if (folders.TryGetValue(userId.Value, out var folder)
             {
-                return folders[userId.Value];
+                return folder;
             }
         }
         return null;

--- a/src/Infrastructure.EntityFramework/Repositories/Queries/UserCipherDetailsQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/UserCipherDetailsQuery.cs
@@ -72,7 +72,7 @@ public class UserCipherDetailsQuery : IQuery<CipherDetails>
         if (userId.HasValue && !string.IsNullOrWhiteSpace(cipher.Folders))
         {
             var folders = JsonSerializer.Deserialize<Dictionary<Guid, Guid>>(cipher.Folders);
-            if (folders.TryGetValue(userId.Value, out var folder)
+            if (folders.TryGetValue(userId.Value, out var folder))
             {
                 return folder;
             }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Fix bugs with EF queries.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CipherRepository.cs:** Use the correct query for `GetManyOrganizationDetailsByOrganizationIdAsync`. Update filters on `ToggleCipherStates` to match the logic from the SQL Server sprocs.
* **UserCipherDetailsQuery.cs:** Correctly handle case when `userId` key doesn't exist in the JSON dictionary. Also change from Newstonsoft to System libraries. 

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
