### PR TITLE
[EC-887] Server fix for managers seeing options to edit/delete Collections they aren't assigned to

### DIFF
--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -3,7 +3,6 @@ using Bit.Api.Models.Response;
 using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Exceptions;
-using Bit.Core.Models.Data;
 using Bit.Core.OrganizationFeatures.OrganizationCollections.Interfaces;
 using Bit.Core.Repositories;
 using Bit.Core.Services;

--- a/src/Api/Models/Response/CollectionResponseModel.cs
+++ b/src/Api/Models/Response/CollectionResponseModel.cs
@@ -50,7 +50,7 @@ public class CollectionAccessDetailsResponseModel : CollectionResponseModel
 
     public IEnumerable<SelectionReadOnlyResponseModel> Groups { get; set; }
     public IEnumerable<SelectionReadOnlyResponseModel> Users { get; set; }
-    
+
     /// <summary>
     /// True if the acting user is explicitly assigned to the collection
     /// </summary>

--- a/src/Api/Models/Response/CollectionResponseModel.cs
+++ b/src/Api/Models/Response/CollectionResponseModel.cs
@@ -50,4 +50,9 @@ public class CollectionAccessDetailsResponseModel : CollectionResponseModel
 
     public IEnumerable<SelectionReadOnlyResponseModel> Groups { get; set; }
     public IEnumerable<SelectionReadOnlyResponseModel> Users { get; set; }
+    
+    /// <summary>
+    /// True if the acting user is explicitly assigned to the collection
+    /// </summary>
+    public bool Assigned { get; set; }
 }

--- a/test/Api.Test/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.Test/Controllers/CollectionsControllerTests.cs
@@ -101,17 +101,17 @@ public class CollectionsControllerTests
     public async Task GetOrganizationCollectionsWithGroups_AdminPermissions_GetsAllCollections(Organization organization, User user, SutProvider<CollectionsController> sutProvider)
     {
         sutProvider.GetDependency<ICurrentContext>().UserId.Returns(user.Id);
-        sutProvider.GetDependency<ICurrentContext>().ViewAssignedCollections(organization.Id).Returns(true);
+        sutProvider.GetDependency<ICurrentContext>().ViewAllCollections(organization.Id).Returns(true);
         sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(organization.Id).Returns(true);
 
         await sutProvider.Sut.GetManyWithDetails(organization.Id);
 
         await sutProvider.GetDependency<ICollectionRepository>().Received().GetManyByOrganizationIdWithAccessAsync(organization.Id);
-        await sutProvider.GetDependency<ICollectionRepository>().DidNotReceiveWithAnyArgs().GetManyByUserIdWithAccessAsync(default, default);
+        await sutProvider.GetDependency<ICollectionRepository>().Received().GetManyByUserIdWithAccessAsync(user.Id, organization.Id);
     }
 
     [Theory, BitAutoData]
-    public async Task GetOrganizationCollectionsWithGroups_ManagerPermissions_GetsAssignedCollections(Organization organization, User user, SutProvider<CollectionsController> sutProvider)
+    public async Task GetOrganizationCollectionsWithGroups_MissingViewAllPermissions_GetsAssignedCollections(Organization organization, User user, SutProvider<CollectionsController> sutProvider)
     {
         sutProvider.GetDependency<ICurrentContext>().UserId.Returns(user.Id);
         sutProvider.GetDependency<ICurrentContext>().ViewAssignedCollections(organization.Id).Returns(true);
@@ -121,20 +121,6 @@ public class CollectionsControllerTests
 
         await sutProvider.GetDependency<ICollectionRepository>().DidNotReceiveWithAnyArgs().GetManyByOrganizationIdWithAccessAsync(default);
         await sutProvider.GetDependency<ICollectionRepository>().Received().GetManyByUserIdWithAccessAsync(user.Id, organization.Id);
-    }
-
-    [Theory, BitAutoData]
-    public async Task GetOrganizationCollectionsWithGroups_CustomUserWithAdminPermissions_GetsAllCollections(Organization organization, User user, SutProvider<CollectionsController> sutProvider)
-    {
-        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(user.Id);
-        sutProvider.GetDependency<ICurrentContext>().ViewAssignedCollections(organization.Id).Returns(true);
-        sutProvider.GetDependency<ICurrentContext>().EditAnyCollection(organization.Id).Returns(true);
-
-
-        await sutProvider.Sut.GetManyWithDetails(organization.Id);
-
-        await sutProvider.GetDependency<ICollectionRepository>().Received().GetManyByOrganizationIdWithAccessAsync(organization.Id);
-        await sutProvider.GetDependency<ICollectionRepository>().DidNotReceiveWithAnyArgs().GetManyByUserIdWithAccessAsync(default, default);
     }
 
     [Theory, BitAutoData]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The `GetManyWithDetails` collection endpoint needs to return all collections for any users with the `ViewAllCollections` permission. If they do not have `ViewAllCollections` then only return collections they've been assigned to. If the user has `ViewAllCollections` we still need to determine which collections they may be explicitly assigned to in order to show the proper editing controls in client Web UI. This information is sent to the client via a new `Assigned` property on the Collection DetailsResponse.

See this associated client PR for more details: https://github.com/bitwarden/clients/pull/4395

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Api/Models/Response/CollectionResponseModel.cs:** Add the new `Assigned` property
* **src/Api/Controllers/CollectionsController.cs:** Update the controller to return all collections if the user has `ViewAllCollections` permission or only assigned collections if they do not. Also, populate the newly added `Assigned` property in the response details
* **test/Api.Test/Controllers/CollectionsControllerTests.cs:** Update unit tests to reflect new logic

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
