### PR TITLE
Fix mssql migration options

### DIFF
--- a/dev/migrate.ps1
+++ b/dev/migrate.ps1
@@ -6,7 +6,15 @@
 #  in the future and investigate if we can migrate back.
 # docker-compose --profile mssql exec mssql bash /mnt/helpers/run_migrations.sh @args
 
-param([switch]$all = $false, [switch]$postgres = $false, [switch]$mysql = $false, [switch]$mssql = $false, [switch]$sqlite = $false)
+param(
+  [switch]$all = $false,
+  [switch]$postgres = $false,
+  [switch]$mysql = $false,
+  [switch]$mssql = $false,
+  [switch]$sqlite = $false,
+  [switch]$selfhost = $false,
+  [switch]$pipeline = $false
+)
 
 if (!$all -and !$postgres -and !$mysql -and !$sqlite) {
   $mssql = $true;
@@ -21,6 +29,12 @@ if ($all -or $postgres -or $mysql -or $sqlite) {
 }
 
 if ($all -or $mssql) {
+  if ($selfhost) {
+    $migrationArgs = "-s"
+  } elseif ($pipeline) {
+    $migrationArgs = "-p"
+  }
+
   Write-Host "Starting Microsoft SQL Server Migrations"
   docker run `
     -v "$(pwd)/helpers/mssql:/mnt/helpers" `
@@ -30,7 +44,7 @@ if ($all -or $mssql) {
     --network=bitwardenserver_default `
     --rm `
     mcr.microsoft.com/mssql-tools `
-    /mnt/helpers/run_migrations.sh @args
+    /mnt/helpers/run_migrations.sh $migrationArgs
 }
 
 $currentDir = Get-Location


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix self-host db migrations.

I wasn't able to update my self-hosted database using `dev/migrate.ps1`. The `-s` flag (previously interpreted as an unnamed argument and passed to `run_migrations.ps1`) is now interpreted as short for the `-sqlite` flag (and runs the sqlite migrations, and is not passed to `run_migration.ps1` because it's not in the `@args` array).

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **dev/migrate.ps1**
  - add selfhost and pipeline flags as explicit parameters to this script
  - parse these and construct the appropriate arguments for `run_migrations.sh` (maybe there is a more elegant solution for this, but I couldn't think of one)

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
