### PR TITLE
SG-955 - On domain verification error or failure, set last checked da…

### DIFF
--- a/src/Core/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs
@@ -56,9 +56,6 @@ public class VerifyOrganizationDomainCommand : IVerifyOrganizationDomainCommand
             if (await _dnsResolverService.ResolveAsync(domain.DomainName, domain.Txt))
             {
                 domain.SetVerifiedDate();
-                domain.SetLastCheckedDate();
-                await _organizationDomainRepository.ReplaceAsync(domain);
-                await _eventService.LogOrganizationDomainEventAsync(domain, EventType.OrganizationDomain_Verified);
             }
         }
         catch (Exception e)
@@ -69,7 +66,8 @@ public class VerifyOrganizationDomainCommand : IVerifyOrganizationDomainCommand
         domain.SetLastCheckedDate();
         await _organizationDomainRepository.ReplaceAsync(domain);
 
-        await _eventService.LogOrganizationDomainEventAsync(domain, EventType.OrganizationDomain_NotVerified);
+        await _eventService.LogOrganizationDomainEventAsync(domain,
+            domain.VerifiedDate != null ? EventType.OrganizationDomain_Verified : EventType.OrganizationDomain_NotVerified);
         return domain;
     }
 }


### PR DESCRIPTION
…te on the org domain.

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
During verification, update the org domain model's last checked date on failure or error. 


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
