### PR TITLE
[License sync] [EC-1036] Show correct license sync date

### DIFF
--- a/src/Api/Controllers/SelfHosted/SelfHostedOrganizationLicensesController.cs
+++ b/src/Api/Controllers/SelfHosted/SelfHostedOrganizationLicensesController.cs
@@ -6,6 +6,7 @@ using Bit.Core.Context;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Business;
+using Bit.Core.Models.OrganizationConnectionConfigs;
 using Bit.Core.OrganizationFeatures.OrganizationLicenses.Interfaces;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
@@ -107,5 +108,10 @@ public class SelfHostedOrganizationLicensesController : Controller
             await _selfHostedGetOrganizationLicenseQuery.GetLicenseAsync(organization, billingSyncConnection);
 
         await _organizationService.UpdateLicenseAsync(organization.Id, license);
+
+        var config = billingSyncConnection.GetConfig<BillingSyncConfig>();
+        config.LastLicenseSync = DateTime.Now;
+        billingSyncConnection.SetConfig(config);
+        await _organizationConnectionRepository.ReplaceAsync(billingSyncConnection);
     }
 }

--- a/src/Core/Models/OrganizationConnectionConfigs/BillingSyncConfig.cs
+++ b/src/Core/Models/OrganizationConnectionConfigs/BillingSyncConfig.cs
@@ -4,6 +4,7 @@ public class BillingSyncConfig : IConnectionConfig
 {
     public string BillingSyncKey { get; set; }
     public Guid CloudOrganizationId { get; set; }
+    public DateTime? LastLicenseSync { get; set; }
 
     public bool Validate(out string exception)
     {

--- a/test/Core.Test/OrganizationFeatures/OrganizationLicenses/SelfHostedGetOrganizationLicenseQueryTests.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationLicenses/SelfHostedGetOrganizationLicenseQueryTests.cs
@@ -88,6 +88,7 @@ public class SelfHostedGetOrganizationLicenseQueryTests
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
             sutProvider.Sut.GetLicenseAsync(organization, billingSyncConnection));
-        Assert.Contains("Organization License sync failed", exception.Message);
+        Assert.Contains("An error has occurred. Check your internet connection and ensure the billing token is correct.",
+            exception.Message);
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The Last License Sync date was still showing the F4E sync date, which is separate.

Update to record the last license sync date and include it in the response to the client.

Goes with https://github.com/bitwarden/clients/pull/4558

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* add `LastLicenseSync` to the billingSync config object. This was discussed extensively but decided this was the best place for it, because (a) it only relates to this type of connection, not all connections, (b) it's separate to the Sponsorship sync dates, and (c) it's not updated frequently enough for json serialization performance to be a concern. We should consider splitting F4E and license sync connection types which might enable us to have a `LastUsed` column, but that's out of scope here.

* update the last sync date after a sync has completed (self-hosted side)

Note that the `OrganizationConnectionResponseModel` just includes the config as a `JsonDocument`, so no changes needed there. It's automatically included in the response to the client.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
