### PR TITLE
[PM-1128] Add Migration to Sync OrganizationUserUserDetailsView

### DIFF
--- a/util/Migrator/DbScripts/2023-02-22_FixOrganizationUserUserDetailsViewOutOfSync.sql
+++ b/util/Migrator/DbScripts/2023-02-22_FixOrganizationUserUserDetailsViewOutOfSync.sql
@@ -20,9 +20,9 @@ SELECT
     U.[UsesKeyConnector]
 FROM
     [dbo].[OrganizationUser] OU
-    LEFT JOIN
+LEFT JOIN
     [dbo].[User] U ON U.[Id] = OU.[UserId]
-    LEFT JOIN
+LEFT JOIN
     [dbo].[SsoUser] SU ON SU.[UserId] = OU.[UserId] AND SU.[OrganizationId] = OU.[OrganizationId]
 END
 GO
@@ -44,5 +44,3 @@ BEGIN
     EXECUTE sp_refreshsqlmodule N'[dbo].[OrganizationUser_ReadByMinimumRole]';
 END
 GO
-
-

--- a/util/Migrator/DbScripts/2023-02-22_FixOrganizationUserUserDetailsViewOutOfSync.sql
+++ b/util/Migrator/DbScripts/2023-02-22_FixOrganizationUserUserDetailsViewOutOfSync.sql
@@ -1,0 +1,48 @@
+CREATE OR ALTER VIEW [dbo].[OrganizationUserUserDetailsView]
+AS
+SELECT
+    OU.[Id],
+    OU.[UserId],
+    OU.[OrganizationId],
+    U.[Name],
+    ISNULL(U.[Email], OU.[Email]) Email,
+    U.[AvatarColor],
+    U.[TwoFactorProviders],
+    U.[Premium],
+    OU.[Status],
+    OU.[Type],
+    OU.[AccessAll],
+    OU.[AccessSecretsManager],
+    OU.[ExternalId],
+    SU.[ExternalId] SsoExternalId,
+    OU.[Permissions],
+    OU.[ResetPasswordKey],
+    U.[UsesKeyConnector]
+FROM
+    [dbo].[OrganizationUser] OU
+    LEFT JOIN
+    [dbo].[User] U ON U.[Id] = OU.[UserId]
+    LEFT JOIN
+    [dbo].[SsoUser] SU ON SU.[UserId] = OU.[UserId] AND SU.[OrganizationId] = OU.[OrganizationId]
+END
+GO
+
+IF OBJECT_ID('[dbo].[OrganizationUserUserDetails_ReadById]') IS NOT NULL
+BEGIN
+    EXECUTE sp_refreshsqlmodule N'[dbo].[OrganizationUserUserDetails_ReadById]';
+END
+GO
+
+IF OBJECT_ID('[dbo].[OrganizationUserUserDetails_ReadByOrganizationId]') IS NOT NULL
+BEGIN
+    EXECUTE sp_refreshsqlmodule N'[dbo].[OrganizationUserUserDetails_ReadByOrganizationId]';
+END
+GO
+
+IF OBJECT_ID('[dbo].[OrganizationUser_ReadByMinimumRole]') IS NOT NULL
+BEGIN
+    EXECUTE sp_refreshsqlmodule N'[dbo].[OrganizationUser_ReadByMinimumRole]';
+END
+GO
+
+

--- a/util/Migrator/DbScripts/2023-02-22_FixOrganizationUserUserDetailsViewOutOfSync.sql
+++ b/util/Migrator/DbScripts/2023-02-22_FixOrganizationUserUserDetailsViewOutOfSync.sql
@@ -24,7 +24,6 @@ LEFT JOIN
     [dbo].[User] U ON U.[Id] = OU.[UserId]
 LEFT JOIN
     [dbo].[SsoUser] SU ON SU.[UserId] = OU.[UserId] AND SU.[OrganizationId] = OU.[OrganizationId]
-END
 GO
 
 IF OBJECT_ID('[dbo].[OrganizationUserUserDetails_ReadById]') IS NOT NULL


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
PR to fix [this](https://bitwarden.atlassian.net/browse/PM-1128) issue. Validate database github action due to `out of sync` between scripts.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **util/Migrator/DbScripts/2023-02-22_FixOrganizationUserUserDetailsViewOutOfSync.sql:** Altered OrganizationUserUserDetailsView to include AccessSecretsManager column and refresh procedures that reference the view.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
