### PR TITLE
[SM-259] Fix create access token scope initialization

### DIFF
--- a/bitwarden_license/test/Commercial.Core.Test/SecretManagerFeatures/ServiceAccounts/CreateServiceAccountCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretManagerFeatures/ServiceAccounts/CreateServiceAccountCommandTests.cs
@@ -7,7 +7,7 @@ using Bit.Test.Common.Helpers;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Commercial.Core.Test.SecretManagerFeatures.Secrets;
+namespace Bit.Commercial.Core.Test.SecretManagerFeatures.ServiceAccounts;
 
 [SutProviderCustomize]
 public class CreateServiceAccountCommandTests

--- a/bitwarden_license/test/Commercial.Core.Test/SecretManagerFeatures/ServiceAccounts/UpdateServiceAccountCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretManagerFeatures/ServiceAccounts/UpdateServiceAccountCommandTests.cs
@@ -8,7 +8,7 @@ using Bit.Test.Common.Helpers;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Commercial.Core.Test.SecretManagerFeatures.Secrets;
+namespace Bit.Commercial.Core.Test.SecretManagerFeatures.ServiceAccounts;
 
 [SutProviderCustomize]
 public class UpdateServiceAccountCommandTests

--- a/src/Api/SecretManagerFeatures/Models/Request/AccessTokenCreateRequestModel.cs
+++ b/src/Api/SecretManagerFeatures/Models/Request/AccessTokenCreateRequestModel.cs
@@ -28,7 +28,7 @@ public class AccessTokenCreateRequestModel
             Name = Name,
             Key = Key,
             ExpireAt = ExpireAt,
-            Scope = "api.secrets",
+            Scope = "[\"api.secrets\"]",
             EncryptedPayload = EncryptedPayload,
 
         };

--- a/src/Api/SecretManagerFeatures/Models/Request/ProjectCreateRequestModel.cs
+++ b/src/Api/SecretManagerFeatures/Models/Request/ProjectCreateRequestModel.cs
@@ -15,7 +15,7 @@ public class ProjectCreateRequestModel
         return new Project()
         {
             OrganizationId = organizationId,
-            Name = this.Name,
+            Name = Name,
         };
     }
 }

--- a/src/Api/SecretManagerFeatures/Models/Request/ProjectUpdateRequestModel.cs
+++ b/src/Api/SecretManagerFeatures/Models/Request/ProjectUpdateRequestModel.cs
@@ -15,7 +15,7 @@ public class ProjectUpdateRequestModel
         return new Project()
         {
             Id = id,
-            Name = this.Name,
+            Name = Name,
         };
     }
 }

--- a/src/Api/SecretManagerFeatures/Models/Request/SecretCreateRequestModel.cs
+++ b/src/Api/SecretManagerFeatures/Models/Request/SecretCreateRequestModel.cs
@@ -23,9 +23,9 @@ public class SecretCreateRequestModel
         return new Secret()
         {
             OrganizationId = organizationId,
-            Key = this.Key,
-            Value = this.Value,
-            Note = this.Note,
+            Key = Key,
+            Value = Value,
+            Note = Note,
             DeletedDate = null,
         };
     }

--- a/src/Api/SecretManagerFeatures/Models/Request/SecretUpdateRequestModel.cs
+++ b/src/Api/SecretManagerFeatures/Models/Request/SecretUpdateRequestModel.cs
@@ -23,9 +23,9 @@ public class SecretUpdateRequestModel
         return new Secret()
         {
             Id = id,
-            Key = this.Key,
-            Value = this.Value,
-            Note = this.Note,
+            Key = Key,
+            Value = Value,
+            Note = Note,
             DeletedDate = null,
         };
     }

--- a/src/Api/SecretManagerFeatures/Models/Request/SerivceAccountUpdateRequestModel.cs
+++ b/src/Api/SecretManagerFeatures/Models/Request/SerivceAccountUpdateRequestModel.cs
@@ -15,7 +15,7 @@ public class ServiceAccountUpdateRequestModel
         return new ServiceAccount()
         {
             Id = id,
-            Name = this.Name,
+            Name = Name,
         };
     }
 }

--- a/src/Api/SecretManagerFeatures/Models/Request/ServiceAccountCreateRequestModel.cs
+++ b/src/Api/SecretManagerFeatures/Models/Request/ServiceAccountCreateRequestModel.cs
@@ -15,7 +15,7 @@ public class ServiceAccountCreateRequestModel
         return new ServiceAccount()
         {
             OrganizationId = organizationId,
-            Name = this.Name,
+            Name = Name,
         };
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The purpose of this PR is to:

-  fix how scope is being set on access token creation.
- No longer use `this.` for Secrets Manager request models
-  Fix a spelling mistake on Service Account Command unit tests.

The `GetAccessTokens` is expecting scope to be in a JSON list format and is failing due to how it is currently being set on creation.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- bitwarden_license/test/Commercial.Core.Test/SecretManagerFeatures/ServiceAccounts/CreateServiceAccountCommandTests.cs
bitwarden_license/test/Commercial.Core.Test/SecretManagerFeatures/ServiceAccounts/UpdateServiceAccountCommandTests.cs

Update ServiceAccount Command tests namespace to the correct name.

- src/Api/SecretManagerFeatures/Models/Request/AccessTokenCreateRequestModel.cs

Fix where Scope was expecting JSON list. This was breaking fetching the access tokens.


Remove the use of `this.` in request models.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
