### PR TITLE
PS-1956: cast EF Min function values to int

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs
@@ -141,8 +141,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                               CreationDate = collectionGroup.Key.CreationDate,
                               RevisionDate = collectionGroup.Key.RevisionDate,
                               ExternalId = collectionGroup.Key.ExternalId,
-                              ReadOnly = collectionGroup.Min(c => c.ReadOnly),
-                              HidePasswords = collectionGroup.Min(c => c.HidePasswords),
+                              ReadOnly = Convert.ToBoolean(collectionGroup.Min(c => Convert.ToInt32(c.ReadOnly))),
+                              HidePasswords = Convert.ToBoolean(collectionGroup.Min(c => Convert.ToInt32(c.HidePasswords))),
                           }).ToListAsync();
         }
     }

--- a/util/PostgresMigrations/HelperScripts/2022-03-01_00_Up_MigrateOrganizationApiKeys.psql
+++ b/util/PostgresMigrations/HelperScripts/2022-03-01_00_Up_MigrateOrganizationApiKeys.psql
@@ -4,7 +4,7 @@ INSERT INTO "OrganizationApiKey"(
     "ApiKey",
     "Type",
     "RevisionDate") 
-SELECT gen_random_uuid(),
+SELECT uuid_in(overlay(overlay(md5(random()::text || ':' || random()::text) placing '4' from 13) placing to_hex(floor(random()*(11-8+1) + 8)::int)::text from 17)::cstring),
     "Id" AS "OrganizationId",
     "ApiKey",
     0 AS "Type",

--- a/util/PostgresMigrations/Scripts/2022-03-25_00_SelfHostF4E.psql
+++ b/util/PostgresMigrations/Scripts/2022-03-25_00_SelfHostF4E.psql
@@ -24,7 +24,7 @@ INSERT INTO "OrganizationApiKey"(
     "ApiKey",
     "Type",
     "RevisionDate") 
-SELECT gen_random_uuid(),
+SELECT uuid_in(overlay(overlay(md5(random()::text || ':' || random()::text) placing '4' from 13) placing to_hex(floor(random()*(11-8+1) + 8)::int)::text from 17)::cstring),
     "Id" AS "OrganizationId",
     "ApiKey",
     0 AS "Type",


### PR DESCRIPTION
Resolves https://bitwarden.atlassian.net/browse/PS-1956
Resolves https://bitwarden.atlassian.net/browse/PS-1958
Resolves https://bitwarden.atlassian.net/browse/PS-1959


## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Postgres does not allow the MIN aggregate function with boolean data types. This change casts the boolean to an int and then back out to a boolean after the MIN function aggregates the expected result from 0 and 1 values.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CollectionRepository.cs:** Convert bool values to int for the Min function and back out to bool again.
* **2022-03-01_00_Up_MigrateOrganizationApiKeys.psql:** gen_random_uuid() is not available in postgres versions <13 without loading extensions. This causes migrations to fail. Switch to something more compatible to generate random UUID values. This shouldn't matter anyways since Postgres is net new and there is no data to migrate for people here.
* **2022-03-25_00_SelfHostF4E.psql:** gen_random_uuid() is not available in postgres versions <13 without loading extensions. This causes migrations to fail. Switch to something more compatible to generate random UUID values. This shouldn't matter anyways since Postgres is net new and there is no data to migrate for people here.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
