### PR TITLE
[PS-2120] Reverting the use of readonly db connection on GetAccountRevisionDate

### DIFF
--- a/src/Infrastructure.Dapper/Repositories/UserRepository.cs
+++ b/src/Infrastructure.Dapper/Repositories/UserRepository.cs
@@ -104,7 +104,7 @@ public class UserRepository : Repository<User, Guid>, IUserRepository
 
     public async Task<DateTime> GetAccountRevisionDateAsync(Guid id)
     {
-        using (var connection = new SqlConnection(ReadOnlyConnectionString))
+        using (var connection = new SqlConnection(ConnectionString))
         {
             var results = await connection.QueryAsync<DateTime>(
                 $"[{Schema}].[{Table}_ReadAccountRevisionDateById]",


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
In some cases the RevisionDate timestamp returned is not returning the expected most recent timestamp but a previous one. We suspect that is caused by the use of the ReadOnly database on this call.


## Code changes
* **UserRepository.cs:** Using ConnectionString on the GetAccountRevisionDate method instead of the readonly.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
