### PR TITLE
[EC-1015] Fixed OrganizationService InviteUser unit tests to not depend on random Org seat number

### DIFF
--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -311,6 +311,7 @@ public class OrganizationServiceTests
     public async Task InviteUser_WithCustomType_WhenUseCustomPermissionsIsTrue_Passes(Organization organization, OrganizationUserInvite invite,
         OrganizationUser invitor, SutProvider<OrganizationService> sutProvider)
     {
+        organization.Seats = 10;
         organization.UseCustomPermissions = true;
 
         invite.Permissions = null;
@@ -336,6 +337,7 @@ public class OrganizationServiceTests
     public async Task InviteUser_WithNonCustomType_WhenUseCustomPermissionsIsFalse_Passes(OrganizationUserType inviteUserType, Organization organization, OrganizationUserInvite invite,
         OrganizationUser invitor, SutProvider<OrganizationService> sutProvider)
     {
+        organization.Seats = 10;
         organization.UseCustomPermissions = false;
 
         invite.Type = inviteUserType;


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective
The unit test `InviteUser_WithNonCustomType_WhenUseCustomPermissionsIsFalse_Passes` has failed occasionally when running in github build actions with the following error: 
```
System.AggregateException : One or more errors occurred while inviting users. (Plan does not allow additional seats.)
  ---- Bit.Core.Exceptions.BadRequestException : Plan does not allow additional seats.
```

This issue seems to be happening because the mock Organization under test has a random Seat number which could be lower than necessary to allow the users to be invited.

## Code changes

* **test/Core.Test/Services/OrganizationServiceTests.cs:** Set a fixed number of seats for the tested Organization

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
