### PR TITLE
[SM-659] Add to SM integration tests

### DIFF
--- a/src/Api/SecretsManager/Models/Response/AccessTokenResponseModel.cs
+++ b/src/Api/SecretsManager/Models/Response/AccessTokenResponseModel.cs
@@ -5,7 +5,9 @@ namespace Bit.Api.SecretsManager.Models.Response;
 
 public class AccessTokenResponseModel : ResponseModel
 {
-    public AccessTokenResponseModel(ApiKey apiKey, string obj = "accessToken")
+    private const string _objectName = "accessToken";
+
+    public AccessTokenResponseModel(ApiKey apiKey, string obj = _objectName)
         : base(obj)
     {
         Id = apiKey.Id;
@@ -15,6 +17,10 @@ public class AccessTokenResponseModel : ResponseModel
         ExpireAt = apiKey.ExpireAt;
         CreationDate = apiKey.CreationDate;
         RevisionDate = apiKey.RevisionDate;
+    }
+
+    public AccessTokenResponseModel() : base(_objectName)
+    {
     }
 
     public Guid Id { get; set; }

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/ServiceAccountsControllerTests.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/ServiceAccountsControllerTests.cs
@@ -124,6 +124,83 @@ public class ServiceAccountsControllerTest : IClassFixture<ApiApplicationFactory
     [InlineData(false, false)]
     [InlineData(true, false)]
     [InlineData(false, true)]
+    public async Task GetByServiceAccountId_SmNotEnabled_NotFound(bool useSecrets, bool accessSecrets)
+    {
+        var (org, _) = await _organizationHelper.Initialize(useSecrets, accessSecrets);
+        await LoginAsync(_email);
+
+        var serviceAccount = await _serviceAccountRepository.CreateAsync(new ServiceAccount
+        {
+            OrganizationId = org.Id,
+            Name = _mockEncryptedString,
+        });
+
+        var response = await _client.GetAsync($"/service-accounts/{serviceAccount.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetByServiceAccountId_UserWithoutPermission_NotFound()
+    {
+        var (org, _) = await _organizationHelper.Initialize(true, true);
+        var (email, orgUser) = await _organizationHelper.CreateNewUser(OrganizationUserType.User, true);
+        await LoginAsync(email);
+
+        var serviceAccount = await _serviceAccountRepository.CreateAsync(new ServiceAccount
+        {
+            OrganizationId = org.Id,
+            Name = _mockEncryptedString,
+        });
+
+        var response = await _client.GetAsync($"/service-accounts/{serviceAccount.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(PermissionType.RunAsAdmin)]
+    [InlineData(PermissionType.RunAsUserWithPermission)]
+    public async Task GetByServiceAccountId_Success(PermissionType permissionType)
+    {
+        var (org, _) = await _organizationHelper.Initialize(true, true);
+        await LoginAsync(_email);
+
+        var serviceAccount = await _serviceAccountRepository.CreateAsync(new ServiceAccount
+        {
+            OrganizationId = org.Id,
+            Name = _mockEncryptedString,
+        });
+
+        if (permissionType == PermissionType.RunAsUserWithPermission)
+        {
+            var (email, orgUser) = await _organizationHelper.CreateNewUser(OrganizationUserType.User, true);
+            await LoginAsync(email);
+
+            await _accessPolicyRepository.CreateManyAsync(new List<BaseAccessPolicy> {
+                new UserServiceAccountAccessPolicy
+                {
+                    GrantedServiceAccountId = serviceAccount.Id,
+                    OrganizationUserId = orgUser.Id,
+                    Write = true,
+                    Read = true,
+                },
+            });
+        }
+
+        var response = await _client.GetAsync($"/service-accounts/{serviceAccount.Id}");
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<ServiceAccountResponseModel>();
+        Assert.NotNull(result);
+        Assert.Equal(serviceAccount.Id.ToString(), result!.Id);
+        Assert.Equal(serviceAccount.OrganizationId.ToString(), result.OrganizationId);
+        Assert.Equal(serviceAccount.Name, result.Name);
+        Assert.Equal(serviceAccount.CreationDate, result.CreationDate);
+        Assert.Equal(serviceAccount.RevisionDate, result.RevisionDate);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
     public async Task Create_SmNotEnabled_NotFound(bool useSecrets, bool accessSecrets)
     {
         var (org, _) = await _organizationHelper.Initialize(useSecrets, accessSecrets);
@@ -359,6 +436,99 @@ public class ServiceAccountsControllerTest : IClassFixture<ApiApplicationFactory
 
         var sa = await _serviceAccountRepository.GetManyByIds(ids);
         Assert.Empty(sa);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task GetAccessTokens_SmNotEnabled_NotFound(bool useSecrets, bool accessSecrets)
+    {
+        var (org, _) = await _organizationHelper.Initialize(useSecrets, accessSecrets);
+        await LoginAsync(_email);
+
+        var serviceAccount = await _serviceAccountRepository.CreateAsync(new ServiceAccount
+        {
+            OrganizationId = org.Id,
+            Name = _mockEncryptedString,
+        });
+
+        var response = await _client.GetAsync($"/service-accounts/{serviceAccount.Id}/access-tokens");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAccessTokens_UserNoPermission_NotFound()
+    {
+        var (org, _) = await _organizationHelper.Initialize(true, true);
+        var (email, _) = await _organizationHelper.CreateNewUser(OrganizationUserType.User, true);
+        await LoginAsync(email);
+
+        var serviceAccount = await _serviceAccountRepository.CreateAsync(new ServiceAccount
+        {
+            OrganizationId = org.Id,
+            Name = _mockEncryptedString,
+        });
+
+        await _apiKeyRepository.CreateAsync(new ApiKey
+        {
+            ServiceAccountId = serviceAccount.Id,
+            Name = _mockEncryptedString,
+            ExpireAt = DateTime.UtcNow.AddDays(30),
+        });
+
+        var response = await _client.GetAsync($"/service-accounts/{serviceAccount.Id}/access-tokens");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(PermissionType.RunAsAdmin)]
+    [InlineData(PermissionType.RunAsUserWithPermission)]
+    public async Task GetAccessTokens_Success(PermissionType permissionType)
+    {
+        var (org, _) = await _organizationHelper.Initialize(true, true);
+        await LoginAsync(_email);
+
+        var serviceAccount = await _serviceAccountRepository.CreateAsync(new ServiceAccount
+        {
+            OrganizationId = org.Id,
+            Name = _mockEncryptedString,
+        });
+
+        if (permissionType == PermissionType.RunAsUserWithPermission)
+        {
+            var (email, orgUser) = await _organizationHelper.CreateNewUser(OrganizationUserType.User, true);
+            await LoginAsync(email);
+
+            await _accessPolicyRepository.CreateManyAsync(new List<BaseAccessPolicy> {
+                new UserServiceAccountAccessPolicy
+                {
+                    GrantedServiceAccountId = serviceAccount.Id,
+                    OrganizationUserId = orgUser.Id,
+                    Write = true,
+                    Read = true,
+                },
+            });
+        }
+
+        var accessToken = await _apiKeyRepository.CreateAsync(new ApiKey
+        {
+            ServiceAccountId = serviceAccount.Id,
+            Name = _mockEncryptedString,
+            ExpireAt = DateTime.UtcNow.AddDays(30),
+        });
+
+
+        var response = await _client.GetAsync($"/service-accounts/{serviceAccount.Id}/access-tokens");
+        response.EnsureSuccessStatusCode();
+        var results = await response.Content.ReadFromJsonAsync<ListResponseModel<AccessTokenResponseModel>>();
+        Assert.NotEmpty(results!.Data);
+        Assert.Equal(accessToken.Id, results.Data.First().Id);
+        Assert.Equal(accessToken.Name, results.Data.First().Name);
+        Assert.Equal(accessToken.GetScopes(), results.Data.First().Scopes);
+        Assert.Equal(accessToken.ExpireAt, results.Data.First().ExpireAt);
+        Assert.Equal(accessToken.CreationDate, results.Data.First().CreationDate);
+        Assert.Equal(accessToken.RevisionDate, results.Data.First().RevisionDate);
     }
 
     [Theory]
@@ -626,7 +796,7 @@ public class ServiceAccountsControllerTest : IClassFixture<ApiApplicationFactory
 
         var accessToken = await _apiKeyRepository.CreateAsync(new ApiKey
         {
-            ServiceAccountId = org.Id,
+            ServiceAccountId = serviceAccount.Id,
             Name = _mockEncryptedString,
             ExpireAt = DateTime.UtcNow.AddDays(30),
         });


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The purpose of this PR is to add in SM integration tests to the few endpoints that are not currently covered.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- src/Api/SecretsManager/Models/Response/AccessTokenResponseModel.cs

Add in parameterless constructor so we can parse results in integration tests.

- test/Api.IntegrationTest/SecretsManager/Controllers/SecretsControllerTest.cs

Add tests for the `GetSecretsByProject` endpoint.

- test/Api.IntegrationTest/SecretsManager/Controllers/ServiceAccountsControllerTests.cs

Add tests for the `GetByServiceAccountId` and `GetAccessTokens` endpoints

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
