### PR TITLE
[EC-584] Add TryParse to ClientVersion due to QA builds having an appended git hash

### DIFF
--- a/src/Api/Controllers/OrganizationExportController.cs
+++ b/src/Api/Controllers/OrganizationExportController.cs
@@ -41,7 +41,7 @@ public class OrganizationExportController : Controller
         IEnumerable<Collection> orgCollections = await _collectionService.GetOrganizationCollections(organizationId);
         (IEnumerable<CipherOrganizationDetails> orgCiphers, Dictionary<Guid, IGrouping<Guid, CollectionCipher>> collectionCiphersGroupDict) = await _cipherService.GetOrganizationCiphers(userId, organizationId);
 
-        if (_currentContext.ClientVersion == null || _currentContext.ClientVersion >= new Version("2023.01.0"))
+        if (_currentContext.ClientVersion == null || _currentContext.ClientVersion >= new Version("2023.1.0"))
         {
             var organizationExportResponseModel = new OrganizationExportResponseModel
             {
@@ -52,7 +52,7 @@ public class OrganizationExportController : Controller
             return Ok(organizationExportResponseModel);
         }
 
-        // Backward compatibility with versions before 2023.01.0 that use ListResponseModel
+        // Backward compatibility with versions before 2023.1.0 that use ListResponseModel
         var organizationExportListResponseModel = new OrganizationExportListResponseModel
         {
             Collections = GetOrganizationCollectionsResponse(orgCollections),

--- a/src/Api/Controllers/OrganizationExportController.cs
+++ b/src/Api/Controllers/OrganizationExportController.cs
@@ -41,7 +41,7 @@ public class OrganizationExportController : Controller
         IEnumerable<Collection> orgCollections = await _collectionService.GetOrganizationCollections(organizationId);
         (IEnumerable<CipherOrganizationDetails> orgCiphers, Dictionary<Guid, IGrouping<Guid, CollectionCipher>> collectionCiphersGroupDict) = await _cipherService.GetOrganizationCiphers(userId, organizationId);
 
-        if (_currentContext.ClientVersion == null || _currentContext.ClientVersion >= new Version("2022.12.0"))
+        if (_currentContext.ClientVersion == null || _currentContext.ClientVersion >= new Version("2023.01.0"))
         {
             var organizationExportResponseModel = new OrganizationExportResponseModel
             {
@@ -52,7 +52,7 @@ public class OrganizationExportController : Controller
             return Ok(organizationExportResponseModel);
         }
 
-        // Backward compatibility with versions before 2022.12.0 that use ListResponseModel
+        // Backward compatibility with versions before 2023.01.0 that use ListResponseModel
         var organizationExportListResponseModel = new OrganizationExportListResponseModel
         {
             Collections = GetOrganizationCollectionsResponse(orgCollections),

--- a/src/Api/Controllers/OrganizationExportController.cs
+++ b/src/Api/Controllers/OrganizationExportController.cs
@@ -42,7 +42,7 @@ public class OrganizationExportController : Controller
         (IEnumerable<CipherOrganizationDetails> orgCiphers, Dictionary<Guid, IGrouping<Guid, CollectionCipher>> collectionCiphersGroupDict) = await _cipherService.GetOrganizationCiphers(userId, organizationId);
 
         // Backward compatibility with versions before 2022.11.0 that use ListResponseModel
-        if (_currentContext.ClientVersion < new Version("2022.11.0"))
+        if (_currentContext.ClientVersion != null && _currentContext.ClientVersion < new Version("2022.11.0"))
         {
             var organizationExportListResponseModel = new OrganizationExportListResponseModel
             {

--- a/src/Api/Controllers/OrganizationExportController.cs
+++ b/src/Api/Controllers/OrganizationExportController.cs
@@ -42,7 +42,7 @@ public class OrganizationExportController : Controller
         (IEnumerable<CipherOrganizationDetails> orgCiphers, Dictionary<Guid, IGrouping<Guid, CollectionCipher>> collectionCiphersGroupDict) = await _cipherService.GetOrganizationCiphers(userId, organizationId);
 
         // Backward compatibility with versions before 2022.11.0 that use ListResponseModel
-        if (_currentContext.ClientVersion != null && _currentContext.ClientVersion < new Version("2022.11.0"))
+        if (_currentContext.ClientVersion != null && _currentContext.ClientVersion < new Version("2022.12.0"))
         {
             var organizationExportListResponseModel = new OrganizationExportListResponseModel
             {

--- a/src/Api/Controllers/OrganizationExportController.cs
+++ b/src/Api/Controllers/OrganizationExportController.cs
@@ -41,25 +41,25 @@ public class OrganizationExportController : Controller
         IEnumerable<Collection> orgCollections = await _collectionService.GetOrganizationCollections(organizationId);
         (IEnumerable<CipherOrganizationDetails> orgCiphers, Dictionary<Guid, IGrouping<Guid, CollectionCipher>> collectionCiphersGroupDict) = await _cipherService.GetOrganizationCiphers(userId, organizationId);
 
-        // Backward compatibility with versions before 2022.11.0 that use ListResponseModel
-        if (_currentContext.ClientVersion != null && _currentContext.ClientVersion < new Version("2022.12.0"))
+        if (_currentContext.ClientVersion == null || _currentContext.ClientVersion >= new Version("2022.12.0"))
         {
-            var organizationExportListResponseModel = new OrganizationExportListResponseModel
+            var organizationExportResponseModel = new OrganizationExportResponseModel
             {
-                Collections = GetOrganizationCollectionsResponse(orgCollections),
-                Ciphers = GetOrganizationCiphersResponse(orgCiphers, collectionCiphersGroupDict)
+                Collections = orgCollections.Select(c => new CollectionResponseModel(c)),
+                Ciphers = orgCiphers.Select(c => new CipherMiniDetailsResponseModel(c, _globalSettings, collectionCiphersGroupDict, c.OrganizationUseTotp))
             };
 
-            return Ok(organizationExportListResponseModel);
+            return Ok(organizationExportResponseModel);
         }
 
-        var organizationExportResponseModel = new OrganizationExportResponseModel
+        // Backward compatibility with versions before 2022.12.0 that use ListResponseModel
+        var organizationExportListResponseModel = new OrganizationExportListResponseModel
         {
-            Collections = orgCollections.Select(c => new CollectionResponseModel(c)),
-            Ciphers = orgCiphers.Select(c => new CipherMiniDetailsResponseModel(c, _globalSettings, collectionCiphersGroupDict, c.OrganizationUseTotp))
+            Collections = GetOrganizationCollectionsResponse(orgCollections),
+            Ciphers = GetOrganizationCiphersResponse(orgCiphers, collectionCiphersGroupDict)
         };
 
-        return Ok(organizationExportResponseModel);
+        return Ok(organizationExportListResponseModel);
     }
 
     private ListResponseModel<CollectionResponseModel> GetOrganizationCollectionsResponse(IEnumerable<Collection> orgCollections)

--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -82,9 +82,9 @@ public class CurrentContext : ICurrentContext
             MaybeBot = httpContext.Request.Headers["X-Cf-Maybe-Bot"] == "1";
         }
 
-        if (httpContext.Request.Headers.ContainsKey("Bitwarden-Client-Version"))
+        if (httpContext.Request.Headers.ContainsKey("Bitwarden-Client-Version") && Version.TryParse(httpContext.Request.Headers["Bitwarden-Client-Version"], out var cVersion))
         {
-            ClientVersion = new Version(httpContext.Request.Headers["Bitwarden-Client-Version"]);
+            ClientVersion = cVersion;
         }
     }
 

--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -82,9 +82,14 @@ public class CurrentContext : ICurrentContext
             MaybeBot = httpContext.Request.Headers["X-Cf-Maybe-Bot"] == "1";
         }
 
-        if (httpContext.Request.Headers.ContainsKey("Bitwarden-Client-Version") && Version.TryParse(httpContext.Request.Headers["Bitwarden-Client-Version"], out var cVersion))
+        if (httpContext.Request.Headers.ContainsKey("Bitwarden-Client-Version"))
         {
-            ClientVersion = cVersion;
+            // The string.Split method is being used for cases where QA builds include the git hash e.g. '2022.10.2 - 5f8c1c1'
+            var clientVersionHeader = httpContext.Request.Headers["Bitwarden-Client-Version"].ToString().Split(' ')[0];
+            if (Version.TryParse(clientVersionHeader, out var cVersion))
+            {
+                ClientVersion = cVersion;
+            }
         }
     }
 

--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -82,14 +82,9 @@ public class CurrentContext : ICurrentContext
             MaybeBot = httpContext.Request.Headers["X-Cf-Maybe-Bot"] == "1";
         }
 
-        if (httpContext.Request.Headers.ContainsKey("Bitwarden-Client-Version"))
+        if (httpContext.Request.Headers.ContainsKey("Bitwarden-Client-Version") && Version.TryParse(httpContext.Request.Headers["Bitwarden-Client-Version"], out var cVersion))
         {
-            // The string.Split method is being used for cases where QA builds include the git hash e.g. '2022.10.2 - 5f8c1c1'
-            var clientVersionHeader = httpContext.Request.Headers["Bitwarden-Client-Version"].ToString().Split(' ')[0];
-            if (Version.TryParse(clientVersionHeader, out var cVersion))
-            {
-                ClientVersion = cVersion;
-            }
+            ClientVersion = cVersion;
         }
     }
 


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
QA builds have the git hash appended to the `Bitwarden-Client-Version` header and it was causing the server to error when trying to parse the value. These changes use the `TryParse` method to check that the value has the correct format.


## Code changes

* **src/Core/Context/CurrentContext.cs:** Add TryParse to not throw an error when the `Bitwarden-Client-Version` has a different format
* **src/Api/Controllers/OrganizationExportController.cs:** Check that the Version value was parsed correctly

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
