### PR TITLE
SM-655: Add Authorizations and Tests for the SM Porting Controller

### DIFF
--- a/src/Api/SecretsManager/Controllers/SecretsManagerPortingController.cs
+++ b/src/Api/SecretsManager/Controllers/SecretsManagerPortingController.cs
@@ -33,7 +33,7 @@ public class SecretsManagerPortingController : Controller
     [HttpGet("sm/{organizationId}/export")]
     public async Task<SMExportResponseModel> Export([FromRoute] Guid organizationId, [FromRoute] string format = "json")
     {
-        if (!await _currentContext.OrganizationAdmin(organizationId))
+        if (!await _currentContext.OrganizationAdmin(organizationId) || !_currentContext.AccessSecretsManager(organizationId))
         {
             throw new NotFoundException();
         }
@@ -53,7 +53,7 @@ public class SecretsManagerPortingController : Controller
     [HttpPost("sm/{organizationId}/import")]
     public async Task Import([FromRoute] Guid organizationId, [FromBody] SMImportRequestModel importRequest)
     {
-        if (!await _currentContext.OrganizationAdmin(organizationId))
+        if (!await _currentContext.OrganizationAdmin(organizationId) || !_currentContext.AccessSecretsManager(organizationId))
         {
             throw new NotFoundException();
         }

--- a/src/Api/SecretsManager/Controllers/SecretsManagerPortingController.cs
+++ b/src/Api/SecretsManager/Controllers/SecretsManagerPortingController.cs
@@ -6,11 +6,13 @@ using Bit.Core.Exceptions;
 using Bit.Core.SecretsManager.Commands.Porting.Interfaces;
 using Bit.Core.SecretsManager.Repositories;
 using Bit.Core.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Bit.Api.SecretsManager.Controllers;
 
 [SecretsManager]
+[Authorize("secrets")]
 public class SecretsManagerPortingController : Controller
 {
     private readonly ISecretRepository _secretRepository;

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/SecretsManagerPortingControllerTest.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/SecretsManagerPortingControllerTest.cs
@@ -1,0 +1,79 @@
+﻿using System.Net;
+using System.Net.Http.Headers;
+using Bit.Api.IntegrationTest.Factories;
+using Bit.Api.SecretsManager.Models.Request;
+using Bit.Core.SecretsManager.Repositories;
+using Xunit;
+
+namespace Bit.Api.IntegrationTest.SecretsManager.Controllers;
+
+public class SecretsManagerPortingControllerTest : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
+{
+    private readonly string _mockEncryptedString =
+        "2.3Uk+WNBIoU5xzmVFNcoWzz==|1MsPIYuRfdOHfu/0uY6H2Q==|/98sp4wb6pHP1VTZ9JcNCYgQjEUMFPlqJgCwRk1YXKg=";
+
+    private readonly HttpClient _client;
+    private readonly ApiApplicationFactory _factory;
+    private readonly IProjectRepository _projectRepository;
+    private readonly IAccessPolicyRepository _accessPolicyRepository;
+
+    private string _email = null!;
+    private SecretsManagerOrganizationHelper _organizationHelper = null!;
+
+    public SecretsManagerPortingControllerTest(ApiApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = _factory.CreateClient();
+        _projectRepository = _factory.GetService<IProjectRepository>();
+        _accessPolicyRepository = _factory.GetService<IAccessPolicyRepository>();
+    }
+
+    public async Task InitializeAsync()
+    {
+        _email = $"integration-test{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(_email);
+        _organizationHelper = new SecretsManagerOrganizationHelper(_factory, _email);
+    }
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private async Task LoginAsync(string email)
+    {
+        var tokens = await _factory.LoginAsync(email);
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.Token);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task Import_SmNotEnabled_NotFound(bool useSecrets, bool accessSecrets)
+    {
+        var (org, _) = await _organizationHelper.Initialize(useSecrets, accessSecrets);
+        await LoginAsync(_email);
+
+        var projectsList = new List<SMImportRequestModel.InnerProjectImportRequestModel>();
+        var secretsList = new List<SMImportRequestModel.InnerSecretImportRequestModel>();
+        var request = new SMImportRequestModel { Projects = projectsList, Secrets = secretsList };
+
+        var response = await _client.PostAsJsonAsync($"sm/{org.Id}/import", request);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task Export_SmNotEnabled_NotFound(bool useSecrets, bool accessSecrets)
+    {
+        var (org, _) = await _organizationHelper.Initialize(useSecrets, accessSecrets);
+        await LoginAsync(_email);
+
+        var response = await _client.GetAsync($"sm/{org.Id}/export");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

- Add the authorize attribute for SM on the SM Porting Controller
- Add a `!_currentContext.AccessSecretsManager(organizationId)` check to import and export endpoints
- Add tests for the SecretsManagerPortingController to catch any future regressions

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
