### PR TITLE
[PM-1012] Feature access using context

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -22,3 +22,8 @@ public static class AuthenticationSchemes
 {
     public const string BitwardenExternalCookieAuthenticationScheme = "bw.external";
 }
+
+public static class FeatureFlagKeys
+{
+    public const string SecretsManager = "secrets-manager";
+}

--- a/src/Core/Services/IFeatureService.cs
+++ b/src/Core/Services/IFeatureService.cs
@@ -1,4 +1,6 @@
-﻿namespace Bit.Core.Services;
+﻿using Bit.Core.Context;
+
+namespace Bit.Core.Services;
 
 public interface IFeatureService
 {
@@ -7,4 +9,31 @@ public interface IFeatureService
     /// </summary>
     /// <returns>True if the service is online, otherwise false.</returns>
     bool IsOnline();
+
+    /// <summary>
+    /// Checks whether a given feature is enabled.
+    /// </summary>
+    /// <param name="key">The key of the feature to check.</param>
+    /// <param name="currentContext">A context providing information that can be used to evaluate whether a feature should be on or off.</param>
+    /// <param name="defaultValue">The default value for the feature.</param>
+    /// <returns>True if the feature is enabled, otherwise false.</returns>
+    bool IsEnabled(string key, ICurrentContext currentContext, bool defaultValue = false);
+
+    /// <summary>
+    /// Gets the integer variation of a feature.
+    /// </summary>
+    /// <param name="key">The key of the feature to check.</param>
+    /// <param name="currentContext">A context providing information that can be used to evaluate the feature value.</param>
+    /// <param name="defaultValue">The default value for the feature.</param>
+    /// <returns>The feature variation value.</returns>
+    int GetIntVariation(string key, ICurrentContext currentContext, int defaultValue = 0);
+
+    /// <summary>
+    /// Gets the string variation of a feature.
+    /// </summary>
+    /// <param name="key">The key of the feature to check.</param>
+    /// <param name="currentContext">A context providing information that can be used to evaluate the feature value.</param>
+    /// <param name="defaultValue">The default value for the feature.</param>
+    /// <returns>The feature variation value.</returns>
+    string GetStringVariation(string key, ICurrentContext currentContext, string defaultValue = null);
 }

--- a/src/Core/Services/IFeatureService.cs
+++ b/src/Core/Services/IFeatureService.cs
@@ -2,5 +2,9 @@
 
 public interface IFeatureService
 {
+    /// <summary>
+    /// Checks whether online access to feature status is available.
+    /// </summary>
+    /// <returns>True if the service is online, otherwise false.</returns>
     bool IsOnline();
 }

--- a/test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs
+++ b/test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs
@@ -89,6 +89,6 @@ public class LaunchDarklyFeatureServiceTests
         var currentContext = Substitute.For<ICurrentContext>();
         currentContext.UserId.Returns(Guid.NewGuid());
 
-        Assert.Equal(null, sutProvider.Sut.GetStringVariation("somekey", currentContext));
+        Assert.Null(sutProvider.Sut.GetStringVariation("somekey", currentContext));
     }
 }

--- a/test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs
+++ b/test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs
@@ -1,8 +1,10 @@
 ﻿using AutoFixture;
+using Bit.Core.Context;
 using Bit.Core.Services;
 using Bit.Core.Settings;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
 using Xunit;
 
 namespace Bit.Core.Test.Services;
@@ -24,5 +26,69 @@ public class LaunchDarklyFeatureServiceTests
         var sutProvider = GetSutProvider(new Core.Settings.GlobalSettings() { SelfHosted = true });
 
         Assert.False(sutProvider.Sut.IsOnline());
+    }
+
+    [Theory, BitAutoData]
+    public void DefaultFeatureValue_WhenSelfHost(string key)
+    {
+        var sutProvider = GetSutProvider(new Core.Settings.GlobalSettings() { SelfHosted = true });
+
+        var currentContext = Substitute.For<ICurrentContext>();
+        currentContext.UserId.Returns(Guid.NewGuid());
+
+        Assert.False(sutProvider.Sut.IsEnabled(key, currentContext));
+    }
+
+    [Fact]
+    public void DefaultFeatureValue_NoSdkKey()
+    {
+        var sutProvider = GetSutProvider(new Core.Settings.GlobalSettings());
+
+        var currentContext = Substitute.For<ICurrentContext>();
+        currentContext.UserId.Returns(Guid.NewGuid());
+
+        Assert.False(sutProvider.Sut.IsEnabled("somekey", currentContext));
+    }
+
+    [Fact(Skip = "For local development")]
+    public void FeatureValue_Boolean()
+    {
+        var settings = new Core.Settings.GlobalSettings();
+        settings.LaunchDarkly.SdkKey = "somevalue";
+
+        var sutProvider = GetSutProvider(settings);
+
+        var currentContext = Substitute.For<ICurrentContext>();
+        currentContext.UserId.Returns(Guid.NewGuid());
+
+        Assert.False(sutProvider.Sut.IsEnabled("somekey", currentContext));
+    }
+
+    [Fact(Skip = "For local development")]
+    public void FeatureValue_Int()
+    {
+        var settings = new Core.Settings.GlobalSettings();
+        settings.LaunchDarkly.SdkKey = "somevalue";
+
+        var sutProvider = GetSutProvider(settings);
+
+        var currentContext = Substitute.For<ICurrentContext>();
+        currentContext.UserId.Returns(Guid.NewGuid());
+
+        Assert.Equal(0, sutProvider.Sut.GetIntVariation("somekey", currentContext));
+    }
+
+    [Fact(Skip = "For local development")]
+    public void FeatureValue_String()
+    {
+        var settings = new Core.Settings.GlobalSettings();
+        settings.LaunchDarkly.SdkKey = "somevalue";
+
+        var sutProvider = GetSutProvider(settings);
+
+        var currentContext = Substitute.For<ICurrentContext>();
+        currentContext.UserId.Returns(Guid.NewGuid());
+
+        Assert.Equal(null, sutProvider.Sut.GetStringVariation("somekey", currentContext));
     }
 }

--- a/test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs
+++ b/test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs
@@ -47,7 +47,7 @@ public class LaunchDarklyFeatureServiceTests
         var currentContext = Substitute.For<ICurrentContext>();
         currentContext.UserId.Returns(Guid.NewGuid());
 
-        Assert.False(sutProvider.Sut.IsEnabled("somekey", currentContext));
+        Assert.False(sutProvider.Sut.IsEnabled(FeatureFlagKeys.SecretsManager, currentContext));
     }
 
     [Fact(Skip = "For local development")]
@@ -61,7 +61,7 @@ public class LaunchDarklyFeatureServiceTests
         var currentContext = Substitute.For<ICurrentContext>();
         currentContext.UserId.Returns(Guid.NewGuid());
 
-        Assert.False(sutProvider.Sut.IsEnabled("somekey", currentContext));
+        Assert.False(sutProvider.Sut.IsEnabled(FeatureFlagKeys.SecretsManager, currentContext));
     }
 
     [Fact(Skip = "For local development")]
@@ -75,7 +75,7 @@ public class LaunchDarklyFeatureServiceTests
         var currentContext = Substitute.For<ICurrentContext>();
         currentContext.UserId.Returns(Guid.NewGuid());
 
-        Assert.Equal(0, sutProvider.Sut.GetIntVariation("somekey", currentContext));
+        Assert.Equal(0, sutProvider.Sut.GetIntVariation(FeatureFlagKeys.SecretsManager, currentContext));
     }
 
     [Fact(Skip = "For local development")]
@@ -89,6 +89,6 @@ public class LaunchDarklyFeatureServiceTests
         var currentContext = Substitute.For<ICurrentContext>();
         currentContext.UserId.Returns(Guid.NewGuid());
 
-        Assert.Null(sutProvider.Sut.GetStringVariation("somekey", currentContext));
+        Assert.Null(sutProvider.Sut.GetStringVariation(FeatureFlagKeys.SecretsManager, currentContext));
     }
 }


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Methods for accessing feature flags as simple Booleans, integers, and strings, all using the current context.

## Code changes

* **src/Core/Constants.cs:** Class for feature flag keys, as constants.
* **src/Core/Services/IFeatureService.cs:** Three new interface methods to retrieve values using context and defaults.
* **src/Core/Services/Implementations/LaunchDarklyFeatureService.cs:** Implementation using LaunchDarkly. Builds a context of the user and organization IDs when available (although the user context is truly needed) and respects default values for when offline.
* **test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs:** Tests to exercise the new methods with a generated user ID. Marked a few as skips so they can stick around as example implementations.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
