### PR TITLE
[PM-1506] fix: mssql error when running docker compose

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   mssql:
     image: mcr.microsoft.com/azure-sql-edge:latest
     environment:
-      ACCEPT_EULA: Y
+      ACCEPT_EULA: "Y"
       MSSQL_SA_PASSWORD: ${MSSQL_PASSWORD}
       MSSQL_PID: Developer
     volumes:
@@ -13,15 +13,15 @@ services:
       - ./helpers/mssql:/mnt/helpers
       - ./.data/mssql:/mnt/data
     ports:
-      - '1433:1433'
+      - "1433:1433"
     profiles:
       - cloud
       - mssql
-  
+
   storage:
     image: mcr.microsoft.com/azure-storage/azurite:latest
-    ports: 
-      - "10000:10000" 
+    ports:
+      - "10000:10000"
       - "10001:10001"
       - "10002:10002"
     volumes:
@@ -29,18 +29,18 @@ services:
     profiles:
       - storage
       - cloud
-  
+
   mail:
     image: sj26/mailcatcher:latest
-    ports: 
-      - "${MAILCATCHER_PORT}:1080" 
+    ports:
+      - "${MAILCATCHER_PORT}:1080"
       - "10250:1025"
     profiles:
       - mail
 
   postgres:
     image: postgres:14
-    ports: 
+    ports:
       - "5432:5432"
     environment:
       POSTGRES_DB: vault_dev
@@ -56,7 +56,7 @@ services:
   mysql:
     image: mysql:8
     container_name: bw-mysql
-    ports: 
+    ports:
       - "3306:3306"
     command: --default-authentication-plugin=mysql_native_password
     environment:
@@ -90,19 +90,19 @@ services:
     volumes:
       - ./directory.ldif:/container/service/slapd/assets/config/bootstrap/ldif/output.ldif
     ports:
-      - '389:389'
-      - '636:636'
+      - "389:389"
+      - "636:636"
     profiles:
       - ldap
-  
+
   reverse-proxy:
     image: nginx:alpine
     container_name: reverse-proxy
     volumes:
       - "./reverse-proxy.conf:/etc/nginx/conf.d/default.conf"
-    ports: 
-      - "${API_PROXY_PORT}:${API_PROXY_PORT}" 
-      - "${IDENTITY_PROXY_PORT}:${IDENTITY_PROXY_PORT}" 
+    ports:
+      - "${API_PROXY_PORT}:${API_PROXY_PORT}"
+      - "${IDENTITY_PROXY_PORT}:${IDENTITY_PROXY_PORT}"
     profiles:
       - proxy
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```


## Objective

Fixes the error message, "services.mssql.environment.ACCEPT_EULA must be a string, number or null" when running `docker compose --profile mssql --profile mail up -d` during [initial dev setup](https://contributing.bitwarden.com/getting-started/server/guide/#configure-docker) on MacOS.



## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **dev/docker-compose.yml:** Changed `ACCEPT_EULA` from `Y` to `"Y"`. There are also some auto-formatting changes that removed trailing whitespace and made all quotes consistently double quotes.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
