### PR TITLE
[EC-277] Remove SHA-1 encryption from SSO Outbound and Minimum Signing Algorithm lists

### DIFF
--- a/src/Core/Sso/SamlSigningAlgorithms.cs
+++ b/src/Core/Sso/SamlSigningAlgorithms.cs
@@ -6,13 +6,11 @@ public static class SamlSigningAlgorithms
     public const string Sha256 = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
     public const string Sha384 = "http://www.w3.org/2000/09/xmldsig#rsa-sha384";
     public const string Sha512 = "http://www.w3.org/2000/09/xmldsig#rsa-sha512";
-    public const string Sha1 = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
 
     public static IEnumerable<string> GetEnumerable()
     {
         yield return Sha256;
         yield return Sha384;
         yield return Sha512;
-        yield return Sha1;
     }
 }


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective
Remove SHA-1 encryption from SSO Outbound and Minimum Signing Algorithm lists as it is not supported.

## Code changes
* **src/Core/Sso/SamlSigningAlgorithms.cs:** Removed the sha-1 entry from the algorithm list

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
