### PR TITLE
[PS-2015] Add support for custom http/s ports in docker-unified

### DIFF
--- a/docker-unified/hbs/nginx-config.hbs
+++ b/docker-unified/hbs/nginx-config.hbs
@@ -1,15 +1,15 @@
 server {
-  listen 80 default_server;
+  listen {{{String.Coalesce env.BW_PORT_HTTP "80"}}} default_server;
   #listen [::]:80 default_server;
   server_name {{{String.Coalesce env.BW_DOMAIN "localhost"}}};
 {{#if (String.Equal env.BW_ENABLE_SSL "true")}}
 
-  return 301 https://{{{String.Coalesce env.BW_DOMAIN "localhost"}}}$request_uri;
+  return 301 https://{{{String.Coalesce env.BW_DOMAIN "localhost"}}}:{{{String.Coalesce env.BW_PORT_HTTPS "443"}}}$request_uri;
 }
 
 server {
-  listen 443 ssl http2;
-  #listen [::]:443 ssl http2;
+  listen {{{String.Coalesce env.BW_PORT_HTTPS "443"}}} ssl http2;
+  #listen [::]:{{{String.Coalesce env.BW_PORT_HTTPS "443"}}} ssl http2;
   server_name {{{String.Coalesce env.BW_DOMAIN "localhost"}}};
 
   ssl_certificate /etc/bitwarden/{{{String.Coalesce env.BW_SSL_CERT "ssl.crt"}}};

--- a/docker-unified/settings.env
+++ b/docker-unified/settings.env
@@ -23,6 +23,10 @@ BW_INSTALLATION_KEY=xxxxxxxxxxxx
 #####################
 # Learn more here: https://bitwarden.com/help/environment-variables/
 
+# PORTS
+#BW_PORT_HTTP=80
+#BW_PORT_HTTPS=443
+
 # SSL
 #BW_ENABLE_SSL=true
 #BW_ENABLE_SSL_CA=true

--- a/docker-unified/settings.env
+++ b/docker-unified/settings.env
@@ -23,10 +23,6 @@ BW_INSTALLATION_KEY=xxxxxxxxxxxx
 #####################
 # Learn more here: https://bitwarden.com/help/environment-variables/
 
-# PORTS
-#BW_PORT_HTTP=80
-#BW_PORT_HTTPS=443
-
 # SSL
 #BW_ENABLE_SSL=true
 #BW_ENABLE_SSL_CA=true
@@ -46,6 +42,10 @@ BW_INSTALLATION_KEY=xxxxxxxxxxxx
 #BW_ENABLE_SSO=false
 
 #BW_ICONS_PROXY_TO_CLOUD=false
+
+# Ports served by the internal webserver (nginx). Defaults shown below.
+#BW_PORT_HTTP=80
+#BW_PORT_HTTPS=443
 
 # Mail
 #globalSettings__mail__replyToEmail=noreply@$BW_DOMAIN


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective
Allow to deploy Bitwarden self-host with different HTTP/HTTPS ports.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why
**docker-unified/hbs/nginx-config.hbs:** changed listen configuration for HTTP and HTTPS to use env variables (BW_PORT_HTTP and BW_PORT_HTTPS). If enviroment parameters are not defined default values are used (80 and 443).
**docker-unified/settings.env:** add optional env variables BW_PORT_HTTP and BW_PORT_HTTPS

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
