### PR TITLE
[SG-1001] Error Thrown When Verifying Sub Domains

### DIFF
--- a/src/Core/Exceptions/DnsQueryException.cs
+++ b/src/Core/Exceptions/DnsQueryException.cs
@@ -1,0 +1,7 @@
+﻿namespace Bit.Core.Exceptions;
+
+public class DnsQueryException : Exception
+{
+    public DnsQueryException(string message)
+        : base(message) { }
+}

--- a/src/Core/Exceptions/TxtRecordNotFoundException.cs
+++ b/src/Core/Exceptions/TxtRecordNotFoundException.cs
@@ -1,7 +1,0 @@
-﻿namespace Bit.Core.Exceptions;
-
-public class TxtRecordNotFoundException : Exception
-{
-    public TxtRecordNotFoundException()
-        : base("TXT record not found.") { }
-}

--- a/src/Core/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs
@@ -60,7 +60,7 @@ public class VerifyOrganizationDomainCommand : IVerifyOrganizationDomainCommand
         }
         catch (Exception e)
         {
-            _logger.LogError("Error verifying Organization domain.", e);
+            _logger.LogError("Error verifying Organization domain. {errorMessage}", e.Message);
         }
 
         domain.SetLastCheckedDate();

--- a/src/Core/Services/Implementations/DnsResolverService.cs
+++ b/src/Core/Services/Implementations/DnsResolverService.cs
@@ -16,6 +16,6 @@ public class DnsResolverService : IDnsResolverService
                 .Any(t => t == txtRecord);
         }
 
-        throw new TxtRecordNotFoundException();
+        throw new DnsQueryException(result.ErrorMessage);
     }
 }

--- a/src/Core/Services/Implementations/OrganizationDomainService.cs
+++ b/src/Core/Services/Implementations/OrganizationDomainService.cs
@@ -52,27 +52,34 @@ public class OrganizationDomainService : IOrganizationDomainService
                 if (status)
                 {
                     _logger.LogInformation(Constants.BypassFiltersEventId, "Successfully validated domain");
+                    
+                    //update entry on OrganizationDomain table 
                     domain.SetLastCheckedDate();
                     domain.SetVerifiedDate();
                     domain.SetJobRunCount();
-
                     await _domainRepository.ReplaceAsync(domain);
+                    
                     await _eventService.LogOrganizationDomainEventAsync(domain, EventType.OrganizationDomain_Verified,
                         EventSystemUser.DomainVerification);
                     return;
                 }
-
+                
+                //update entry on OrganizationDomain table 
                 domain.SetLastCheckedDate();
                 domain.SetJobRunCount();
                 domain.SetNextRunDate(_globalSettings.DomainVerification.VerificationInterval);
                 await _domainRepository.ReplaceAsync(domain);
+                
                 await _eventService.LogOrganizationDomainEventAsync(domain, EventType.OrganizationDomain_NotVerified,
                     EventSystemUser.DomainVerification);
                 _logger.LogInformation(Constants.BypassFiltersEventId, "Verification for organization {OrgId} with domain {Domain} failed", domain.OrganizationId, domain.DomainName);
             }
             catch (Exception ex)
             {
+                //update entry on OrganizationDomain table 
                 domain.SetLastCheckedDate();
+                domain.SetJobRunCount();
+                domain.SetNextRunDate(_globalSettings.DomainVerification.VerificationInterval);
                 await _domainRepository.ReplaceAsync(domain);
 
                 _logger.LogError(ex, "Verification for organization {OrgId} with domain {Domain} threw an exception", domain.OrganizationId, domain.DomainName);

--- a/src/Core/Services/Implementations/OrganizationDomainService.cs
+++ b/src/Core/Services/Implementations/OrganizationDomainService.cs
@@ -52,24 +52,24 @@ public class OrganizationDomainService : IOrganizationDomainService
                 if (status)
                 {
                     _logger.LogInformation(Constants.BypassFiltersEventId, "Successfully validated domain");
-                    
+
                     //update entry on OrganizationDomain table 
                     domain.SetLastCheckedDate();
                     domain.SetVerifiedDate();
                     domain.SetJobRunCount();
                     await _domainRepository.ReplaceAsync(domain);
-                    
+
                     await _eventService.LogOrganizationDomainEventAsync(domain, EventType.OrganizationDomain_Verified,
                         EventSystemUser.DomainVerification);
                     return;
                 }
-                
+
                 //update entry on OrganizationDomain table 
                 domain.SetLastCheckedDate();
                 domain.SetJobRunCount();
                 domain.SetNextRunDate(_globalSettings.DomainVerification.VerificationInterval);
                 await _domainRepository.ReplaceAsync(domain);
-                
+
                 await _eventService.LogOrganizationDomainEventAsync(domain, EventType.OrganizationDomain_NotVerified,
                     EventSystemUser.DomainVerification);
                 _logger.LogInformation(Constants.BypassFiltersEventId, "Verification for organization {OrgId} with domain {Domain} failed", domain.OrganizationId, domain.DomainName);

--- a/src/Core/Services/Implementations/OrganizationDomainService.cs
+++ b/src/Core/Services/Implementations/OrganizationDomainService.cs
@@ -82,7 +82,8 @@ public class OrganizationDomainService : IOrganizationDomainService
                 domain.SetNextRunDate(_globalSettings.DomainVerification.VerificationInterval);
                 await _domainRepository.ReplaceAsync(domain);
 
-                _logger.LogError(ex, "Verification for organization {OrgId} with domain {Domain} threw an exception", domain.OrganizationId, domain.DomainName);
+                _logger.LogError(ex, "Verification for organization {OrgId} with domain {Domain} threw an exception: {errorMessage}",
+                    domain.OrganizationId, domain.DomainName, ex.Message);
             }
         }
     }

--- a/test/Core.Test/OrganizationFeatures/OrganizationDomains/CreateOrganizationDomainCommandTests.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationDomains/CreateOrganizationDomainCommandTests.cs
@@ -92,7 +92,7 @@ public class CreateOrganizationDomainCommandTests
             .ReturnsNull();
         sutProvider.GetDependency<IDnsResolverService>()
             .ResolveAsync(orgDomain.DomainName, orgDomain.Txt)
-            .Throws(new TxtRecordNotFoundException());
+            .Throws(new DnsQueryException(""));
         sutProvider.GetDependency<IOrganizationDomainRepository>()
             .CreateAsync(orgDomain)
             .Returns(orgDomain);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
DNSClient.net throws an exception when validating non-existent domains, and this exception was not properly captured in the logs, and necessary updates like `nextRunDate` and `jobRunCount` are not updated; hence the entries were never picked up by the background service.


## Code changes
<!--Explain your changes to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/Exceptions/DnsQueryException.cs:** Renamed `TxtRecordNotFoundException` to a more generic name and added a `message` parameter in the constructor to receive the actual error message from DNSClient.Net.
* **src/Core/Services/Implementations/OrganizationDomainService.cs:** Added setters for job count and next run date when an exception is thrown.
* **test/Core.Test/OrganizationFeatures/OrganizationDomains/CreateOrganizationDomainCommandTests.cs:** Updated unit test with the updated exception name.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
