### PR TITLE
[AC-1252] Org identifier not skipped for verified domain

### DIFF
--- a/src/Api/Models/Response/Organizations/OrganizationDomainSsoDetailsResponseModel.cs
+++ b/src/Api/Models/Response/Organizations/OrganizationDomainSsoDetailsResponseModel.cs
@@ -16,13 +16,11 @@ public class OrganizationDomainSsoDetailsResponseModel : ResponseModel
         SsoAvailable = data.SsoAvailable;
         DomainName = data.DomainName;
         OrganizationIdentifier = data.OrganizationIdentifier;
-        SsoRequired = data.SsoRequired;
         VerifiedDate = data.VerifiedDate;
     }
 
     public bool SsoAvailable { get; private set; }
     public string DomainName { get; private set; }
     public string OrganizationIdentifier { get; private set; }
-    public bool SsoRequired { get; private set; }
     public DateTime? VerifiedDate { get; private set; }
 }

--- a/src/Core/Models/Data/Organizations/OrganizationDomainSsoDetailsData.cs
+++ b/src/Core/Models/Data/Organizations/OrganizationDomainSsoDetailsData.cs
@@ -1,6 +1,4 @@
-﻿using Bit.Core.Enums;
-
-namespace Bit.Core.Models.Data.Organizations;
+﻿namespace Bit.Core.Models.Data.Organizations;
 
 public class OrganizationDomainSsoDetailsData
 {
@@ -9,8 +7,6 @@ public class OrganizationDomainSsoDetailsData
     public string DomainName { get; set; }
     public bool SsoAvailable { get; set; }
     public string OrganizationIdentifier { get; set; }
-    public bool SsoRequired { get; set; }
-    public PolicyType? PolicyType { get; set; }
     public DateTime? VerifiedDate { get; set; }
     public bool OrganizationEnabled { get; set; }
 }

--- a/src/Infrastructure.EntityFramework/Repositories/OrganizationDomainRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/OrganizationDomainRepository.cs
@@ -1,6 +1,5 @@
 ﻿using System.Net.Mail;
 using AutoMapper;
-using Bit.Core.Enums;
 using Bit.Core.Models.Data.Organizations;
 using Bit.Core.Repositories;
 using Bit.Infrastructure.EntityFramework.Models;
@@ -78,19 +77,14 @@ public class OrganizationDomainRepository : Repository<Core.Entities.Organizatio
                                 from od in o.Domains
                                 join s in dbContext.SsoConfigs on o.Id equals s.OrganizationId into sJoin
                                 from s in sJoin.DefaultIfEmpty()
-                                join p in dbContext.Policies.Where(p => p.Type == PolicyType.RequireSso) on o.Id
-                                    equals p.OrganizationId into pJoin
-                                from p in pJoin.DefaultIfEmpty()
                                 where od.DomainName == domainName && o.Enabled
                                 select new OrganizationDomainSsoDetailsData
                                 {
                                     OrganizationId = o.Id,
                                     OrganizationName = o.Name,
                                     SsoAvailable = o.SsoConfigs.Any(sc => sc.Enabled),
-                                    SsoRequired = p != null && p.Enabled,
                                     OrganizationIdentifier = o.Identifier,
                                     VerifiedDate = od.VerifiedDate,
-                                    PolicyType = p.Type,
                                     DomainName = od.DomainName
                                 })
             .AsNoTracking()

--- a/src/Sql/dbo/Stored Procedures/OrganizationDomainSsoDetails_ReadByEmail.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationDomainSsoDetails_ReadByEmail.sql
@@ -12,20 +12,15 @@ BEGIN
         O.Id AS OrganizationId,
         O.[Name] AS OrganizationName,
         S.Enabled AS SsoAvailable,
-        P.Enabled AS SsoRequired,
         O.Identifier AS OrganizationIdentifier,
         OD.VerifiedDate,
-        P.[Type] AS PolicyType,
         OD.DomainName
     FROM
         [dbo].[OrganizationView] O
     INNER JOIN [dbo].[OrganizationDomainView] OD
         ON O.Id = OD.OrganizationId
-    LEFT JOIN [dbo].[PolicyView] P
-        ON O.Id = P.OrganizationId
     LEFT JOIN [dbo].[Ssoconfig] S
         ON O.Id = S.OrganizationId
     WHERE OD.DomainName = @Domain
     AND O.Enabled = 1
-    AND (P.Id is NULL OR (P.Id IS NOT NULL AND P.[Type] = 4)) -- SSO Type
 END    

--- a/util/Migrator/DbScripts/2023-03-30_00_RemovePolicyCheckOrganizationDomainSsoDetais.sql
+++ b/util/Migrator/DbScripts/2023-03-30_00_RemovePolicyCheckOrganizationDomainSsoDetais.sql
@@ -1,0 +1,26 @@
+CREATE OR ALTER PROCEDURE [dbo].[OrganizationDomainSsoDetails_ReadByEmail]
+    @Email NVARCHAR(256)
+AS
+BEGIN
+    SET NOCOUNT ON
+        
+    DECLARE @Domain NVARCHAR(256)
+
+SELECT @Domain = SUBSTRING(@Email, CHARINDEX( '@', @Email) + 1, LEN(@Email))
+
+SELECT
+    O.Id AS OrganizationId,
+    O.[Name] AS OrganizationName,
+    S.Enabled AS SsoAvailable,
+    O.Identifier AS OrganizationIdentifier,
+    OD.VerifiedDate,
+    OD.DomainName
+FROM
+    [dbo].[OrganizationView] O
+INNER JOIN [dbo].[OrganizationDomainView] OD
+    ON O.Id = OD.OrganizationId
+LEFT JOIN [dbo].[Ssoconfig] S
+    ON O.Id = S.OrganizationId
+WHERE OD.DomainName = @Domain
+  AND O.Enabled = 1
+END    


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Organizations with only verified domains cannot skip the `org identifier` because there is an additional check to ensure only organizations with the `SsoRequired` policy can skip that step. This is no longer required, and organizations with certified domains should be able to skip the `org identifier` step.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

I modified the `OrganizationDomainSsoDetails_ReadByEmail` procedure to remove the join on the `Policy` view and the extra condition to allow only `Policy Type` 4 when a policy exists for the organization.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
