### PR TITLE
[PS-2416 and PS-2417] dont set CSP config value by default

### DIFF
--- a/util/Setup/Configuration.cs
+++ b/util/Setup/Configuration.cs
@@ -76,13 +76,7 @@ public class Configuration
     [Description("Nginx Header Content-Security-Policy parameter\n" +
         "WARNING: Reconfiguring this parameter may break features. By changing this parameter\n" +
         "you become responsible for maintaining this value.")]
-    public string NginxHeaderContentSecurityPolicy { get; set; } = "default-src 'self'; " +
-        "script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; " +
-        "img-src 'self' data: https://haveibeenpwned.com; " +
-        "child-src 'self' https://*.duosecurity.com https://*.duofederal.com; " +
-        "frame-src 'self' https://*.duosecurity.com https://*.duofederal.com; " +
-        "connect-src 'self' wss://{0} https://api.pwnedpasswords.com " +
-        "https://api.2fa.directory; object-src 'self' blob:;";
+    public string NginxHeaderContentSecurityPolicy { get; set; }
 
     [Description("Communicate with the Bitwarden push relay service (push.bitwarden.com) for mobile\n" +
         "app live sync.")]

--- a/util/Setup/Context.cs
+++ b/util/Setup/Context.cs
@@ -6,7 +6,7 @@ namespace Bit.Setup;
 public class Context
 {
     private const string ConfigPath = "/bitwarden/config.yml";
-    // This keeps track of the value of the CSPthat was defined as of Jan 2023.
+    // This keeps track of the value of the CSP that was defined as of Jan 2023.
     // Do not change this value.
     private const string Jan2023ContentSecurityPolicy = "default-src 'self'; style-src 'self' " +
         "'unsafe-inline'; img-src 'self' data: https://haveibeenpwned.com; " +

--- a/util/Setup/NginxConfigBuilder.cs
+++ b/util/Setup/NginxConfigBuilder.cs
@@ -4,6 +4,14 @@ public class NginxConfigBuilder
 {
     private const string ConfFile = "/bitwarden/nginx/default.conf";
 
+    private const string DefaultContentSecurityPolicy = "default-src 'self'; " +
+        "script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; " +
+        "img-src 'self' data: https://haveibeenpwned.com; " +
+        "child-src 'self' https://*.duosecurity.com https://*.duofederal.com; " +
+        "frame-src 'self' https://*.duosecurity.com https://*.duofederal.com; " +
+        "connect-src 'self' wss://{0} https://api.pwnedpasswords.com " +
+        "https://api.2fa.directory; object-src 'self' blob:;";
+
     private readonly Context _context;
 
     public NginxConfigBuilder(Context context)
@@ -72,7 +80,12 @@ public class NginxConfigBuilder
             Domain = context.Config.Domain;
             Url = context.Config.Url;
             RealIps = context.Config.RealIps;
-            ContentSecurityPolicy = string.Format(context.Config.NginxHeaderContentSecurityPolicy, Domain);
+            var csp = DefaultContentSecurityPolicy;
+            if (!string.IsNullOrWhiteSpace(context.Config.NginxHeaderContentSecurityPolicy))
+            {
+                csp = context.Config.NginxHeaderContentSecurityPolicy;
+            }
+            ContentSecurityPolicy = string.Format(csp, Domain);
 
             if (Ssl)
             {


### PR DESCRIPTION
ref https://bitwarden.atlassian.net/browse/PS-2416
ref https://bitwarden.atlassian.net/browse/PS-2417

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Today we are defaulting the CSP property in config.yml to a value and persisting that. This is problematic because the Configuration object will retain that value going forward, which doesn't allow us to adjust the default value to accommodate new features (such as WASM support). config.yml will always keep the same value of the CSP that was written at the time of installation.

This change attempts to adjust the CSP values defined in config.yml back to `null` if it detects that the value still represents the default value as of the Jan 2023 release, so that it can be treated as wanting the default value for CSP going forward.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Configuration.cs:** Remove default definition of the CSP property since this is what gets serialized to disk for config.yml
* **Context.cs:** When reading the configuration object, detect if the value is intended to be the default (as of Jan 2023), and reset it back to null.
* **NginxConfigBuilder.cs:** Default the CSP value if the Configuration object CSP property is null.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
