### PR TITLE
[PS-2024] Respect name set in BW_SSL_KEY for cert generation

### DIFF
--- a/docker-unified/entrypoint.sh
+++ b/docker-unified/entrypoint.sh
@@ -48,7 +48,7 @@ cp /etc/bitwarden/identity.pfx /app/Identity/identity.pfx
 cp /etc/bitwarden/identity.pfx /app/Sso/identity.pfx
 
 # Generate SSL certificates
-if [ "$BW_ENABLE_SSL" == "true" -a ! -f /etc/bitwarden/ssl.key ]; then
+if [ "$BW_ENABLE_SSL" == "true" -a ! -f /etc/bitwarden/${BW_SSL_KEY:-ssl.key} ]; then
   openssl req \
   -x509 \
   -newkey rsa:4096 \


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This small fix makes the `entrypoint.sh` respect the key name set via `BW_SSL_KEY` in BW Unified's `settings.env`. Before, it always tried to create new certificates when a file named `ssl.key` was not found.

Fixes https://github.com/bitwarden/server/issues/2489.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **entrypoint.sh:** If `BW_SSL_KEY` is set, its value is used instead of the hard-coded value `ssl.key`.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
