### PR TITLE
[PS-1806] Fix EF CollectionRepository `GetManyByUserId`

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/Queries/UserCollectionDetailsQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/UserCollectionDetailsQuery.cs
@@ -10,6 +10,7 @@ public class UserCollectionDetailsQuery : IQuery<CollectionDetails>
     {
         _userId = userId;
     }
+
     public virtual IQueryable<CollectionDetails> Run(DatabaseContext dbContext)
     {
         var query = from c in dbContext.Collections
@@ -44,6 +45,8 @@ public class UserCollectionDetailsQuery : IQuery<CollectionDetails>
                         o.Enabled &&
                         (ou.AccessAll || cu.CollectionId != null || g.AccessAll || cg.CollectionId != null)
                     select new { c, ou, o, cu, gu, g, cg };
+#pragma warning disable IDE0075
+// I want to leave the ReadOnly and HidePasswords the way they are because it helps show the exact logic we are trying to replicate
         return query.Select(x => new CollectionDetails
         {
             Id = x.c.Id,
@@ -52,8 +55,11 @@ public class UserCollectionDetailsQuery : IQuery<CollectionDetails>
             ExternalId = x.c.ExternalId,
             CreationDate = x.c.CreationDate,
             RevisionDate = x.c.RevisionDate,
-            ReadOnly = !x.ou.AccessAll || !x.g.AccessAll || (x.cu.ReadOnly || x.cg.ReadOnly),
-            HidePasswords = !x.ou.AccessAll || !x.g.AccessAll || (x.cu.HidePasswords || x.cg.HidePasswords),
+            ReadOnly = x.ou.AccessAll || x.g.AccessAll || ((x.cu != null ? x.cu.ReadOnly : (bool?)null) ?? (x.cg != null ? x.cg.ReadOnly : (bool?)null) ?? false) ? false : true,
+            HidePasswords = x.ou.AccessAll || x.g.AccessAll || ((x.cu != null ? x.cu.HidePasswords : (bool?)null) ?? (x.cg != null ? x.cg.HidePasswords : (bool?)null) ?? false) ? false : true,
         });
+#pragma warning restore IDE0075
     }
+
+
 }

--- a/src/Infrastructure.EntityFramework/Repositories/Queries/UserCollectionDetailsQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/UserCollectionDetailsQuery.cs
@@ -46,7 +46,7 @@ public class UserCollectionDetailsQuery : IQuery<CollectionDetails>
                         (ou.AccessAll || cu.CollectionId != null || g.AccessAll || cg.CollectionId != null)
                     select new { c, ou, o, cu, gu, g, cg };
 #pragma warning disable IDE0075
-// I want to leave the ReadOnly and HidePasswords the way they are because it helps show the exact logic we are trying to replicate
+        // I want to leave the ReadOnly and HidePasswords the way they are because it helps show the exact logic we are trying to replicate
         return query.Select(x => new CollectionDetails
         {
             Id = x.c.Id,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Try to get EFCore to generate SQL more closely to the hand written T-SQL calls.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Infrastructure.EntityFramework/Repositories/Queries/UserCollectionDetailsQuery.cs:**
Now generates SQL like this in comparison to https://github.com/bitwarden/server/blob/9ecf69d9cabce732cf2c57976dd9afa5728578fb/src/Sql/dbo/Functions/UserCollectionDetails.sql: 
```sql
SELECT `c`.`Id`, `c`.`OrganizationId`, `c`.`Name`, `c`.`CreationDate`, `c`.`RevisionDate`, `c`.`ExternalId`, CASE
    WHEN (`o`.`AccessAll` OR `g0`.`AccessAll`) OR COALESCE(`c0`.`ReadOnly`, COALESCE(`c1`.`ReadOnly`, FALSE)) THEN FALSE
    ELSE TRUE
END AS `ReadOnly`, CASE
    WHEN (`o`.`AccessAll` OR `g0`.`AccessAll`) OR COALESCE(`c0`.`HidePasswords`, COALESCE(`c1`.`HidePasswords`, FALSE)) THEN FALSE
    ELSE TRUE
END AS `HidePasswords`
FROM `Collection` AS `c`
INNER JOIN `OrganizationUser` AS `o` ON `c`.`OrganizationId` = `o`.`OrganizationId`
INNER JOIN `Organization` AS `o0` ON `c`.`OrganizationId` = `o0`.`Id`
LEFT JOIN `CollectionUsers` AS `c0` ON (NOT (`o`.`AccessAll`) AND (`c`.`Id` = `c0`.`CollectionId`)) AND (`o`.`Id` = `c0`.`OrganizationUserId`)
LEFT JOIN `GroupUser` AS `g` ON (`c0`.`CollectionId` IS NULL AND NOT (`o`.`AccessAll`)) AND (`o`.`Id` = `g`.`OrganizationUserId`)
LEFT JOIN `Group` AS `g0` ON `g`.`GroupId` = `g0`.`Id`
LEFT JOIN `CollectionGroups` AS `c1` ON ((`g0`.`AccessAll` = FALSE) AND (`c`.`Id` = `c1`.`CollectionId`)) AND (`g`.`GroupId` = `c1`.`GroupId`)
WHERE (((`o`.`UserId` = 'my_user_id') AND (`o`.`Status` = 2)) AND `o0`.`Enabled`) AND (((`o`.`AccessAll` OR (`c0`.`CollectionId` IS NOT NULL)) OR `g0`.`AccessAll`) OR `c1`.`CollectionId` IS NOT NULL)
```
* **src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs:**
Now generates SQL like this in comparison to https://github.com/bitwarden/server/blob/9ecf69d9cabce732cf2c57976dd9afa5728578fb/src/Sql/dbo/Stored%20Procedures/Collection_ReadByUserId.sql
```sql
SELECT `c`.`Id`, `c`.`OrganizationId`, `c`.`Name`, `c`.`CreationDate`, `c`.`RevisionDate`, `c`.`ExternalId`, MIN(CASE
    WHEN (`o`.`AccessAll` OR `g0`.`AccessAll`) OR COALESCE(`c0`.`ReadOnly`, COALESCE(`c1`.`ReadOnly`, FALSE)) THEN FALSE
    ELSE TRUE
END) AS `ReadOnly`, MIN(CASE
    WHEN (`o`.`AccessAll` OR `g0`.`AccessAll`) OR COALESCE(`c0`.`HidePasswords`, COALESCE(`c1`.`HidePasswords`, FALSE)) THEN FALSE
    ELSE TRUE
END) AS `HidePasswords`
FROM `Collection` AS `c`
INNER JOIN `OrganizationUser` AS `o` ON `c`.`OrganizationId` = `o`.`OrganizationId`
INNER JOIN `Organization` AS `o0` ON `c`.`OrganizationId` = `o0`.`Id`
LEFT JOIN `CollectionUsers` AS `c0` ON (NOT (`o`.`AccessAll`) AND (`c`.`Id` = `c0`.`CollectionId`)) AND (`o`.`Id` = `c0`.`OrganizationUserId`)
LEFT JOIN `GroupUser` AS `g` ON (`c0`.`CollectionId` IS NULL AND NOT (`o`.`AccessAll`)) AND (`o`.`Id` = `g`.`OrganizationUserId`)
LEFT JOIN `Group` AS `g0` ON `g`.`GroupId` = `g0`.`Id`
LEFT JOIN `CollectionGroups` AS `c1` ON ((`g0`.`AccessAll` = FALSE) AND (`c`.`Id` = `c1`.`CollectionId`)) AND (`g`.`GroupId` = `c1`.`GroupId`)
WHERE (((`o`.`UserId` = '0f7cc63b-2276-471e-928d-af4c01686d2b') AND (`o`.`Status` = 2)) AND `o0`.`Enabled`) AND (((`o`.`AccessAll` OR (`c0`.`CollectionId` IS NOT NULL)) OR `g0`.`AccessAll`) OR `c1`.`CollectionId` IS NOT NULL)
GROUP BY `c`.`Id`, `c`.`OrganizationId`, `c`.`Name`, `c`.`CreationDate`, `c`.`RevisionDate`, `c`.`ExternalId`
```


## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
