### PR TITLE
Fix DateTime handling for Postgres 

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CipherRepository.cs
@@ -139,7 +139,7 @@ public class CipherRepository : Repository<Core.Entities.Cipher, Cipher, Guid>, 
             await dbContext.BulkCopyAsync(base.DefaultBulkCopyOptions, folderEntities);
             var cipherEntities = Mapper.Map<List<Cipher>>(ciphers);
             await dbContext.BulkCopyAsync(base.DefaultBulkCopyOptions, cipherEntities);
-            await dbContext.UserBumpAccountRevisionDateByCipherIdAsync(ciphers);
+            await dbContext.UserBumpAccountRevisionDateAsync(ciphers.First().UserId.GetValueOrDefault());
             await dbContext.SaveChangesAsync();
         }
     }

--- a/src/Infrastructure.EntityFramework/Repositories/DatabaseContextExtensions.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/DatabaseContextExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Core.Entities;
-using Bit.Core.Enums;
+﻿using Bit.Core.Enums;
 using Bit.Core.Enums.Provider;
 using Bit.Infrastructure.EntityFramework.Repositories.Queries;
 using Microsoft.EntityFrameworkCore;
@@ -40,14 +39,6 @@ public static class DatabaseContextExtensions
         var query = new UserBumpAccountRevisionDateByCipherIdQuery(cipherId, organizationId);
         var users = await query.Run(context).ToListAsync();
         UpdateUserRevisionDate(users);
-    }
-
-    public static async Task UserBumpAccountRevisionDateByCipherIdAsync(this DatabaseContext context, IEnumerable<Cipher> ciphers)
-    {
-        foreach (var cipher in ciphers)
-        {
-            await context.UserBumpAccountRevisionDateByCipherIdAsync(cipher.Id, cipher.OrganizationId);
-        }
     }
 
     public static async Task UserBumpAccountRevisionDateByCollectionIdAsync(this DatabaseContext context, Guid collectionId, Guid organizationId)


### PR DESCRIPTION
* Update AccountRevisionDate directly by userId
* Have special DateTime handling on postgres

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Make it so that the `AccountRevisionDate` gets properly updated when importing ciphers and make it so that postgres dates have the proper time and kind when read.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Infrastructure.EntityFramework/Repositories/CipherRepository.cs:** Make call to update `AccountRevisionDate` by the first `UserId` on the ciphers much like SQL Server
* **src/Infrastructure.EntityFramework/Repositories/DatabaseContext.cs:** Have special `DateTime` handling for Postgres
* **src/Infrastructure.EntityFramework/Repositories/DatabaseContextExtensions.cs:** Delete unused code.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
