### PR TITLE
SM-609: Block import when any secret's project list is greater than zero

### DIFF
--- a/src/Api/SecretsManager/Controllers/SecretsManagerPortingController.cs
+++ b/src/Api/SecretsManager/Controllers/SecretsManagerPortingController.cs
@@ -61,6 +61,11 @@ public class SecretsManagerPortingController : Controller
             throw new BadRequestException("You cannot import this much data at once, the limit is 1000 projects and 6000 secrets.");
         }
 
+        if (importRequest.Secrets.Any(s => s.ProjectIds.Count() > 1))
+        {
+            throw new BadRequestException("A secret can only be in one project at a time.");
+        }
+
         await _importCommand.ImportAsync(organizationId, importRequest.ToSMImport());
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

A secret should only be able to be in one project. Import was overlooked for this check. This PR fixes that.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **SecretsManagerPortingController.cs:** Check if there is any secret in the import file that is in more than one project

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
