### PR TITLE
[PS-2136] Fix Inactive two-step login check

### DIFF
--- a/docker-unified/hbs/nginx-config.hbs
+++ b/docker-unified/hbs/nginx-config.hbs
@@ -57,7 +57,7 @@ server {
     include /etc/nginx/security-headers-ssl.conf;
 {{/if}}
     include /etc/nginx/security-headers.conf;
-    add_header Content-Security-Policy "{{{String.Coalesce env.BW_CSP "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://haveibeenpwned.com https://www.gravatar.com; child-src 'self' https://*.duosecurity.com https://*.duofederal.com; frame-src 'self' https://*.duosecurity.com https://*.duofederal.com; connect-src 'self' https://api.pwnedpasswords.com https://2fa.directory; object-src 'self' blob:;"}}}";
+    add_header Content-Security-Policy "{{{String.Coalesce env.BW_CSP "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://haveibeenpwned.com https://www.gravatar.com; child-src 'self' https://*.duosecurity.com https://*.duofederal.com; frame-src 'self' https://*.duosecurity.com https://*.duofederal.com; connect-src 'self' https://api.pwnedpasswords.com https://api.2fa.directory; object-src 'self' blob:;"}}}";
     add_header X-Frame-Options SAMEORIGIN;
     add_header X-Robots-Tag "noindex, nofollow";
   }

--- a/util/Setup/Configuration.cs
+++ b/util/Setup/Configuration.cs
@@ -81,7 +81,7 @@ public class Configuration
         "child-src 'self' https://*.duosecurity.com https://*.duofederal.com; " +
         "frame-src 'self' https://*.duosecurity.com https://*.duofederal.com; " +
         "connect-src 'self' wss://{0} https://api.pwnedpasswords.com " +
-        "https://2fa.directory; object-src 'self' blob:;";
+        "https://api.2fa.directory; object-src 'self' blob:;";
 
     [Description("Communicate with the Bitwarden push relay service (push.bitwarden.com) for mobile\n" +
         "app live sync.")]


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Checking the vault for inactive two-step logins is broken, because 2fa.directory has changed there API endpoint.
According to https://2fa.directory/api/ it now uses `api.2fa.directory` instead of `2fa.directory/api`.


## Code changes

Changed the API endpoint to the new working endpoint.

## Client side PR

https://github.com/bitwarden/clients/pull/4345

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
