### PR TITLE
[DEVOPS-1211] Push docker only to bitwardenprod ACR

### DIFF
--- a/.github/workflows/build-self-host.yml
+++ b/.github/workflows/build-self-host.yml
@@ -45,7 +45,7 @@ jobs:
           creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Login to Azure ACR
-        run: az acr login -n bitwardenqa
+        run: az acr login -n bitwardenprod
 
       - name: Login to Azure - Prod Subscription
         uses: Azure/login@1f63701bf3e6892515f1b7ce2d2bf1708b46beaf
@@ -109,9 +109,9 @@ jobs:
           IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
         run: |
           if [ "$IMAGE_TAG" = "dev" ] || [ "$IMAGE_TAG" = "beta" ]; then
-            echo "tags=bitwardenqa.azurecr.io/self-host:${IMAGE_TAG},bitwarden/self-host:${IMAGE_TAG}" >> $GITHUB_OUTPUT
+            echo "tags=bitwardenprod.azurecr.io/self-host:${IMAGE_TAG},bitwarden/self-host:${IMAGE_TAG}" >> $GITHUB_OUTPUT
           else
-            echo "tags=bitwardenqa.azurecr.io/self-host:${IMAGE_TAG}" >> $GITHUB_OUTPUT
+            echo "tags=bitwardenprod.azurecr.io/self-host:${IMAGE_TAG}" >> $GITHUB_OUTPUT
           fi
 
       - name: Build Docker image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,65 +191,65 @@ jobs:
         include:
           - project_name: Admin
             base_path: ./src
-            docker_repos: [bitwarden, bitwardenqa.azurecr.io]
+            docker_repos: [bitwarden, bitwardenprod.azurecr.io]
             dotnet: true
           - project_name: Api
             base_path: ./src
-            docker_repos: [bitwarden, bitwardenqa.azurecr.io]
+            docker_repos: [bitwarden, bitwardenprod.azurecr.io]
             dotnet: true
           - project_name: Attachments
             base_path: ./util
-            docker_repos: [bitwarden, bitwardenqa.azurecr.io]
+            docker_repos: [bitwarden, bitwardenprod.azurecr.io]
           - project_name: Events
             base_path: ./src
-            docker_repos: [bitwarden, bitwardenqa.azurecr.io]
+            docker_repos: [bitwarden, bitwardenprod.azurecr.io]
             dotnet: true
           - project_name: EventsProcessor
             base_path: ./src
-            docker_repos: [bitwardenqa.azurecr.io]
+            docker_repos: [bitwardenprod.azurecr.io]
             dotnet: true
           - project_name: Icons
             base_path: ./src
-            docker_repos: [bitwarden, bitwardenqa.azurecr.io]
+            docker_repos: [bitwarden, bitwardenprod.azurecr.io]
             dotnet: true
           - project_name: Identity
             base_path: ./src
-            docker_repos: [bitwarden, bitwardenqa.azurecr.io]
+            docker_repos: [bitwarden, bitwardenprod.azurecr.io]
             dotnet: true
           - project_name: MsSql
             base_path: ./util
-            docker_repos: [bitwarden, bitwardenqa.azurecr.io]
+            docker_repos: [bitwarden, bitwardenprod.azurecr.io]
           - project_name: Nginx
             base_path: ./util
-            docker_repos: [bitwarden, bitwardenqa.azurecr.io]
+            docker_repos: [bitwarden, bitwardenprod.azurecr.io]
           - project_name: Notifications
             base_path: ./src
-            docker_repos: [bitwarden, bitwardenqa.azurecr.io]
+            docker_repos: [bitwarden, bitwardenprod.azurecr.io]
             dotnet: true
           - project_name: Server
             base_path: ./util
-            docker_repos: [bitwarden, bitwardenqa.azurecr.io]
+            docker_repos: [bitwarden, bitwardenprod.azurecr.io]
             dotnet: true
           - project_name: Setup
             base_path: ./util
-            docker_repos: [bitwarden, bitwardenqa.azurecr.io]
+            docker_repos: [bitwarden, bitwardenprod.azurecr.io]
             dotnet: true
           - project_name: Sso
             base_path: ./bitwarden_license/src
-            docker_repos: [bitwarden, bitwardenqa.azurecr.io]
+            docker_repos: [bitwarden, bitwardenprod.azurecr.io]
             dotnet: true
           - project_name: Scim
             base_path: ./bitwarden_license/src
-            docker_repos: [bitwarden, bitwardenqa.azurecr.io]
+            docker_repos: [bitwarden, bitwardenprod.azurecr.io]
             dotnet: true
           - project_name: Billing
             base_path: ./src
-            docker_repos: [bitwardenqa.azurecr.io]
+            docker_repos: [bitwardenprod.azurecr.io]
             dotnet: true
     steps:
       - name: Checkout repo
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
-      
+
       - name: Set up image tag
         run: |
           IMAGE_TAG=$(echo "${GITHUB_REF:11}" | sed "s#/#-#g")  # slash safe branch name
@@ -284,27 +284,6 @@ jobs:
         env:
           PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
         run: docker build -t $PROJECT_NAME ${{ matrix.base_path }}/${{ matrix.project_name }}
-
-      ########## QA ACR ##########
-      - name: Login to Azure - QA Subscription
-        uses: Azure/login@1f63701bf3e6892515f1b7ce2d2bf1708b46beaf
-        with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Login to QA ACR
-        run: az acr login -n bitwardenqa
-
-      - name: Tag and push image to QA ACR
-        env:
-          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-          REGISTRY: bitwardenqa.azurecr.io
-        run: |
-          docker tag $PROJECT_NAME \
-            $REGISTRY/$PROJECT_NAME:${{ env.IMAGE_TAG }}
-          docker push $REGISTRY/$PROJECT_NAME:${{ env.IMAGE_TAG }}
-
-      - name: Log out of Docker
-        run: docker logout
 
       ########## PROD ACR ##########
       - name: Login to Azure - PROD Subscription

--- a/.github/workflows/cleanup-after-pr.yml
+++ b/.github/workflows/cleanup-after-pr.yml
@@ -14,18 +14,18 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       ########## ACR ##########
-      - name: Login to Azure - QA Subscription
+      - name: Login to Azure - PROD Subscription
         uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
         with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
+          creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
 
       - name: Login to Azure ACR
-        run: az acr login -n bitwardenqa
+        run: az acr login -n bitwardenprod
 
       ########## Remove Docker images ##########
       - name: Remove the docker image from ACR
         env:
-          REGISTRY_NAME: bitwardenqa
+          REGISTRY_NAME: bitwardenprod
           SERVICES: |
             services:
               - Admin

--- a/.github/workflows/container-registry-purge.yml
+++ b/.github/workflows/container-registry-purge.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: bitwardenqa
+          - name: bitwardenprod
           - name: bitwardenprod
     steps:
       - name: Login to Azure
@@ -25,7 +25,7 @@ jobs:
           creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
 
       - name: Login to Azure
-        if: matrix.name == 'bitwardenqa'
+        if: matrix.name == 'bitwardenprod'
         uses: Azure/login@1f63701bf3e6892515f1b7ce2d2bf1708b46beaf
         with:
           creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}

--- a/.github/workflows/container-registry-purge.yml
+++ b/.github/workflows/container-registry-purge.yml
@@ -11,28 +11,15 @@ jobs:
   purge:
     name: Purge old images
     runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: bitwardenprod
-          - name: bitwardenprod
     steps:
       - name: Login to Azure
-        if: matrix.name == 'bitwardenprod'
         uses: Azure/login@1f63701bf3e6892515f1b7ce2d2bf1708b46beaf
         with:
           creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
 
-      - name: Login to Azure
-        if: matrix.name == 'bitwardenprod'
-        uses: Azure/login@1f63701bf3e6892515f1b7ce2d2bf1708b46beaf
-        with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
       - name: Purge images
         env:
-          REGISTRY: ${{ matrix.name }}
+          REGISTRY: bitwardenprod
           AGO_DUR_VER: "180d"
           AGO_DUR: "30d"
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,7 @@ jobs:
             origin_docker_repo: bitwarden
           - project_name: EventsProcessor
             prod_acr: true
-            origin_docker_repo: bitwardenqa.azurecr.io
+            origin_docker_repo: bitwardenprod.azurecr.io
           - project_name: Icons
             origin_docker_repo: bitwarden
             prod_acr: true
@@ -209,7 +209,7 @@ jobs:
           - project_name: Scim
             origin_docker_repo: bitwarden
           - project_name: Billing
-            origin_docker_repo: bitwardenqa.azurecr.io
+            origin_docker_repo: bitwardenprod.azurecr.io
     steps:
       - name: Print environment
         env:
@@ -277,31 +277,19 @@ jobs:
           docker logout
           echo "DOCKER_CONTENT_TRUST=0" >> $GITHUB_ENV
 
-      ########## ACR QA ##########
-      - name: Login to Azure - QA Subscription
+      ########## ACR PROD ##########
+      - name: Login to Azure - PROD Subscription
         uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
         with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
+          creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
 
       - name: Login to Azure ACR
-        run: az acr login -n bitwardenqa
-
-      - name: Pull latest project image
-        if: matrix.origin_docker_repo == 'bitwardenqa.azurecr.io'
-        env:
-          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-          REGISTRY: bitwardenqa.azurecr.io
-        run: |
-          if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
-            docker pull $REGISTRY/$PROJECT_NAME:latest
-          else
-            docker pull $REGISTRY/$PROJECT_NAME:$_BRANCH_NAME
-          fi
+        run: az acr login -n bitwardenprod
 
       - name: Tag version and latest
         env:
           PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-          REGISTRY: bitwardenqa.azurecr.io
+          REGISTRY: bitwardenprod.azurecr.io
           ORIGIN_REGISTRY: ${{ matrix.origin_docker_repo }}
         run: |
           if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
@@ -315,50 +303,12 @@ jobs:
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
         env:
           PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-          REGISTRY: bitwardenqa.azurecr.io
-        run: |
-          docker push $REGISTRY/$PROJECT_NAME:latest
-          docker push $REGISTRY/$PROJECT_NAME:$_RELEASE_VERSION
-
-      - name: Log out of Docker
-        run: docker logout
-
-      ########## ACR PROD ##########
-      - name: Login to Azure - PROD Subscription
-        if: matrix.prod_acr == true
-        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
-        with:
-          creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
-
-      - name: Login to Azure ACR
-        if: matrix.prod_acr == true
-        run: az acr login -n bitwardenprod
-
-      - name: Tag version and latest
-        if: matrix.prod_acr == true
-        env:
-          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-          REGISTRY: bitwardenprod.azurecr.io
-          ORIGIN_REGISTRY: ${{ matrix.origin_docker_repo }}
-        run: |
-          if [[ "${{ github.event.inputs.release_type }}" == "Dry Run" ]]; then
-            docker tag $ORIGIN_REGISTRY/$PROJECT_NAME:latest $REGISTRY/$PROJECT_NAME:dryrun
-          else
-            docker tag $ORIGIN_REGISTRY/$PROJECT_NAME:$_BRANCH_NAME $REGISTRY/$PROJECT_NAME:$_RELEASE_VERSION
-            docker tag $ORIGIN_REGISTRY/$PROJECT_NAME:$_BRANCH_NAME $REGISTRY/$PROJECT_NAME:latest
-          fi
-
-      - name: Push version and latest image
-        if: ${{ github.event.inputs.release_type != 'Dry Run' && matrix.prod_acr == true }}
-        env:
-          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
           REGISTRY: bitwardenprod.azurecr.io
         run: |
           docker push $REGISTRY/$PROJECT_NAME:$_RELEASE_VERSION
           docker push $REGISTRY/$PROJECT_NAME:latest
 
       - name: Log out of Docker
-        if: matrix.prod_acr == true
         run: docker logout
 
   release:


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Update pipelines to push to the `bitwardenprod `ACR instead of pushing everything to the `bitwardenqa`.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **.github/workflows/build-self-host.yml:** push to the `bitwardenprod `ACR instead of pushing to the `bitwardenqa`.
* **.github/workflows/build.yml** change `bitwardenqa` to the `bitwardenprod` in the build matrix. Remove the QA ACR push steps.
* **.github/workflows/cleanup-after-pr.yml** change `bitwardenqa` ACR to the `bitwardenprod`.
* **.github/workflows/container-registry-purge.yml** Remove `bitwardenqa` steps and remove matrix strategy.
* **.github/workflows/release.yml** Remove QA ACR steps and `prod_acr` matrix bool

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
