### PR TITLE
[DEVOPS-1161] fix the rate limiting issue in building bitwarden unified

### DIFF
--- a/.github/workflows/build-self-host.yml
+++ b/.github/workflows/build-self-host.yml
@@ -62,7 +62,8 @@ jobs:
           secrets: "docker-password,
             docker-username,
             dct-delegate-2-repo-passphrase,
-            dct-delegate-2-key"
+            dct-delegate-2-key
+            github-pat-bitwarden-devops-bot-repo-scope"
 
       - name: Log into Docker
         if: ${{ env.is_publish_branch == 'true' }}
@@ -118,6 +119,8 @@ jobs:
             linux/arm64/v8
           push: true
           tags: ${{ steps.tag-list.outputs.tags }}
+          secrets:
+            GH_PAT=${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
 
       - name: Log out of Docker and disable Docker Notary
         if: ${{ env.is_publish_branch == 'true' }}

--- a/.github/workflows/build-self-host.yml
+++ b/.github/workflows/build-self-host.yml
@@ -120,7 +120,7 @@ jobs:
           push: true
           tags: ${{ steps.tag-list.outputs.tags }}
           secrets: |
-            "GH_PAT=${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}""
+            "GH_PAT=${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}"
 
       - name: Log out of Docker and disable Docker Notary
         if: ${{ env.is_publish_branch == 'true' }}

--- a/.github/workflows/build-self-host.yml
+++ b/.github/workflows/build-self-host.yml
@@ -48,10 +48,16 @@ jobs:
         run: az acr login -n bitwardenqa
 
       - name: Login to Azure - Prod Subscription
-        if: ${{ env.is_publish_branch == 'true' }}
         uses: Azure/login@1f63701bf3e6892515f1b7ce2d2bf1708b46beaf
         with:
           creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
+
+      - name: Retrieve github PAT secrets
+        id: retrieve-secret-pat
+        uses: bitwarden/gh-actions/get-keyvault-secrets@c3b3285993151c5af47cefcb3b9134c28ab479af
+        with:
+          keyvault: "bitwarden-prod-kv"
+          secrets: "github-pat-bitwarden-devops-bot-repo-scope"
 
       - name: Retrieve secrets
         if: ${{ env.is_publish_branch == 'true' }}
@@ -120,7 +126,7 @@ jobs:
           push: true
           tags: ${{ steps.tag-list.outputs.tags }}
           secrets: |
-            "GH_PAT=${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}"
+            "GH_PAT=${{ steps.retrieve-secret-pat.outputs.github-pat-bitwarden-devops-bot-repo-scope }}"
 
       - name: Log out of Docker and disable Docker Notary
         if: ${{ env.is_publish_branch == 'true' }}

--- a/.github/workflows/build-self-host.yml
+++ b/.github/workflows/build-self-host.yml
@@ -119,8 +119,8 @@ jobs:
             linux/arm64/v8
           push: true
           tags: ${{ steps.tag-list.outputs.tags }}
-          secrets:
-            GH_PAT=${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
+          secrets: |
+            "GH_PAT=${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}""
 
       - name: Log out of Docker and disable Docker Notary
         if: ${{ env.is_publish_branch == 'true' }}

--- a/docker-unified/Dockerfile
+++ b/docker-unified/Dockerfile
@@ -13,15 +13,11 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /tmp
 
+# Download tags from 'clients' repository
 RUN --mount=type=secret,id=GH_PAT,target=/etc/secrets/GH_PAT if [ -e "/etc/secrets/GH_PAT" ]; then \
 curl --header "Authorization: token $(cat /etc/secrets/GH_PAT)" \
   https://api.github.com/repos/bitwarden/clients/git/refs/tags --output tags.json ; else \
   curl https://api.github.com/repos/bitwarden/clients/git/refs/tags --output tags.json ; fi
-
-# Download tags from 'clients' repository
-RUN --mount=type=secret,id=GH_PAT,target=/etc/secrets/GH_PAT \
-  curl --header "Authorization: token $(cat /etc/secrets/GH_PAT)" \
-  https://api.github.com/repos/bitwarden/clients/git/refs/tags --output tags.json
 
 RUN cat tags.json
 

--- a/docker-unified/Dockerfile
+++ b/docker-unified/Dockerfile
@@ -13,7 +13,10 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /tmp
 
 # Download tags from 'clients' repository
-RUN curl https://api.github.com/repos/bitwarden/clients/git/refs/tags --output tags.json
+RUN --mount=type=bind,target=. \
+  --mount=type=secret,id=GH_PAT \
+  GH_PAT=$(cat /run/secrets/GH_PAT) curl --header "Authorization: token $GH_PAT" \
+  https://api.github.com/repos/bitwarden/clients/git/refs/tags --output tags.json
 
 # Grab last tag/release of the 'web' client
 RUN cat tags.json | jq -r 'last(.[] | select(.ref|test("refs/tags/web-v[0-9]{4}.[0-9]{1,2}.[0-9]+"))) | .ref | split("/")[2]' > tag.txt

--- a/docker-unified/Dockerfile
+++ b/docker-unified/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /tmp
 
 # Download tags from 'clients' repository
 RUN --mount=type=secret,id=GH_PAT \
-  GH_PAT=$(cat /run/secrets/GH_PAT) curl --header "Authorization: token $GH_PAT" \
+  GH_PAT=$(cat /run/secrets/GH_PAT) && curl --header "Authorization: token $GH_PAT" \
   https://api.github.com/repos/bitwarden/clients/git/refs/tags --output tags.json
 
 RUN cat tags.json

--- a/docker-unified/Dockerfile
+++ b/docker-unified/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /tmp
 
 # Download tags from 'clients' repository
-RUN --mount=type=secret,id=GH_PAT \
-  GH_PAT=$(cat /run/secrets/GH_PAT) && curl --header "Authorization: token $GH_PAT" \
+RUN --mount=type=secret,id=GH_PAT,target=/run/secrets/GH_PAT \
+  GH_PAT=$(cat /run/secrets/GH_PAT) curl --header "Authorization: token $GH_PAT" \
   https://api.github.com/repos/bitwarden/clients/git/refs/tags --output tags.json
 
 RUN cat tags.json

--- a/docker-unified/Dockerfile
+++ b/docker-unified/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.2
 ###############################################
 #                 Build stage                 #
 ###############################################
@@ -13,8 +14,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /tmp
 
 # Download tags from 'clients' repository
-RUN --mount=type=bind,target=. \
-  --mount=type=secret,id=GH_PAT \
+RUN --mount=type=secret,id=GH_PAT \
   GH_PAT=$(cat /run/secrets/GH_PAT) curl --header "Authorization: token $GH_PAT" \
   https://api.github.com/repos/bitwarden/clients/git/refs/tags --output tags.json
 

--- a/docker-unified/Dockerfile
+++ b/docker-unified/Dockerfile
@@ -18,6 +18,8 @@ RUN --mount=type=secret,id=GH_PAT \
   GH_PAT=$(cat /run/secrets/GH_PAT) curl --header "Authorization: token $GH_PAT" \
   https://api.github.com/repos/bitwarden/clients/git/refs/tags --output tags.json
 
+RUN cat tags.json
+
 # Grab last tag/release of the 'web' client
 RUN cat tags.json | jq -r 'last(.[] | select(.ref|test("refs/tags/web-v[0-9]{4}.[0-9]{1,2}.[0-9]+"))) | .ref | split("/")[2]' > tag.txt
 

--- a/docker-unified/Dockerfile
+++ b/docker-unified/Dockerfile
@@ -13,6 +13,11 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /tmp
 
+RUN --mount=type=secret,id=GH_PAT,target=/etc/secrets/GH_PAT if [ -e "/etc/secrets/GH_PAT" ]; then \
+curl --header "Authorization: token $(cat /etc/secrets/GH_PAT)" \
+  https://api.github.com/repos/bitwarden/clients/git/refs/tags --output tags.json ; else \
+  curl https://api.github.com/repos/bitwarden/clients/git/refs/tags --output tags.json ; fi
+
 # Download tags from 'clients' repository
 RUN --mount=type=secret,id=GH_PAT,target=/etc/secrets/GH_PAT \
   curl --header "Authorization: token $(cat /etc/secrets/GH_PAT)" \

--- a/docker-unified/Dockerfile
+++ b/docker-unified/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /tmp
 
 # Download tags from 'clients' repository
 RUN --mount=type=secret,id=GH_PAT,target=/run/secrets/GH_PAT \
-  GH_PAT=$(cat /run/secrets/GH_PAT) curl --header "Authorization: token $GH_PAT" \
+  export GH_PAT=$(cat /run/secrets/GH_PAT) curl --header "Authorization: token $GH_PAT" \
   https://api.github.com/repos/bitwarden/clients/git/refs/tags --output tags.json
 
 RUN cat tags.json

--- a/docker-unified/Dockerfile
+++ b/docker-unified/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /tmp
 
 # Download tags from 'clients' repository
-RUN --mount=type=secret,id=GH_PAT,target=/run/secrets/GH_PAT \
-  export GH_PAT=$(cat /run/secrets/GH_PAT) curl --header "Authorization: token $GH_PAT" \
+RUN --mount=type=secret,id=GH_PAT,target=/etc/secrets/GH_PAT \
+  curl --header "Authorization: token $(cat /etc/secrets/GH_PAT)" \
   https://api.github.com/repos/bitwarden/clients/git/refs/tags --output tags.json
 
 RUN cat tags.json


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix the rate limiting issue on the tags API in GitHub while building Unified docker image.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **docker-unified/Dockerfile:** Add docker build secret support for github PAT token when calling GitHub API for the list of tags from `clients` repository
* **.github/workflows/build-self-host.yml:** Get GitHub PAT from keyvault and pass it to the docker build step.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
