### PR TITLE
Use all organization memberships for LaunchDarkly user context, better separate context kinds

### DIFF
--- a/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
+++ b/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
@@ -109,7 +109,7 @@ public class LaunchDarklyFeatureService : IFeatureService, IDisposable
             var ldUser = LaunchDarkly.Sdk.Context.Builder(currentContext.UserId.Value.ToString());
             ldUser.Kind(LaunchDarkly.Sdk.ContextKind.Default);
 
-            if (currentContext.Organizations != null && currentContext.Organizations.Any())
+            if (currentContext.Organizations?.Any() ?? false)
             {
                 var ldOrgs = currentContext.Organizations.Select(o => LaunchDarkly.Sdk.LdValue.Of(o.Id.ToString()));
                 ldUser.Set("orgs", LaunchDarkly.Sdk.LdValue.ArrayFrom(ldOrgs));

--- a/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
+++ b/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
@@ -112,7 +112,7 @@ public class LaunchDarklyFeatureService : IFeatureService, IDisposable
             if (currentContext.Organizations?.Any() ?? false)
             {
                 var ldOrgs = currentContext.Organizations.Select(o => LaunchDarkly.Sdk.LdValue.Of(o.Id.ToString()));
-                ldUser.Set("orgs", LaunchDarkly.Sdk.LdValue.ArrayFrom(ldOrgs));
+                ldUser.Set("organizations", LaunchDarkly.Sdk.LdValue.ArrayFrom(ldOrgs));
             }
 
             builder.Add(ldUser.Build());
@@ -121,7 +121,7 @@ public class LaunchDarklyFeatureService : IFeatureService, IDisposable
         if (currentContext.OrganizationId.HasValue)
         {
             var ldOrg = LaunchDarkly.Sdk.Context.Builder(currentContext.OrganizationId.Value.ToString());
-            ldOrg.Kind("org");
+            ldOrg.Kind("organization");
             builder.Add(ldOrg.Build());
         }
 

--- a/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
+++ b/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
@@ -106,16 +106,23 @@ public class LaunchDarklyFeatureService : IFeatureService, IDisposable
 
         if (currentContext.UserId.HasValue)
         {
-            var user = LaunchDarkly.Sdk.Context.Builder(currentContext.UserId.Value.ToString());
-            user.Kind(LaunchDarkly.Sdk.ContextKind.Default);
-            builder.Add(user.Build());
+            var ldUser = LaunchDarkly.Sdk.Context.Builder(currentContext.UserId.Value.ToString());
+            ldUser.Kind(LaunchDarkly.Sdk.ContextKind.Default);
+
+            if (currentContext.Organizations != null && currentContext.Organizations.Any())
+            {
+                var ldOrgs = currentContext.Organizations.Select(o => LaunchDarkly.Sdk.LdValue.Of(o.Id.ToString()));
+                ldUser.Set("orgs", LaunchDarkly.Sdk.LdValue.ArrayFrom(ldOrgs));
+            }
+
+            builder.Add(ldUser.Build());
         }
 
         if (currentContext.OrganizationId.HasValue)
         {
-            var org = LaunchDarkly.Sdk.Context.Builder(currentContext.OrganizationId.Value.ToString());
-            org.Kind("org");
-            builder.Add(org.Build());
+            var ldOrg = LaunchDarkly.Sdk.Context.Builder(currentContext.OrganizationId.Value.ToString());
+            ldOrg.Kind("org");
+            builder.Add(ldOrg.Build());
         }
 
         return builder.Build();

--- a/test/Api.IntegrationTest/Controllers/ConfigControllerTests.cs
+++ b/test/Api.IntegrationTest/Controllers/ConfigControllerTests.cs
@@ -69,7 +69,7 @@ public class ConfigControllerTests : IClassFixture<ApiApplicationFactory>, IAsyn
 
         await LoginAsync();
 
-        var response = await _client.GetAsync($"/config");
+        var response = await _client.GetAsync("/config");
         response.EnsureSuccessStatusCode();
         var result = await response.Content.ReadFromJsonAsync<ConfigResponseModel>();
 

--- a/test/Api.IntegrationTest/Controllers/ConfigControllerTests.cs
+++ b/test/Api.IntegrationTest/Controllers/ConfigControllerTests.cs
@@ -43,7 +43,7 @@ public class ConfigControllerTests : IClassFixture<ApiApplicationFactory>, IAsyn
     [Fact]
     public async Task GetConfigs()
     {
-        var response = await _client.GetAsync($"/config");
+        var response = await _client.GetAsync("/config");
         response.EnsureSuccessStatusCode();
         var result = await response.Content.ReadFromJsonAsync<ConfigResponseModel>();
 

--- a/test/Api.IntegrationTest/Controllers/ConfigControllerTests.cs
+++ b/test/Api.IntegrationTest/Controllers/ConfigControllerTests.cs
@@ -1,30 +1,79 @@
 ﻿using System.Net.Http.Headers;
 using Bit.Api.IntegrationTest.Factories;
+using Bit.Api.IntegrationTest.Helpers;
 using Bit.Api.Models.Response;
+using Bit.Core.Entities;
 using Xunit;
 
 namespace Bit.Api.IntegrationTest.Controllers;
 
-public class ConfigControllerTests : IClassFixture<ApiApplicationFactory>
+public class ConfigControllerTests : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
 {
+    private readonly HttpClient _client;
     private readonly ApiApplicationFactory _factory;
 
-    public ConfigControllerTests(ApiApplicationFactory factory) => _factory = factory;
+    private string _email = null!;
+
+    public ConfigControllerTests(ApiApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = _factory.CreateClient();
+    }
+
+    public async Task InitializeAsync()
+    {
+        _email = $"integration-test{Guid.NewGuid()}@bitwarden.com";
+
+        var tokens = await _factory.LoginWithNewAccount(_email);
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.Token);
+    }
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private async Task LoginAsync()
+    {
+        var tokens = await _factory.LoginAsync(_email);
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.Token);
+    }
 
     [Fact]
     public async Task GetConfigs()
     {
-        var tokens = await _factory.LoginWithNewAccount();
-        var client = _factory.CreateClient();
-
-        using var message = new HttpRequestMessage(HttpMethod.Get, "/config");
-        message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokens.Token);
-        var response = await client.SendAsync(message);
-
+        var response = await _client.GetAsync($"/config");
         response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<ConfigResponseModel>();
 
-        var content = await response.Content.ReadFromJsonAsync<ConfigResponseModel>();
+        Assert.NotNull(result);
+        Assert.NotEmpty(result!.Version);
+    }
 
-        Assert.NotEmpty(content!.Version);
+    [Theory]
+    [InlineData(1)]
+    [InlineData(3)]
+    public async Task GetConfigs_WithOrganizations(int orgCount)
+    {
+        for (var i = 0; i < orgCount; i++)
+        {
+            var ownerEmail = $"integration-test{Guid.NewGuid()}@bitwarden.com";
+            await _factory.LoginWithNewAccount(ownerEmail);
+
+            Organization org;
+            (org, _) = await OrganizationTestHelpers.SignUpAsync(_factory, plan: Core.Enums.PlanType.Free, ownerEmail: ownerEmail,
+                name: i.ToString(), billingEmail: ownerEmail, ownerKey: i.ToString());
+            await OrganizationTestHelpers.CreateUserAsync(_factory, org.Id, _email, Core.Enums.OrganizationUserType.User);
+        }
+
+        await LoginAsync();
+
+        var response = await _client.GetAsync($"/config");
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<ConfigResponseModel>();
+
+        Assert.NotNull(result);
+        Assert.NotEmpty(result!.Version);
     }
 }


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Keep the organization API context separate from the user's organization memberships. Provides a collection of organization IDs as an attribute under the user context. The organization context is maintained in parallel as well as a new context for service accounts, with accurate attributes for each.

## Code changes

* **src/Core/Services/Implementations/LaunchDarklyFeatureService.cs:** Enumeration of the organization IDs to provide to LaunchDarkly in context, along with some minor renaming for readability.
* **test/Api.IntegrationTest/Controllers/ConfigControllerTests.cs:** Expansion to the API integration tests to exercise organization-specific context. Picks up some better usage of common classes overall and creates organizations before acting as a member user in a new theory test.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
