### PR TITLE
Disable storage in tests

### DIFF
--- a/test/IntegrationTestCommon/Factories/WebApplicationFactoryBase.cs
+++ b/test/IntegrationTestCommon/Factories/WebApplicationFactoryBase.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using NoopRepos = Bit.Core.Repositories.Noop;
 
 namespace Bit.IntegrationTestCommon.Factories;
 
@@ -50,7 +51,14 @@ public abstract class WebApplicationFactoryBase<T> : WebApplicationFactory<T>
                 { "globalSettings:postgreSql:connectionString", "Host=localhost;Username=test;Password=test;Database=test" },
 
                 // Clear the redis connection string for distributed caching, forcing an in-memory implementation
-                { "globalSettings:redis:connectionString", ""}
+                { "globalSettings:redis:connectionString", ""},
+
+                // Clear Storage
+                { "globalSettings:attachment:connectionString", null},
+                { "globalSettings:events:connectionString", null},
+                { "globalSettings:send:connectionString", null},
+                { "globalSettings:notifications:connectionString", null},
+                { "globalSettings:storage:connectionString", null},
             });
         });
 
@@ -96,6 +104,28 @@ public abstract class WebApplicationFactoryBase<T> : WebApplicationFactory<T>
             var captchaValidationService = services.First(sd => sd.ServiceType == typeof(ICaptchaValidationService));
             services.Remove(captchaValidationService);
             services.AddSingleton<ICaptchaValidationService, NoopCaptchaValidationService>();
+
+            // Disable blocking
+            var blockingService = services.First(sd => sd.ServiceType == typeof(IBlockIpService));
+            services.Remove(blockingService);
+            services.AddSingleton<IBlockIpService, NoopBlockIpService>();
+
+            // TODO: Install and use azurite in CI pipeline
+            var installationDeviceRepository =
+                services.First(sd => sd.ServiceType == typeof(IInstallationDeviceRepository));
+            services.Remove(installationDeviceRepository);
+            services.AddSingleton<IInstallationDeviceRepository, NoopRepos.InstallationDeviceRepository>();
+
+            // TODO: Install and use azurite in CI pipeline
+            var metaDataRepository =
+                services.First(sd => sd.ServiceType == typeof(IMetaDataRepository));
+            services.Remove(metaDataRepository);
+            services.AddSingleton<IMetaDataRepository, NoopRepos.MetaDataRepository>();
+
+            // TODO: Install and use azurite in CI pipeline
+            var referenceEventService = services.First(sd => sd.ServiceType == typeof(IReferenceEventService));
+            services.Remove(referenceEventService);
+            services.AddSingleton<IReferenceEventService, NoopReferenceEventService>();
 
             // Our Rate limiter works so well that it begins to fail tests unless we carve out
             // one whitelisted ip. We should still test the rate limiter though and they should change the Ip


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

@Thomas-Avery discovered that the Integration Tests attempted to connect to the Azurite storage container which is not available in CI. This caused a connection timeout to occur after a certain time which slowed down the CI tests drastically.

For now this PR sets all connection strings to null, and overrides some services which depends on the connection strings being set in cloud environment.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
