### PR TITLE
[PS-1961] Fix Admin Email Search

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/UserRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/UserRepository.cs
@@ -47,7 +47,7 @@ public class UserRepository : Repository<Core.Entities.User, User, Guid>, IUserR
             {
                 users = await GetDbSet(dbContext)
                     .Where(e => e.Email == null ||
-                        EF.Functions.ILike(EF.Functions.Collate(e.Email, "default"), "a%"))
+                        EF.Functions.ILike(EF.Functions.Collate(e.Email, "default"), $"{email}%"))
                     .OrderBy(e => e.Email)
                     .Skip(skip).Take(take)
                     .ToListAsync();


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix Admin search so that it's not always searching for emails that start with `a`. 


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Infrastructure.EntityFramework/Repositories/UserRepository.cs:** Fix an oversight that was always searching for starting with `a` on Postgres.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
