### PR TITLE
[SG-841] Fixed null issue when an organization key does not exist

### DIFF
--- a/src/Core/OrganizationFeatures/OrganizationApiKeys/GetOrganizationApiKeyQuery.cs
+++ b/src/Core/OrganizationFeatures/OrganizationApiKeys/GetOrganizationApiKeyQuery.cs
@@ -25,6 +25,6 @@ public class GetOrganizationApiKeyQuery : IGetOrganizationApiKeyQuery
             .GetManyByOrganizationIdTypeAsync(organizationId, organizationApiKeyType);
 
         // NOTE: Currently we only allow one type of api key per organization
-        return apiKeys.Single();
+        return apiKeys.SingleOrDefault();
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
During the refactoring of `GetOrganizationApiKeyComand` to a separate `query` and `command` an empty `apiKeys` list was not handled properly to return a null value so a key can be created.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/OrganizationFeatures/OrganizationApiKeys/GetOrganizationApiKeyQuery.cs:** Switched from a linq `Single` to `SingleOrDefault` so a default null value can be returned when an `apiKeys` list is empty.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
