### PR TITLE
PS-1806 fix boolean logic with UserCollectionDetailsQuery query

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/Queries/UserCollectionDetailsQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/UserCollectionDetailsQuery.cs
@@ -55,11 +55,11 @@ public class UserCollectionDetailsQuery : IQuery<CollectionDetails>
             ExternalId = x.c.ExternalId,
             CreationDate = x.c.CreationDate,
             RevisionDate = x.c.RevisionDate,
-            ReadOnly = x.ou.AccessAll || x.g.AccessAll || ((x.cu != null ? x.cu.ReadOnly : (bool?)null) ?? (x.cg != null ? x.cg.ReadOnly : (bool?)null) ?? false) ? false : true,
-            HidePasswords = x.ou.AccessAll || x.g.AccessAll || ((x.cu != null ? x.cu.HidePasswords : (bool?)null) ?? (x.cg != null ? x.cg.HidePasswords : (bool?)null) ?? false) ? false : true,
+            ReadOnly = x.ou.AccessAll || x.g.AccessAll ||
+                !((bool?)x.cu.ReadOnly ?? (bool?)x.cg.ReadOnly ?? false) ? false : true,
+            HidePasswords = x.ou.AccessAll || x.g.AccessAll ||
+                !((bool?)x.cu.HidePasswords ?? (bool?)x.cg.HidePasswords ?? false) ? false : true,
         });
 #pragma warning restore IDE0075
     }
-
-
 }

--- a/src/Infrastructure.EntityFramework/Repositories/Queries/UserCollectionDetailsQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/UserCollectionDetailsQuery.cs
@@ -59,6 +59,5 @@ public class UserCollectionDetailsQuery : IQuery<CollectionDetails>
             HidePasswords = x.ou.AccessAll || x.g.AccessAll ||
                 !((bool?)x.cu.HidePasswords ?? (bool?)x.cg.HidePasswords ?? false) ? false : true,
         });
-#pragma warning restore IDE0075
     }
 }

--- a/src/Infrastructure.EntityFramework/Repositories/Queries/UserCollectionDetailsQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/UserCollectionDetailsQuery.cs
@@ -45,8 +45,7 @@ public class UserCollectionDetailsQuery : IQuery<CollectionDetails>
                         o.Enabled &&
                         (ou.AccessAll || cu.CollectionId != null || g.AccessAll || cg.CollectionId != null)
                     select new { c, ou, o, cu, gu, g, cg };
-#pragma warning disable IDE0075
-        // I want to leave the ReadOnly and HidePasswords the way they are because it helps show the exact logic we are trying to replicate
+
         return query.Select(x => new CollectionDetails
         {
             Id = x.c.Id,


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PS-1806

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The ReadOnly and HidePasswords fields did not have the correct logic to match the equivalent TSQL sproc. This PR fixes that.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **UserCollectionDetailsQuery.cs:** Fix boolean logic with ReadOnly and HidePasswords fields. Simplify logic so that we can remove pragma warning.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
