### PR TITLE
[SM-604] Filter for only confirmed Org users in potential grantees

### DIFF
--- a/src/Api/SecretsManager/Controllers/AccessPoliciesController.cs
+++ b/src/Api/SecretsManager/Controllers/AccessPoliciesController.cs
@@ -204,7 +204,7 @@ public class AccessPoliciesController : Controller
         var organizationUsers =
             await _organizationUserRepository.GetManyDetailsByOrganizationAsync(id);
         var userResponses = organizationUsers
-            .Where(user => user.AccessSecretsManager)
+            .Where(user => user.AccessSecretsManager && user.Status == OrganizationUserStatusType.Confirmed)
             .Select(userDetails => new PotentialGranteeResponseModel(userDetails));
 
         return new ListResponseModel<PotentialGranteeResponseModel>(userResponses.Concat(groupResponses));

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/AccessPoliciesControllerTest.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/AccessPoliciesControllerTest.cs
@@ -702,7 +702,6 @@ public class AccessPoliciesControllerTest : IClassFixture<ApiApplicationFactory>
             result!.UserAccessPolicies.First(ap => ap.OrganizationUserId == ownerOrgUserId).OrganizationUserId);
         Assert.True(result.UserAccessPolicies.First().Read);
         Assert.True(result.UserAccessPolicies.First().Write);
-        AssertHelper.AssertRecent(result.UserAccessPolicies.First().RevisionDate);
 
         var createdAccessPolicy =
             await _accessPolicyRepository.GetByIdAsync(result.UserAccessPolicies.First().Id);
@@ -710,7 +709,6 @@ public class AccessPoliciesControllerTest : IClassFixture<ApiApplicationFactory>
         Assert.Equal(result.UserAccessPolicies.First().Read, createdAccessPolicy!.Read);
         Assert.Equal(result.UserAccessPolicies.First().Write, createdAccessPolicy.Write);
         Assert.Equal(result.UserAccessPolicies.First().Id, createdAccessPolicy.Id);
-        AssertHelper.AssertRecent(createdAccessPolicy.RevisionDate);
     }
 
     [Fact]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The purpose of this PR is to only returned confirmed users for the potential grantees endpoint.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* src/Api/SecretsManager/Controllers/AccessPoliciesController.cs
Filter for only users that are confirmed.

- test/Api.IntegrationTest/SecretsManager/Controllers/AccessPoliciesControllerTest.cs

Removing the `assert.recent` check as they fail on long runs in the GitHub runners and aren't providing value for that specific test.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
