### PR TITLE
[PS-2470] Global domains dup fix

### DIFF
--- a/src/Core/Enums/GlobalEquivalentDomainsType.cs
+++ b/src/Core/Enums/GlobalEquivalentDomainsType.cs
@@ -44,7 +44,7 @@ public enum GlobalEquivalentDomainsType : byte
     Dropbox = 39,
     Snapfish = 40,
     Alibaba = 41,
-    Playstation = 42,
+    Playstation = 42, // deprecated
     Mercado = 43,
     Zendesk = 44,
     Autodesk = 45,

--- a/src/Core/Utilities/StaticStore.cs
+++ b/src/Core/Utilities/StaticStore.cs
@@ -54,7 +54,6 @@ public class StaticStore
         GlobalDomains.Add(GlobalEquivalentDomainsType.Dropbox, new List<string> { "dropbox.com", "getdropbox.com" });
         GlobalDomains.Add(GlobalEquivalentDomainsType.Snapfish, new List<string> { "snapfish.com", "snapfish.ca" });
         GlobalDomains.Add(GlobalEquivalentDomainsType.Alibaba, new List<string> { "alibaba.com", "aliexpress.com", "aliyun.com", "net.cn" });
-        GlobalDomains.Add(GlobalEquivalentDomainsType.Playstation, new List<string> { "playstation.com", "sonyentertainmentnetwork.com" });
         GlobalDomains.Add(GlobalEquivalentDomainsType.Mercado, new List<string> { "mercadolivre.com", "mercadolivre.com.br", "mercadolibre.com", "mercadolibre.com.ar", "mercadolibre.com.mx" });
         GlobalDomains.Add(GlobalEquivalentDomainsType.Zendesk, new List<string> { "zendesk.com", "zopim.com" });
         GlobalDomains.Add(GlobalEquivalentDomainsType.Autodesk, new List<string> { "autodesk.com", "tinkercad.com" });
@@ -95,7 +94,7 @@ public class StaticStore
         GlobalDomains.Add(GlobalEquivalentDomainsType.Discord, new List<string> { "discordapp.com", "discord.com" });
         GlobalDomains.Add(GlobalEquivalentDomainsType.Netcup, new List<string> { "netcup.de", "netcup.eu", "customercontrolpanel.de" });
         GlobalDomains.Add(GlobalEquivalentDomainsType.Yandex, new List<string> { "yandex.com", "ya.ru", "yandex.az", "yandex.by", "yandex.co.il", "yandex.com.am", "yandex.com.ge", "yandex.com.tr", "yandex.ee", "yandex.fi", "yandex.fr", "yandex.kg", "yandex.kz", "yandex.lt", "yandex.lv", "yandex.md", "yandex.pl", "yandex.ru", "yandex.tj", "yandex.tm", "yandex.ua", "yandex.uz" });
-        GlobalDomains.Add(GlobalEquivalentDomainsType.Sony, new List<string> { "sonyentertainmentnetwork.com", "sony.com" });
+        GlobalDomains.Add(GlobalEquivalentDomainsType.Sony, new List<string> { "sonyentertainmentnetwork.com", "sony.com", "playstation.com" });
         GlobalDomains.Add(GlobalEquivalentDomainsType.Proton, new List<string> { "proton.me", "protonmail.com", "protonvpn.com" });
         GlobalDomains.Add(GlobalEquivalentDomainsType.Ubisoft, new List<string> { "ubisoft.com", "ubi.com" });
         GlobalDomains.Add(GlobalEquivalentDomainsType.TransferWise, new List<string> { "transferwise.com", "wise.com" });


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This addresses #2585 properly (deprecating the duplicate enum and adding all of the equivalent domains to the same entry). The Sony group has a variety of login paths across their group businesses[1], some shared and some *potentially* shared (at the discretion of the user or depending on what's been encouraged/forced over time) as well as both legacy and historical variations (as is pretty typical across large global enterprises like this). 

It appears that there may be some sharing between regional specific offerings (e.g. Sony Europe[2]), but I was unable to confirm with certainty so I did not add those to the list at this time. 

[1] e.g. https://acm.account.sony.com/linking-account?language=en-US#page-top
[2] e.g. https://www.sony.co.uk/mysony

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

This PR simply retains the existing domains that were already in place, eliminates their inadvertent overlap between >1 global domain equivalent entries, and cleanly deprecates the old enum. It addresses the change from #1129 that didn't account for a prior Sony group property entry and fixes #2585.

* **src/Core/Enums/GlobalEquivalentDomainsType.cs** Deprecate Playstation specific entry
* **src/Core/Utilities/StaticStore.cs:** Merge Playstation entry into Sony entry and eliminate duplicate