### PR TITLE
Fix build.yml - Update tag generator to not use `beta`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -325,7 +325,7 @@ jobs:
           if [[ "$IMAGE_TAG" == "master" ]]; then
             IMAGE_TAG=dev
           fi
-          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+          echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Setup project name
         id: setup


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Removes logic that tags `rc` and `hotfix-rc` as `beta`.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* *.github/workflows/build.yml:** Removed tagging logic for `beta` tag.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
