### PR TITLE
[PS-2409] Prune empty URIs upon saving login credentials

### DIFF
--- a/src/Api/Models/Request/CipherRequestModel.cs
+++ b/src/Api/Models/Request/CipherRequestModel.cs
@@ -150,7 +150,7 @@ public class CipherRequestModel
 
     private CipherLoginData ToCipherLoginData()
     {
-        return new CipherLoginData
+        CipherLoginData ret = new CipherLoginData
         {
             Name = Name,
             Notes = Notes,
@@ -166,6 +166,12 @@ public class CipherRequestModel
             Totp = Login.Totp,
             AutofillOnPageLoad = Login.AutofillOnPageLoad,
         };
+        if (!ret.Uris.Any())
+        {
+            ret.Uris = null;
+        }
+
+        return ret;
     }
 
     private CipherIdentityData ToCipherIdentityData()


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc.)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

To remove unfilled URI entries on the user's behalf automatically.

Fixes https://github.com/bitwarden/clients/issues/1844

## Code changes

- **CipherRequestModel.cs:** adjusts predicate to test the `Uri` data member of the `CipherLoginUriModel` instance.

This change obviates the need for some logic in the front end. See bitwarden/clients#4500 and bitwarden/mobile#2337 for details.

## Screenshots

The following GIF demonstrates the addition:

![prune-uris-demo](https://user-images.githubusercontent.com/39540565/216355270-14907eb4-f58c-4d30-9adc-baba52ea789c.gif)

