### PR TITLE
Provide anonymous user context for unauthenticated requests using LaunchDarkly

### DIFF
--- a/test/Api.IntegrationTest/Controllers/ConfigControllerTests.cs
+++ b/test/Api.IntegrationTest/Controllers/ConfigControllerTests.cs
@@ -41,8 +41,23 @@ public class ConfigControllerTests : IClassFixture<ApiApplicationFactory>, IAsyn
     }
 
     [Fact]
-    public async Task GetConfigs()
+    public async Task GetConfigs_Unauthenticated()
     {
+        _client.DefaultRequestHeaders.Authorization = null;
+
+        var response = await _client.GetAsync("/config");
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<ConfigResponseModel>();
+
+        Assert.NotNull(result);
+        Assert.NotEmpty(result!.Version);
+    }
+
+    [Fact]
+    public async Task GetConfigs_Authenticated()
+    {
+        await LoginAsync();
+
         var response = await _client.GetAsync("/config");
         response.EnsureSuccessStatusCode();
         var result = await response.Content.ReadFromJsonAsync<ConfigResponseModel>();


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Resolves a bug with the use case of an authenticated request asking for LaunchDarkly context. In https://github.com/bitwarden/server/pull/2807 some assumptions were made on context availability but a user ID may not be available. Instead -- and per [documentation](https://docs.launchdarkly.com/home/contexts/anonymous-contexts) -- group anonymous requests to one shared key and mark it as anonymous; context must be available in all requests to LaunchDarkly.

## Code changes

* **src/Core/Services/Implementations/LaunchDarklyFeatureService.cs:** New constant for anonymous users (that will never be referenced) that's used in context when unauthenticated, as well as additional safety checks.
* **test/Api.IntegrationTest/Controllers/ConfigControllerTests.cs:** Separation of authenticated vs. unauthenticated user tests that are in part why this was missed.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
