### PR TITLE
[PM-1191] collections cannot be managed in family organization

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs
@@ -188,11 +188,13 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
             var groups =
                 from c in collections
                 join cg in dbContext.CollectionGroups on c.Id equals cg.CollectionId
-                select cg;
+                group cg by cg.CollectionId into g
+                select g;
             var users =
                 from c in collections
                 join cu in dbContext.CollectionUsers on c.Id equals cu.CollectionId
-                select cu;
+                group cu by cu.CollectionId into u
+                select u;
 
             return collections.Select(collection =>
                 new Tuple<Core.Entities.Collection, CollectionAccessDetails>(
@@ -200,6 +202,7 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                     new CollectionAccessDetails
                     {
                         Groups = groups
+                            .FirstOrDefault(g => g.Key == collection.Id)?
                             .Select(g => new CollectionAccessSelection
                             {
                                 Id = g.GroupId,
@@ -207,6 +210,7 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                                 ReadOnly = g.ReadOnly
                             }).ToList() ?? new List<CollectionAccessSelection>(),
                         Users = users
+                            .FirstOrDefault(u => u.Key == collection.Id)?
                             .Select(c => new CollectionAccessSelection
                             {
                                 Id = c.OrganizationUserId,
@@ -228,11 +232,13 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
             var groups =
                 from c in collections
                 join cg in dbContext.CollectionGroups on c.Id equals cg.CollectionId
-                select cg;
+                group cg by cg.CollectionId into g
+                select g;
             var users =
                 from c in collections
                 join cu in dbContext.CollectionUsers on c.Id equals cu.CollectionId
-                select cu;
+                group cu by cu.CollectionId into u
+                select u;
 
             return collections.Select(collection =>
                 new Tuple<Core.Entities.Collection, CollectionAccessDetails>(
@@ -240,6 +246,7 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                     new CollectionAccessDetails
                     {
                         Groups = groups
+                            .FirstOrDefault(g => g.Key == collection.Id)?
                             .Select(g => new CollectionAccessSelection
                             {
                                 Id = g.GroupId,
@@ -247,6 +254,7 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                                 ReadOnly = g.ReadOnly
                             }).ToList() ?? new List<CollectionAccessSelection>(),
                         Users = users
+                            .FirstOrDefault(u => u.Key == collection.Id)?
                             .Select(c => new CollectionAccessSelection
                             {
                                 Id = c.OrganizationUserId,

--- a/src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs
@@ -186,13 +186,13 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
         {
             var dbContext = GetDatabaseContext(scope);
             var groups =
-                from cg in dbContext.CollectionGroups
-                where cg.Collection.OrganizationId == organizationId
+                from c in collections
+                join cg in dbContext.CollectionGroups on c.Id equals cg.CollectionId
                 group cg by cg.CollectionId into g
                 select g;
             var users =
-                from cu in dbContext.CollectionUsers
-                where cu.Collection.OrganizationId == organizationId
+                from c in collections
+                join cu in dbContext.CollectionUsers on c.Id equals cu.CollectionId
                 group cu by cu.CollectionId into u
                 select u;
 
@@ -230,18 +230,15 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
         {
             var dbContext = GetDatabaseContext(scope);
             var groups =
-                from cg in dbContext.CollectionGroups
-                where cg.Collection.OrganizationId == organizationId
-                 && collections.Select(c => c.Id).Contains(cg.Collection.Id)
+                from c in collections
+                join cg in dbContext.CollectionGroups on c.Id equals cg.CollectionId
                 group cg by cg.CollectionId into g
                 select g;
             var users =
-                from cu in dbContext.CollectionUsers
-                where cu.Collection.OrganizationId == organizationId
-                 && collections.Select(c => c.Id).Contains(cu.Collection.Id)
+                from c in collections
+                join cu in dbContext.CollectionUsers on c.Id equals cu.CollectionId
                 group cu by cu.CollectionId into u
                 select u;
-
 
             return collections.Select(collection =>
                 new Tuple<Core.Entities.Collection, CollectionAccessDetails>(

--- a/src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs
@@ -188,13 +188,11 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
             var groups =
                 from c in collections
                 join cg in dbContext.CollectionGroups on c.Id equals cg.CollectionId
-                group cg by cg.CollectionId into g
-                select g;
+                select cg;
             var users =
                 from c in collections
                 join cu in dbContext.CollectionUsers on c.Id equals cu.CollectionId
-                group cu by cu.CollectionId into u
-                select u;
+                select cu;
 
             return collections.Select(collection =>
                 new Tuple<Core.Entities.Collection, CollectionAccessDetails>(
@@ -202,7 +200,6 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                     new CollectionAccessDetails
                     {
                         Groups = groups
-                            .FirstOrDefault(g => g.Key == collection.Id)?
                             .Select(g => new CollectionAccessSelection
                             {
                                 Id = g.GroupId,
@@ -210,7 +207,6 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                                 ReadOnly = g.ReadOnly
                             }).ToList() ?? new List<CollectionAccessSelection>(),
                         Users = users
-                            .FirstOrDefault(u => u.Key == collection.Id)?
                             .Select(c => new CollectionAccessSelection
                             {
                                 Id = c.OrganizationUserId,
@@ -232,13 +228,11 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
             var groups =
                 from c in collections
                 join cg in dbContext.CollectionGroups on c.Id equals cg.CollectionId
-                group cg by cg.CollectionId into g
-                select g;
+                select cg;
             var users =
                 from c in collections
                 join cu in dbContext.CollectionUsers on c.Id equals cu.CollectionId
-                group cu by cu.CollectionId into u
-                select u;
+                select cu;
 
             return collections.Select(collection =>
                 new Tuple<Core.Entities.Collection, CollectionAccessDetails>(
@@ -246,7 +240,6 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                     new CollectionAccessDetails
                     {
                         Groups = groups
-                            .FirstOrDefault(g => g.Key == collection.Id)?
                             .Select(g => new CollectionAccessSelection
                             {
                                 Id = g.GroupId,
@@ -254,7 +247,6 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                                 ReadOnly = g.ReadOnly
                             }).ToList() ?? new List<CollectionAccessSelection>(),
                         Users = users
-                            .FirstOrDefault(u => u.Key == collection.Id)?
                             .Select(c => new CollectionAccessSelection
                             {
                                 Id = c.OrganizationUserId,


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Fix issue reported by users that org vault is broken after OAVR v2 when using EF.

Fixes #2750 

## Code changes
EF6 is currently not able to translate LINQ that include selects after `group` statements (see [github issue](https://github.com/dotnet/efcore/issues/26748)). Using `join` let's us bypass this issue.

This new solution is probably a bit faster too so win-win :)

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
