### PR TITLE
[PS-1909] Make LicenseKey check null safe

### DIFF
--- a/src/Core/Services/Implementations/LicensingService.cs
+++ b/src/Core/Services/Implementations/LicensingService.cs
@@ -115,7 +115,7 @@ public class LicensingService : ILicensingService
                     continue;
                 }
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 exceptions.Add(ex);
             }

--- a/src/Core/Services/Implementations/LicensingService.cs
+++ b/src/Core/Services/Implementations/LicensingService.cs
@@ -81,35 +81,49 @@ public class LicensingService : ILicensingService
 
         var enabledOrgs = await _organizationRepository.GetManyByEnabledAsync();
         _logger.LogInformation(Constants.BypassFiltersEventId, null,
-            "Validating licenses for {0} organizations.", enabledOrgs.Count);
+            "Validating licenses for {NumberOfOrganizations} organizations.", enabledOrgs.Count);
+
+        var exceptions = new List<Exception>();
 
         foreach (var org in enabledOrgs)
         {
-            var license = await ReadOrganizationLicenseAsync(org);
-            if (license == null)
+            try
             {
-                await DisableOrganizationAsync(org, null, "No license file.");
-                continue;
-            }
+                var license = await ReadOrganizationLicenseAsync(org);
+                if (license == null)
+                {
+                    await DisableOrganizationAsync(org, null, "No license file.");
+                    continue;
+                }
 
-            var totalLicensedOrgs = enabledOrgs.Count(o => o.LicenseKey.Equals(license.LicenseKey));
-            if (totalLicensedOrgs > 1)
-            {
-                await DisableOrganizationAsync(org, license, "Multiple organizations.");
-                continue;
-            }
+                var totalLicensedOrgs = enabledOrgs.Count(o => string.Equals(o.LicenseKey, license.LicenseKey));
+                if (totalLicensedOrgs > 1)
+                {
+                    await DisableOrganizationAsync(org, license, "Multiple organizations.");
+                    continue;
+                }
 
-            if (!license.VerifyData(org, _globalSettings))
-            {
-                await DisableOrganizationAsync(org, license, "Invalid data.");
-                continue;
-            }
+                if (!license.VerifyData(org, _globalSettings))
+                {
+                    await DisableOrganizationAsync(org, license, "Invalid data.");
+                    continue;
+                }
 
-            if (!license.VerifySignature(_certificate))
-            {
-                await DisableOrganizationAsync(org, license, "Invalid signature.");
-                continue;
+                if (!license.VerifySignature(_certificate))
+                {
+                    await DisableOrganizationAsync(org, license, "Invalid signature.");
+                    continue;
+                }
             }
+            catch(Exception ex)
+            {
+                exceptions.Add(ex);
+            }
+        }
+
+        if (exceptions.Any())
+        {
+            throw new AggregateException("There were one or more exceptions while validating organizations.", exceptions);
         }
     }
 

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -700,7 +700,7 @@ public class OrganizationService : IOrganizationService
         }
 
         var enabledOrgs = await _organizationRepository.GetManyByEnabledAsync();
-        if (enabledOrgs.Any(o => o.LicenseKey.Equals(license.LicenseKey)))
+        if (enabledOrgs.Any(o => string.Equals(o.LicenseKey, license.LicenseKey)))
         {
             throw new BadRequestException("License is already in use by another organization.");
         }

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -852,7 +852,7 @@ public class OrganizationService : IOrganizationService
         }
 
         var enabledOrgs = await _organizationRepository.GetManyByEnabledAsync();
-        if (enabledOrgs.Any(o => o.LicenseKey.Equals(license.LicenseKey) && o.Id != organizationId))
+        if (enabledOrgs.Any(o => string.Equals(o.LicenseKey, license.LicenseKey) && o.Id != organizationId))
         {
             throw new BadRequestException("License is already in use by another organization.");
         }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Make the `LicenseKey` check null safe in case an organization has a null license key or the incoming license has a null license key. This also helps address the exception that was being logged here: PS-988


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/Services/Implementations/OrganizationService.cs:** Use static `Equals` method incase either side are null.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
