### PR TITLE
Add Certificate Helper for Developing on Linux (Debian)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -19,6 +19,12 @@
       "commands": [
         "reportgenerator"
       ]
+    },
+    "dotnet-certificate-tool": {
+      "version": "2.0.7",
+      "commands": [
+        "certificate-tool"
+      ]
     }
   }
 }

--- a/dev/create_certificates_linux.sh
+++ b/dev/create_certificates_linux.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-dotnet tool install -g dotnet-certificate-tool
+dotnet tool restore
 
 stty -echo
-printf "Identity Server Dev Password: "
+printf "Identity Server Dev Password (enter for no password):"
 read identity_server_dev_pass
 stty echo
 printf "\n"
@@ -15,10 +15,15 @@ openssl pkcs12 -export -out identity_server_dev.pfx -inkey identity_server_dev.k
 
 identity="$(openssl x509 -in identity_server_dev.crt -outform der | shasum -a 1 | head -c 40 | tr a-z A-Z)"
 
-dotnet certificate-tool add --file ./identity_server_dev.pfx --password $identity_server_dev_pass
+if [ -z "$identity_server_dev_pass"]; 
+then
+    dotnet tool run certificate-tool add --file ./identity_server_dev.pfx
+else
+    dotnet tool run certificate-tool add --file ./identity_server_dev.pfx --password $identity_server_dev_pass
+fi
 
 stty -echo
-printf "Bitwarden Data Protection Dev Password:"
+printf "Bitwarden Data Protection Dev Password (enter for no password):"
 read bitwarden_data_protection_pass
 stty echo
 printf "\n"
@@ -30,7 +35,12 @@ openssl pkcs12 -export -out data_protection_dev.pfx -inkey data_protection_dev.k
 
 data="$(openssl x509 -in data_protection_dev.crt -outform der | shasum -a 1 | head -c 40 | tr a-z A-Z)"
 
-dotnet certificate-tool add --file ./data_protection_dev.pfx --password $bitwarden_data_protection_pass
+if [ -z "$bitwarden_data_protection_pass"]; 
+then
+    dotnet tool run certificate-tool add --file ./data_protection_dev.pfx
+else
+    dotnet tool run certificate-tool add --file ./data_protection_dev.pfx --password $bitwarden_data_protection_pass
+fi
 
 echo "Certificate fingerprints:"
 

--- a/dev/create_certificates_linux.sh
+++ b/dev/create_certificates_linux.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+dotnet tool install -g dotnet-certificate-tool
+
+stty -echo
+printf "Identity Server Dev Password: "
+read identity_server_dev_pass
+stty echo
+printf "\n"
+
+openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout identity_server_dev.key -out identity_server_dev.crt \
+    -subj "/CN=Bitwarden Identity Server Dev" -days 3650
+openssl pkcs12 -export -out identity_server_dev.pfx -inkey identity_server_dev.key -in identity_server_dev.crt \
+    -certfile identity_server_dev.crt -password pass:$identity_server_dev_pass
+
+identity="$(openssl x509 -in identity_server_dev.crt -outform der | shasum -a 1 | head -c 40 | tr a-z A-Z)"
+
+dotnet certificate-tool add --file ./identity_server_dev.pfx --password $identity_server_dev_pass
+
+stty -echo
+printf "Bitwarden Data Protection Dev Password:"
+read bitwarden_data_protection_pass
+stty echo
+printf "\n"
+
+openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout data_protection_dev.key -out data_protection_dev.crt \
+    -subj "/CN=Bitwarden Data Protection Dev" -days 3650
+openssl pkcs12 -export -out data_protection_dev.pfx -inkey data_protection_dev.key -in data_protection_dev.crt \
+    -certfile data_protection_dev.crt -password pass:$bitwarden_data_protection_pass
+
+data="$(openssl x509 -in data_protection_dev.crt -outform der | shasum -a 1 | head -c 40 | tr a-z A-Z)"
+
+dotnet certificate-tool add --file ./data_protection_dev.pfx --password $bitwarden_data_protection_pass
+
+echo "Certificate fingerprints:"
+
+echo "Identity Server Dev: ${identity}"
+echo "Data Protection Dev: ${data}"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
I am looking to do more of my development on WSL Ubuntu and this is the main thing keeping me from getting my dev environment working. This will make it so that `Identity` will be able to find the dev certificate on my machine. The environment this was explicitly tested for was: 
```shell
Distributor ID: Ubuntu
Description:    Ubuntu 22.04.1 LTS
Release:        22.04
Codename:       jammy
```


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **dev/create_certificates_linux.sh:** Creates a `dash` compatible shell script to be able to generate and install valid certificates on a debian based linux install that might not even have bash installed. 

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
