### PR TITLE
Revert change on EF CipherRepository

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CipherRepository.cs
@@ -562,7 +562,8 @@ public class CipherRepository : Repository<Core.Entities.Cipher, Cipher, Guid>, 
             var attachments = string.IsNullOrWhiteSpace(cipher.Attachments) ?
                 new Dictionary<string, CipherAttachment.MetaData>() :
                 JsonConvert.DeserializeObject<Dictionary<string, CipherAttachment.MetaData>>(cipher.Attachments);
-            attachments.Add(attachment.AttachmentId, JsonConvert.DeserializeObject<CipherAttachment.MetaData>(attachment.AttachmentData));
+            var metaData = JsonConvert.DeserializeObject<CipherAttachment.MetaData>(attachment.AttachmentData);
+            attachments[attachment.AttachmentId] = metaData;
             cipher.Attachments = JsonConvert.SerializeObject(attachments);
             await dbContext.SaveChangesAsync();
 


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Revert a change [in a PR](https://github.com/bitwarden/server/commit/37ed4f43b2721aa0d3e02c87e9e2031b15f91517#diff-02a9cc20539cace5e925e4bd7280326a80e0199b64d9156626af0e30c40e0879) that was reverting a fix (https://github.com/bitwarden/server/pull/2374) to the attachments on the EF repo.

## Code changes

* **src/Infrastructure.EntityFramework/Repositories/CipherRepository.cs:** Re-apply the fix from https://github.com/bitwarden/server/pull/2374.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
