### PR TITLE
[SG-1009] Users with Custom Role and "Manage SSO" permission don't receive verification failed email

### DIFF
--- a/src/Core/Models/Data/Organizations/OrganizationUsers/OrganizationUserUserDetails.cs
+++ b/src/Core/Models/Data/Organizations/OrganizationUsers/OrganizationUserUserDetails.cs
@@ -67,4 +67,10 @@ public class OrganizationUserUserDetails : IExternal, ITwoFactorProvidersUser
             return Status != OrganizationUserStatusType.Revoked;
         }
     }
+    
+    public Permissions GetPermissions()
+    {
+        return string.IsNullOrWhiteSpace(Permissions) ? null 
+            : CoreHelpers.LoadClassFromJsonData<Permissions>(Permissions);
+    }
 }

--- a/src/Core/Models/Data/Organizations/OrganizationUsers/OrganizationUserUserDetails.cs
+++ b/src/Core/Models/Data/Organizations/OrganizationUsers/OrganizationUserUserDetails.cs
@@ -67,10 +67,10 @@ public class OrganizationUserUserDetails : IExternal, ITwoFactorProvidersUser
             return Status != OrganizationUserStatusType.Revoked;
         }
     }
-    
+
     public Permissions GetPermissions()
     {
-        return string.IsNullOrWhiteSpace(Permissions) ? null 
+        return string.IsNullOrWhiteSpace(Permissions) ? null
             : CoreHelpers.LoadClassFromJsonData<Permissions>(Permissions);
     }
 }

--- a/src/Core/Services/Implementations/OrganizationDomainService.cs
+++ b/src/Core/Services/Implementations/OrganizationDomainService.cs
@@ -2,7 +2,6 @@
 using Bit.Core.Repositories;
 using Bit.Core.Settings;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
 
 namespace Bit.Core.Services;
 
@@ -129,10 +128,10 @@ public class OrganizationDomainService : IOrganizationDomainService
     private async Task<List<string>> GetAdminEmailsAsync(Guid organizationId)
     {
         var orgUsers = await _organizationUserRepository.GetManyDetailsByOrganizationAsync(organizationId);
-        var emailList = orgUsers.Where(o => o.Type <= OrganizationUserType.Admin 
+        var emailList = orgUsers.Where(o => o.Type <= OrganizationUserType.Admin
                                         || o.GetPermissions()?.ManageSso == true)
             .Select(a => a.Email).Distinct().ToList();
-        
+
         return emailList;
     }
 }

--- a/src/Infrastructure.EntityFramework/Repositories/OrganizationDomainRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/OrganizationDomainRepository.cs
@@ -126,7 +126,7 @@ public class OrganizationDomainRepository : Repository<Core.Entities.Organizatio
         //Get domains that have not been verified after 72 hours
         var domains = dbContext.OrganizationDomains
             .AsEnumerable()
-            .Where(x => (DateTime.UtcNow - x.CreationDate).Days == 4
+            .Where(x => (DateTime.UtcNow - x.CreationDate).Days >= 4
                         && x.VerifiedDate == null)
             .ToList();
 

--- a/src/Sql/dbo/Stored Procedures/OrganizationDomain_ReadIfExpired.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationDomain_ReadIfExpired.sql
@@ -8,6 +8,6 @@ BEGIN
     FROM
         [dbo].[OrganizationDomain]
     WHERE
-        DATEDIFF(DAY, [CreationDate], GETUTCDATE()) = 4 --Get domains that have not been verified after 3 days (72 hours)
+        DATEDIFF(DAY, [CreationDate], GETUTCDATE()) >= 4 --Get domains that have not been verified after 3 days (72 hours)
     AND
         [VerifiedDate] IS NULL

--- a/util/Migrator/DbScripts/2022-11-03_00_OrganizationDomainInit.sql
+++ b/util/Migrator/DbScripts/2022-11-03_00_OrganizationDomainInit.sql
@@ -229,7 +229,7 @@ SELECT
 FROM
     [dbo].[OrganizationDomain]
 WHERE
-    DATEDIFF(DAY, [CreationDate], GETUTCDATE()) = 4 --Get domains that have not been verified after 3 days (72 hours)
+    DATEDIFF(DAY, [CreationDate], GETUTCDATE()) >= 4 --Get domains that have not been verified after 3 days (72 hours)
   AND
     [VerifiedDate] IS NULL
 END


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Users who have the “Custom” role and also have the “Manage SSO” permission selected should receive the domain verification failed email, along with organization Owners and Admins. Currently, only owners and admins are receiving the email.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/Models/Data/Organizations/OrganizationUsers/OrganizationUserUserDetails.cs:** Method to deserialize JSON string to `Permissions` object.
* **src/Core/Services/Implementations/OrganizationDomainService.cs** Added `GetAdminEmailsAsync` method to return admin, owners and custom user emails.
* **src/Sql/dbo/Stored Procedures/OrganizationDomain_ReadIfExpired.sql** Modified stored procedure to return expired domains greater than the specified period.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
