### PR TITLE
EF repos: fix attachments update

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CipherRepository.cs
@@ -562,7 +562,15 @@ public class CipherRepository : Repository<Core.Entities.Cipher, Cipher, Guid>, 
             var attachments = string.IsNullOrWhiteSpace(cipher.Attachments) ?
                 new Dictionary<string, CipherAttachment.MetaData>() :
                 JsonConvert.DeserializeObject<Dictionary<string, CipherAttachment.MetaData>>(cipher.Attachments);
-            attachments.Add(attachment.AttachmentId, JsonConvert.DeserializeObject<CipherAttachment.MetaData>(attachment.AttachmentData));
+            var metaData = JsonConvert.DeserializeObject<CipherAttachment.MetaData>(attachment.AttachmentData);
+            if (attachments.ContainsKey(attachment.AttachmentId))
+            {
+                attachments[attachment.AttachmentId] = metaData;
+            }
+            else
+            {
+                attachments.Add(attachment.AttachmentId, metaData);
+            }
             cipher.Attachments = JsonConvert.SerializeObject(attachments);
             await dbContext.SaveChangesAsync();
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Fix error when trying to upload attachments using EF repositories.

## Code changes
* **CipherRepository.cs:** Existing attachment data may already contain the same attachment ID, so make sure to check for an existing key and overwrite the valie.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
