### PR TITLE
Fix spelling of EF query name

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CipherRepository.cs
@@ -261,7 +261,7 @@ public class CipherRepository : Repository<Core.Entities.Cipher, Cipher, Guid>, 
         using (var scope = ServiceScopeFactory.CreateScope())
         {
             var dbContext = GetDatabaseContext(scope);
-            var query = new CipherOrganizationDetailsReadByOrgizationIdQuery(organizationId);
+            var query = new CipherOrganizationDetailsReadByOrganizationIdQuery(organizationId);
             var data = await query.Run(dbContext).ToListAsync();
             return data;
         }

--- a/src/Infrastructure.EntityFramework/Repositories/Queries/CipherOrganizationDetailsReadByOrganizationIdQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/CipherOrganizationDetailsReadByOrganizationIdQuery.cs
@@ -2,11 +2,11 @@
 
 namespace Bit.Infrastructure.EntityFramework.Repositories.Queries;
 
-public class CipherOrganizationDetailsReadByOrgizationIdQuery : IQuery<CipherOrganizationDetails>
+public class CipherOrganizationDetailsReadByOrganizationIdQuery : IQuery<CipherOrganizationDetails>
 {
     private readonly Guid _organizationId;
 
-    public CipherOrganizationDetailsReadByOrgizationIdQuery(Guid organizationId)
+    public CipherOrganizationDetailsReadByOrganizationIdQuery(Guid organizationId)
     {
         _organizationId = organizationId;
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR fixes a spelling error in the query name.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Infrastructure.EntityFramework/Repositories/CipherRepository.cs:** Change query name from `CipherOrganizationDetailsReadByOrgizationIdQuery` to `CipherOrganizationDetailsReadByOrganizationIdQuery`
* **src/Infrastructure.EntityFramework/Repositories/Queries/CipherOrganizationDetailsReadByOrganizationIdQuery.cs:** Rename class and constructor to `CipherOrganizationDetailsReadByOrganizationIdQuery`.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
