### PR TITLE
[SM-412] Remove postgres timezone legacy behavior

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -21,7 +21,7 @@
       ]
     },
     "dotnet-ef": {
-      "version": "6.0.11",
+      "version": "6.0.12",
       "commands": [
         "dotnet-ef"
       ]

--- a/src/Infrastructure.EntityFramework/Repositories/DatabaseContext.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/DatabaseContext.cs
@@ -157,20 +157,10 @@ public class DatabaseContext : DbContext
             {
                 if (property.ClrType == typeof(DateTime) || property.ClrType == typeof(DateTime?))
                 {
-                    if (Database.IsNpgsql())
-                    {
-                        property.SetValueConverter(
-                            new ValueConverter<DateTime, DateTime>(
-                                v => v,
-                                v => v.ToUniversalTime()));
-                    }
-                    else
-                    {
-                        property.SetValueConverter(
-                            new ValueConverter<DateTime, DateTime>(
-                                v => v,
-                                v => new DateTime(v.Ticks, DateTimeKind.Utc)));
-                    }
+                    property.SetValueConverter(
+                        new ValueConverter<DateTime, DateTime>(
+                            v => v,
+                            v => new DateTime(v.Ticks, DateTimeKind.Utc)));
                 }
             }
         }

--- a/util/PostgresMigrations/Factories.cs
+++ b/util/PostgresMigrations/Factories.cs
@@ -25,9 +25,6 @@ public class DatabaseContextFactory : IDesignTimeDbContextFactory<DatabaseContex
         var globalSettings = GlobalSettingsFactory.GlobalSettings;
         var optionsBuilder = new DbContextOptionsBuilder<DatabaseContext>();
         var connectionString = globalSettings.PostgreSql?.ConnectionString;
-        // NpgSql 6.0 changed how timezones works. We have not yet updated our projects to support this new behavior and need to fallback to the previous behavior.
-        // Check https://www.npgsql.org/doc/release-notes/6.0.html#timestamp-rationalization-and-improvements for more details.
-        AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
         if (string.IsNullOrWhiteSpace(connectionString))
         {
             throw new Exception("No Postgres connection string found.");


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Remove the legazy postgres timezone behavior since we should already be migrated.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
