### PR TITLE
Allow changing default NGINX port in unified

### DIFF
--- a/docker-unified/Dockerfile
+++ b/docker-unified/Dockerfile
@@ -288,5 +288,5 @@ VOLUME ["/etc/bitwarden"]
 
 WORKDIR /app
 USER bitwarden:bitwarden
-HEALTHCHECK CMD curl --insecure -Lfs https://localhost/alive || curl -Lfs http://localhost/alive || exit 1
+HEALTHCHECK CMD curl --insecure -Lfs https://localhost:8443/alive || curl -Lfs http://localhost:8080/alive || exit 1
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-unified/Dockerfile
+++ b/docker-unified/Dockerfile
@@ -202,8 +202,6 @@ ENV globalSettings__send__baseDirectory="/etc/bitwarden/attachments/send"
 ENV globalSettings__licenseDirectory="/etc/bitwarden/licenses"
 ENV globalSettings__logDirectoryByProject="false"
 ENV globalSettings__logRollBySizeLimit="1073741824"
-EXPOSE 80
-EXPOSE 443
 
 # Add packages
 RUN apk add --update-cache \
@@ -288,5 +286,4 @@ VOLUME ["/etc/bitwarden"]
 
 WORKDIR /app
 USER bitwarden:bitwarden
-HEALTHCHECK CMD curl --insecure -Lfs https://localhost:8443/alive || curl -Lfs http://localhost:8080/alive || exit 1
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-unified/docker-compose.yml
+++ b/docker-unified/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     image: ${REGISTRY:-bitwarden}/self-host:${TAG:-beta}
     restart: always
     ports:
-      - "80:80"
-      - "443:443"
+      - "80:8080"
+      - "443:8443"
     volumes:
       - bitwarden:/etc/bitwarden
       - logs:/var/log/bitwarden

--- a/docker-unified/hbs/nginx-config.hbs
+++ b/docker-unified/hbs/nginx-config.hbs
@@ -1,15 +1,15 @@
 server {
-  listen 8080 default_server;
-  #listen [::]:8080 default_server;
+  listen {{{String.Coalesce env.BW_PORT_HTTP "8080"}}} default_server;
+  #listen [::]:{{{String.Coalesce env.BW_PORT_HTTP "8080"}}} default_server;
   server_name {{{String.Coalesce env.BW_DOMAIN "localhost"}}};
 {{#if (String.Equal env.BW_ENABLE_SSL "true")}}
 
-  return 301 https://{{{String.Coalesce env.BW_DOMAIN "localhost"}}}$request_uri;
+  return 301 https://{{{String.Coalesce env.BW_DOMAIN "localhost"}}}:{{{String.Coalesce env.BW_PORT_HTTPS "8443"}}}$request_uri;
 }
 
 server {
-  listen 8443 ssl http2;
-  #listen [::]:8443 ssl http2;
+  listen {{{String.Coalesce env.BW_PORT_HTTPS "8443"}}} ssl http2;
+  #listen [::]:{{{String.Coalesce env.BW_PORT_HTTPS "8443"}}} ssl http2;
   server_name {{{String.Coalesce env.BW_DOMAIN "localhost"}}};
 
   ssl_certificate /etc/bitwarden/{{{String.Coalesce env.BW_SSL_CERT "ssl.crt"}}};

--- a/docker-unified/hbs/nginx-config.hbs
+++ b/docker-unified/hbs/nginx-config.hbs
@@ -1,6 +1,6 @@
 server {
-  listen 80 default_server;
-  #listen [::]:80 default_server;
+  listen 8080 default_server;
+  #listen [::]:8080 default_server;
   server_name {{{String.Coalesce env.BW_DOMAIN "localhost"}}};
 {{#if (String.Equal env.BW_ENABLE_SSL "true")}}
 
@@ -8,8 +8,8 @@ server {
 }
 
 server {
-  listen 443 ssl http2;
-  #listen [::]:443 ssl http2;
+  listen 8443 ssl http2;
+  #listen [::]:8443 ssl http2;
   server_name {{{String.Coalesce env.BW_DOMAIN "localhost"}}};
 
   ssl_certificate /etc/bitwarden/{{{String.Coalesce env.BW_SSL_CERT "ssl.crt"}}};

--- a/docker-unified/settings.env
+++ b/docker-unified/settings.env
@@ -23,6 +23,10 @@ BW_INSTALLATION_KEY=xxxxxxxxxxxx
 #####################
 # Learn more here: https://bitwarden.com/help/environment-variables/
 
+# Webserver ports
+#BW_PORT_HTTP=8080
+#BW_PORT_HTTPS=8443
+
 # SSL
 #BW_ENABLE_SSL=true
 #BW_ENABLE_SSL_CA=true


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR adds the ability to change the default NGINX port and also sets the defaults to `8080` for HTTP and `8443` for HTTPS.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **docker-unified/Dockerfile:** Remove `EXPOSE` commands as they aren't necessary. Remove `HEALTHCHECK` until we can define a better one.
* **docker-unified/docker-compose.yml:** Change default container ports to `8080` for HTTP and `8443` for HTTPS.
* **docker-unified/hbs/nginx-config.hbs:** Add template logic for new `BW_PORT_HTTP` and `BW_PORT_HTTPS` environment variables.
* **docker-unified/settings.env:** Add `BW_PORT_HTTP` and `BW_PORT_HTTPS` environment variables.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
