### PR TITLE
[SM-352] Add support for granting service account access to projects

### DIFF
--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/AccessPolicyRepository.cs
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/AccessPolicyRepository.cs
@@ -180,9 +180,11 @@ public class AccessPolicyRepository : BaseEntityFrameworkRepository, IAccessPoli
 
         var entities = await dbContext.AccessPolicies.Where(ap =>
                 ((UserServiceAccountAccessPolicy)ap).GrantedServiceAccountId == id ||
-                ((GroupServiceAccountAccessPolicy)ap).GrantedServiceAccountId == id)
+                ((GroupServiceAccountAccessPolicy)ap).GrantedServiceAccountId == id ||
+                ((ServiceAccountProjectAccessPolicy)ap).ServiceAccountId == id)
             .Include(ap => ((UserServiceAccountAccessPolicy)ap).OrganizationUser.User)
             .Include(ap => ((GroupServiceAccountAccessPolicy)ap).Group)
+            .Include(ap => ((ServiceAccountProjectAccessPolicy)ap).GrantedProject)
             .ToListAsync();
 
         return entities.Select(MapToCore);

--- a/src/Api/SecretsManager/Models/Request/AccessPoliciesCreateRequest.cs
+++ b/src/Api/SecretsManager/Models/Request/AccessPoliciesCreateRequest.cs
@@ -13,6 +13,8 @@ public class AccessPoliciesCreateRequest
 
     public IEnumerable<AccessPolicyRequest>? ServiceAccountAccessPolicyRequests { get; set; }
 
+    public IEnumerable<AccessPolicyRequest>? ProjectAccessPolicyRequests { get; set; }
+
     public List<BaseAccessPolicy> ToBaseAccessPoliciesForProject(Guid grantedProjectId)
     {
         if (UserAccessPolicyRequests == null && GroupAccessPolicyRequests == null && ServiceAccountAccessPolicyRequests == null)
@@ -49,7 +51,7 @@ public class AccessPoliciesCreateRequest
 
     public List<BaseAccessPolicy> ToBaseAccessPoliciesForServiceAccount(Guid grantedServiceAccountId)
     {
-        if (UserAccessPolicyRequests == null && GroupAccessPolicyRequests == null)
+        if (UserAccessPolicyRequests == null && GroupAccessPolicyRequests == null && ProjectAccessPolicyRequests == null)
         {
             throw new BadRequestException("No creation requests provided.");
         }
@@ -59,6 +61,9 @@ public class AccessPoliciesCreateRequest
 
         var groupAccessPolicies = GroupAccessPolicyRequests?
             .Select(x => x.ToGroupServiceAccountAccessPolicy(grantedServiceAccountId)).ToList();
+
+        var projectAccessPolicies = ProjectAccessPolicyRequests?
+            .Select(x => x.ToProjectServiceAccountAccessPolicy(grantedServiceAccountId)).ToList();
 
         var policies = new List<BaseAccessPolicy>();
         if (userAccessPolicies != null)
@@ -70,6 +75,12 @@ public class AccessPoliciesCreateRequest
         {
             policies.AddRange(groupAccessPolicies);
         }
+
+        if (projectAccessPolicies != null)
+        {
+            policies.AddRange(projectAccessPolicies);
+        }
+
         return policies;
     }
 
@@ -146,6 +157,15 @@ public class AccessPolicyRequest
         {
             GroupId = GranteeId,
             GrantedServiceAccountId = id,
+            Read = Read,
+            Write = Write
+        };
+
+    public ServiceAccountProjectAccessPolicy ToProjectServiceAccountAccessPolicy(Guid serviceAccountId) =>
+        new()
+        {
+            ServiceAccountId = serviceAccountId,
+            GrantedProjectId = GranteeId,
             Read = Read,
             Write = Write
         };

--- a/src/Api/SecretsManager/Models/Response/ServiceAccountAccessPoliciesResponseModel.cs
+++ b/src/Api/SecretsManager/Models/Response/ServiceAccountAccessPoliciesResponseModel.cs
@@ -25,6 +25,9 @@ public class ServiceAccountAccessPoliciesResponseModel : ResponseModel
                 case GroupServiceAccountAccessPolicy accessPolicy:
                     GroupAccessPolicies.Add(new GroupServiceAccountAccessPolicyResponseModel(accessPolicy));
                     break;
+                case ServiceAccountProjectAccessPolicy accessPolicy:
+                    ProjectAccessPolicies.Add(new ServiceAccountProjectAccessPolicyResponseModel(accessPolicy));
+                    break;
             }
         }
     }
@@ -36,4 +39,5 @@ public class ServiceAccountAccessPoliciesResponseModel : ResponseModel
     public List<UserServiceAccountAccessPolicyResponseModel> UserAccessPolicies { get; set; } = new();
 
     public List<GroupServiceAccountAccessPolicyResponseModel> GroupAccessPolicies { get; set; } = new();
+    public List<ServiceAccountProjectAccessPolicyResponseModel> ProjectAccessPolicies { get; set; } = new();
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Adds support for granting access to projects for service accounts from the service accounts view point

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
