### PR TITLE
[SM-465] Add access policy on service account creation

### DIFF
--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/ServiceAccounts/CreateServiceAccountCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/ServiceAccounts/CreateServiceAccountCommand.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.SecretsManager.Commands.ServiceAccounts.Interfaces;
+﻿using Bit.Core.Repositories;
+using Bit.Core.SecretsManager.Commands.ServiceAccounts.Interfaces;
 using Bit.Core.SecretsManager.Entities;
 using Bit.Core.SecretsManager.Repositories;
 
@@ -6,15 +7,34 @@ namespace Bit.Commercial.Core.SecretsManager.Commands.ServiceAccounts;
 
 public class CreateServiceAccountCommand : ICreateServiceAccountCommand
 {
+    private readonly IAccessPolicyRepository _accessPolicyRepository;
+    private readonly IOrganizationUserRepository _organizationUserRepository;
     private readonly IServiceAccountRepository _serviceAccountRepository;
 
-    public CreateServiceAccountCommand(IServiceAccountRepository serviceAccountRepository)
+    public CreateServiceAccountCommand(
+        IAccessPolicyRepository accessPolicyRepository,
+        IOrganizationUserRepository organizationUserRepository,
+        IServiceAccountRepository serviceAccountRepository)
     {
+        _accessPolicyRepository = accessPolicyRepository;
+        _organizationUserRepository = organizationUserRepository;
         _serviceAccountRepository = serviceAccountRepository;
     }
 
-    public async Task<ServiceAccount> CreateAsync(ServiceAccount serviceAccount)
+    public async Task<ServiceAccount> CreateAsync(ServiceAccount serviceAccount, Guid userId)
     {
-        return await _serviceAccountRepository.CreateAsync(serviceAccount);
+        var createdServiceAccount = await _serviceAccountRepository.CreateAsync(serviceAccount);
+
+        var user = await _organizationUserRepository.GetByOrganizationAsync(createdServiceAccount.OrganizationId,
+            userId);
+        var accessPolicy = new UserServiceAccountAccessPolicy
+        {
+            OrganizationUserId = user.Id,
+            GrantedServiceAccountId = createdServiceAccount.Id,
+            Read = true,
+            Write = true,
+        };
+        await _accessPolicyRepository.CreateManyAsync(new List<BaseAccessPolicy> { accessPolicy });
+        return createdServiceAccount;
     }
 }

--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/AccessPolicyRepository.cs
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/AccessPolicyRepository.cs
@@ -138,7 +138,7 @@ public class AccessPolicyRepository : BaseEntityFrameworkRepository, IAccessPoli
         }
     }
 
-    public async Task<IEnumerable<Core.SecretsManager.Entities.BaseAccessPolicy>?> GetManyByProjectId(Guid id)
+    public async Task<IEnumerable<Core.SecretsManager.Entities.BaseAccessPolicy>?> GetManyByGrantedProjectIdAsync(Guid id)
     {
         using (var scope = ServiceScopeFactory.CreateScope())
         {
@@ -157,14 +157,14 @@ public class AccessPolicyRepository : BaseEntityFrameworkRepository, IAccessPoli
         }
     }
 
-    public async Task<IEnumerable<Core.SecretsManager.Entities.BaseAccessPolicy>?> GetManyByServiceAccountAsync(Guid serviceAcountId)
+    public async Task<IEnumerable<Core.SecretsManager.Entities.BaseAccessPolicy>?> GetManyByGrantedServiceAccountIdAsync(Guid id)
     {
         using var scope = ServiceScopeFactory.CreateScope();
         var dbContext = GetDatabaseContext(scope);
 
         var entities = await dbContext.AccessPolicies.Where(ap =>
-                ((UserServiceAccountAccessPolicy)ap).GrantedServiceAccountId == serviceAcountId ||
-                ((GroupServiceAccountAccessPolicy)ap).GrantedServiceAccountId == serviceAcountId)
+                ((UserServiceAccountAccessPolicy)ap).GrantedServiceAccountId == id ||
+                ((GroupServiceAccountAccessPolicy)ap).GrantedServiceAccountId == id)
             .Include(ap => ((UserServiceAccountAccessPolicy)ap).OrganizationUser.User)
             .Include(ap => ((GroupServiceAccountAccessPolicy)ap).Group)
             .ToListAsync();

--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/AccessPolicyRepository.cs
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/AccessPolicyRepository.cs
@@ -153,7 +153,7 @@ public class AccessPolicyRepository : BaseEntityFrameworkRepository, IAccessPoli
                 .Include(ap => ((ServiceAccountProjectAccessPolicy)ap).ServiceAccount)
                 .ToListAsync();
 
-            return !entities.Any() ? null : entities.Select(MapToCore);
+            return entities.Select(MapToCore);
         }
     }
 
@@ -169,7 +169,7 @@ public class AccessPolicyRepository : BaseEntityFrameworkRepository, IAccessPoli
             .Include(ap => ((GroupServiceAccountAccessPolicy)ap).Group)
             .ToListAsync();
 
-        return !entities.Any() ? null : entities.Select(MapToCore);
+        return entities.Select(MapToCore);
     }
 
     public async Task DeleteAsync(Guid id)

--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/AccessPolicyRepository.cs
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/AccessPolicyRepository.cs
@@ -138,7 +138,7 @@ public class AccessPolicyRepository : BaseEntityFrameworkRepository, IAccessPoli
         }
     }
 
-    public async Task<IEnumerable<Core.SecretsManager.Entities.BaseAccessPolicy>?> GetManyByGrantedProjectIdAsync(Guid id)
+    public async Task<IEnumerable<Core.SecretsManager.Entities.BaseAccessPolicy>> GetManyByGrantedProjectIdAsync(Guid id)
     {
         using (var scope = ServiceScopeFactory.CreateScope())
         {
@@ -157,7 +157,7 @@ public class AccessPolicyRepository : BaseEntityFrameworkRepository, IAccessPoli
         }
     }
 
-    public async Task<IEnumerable<Core.SecretsManager.Entities.BaseAccessPolicy>?> GetManyByGrantedServiceAccountIdAsync(Guid id)
+    public async Task<IEnumerable<Core.SecretsManager.Entities.BaseAccessPolicy>> GetManyByGrantedServiceAccountIdAsync(Guid id)
     {
         using var scope = ServiceScopeFactory.CreateScope();
         var dbContext = GetDatabaseContext(scope);

--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/AccessPolicyRepository.cs
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/AccessPolicyRepository.cs
@@ -157,6 +157,21 @@ public class AccessPolicyRepository : BaseEntityFrameworkRepository, IAccessPoli
         }
     }
 
+    public async Task<IEnumerable<Core.SecretsManager.Entities.BaseAccessPolicy>?> GetManyByServiceAccountAsync(Guid serviceAcountId)
+    {
+        using var scope = ServiceScopeFactory.CreateScope();
+        var dbContext = GetDatabaseContext(scope);
+
+        var entities = await dbContext.AccessPolicies.Where(ap =>
+                ((UserServiceAccountAccessPolicy)ap).GrantedServiceAccountId == serviceAcountId ||
+                ((GroupServiceAccountAccessPolicy)ap).GrantedServiceAccountId == serviceAcountId)
+            .Include(ap => ((UserServiceAccountAccessPolicy)ap).OrganizationUser.User)
+            .Include(ap => ((GroupServiceAccountAccessPolicy)ap).Group)
+            .ToListAsync();
+
+        return !entities.Any() ? null : entities.Select(MapToCore);
+    }
+
     public async Task DeleteAsync(Guid id)
     {
         using (var scope = ServiceScopeFactory.CreateScope())
@@ -178,6 +193,8 @@ public class AccessPolicyRepository : BaseEntityFrameworkRepository, IAccessPoli
             UserProjectAccessPolicy ap => Mapper.Map<Core.SecretsManager.Entities.UserProjectAccessPolicy>(ap),
             GroupProjectAccessPolicy ap => Mapper.Map<Core.SecretsManager.Entities.GroupProjectAccessPolicy>(ap),
             ServiceAccountProjectAccessPolicy ap => Mapper.Map<Core.SecretsManager.Entities.ServiceAccountProjectAccessPolicy>(ap),
+            UserServiceAccountAccessPolicy ap => Mapper.Map<Core.SecretsManager.Entities.UserServiceAccountAccessPolicy>(ap),
+            GroupServiceAccountAccessPolicy ap => Mapper.Map<Core.SecretsManager.Entities.GroupServiceAccountAccessPolicy>(ap),
             _ => throw new ArgumentException("Unsupported access policy type")
         };
     }

--- a/src/Api/SecretsManager/Controllers/AccessPoliciesController.cs
+++ b/src/Api/SecretsManager/Controllers/AccessPoliciesController.cs
@@ -40,7 +40,7 @@ public class AccessPoliciesController : Controller
     [HttpGet("/projects/{id}/access-policies")]
     public async Task<ProjectAccessPoliciesResponseModel> GetProjectAccessPoliciesAsync([FromRoute] Guid id)
     {
-        var results = await _accessPolicyRepository.GetManyByProjectId(id);
+        var results = await _accessPolicyRepository.GetManyByGrantedProjectIdAsync(id);
         return new ProjectAccessPoliciesResponseModel(results);
     }
 

--- a/src/Api/SecretsManager/Controllers/ServiceAccountsController.cs
+++ b/src/Api/SecretsManager/Controllers/ServiceAccountsController.cs
@@ -64,8 +64,8 @@ public class ServiceAccountsController : Controller
         {
             throw new NotFoundException();
         }
-
-        var result = await _createServiceAccountCommand.CreateAsync(createRequest.ToServiceAccount(organizationId));
+        var userId = _userService.GetProperUserId(User).Value;
+        var result = await _createServiceAccountCommand.CreateAsync(createRequest.ToServiceAccount(organizationId), userId);
         return new ServiceAccountResponseModel(result);
     }
 

--- a/src/Api/SecretsManager/Models/Response/ProjectAccessPoliciesResponseModel.cs
+++ b/src/Api/SecretsManager/Models/Response/ProjectAccessPoliciesResponseModel.cs
@@ -10,11 +10,6 @@ public class ProjectAccessPoliciesResponseModel : ResponseModel
     public ProjectAccessPoliciesResponseModel(IEnumerable<BaseAccessPolicy> baseAccessPolicies)
         : base(_objectName)
     {
-        if (baseAccessPolicies == null)
-        {
-            return;
-        }
-
         foreach (var baseAccessPolicy in baseAccessPolicies)
             switch (baseAccessPolicy)
             {

--- a/src/Core/SecretsManager/Commands/ServiceAccounts/Interfaces/ICreateServiceAccountCommand.cs
+++ b/src/Core/SecretsManager/Commands/ServiceAccounts/Interfaces/ICreateServiceAccountCommand.cs
@@ -4,5 +4,5 @@ namespace Bit.Core.SecretsManager.Commands.ServiceAccounts.Interfaces;
 
 public interface ICreateServiceAccountCommand
 {
-    Task<ServiceAccount> CreateAsync(ServiceAccount serviceAccount);
+    Task<ServiceAccount> CreateAsync(ServiceAccount serviceAccount, Guid userId);
 }

--- a/src/Core/SecretsManager/Repositories/IAccessPolicyRepository.cs
+++ b/src/Core/SecretsManager/Repositories/IAccessPolicyRepository.cs
@@ -8,8 +8,8 @@ public interface IAccessPolicyRepository
     Task<List<BaseAccessPolicy>> CreateManyAsync(List<BaseAccessPolicy> baseAccessPolicies);
     Task<bool> AccessPolicyExists(BaseAccessPolicy baseAccessPolicy);
     Task<BaseAccessPolicy?> GetByIdAsync(Guid id);
-    Task<IEnumerable<BaseAccessPolicy>?> GetManyByProjectId(Guid id);
-    Task<IEnumerable<BaseAccessPolicy>?> GetManyByServiceAccountAsync(Guid serviceAccountId);
+    Task<IEnumerable<BaseAccessPolicy>?> GetManyByGrantedProjectIdAsync(Guid id);
+    Task<IEnumerable<BaseAccessPolicy>?> GetManyByGrantedServiceAccountIdAsync(Guid id);
     Task ReplaceAsync(BaseAccessPolicy baseAccessPolicy);
     Task DeleteAsync(Guid id);
 }

--- a/src/Core/SecretsManager/Repositories/IAccessPolicyRepository.cs
+++ b/src/Core/SecretsManager/Repositories/IAccessPolicyRepository.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.SecretsManager.Entities;
+﻿#nullable enable
+using Bit.Core.SecretsManager.Entities;
 
 namespace Bit.Core.SecretsManager.Repositories;
 

--- a/src/Core/SecretsManager/Repositories/IAccessPolicyRepository.cs
+++ b/src/Core/SecretsManager/Repositories/IAccessPolicyRepository.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using Bit.Core.SecretsManager.Entities;
+﻿using Bit.Core.SecretsManager.Entities;
 
 namespace Bit.Core.SecretsManager.Repositories;
 
@@ -8,8 +7,8 @@ public interface IAccessPolicyRepository
     Task<List<BaseAccessPolicy>> CreateManyAsync(List<BaseAccessPolicy> baseAccessPolicies);
     Task<bool> AccessPolicyExists(BaseAccessPolicy baseAccessPolicy);
     Task<BaseAccessPolicy?> GetByIdAsync(Guid id);
-    Task<IEnumerable<BaseAccessPolicy>?> GetManyByGrantedProjectIdAsync(Guid id);
-    Task<IEnumerable<BaseAccessPolicy>?> GetManyByGrantedServiceAccountIdAsync(Guid id);
+    Task<IEnumerable<BaseAccessPolicy>> GetManyByGrantedProjectIdAsync(Guid id);
+    Task<IEnumerable<BaseAccessPolicy>> GetManyByGrantedServiceAccountIdAsync(Guid id);
     Task ReplaceAsync(BaseAccessPolicy baseAccessPolicy);
     Task DeleteAsync(Guid id);
 }

--- a/src/Core/SecretsManager/Repositories/IAccessPolicyRepository.cs
+++ b/src/Core/SecretsManager/Repositories/IAccessPolicyRepository.cs
@@ -9,6 +9,7 @@ public interface IAccessPolicyRepository
     Task<bool> AccessPolicyExists(BaseAccessPolicy baseAccessPolicy);
     Task<BaseAccessPolicy?> GetByIdAsync(Guid id);
     Task<IEnumerable<BaseAccessPolicy>?> GetManyByProjectId(Guid id);
+    Task<IEnumerable<BaseAccessPolicy>?> GetManyByServiceAccountAsync(Guid serviceAccountId);
     Task ReplaceAsync(BaseAccessPolicy baseAccessPolicy);
     Task DeleteAsync(Guid id);
 }

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/AccessPoliciesControllerTest.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/AccessPoliciesControllerTest.cs
@@ -130,6 +130,26 @@ public class AccessPoliciesControllerTest : IClassFixture<ApiApplicationFactory>
     }
 
     [Fact]
+    public async Task GetProjectAccessPolicies_ReturnsEmpty()
+    {
+        var initialProject = await _projectRepository.CreateAsync(new Project
+        {
+            OrganizationId = _organization.Id,
+            Name = _mockEncryptedString,
+        });
+
+        var response = await _client.GetAsync($"/projects/{initialProject.Id}/access-policies");
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<ProjectAccessPoliciesResponseModel>();
+
+        Assert.NotNull(result);
+        Assert.Empty(result!.UserAccessPolicies);
+        Assert.Empty(result!.GroupAccessPolicies);
+        Assert.Empty(result!.ServiceAccountAccessPolicies);
+    }
+
+    [Fact]
     public async Task GetProjectAccessPolicies()
     {
         var initData = await SetupAccessPolicyRequest();

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/ServiceAccountsControllerTests.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/ServiceAccountsControllerTests.cs
@@ -127,6 +127,15 @@ public class ServiceAccountsControllerTest : IClassFixture<ApiApplicationFactory
         Assert.Equal(request.Name, createdServiceAccount.Name);
         AssertHelper.AssertRecent(createdServiceAccount.RevisionDate);
         AssertHelper.AssertRecent(createdServiceAccount.CreationDate);
+
+        // Check permissions have been bootstrapped.
+        var accessPolicies = await _accessPolicyRepository.GetManyByServiceAccountAsync(createdServiceAccount.Id);
+        Assert.NotNull(accessPolicies);
+        var ap = accessPolicies!.First();
+        Assert.True(ap.Read);
+        Assert.True(ap.Write);
+        AssertHelper.AssertRecent(ap.CreationDate);
+        AssertHelper.AssertRecent(ap.RevisionDate);
     }
 
     [Fact]

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/ServiceAccountsControllerTests.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/ServiceAccountsControllerTests.cs
@@ -129,7 +129,7 @@ public class ServiceAccountsControllerTest : IClassFixture<ApiApplicationFactory
         AssertHelper.AssertRecent(createdServiceAccount.CreationDate);
 
         // Check permissions have been bootstrapped.
-        var accessPolicies = await _accessPolicyRepository.GetManyByServiceAccountAsync(createdServiceAccount.Id);
+        var accessPolicies = await _accessPolicyRepository.GetManyByGrantedServiceAccountIdAsync(createdServiceAccount.Id);
         Assert.NotNull(accessPolicies);
         var ap = accessPolicies!.First();
         Assert.True(ap.Read);

--- a/test/Api.Test/SecretsManager/Controllers/AccessPoliciesControllerTests.cs
+++ b/test/Api.Test/SecretsManager/Controllers/AccessPoliciesControllerTests.cs
@@ -25,7 +25,7 @@ public class AccessPoliciesControllerTests
         var result = await sutProvider.Sut.GetProjectAccessPoliciesAsync(id);
 
         await sutProvider.GetDependency<IAccessPolicyRepository>().Received(1)
-            .GetManyByProjectId(Arg.Is(AssertHelper.AssertPropertyEqual(id)));
+            .GetManyByGrantedProjectIdAsync(Arg.Is(AssertHelper.AssertPropertyEqual(id)));
 
         Assert.Empty(result.GroupAccessPolicies);
         Assert.Empty(result.UserAccessPolicies);
@@ -37,13 +37,13 @@ public class AccessPoliciesControllerTests
     public async void GetAccessPoliciesByProject_Success(SutProvider<AccessPoliciesController> sutProvider, Guid id,
         UserProjectAccessPolicy resultAccessPolicy)
     {
-        sutProvider.GetDependency<IAccessPolicyRepository>().GetManyByProjectId(default)
+        sutProvider.GetDependency<IAccessPolicyRepository>().GetManyByGrantedProjectIdAsync(default)
             .ReturnsForAnyArgs(new List<BaseAccessPolicy> { resultAccessPolicy });
 
         var result = await sutProvider.Sut.GetProjectAccessPoliciesAsync(id);
 
         await sutProvider.GetDependency<IAccessPolicyRepository>().Received(1)
-            .GetManyByProjectId(Arg.Is(AssertHelper.AssertPropertyEqual(id)));
+            .GetManyByGrantedProjectIdAsync(Arg.Is(AssertHelper.AssertPropertyEqual(id)));
 
         Assert.Empty(result.GroupAccessPolicies);
         Assert.NotEmpty(result.UserAccessPolicies);

--- a/test/Api.Test/SecretsManager/Controllers/ServiceAccountsControllerTests.cs
+++ b/test/Api.Test/SecretsManager/Controllers/ServiceAccountsControllerTests.cs
@@ -55,13 +55,14 @@ public class ServiceAccountsControllerTests
     [BitAutoData]
     public async void CreateServiceAccount_Success(SutProvider<ServiceAccountsController> sutProvider, ServiceAccountCreateRequestModel data, Guid organizationId)
     {
+        sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(Guid.NewGuid());
         sutProvider.GetDependency<ICurrentContext>().OrganizationUser(default).ReturnsForAnyArgs(true);
         var resultServiceAccount = data.ToServiceAccount(organizationId);
-        sutProvider.GetDependency<ICreateServiceAccountCommand>().CreateAsync(default).ReturnsForAnyArgs(resultServiceAccount);
+        sutProvider.GetDependency<ICreateServiceAccountCommand>().CreateAsync(default, default).ReturnsForAnyArgs(resultServiceAccount);
 
         var result = await sutProvider.Sut.CreateServiceAccountAsync(organizationId, data);
         await sutProvider.GetDependency<ICreateServiceAccountCommand>().Received(1)
-                     .CreateAsync(Arg.Any<ServiceAccount>());
+                     .CreateAsync(Arg.Any<ServiceAccount>(), Arg.Any<Guid>());
     }
 
     [Theory]
@@ -70,11 +71,13 @@ public class ServiceAccountsControllerTests
     {
         sutProvider.GetDependency<ICurrentContext>().OrganizationUser(default).ReturnsForAnyArgs(false);
         var resultServiceAccount = data.ToServiceAccount(organizationId);
-        sutProvider.GetDependency<ICreateServiceAccountCommand>().CreateAsync(default).ReturnsForAnyArgs(resultServiceAccount);
+        sutProvider.GetDependency<ICreateServiceAccountCommand>().CreateAsync(default, default).ReturnsForAnyArgs(resultServiceAccount);
 
         await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.CreateServiceAccountAsync(organizationId, data));
 
-        await sutProvider.GetDependency<ICreateServiceAccountCommand>().DidNotReceiveWithAnyArgs().CreateAsync(Arg.Any<ServiceAccount>());
+        await sutProvider.GetDependency<ICreateServiceAccountCommand>()
+            .DidNotReceiveWithAnyArgs()
+            .CreateAsync(Arg.Any<ServiceAccount>(), Arg.Any<Guid>());
     }
 
     [Theory]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The objective of this PR is to add access policy bootstrapping to service account creation.

When a service account is created, an access policy will be applied for the user making the request.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- bitwarden_license/src/Commercial.Core/SecretsManager/Commands/ServiceAccounts/CreateServiceAccountCommand.cs
src/Core/SecretsManager/Commands/ServiceAccounts/Interfaces/ICreateServiceAccountCommand.cs

Updating command to bootstrap an access policy for the user creating the service account.

- bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/AccessPolicyRepository.cs
src/Core/SecretsManager/Repositories/IAccessPolicyRepository.cs

Add in a method to fetch all access policies targeting a specific service account.

- bitwarden_license/test/Commercial.Core.Test/SecretsManager/ServiceAccounts/CreateServiceAccountCommandTests.cs
test/Api.Test/SecretsManager/Controllers/ServiceAccountsControllerTests.cs

update unit tests

- src/Api/SecretsManager/Controllers/ServiceAccountsController.cs

Pass in the user ID of the user requesting creation.

- test/Api.IntegrationTest/SecretsManager/Controllers/ServiceAccountsControllerTests.cs

Check access policy is bootstrapped in integration testing.


## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
