### PR TITLE
[EC-1032] if name is Empty, set to null before saving

### DIFF
--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -178,6 +178,12 @@ public class UserService : UserManager<User>, IUserService, IDisposable
             throw new ApplicationException("Use register method to create a new user.");
         }
 
+        // if the name is empty, set it to null
+        if (String.Equals(user.Name, String.Empty))
+        {
+            user.Name = null;
+        }
+
         user.RevisionDate = user.AccountRevisionDate = DateTime.UtcNow;
         await _userRepository.ReplaceAsync(user);
 

--- a/test/Core.Test/Services/UserServiceTests.cs
+++ b/test/Core.Test/Services/UserServiceTests.cs
@@ -20,6 +20,14 @@ namespace Bit.Core.Test.Services;
 public class UserServiceTests
 {
     [Theory, BitAutoData]
+    public async Task SaveUserAsync_SetsNameToNull_WhenNameIsEmpty(SutProvider<UserService> sutProvider, User user)
+    {
+        user.Name = string.Empty;
+        await sutProvider.Sut.SaveUserAsync(user);
+        Assert.Null(user.Name);
+    }
+
+    [Theory, BitAutoData]
     public async Task UpdateLicenseAsync_Success(SutProvider<UserService> sutProvider,
         User user, UserLicense userLicense)
     {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
If an organization member uses a client to change their name to "", the database saves it as that instead of `null`. Clients expect the name to be `null` if empty. This change will always save `null` in the DB if the name is "".


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
