### PR TITLE
[PM-1013] All feature state access through config API

### DIFF
--- a/src/Api/Controllers/ConfigController.cs
+++ b/src/Api/Controllers/ConfigController.cs
@@ -1,4 +1,6 @@
 ﻿using Bit.Api.Models.Response;
+using Bit.Core.Context;
+using Bit.Core.Services;
 using Bit.Core.Settings;
 
 using Microsoft.AspNetCore.Mvc;
@@ -9,15 +11,22 @@ namespace Bit.Api.Controllers;
 public class ConfigController : Controller
 {
     private readonly IGlobalSettings _globalSettings;
+    private readonly ICurrentContext _currentContext;
+    private readonly IFeatureService _featureService;
 
-    public ConfigController(IGlobalSettings globalSettings)
+    public ConfigController(
+        IGlobalSettings globalSettings,
+        ICurrentContext currentContext,
+        IFeatureService featureService)
     {
         _globalSettings = globalSettings;
+        _currentContext = currentContext;
+        _featureService = featureService;
     }
 
     [HttpGet("")]
     public ConfigResponseModel GetConfigs()
     {
-        return new ConfigResponseModel(_globalSettings);
+        return new ConfigResponseModel(_globalSettings, _featureService.GetAll(_currentContext));
     }
 }

--- a/src/Api/Models/Response/ConfigResponseModel.cs
+++ b/src/Api/Models/Response/ConfigResponseModel.cs
@@ -10,15 +10,19 @@ public class ConfigResponseModel : ResponseModel
     public string GitHash { get; set; }
     public ServerConfigResponseModel Server { get; set; }
     public EnvironmentConfigResponseModel Environment { get; set; }
+    public IDictionary<string, object> FeatureStates { get; set; }
 
-    public ConfigResponseModel(string obj = "config") : base(obj)
+    public ConfigResponseModel() : base("config")
     {
         Version = AssemblyHelpers.GetVersion();
         GitHash = AssemblyHelpers.GetGitHash();
         Environment = new EnvironmentConfigResponseModel();
+        FeatureStates = new Dictionary<string, object>();
     }
 
-    public ConfigResponseModel(IGlobalSettings globalSettings, string obj = "config") : base(obj)
+    public ConfigResponseModel(
+        IGlobalSettings globalSettings,
+        IDictionary<string, object> featureStates) : base("config")
     {
         Version = AssemblyHelpers.GetVersion();
         GitHash = AssemblyHelpers.GetGitHash();
@@ -30,6 +34,7 @@ public class ConfigResponseModel : ResponseModel
             Notifications = globalSettings.BaseServiceUri.Notifications,
             Sso = globalSettings.BaseServiceUri.Sso
         };
+        FeatureStates = featureStates;
     }
 }
 

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -1,4 +1,6 @@
-﻿namespace Bit.Core;
+﻿using System.Reflection;
+
+namespace Bit.Core;
 
 public static class Constants
 {
@@ -26,4 +28,12 @@ public static class AuthenticationSchemes
 public static class FeatureFlagKeys
 {
     public const string SecretsManager = "secrets-manager";
+
+    public static List<string> GetAllKeys()
+    {
+        return typeof(FeatureFlagKeys).GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Where(fi => fi.IsLiteral && !fi.IsInitOnly && fi.FieldType == typeof(string))
+            .Select(x => (string)x.GetRawConstantValue())
+            .ToList();
+    }
 }

--- a/src/Core/Services/IFeatureService.cs
+++ b/src/Core/Services/IFeatureService.cs
@@ -36,4 +36,11 @@ public interface IFeatureService
     /// <param name="defaultValue">The default value for the feature.</param>
     /// <returns>The feature variation value.</returns>
     string GetStringVariation(string key, ICurrentContext currentContext, string defaultValue = null);
+
+    /// <summary>
+    /// Gets all feature values.
+    /// </summary>
+    /// <param name="currentContext">A context providing information that can be used to evaluate the feature values.</param>
+    /// <returns>A dictionary of feature keys and their values.</returns>
+    Dictionary<string, object> GetAll(ICurrentContext currentContext);
 }

--- a/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
+++ b/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
@@ -63,6 +63,38 @@ public class LaunchDarklyFeatureService : IFeatureService, IDisposable
         return _client.StringVariation(key, BuildContext(currentContext), defaultValue);
     }
 
+    public Dictionary<string, object> GetAll(ICurrentContext currentContext)
+    {
+        var results = new Dictionary<string, object>();
+
+        var keys = FeatureFlagKeys.GetAllKeys();
+
+        var values = _client.AllFlagsState(BuildContext(currentContext));
+        if (values.Valid)
+        {
+            foreach (var key in keys)
+            {
+                var value = values.GetFlagValueJson(key);
+                switch (value.Type)
+                {
+                    case LaunchDarkly.Sdk.LdValueType.Bool:
+                        results.Add(key, value.AsBool);
+                        break;
+
+                    case LaunchDarkly.Sdk.LdValueType.Number:
+                        results.Add(key, value.AsInt);
+                        break;
+
+                    case LaunchDarkly.Sdk.LdValueType.String:
+                        results.Add(key, value.AsString);
+                        break;
+                }
+            }
+        }
+
+        return results;
+    }
+
     public void Dispose()
     {
         _client?.Dispose();

--- a/test/Api.IntegrationTest/Controllers/ConfigControllerTests.cs
+++ b/test/Api.IntegrationTest/Controllers/ConfigControllerTests.cs
@@ -1,0 +1,30 @@
+﻿using System.Net.Http.Headers;
+using Bit.Api.IntegrationTest.Factories;
+using Bit.Api.Models.Response;
+using Xunit;
+
+namespace Bit.Api.IntegrationTest.Controllers;
+
+public class ConfigControllerTests : IClassFixture<ApiApplicationFactory>
+{
+    private readonly ApiApplicationFactory _factory;
+
+    public ConfigControllerTests(ApiApplicationFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task GetConfigs()
+    {
+        var tokens = await _factory.LoginWithNewAccount();
+        var client = _factory.CreateClient();
+
+        using var message = new HttpRequestMessage(HttpMethod.Get, "/config");
+        message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokens.Token);
+        var response = await client.SendAsync(message);
+
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadFromJsonAsync<ConfigResponseModel>();
+
+        Assert.NotEmpty(content!.Version);
+    }
+}

--- a/test/Api.Test/Controllers/ConfigControllerTests.cs
+++ b/test/Api.Test/Controllers/ConfigControllerTests.cs
@@ -1,0 +1,47 @@
+﻿using AutoFixture.Xunit2;
+using Bit.Api.Controllers;
+using Bit.Core.Context;
+using Bit.Core.Services;
+using Bit.Core.Settings;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Api.Test.Controllers;
+
+public class ConfigControllerTests : IDisposable
+{
+    private readonly ConfigController _sut;
+    private readonly GlobalSettings _globalSettings;
+    private readonly IFeatureService _featureService;
+    private readonly ICurrentContext _currentContext;
+
+    public ConfigControllerTests()
+    {
+        _globalSettings = new GlobalSettings();
+        _currentContext = Substitute.For<ICurrentContext>();
+        _featureService = Substitute.For<IFeatureService>();
+
+        _sut = new ConfigController(
+            _globalSettings,
+            _currentContext,
+            _featureService
+        );
+    }
+
+    public void Dispose()
+    {
+        _sut?.Dispose();
+    }
+
+    [Theory, AutoData]
+    public void GetConfigs_WithFeatureStates(Dictionary<string, object> featureStates)
+    {
+        _featureService.GetAll(_currentContext).Returns(featureStates);
+
+        var response = _sut.GetConfigs();
+
+        Assert.NotNull(response);
+        Assert.NotNull(response.FeatureStates);
+        Assert.Equal(featureStates, response.FeatureStates);
+    }
+}

--- a/test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs
+++ b/test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs
@@ -91,4 +91,18 @@ public class LaunchDarklyFeatureServiceTests
 
         Assert.Null(sutProvider.Sut.GetStringVariation(FeatureFlagKeys.SecretsManager, currentContext));
     }
+
+    [Fact(Skip = "For local development")]
+    public void GetAll()
+    {
+        var sutProvider = GetSutProvider(new Core.Settings.GlobalSettings());
+
+        var currentContext = Substitute.For<ICurrentContext>();
+        currentContext.UserId.Returns(Guid.NewGuid());
+
+        var results = sutProvider.Sut.GetAll(currentContext);
+
+        Assert.NotNull(results);
+        Assert.NotEmpty(results);
+    }
 }


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

API expansion to return all features states to calling clients.

## Code changes

* **src/Api/Controllers/ConfigController.cs:** Constructor expansion to use the feature service and retrieve all flag states.
* **src/Api/Models/Response/ConfigResponseModel.cs:** New "feature states" dictionary. Also tweaks the constructor a bit so it can be deserialized with tests (need a parameterless constructor).
* **src/Core/Constants.cs:** Small helper to get all the keys using reflection, since LaunchDarkly cannot give the keys themselves (and shouldn't).
* **src/Core/Services/IFeatureService.cs:** New method for retrieving all flag states.
* **src/Core/Services/Implementations/LaunchDarklyFeatureService.cs:** LaunchDarkly implementation to retrieve all the keys from our required constants definition and iterate through the values collection to put together a dictionary.
* **test/Api.IntegrationTest/Controllers/ConfigControllerTests.cs:** New integration test class that calls the config endpoint to inspect real results.
* **test/Api.Test/Controllers/ConfigControllerTests.cs:** New unit test with a method checking for the substituted flag states dictionary.
* **test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs:** Existing unit test expansion for the new method that retrievals all flag states.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
