### PR TITLE
[PS-1806] Fix EF `LEFT JOIN`'s on multiple values

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/Queries/OrganizationUserOrganizationDetailsViewQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/OrganizationUserOrganizationDetailsViewQuery.cs
@@ -7,58 +7,58 @@ public class OrganizationUserOrganizationDetailsViewQuery : IQuery<OrganizationU
     public IQueryable<OrganizationUserOrganizationDetails> Run(DatabaseContext dbContext)
     {
         var query = from ou in dbContext.OrganizationUsers
-                    join o in dbContext.Organizations on ou.OrganizationId equals o.Id
-                    join su in dbContext.SsoUsers on ou.UserId equals su.UserId into su_g
+                    join o in dbContext.Organizations on ou.OrganizationId equals o.Id into outerOrganization
+                    from o in outerOrganization.DefaultIfEmpty()
+                    join su in dbContext.SsoUsers on new { ou.UserId, OrganizationId = (Guid?)ou.OrganizationId } equals new { UserId = (Guid?)su.UserId, su.OrganizationId } into su_g
                     from su in su_g.DefaultIfEmpty()
                     join po in dbContext.ProviderOrganizations on o.Id equals po.OrganizationId into po_g
                     from po in po_g.DefaultIfEmpty()
                     join p in dbContext.Providers on po.ProviderId equals p.Id into p_g
                     from p in p_g.DefaultIfEmpty()
-                    join os in dbContext.OrganizationSponsorships on ou.Id equals os.SponsoringOrganizationUserId into os_g
-                    from os in os_g.DefaultIfEmpty()
                     join ss in dbContext.SsoConfigs on ou.OrganizationId equals ss.OrganizationId into ss_g
                     from ss in ss_g.DefaultIfEmpty()
-                    where ((su == null || !su.OrganizationId.HasValue) || su.OrganizationId == ou.OrganizationId)
-                    select new { ou, o, su, p, ss, os };
-
-        return query.Select(x => new OrganizationUserOrganizationDetails
-        {
-            OrganizationId = x.ou.OrganizationId,
-            UserId = x.ou.UserId,
-            Name = x.o.Name,
-            Enabled = x.o.Enabled,
-            PlanType = x.o.PlanType,
-            UsePolicies = x.o.UsePolicies,
-            UseSso = x.o.UseSso,
-            UseKeyConnector = x.o.UseKeyConnector,
-            UseScim = x.o.UseScim,
-            UseGroups = x.o.UseGroups,
-            UseDirectory = x.o.UseDirectory,
-            UseEvents = x.o.UseEvents,
-            UseTotp = x.o.UseTotp,
-            Use2fa = x.o.Use2fa,
-            UseApi = x.o.UseApi,
-            SelfHost = x.o.SelfHost,
-            UsersGetPremium = x.o.UsersGetPremium,
-            Seats = x.o.Seats,
-            MaxCollections = x.o.MaxCollections,
-            MaxStorageGb = x.o.MaxStorageGb,
-            Identifier = x.o.Identifier,
-            Key = x.ou.Key,
-            ResetPasswordKey = x.ou.ResetPasswordKey,
-            Status = x.ou.Status,
-            Type = x.ou.Type,
-            SsoExternalId = x.su.ExternalId,
-            Permissions = x.ou.Permissions,
-            PublicKey = x.o.PublicKey,
-            PrivateKey = x.o.PrivateKey,
-            ProviderId = x.p.Id,
-            ProviderName = x.p.Name,
-            SsoConfig = x.ss.Data,
-            FamilySponsorshipFriendlyName = x.os.FriendlyName,
-            FamilySponsorshipLastSyncDate = x.os.LastSyncDate,
-            FamilySponsorshipToDelete = x.os.ToDelete,
-            FamilySponsorshipValidUntil = x.os.ValidUntil
-        });
+                    join os in dbContext.OrganizationSponsorships on ou.Id equals os.SponsoringOrganizationUserId into os_g
+                    from os in os_g.DefaultIfEmpty()
+                    select new OrganizationUserOrganizationDetails
+                    { 
+                        UserId = ou.UserId,
+                        OrganizationId = ou.OrganizationId,
+                        Name = o.Name,
+                        Enabled = o.Enabled,
+                        PlanType = o.PlanType,
+                        UsePolicies = o.UsePolicies,
+                        UseSso = o.UseSso,
+                        UseKeyConnector = o.UseKeyConnector,
+                        UseScim = o.UseScim,
+                        UseGroups = o.UseGroups,
+                        UseDirectory = o.UseDirectory,
+                        UseEvents = o.UseEvents,
+                        UseTotp = o.UseTotp,
+                        Use2fa = o.Use2fa,
+                        UseApi = o.UseApi,
+                        UseResetPassword = o.UseResetPassword,
+                        SelfHost = o.SelfHost,
+                        UsersGetPremium = o.UsersGetPremium,
+                        Seats = o.Seats,
+                        MaxCollections = o.MaxCollections,
+                        MaxStorageGb = o.MaxStorageGb,
+                        Identifier = o.Identifier,
+                        Key = ou.Key,
+                        ResetPasswordKey = ou.ResetPasswordKey,
+                        PublicKey = o.PublicKey,
+                        PrivateKey = o.PrivateKey,
+                        Status = ou.Status,
+                        Type = ou.Type,
+                        SsoExternalId = su.ExternalId,
+                        Permissions = ou.Permissions,
+                        ProviderId = p.Id,
+                        ProviderName = p.Name,
+                        SsoConfig = ss.Data,
+                        FamilySponsorshipFriendlyName = os.FriendlyName,
+                        FamilySponsorshipLastSyncDate = os.LastSyncDate,
+                        FamilySponsorshipToDelete = os.ToDelete,
+                        FamilySponsorshipValidUntil = os.ValidUntil
+                    };
+        return query;
     }
 }

--- a/src/Infrastructure.EntityFramework/Repositories/Queries/OrganizationUserOrganizationDetailsViewQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/OrganizationUserOrganizationDetailsViewQuery.cs
@@ -20,7 +20,7 @@ public class OrganizationUserOrganizationDetailsViewQuery : IQuery<OrganizationU
                     join os in dbContext.OrganizationSponsorships on ou.Id equals os.SponsoringOrganizationUserId into os_g
                     from os in os_g.DefaultIfEmpty()
                     select new OrganizationUserOrganizationDetails
-                    { 
+                    {
                         UserId = ou.UserId,
                         OrganizationId = ou.OrganizationId,
                         Name = o.Name,

--- a/src/Infrastructure.EntityFramework/Repositories/Queries/OrganizationUserUserViewQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/OrganizationUserUserViewQuery.cs
@@ -9,14 +9,14 @@ public class OrganizationUserUserDetailsViewQuery : IQuery<OrganizationUserUserD
         var query = from ou in dbContext.OrganizationUsers
                     join u in dbContext.Users on ou.UserId equals u.Id into u_g
                     from u in u_g.DefaultIfEmpty()
-                    join su in dbContext.SsoUsers on u.Id equals su.UserId into su_g
+                    join su in dbContext.SsoUsers on new { ou.UserId, OrganizationId = (Guid?)ou.OrganizationId } equals new { UserId = (Guid?)su.UserId, su.OrganizationId } into su_g
                     from su in su_g.DefaultIfEmpty()
                     select new { ou, u, su };
         return query.Select(x => new OrganizationUserUserDetails
         {
             Id = x.ou.Id,
-            OrganizationId = x.ou.OrganizationId,
             UserId = x.ou.UserId,
+            OrganizationId = x.ou.OrganizationId,
             Name = x.u.Name,
             Email = x.u.Email ?? x.ou.Email,
             TwoFactorProviders = x.u.TwoFactorProviders,
@@ -28,7 +28,7 @@ public class OrganizationUserUserDetailsViewQuery : IQuery<OrganizationUserUserD
             SsoExternalId = x.su.ExternalId,
             Permissions = x.ou.Permissions,
             ResetPasswordKey = x.ou.ResetPasswordKey,
-            UsesKeyConnector = x.u != null && x.u.UsesKeyConnector,
+            UsesKeyConnector = x.u.UsesKeyConnector,
         });
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix a couple more LEFT JOINs so that EF generates SQL equal to the SQL we run for SQL Server manually. 


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Infrastructure.EntityFramework/Repositories/Queries/OrganizationUserOrganizationDetailsViewQuery.cs:** Made the Organization join into a `LEFT JOIN` and joined `SsoUser` on `UserId` and `OrganizationId`.
* **src/Infrastructure.EntityFramework/Repositories/Queries/OrganizationUserUserViewQuery.cs:** Joined `SsoUser` on `UserId` and `OrganizationId` *NOTE* user has no part in this join anymore but this is inline with what SQL Server does.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
