### PR TITLE
[EC-1003] Make External ID in group modal to read-only

### DIFF
--- a/src/Api/Models/Request/GroupRequestModel.cs
+++ b/src/Api/Models/Request/GroupRequestModel.cs
@@ -10,8 +10,6 @@ public class GroupRequestModel
     public string Name { get; set; }
     [Required]
     public bool? AccessAll { get; set; }
-    [StringLength(300)]
-    public string ExternalId { get; set; }
     public IEnumerable<SelectionReadOnlyRequestModel> Collections { get; set; }
     public IEnumerable<Guid> Users { get; set; }
 
@@ -27,7 +25,6 @@ public class GroupRequestModel
     {
         existingGroup.Name = Name;
         existingGroup.AccessAll = AccessAll.Value;
-        existingGroup.ExternalId = ExternalId;
         return existingGroup;
     }
 }

--- a/test/Api.Test/Controllers/GroupsControllerTests.cs
+++ b/test/Api.Test/Controllers/GroupsControllerTests.cs
@@ -29,7 +29,7 @@ public class GroupsControllerTests
         await sutProvider.GetDependency<ICreateGroupCommand>().Received(1).CreateGroupAsync(
             Arg.Is<Group>(g =>
                 g.OrganizationId == organization.Id && g.Name == groupRequestModel.Name &&
-                g.AccessAll == groupRequestModel.AccessAll && g.ExternalId == groupRequestModel.ExternalId),
+                g.AccessAll == groupRequestModel.AccessAll),
             organization,
             Arg.Any<IEnumerable<CollectionAccessSelection>>(),
             Arg.Any<IEnumerable<Guid>>());
@@ -38,7 +38,6 @@ public class GroupsControllerTests
         Assert.Equal(groupRequestModel.Name, response.Name);
         Assert.Equal(organization.Id.ToString(), response.OrganizationId);
         Assert.Equal(groupRequestModel.AccessAll, response.AccessAll);
-        Assert.Equal(groupRequestModel.ExternalId, response.ExternalId);
     }
 
     [Theory]
@@ -57,7 +56,7 @@ public class GroupsControllerTests
         await sutProvider.GetDependency<IUpdateGroupCommand>().Received(1).UpdateGroupAsync(
             Arg.Is<Group>(g =>
                 g.OrganizationId == organization.Id && g.Name == groupRequestModel.Name &&
-                g.AccessAll == groupRequestModel.AccessAll && g.ExternalId == groupRequestModel.ExternalId),
+                g.AccessAll == groupRequestModel.AccessAll),
             Arg.Is<Organization>(o => o.Id == organization.Id),
             Arg.Any<IEnumerable<CollectionAccessSelection>>(),
             Arg.Any<IEnumerable<Guid>>());
@@ -66,6 +65,5 @@ public class GroupsControllerTests
         Assert.Equal(groupRequestModel.Name, response.Name);
         Assert.Equal(organization.Id.ToString(), response.OrganizationId);
         Assert.Equal(groupRequestModel.AccessAll, response.AccessAll);
-        Assert.Equal(groupRequestModel.ExternalId, response.ExternalId);
     }
 }


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective
The external ID field in the group modal needs to be read-only. This is because edits to the group ID will break the SCIM connection (if SCIM is enabled).

## Code changes
Just remove field from Request model. `externalId` is still editable through our public api.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
