### PR TITLE
CSA-29: Time safe comparison for access code

### DIFF
--- a/src/Api/Controllers/AuthRequestsController.cs
+++ b/src/Api/Controllers/AuthRequestsController.cs
@@ -6,6 +6,7 @@ using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Settings;
+using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -68,7 +69,7 @@ public class AuthRequestsController : Controller
     public async Task<AuthRequestResponseModel> GetResponse(string id, [FromQuery] string code)
     {
         var authRequest = await _authRequestRepository.GetByIdAsync(new Guid(id));
-        if (authRequest == null || code != authRequest.AccessCode || authRequest.GetExpirationDate() < DateTime.UtcNow)
+        if (authRequest == null || !CoreHelpers.FixedTimeEquals(authRequest.AccessCode, code) || authRequest.GetExpirationDate() < DateTime.UtcNow)
         {
             throw new NotFoundException();
         }

--- a/src/Core/LoginFeatures/PasswordlessLogin/VerifyAuthRequest.cs
+++ b/src/Core/LoginFeatures/PasswordlessLogin/VerifyAuthRequest.cs
@@ -15,7 +15,6 @@ public class VerifyAuthRequestCommand : IVerifyAuthRequestCommand
 
     public async Task<bool> VerifyAuthRequestAsync(Guid authRequestId, string accessCode)
     {
-        
         var authRequest = await _authRequestRepository.GetByIdAsync(authRequestId);
         if (authRequest == null || !CoreHelpers.FixedTimeEquals(authRequest.AccessCode, accessCode))
         {

--- a/src/Core/LoginFeatures/PasswordlessLogin/VerifyAuthRequest.cs
+++ b/src/Core/LoginFeatures/PasswordlessLogin/VerifyAuthRequest.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Core.LoginFeatures.PasswordlessLogin.Interfaces;
 using Bit.Core.Repositories;
+using Bit.Core.Utilities;
 
 namespace Bit.Core.LoginFeatures.PasswordlessLogin;
 
@@ -14,8 +15,9 @@ public class VerifyAuthRequestCommand : IVerifyAuthRequestCommand
 
     public async Task<bool> VerifyAuthRequestAsync(Guid authRequestId, string accessCode)
     {
+        
         var authRequest = await _authRequestRepository.GetByIdAsync(authRequestId);
-        if (authRequest == null || authRequest.AccessCode != accessCode)
+        if (authRequest == null || !CoreHelpers.FixedTimeEquals(authRequest.AccessCode, accessCode))
         {
             return false;
         }


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/CSA-29

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Use a time safe comparison on the passwordless access code to prevent timing attacks.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **AuthRequestsController.cs:** Use `CoreHelpers.FixedTimeEquals` instead of standard string comparison.
* **VerifyAuthRequest.cs:** Use `CoreHelpers.FixedTimeEquals` instead of standard string comparison.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
