### PR TITLE
[PS-2242] Quotes break adminSettings__admins

### DIFF
--- a/docker-unified/settings.env
+++ b/docker-unified/settings.env
@@ -66,4 +66,4 @@ BW_INSTALLATION_KEY=xxxxxxxxxxxx
 # Other
 #globalSettings__disableUserRegistration=false
 #globalSettings__hibpApiKey=REPLACE
-#adminSettings__admins="admin1@email.com,admin2@email.com"
+#adminSettings__admins=admin1@email.com,admin2@email.com


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Setting up the unified server, I copied the default settings.env and changed the adminSettings__admins string to a single email address in quotes:
`#adminSettings__admins="admin1@example.com"`

But when trying to log into the admin panel, BW never sent me an email. Removing the quotes fixed the issue. Since this is the only example setting with quotes, I have to think that they are not supposed to be there.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **settings.env:** Remove quotes from adminSettings__admins

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
