### PR TITLE
Auth/pm-48

### DIFF
--- a/src/Admin/IdentityServer/CustomClaimsPrincipalFactory.cs
+++ b/src/Admin/IdentityServer/CustomClaimsPrincipalFactory.cs
@@ -32,7 +32,7 @@ public class CustomClaimsPrincipalFactory : UserClaimsPrincipalFactory<IdentityU
             if (!string.IsNullOrEmpty(role))
             {
                 ((ClaimsIdentity)principal.Identity).AddClaims(
-                new[] { new Claim("Role", role) });
+                new[] { new Claim(ClaimTypes.Role, role) });
             }
         }
 

--- a/src/Admin/IdentityServer/CustomClaimsPrincipalFactory.cs
+++ b/src/Admin/IdentityServer/CustomClaimsPrincipalFactory.cs
@@ -1,0 +1,41 @@
+using System.Security.Claims;
+using Bit.Core.Settings;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
+public class CustomClaimsPrincipalFactory : UserClaimsPrincipalFactory<IdentityUser>
+{  
+    private IAccessControlService _accessControlService;
+    private readonly IGlobalSettings _globalSettings;
+
+    public CustomClaimsPrincipalFactory(  
+        UserManager<IdentityUser> userManager,  
+        IOptions<IdentityOptions> optionsAccessor,
+        IAccessControlService accessControlService,
+        IGlobalSettings globalSettings)  
+            : base(userManager, optionsAccessor)  
+    {
+        _accessControlService = accessControlService;
+        _globalSettings = globalSettings;
+    }  
+
+    public async override Task<ClaimsPrincipal> CreateAsync(IdentityUser user)  
+    {  
+        var principal = await base.CreateAsync(user);  
+            
+        if (!_globalSettings.SelfHosted 
+            && !string.IsNullOrEmpty(user.Email) 
+            && principal.Identity != null)  
+        {  
+            var role = _accessControlService.GetUserRole(user.Email);
+
+            if(!string.IsNullOrEmpty(role)) 
+            {
+                ((ClaimsIdentity)principal.Identity).AddClaims(
+                new[] {  new Claim("Role", role) });  
+            }
+        }  
+
+        return principal;  
+    }  
+} 

--- a/src/Admin/IdentityServer/CustomClaimsPrincipalFactory.cs
+++ b/src/Admin/IdentityServer/CustomClaimsPrincipalFactory.cs
@@ -1,41 +1,41 @@
-using System.Security.Claims;
+﻿using System.Security.Claims;
 using Bit.Core.Settings;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 
 public class CustomClaimsPrincipalFactory : UserClaimsPrincipalFactory<IdentityUser>
-{  
+{
     private IAccessControlService _accessControlService;
     private readonly IGlobalSettings _globalSettings;
 
-    public CustomClaimsPrincipalFactory(  
-        UserManager<IdentityUser> userManager,  
+    public CustomClaimsPrincipalFactory(
+        UserManager<IdentityUser> userManager,
         IOptions<IdentityOptions> optionsAccessor,
         IAccessControlService accessControlService,
-        IGlobalSettings globalSettings)  
-            : base(userManager, optionsAccessor)  
+        IGlobalSettings globalSettings)
+            : base(userManager, optionsAccessor)
     {
         _accessControlService = accessControlService;
         _globalSettings = globalSettings;
-    }  
+    }
 
-    public async override Task<ClaimsPrincipal> CreateAsync(IdentityUser user)  
-    {  
-        var principal = await base.CreateAsync(user);  
-            
-        if (!_globalSettings.SelfHosted 
-            && !string.IsNullOrEmpty(user.Email) 
-            && principal.Identity != null)  
-        {  
+    public async override Task<ClaimsPrincipal> CreateAsync(IdentityUser user)
+    {
+        var principal = await base.CreateAsync(user);
+
+        if (!_globalSettings.SelfHosted
+            && !string.IsNullOrEmpty(user.Email)
+            && principal.Identity != null)
+        {
             var role = _accessControlService.GetUserRole(user.Email);
 
-            if(!string.IsNullOrEmpty(role)) 
+            if (!string.IsNullOrEmpty(role))
             {
                 ((ClaimsIdentity)principal.Identity).AddClaims(
-                new[] {  new Claim("Role", role) });  
+                new[] { new Claim("Role", role) });
             }
-        }  
+        }
 
-        return principal;  
-    }  
-} 
+        return principal;
+    }
+}

--- a/src/Admin/IdentityServer/ServiceCollectionExtensions.cs
+++ b/src/Admin/IdentityServer/ServiceCollectionExtensions.cs
@@ -20,7 +20,8 @@ public static class ServiceCollectionExtensions
         var passwordlessIdentityBuilder = services.AddIdentity<IdentityUser, Role>()
             .AddUserStore<TUserStore>()
             .AddRoleStore<RoleStore>()
-            .AddDefaultTokenProviders();
+            .AddDefaultTokenProviders()
+            .AddClaimsPrincipalFactory<CustomClaimsPrincipalFactory>();
 
         var regularIdentityBuilder = services.AddIdentityCore<User>()
             .AddUserStore<UserStore>();

--- a/src/Admin/Services/AccessControlService.cs
+++ b/src/Admin/Services/AccessControlService.cs
@@ -1,4 +1,4 @@
-using Bit.Core.Settings;
+﻿using Bit.Core.Settings;
 
 public class AccessControlService : IAccessControlService
 {
@@ -7,7 +7,7 @@ public class AccessControlService : IAccessControlService
     private readonly IGlobalSettings _globalSettings;
 
     public AccessControlService(
-        IHttpContextAccessor httpContextAccessor, 
+        IHttpContextAccessor httpContextAccessor,
         IConfiguration configuration,
         IGlobalSettings globalSettings)
     {
@@ -17,10 +17,10 @@ public class AccessControlService : IAccessControlService
     }
 
     public string GetUserRole(string userEmail)
-    { 
+    {
         var settings = _configuration.GetSection("adminSettings").GetChildren();
 
-        if(settings == null || !settings.Any())
+        if (settings == null || !settings.Any())
             return null;
 
         var rolePrefix = "role";
@@ -28,19 +28,19 @@ public class AccessControlService : IAccessControlService
         foreach (var setting in settings)
         {
             var key = setting.Key;
-            
+
             if (setting.Value == null || !key.Contains(rolePrefix))
                 continue;
-            
+
             var usersInRole = setting.Value.ToLowerInvariant().Split(',');
 
-            if(!usersInRole.Contains(userEmail))
+            if (!usersInRole.Contains(userEmail))
                 continue;
 
             var role = key.Substring(key.IndexOf(rolePrefix) + rolePrefix.Length);
             return role;
         }
-     
+
         return null;
     }
 

--- a/src/Admin/Services/AccessControlService.cs
+++ b/src/Admin/Services/AccessControlService.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.Settings;
+﻿using System.Security.Claims;
+using Bit.Core.Settings;
 
 public class AccessControlService : IAccessControlService
 {
@@ -24,32 +25,21 @@ public class AccessControlService : IAccessControlService
             return null;
 
         var rolePrefix = "role";
+        userEmail = userEmail.ToLowerInvariant();
 
-        foreach (var setting in settings)
-        {
-            var key = setting.Key;
+        var roleSetting = settings.FirstOrDefault(s => s.Key.StartsWith(rolePrefix)
+                                                 && (s.Value != null ? s.Value.ToLowerInvariant().Split(',').Contains(userEmail) : false));
 
-            if (setting.Value == null || !key.Contains(rolePrefix))
-                continue;
+        if (roleSetting == null)
+            return null;
 
-            var usersInRole = setting.Value.ToLowerInvariant().Split(',');
-
-            if (!usersInRole.Contains(userEmail))
-                continue;
-
-            var role = key.Substring(key.IndexOf(rolePrefix) + rolePrefix.Length);
-            return role;
-        }
-
-        return null;
+        var role = roleSetting.Key.Substring(roleSetting.Key.IndexOf(rolePrefix) + rolePrefix.Length);
+        return role;
     }
 
     private string GetUserRoleFromClaim()
     {
-        var claims = _httpContextAccessor.HttpContext?.User?.Claims;
-        if (claims == null || !claims.Any())
-            return null;
-
-        return claims.FirstOrDefault(c => c.Type == "Role")?.Value;
+        return _httpContextAccessor.HttpContext?.User?.Claims?
+                 .FirstOrDefault(c => c.Type == ClaimTypes.Role)?.Value;
     }
 }

--- a/src/Admin/Services/AccessControlService.cs
+++ b/src/Admin/Services/AccessControlService.cs
@@ -16,17 +16,6 @@ public class AccessControlService : IAccessControlService
         _globalSettings = globalSettings;
     }
 
-    public bool UserHasPermission(Permission permission)
-    {
-        var userRole = GetUserRoleFromClaim();
-        if(string.IsNullOrEmpty(userRole))
-            return false;
-
-        //The check for if the role has the given permission will be implemented
-        //in a future ticket
-        return false;
-    }
-
     public string GetUserRole(string userEmail)
     { 
         var settings = _configuration.GetSection("adminSettings").GetChildren();

--- a/src/Admin/Services/AccessControlService.cs
+++ b/src/Admin/Services/AccessControlService.cs
@@ -1,0 +1,66 @@
+using Bit.Core.Settings;
+
+public class AccessControlService : IAccessControlService
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IConfiguration _configuration;
+    private readonly IGlobalSettings _globalSettings;
+
+    public AccessControlService(
+        IHttpContextAccessor httpContextAccessor, 
+        IConfiguration configuration,
+        IGlobalSettings globalSettings)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _configuration = configuration;
+        _globalSettings = globalSettings;
+    }
+
+    public bool UserHasPermission(Permission permission)
+    {
+        var userRole = GetUserRoleFromClaim();
+        if(string.IsNullOrEmpty(userRole))
+            return false;
+
+        //The check for if the role has the given permission will be implemented
+        //in a future ticket
+        return false;
+    }
+
+    public string GetUserRole(string userEmail)
+    { 
+        var settings = _configuration.GetSection("adminSettings").GetChildren();
+
+        if(settings == null || !settings.Any())
+            return null;
+
+        var rolePrefix = "role";
+
+        foreach (var setting in settings)
+        {
+            var key = setting.Key;
+            
+            if (setting.Value == null || !key.Contains(rolePrefix))
+                continue;
+            
+            var usersInRole = setting.Value.ToLowerInvariant().Split(',');
+
+            if(!usersInRole.Contains(userEmail))
+                continue;
+
+            var role = key.Substring(key.IndexOf(rolePrefix) + rolePrefix.Length);
+            return role;
+        }
+     
+        return null;
+    }
+
+    private string GetUserRoleFromClaim()
+    {
+        var claims = _httpContextAccessor.HttpContext?.User?.Claims;
+        if (claims == null || !claims.Any())
+            return null;
+
+        return claims.FirstOrDefault(c => c.Type == "Role")?.Value;
+    }
+}

--- a/src/Admin/Services/IAccessControlService.cs
+++ b/src/Admin/Services/IAccessControlService.cs
@@ -1,4 +1,4 @@
-public interface IAccessControlService
+﻿public interface IAccessControlService
 {
     public string GetUserRole(string userEmail);
 }

--- a/src/Admin/Services/IAccessControlService.cs
+++ b/src/Admin/Services/IAccessControlService.cs
@@ -1,0 +1,5 @@
+public interface IAccessControlService
+{
+    public bool UserHasPermission(Permission permission);
+    public string GetUserRole(string userEmail);
+}

--- a/src/Admin/Services/IAccessControlService.cs
+++ b/src/Admin/Services/IAccessControlService.cs
@@ -1,5 +1,4 @@
 public interface IAccessControlService
 {
-    public bool UserHasPermission(Permission permission);
     public string GetUserRole(string userEmail);
 }

--- a/src/Admin/Startup.cs
+++ b/src/Admin/Startup.cs
@@ -6,6 +6,7 @@ using Bit.Core.Utilities;
 using Bit.SharedWeb.Utilities;
 using Microsoft.AspNetCore.Identity;
 using Stripe;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 #if !OSS
 using Bit.Commercial.Core.Utilities;
@@ -63,6 +64,7 @@ public class Startup
 
         // Context
         services.AddScoped<ICurrentContext, CurrentContext>();
+        services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
         // Identity
         services.AddPasswordlessIdentityServices<ReadOnlyEnvIdentityUserStore>(globalSettings);
@@ -77,10 +79,12 @@ public class Startup
                 options.Cookie.Path = "/admin";
             });
         }
+        services.AddScoped<IUserClaimsPrincipalFactory<IdentityUser>, CustomClaimsPrincipalFactory>();
 
         // Services
         services.AddBaseServices(globalSettings);
         services.AddDefaultServices(globalSettings);
+        services.AddScoped<IAccessControlService, AccessControlService>();
 
 #if OSS
         services.AddOosServices();

--- a/src/Admin/Startup.cs
+++ b/src/Admin/Startup.cs
@@ -79,7 +79,7 @@ public class Startup
                 options.Cookie.Path = "/admin";
             });
         }
-        services.AddScoped<IUserClaimsPrincipalFactory<IdentityUser>, CustomClaimsPrincipalFactory>();
+
 
         // Services
         services.AddBaseServices(globalSettings);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
This is the first step of adding role-based access control to the Bitwarden Admin Portal. In this PR, custom claims-setting middleware is added that retrieves the user's role from the config file, then adds the role as a claim. In upcoming work, the role claim will be used during each permission check to determine if the user has a given permission.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CustomClaimsPrincipalFactory.cs** This sets all the standard claims, and additionally sets the user's role claim. The role is retrieved using the AccessControlService
* **AccessControlService.cs** New service added to handle behavior related to access control. The function added here, GetUserRole(), determines the role from the config, and is used to set the claim.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
