### PR TITLE
[PS-2363] fix bumping `AccountRevisionDate` when creating and updating ciphers

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CipherRepository.cs
@@ -29,7 +29,7 @@ public class CipherRepository : Repository<Core.Entities.Cipher, Cipher, Guid>, 
             var dbContext = GetDatabaseContext(scope);
             if (cipher.OrganizationId.HasValue)
             {
-                await dbContext.UserBumpAccountRevisionDateByCipherIdAsync(cipher.Id, cipher.OrganizationId);
+                await dbContext.UserBumpAccountRevisionDateByCipherIdAsync(cipher.Id, cipher.OrganizationId.Value);
             }
             else if (cipher.UserId.HasValue)
             {
@@ -59,7 +59,7 @@ public class CipherRepository : Repository<Core.Entities.Cipher, Cipher, Guid>, 
                     await OrganizationUpdateStorage(cipherInfo.OrganizationId.Value);
                 }
 
-                await dbContext.UserBumpAccountRevisionDateByCipherIdAsync(cipher.Id, cipherInfo.OrganizationId);
+                await dbContext.UserBumpAccountRevisionDateByCipherIdAsync(cipher.Id, cipherInfo.OrganizationId.Value);
             }
             else if (cipherInfo?.UserId != null)
             {
@@ -107,7 +107,16 @@ public class CipherRepository : Repository<Core.Entities.Cipher, Cipher, Guid>, 
                 null;
             var entity = Mapper.Map<Cipher>((Core.Entities.Cipher)cipher);
             await dbContext.AddAsync(entity);
-            await dbContext.UserBumpAccountRevisionDateByCipherIdAsync(cipher.Id, cipher.OrganizationId.GetValueOrDefault());
+
+            if (cipher.OrganizationId.HasValue)
+            {
+                await dbContext.UserBumpAccountRevisionDateByCipherIdAsync(cipher.Id, cipher.OrganizationId.Value);
+            }
+            else if (cipher.UserId.HasValue)
+            {
+                await dbContext.UserBumpAccountRevisionDateAsync(cipher.UserId.Value);
+            }
+
             await dbContext.SaveChangesAsync();
         }
         return cipher;
@@ -458,7 +467,16 @@ public class CipherRepository : Repository<Core.Entities.Cipher, Cipher, Guid>, 
                 }
                 var mappedEntity = Mapper.Map<Cipher>((Core.Entities.Cipher)cipher);
                 dbContext.Entry(entity).CurrentValues.SetValues(mappedEntity);
-                await dbContext.UserBumpAccountRevisionDateByCipherIdAsync(cipher.Id, cipher.OrganizationId.GetValueOrDefault());
+
+                if (cipher.OrganizationId.HasValue)
+                {
+                    await dbContext.UserBumpAccountRevisionDateByCipherIdAsync(cipher.Id, cipher.OrganizationId.Value);
+                }
+                else if (cipher.UserId.HasValue)
+                {
+                    await dbContext.UserBumpAccountRevisionDateAsync(cipher.UserId.Value);
+                }
+
                 await dbContext.SaveChangesAsync();
             }
         }
@@ -566,7 +584,15 @@ public class CipherRepository : Repository<Core.Entities.Cipher, Cipher, Guid>, 
                 }
             }
 
-            await dbContext.UserBumpAccountRevisionDateByCipherIdAsync(cipher.Id, cipher.OrganizationId.GetValueOrDefault());
+            if (cipher.OrganizationId.HasValue)
+            {
+                await dbContext.UserBumpAccountRevisionDateByCipherIdAsync(cipher.Id, cipher.OrganizationId.Value);
+            }
+            else if (cipher.UserId.HasValue)
+            {
+                await dbContext.UserBumpAccountRevisionDateAsync(cipher.UserId.Value);
+            }
+
             await dbContext.SaveChangesAsync();
             return true;
         }
@@ -677,7 +703,7 @@ public class CipherRepository : Repository<Core.Entities.Cipher, Cipher, Guid>, 
             if (attachment.OrganizationId.HasValue)
             {
                 await OrganizationUpdateStorage(cipher.OrganizationId.Value);
-                await dbContext.UserBumpAccountRevisionDateByCipherIdAsync(cipher.Id, cipher.OrganizationId);
+                await dbContext.UserBumpAccountRevisionDateByCipherIdAsync(cipher.Id, cipher.OrganizationId.Value);
             }
             else if (attachment.UserId.HasValue)
             {

--- a/src/Infrastructure.EntityFramework/Repositories/DatabaseContextExtensions.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/DatabaseContextExtensions.cs
@@ -34,7 +34,7 @@ public static class DatabaseContextExtensions
         UpdateUserRevisionDate(users);
     }
 
-    public static async Task UserBumpAccountRevisionDateByCipherIdAsync(this DatabaseContext context, Guid cipherId, Guid? organizationId)
+    public static async Task UserBumpAccountRevisionDateByCipherIdAsync(this DatabaseContext context, Guid cipherId, Guid organizationId)
     {
         var query = new UserBumpAccountRevisionDateByCipherIdQuery(cipherId, organizationId);
         var users = await query.Run(context).ToListAsync();

--- a/src/Infrastructure.EntityFramework/Repositories/Queries/UserBumpAccountRevisionDateByCipherIdQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/UserBumpAccountRevisionDateByCipherIdQuery.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Core.Entities;
-using Bit.Core.Enums;
+﻿using Bit.Core.Enums;
 using User = Bit.Infrastructure.EntityFramework.Models.User;
 
 namespace Bit.Infrastructure.EntityFramework.Repositories.Queries;
@@ -7,15 +6,9 @@ namespace Bit.Infrastructure.EntityFramework.Repositories.Queries;
 public class UserBumpAccountRevisionDateByCipherIdQuery : IQuery<User>
 {
     private readonly Guid _cipherId;
-    private readonly Guid? _organizationId;
+    private readonly Guid _organizationId;
 
-    public UserBumpAccountRevisionDateByCipherIdQuery(Cipher cipher)
-    {
-        _cipherId = cipher.Id;
-        _organizationId = cipher.OrganizationId;
-    }
-
-    public UserBumpAccountRevisionDateByCipherIdQuery(Guid cipherId, Guid? organizationId)
+    public UserBumpAccountRevisionDateByCipherIdQuery(Guid cipherId, Guid organizationId)
     {
         _cipherId = cipherId;
         _organizationId = organizationId;

--- a/test/Infrastructure.EFIntegration.Test/Repositories/CipherRepositoryTests.cs
+++ b/test/Infrastructure.EFIntegration.Test/Repositories/CipherRepositoryTests.cs
@@ -159,7 +159,7 @@ public class CipherRepositoryTests
             var postEfCipher = await sut.CreateAsync(cipher);
             sut.ClearChangeTracking();
 
-            var query = new UserBumpAccountRevisionDateByCipherIdQuery(cipher);
+            var query = new UserBumpAccountRevisionDateByCipherIdQuery(cipher, cipher.OrganizationId.Value);
             var modifiedUsers = await sut.Run(query).ToListAsync();
             Assert.True(modifiedUsers
                 .All(u => u.AccountRevisionDate.ToShortDateString() ==


### PR DESCRIPTION
When the user is not part of an organization,
`UserBumpAccountRevisionDateByCipherIdQuery` doesn't work. In that case we have to use `UserBumpAccountRevisionDateAsync` instead.

This was already done by most parts of the code but a few more were missing.

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Fixes #2615
