### PR TITLE
fix ef query joins with multi-condition ON clauses

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/Queries/CipherReadCanEditByIdUserIdQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/CipherReadCanEditByIdUserIdQuery.cs
@@ -17,37 +17,50 @@ public class CipherReadCanEditByIdUserIdQuery : IQuery<Cipher>
     public virtual IQueryable<Cipher> Run(DatabaseContext dbContext)
     {
         var query = from c in dbContext.Ciphers
+
                     join o in dbContext.Organizations
-                        on c.OrganizationId equals o.Id into o_g
+                        on new { c.UserId, c.OrganizationId } equals
+                           new { UserId = (Guid?)null, OrganizationId = (Guid?)o.Id } into o_g
                     from o in o_g.DefaultIfEmpty()
-                    where !c.UserId.HasValue
+
                     join ou in dbContext.OrganizationUsers
-                        on o.Id equals ou.OrganizationId into ou_g
+                        on new { OrganizationId = o.Id, UserId = (Guid?)_userId } equals
+                           new { ou.OrganizationId, ou.UserId } into ou_g
                     from ou in ou_g.DefaultIfEmpty()
-                    where ou.UserId == _userId
+
                     join cc in dbContext.CollectionCiphers
-                        on c.Id equals cc.CipherId into cc_g
+                        on new { c.UserId, ou.AccessAll, CipherId = c.Id } equals
+                           new { UserId = (Guid?)null, AccessAll = false, cc.CipherId } into cc_g
                     from cc in cc_g.DefaultIfEmpty()
-                    where !c.UserId.HasValue && !ou.AccessAll
+
                     join cu in dbContext.CollectionUsers
-                        on cc.CollectionId equals cu.CollectionId into cu_g
+                        on new { cc.CollectionId, OrganizationUserId = ou.Id } equals
+                           new { cu.CollectionId, cu.OrganizationUserId } into cu_g
                     from cu in cu_g.DefaultIfEmpty()
-                    where ou.Id == cu.OrganizationUserId
+
                     join gu in dbContext.GroupUsers
-                        on ou.Id equals gu.OrganizationUserId into gu_g
+                        on new { c.UserId, CollectionId = (Guid?)cu.CollectionId, ou.AccessAll, OrganizationUserId = ou.Id } equals
+                           new { UserId = (Guid?)null, CollectionId = (Guid?)null, AccessAll = false, gu.OrganizationUserId } into gu_g
                     from gu in gu_g.DefaultIfEmpty()
-                    where !c.UserId.HasValue && cu.CollectionId == null && !ou.AccessAll
+
                     join g in dbContext.Groups
                         on gu.GroupId equals g.Id into g_g
                     from g in g_g.DefaultIfEmpty()
+
                     join cg in dbContext.CollectionGroups
-                        on gu.GroupId equals cg.GroupId into cg_g
+                        on new { g.AccessAll, cc.CollectionId, gu.GroupId } equals
+                           new { AccessAll = false, cg.CollectionId, cg.GroupId } into cg_g
                     from cg in cg_g.DefaultIfEmpty()
-                    where !g.AccessAll && cg.CollectionId == cc.CollectionId &&
-                    (c.Id == _cipherId &&
-                    (c.UserId == _userId ||
-                    (!c.UserId.HasValue && ou.Status == OrganizationUserStatusType.Confirmed && o.Enabled &&
-                    (ou.AccessAll || cu.CollectionId != null || g.AccessAll || cg.CollectionId != null)))) &&
+
+                    where
+                    c.Id == _cipherId &&
+                    (
+                        c.UserId == _userId ||
+                        (
+                            !c.UserId.HasValue && ou.Status == OrganizationUserStatusType.Confirmed && o.Enabled &&
+                            (ou.AccessAll || cu.CollectionId != null || g.AccessAll || cg.CollectionId != null)
+                        )
+                    ) &&
                     (c.UserId.HasValue || ou.AccessAll || !cu.ReadOnly || g.AccessAll || !cg.ReadOnly)
                     select c;
         return query;

--- a/src/Infrastructure.EntityFramework/Repositories/Queries/UserCipherDetailsQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/UserCipherDetailsQuery.cs
@@ -14,33 +14,41 @@ public class UserCipherDetailsQuery : IQuery<CipherDetails>
     public virtual IQueryable<CipherDetails> Run(DatabaseContext dbContext)
     {
         var query = from c in dbContext.Ciphers
+
                     join ou in dbContext.OrganizationUsers
-                        on c.OrganizationId equals ou.OrganizationId
-                    where ou.UserId == _userId &&
-                        ou.Status == OrganizationUserStatusType.Confirmed
+                        on new { CipherUserId = c.UserId, c.OrganizationId, UserId = _userId, Status = OrganizationUserStatusType.Confirmed } equals
+                           new { CipherUserId = (Guid?)null, OrganizationId = (Guid?)ou.OrganizationId, ou.UserId, ou.Status }
+
                     join o in dbContext.Organizations
-                        on c.OrganizationId equals o.Id
-                    where o.Id == ou.OrganizationId && o.Enabled
+                        on new { c.OrganizationId, OuOrganizationId = ou.OrganizationId, Enabled = true } equals
+                           new { OrganizationId = (Guid?)o.Id, OuOrganizationId = o.Id, o.Enabled }
+
                     join cc in dbContext.CollectionCiphers
-                        on c.Id equals cc.CipherId into cc_g
+                        on new { ou.AccessAll, CipherId = c.Id } equals
+                           new { AccessAll = false, cc.CipherId } into cc_g
                     from cc in cc_g.DefaultIfEmpty()
-                    where ou.AccessAll
+
                     join cu in dbContext.CollectionUsers
-                        on cc.CollectionId equals cu.CollectionId into cu_g
+                        on new { cc.CollectionId, OrganizationUserId = ou.Id } equals
+                           new { cu.CollectionId, cu.OrganizationUserId } into cu_g
                     from cu in cu_g.DefaultIfEmpty()
-                    where cu.OrganizationUserId == ou.Id
+
                     join gu in dbContext.GroupUsers
-                        on ou.Id equals gu.OrganizationUserId into gu_g
+                        on new { CollectionId = (Guid?)cu.CollectionId, ou.AccessAll, OrganizationUserId = ou.Id } equals
+                           new { CollectionId = (Guid?)null, AccessAll = false, gu.OrganizationUserId } into gu_g
                     from gu in gu_g.DefaultIfEmpty()
-                    where cu.CollectionId == null && !ou.AccessAll
+
                     join g in dbContext.Groups
                         on gu.GroupId equals g.Id into g_g
                     from g in g_g.DefaultIfEmpty()
+
                     join cg in dbContext.CollectionGroups
-                        on cc.CollectionId equals cg.CollectionId into cg_g
+                        on new { g.AccessAll, cc.CollectionId, gu.GroupId } equals
+                           new { AccessAll = false, cg.CollectionId, cg.GroupId } into cg_g
                     from cg in cg_g.DefaultIfEmpty()
-                    where !g.AccessAll && cg.GroupId == gu.GroupId &&
-                    ou.AccessAll || cu.CollectionId != null || g.AccessAll || cg.CollectionId != null
+
+                    where ou.AccessAll || cu.CollectionId != null || g.AccessAll || cg.CollectionId != null
+
                     select new { c, ou, o, cc, cu, gu, g, cg }.c;
 
         var query2 = from c in dbContext.Ciphers

--- a/src/Infrastructure.EntityFramework/Repositories/Queries/UserCollectionDetailsQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/UserCollectionDetailsQuery.cs
@@ -13,26 +13,33 @@ public class UserCollectionDetailsQuery : IQuery<CollectionDetails>
     public virtual IQueryable<CollectionDetails> Run(DatabaseContext dbContext)
     {
         var query = from c in dbContext.Collections
+
                     join ou in dbContext.OrganizationUsers
                         on c.OrganizationId equals ou.OrganizationId
+
                     join o in dbContext.Organizations
                         on c.OrganizationId equals o.Id
+
                     join cu in dbContext.CollectionUsers
-                        on c.Id equals cu.CollectionId into cu_g
+                        on new { ou.AccessAll, CollectionId = c.Id, OrganizationUserId = ou.Id } equals
+                           new { AccessAll = false, cu.CollectionId, cu.OrganizationUserId } into cu_g
                     from cu in cu_g.DefaultIfEmpty()
-                    where ou.AccessAll && cu.OrganizationUserId == ou.Id
+
                     join gu in dbContext.GroupUsers
-                        on ou.Id equals gu.OrganizationUserId into gu_g
+                        on new { CollectionId = (Guid?)cu.CollectionId, ou.AccessAll, OrganizationUserId = ou.Id } equals
+                           new { CollectionId = (Guid?)null, AccessAll = false, gu.OrganizationUserId } into gu_g
                     from gu in gu_g.DefaultIfEmpty()
-                    where cu.CollectionId == null && !ou.AccessAll
+
                     join g in dbContext.Groups
                         on gu.GroupId equals g.Id into g_g
                     from g in g_g.DefaultIfEmpty()
+
                     join cg in dbContext.CollectionGroups
-                        on gu.GroupId equals cg.GroupId into cg_g
+                        on new { g.AccessAll, CollectionId = c.Id, gu.GroupId } equals
+                           new { AccessAll = false, cg.CollectionId, cg.GroupId } into cg_g
                     from cg in cg_g.DefaultIfEmpty()
-                    where !g.AccessAll && cg.CollectionId == c.Id &&
-                        ou.UserId == _userId &&
+
+                    where ou.UserId == _userId &&
                         ou.Status == OrganizationUserStatusType.Confirmed &&
                         o.Enabled &&
                         (ou.AccessAll || cu.CollectionId != null || g.AccessAll || cg.CollectionId != null)


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PS-1806

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Several EF queries that deal with organization collection, group, and cipher access are not performing their JOINs correctly. This PR is the start of correcting those joins.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **All files:** Convert multi-condition ON clauses to use anonymous object comparisons. See https://stackoverflow.com/questions/7664727/linq-join-with-multiple-conditions-in-on-clause

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
