### PR TITLE
[AC-1255] Search Existing Organizations by partial Email

### DIFF
--- a/src/Admin/Views/Providers/AddExistingOrganization.cshtml
+++ b/src/Admin/Views/Providers/AddExistingOrganization.cshtml
@@ -14,7 +14,7 @@
             <label class="sr-only" asp-for="OrganizationName"></label>
             <input type="text" class="form-control mb-2 mr-2 flex-fill" placeholder="@Html.DisplayNameFor(m => m.OrganizationName)" asp-for="OrganizationName" name="name">
             <label class="sr-only" asp-for="OrganizationOwnerEmail"></label>
-            <input type="email" class="form-control mb-2 mr-2 flex-fill" placeholder="@Html.DisplayNameFor(m => m.OrganizationOwnerEmail)" asp-for="OrganizationOwnerEmail" name="ownerEmail">
+            <input pattern="^\w+([\.-]?\w+)*@@\w+([\.-]?\w+)*(\.\w{2,3})+$" type="email" class="form-control mb-2 mr-2 flex-fill" placeholder="@Html.DisplayNameFor(m => m.OrganizationOwnerEmail)" asp-for="OrganizationOwnerEmail" name="ownerEmail">
             <button type="submit" class="btn btn-primary mb-2" title="Search" formmethod="get"><i class="fa fa-search"></i> Search</button>
         </form>
     </div>

--- a/src/Admin/Views/Providers/AddExistingOrganization.cshtml
+++ b/src/Admin/Views/Providers/AddExistingOrganization.cshtml
@@ -14,7 +14,7 @@
             <label class="sr-only" asp-for="OrganizationName"></label>
             <input type="text" class="form-control mb-2 mr-2 flex-fill" placeholder="@Html.DisplayNameFor(m => m.OrganizationName)" asp-for="OrganizationName" name="name">
             <label class="sr-only" asp-for="OrganizationOwnerEmail"></label>
-            <input pattern="^\w+([\.-]?\w+)*@@\w+([\.-]?\w+)*(\.\w{2,3})+$" type="email" class="form-control mb-2 mr-2 flex-fill" placeholder="@Html.DisplayNameFor(m => m.OrganizationOwnerEmail)" asp-for="OrganizationOwnerEmail" name="ownerEmail">
+            <input type="email" class="form-control mb-2 mr-2 flex-fill" placeholder="@Html.DisplayNameFor(m => m.OrganizationOwnerEmail)" asp-for="OrganizationOwnerEmail" name="ownerEmail">
             <button type="submit" class="btn btn-primary mb-2" title="Search" formmethod="get"><i class="fa fa-search"></i> Search</button>
         </form>
     </div>

--- a/src/Sql/dbo/Stored Procedures/Organization_UnassignedToProviderSearch.sql
+++ b/src/Sql/dbo/Stored Procedures/Organization_UnassignedToProviderSearch.sql
@@ -8,7 +8,8 @@ AS
 BEGIN
     SET NOCOUNT ON
     DECLARE @NameLikeSearch NVARCHAR(55) = '%' + @Name + '%'
-
+    DECLARE @OwnerLikeSearch NVARCHAR(55) = @OwnerEmail + '%'
+        
     IF @OwnerEmail IS NOT NULL
     BEGIN
         SELECT
@@ -23,7 +24,7 @@ BEGIN
             O.[PlanType] >= 8 AND O.[PlanType] <= 11 -- Get 'Team' and 'Enterprise' Organizations
             AND NOT EXISTS (SELECT * FROM [dbo].[ProviderOrganizationView] PO WHERE PO.[OrganizationId] = O.[Id])
             AND (@Name IS NULL OR O.[Name] LIKE @NameLikeSearch)
-            AND (U.[Email] = @OwnerEmail)
+            AND (U.[Email] LIKE @OwnerLikeSearch)
         ORDER BY O.[CreationDate] DESC
         OFFSET @Skip ROWS
         FETCH NEXT @Take ROWS ONLY

--- a/util/Migrator/DbScripts/2023-03-22_00_ProviderAddExistingOrganizations.sql
+++ b/util/Migrator/DbScripts/2023-03-22_00_ProviderAddExistingOrganizations.sql
@@ -15,6 +15,7 @@ AS
 BEGIN
     SET NOCOUNT ON
     DECLARE @NameLikeSearch NVARCHAR(55) = '%' + @Name + '%'
+    DECLARE @OwnerLikeSearch NVARCHAR(55) = @OwnerEmail + '%'
 
     IF @OwnerEmail IS NOT NULL
     BEGIN
@@ -30,7 +31,7 @@ BEGIN
             O.[PlanType] >= 8 AND O.[PlanType] <= 11 -- Get 'Team' and 'Enterprise' Organizations
             AND NOT EXISTS (SELECT * FROM [dbo].[ProviderOrganizationView] PO WHERE PO.[OrganizationId] = O.[Id])
             AND (@Name IS NULL OR O.[Name] LIKE @NameLikeSearch)
-            AND (U.[Email] = @OwnerEmail)
+            AND (U.[Email] LIKE @OwnerLikeSearch)
         ORDER BY O.[CreationDate] DESC
         OFFSET @Skip ROWS
         FETCH NEXT @Take ROWS ONLY


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Add input validation for the email search field on the "Add Existing Organization" view.


## Code changes

* **src/Infrastructure.EntityFramework/Repositories/OrganizationRepository.cs:** Changed query to search Email using substring. Added specific query for Postgres database
* **src/Sql/dbo/Stored Procedures/Organization_UnassignedToProviderSearch.sql:** Modified SQL query to search using LIKE
* **util/Migrator/DbScripts/2023-03-22_00_ProviderAddExistingOrganizations.sql:** Updated script for data migration


## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
