### PR TITLE
[EC-619] Exceeding seat limit results in vague "Unhandled server error" message

### DIFF
--- a/src/Api/Utilities/ExceptionHandlerFilterAttribute.cs
+++ b/src/Api/Utilities/ExceptionHandlerFilterAttribute.cs
@@ -92,6 +92,11 @@ public class ExceptionHandlerFilterAttribute : ExceptionFilterAttribute
             errorMessage = "Unauthorized.";
             context.HttpContext.Response.StatusCode = 401;
         }
+        else if (exception is AggregateException aggregateException)
+        {
+            errorMessage = string.Join(Environment.NewLine, aggregateException.InnerExceptions.Select(ex => ex.Message));
+            context.HttpContext.Response.StatusCode = 400;
+        }
         else
         {
             var logger = context.HttpContext.RequestServices.GetRequiredService<ILogger<ExceptionHandlerFilterAttribute>>();

--- a/src/Api/Utilities/ExceptionHandlerFilterAttribute.cs
+++ b/src/Api/Utilities/ExceptionHandlerFilterAttribute.cs
@@ -94,8 +94,16 @@ public class ExceptionHandlerFilterAttribute : ExceptionFilterAttribute
         }
         else if (exception is AggregateException aggregateException)
         {
-            errorMessage = string.Join(Environment.NewLine, aggregateException.InnerExceptions.Select(ex => ex.Message));
             context.HttpContext.Response.StatusCode = 400;
+            var errorValues = aggregateException.InnerExceptions.Select(ex => ex.Message);
+            if (_publicApi)
+            {
+                publicErrorModel = new ErrorResponseModel(errorMessage, errorValues);
+            }
+            else
+            {
+                internalErrorModel = new InternalApi.ErrorResponseModel(errorMessage, errorValues);
+            }
         }
         else
         {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
When an Organization that has reached their maximum seat limit tries to invite a new user, they are shown an error message that says “Unhandled server error.” 

This is due to the server throwing an exception of the type `AggregateException` which is then not handled. This PR adds that exception type to `ExceptionHandlerFilterAttribute` which is responsible to send the error message in the client response.

## Code changes
* **src/Api/Utilities/ExceptionHandlerFilterAttribute.cs:** Added the missing type `AggregateException` with the returning error message being a concatenation of all exception messages

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
