### PR TITLE
[AC-1214] ExternalId field unmodifiable for users and groups after org vault refresh

### DIFF
--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -146,7 +146,7 @@ public class OrganizationUsersController : Controller
 
         var userId = _userService.GetProperUserId(User);
         var result = await _organizationService.InviteUsersAsync(orgGuidId, userId.Value,
-            new (OrganizationUserInvite, string)[] { (new OrganizationUserInvite(model.ToData()), null) });
+            new (OrganizationUserInvite, string)[] { (new OrganizationUserInvite(model.ToData()), model.ExternalId) });
     }
 
     [HttpPost("reinvite")]

--- a/src/Api/Models/Request/GroupRequestModel.cs
+++ b/src/Api/Models/Request/GroupRequestModel.cs
@@ -10,6 +10,8 @@ public class GroupRequestModel
     public string Name { get; set; }
     [Required]
     public bool? AccessAll { get; set; }
+    [StringLength(300)]
+    public string ExternalId { get; set; }
     public IEnumerable<SelectionReadOnlyRequestModel> Collections { get; set; }
     public IEnumerable<Guid> Users { get; set; }
 
@@ -25,6 +27,7 @@ public class GroupRequestModel
     {
         existingGroup.Name = Name;
         existingGroup.AccessAll = AccessAll.Value;
+        existingGroup.ExternalId = ExternalId;
         return existingGroup;
     }
 }

--- a/src/Api/Models/Request/Organizations/OrganizationUserRequestModels.cs
+++ b/src/Api/Models/Request/Organizations/OrganizationUserRequestModels.cs
@@ -18,6 +18,7 @@ public class OrganizationUserInviteRequestModel
     public OrganizationUserType? Type { get; set; }
     public bool AccessAll { get; set; }
     public bool AccessSecretsManager { get; set; }
+    public string ExternalId { get; set; }
     public Permissions Permissions { get; set; }
     public IEnumerable<SelectionReadOnlyRequestModel> Collections { get; set; }
     public IEnumerable<Guid> Groups { get; set; }
@@ -30,6 +31,7 @@ public class OrganizationUserInviteRequestModel
             Type = Type,
             AccessAll = AccessAll,
             AccessSecretsManager = AccessSecretsManager,
+            ExternalId = ExternalId,
             Collections = Collections?.Select(c => c.ToSelectionReadOnly()),
             Groups = Groups,
             Permissions = Permissions,
@@ -76,6 +78,7 @@ public class OrganizationUserUpdateRequestModel
     public OrganizationUserType? Type { get; set; }
     public bool AccessAll { get; set; }
     public bool AccessSecretsManager { get; set; }
+    public string ExternalId { get; set; }
     public Permissions Permissions { get; set; }
     public IEnumerable<SelectionReadOnlyRequestModel> Collections { get; set; }
     public IEnumerable<Guid> Groups { get; set; }
@@ -89,6 +92,7 @@ public class OrganizationUserUpdateRequestModel
         });
         existingUser.AccessAll = AccessAll;
         existingUser.AccessSecretsManager = AccessSecretsManager;
+        existingUser.ExternalId = ExternalId;
         return existingUser;
     }
 }

--- a/src/Core/Models/Data/Organizations/OrganizationUsers/OrganizationUserInviteData.cs
+++ b/src/Core/Models/Data/Organizations/OrganizationUsers/OrganizationUserInviteData.cs
@@ -8,6 +8,7 @@ public class OrganizationUserInviteData
     public OrganizationUserType? Type { get; set; }
     public bool AccessAll { get; set; }
     public bool AccessSecretsManager { get; set; }
+    public string ExternalId { get; set; }
     public IEnumerable<CollectionAccessSelection> Collections { get; set; }
     public IEnumerable<Guid> Groups { get; set; }
     public Permissions Permissions { get; set; }

--- a/test/Api.Test/Controllers/GroupsControllerTests.cs
+++ b/test/Api.Test/Controllers/GroupsControllerTests.cs
@@ -29,7 +29,7 @@ public class GroupsControllerTests
         await sutProvider.GetDependency<ICreateGroupCommand>().Received(1).CreateGroupAsync(
             Arg.Is<Group>(g =>
                 g.OrganizationId == organization.Id && g.Name == groupRequestModel.Name &&
-                g.AccessAll == groupRequestModel.AccessAll),
+                g.AccessAll == groupRequestModel.AccessAll && g.ExternalId == groupRequestModel.ExternalId),
             organization,
             Arg.Any<IEnumerable<CollectionAccessSelection>>(),
             Arg.Any<IEnumerable<Guid>>());
@@ -38,6 +38,7 @@ public class GroupsControllerTests
         Assert.Equal(groupRequestModel.Name, response.Name);
         Assert.Equal(organization.Id.ToString(), response.OrganizationId);
         Assert.Equal(groupRequestModel.AccessAll, response.AccessAll);
+        Assert.Equal(groupRequestModel.ExternalId, response.ExternalId);
     }
 
     [Theory]
@@ -56,7 +57,7 @@ public class GroupsControllerTests
         await sutProvider.GetDependency<IUpdateGroupCommand>().Received(1).UpdateGroupAsync(
             Arg.Is<Group>(g =>
                 g.OrganizationId == organization.Id && g.Name == groupRequestModel.Name &&
-                g.AccessAll == groupRequestModel.AccessAll),
+                g.AccessAll == groupRequestModel.AccessAll && g.ExternalId == groupRequestModel.ExternalId),
             Arg.Is<Organization>(o => o.Id == organization.Id),
             Arg.Any<IEnumerable<CollectionAccessSelection>>(),
             Arg.Any<IEnumerable<Guid>>());
@@ -65,5 +66,6 @@ public class GroupsControllerTests
         Assert.Equal(groupRequestModel.Name, response.Name);
         Assert.Equal(organization.Id.ToString(), response.OrganizationId);
         Assert.Equal(groupRequestModel.AccessAll, response.AccessAll);
+        Assert.Equal(groupRequestModel.ExternalId, response.ExternalId);
     }
 }


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The ExternalId fields should be editable within the Web Portal as they are editable through the API.
This PR aims to revert back the change made on the Organization and User ExternalId fields that made them uneditable.

## Code changes
This PR is coupled with a [clients PR](https://github.com/bitwarden/clients/pull/5132).

* **src/Api/Controllers/OrganizationUsersController.cs:** Passing the ExternalId value to be saved
* **src/Api/Models/Request/GroupRequestModel.cs:** Added property ExternalId
* **src/Api/Models/Request/Organizations/OrganizationUserRequestModels.cs:** Added property ExternalId
* **src/Core/Models/Data/Organizations/OrganizationUsers/OrganizationUserInviteData.cs:** Added property ExternalId
* **test/Api.Test/Controllers/GroupsControllerTests.cs:** Updated tests to assert the ExternalId property

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
