### PR TITLE
add more CSPs to the default correction check

### DIFF
--- a/util/Setup/Context.cs
+++ b/util/Setup/Context.cs
@@ -6,14 +6,34 @@ namespace Bit.Setup;
 public class Context
 {
     private const string ConfigPath = "/bitwarden/config.yml";
-    // This keeps track of the value of the CSP that was defined as of Jan 2023.
-    // Do not change this value.
+
+    // These track of old CSP default values to correct.
+    // Do not change these values.
+    private const string Jan2021ContentSecurityPolicy = "default-src 'self'; style-src 'self' " +
+        "'unsafe-inline'; img-src 'self' data: https://haveibeenpwned.com https://www.gravatar.com; " +
+        "child-src 'self' https://*.duosecurity.com https://*.duofederal.com; " +
+        "frame-src 'self' https://*.duosecurity.com https://*.duofederal.com; " +
+        "connect-src 'self' wss://{0} https://api.pwnedpasswords.com " +
+        "https://twofactorauth.org; object-src 'self' blob:;";
+    private const string Feb2021ContentSecurityPolicy = "default-src 'self'; style-src 'self' " +
+        "'unsafe-inline'; img-src 'self' data: https://haveibeenpwned.com https://www.gravatar.com; " +
+        "child-src 'self' https://*.duosecurity.com https://*.duofederal.com; " +
+        "frame-src 'self' https://*.duosecurity.com https://*.duofederal.com; " +
+        "connect-src 'self' wss://{0} https://api.pwnedpasswords.com " +
+        "https://2fa.directory; object-src 'self' blob:;";
     private const string Jan2023ContentSecurityPolicy = "default-src 'self'; style-src 'self' " +
         "'unsafe-inline'; img-src 'self' data: https://haveibeenpwned.com; " +
         "child-src 'self' https://*.duosecurity.com https://*.duofederal.com; " +
         "frame-src 'self' https://*.duosecurity.com https://*.duofederal.com; " +
         "connect-src 'self' wss://{0} https://api.pwnedpasswords.com " +
         "https://api.2fa.directory; object-src 'self' blob:;";
+
+    private string[] _oldCspDefaults =
+    {
+        Jan2021ContentSecurityPolicy,
+        Feb2021ContentSecurityPolicy,
+        Jan2023ContentSecurityPolicy
+    };
 
     public string[] Args { get; set; }
     public bool Quiet { get; set; }
@@ -127,7 +147,7 @@ public class Context
         Config = deserializer.Deserialize<Configuration>(configText);
 
         // Fix old explicit config assignments of CSP which should be treated as a default value
-        if (Config.NginxHeaderContentSecurityPolicy == Jan2023ContentSecurityPolicy)
+        if (_oldCspDefaults.Any(c => c == Config.NginxHeaderContentSecurityPolicy))
         {
             Config.NginxHeaderContentSecurityPolicy = null;
             SaveConfiguration();

--- a/util/Setup/Context.cs
+++ b/util/Setup/Context.cs
@@ -9,6 +9,11 @@ public class Context
 
     // These track of old CSP default values to correct.
     // Do not change these values.
+    private const string Dec2020ContentSecurityPolicy = "default-src 'self'; style-src 'self' " +
+        "'unsafe-inline'; img-src 'self' data: https://haveibeenpwned.com https://www.gravatar.com; " +
+        "child-src 'self' https://*.duosecurity.com; frame-src 'self' https://*.duosecurity.com; " +
+        "connect-src 'self' wss://{0} https://api.pwnedpasswords.com " +
+        "https://twofactorauth.org; object-src 'self' blob:;";
     private const string Jan2021ContentSecurityPolicy = "default-src 'self'; style-src 'self' " +
         "'unsafe-inline'; img-src 'self' data: https://haveibeenpwned.com https://www.gravatar.com; " +
         "child-src 'self' https://*.duosecurity.com https://*.duofederal.com; " +
@@ -30,6 +35,7 @@ public class Context
 
     private string[] _oldCspDefaults =
     {
+        Dec2020ContentSecurityPolicy,
         Jan2021ContentSecurityPolicy,
         Feb2021ContentSecurityPolicy,
         Jan2023ContentSecurityPolicy


### PR DESCRIPTION
ref https://bitwarden.atlassian.net/browse/PS-2416
ref https://bitwarden.atlassian.net/browse/PS-2417

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
This extends https://github.com/bitwarden/server/pull/2667 a bit more. Turns out there are more CSPs that we need to handle. I went back in history and located any changes back to Dec 2020 and added them to the check to correct here.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **util/Setup/Context.cs:** Add Dec 20202, Jan 2021, and Feb 2021 CSPs to the list of CSPs to correct back to a default value.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
