### PR TITLE
[SM-677] Match access policy creation responses

### DIFF
--- a/src/Api/SecretsManager/Controllers/AccessPoliciesController.cs
+++ b/src/Api/SecretsManager/Controllers/AccessPoliciesController.cs
@@ -72,8 +72,7 @@ public class AccessPoliciesController : Controller
 
         var (accessClient, userId) = await GetAccessClientTypeAsync(project.OrganizationId);
         var policies = request.ToBaseAccessPoliciesForProject(id);
-        await _createAccessPoliciesCommand.CreateManyAsync(policies, userId, accessClient);
-        var results = await _accessPolicyRepository.GetManyByGrantedProjectIdAsync(id, userId);
+        var results = await _createAccessPoliciesCommand.CreateManyAsync(policies, userId, accessClient);
         return new ProjectAccessPoliciesResponseModel(results);
     }
 
@@ -104,8 +103,7 @@ public class AccessPoliciesController : Controller
 
         var (accessClient, userId) = await GetAccessClientTypeAsync(serviceAccount.OrganizationId);
         var policies = request.ToBaseAccessPoliciesForServiceAccount(id);
-        await _createAccessPoliciesCommand.CreateManyAsync(policies, userId, accessClient);
-        var results = await _accessPolicyRepository.GetManyByGrantedServiceAccountIdAsync(id, userId);
+        var results = await _createAccessPoliciesCommand.CreateManyAsync(policies, userId, accessClient);
         return new ServiceAccountAccessPoliciesResponseModel(results);
     }
 
@@ -117,23 +115,6 @@ public class AccessPoliciesController : Controller
         var (_, userId) = await CheckUserHasWriteAccessToServiceAccountAsync(serviceAccount);
         var results = await _accessPolicyRepository.GetManyByGrantedServiceAccountIdAsync(id, userId);
         return new ServiceAccountAccessPoliciesResponseModel(results);
-    }
-
-    [HttpGet("/service-accounts/{id}/granted-policies")]
-    public async Task<ListResponseModel<ServiceAccountProjectAccessPolicyResponseModel>>
-        GetServiceAccountGrantedPoliciesAsync([FromRoute] Guid id)
-    {
-        var serviceAccount = await _serviceAccountRepository.GetByIdAsync(id);
-        if (serviceAccount == null)
-        {
-            throw new NotFoundException();
-        }
-
-        var (accessClient, userId) = await GetAccessClientTypeAsync(serviceAccount.OrganizationId);
-        var results = await _accessPolicyRepository.GetManyByServiceAccountIdAsync(id, userId, accessClient);
-        var responses = results.Select(ap =>
-            new ServiceAccountProjectAccessPolicyResponseModel((ServiceAccountProjectAccessPolicy)ap));
-        return new ListResponseModel<ServiceAccountProjectAccessPolicyResponseModel>(responses);
     }
 
     [HttpPost("/service-accounts/{id}/granted-policies")]
@@ -155,7 +136,25 @@ public class AccessPoliciesController : Controller
         var (accessClient, userId) = await GetAccessClientTypeAsync(serviceAccount.OrganizationId);
         var policies = requests.Select(request => request.ToServiceAccountProjectAccessPolicy(id));
         var results =
-            await _createAccessPoliciesCommand.CreateManyAsync(new List<BaseAccessPolicy>(policies), userId, accessClient);
+            await _createAccessPoliciesCommand.CreateManyAsync(new List<BaseAccessPolicy>(policies), userId,
+                accessClient);
+        var responses = results.Select(ap =>
+            new ServiceAccountProjectAccessPolicyResponseModel((ServiceAccountProjectAccessPolicy)ap));
+        return new ListResponseModel<ServiceAccountProjectAccessPolicyResponseModel>(responses);
+    }
+
+    [HttpGet("/service-accounts/{id}/granted-policies")]
+    public async Task<ListResponseModel<ServiceAccountProjectAccessPolicyResponseModel>>
+        GetServiceAccountGrantedPoliciesAsync([FromRoute] Guid id)
+    {
+        var serviceAccount = await _serviceAccountRepository.GetByIdAsync(id);
+        if (serviceAccount == null)
+        {
+            throw new NotFoundException();
+        }
+
+        var (accessClient, userId) = await GetAccessClientTypeAsync(serviceAccount.OrganizationId);
+        var results = await _accessPolicyRepository.GetManyByServiceAccountIdAsync(id, userId, accessClient);
         var responses = results.Select(ap =>
             new ServiceAccountProjectAccessPolicyResponseModel((ServiceAccountProjectAccessPolicy)ap));
         return new ListResponseModel<ServiceAccountProjectAccessPolicyResponseModel>(responses);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The purpose of this PR is to have all the access policy creation endpoints return only the newly created access policies.

Since the client no longer requires a full view to be returned on creation, it will be more efficient to just return the newly created policies.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* src/Api/SecretsManager/Controllers/AccessPoliciesController.cs

`CreateProjectAccessPoliciesAsync` swapping to only returning the newly created policies.

`CreateServiceAccountAccessPoliciesAsync` swapping to only returning the newly created policies.

`[HttpPost("/service-accounts/{id}/granted-policies")]`
`[HttpGet("/service-accounts/{id}/granted-policies")]`

Swapped the ordering, so the creation is first to match other endpoint ordering. 
The creation already only returned newly created access policies.


## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
