### PR TITLE
try parse Size as a long

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/BaseEntityFrameworkRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/BaseEntityFrameworkRepository.cs
@@ -124,8 +124,14 @@ public abstract class BaseEntityFrameworkRepository
                     !string.IsNullOrWhiteSpace(e.Attachments))
                 .Select(e => e.Attachments)
                 .ToListAsync();
-            var storage = attachments.Sum(e => JsonDocument.Parse(e)?.RootElement.EnumerateObject()
-                .Sum(p => p.Value.GetProperty("Size").GetInt64()) ?? 0);
+            var storage = attachments.Sum(e => JsonDocument.Parse(e)?.RootElement.EnumerateObject().Sum(p =>
+            {
+                if (long.TryParse(p.Value.GetProperty("Size").ToString(), out var s))
+                {
+                    return s;
+                }
+                return 0;
+            }) ?? 0);
             var organization = new Organization
             {
                 Id = organizationId,
@@ -152,8 +158,14 @@ public abstract class BaseEntityFrameworkRepository
                     !string.IsNullOrWhiteSpace(e.Attachments))
                 .Select(e => e.Attachments)
                 .ToListAsync();
-            var storage = attachments.Sum(e => JsonDocument.Parse(e)?.RootElement.EnumerateObject()
-                .Sum(p => p.Value.GetProperty("Size").GetInt64()) ?? 0);
+            var storage = attachments.Sum(e => JsonDocument.Parse(e)?.RootElement.EnumerateObject().Sum(p =>
+            {
+                if (long.TryParse(p.Value.GetProperty("Size").ToString(), out var s))
+                {
+                    return s;
+                }
+                return 0;
+            }) ?? 0);
             var user = new Models.User
             {
                 Id = userId,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The "Size" field for attachments JSON seems to be stored as a long or a string in certain conditions. I believe this is happening because of the attributes defined here: https://github.com/bitwarden/server/blob/master/src/Core/Models/Data/CipherAttachment.cs#L18

I confirmed this also happens in production for SQL Server, however, the sproc there does proper casting to a long already.

In that light, I translated the same casting logic to EF so to resolve runtime errors when computing storage size updates from attachments.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Infrastructure.EntityFramework/Repositories/BaseEntityFrameworkRepository.cs:** Tryparse the `Size` property to a long.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
