### PR TITLE
add custom dp services to more projects

### DIFF
--- a/src/Billing/Startup.cs
+++ b/src/Billing/Startup.cs
@@ -33,6 +33,9 @@ public class Startup
         StripeConfiguration.ApiKey = globalSettings.Stripe.ApiKey;
         StripeConfiguration.MaxNetworkRetries = globalSettings.Stripe.MaxNetworkRetries;
 
+        // Data Protection
+        services.AddCustomDataProtectionServices(Environment, globalSettings);
+
         // Repositories
         services.AddDatabaseRepositories(globalSettings);
 

--- a/src/Events/Startup.cs
+++ b/src/Events/Startup.cs
@@ -29,6 +29,9 @@ public class Startup
         // Settings
         var globalSettings = services.AddGlobalSettingsServices(Configuration, Environment);
 
+        // Data Protection
+        services.AddCustomDataProtectionServices(Environment, globalSettings);
+
         // Repositories
         services.AddDatabaseRepositories(globalSettings);
 


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PS-2274

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
This is a follow up to https://github.com/bitwarden/server/pull/2571. Any service that might query the User table needs to have data protection services registered or it will not be able to encrypt/decrypt the Key and MasterPassword fields.

I just checked for all projects that register database repositories and made sure that data protection was already registered in those.

@bitwarden/dept-cloudops and @bitwarden/dept-devops Need to be aware of this change incase any environment configurations need to be adjusted for these two services (Events and Billing).

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Startup.cs:** `AddCustomDataProtectionServices` for both Billing and Events startup classes.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
