### PR TITLE
[SM-359] Fix project secrets migration

### DIFF
--- a/util/MySqlMigrations/Migrations/20221018133046_ProjectSecret.Designer.cs
+++ b/util/MySqlMigrations/Migrations/20221018133046_ProjectSecret.Designer.cs
@@ -11,8 +11,8 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Bit.MySqlMigrations.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    [Migration("20221018133046_projectSecretMapping")]
-    partial class projectSecretMapping
+    [Migration("20221018133046_ProjectSecret")]
+    partial class ProjectSecret
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {

--- a/util/MySqlMigrations/Migrations/20221018133046_ProjectSecret.cs
+++ b/util/MySqlMigrations/Migrations/20221018133046_ProjectSecret.cs
@@ -2,9 +2,9 @@
 
 #nullable disable
 
-namespace Bit.PostgresMigrations.Migrations;
+namespace Bit.MySqlMigrations.Migrations;
 
-public partial class ProjectSecretsTable : Migration
+public partial class ProjectSecret : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)
     {
@@ -12,8 +12,8 @@ public partial class ProjectSecretsTable : Migration
             name: "ProjectSecret",
             columns: table => new
             {
-                ProjectsId = table.Column<Guid>(type: "uuid", nullable: false),
-                SecretsId = table.Column<Guid>(type: "uuid", nullable: false)
+                ProjectsId = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci"),
+                SecretsId = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci")
             },
             constraints: table =>
             {
@@ -30,7 +30,8 @@ public partial class ProjectSecretsTable : Migration
                     principalTable: "Secret",
                     principalColumn: "Id",
                     onDelete: ReferentialAction.Cascade);
-            });
+            })
+            .Annotation("MySql:CharSet", "utf8mb4");
 
         migrationBuilder.CreateIndex(
             name: "IX_ProjectSecret_SecretsId",

--- a/util/MySqlMigrations/Scripts/2022-10-18_00_ProjectSecret.sql
+++ b/util/MySqlMigrations/Scripts/2022-10-18_00_ProjectSecret.sql
@@ -11,6 +11,6 @@ CREATE TABLE `ProjectSecret` (
 CREATE INDEX `IX_ProjectSecret_SecretsId` ON `ProjectSecret` (`SecretsId`);
 
 INSERT INTO `__EFMigrationsHistory` (`MigrationId`, `ProductVersion`)
-VALUES ('20221018133046_projectSecretMapping', '6.0.4');
+VALUES ('20221018133046_ProjectSecret', '6.0.4');
 
 COMMIT;

--- a/util/PostgresMigrations/Migrations/20221018155821_ProjectSecret.Designer.cs
+++ b/util/PostgresMigrations/Migrations/20221018155821_ProjectSecret.Designer.cs
@@ -12,8 +12,8 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Bit.PostgresMigrations.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    [Migration("20221018155821_ProjectSecretsTable")]
-    partial class ProjectSecretsTable
+    [Migration("20221018155821_ProjectSecret")]
+    partial class ProjectSecret
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {

--- a/util/PostgresMigrations/Migrations/20221018155821_ProjectSecret.cs
+++ b/util/PostgresMigrations/Migrations/20221018155821_ProjectSecret.cs
@@ -2,9 +2,9 @@
 
 #nullable disable
 
-namespace Bit.MySqlMigrations.Migrations;
+namespace Bit.PostgresMigrations.Migrations;
 
-public partial class projectSecretMapping : Migration
+public partial class ProjectSecret : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)
     {
@@ -12,8 +12,8 @@ public partial class projectSecretMapping : Migration
             name: "ProjectSecret",
             columns: table => new
             {
-                ProjectsId = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci"),
-                SecretsId = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci")
+                ProjectsId = table.Column<Guid>(type: "uuid", nullable: false),
+                SecretsId = table.Column<Guid>(type: "uuid", nullable: false)
             },
             constraints: table =>
             {
@@ -30,8 +30,7 @@ public partial class projectSecretMapping : Migration
                     principalTable: "Secret",
                     principalColumn: "Id",
                     onDelete: ReferentialAction.Cascade);
-            })
-            .Annotation("MySql:CharSet", "utf8mb4");
+            });
 
         migrationBuilder.CreateIndex(
             name: "IX_ProjectSecret_SecretsId",

--- a/util/PostgresMigrations/Scripts/2022-10-18_00_ProjectSecret.psql
+++ b/util/PostgresMigrations/Scripts/2022-10-18_00_ProjectSecret.psql
@@ -1,4 +1,6 @@
-﻿CREATE TABLE "ProjectSecret" (
+﻿START TRANSACTION;
+
+CREATE TABLE "ProjectSecret" (
     "ProjectsId" uuid NOT NULL,
     "SecretsId" uuid NOT NULL,
     CONSTRAINT "PK_ProjectSecret" PRIMARY KEY ("ProjectsId", "SecretsId"),
@@ -7,3 +9,8 @@
 );
 
 CREATE INDEX "IX_ProjectSecret_SecretsId" ON "ProjectSecret" ("SecretsId");
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('20221018155821_ProjectSecret', '6.0.4');
+
+COMMIT;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

I noticed the EF migrations for project secrets had some inconsistencies in the migrations and scripts.

- Rename files to `ProjectSecret`.
- Add missing migration history to postgres

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
