### PR TITLE
[EC-812] Fix broken EF update user groups query

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/Queries/GroupUserUpdateGroupsQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/GroupUserUpdateGroupsQuery.cs
@@ -36,7 +36,7 @@ public class GroupUserUpdateGroupsInsertQuery : IQuery<GroupUser>
                         on g.OrganizationId equals ou.OrganizationId
                     join gie in groupIdEntities
                         on g.Id equals gie.Id
-                    where !dbContext.GroupUsers.Any(gu => _groupIds.Contains(gu.GroupId) && gu.OrganizationUserId == _organizationUserId)
+                    where !dbContext.GroupUsers.Any(gu => gu.GroupId == gie.Id && gu.OrganizationUserId == _organizationUserId)
                     select g;
         return query.Select(x => new GroupUser
         {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The EF query to insert multiple `GroupUser` entities was not properly filtering out duplicate `GroupUser` entities and was preventing multiple `Groups` from being assigned to a user.



## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Infrastructure.EntityFramework/Repositories/Queries/GroupUserUpdateGroupsQuery.cs:** Update the query to use the joined `groupIdEntities` instead of using `_groupIds.Contains()`. This now more closely matches the logic in the [mssql sproc](https://github.com/bitwarden/server/blob/fe59186c9667d48421ce7ee1bee2f87ff433168a/src/Sql/dbo/Stored%20Procedures/GroupUser_UpdateGroups.sql#L28-L36).

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
