### PR TITLE
[SG-911] Added Configurable Days

### DIFF
--- a/src/Core/Entities/OrganizationDomain.cs
+++ b/src/Core/Entities/OrganizationDomain.cs
@@ -17,13 +17,13 @@ public class OrganizationDomain : ITableObject<Guid>
     public int JobRunCount { get; private set; }
     public void SetNewId() => Id = CoreHelpers.GenerateComb();
 
-    public void SetNextRunDate()
+    public void SetNextRunDate(int interval)
     {
         //verification can take up to 72 hours
         //1st job runs after 12hrs, 2nd after 24hrs and 3rd after 36hrs
         NextRunDate = JobRunCount == 0
-            ? CreationDate.AddHours(12)
-            : NextRunDate.AddHours((JobRunCount + 1) * 12);
+            ? CreationDate.AddHours(interval)
+            : NextRunDate.AddHours((JobRunCount + 1) * interval);
     }
 
     public void SetJobRunCount()

--- a/src/Core/OrganizationFeatures/OrganizationDomains/CreateOrganizationDomainCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationDomains/CreateOrganizationDomainCommand.cs
@@ -4,6 +4,7 @@ using Bit.Core.Exceptions;
 using Bit.Core.OrganizationFeatures.OrganizationDomains.Interfaces;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
+using Bit.Core.Settings;
 using Microsoft.Extensions.Logging;
 
 namespace Bit.Core.OrganizationFeatures.OrganizationDomains;
@@ -14,17 +15,20 @@ public class CreateOrganizationDomainCommand : ICreateOrganizationDomainCommand
     private readonly IEventService _eventService;
     private readonly IDnsResolverService _dnsResolverService;
     private readonly ILogger<VerifyOrganizationDomainCommand> _logger;
+    private readonly IGlobalSettings _globalSettings;
 
     public CreateOrganizationDomainCommand(
         IOrganizationDomainRepository organizationDomainRepository,
         IEventService eventService,
         IDnsResolverService dnsResolverService,
-        ILogger<VerifyOrganizationDomainCommand> logger)
+        ILogger<VerifyOrganizationDomainCommand> logger,
+        IGlobalSettings globalSettings)
     {
         _organizationDomainRepository = organizationDomainRepository;
         _eventService = eventService;
         _dnsResolverService = dnsResolverService;
         _logger = logger;
+        _globalSettings = globalSettings;
     }
 
     public async Task<OrganizationDomain> CreateAsync(OrganizationDomain organizationDomain)
@@ -58,7 +62,7 @@ public class CreateOrganizationDomainCommand : ICreateOrganizationDomainCommand
             _logger.LogError("Error verifying Organization domain.", e);
         }
 
-        organizationDomain.SetNextRunDate();
+        organizationDomain.SetNextRunDate(_globalSettings.DomainVerification.VerificationInterval);
         organizationDomain.SetLastCheckedDate();
 
         var orgDomain = await _organizationDomainRepository.CreateAsync(organizationDomain);

--- a/src/Core/Repositories/IOrganizationDomainRepository.cs
+++ b/src/Core/Repositories/IOrganizationDomainRepository.cs
@@ -11,5 +11,5 @@ public interface IOrganizationDomainRepository : IRepository<OrganizationDomain,
     Task<OrganizationDomainSsoDetailsData> GetOrganizationDomainSsoDetailsAsync(string email);
     Task<OrganizationDomain> GetDomainByOrgIdAndDomainNameAsync(Guid orgId, string domainName);
     Task<ICollection<OrganizationDomain>> GetExpiredOrganizationDomainsAsync();
-    Task<bool> DeleteExpiredAsync();
+    Task<bool> DeleteExpiredAsync(int expirationPeriod);
 }

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -77,6 +77,7 @@ public class GlobalSettings : IGlobalSettings
     public virtual DistributedIpRateLimitingSettings DistributedIpRateLimiting { get; set; } =
         new DistributedIpRateLimitingSettings();
     public virtual IPasswordlessAuthSettings PasswordlessAuth { get; set; } = new PasswordlessAuthSettings();
+    public virtual IDomainVerificationSettings DomainVerification { get; set; } = new DomainVerificationSettings();
 
     public string BuildExternalUri(string explicitValue, string name)
     {
@@ -535,5 +536,11 @@ public class GlobalSettings : IGlobalSettings
     public class PasswordlessAuthSettings : IPasswordlessAuthSettings
     {
         public bool KnownDevicesOnly { get; set; } = true;
+    }
+
+    public class DomainVerificationSettings : IDomainVerificationSettings
+    {
+        public int VerificationInterval { get; set; } = 12;
+        public int ExpirationPeriod { get; set; } = 7;
     }
 }

--- a/src/Core/Settings/IDomainVerificationSettings.cs
+++ b/src/Core/Settings/IDomainVerificationSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace Bit.Core.Settings;
+
+public interface IDomainVerificationSettings
+{
+    public int VerificationInterval { get; set; }
+    public int ExpirationPeriod { get; set; }
+}

--- a/src/Core/Settings/IGlobalSettings.cs
+++ b/src/Core/Settings/IGlobalSettings.cs
@@ -17,4 +17,5 @@ public interface IGlobalSettings
     ISsoSettings Sso { get; set; }
     ILogLevelSettings MinLogLevel { get; set; }
     IPasswordlessAuthSettings PasswordlessAuth { get; set; }
+    IDomainVerificationSettings DomainVerification { get; set; }
 }

--- a/src/Infrastructure.Dapper/Repositories/OrganizationDomainRepository.cs
+++ b/src/Infrastructure.Dapper/Repositories/OrganizationDomainRepository.cs
@@ -97,13 +97,13 @@ public class OrganizationDomainRepository : Repository<OrganizationDomain, Guid>
         }
     }
 
-    public async Task<bool> DeleteExpiredAsync()
+    public async Task<bool> DeleteExpiredAsync(int expirationPeriod)
     {
         using (var connection = new SqlConnection(ConnectionString))
         {
             return await connection.ExecuteAsync(
                 $"[{Schema}].[OrganizationDomain_DeleteIfExpired]",
-                null,
+                new { ExpirationPeriod = expirationPeriod },
                 commandType: CommandType.StoredProcedure) > 0;
         }
     }

--- a/src/Infrastructure.EntityFramework/Repositories/OrganizationDomainRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/OrganizationDomainRepository.cs
@@ -157,12 +157,13 @@ public class OrganizationDomainRepository : Repository<Core.Entities.Organizatio
         return Mapper.Map<List<Core.Entities.OrganizationDomain>>(domains);
     }
 
-    public async Task<bool> DeleteExpiredAsync()
+    public async Task<bool> DeleteExpiredAsync(int expirationPeriod)
     {
         using var scope = ServiceScopeFactory.CreateScope();
         var dbContext = GetDatabaseContext(scope);
+
         var expiredDomains = await dbContext.OrganizationDomains
-            .Where(x => x.CreationDate < DateTime.UtcNow.AddDays(-7))
+            .Where(x => x.LastCheckedDate < DateTime.UtcNow.AddDays(-expirationPeriod))
             .ToListAsync();
         dbContext.OrganizationDomains.RemoveRange(expiredDomains);
         return await dbContext.SaveChangesAsync() > 0;

--- a/src/Sql/dbo/Stored Procedures/OrganizationDomain_DeleteIfExpired.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationDomain_DeleteIfExpired.sql
@@ -1,9 +1,10 @@
 CREATE PROCEDURE [dbo].[OrganizationDomain_DeleteIfExpired]
+    @ExpirationPeriod TINYINT
 AS
 BEGIN
     SET NOCOUNT OFF
         
     DELETE FROM [dbo].[OrganizationDomain]
-    WHERE [CreationDate] < DATEADD(day, -7, GETUTCDATE())
+    WHERE DATEDIFF(DAY, [LastCheckedDate], GETUTCDATE()) >= @ExpirationPeriod
     AND [VerifiedDate] IS NULL
 END

--- a/util/Migrator/DbScripts/2022-11-03_00_OrganizationDomainInit.sql
+++ b/util/Migrator/DbScripts/2022-11-03_00_OrganizationDomainInit.sql
@@ -237,12 +237,13 @@ GO
 
 -- SP to delete domains that have been left unverified for 7 days
 CREATE OR ALTER PROCEDURE [dbo].[OrganizationDomain_DeleteIfExpired]
+     @ExpirationPeriod TINYINT
 AS
 BEGIN
     SET NOCOUNT OFF
 
 DELETE FROM [dbo].[OrganizationDomain]
-WHERE [CreationDate] < DATEADD(day, -7, GETUTCDATE())
+WHERE DATEDIFF(DAY, [LastCheckedDate], GETUTCDATE()) >= @ExpirationPeriod
   AND [VerifiedDate] IS NULL
 END
 GO


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Due to wait time to fully verify and delete an expired domain, it's important to make the days configurable and reduce QA test time.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/Entities/OrganizationDomain.cs:** Added an `interval` parameter to the `SetNextRunDate` method.
* **src/Core/OrganizationFeatures/OrganizationDomains/CreateOrganizationDomainCommand.cs:** Modified method to pass interval argument
* **src/Core/Repositories/IOrganizationDomainRepository.cs**  Added an `expirationPeriod` parameter to the `DeleteExpiredAsync` abstract method.
* **src/Infrastructure.Dapper/Repositories/OrganizationDomainRepository.cs** modified method from interface change
* **src/Infrastructure.EntityFramework/Repositories/OrganizationDomainRepository.cs** modified method from interface change
* **src/Core/Services/Implementations/OrganizationDomainService.cs** Modified `ValidateOrganizationsDomainAsync` to accept configurable interval and expiration period.
* **src/Core/Settings/GlobalSettings.cs** Configurable settings related to domain claiming feature
* **src/Sql/dbo/Stored Procedures/OrganizationDomain_DeleteIfExpired.sql** Updated stored procedure to handle `expirationPeriod` parameter
## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
