### PR TITLE
[SM-577] - ACCESS POLICY fixing issue with user being able to update a secret if they are assi…

### DIFF
--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
@@ -48,17 +48,18 @@ public class UpdateSecretCommand : IUpdateSecretCommand
 
     public async Task<bool> hasAccessToOriginalAndUpdatedProject(AccessClientType accessClient, Secret secret, Secret updatedSecret, Guid userId)
     {
-        switch (accessClient) { 
-            case AccessClientType.NoAccessCheck: 
-                return true; 
-            case AccessClientType.User: 
-                var oldProject = secret.Projects?.FirstOrDefault(); 
-                var newProject = updatedSecret.Projects?.FirstOrDefault(); 
+        switch (accessClient)
+        {
+            case AccessClientType.NoAccessCheck:
+                return true;
+            case AccessClientType.User:
+                var oldProject = secret.Projects?.FirstOrDefault();
+                var newProject = updatedSecret.Projects?.FirstOrDefault();
                 var accessToOld = oldProject != null && await _projectRepository.UserHasWriteAccessToProject(oldProject.Id, userId);
-                var accessToNew = newProject != null && await _projectRepository.UserHasWriteAccessToProject(newProject.Id, userId); 
-                return accessToOld && accessToNew; 
+                var accessToNew = newProject != null && await _projectRepository.UserHasWriteAccessToProject(newProject.Id, userId);
+                return accessToOld && accessToNew;
             default:
-                return false; 
+                return false;
         }
     }
 }

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
@@ -31,7 +31,7 @@ public class UpdateSecretCommand : IUpdateSecretCommand
         var orgAdmin = await _currentContext.OrganizationAdmin(secret.OrganizationId);
         var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
 
-        if (!await hasAccess(accessClient, secret, updatedSecret, userId))
+        if (!await hasAccessToOriginalAndUpdatedProject(accessClient, secret, updatedSecret, userId))
         {
             throw new NotFoundException();
         }
@@ -46,7 +46,7 @@ public class UpdateSecretCommand : IUpdateSecretCommand
         return secret;
     }
 
-    public async Task<bool> hasAccess(AccessClientType accessClient, Secret secret, Secret updatedSecret, Guid userId)
+    public async Task<bool> hasAccessToOriginalAndUpdatedProject(AccessClientType accessClient, Secret secret, Secret updatedSecret, Guid userId)
     {
         switch (accessClient) { 
             case AccessClientType.NoAccessCheck: 

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
@@ -31,12 +31,12 @@ public class UpdateSecretCommand : IUpdateSecretCommand
         var orgAdmin = await _currentContext.OrganizationAdmin(secret.OrganizationId);
         var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
 
-        var project = updatedSecret.Projects?.FirstOrDefault();
+        var originalSecretsProject = secret.Projects?.FirstOrDefault();
 
         var hasAccess = accessClient switch
         {
             AccessClientType.NoAccessCheck => true,
-            AccessClientType.User => project != null && await _projectRepository.UserHasWriteAccessToProject(project.Id, userId),
+            AccessClientType.User => originalSecretsProject != null && await _projectRepository.UserHasWriteAccessToProject(originalSecretsProject.Id, userId),
             _ => false,
         };
 

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
@@ -42,7 +42,7 @@ public class UpdateSecretCommand : IUpdateSecretCommand
         var newlyAssignedProject = updatedSecret.Projects?.FirstOrDefault();
         var hasAccessToNewlyAssignedProject = hasAccessToOriginalProject;
 
-        if(newlyAssignedProject.Id != originalProject.Id)
+        if (newlyAssignedProject.Id != originalProject.Id)
         {
             hasAccessToNewlyAssignedProject = accessClient switch
             {

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
@@ -31,7 +31,7 @@ public class UpdateSecretCommand : IUpdateSecretCommand
         var orgAdmin = await _currentContext.OrganizationAdmin(secret.OrganizationId);
         var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
 
-        if (!await hasAccessToOriginalAndUpdatedProject(accessClient, secret, updatedSecret, userId))
+        if (!await HasAccessToOriginalAndUpdatedProject(accessClient, secret, updatedSecret, userId))
         {
             throw new NotFoundException();
         }
@@ -46,7 +46,7 @@ public class UpdateSecretCommand : IUpdateSecretCommand
         return secret;
     }
 
-    public async Task<bool> hasAccessToOriginalAndUpdatedProject(AccessClientType accessClient, Secret secret, Secret updatedSecret, Guid userId)
+    public async Task<bool> HasAccessToOriginalAndUpdatedProject(AccessClientType accessClient, Secret secret, Secret updatedSecret, Guid userId)
     {
         switch (accessClient)
         {

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
@@ -42,7 +42,7 @@ public class UpdateSecretCommand : IUpdateSecretCommand
         var newlyAssignedProject = updatedSecret.Projects?.FirstOrDefault();
         var hasAccessToNewlyAssignedProject = hasAccessToOriginalProject;
 
-        if (newlyAssignedProject.Id != originalProject.Id)
+        if (newlyAssignedProject != null && (newlyAssignedProject.Id != originalProject?.Id))
         {
             hasAccessToNewlyAssignedProject = accessClient switch
             {

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Secrets/UpdateSecretCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Secrets/UpdateSecretCommandTests.cs
@@ -55,7 +55,7 @@ public class UpdateSecretCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task UpdateAsync_DoesNotModifyOrganizationId(Secret existingSecret, SutProvider<UpdateSecretCommand> sutProvider, Guid userId, Project mockProject)
+    public async Task UpdateAsync_DoesNotModifyOrganizationId(Secret existingSecret, SutProvider<UpdateSecretCommand> sutProvider, Guid userId)
     {
         var updatedOrgId = Guid.NewGuid();
         sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(existingSecret.OrganizationId).Returns(true);

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Secrets/UpdateSecretCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Secrets/UpdateSecretCommandTests.cs
@@ -34,6 +34,7 @@ public class UpdateSecretCommandTests
     public async Task UpdateAsync_Success(PermissionType permissionType, Secret data, SutProvider<UpdateSecretCommand> sutProvider, Guid userId, Project mockProject)
     {
         sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(data.OrganizationId).Returns(true);
+        data.Projects = new List<Project>() { mockProject };
 
         if (permissionType == PermissionType.RunAsAdmin)
         {
@@ -41,7 +42,6 @@ public class UpdateSecretCommandTests
         }
         else
         {
-            data.Projects = new List<Project>() { mockProject };
             sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(data.OrganizationId).Returns(false);
             sutProvider.GetDependency<IProjectRepository>().UserHasWriteAccessToProject((Guid)(data.Projects?.First().Id), userId).Returns(true);
         }
@@ -55,7 +55,7 @@ public class UpdateSecretCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task UpdateAsync_DoesNotModifyOrganizationId(Secret existingSecret, SutProvider<UpdateSecretCommand> sutProvider, Guid userId)
+    public async Task UpdateAsync_DoesNotModifyOrganizationId(Secret existingSecret, SutProvider<UpdateSecretCommand> sutProvider, Guid userId, Project mockProject)
     {
         var updatedOrgId = Guid.NewGuid();
         sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(existingSecret.OrganizationId).Returns(true);


### PR DESCRIPTION
…gning it to a project that has read/write permissions. Even though the customer is only allowed to read.

## Type of change

<!-- (mark with an `X`) -->

```
- [ x ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Disable users from updating a secret they aren't allowed to update


## Code changes
Updated UpdateSecretCommand to check the existing secret's project permissions, not the newly assigned secrets project permissions 

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
