### PR TITLE
HeartbeatHostedService use cancel token

### DIFF
--- a/src/Notifications/HeartbeatHostedService.cs
+++ b/src/Notifications/HeartbeatHostedService.cs
@@ -49,7 +49,7 @@ public class HeartbeatHostedService : IHostedService, IDisposable
         while (!cancellationToken.IsCancellationRequested)
         {
             await _hubContext.Clients.All.SendAsync("Heartbeat");
-            await Task.Delay(120000);
+            await Task.Delay(120000, cancellationToken);
         }
         _logger.LogWarning("Done with heartbeat.");
     }


### PR DESCRIPTION
ref https://github.com/bitwarden/server/issues/2612

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
As reported in https://github.com/bitwarden/server/issues/2612 , shutting down the notifications service is throwing unhandled exceptions. I believe this is due to the long sleep/Task.delay that wasn't being passed the existing cancellationToken, so that it knew to cancel the task.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **HeartbeatHostedService.cs:** Pass the `cancellationToken` to the `Task.Delay` in `ExecuteAsync`.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
