### PR TITLE
Set Id property of Device to force a save instead of a create

### DIFF
--- a/src/Identity/IdentityServer/BaseRequestValidator.cs
+++ b/src/Identity/IdentityServer/BaseRequestValidator.cs
@@ -562,6 +562,10 @@ public abstract class BaseRequestValidator<T> where T : class
                     }
                 }
             }
+            else
+            {
+                deviceFromRequest.Id = existingDevice.Id;
+            }
 
             deviceFromRequest.UserId = user.Id;
             await _deviceService.SaveAsync(deviceFromRequest);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
In [this](https://github.com/bitwarden/server/pull/2404) PR, I added logic to save a known device regardless of whether it existed or not, in order to always update the push token (if there was one on the request).  In doing so, I introduced a bug in which it attempted to always do a "Create" on the `Device` table for existing devices.  The `SaveAsync()` method determines whether to create or update based on the presence of the `Id` property.  I missed setting the `Id` of the device to the one previously retrieved.

## Code changes

* **BaseRequestValidator.cs:** Set the `Id` property on the request.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
