### PR TITLE
Fix/Check to throw exception when domain is claimed by another organization

### DIFF
--- a/src/Core/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs
@@ -43,7 +43,7 @@ public class VerifyOrganizationDomainCommand : IVerifyOrganizationDomainCommand
             await _organizationDomainRepository.GetClaimedDomainsByDomainNameAsync(domain.DomainName);
         if (claimedDomain.Any())
         {
-            throw new ConflictException("The domain has been verified by another organization.");
+            throw new ConflictException("The domain is not available to be claimed.");
         }
 
         try

--- a/src/Core/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs
@@ -39,6 +39,13 @@ public class VerifyOrganizationDomainCommand : IVerifyOrganizationDomainCommand
             throw new ConflictException("Domain has already been verified.");
         }
 
+        var claimedDomain =
+            await _organizationDomainRepository.GetClaimedDomainsByDomainNameAsync(domain.DomainName);
+        if (claimedDomain.Any())
+        {
+            throw new ConflictException("The domain has been verified by another organization.");
+        }
+
         try
         {
             if (await _dnsResolverService.ResolveAsync(domain.DomainName, domain.Txt))


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Added check to ensure an exception with the right message is thrown when another organization has claimed a domain.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs:** Added get claimed domain by domain name check and throw an exception if the list is not empty.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
