### PR TITLE
[SG-701] Updated controller to not send notification if request was denied

### DIFF
--- a/src/Api/Controllers/AuthRequestsController.cs
+++ b/src/Api/Controllers/AuthRequestsController.cs
@@ -142,7 +142,13 @@ public class AuthRequestsController : Controller
         authRequest.ResponseDate = DateTime.UtcNow;
         authRequest.Approved = model.RequestApproved;
         await _authRequestRepository.ReplaceAsync(authRequest);
-        await _pushNotificationService.PushAuthRequestResponseAsync(authRequest);
+
+        // We only want to send an approval notification if the request is approved (or null), 
+        // to not leak that it was denied to the originating client if it was originated by a malicious actor.
+        if(authRequest.Approved ?? true)
+        {
+            await _pushNotificationService.PushAuthRequestResponseAsync(authRequest);
+        }
 
         return new AuthRequestResponseModel(authRequest, _globalSettings.BaseServiceUri.Vault);
     }

--- a/src/Api/Controllers/AuthRequestsController.cs
+++ b/src/Api/Controllers/AuthRequestsController.cs
@@ -145,7 +145,7 @@ public class AuthRequestsController : Controller
 
         // We only want to send an approval notification if the request is approved (or null), 
         // to not leak that it was denied to the originating client if it was originated by a malicious actor.
-        if(authRequest.Approved ?? true)
+        if (authRequest.Approved ?? true)
         {
             await _pushNotificationService.PushAuthRequestResponseAsync(authRequest);
         }


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Prevent sending a push notification to clients when a passwordless login request is denied.


## Code changes

* **AuthRequestsController.cs:** Added check to whether we send the push notification.  It should send if `Approved` is `NULL` (meaning that it has not been approved or denied) or if `Approved` is `true`.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
