### PR TITLE
[EC-429] Only show Create/Add Existing Organization buttons for Reseller providers

### DIFF
--- a/src/Admin/Views/Providers/Organizations.cshtml
+++ b/src/Admin/Views/Providers/Organizations.cshtml
@@ -9,10 +9,13 @@
                         <th style="width: 50%;">Name</th>
                         <th style="width: 50%;">Status</th>
                         <th>
-                            <div class="float-right text-nowrap">
-                                <a asp-controller="Organizations" asp-action="Create" asp-route-providerId="@Model.Provider.Id" class="btn btn-sm btn-primary">New Organization</a>
-                                <a asp-controller="Providers" asp-action="AddExistingOrganization" asp-route-id="@Model.Provider.Id" class="btn btn-sm btn-outline-primary">Add Existing Organization</a>
-                            </div>
+                            @if (Model.Provider.Type == ProviderType.Reseller)
+                            {
+                                <div class="float-right text-nowrap">
+                                    <a asp-controller="Organizations" asp-action="Create" asp-route-providerId="@Model.Provider.Id" class="btn btn-sm btn-primary">New Organization</a>
+                                    <a asp-controller="Providers" asp-action="AddExistingOrganization" asp-route-id="@Model.Provider.Id" class="btn btn-sm btn-outline-primary">Add Existing Organization</a>
+                                </div>
+                            }
                         </th>
                     </tr>
                 </thead>


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
**This PR is targeting a feature branch for Billing Obfuscation.**
The Create/Add Existing Organization buttons on the Provider details page are only meant to be displayed if the Provider is of the type 'Reseller'.

## Code changes

* **src/Admin/Views/Providers/Organizations.cshtml:** Add a condition to check the Provider type

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
