### PR TITLE
[EC-634] Extract GenerateLicenseAsync to a query

### DIFF
--- a/src/Admin/Controllers/ToolsController.cs
+++ b/src/Admin/Controllers/ToolsController.cs
@@ -3,6 +3,8 @@ using System.Text.Json;
 using Bit.Admin.Models;
 using Bit.Core.Entities;
 using Bit.Core.Models.BitStripe;
+using Bit.Core.OrganizationFeatures.OrganizationLicenses;
+using Bit.Core.OrganizationFeatures.OrganizationLicenses.Interfaces;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Settings;
@@ -18,7 +20,7 @@ public class ToolsController : Controller
 {
     private readonly GlobalSettings _globalSettings;
     private readonly IOrganizationRepository _organizationRepository;
-    private readonly IOrganizationService _organizationService;
+    private readonly IGetOrganizationLicenseQuery _getOrganizationLicenseQuery;
     private readonly IUserService _userService;
     private readonly ITransactionRepository _transactionRepository;
     private readonly IInstallationRepository _installationRepository;
@@ -30,7 +32,7 @@ public class ToolsController : Controller
     public ToolsController(
         GlobalSettings globalSettings,
         IOrganizationRepository organizationRepository,
-        IOrganizationService organizationService,
+        IGetOrganizationLicenseQuery getOrganizationLicenseQuery,
         IUserService userService,
         ITransactionRepository transactionRepository,
         IInstallationRepository installationRepository,
@@ -41,7 +43,7 @@ public class ToolsController : Controller
     {
         _globalSettings = globalSettings;
         _organizationRepository = organizationRepository;
-        _organizationService = organizationService;
+        _getOrganizationLicenseQuery = getOrganizationLicenseQuery;
         _userService = userService;
         _transactionRepository = transactionRepository;
         _installationRepository = installationRepository;
@@ -259,7 +261,7 @@ public class ToolsController : Controller
 
         if (organization != null)
         {
-            var license = await _organizationService.GenerateLicenseAsync(organization,
+            var license = await _getOrganizationLicenseQuery.GetLicenseAsync(organization,
                 model.InstallationId.Value, model.Version);
             var ms = new MemoryStream();
             await JsonSerializer.SerializeAsync(ms, license, JsonHelpers.Indented);

--- a/src/Api/Controllers/LicensesController.cs
+++ b/src/Api/Controllers/LicensesController.cs
@@ -1,6 +1,7 @@
 ﻿using Bit.Core.Context;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Business;
+using Bit.Core.OrganizationFeatures.OrganizationLicenses.Interfaces;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Utilities;
@@ -14,26 +15,23 @@ namespace Bit.Api.Controllers;
 [SelfHosted(NotSelfHostedOnly = true)]
 public class LicensesController : Controller
 {
-    private readonly ILicensingService _licensingService;
     private readonly IUserRepository _userRepository;
     private readonly IUserService _userService;
     private readonly IOrganizationRepository _organizationRepository;
-    private readonly IOrganizationService _organizationService;
+    private readonly IGetOrganizationLicenseQuery _getOrganizationLicenseQuery;
     private readonly ICurrentContext _currentContext;
 
     public LicensesController(
-        ILicensingService licensingService,
         IUserRepository userRepository,
         IUserService userService,
         IOrganizationRepository organizationRepository,
-        IOrganizationService organizationService,
+        IGetOrganizationLicenseQuery getOrganizationLicenseQuery,
         ICurrentContext currentContext)
     {
-        _licensingService = licensingService;
         _userRepository = userRepository;
         _userService = userService;
         _organizationRepository = organizationRepository;
-        _organizationService = organizationService;
+        _getOrganizationLicenseQuery = getOrganizationLicenseQuery;
         _currentContext = currentContext;
     }
 
@@ -63,13 +61,14 @@ public class LicensesController : Controller
         {
             return null;
         }
-        else if (!org.LicenseKey.Equals(key))
+        
+        if (!org.LicenseKey.Equals(key))
         {
             await Task.Delay(2000);
             throw new BadRequestException("Invalid license key.");
         }
 
-        var license = await _organizationService.GenerateLicenseAsync(org, _currentContext.InstallationId.Value);
+        var license = await _getOrganizationLicenseQuery.GetLicenseAsync(org, _currentContext.InstallationId.Value);
         return license;
     }
 }

--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -11,6 +11,7 @@ using Bit.Core.Exceptions;
 using Bit.Core.Models.Business;
 using Bit.Core.Models.Data.Organizations.Policies;
 using Bit.Core.OrganizationFeatures.OrganizationApiKeys.Interfaces;
+using Bit.Core.OrganizationFeatures.OrganizationLicenses.Interfaces;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Settings;
@@ -36,6 +37,7 @@ public class OrganizationsController : Controller
     private readonly IGetOrganizationApiKeyCommand _getOrganizationApiKeyCommand;
     private readonly IRotateOrganizationApiKeyCommand _rotateOrganizationApiKeyCommand;
     private readonly IOrganizationApiKeyRepository _organizationApiKeyRepository;
+    private readonly IGetOrganizationLicenseQuery _getOrganizationLicenseQuery;
     private readonly GlobalSettings _globalSettings;
 
     public OrganizationsController(
@@ -51,6 +53,7 @@ public class OrganizationsController : Controller
         IGetOrganizationApiKeyCommand getOrganizationApiKeyCommand,
         IRotateOrganizationApiKeyCommand rotateOrganizationApiKeyCommand,
         IOrganizationApiKeyRepository organizationApiKeyRepository,
+        IGetOrganizationLicenseQuery getOrganizationLicenseQuery,
         GlobalSettings globalSettings)
     {
         _organizationRepository = organizationRepository;
@@ -65,6 +68,7 @@ public class OrganizationsController : Controller
         _getOrganizationApiKeyCommand = getOrganizationApiKeyCommand;
         _rotateOrganizationApiKeyCommand = rotateOrganizationApiKeyCommand;
         _organizationApiKeyRepository = organizationApiKeyRepository;
+        _getOrganizationLicenseQuery = getOrganizationLicenseQuery;
         _globalSettings = globalSettings;
     }
 
@@ -145,8 +149,9 @@ public class OrganizationsController : Controller
         {
             throw new NotFoundException();
         }
-
-        var license = await _organizationService.GenerateLicenseAsync(orgIdGuid, installationId);
+        
+        var org = await _organizationRepository.GetByIdAsync(new Guid(id));
+        var license = await _getOrganizationLicenseQuery.GetLicenseAsync(org, installationId);
         if (license == null)
         {
             throw new NotFoundException();

--- a/src/Core/OrganizationFeatures/OrganizationLicenses/GetOrganizationLicenseQuery.cs
+++ b/src/Core/OrganizationFeatures/OrganizationLicenses/GetOrganizationLicenseQuery.cs
@@ -1,0 +1,38 @@
+﻿using Bit.Core.Models.Business;
+using Bit.Core.Entities;
+using Bit.Core.Exceptions;
+using Bit.Core.OrganizationFeatures.OrganizationLicenses.Interfaces;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+
+namespace Bit.Core.OrganizationFeatures.OrganizationLicenses;
+
+public class GetOrganizationLicenseQuery : IGetOrganizationLicenseQuery
+{
+    private readonly IInstallationRepository _installationRepository;
+    private readonly IPaymentService _paymentService;
+    private readonly ILicensingService _licensingService;
+
+    public GetOrganizationLicenseQuery(
+        IInstallationRepository installationRepository,
+        IPaymentService paymentService,
+        ILicensingService licensingService)
+    {
+        _installationRepository = installationRepository;
+        _paymentService = paymentService;
+        _licensingService = licensingService;
+    }
+    
+    public async Task<OrganizationLicense> GetLicenseAsync(Organization organization, Guid installationId,
+        int? version = null)
+    {
+        var installation = await _installationRepository.GetByIdAsync(installationId);
+        if (installation is not { Enabled: true })
+        {
+            throw new BadRequestException("Invalid installation id");
+        }
+
+        var subInfo = await _paymentService.GetSubscriptionAsync(organization);
+        return new OrganizationLicense(organization, subInfo, installationId, _licensingService, version);
+    }
+}

--- a/src/Core/OrganizationFeatures/OrganizationLicenses/Interfaces/IGetOrganizationLicenseQuery.cs
+++ b/src/Core/OrganizationFeatures/OrganizationLicenses/Interfaces/IGetOrganizationLicenseQuery.cs
@@ -1,0 +1,10 @@
+﻿using Bit.Core.Models.Business;
+using Bit.Core.Entities;
+
+namespace Bit.Core.OrganizationFeatures.OrganizationLicenses.Interfaces;
+
+public interface IGetOrganizationLicenseQuery
+{
+    Task<OrganizationLicense> GetLicenseAsync(Organization organization, Guid installationId,
+        int? version = null);
+}

--- a/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
+++ b/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
@@ -3,6 +3,8 @@ using Bit.Core.OrganizationFeatures.OrganizationApiKeys;
 using Bit.Core.OrganizationFeatures.OrganizationApiKeys.Interfaces;
 using Bit.Core.OrganizationFeatures.OrganizationConnections;
 using Bit.Core.OrganizationFeatures.OrganizationConnections.Interfaces;
+using Bit.Core.OrganizationFeatures.OrganizationLicenses;
+using Bit.Core.OrganizationFeatures.OrganizationLicenses.Interfaces;
 using Bit.Core.OrganizationFeatures.OrganizationSponsorships.FamiliesForEnterprise;
 using Bit.Core.OrganizationFeatures.OrganizationSponsorships.FamiliesForEnterprise.Cloud;
 using Bit.Core.OrganizationFeatures.OrganizationSponsorships.FamiliesForEnterprise.Interfaces;
@@ -25,6 +27,7 @@ public static class OrganizationServiceCollectionExtensions
         services.AddOrganizationConnectionCommands();
         services.AddOrganizationSponsorshipCommands(globalSettings);
         services.AddOrganizationApiKeyCommands();
+        services.AddOrganizationLicenseQueries();
     }
 
     private static void AddOrganizationConnectionCommands(this IServiceCollection services)
@@ -63,6 +66,11 @@ public static class OrganizationServiceCollectionExtensions
     {
         services.AddScoped<IGetOrganizationApiKeyCommand, GetOrganizationApiKeyCommand>();
         services.AddScoped<IRotateOrganizationApiKeyCommand, RotateOrganizationApiKeyCommand>();
+    }
+
+    private static void AddOrganizationLicenseQueries(this IServiceCollection services)
+    {
+        services.AddScoped<IGetOrganizationLicenseQuery, GetOrganizationLicenseQuery>();
     }
 
     private static void AddTokenizers(this IServiceCollection services)

--- a/src/Core/Services/IOrganizationService.cs
+++ b/src/Core/Services/IOrganizationService.cs
@@ -49,9 +49,6 @@ public interface IOrganizationService
         IEnumerable<Guid> organizationUserIds, Guid? deletingUserId);
     Task UpdateUserGroupsAsync(OrganizationUser organizationUser, IEnumerable<Guid> groupIds, Guid? loggedInUserId);
     Task UpdateUserResetPasswordEnrollmentAsync(Guid organizationId, Guid userId, string resetPasswordKey, Guid? callingUserId);
-    Task<OrganizationLicense> GenerateLicenseAsync(Guid organizationId, Guid installationId);
-    Task<OrganizationLicense> GenerateLicenseAsync(Organization organization, Guid installationId,
-        int? version = null);
     Task ImportAsync(Guid organizationId, Guid? importingUserId, IEnumerable<ImportedGroup> groups,
         IEnumerable<ImportedOrganizationUser> newUsers, IEnumerable<string> removeUserExternalIds,
         bool overwriteExisting);

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1825,30 +1825,6 @@ public class OrganizationService : IOrganizationService
             EventType.OrganizationUser_ResetPassword_Enroll : EventType.OrganizationUser_ResetPassword_Withdraw);
     }
 
-    public async Task<OrganizationLicense> GenerateLicenseAsync(Guid organizationId, Guid installationId)
-    {
-        var organization = await GetOrgById(organizationId);
-        return await GenerateLicenseAsync(organization, installationId);
-    }
-
-    public async Task<OrganizationLicense> GenerateLicenseAsync(Organization organization, Guid installationId,
-        int? version = null)
-    {
-        if (organization == null)
-        {
-            throw new NotFoundException();
-        }
-
-        var installation = await _installationRepository.GetByIdAsync(installationId);
-        if (installation == null || !installation.Enabled)
-        {
-            throw new BadRequestException("Invalid installation id");
-        }
-
-        var subInfo = await _paymentService.GetSubscriptionAsync(organization);
-        return new OrganizationLicense(organization, subInfo, installationId, _licensingService, version);
-    }
-
     public async Task<OrganizationUser> InviteUserAsync(Guid organizationId, Guid? invitingUserId, string email,
         OrganizationUserType type, bool accessAll, string externalId, IEnumerable<SelectionReadOnly> collections)
     {

--- a/test/Api.Test/Controllers/OrganizationsControllerTests.cs
+++ b/test/Api.Test/Controllers/OrganizationsControllerTests.cs
@@ -6,6 +6,7 @@ using Bit.Core.Entities;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Data;
 using Bit.Core.OrganizationFeatures.OrganizationApiKeys.Interfaces;
+using Bit.Core.OrganizationFeatures.OrganizationLicenses.Interfaces;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Settings;
@@ -29,6 +30,7 @@ public class OrganizationsControllerTests : IDisposable
     private readonly IGetOrganizationApiKeyCommand _getOrganizationApiKeyCommand;
     private readonly IRotateOrganizationApiKeyCommand _rotateOrganizationApiKeyCommand;
     private readonly IOrganizationApiKeyRepository _organizationApiKeyRepository;
+    private readonly IGetOrganizationLicenseQuery _getOrganizationLicenseQuery;
 
     private readonly OrganizationsController _sut;
 
@@ -47,11 +49,12 @@ public class OrganizationsControllerTests : IDisposable
         _rotateOrganizationApiKeyCommand = Substitute.For<IRotateOrganizationApiKeyCommand>();
         _organizationApiKeyRepository = Substitute.For<IOrganizationApiKeyRepository>();
         _userService = Substitute.For<IUserService>();
+        _getOrganizationLicenseQuery = Substitute.For<IGetOrganizationLicenseQuery>();
 
         _sut = new OrganizationsController(_organizationRepository, _organizationUserRepository,
             _policyRepository, _organizationService, _userService, _paymentService, _currentContext,
             _ssoConfigRepository, _ssoConfigService, _getOrganizationApiKeyCommand, _rotateOrganizationApiKeyCommand,
-            _organizationApiKeyRepository, _globalSettings);
+            _organizationApiKeyRepository, _getOrganizationLicenseQuery, _globalSettings);
     }
 
     public void Dispose()


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Refactor `OrganizationService.GenerateLicenseAsync` to a query. This is tech debt work in preparation of implementing license sync for self-hosted.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* move method to its own query
  * Updated the "is the installation enabled?" check to use pattern matching
  * removed an unnecessary null check on `organization`. It's not a nullable parameter, callers should be responsible for ensuring that they pass in a not-null value - and in fact, they already do.
* remove the interface that takes the organizationId - callers should look up the org if required
* register the new query with DI and update all calling locations

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
