### PR TITLE
Fix failing ACR purge workflow

### DIFF
--- a/.github/workflows/container-registry-purge.yml
+++ b/.github/workflows/container-registry-purge.yml
@@ -39,18 +39,43 @@ jobs:
           REPO_LIST=$(az acr repository list -n $REGISTRY -o tsv)
           for REPO in $REPO_LIST
           do
+
+            PURGE_LATEST=""
+            PURGE_VERSION=""
+            PURGE_ELSE=""
+
             TAG_LIST=$(az acr repository show-tags -n $REGISTRY --repository $REPO -o tsv)
             for TAG in $TAG_LIST
             do
               if [ $TAG = "latest" ] || [ $TAG = "dev" ]; then
-                PURGE_CMD="acr purge --filter '$REPO:$TAG' --ago $AGO_DUR_VER --untagged --keep 1"
+                PURGE_LATEST+="--filter '$REPO:$TAG' "
               elif [[ $TAG =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
-                PURGE_CMD="acr purge --filter '$REPO:$TAG' --ago $AGO_DUR_VER --untagged"
+                PURGE_VERSION+="--filter '$REPO:$TAG' "
               else
-                PURGE_CMD="acr purge --filter '$REPO:$TAG' --ago $AGO_DUR --untagged"
+                PURGE_ELSE+="--filter '$REPO:$TAG' "
               fi
-              az acr run --cmd "$PURGE_CMD" --registry $REGISTRY /dev/null
             done
+
+            if [ ! -z "$PURGE_LATEST" ]
+            then
+              PURGE_LATEST_CMD="acr purge $PURGE_LATEST --ago $AGO_DUR_VER --untagged --keep 1"
+              az acr run --cmd "$PURGE_LATEST_CMD" --registry $REGISTRY /dev/null &
+            fi
+
+            if [ ! -z "$PURGE_VERSION" ]
+            then
+              PURGE_VERSION_CMD="acr purge $PURGE_VERSION --ago $AGO_DUR_VER --untagged"
+              az acr run --cmd "$PURGE_VERSION_CMD" --registry $REGISTRY /dev/null &
+            fi
+
+            if [ ! -z "$PURGE_ELSE" ]
+            then
+              PURGE_ELSE_CMD="acr purge $PURGE_ELSE --ago $AGO_DUR --untagged"
+              az acr run --cmd "$PURGE_ELSE_CMD" --registry $REGISTRY /dev/null &
+            fi
+
+            wait
+
           done
 
 

--- a/.github/workflows/container-registry-purge.yml
+++ b/.github/workflows/container-registry-purge.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
           - name: bitwardenqa
-          - name: bitwardenprod
+          # - name: bitwardenprod
     steps:
       - name: Login to Azure
         if: matrix.name == 'bitwardenprod'

--- a/.github/workflows/container-registry-purge.yml
+++ b/.github/workflows/container-registry-purge.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
           - name: bitwardenqa
-          # - name: bitwardenprod
+          - name: bitwardenprod
     steps:
       - name: Login to Azure
         if: matrix.name == 'bitwardenprod'


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The current ACR purge workflow is failing due to timing out. The below fix reduces execution time from timing out after 6 hours to 7 minutes on GitHub Actions (and 17 minutes running locally) using filtering aggregation and executing `acr purge` in the background per repository. Only tag filtering aggregation took the time down to 22 minutes locally.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **.github/workflows/container-registry-purge.yml:** Aggregate tags from the same docker repository to speed up filtering. Introduce running purge commands in the background per docker repository to speed up removing containers.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
