### PR TITLE
fix: Use camel case for docker default network

### DIFF
--- a/dev/migrate.ps1
+++ b/dev/migrate.ps1
@@ -41,7 +41,7 @@ if ($all -or $mssql) {
     -v "$(pwd)/../util/Migrator:/mnt/migrator/" `
     -v "$(pwd)/.data/mssql:/mnt/data" `
     --env-file .env `
-    --network=bitwardenserver_default `
+    --network=BitwardenServer_default `
     --rm `
     mcr.microsoft.com/mssql-tools `
     /mnt/helpers/run_migrations.sh $migrationArgs


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Running the `pwsh migrate.ps1` command from the [server setup guide](https://contributing.bitwarden.com/getting-started/server/guide/#create-database) resulted in the following error on MacOS (Docker Desktop v3.5.1.7): `docker: Error response from daemon: network bitwardenserver_default not found`. I did `docker network ls` and saw the value was `BitwardenServer_default`. This change updates the migration script to use that value.




## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **dev/migrate.ps1:** Change Docker network value to `BitwardenServer_default`

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
