### PR TITLE
SM-662: Make Test Class Names Plural

### DIFF
--- a/test/Api.IntegrationTest/SecretsManager/Controllers/AccessPoliciesControllerTests.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/AccessPoliciesControllerTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Bit.Api.IntegrationTest.SecretsManager.Controllers;
 
-public class AccessPoliciesControllerTest : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
+public class AccessPoliciesControllerTests : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
 {
     private const string _mockEncryptedString =
         "2.3Uk+WNBIoU5xzmVFNcoWzz==|1MsPIYuRfdOHfu/0uY6H2Q==|/98sp4wb6pHP1VTZ9JcNCYgQjEUMFPlqJgCwRk1YXKg=";
@@ -27,7 +27,7 @@ public class AccessPoliciesControllerTest : IClassFixture<ApiApplicationFactory>
     private string _email = null!;
     private SecretsManagerOrganizationHelper _organizationHelper = null!;
 
-    public AccessPoliciesControllerTest(ApiApplicationFactory factory)
+    public AccessPoliciesControllerTests(ApiApplicationFactory factory)
     {
         _factory = factory;
         _client = _factory.CreateClient();

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/ProjectsControllerTests.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/ProjectsControllerTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Bit.Api.IntegrationTest.SecretsManager.Controllers;
 
-public class ProjectsControllerTest : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
+public class ProjectsControllerTests : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
 {
     private readonly string _mockEncryptedString =
         "2.3Uk+WNBIoU5xzmVFNcoWzz==|1MsPIYuRfdOHfu/0uY6H2Q==|/98sp4wb6pHP1VTZ9JcNCYgQjEUMFPlqJgCwRk1YXKg=";
@@ -27,7 +27,7 @@ public class ProjectsControllerTest : IClassFixture<ApiApplicationFactory>, IAsy
     private string _email = null!;
     private SecretsManagerOrganizationHelper _organizationHelper = null!;
 
-    public ProjectsControllerTest(ApiApplicationFactory factory)
+    public ProjectsControllerTests(ApiApplicationFactory factory)
     {
         _factory = factory;
         _client = _factory.CreateClient();

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/SecretsControllerTests.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/SecretsControllerTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Bit.Api.IntegrationTest.SecretsManager.Controllers;
 
-public class SecretsControllerTest : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
+public class SecretsControllerTests : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
 {
     private readonly string _mockEncryptedString =
         "2.3Uk+WNBIoU5xzmVFNcoWzz==|1MsPIYuRfdOHfu/0uY6H2Q==|/98sp4wb6pHP1VTZ9JcNCYgQjEUMFPlqJgCwRk1YXKg=";
@@ -27,7 +27,7 @@ public class SecretsControllerTest : IClassFixture<ApiApplicationFactory>, IAsyn
     private string _email = null!;
     private SecretsManagerOrganizationHelper _organizationHelper = null!;
 
-    public SecretsControllerTest(ApiApplicationFactory factory)
+    public SecretsControllerTests(ApiApplicationFactory factory)
     {
         _factory = factory;
         _client = _factory.CreateClient();

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/SecretsManagerPortingControllerTests.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/SecretsManagerPortingControllerTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Bit.Api.IntegrationTest.SecretsManager.Controllers;
 
-public class SecretsManagerPortingControllerTest : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
+public class SecretsManagerPortingControllerTests : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
 {
     private readonly string _mockEncryptedString =
         "2.3Uk+WNBIoU5xzmVFNcoWzz==|1MsPIYuRfdOHfu/0uY6H2Q==|/98sp4wb6pHP1VTZ9JcNCYgQjEUMFPlqJgCwRk1YXKg=";
@@ -20,7 +20,7 @@ public class SecretsManagerPortingControllerTest : IClassFixture<ApiApplicationF
     private string _email = null!;
     private SecretsManagerOrganizationHelper _organizationHelper = null!;
 
-    public SecretsManagerPortingControllerTest(ApiApplicationFactory factory)
+    public SecretsManagerPortingControllerTests(ApiApplicationFactory factory)
     {
         _factory = factory;
         _client = _factory.CreateClient();

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/SecretsTrashControllerTests.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/SecretsTrashControllerTests.cs
@@ -9,7 +9,7 @@ using Secret = Bit.Core.SecretsManager.Entities.Secret;
 
 namespace Bit.Api.IntegrationTest.SecretsManager.Controllers;
 
-public class SecretsTrashControllerTest : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
+public class SecretsTrashControllerTests : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
 {
     private readonly string _mockEncryptedString =
         "2.3Uk+WNBIoU5xzmVFNcoWzz==|1MsPIYuRfdOHfu/0uY6H2Q==|/98sp4wb6pHP1VTZ9JcNCYgQjEUMFPlqJgCwRk1YXKg=";
@@ -21,7 +21,7 @@ public class SecretsTrashControllerTest : IClassFixture<ApiApplicationFactory>, 
     private string _email = null!;
     private SecretsManagerOrganizationHelper _organizationHelper = null!;
 
-    public SecretsTrashControllerTest(ApiApplicationFactory factory)
+    public SecretsTrashControllerTests(ApiApplicationFactory factory)
     {
         _factory = factory;
         _client = _factory.CreateClient();

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/ServiceAccountsControllerTests.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/ServiceAccountsControllerTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Bit.Api.IntegrationTest.SecretsManager.Controllers;
 
-public class ServiceAccountsControllerTest : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
+public class ServiceAccountsControllerTests : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
 {
     private const string _mockEncryptedString =
         "2.3Uk+WNBIoU5xzmVFNcoWzz==|1MsPIYuRfdOHfu/0uY6H2Q==|/98sp4wb6pHP1VTZ9JcNCYgQjEUMFPlqJgCwRk1YXKg=";
@@ -32,7 +32,7 @@ public class ServiceAccountsControllerTest : IClassFixture<ApiApplicationFactory
     private string _email = null!;
     private SecretsManagerOrganizationHelper _organizationHelper = null!;
 
-    public ServiceAccountsControllerTest(ApiApplicationFactory factory)
+    public ServiceAccountsControllerTests(ApiApplicationFactory factory)
     {
         _factory = factory;
         _client = _factory.CreateClient();


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

For some reason, in `Api.IntegrationTest/SecretsManager/Controllers` our class names for tests are singular despite containing multiple tests. This is inconsistent with the Controller tests in `Api.Test`. This PR makes the test class names plural.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
