### PR TITLE
[SG-814] Changed query for device to include userId

### DIFF
--- a/src/Api/Controllers/AuthRequestsController.cs
+++ b/src/Api/Controllers/AuthRequestsController.cs
@@ -130,7 +130,7 @@ public class AuthRequestsController : Controller
             throw new DuplicateAuthRequestException();
         }
 
-        var device = await _deviceRepository.GetByIdentifierAsync(model.DeviceIdentifier);
+        var device = await _deviceRepository.GetByIdentifierAsync(model.DeviceIdentifier, userId);
         if (device == null)
         {
             throw new BadRequestException("Invalid device.");


### PR DESCRIPTION

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The `Put` on AuthRequests looks up the existing device.  It was doing that only by device identifier, not by identifier and userId.  This produced inconsistent behavior when there were multiple accounts for a given device identifier.

## Code changes

* **AuthRequestsController.cs:** Added `userId` to query.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
