### PR TITLE
[SM-504] Fix service account not accessing secrets

### DIFF
--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -35,6 +35,7 @@ public class CurrentContext : ICurrentContext
     public virtual string ClientId { get; set; }
     public virtual Version ClientVersion { get; set; }
     public virtual ClientType ClientType { get; set; }
+    public virtual Guid? ServiceAccountOrganizationId { get; set; }
 
     public CurrentContext(IProviderUserRepository providerUserRepository)
     {
@@ -144,6 +145,11 @@ public class CurrentContext : ICurrentContext
         {
             Enum.TryParse(clientType, out ClientType c);
             ClientType = c;
+        }
+
+        if (ClientType == ClientType.ServiceAccount)
+        {
+            ServiceAccountOrganizationId = new Guid(GetClaimValue(claimsDict, Claims.Organization));
         }
 
         DeviceIdentifier = GetClaimValue(claimsDict, Claims.Device);
@@ -445,6 +451,11 @@ public class CurrentContext : ICurrentContext
 
     public bool AccessSecretsManager(Guid orgId)
     {
+        if (ServiceAccountOrganizationId.HasValue && ServiceAccountOrganizationId.Value == orgId)
+        {
+            return true;
+        }
+
         return Organizations?.Any(o => o.Id == orgId && o.AccessSecretsManager) ?? false;
     }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

After implementing the access checks for secrets managers the service accounts stopped working. This changes the check in `CurrentContext` to also check the service accounts organization when checking access.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
