### PR TITLE
[PS-1930] Fix `UpdateCollectionsForAdminAsync`

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/CollectionCipherRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CollectionCipherRepository.cs
@@ -152,8 +152,8 @@ public class CollectionCipherRepository : BaseEntityFrameworkRepository, ICollec
                                               select c).ToListAsync();
 
             var currentCollectionCiphers = await (from cc in dbContext.CollectionCiphers
-                                                 where cc.CipherId == cipherId
-                                                 select cc).ToListAsync();
+                                                  where cc.CipherId == cipherId
+                                                  select cc).ToListAsync();
 
             foreach (var requestedCollectionId in collectionIds)
             {

--- a/src/Infrastructure.EntityFramework/Repositories/CollectionCipherRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CollectionCipherRepository.cs
@@ -147,42 +147,30 @@ public class CollectionCipherRepository : BaseEntityFrameworkRepository, ICollec
         using (var scope = ServiceScopeFactory.CreateScope())
         {
             var dbContext = GetDatabaseContext(scope);
-            var availableCollectionsCte = from c in dbContext.Collections
-                                          where c.OrganizationId == organizationId
-                                          select c;
-            var target = from cc in dbContext.CollectionCiphers
-                         where cc.CipherId == cipherId
-                         select new { cc.CollectionId, cc.CipherId };
-            var source = collectionIds.Select(x => new { CollectionId = x, CipherId = cipherId });
-            var merge1 = from t in target
-                         join s in source
-                             on t.CollectionId equals s.CollectionId into s_g
-                         from s in s_g.DefaultIfEmpty()
-                         where t.CipherId == s.CipherId
-                         select new { t, s };
-            var merge2 = from s in source
-                         join t in target
-                             on s.CollectionId equals t.CollectionId into t_g
-                         from t in t_g.DefaultIfEmpty()
-                         where t.CipherId == s.CipherId
-                         select new { t, s };
-            var union = merge1.Union(merge2).Distinct();
-            var insert = union
-                .Where(x => x.t == null && collectionIds.Contains(x.s.CollectionId))
-                .Select(x => new Models.CollectionCipher
+            var availableCollections = await (from c in dbContext.Collections
+                                              where c.OrganizationId == organizationId
+                                              select c).ToListAsync();
+
+            var currentCollectionCiphers = await (from cc in dbContext.CollectionCiphers
+                                                 where cc.CipherId == cipherId
+                                                 select cc).ToListAsync();
+
+            foreach (var requestedCollectionId in collectionIds)
+            {
+                var requestedCollectionCipher = currentCollectionCiphers
+                    .FirstOrDefault(cc => cc.CollectionId == requestedCollectionId);
+
+                if (requestedCollectionCipher == null)
                 {
-                    CollectionId = x.s.CollectionId,
-                    CipherId = x.s.CipherId,
-                });
-            var delete = union
-                .Where(x => x.s == null && x.t.CipherId == cipherId)
-                .Select(x => new Models.CollectionCipher
-                {
-                    CollectionId = x.t.CollectionId,
-                    CipherId = x.t.CipherId,
-                });
-            await dbContext.AddRangeAsync(insert);
-            dbContext.RemoveRange(delete);
+                    dbContext.CollectionCiphers.Add(new Models.CollectionCipher
+                    {
+                        CipherId = cipherId,
+                        CollectionId = requestedCollectionId,
+                    });
+                }
+            }
+
+            dbContext.RemoveRange(currentCollectionCiphers.Where(cc => !collectionIds.Contains(cc.CollectionId)));
             await dbContext.UserBumpAccountRevisionDateByOrganizationIdAsync(organizationId);
             await dbContext.SaveChangesAsync();
         }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix Collection management per cipher while in the organization vault.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Infrastructure.EntityFramework/Repositories/CollectionCipherRepository.cs:** Rewrite logic for updating CollectionCiphers as an admin.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
