### PR TITLE
[SM-516] Refactor access policies checks out of commands

### DIFF
--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/AccessPolicies/CreateAccessPoliciesCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/AccessPolicies/CreateAccessPoliciesCommand.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Core.Enums;
-using Bit.Core.Exceptions;
+﻿using Bit.Core.Exceptions;
 using Bit.Core.SecretsManager.Commands.AccessPolicies.Interfaces;
 using Bit.Core.SecretsManager.Entities;
 using Bit.Core.SecretsManager.Repositories;
@@ -9,35 +8,14 @@ namespace Bit.Commercial.Core.SecretsManager.Commands.AccessPolicies;
 public class CreateAccessPoliciesCommand : ICreateAccessPoliciesCommand
 {
     private readonly IAccessPolicyRepository _accessPolicyRepository;
-    private readonly IProjectRepository _projectRepository;
-    private readonly IServiceAccountRepository _serviceAccountRepository;
 
     public CreateAccessPoliciesCommand(
-        IAccessPolicyRepository accessPolicyRepository,
-        IProjectRepository projectRepository,
-        IServiceAccountRepository serviceAccountRepository)
+        IAccessPolicyRepository accessPolicyRepository)
     {
         _accessPolicyRepository = accessPolicyRepository;
-        _projectRepository = projectRepository;
-        _serviceAccountRepository = serviceAccountRepository;
     }
 
-    private static IEnumerable<Guid?> GetDistinctGrantedProjectIds(List<BaseAccessPolicy> accessPolicies)
-    {
-        var userGrantedIds = accessPolicies.OfType<UserProjectAccessPolicy>().Select(ap => ap.GrantedProjectId);
-        var groupGrantedIds = accessPolicies.OfType<GroupProjectAccessPolicy>().Select(ap => ap.GrantedProjectId);
-        var saGrantedIds = accessPolicies.OfType<ServiceAccountProjectAccessPolicy>().Select(ap => ap.GrantedProjectId);
-        return userGrantedIds.Concat(groupGrantedIds).Concat(saGrantedIds).Distinct();
-    }
-
-    private static IEnumerable<Guid?> GetDistinctGrantedServiceAccountIds(List<BaseAccessPolicy> accessPolicies)
-    {
-        var userGrantedIds = accessPolicies.OfType<UserServiceAccountAccessPolicy>().Select(ap => ap.GrantedServiceAccountId);
-        var groupGrantedIds = accessPolicies.OfType<GroupServiceAccountAccessPolicy>()
-            .Select(ap => ap.GrantedServiceAccountId);
-        return userGrantedIds.Concat(groupGrantedIds).Distinct();
-    }
-
+    // FIXME can put this in the request models?
     private static void CheckForDistinctAccessPolicies(IReadOnlyCollection<BaseAccessPolicy> accessPolicies)
     {
         var distinctAccessPolicies = accessPolicies.DistinctBy(baseAccessPolicy =>
@@ -61,38 +39,11 @@ public class CreateAccessPoliciesCommand : ICreateAccessPoliciesCommand
         }
     }
 
-    public async Task<IEnumerable<BaseAccessPolicy>> CreateManyAsync(List<BaseAccessPolicy> accessPolicies, Guid userId, AccessClientType accessType)
+    public async Task<IEnumerable<BaseAccessPolicy>> CreateManyAsync(List<BaseAccessPolicy> accessPolicies)
     {
         CheckForDistinctAccessPolicies(accessPolicies);
         await CheckAccessPoliciesDoNotExistAsync(accessPolicies);
-        await CheckCanCreateAsync(accessPolicies, userId, accessType);
         return await _accessPolicyRepository.CreateManyAsync(accessPolicies);
-    }
-
-    private async Task CheckCanCreateAsync(List<BaseAccessPolicy> accessPolicies, Guid userId, AccessClientType accessType)
-    {
-        var projectIds = GetDistinctGrantedProjectIds(accessPolicies).ToList();
-        var serviceAccountIds = GetDistinctGrantedServiceAccountIds(accessPolicies).ToList();
-
-        if (projectIds.Any())
-        {
-            foreach (var projectId in projectIds)
-            {
-                await CheckPermissionAsync(accessType, userId, projectId);
-            }
-        }
-        if (serviceAccountIds.Any())
-        {
-            foreach (var serviceAccountId in serviceAccountIds)
-            {
-                await CheckPermissionAsync(accessType, userId, serviceAccountIdToCheck: serviceAccountId);
-            }
-        }
-
-        if (!projectIds.Any() && !serviceAccountIds.Any())
-        {
-            throw new BadRequestException("No granted IDs specified");
-        }
     }
 
     private async Task CheckAccessPoliciesDoNotExistAsync(List<BaseAccessPolicy> accessPolicies)
@@ -103,43 +54,6 @@ public class CreateAccessPoliciesCommand : ICreateAccessPoliciesCommand
             {
                 throw new BadRequestException("Resource already exists");
             }
-        }
-    }
-
-    private async Task CheckPermissionAsync(AccessClientType accessClient, Guid userId, Guid? projectIdToCheck = null,
-        Guid? serviceAccountIdToCheck = null)
-    {
-        bool hasAccess;
-        switch (accessClient)
-        {
-            case AccessClientType.NoAccessCheck:
-                hasAccess = true;
-                break;
-            case AccessClientType.User:
-                if (projectIdToCheck.HasValue)
-                {
-                    hasAccess = await _projectRepository.UserHasWriteAccessToProject(projectIdToCheck.Value, userId);
-                }
-                else if (serviceAccountIdToCheck.HasValue)
-                {
-                    hasAccess =
-                        await _serviceAccountRepository.UserHasWriteAccessToServiceAccount(
-                            serviceAccountIdToCheck.Value, userId);
-                }
-                else
-                {
-                    throw new ArgumentException("No ID to check provided.");
-                }
-
-                break;
-            default:
-                hasAccess = false;
-                break;
-        }
-
-        if (!hasAccess)
-        {
-            throw new NotFoundException();
         }
     }
 }

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/AccessPolicies/DeleteAccessPolicyCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/AccessPolicies/DeleteAccessPolicyCommand.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.SecretsManager.Commands.AccessPolicies.Interfaces;
+﻿using Bit.Core.Exceptions;
+using Bit.Core.SecretsManager.Commands.AccessPolicies.Interfaces;
 using Bit.Core.SecretsManager.Repositories;
 
 namespace Bit.Commercial.Core.SecretsManager.Commands.AccessPolicies;
@@ -16,6 +17,12 @@ public class DeleteAccessPolicyCommand : IDeleteAccessPolicyCommand
 
     public async Task DeleteAsync(Guid id)
     {
+        var accessPolicy = await _accessPolicyRepository.GetByIdAsync(id);
+        if (accessPolicy == null)
+        {
+            throw new NotFoundException();
+        }
+
         await _accessPolicyRepository.DeleteAsync(id);
     }
 }

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/AccessPolicies/DeleteAccessPolicyCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/AccessPolicies/DeleteAccessPolicyCommand.cs
@@ -1,8 +1,4 @@
-﻿using Bit.Core.Context;
-using Bit.Core.Enums;
-using Bit.Core.Exceptions;
-using Bit.Core.SecretsManager.Commands.AccessPolicies.Interfaces;
-using Bit.Core.SecretsManager.Entities;
+﻿using Bit.Core.SecretsManager.Commands.AccessPolicies.Interfaces;
 using Bit.Core.SecretsManager.Repositories;
 
 namespace Bit.Commercial.Core.SecretsManager.Commands.AccessPolicies;
@@ -10,98 +6,16 @@ namespace Bit.Commercial.Core.SecretsManager.Commands.AccessPolicies;
 public class DeleteAccessPolicyCommand : IDeleteAccessPolicyCommand
 {
     private readonly IAccessPolicyRepository _accessPolicyRepository;
-    private readonly ICurrentContext _currentContext;
-    private readonly IProjectRepository _projectRepository;
-    private readonly IServiceAccountRepository _serviceAccountRepository;
+
 
     public DeleteAccessPolicyCommand(
-        IAccessPolicyRepository accessPolicyRepository,
-        ICurrentContext currentContext,
-        IProjectRepository projectRepository,
-        IServiceAccountRepository serviceAccountRepository)
+        IAccessPolicyRepository accessPolicyRepository)
     {
-        _projectRepository = projectRepository;
-        _serviceAccountRepository = serviceAccountRepository;
         _accessPolicyRepository = accessPolicyRepository;
-        _currentContext = currentContext;
     }
 
-    public async Task DeleteAsync(Guid id, Guid userId)
+    public async Task DeleteAsync(Guid id)
     {
-        var accessPolicy = await _accessPolicyRepository.GetByIdAsync(id);
-        if (accessPolicy == null)
-        {
-            throw new NotFoundException();
-        }
-
-        if (!await IsAllowedToDeleteAsync(accessPolicy, userId))
-        {
-            throw new NotFoundException();
-        }
-
         await _accessPolicyRepository.DeleteAsync(id);
-    }
-
-    private async Task<bool> IsAllowedToDeleteAsync(BaseAccessPolicy baseAccessPolicy, Guid userId) =>
-        baseAccessPolicy switch
-        {
-            UserProjectAccessPolicy ap => await HasPermissionAsync(ap.GrantedProject!.OrganizationId, userId,
-                ap.GrantedProjectId),
-            GroupProjectAccessPolicy ap => await HasPermissionAsync(ap.GrantedProject!.OrganizationId, userId,
-                ap.GrantedProjectId),
-            ServiceAccountProjectAccessPolicy ap => await HasPermissionAsync(ap.GrantedProject!.OrganizationId,
-                userId, ap.GrantedProjectId),
-            UserServiceAccountAccessPolicy ap => await HasPermissionAsync(
-                ap.GrantedServiceAccount!.OrganizationId,
-                userId, serviceAccountIdToCheck: ap.GrantedServiceAccountId),
-            GroupServiceAccountAccessPolicy ap => await HasPermissionAsync(
-                ap.GrantedServiceAccount!.OrganizationId,
-                userId, serviceAccountIdToCheck: ap.GrantedServiceAccountId),
-            _ => throw new ArgumentException("Unsupported access policy type provided."),
-        };
-
-    private async Task<bool> HasPermissionAsync(
-        Guid organizationId,
-        Guid userId,
-        Guid? projectIdToCheck = null,
-        Guid? serviceAccountIdToCheck = null)
-    {
-        if (!_currentContext.AccessSecretsManager(organizationId))
-        {
-            return false;
-        }
-
-        var orgAdmin = await _currentContext.OrganizationAdmin(organizationId);
-        var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
-
-        bool hasAccess;
-        switch (accessClient)
-        {
-            case AccessClientType.NoAccessCheck:
-                hasAccess = true;
-                break;
-            case AccessClientType.User:
-                if (projectIdToCheck.HasValue)
-                {
-                    hasAccess = await _projectRepository.UserHasWriteAccessToProject(projectIdToCheck.Value, userId);
-                }
-                else if (serviceAccountIdToCheck.HasValue)
-                {
-                    hasAccess =
-                        await _serviceAccountRepository.UserHasWriteAccessToServiceAccount(
-                            serviceAccountIdToCheck.Value, userId);
-                }
-                else
-                {
-                    throw new ArgumentException("No ID to check provided.");
-                }
-
-                break;
-            default:
-                hasAccess = false;
-                break;
-        }
-
-        return hasAccess;
     }
 }

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/AccessPolicies/UpdateAccessPolicyCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/AccessPolicies/UpdateAccessPolicyCommand.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.SecretsManager.Commands.AccessPolicies.Interfaces;
+﻿using Bit.Core.Exceptions;
+using Bit.Core.SecretsManager.Commands.AccessPolicies.Interfaces;
 using Bit.Core.SecretsManager.Entities;
 using Bit.Core.SecretsManager.Repositories;
 
@@ -14,8 +15,14 @@ public class UpdateAccessPolicyCommand : IUpdateAccessPolicyCommand
         _accessPolicyRepository = accessPolicyRepository;
     }
 
-    public async Task<BaseAccessPolicy> UpdateAsync(BaseAccessPolicy accessPolicy, bool read, bool write)
+    public async Task<BaseAccessPolicy> UpdateAsync(Guid id, bool read, bool write)
     {
+        var accessPolicy = await _accessPolicyRepository.GetByIdAsync(id);
+        if (accessPolicy == null)
+        {
+            throw new NotFoundException();
+        }
+
         accessPolicy.Read = read;
         accessPolicy.Write = write;
         accessPolicy.RevisionDate = DateTime.UtcNow;

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/AccessPolicies/UpdateAccessPolicyCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/AccessPolicies/UpdateAccessPolicyCommand.cs
@@ -1,7 +1,4 @@
-﻿using Bit.Core.Context;
-using Bit.Core.Enums;
-using Bit.Core.Exceptions;
-using Bit.Core.SecretsManager.Commands.AccessPolicies.Interfaces;
+﻿using Bit.Core.SecretsManager.Commands.AccessPolicies.Interfaces;
 using Bit.Core.SecretsManager.Entities;
 using Bit.Core.SecretsManager.Repositories;
 
@@ -10,102 +7,19 @@ namespace Bit.Commercial.Core.SecretsManager.Commands.AccessPolicies;
 public class UpdateAccessPolicyCommand : IUpdateAccessPolicyCommand
 {
     private readonly IAccessPolicyRepository _accessPolicyRepository;
-    private readonly ICurrentContext _currentContext;
-    private readonly IProjectRepository _projectRepository;
-    private readonly IServiceAccountRepository _serviceAccountRepository;
 
     public UpdateAccessPolicyCommand(
-        IAccessPolicyRepository accessPolicyRepository,
-        ICurrentContext currentContext,
-        IProjectRepository projectRepository,
-        IServiceAccountRepository serviceAccountRepository)
+        IAccessPolicyRepository accessPolicyRepository)
     {
         _accessPolicyRepository = accessPolicyRepository;
-        _currentContext = currentContext;
-        _projectRepository = projectRepository;
-        _serviceAccountRepository = serviceAccountRepository;
     }
 
-    public async Task<BaseAccessPolicy> UpdateAsync(Guid id, bool read, bool write, Guid userId)
+    public async Task<BaseAccessPolicy> UpdateAsync(BaseAccessPolicy accessPolicy, bool read, bool write)
     {
-        var accessPolicy = await _accessPolicyRepository.GetByIdAsync(id);
-        if (accessPolicy == null)
-        {
-            throw new NotFoundException();
-        }
-
-        if (!await IsAllowedToUpdateAsync(accessPolicy, userId))
-        {
-            throw new NotFoundException();
-        }
-
         accessPolicy.Read = read;
         accessPolicy.Write = write;
         accessPolicy.RevisionDate = DateTime.UtcNow;
         await _accessPolicyRepository.ReplaceAsync(accessPolicy);
         return accessPolicy;
-    }
-
-    private async Task<bool> IsAllowedToUpdateAsync(BaseAccessPolicy baseAccessPolicy, Guid userId) =>
-        baseAccessPolicy switch
-        {
-            UserProjectAccessPolicy ap => await HasPermissionsAsync(ap.GrantedProject!.OrganizationId, userId,
-                ap.GrantedProjectId),
-            GroupProjectAccessPolicy ap => await HasPermissionsAsync(ap.GrantedProject!.OrganizationId, userId,
-                ap.GrantedProjectId),
-            ServiceAccountProjectAccessPolicy ap => await HasPermissionsAsync(ap.GrantedProject!.OrganizationId,
-                userId, ap.GrantedProjectId),
-            UserServiceAccountAccessPolicy ap => await HasPermissionsAsync(
-                ap.GrantedServiceAccount!.OrganizationId,
-                userId, serviceAccountIdToCheck: ap.GrantedServiceAccountId),
-            GroupServiceAccountAccessPolicy ap => await HasPermissionsAsync(
-                ap.GrantedServiceAccount!.OrganizationId,
-                userId, serviceAccountIdToCheck: ap.GrantedServiceAccountId),
-            _ => throw new ArgumentException("Unsupported access policy type provided."),
-        };
-
-    private async Task<bool> HasPermissionsAsync(
-        Guid organizationId,
-        Guid userId,
-        Guid? projectIdToCheck = null,
-        Guid? serviceAccountIdToCheck = null)
-    {
-        if (!_currentContext.AccessSecretsManager(organizationId))
-        {
-            return false;
-        }
-
-        var orgAdmin = await _currentContext.OrganizationAdmin(organizationId);
-        var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
-
-        bool hasAccess;
-        switch (accessClient)
-        {
-            case AccessClientType.NoAccessCheck:
-                hasAccess = true;
-                break;
-            case AccessClientType.User:
-                if (projectIdToCheck.HasValue)
-                {
-                    hasAccess = await _projectRepository.UserHasWriteAccessToProject(projectIdToCheck.Value, userId);
-                }
-                else if (serviceAccountIdToCheck.HasValue)
-                {
-                    hasAccess =
-                        await _serviceAccountRepository.UserHasWriteAccessToServiceAccount(
-                            serviceAccountIdToCheck.Value, userId);
-                }
-                else
-                {
-                    throw new ArgumentException("No ID to check provided.");
-                }
-
-                break;
-            default:
-                hasAccess = false;
-                break;
-        }
-
-        return hasAccess;
     }
 }

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/AccessTokens/CreateAccessTokenCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/AccessTokens/CreateAccessTokenCommand.cs
@@ -1,7 +1,4 @@
-﻿using Bit.Core.Context;
-using Bit.Core.Enums;
-using Bit.Core.Exceptions;
-using Bit.Core.SecretsManager.Commands.AccessTokens.Interfaces;
+﻿using Bit.Core.SecretsManager.Commands.AccessTokens.Interfaces;
 using Bit.Core.SecretsManager.Entities;
 using Bit.Core.SecretsManager.Repositories;
 using Bit.Core.Utilities;
@@ -12,49 +9,15 @@ public class CreateAccessTokenCommand : ICreateAccessTokenCommand
 {
     private readonly IApiKeyRepository _apiKeyRepository;
     private readonly int _clientSecretMaxLength = 30;
-    private readonly ICurrentContext _currentContext;
-    private readonly IServiceAccountRepository _serviceAccountRepository;
 
     public CreateAccessTokenCommand(
-        IApiKeyRepository apiKeyRepository,
-        ICurrentContext currentContext,
-        IServiceAccountRepository serviceAccountRepository)
+        IApiKeyRepository apiKeyRepository)
     {
         _apiKeyRepository = apiKeyRepository;
-        _currentContext = currentContext;
-        _serviceAccountRepository = serviceAccountRepository;
     }
 
-    public async Task<ApiKey> CreateAsync(ApiKey apiKey, Guid userId)
+    public async Task<ApiKey> CreateAsync(ApiKey apiKey)
     {
-        if (apiKey.ServiceAccountId == null)
-        {
-            throw new BadRequestException();
-        }
-
-        var serviceAccount = await _serviceAccountRepository.GetByIdAsync(apiKey.ServiceAccountId.Value);
-
-        if (!_currentContext.AccessSecretsManager(serviceAccount.OrganizationId))
-        {
-            throw new NotFoundException();
-        }
-
-        var orgAdmin = await _currentContext.OrganizationAdmin(serviceAccount.OrganizationId);
-        var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
-
-        var hasAccess = accessClient switch
-        {
-            AccessClientType.NoAccessCheck => true,
-            AccessClientType.User => await _serviceAccountRepository.UserHasWriteAccessToServiceAccount(
-                apiKey.ServiceAccountId.Value, userId),
-            _ => false,
-        };
-
-        if (!hasAccess)
-        {
-            throw new NotFoundException();
-        }
-
         apiKey.ClientSecret = CoreHelpers.SecureRandomString(_clientSecretMaxLength);
         return await _apiKeyRepository.CreateAsync(apiKey);
     }

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Projects/UpdateProjectCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Projects/UpdateProjectCommand.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.SecretsManager.Commands.Projects.Interfaces;
+﻿using Bit.Core.Exceptions;
+using Bit.Core.SecretsManager.Commands.Projects.Interfaces;
 using Bit.Core.SecretsManager.Entities;
 using Bit.Core.SecretsManager.Repositories;
 
@@ -13,8 +14,14 @@ public class UpdateProjectCommand : IUpdateProjectCommand
         _projectRepository = projectRepository;
     }
 
-    public async Task<Project> UpdateAsync(Project project, Project updatedProject)
+    public async Task<Project> UpdateAsync(Project updatedProject)
     {
+        var project = await _projectRepository.GetByIdAsync(updatedProject.Id);
+        if (project == null)
+        {
+            throw new NotFoundException();
+        }
+
         project.Name = updatedProject.Name;
         project.RevisionDate = DateTime.UtcNow;
 

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Projects/UpdateProjectCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Projects/UpdateProjectCommand.cs
@@ -1,7 +1,4 @@
-﻿using Bit.Core.Context;
-using Bit.Core.Enums;
-using Bit.Core.Exceptions;
-using Bit.Core.SecretsManager.Commands.Projects.Interfaces;
+﻿using Bit.Core.SecretsManager.Commands.Projects.Interfaces;
 using Bit.Core.SecretsManager.Entities;
 using Bit.Core.SecretsManager.Repositories;
 
@@ -10,42 +7,14 @@ namespace Bit.Commercial.Core.SecretsManager.Commands.Projects;
 public class UpdateProjectCommand : IUpdateProjectCommand
 {
     private readonly IProjectRepository _projectRepository;
-    private readonly ICurrentContext _currentContext;
 
-    public UpdateProjectCommand(IProjectRepository projectRepository, ICurrentContext currentContext)
+    public UpdateProjectCommand(IProjectRepository projectRepository)
     {
         _projectRepository = projectRepository;
-        _currentContext = currentContext;
     }
 
-    public async Task<Project> UpdateAsync(Project updatedProject, Guid userId)
+    public async Task<Project> UpdateAsync(Project project, Project updatedProject)
     {
-        var project = await _projectRepository.GetByIdAsync(updatedProject.Id);
-        if (project == null)
-        {
-            throw new NotFoundException();
-        }
-
-        if (!_currentContext.AccessSecretsManager(project.OrganizationId))
-        {
-            throw new NotFoundException();
-        }
-
-        var orgAdmin = await _currentContext.OrganizationAdmin(project.OrganizationId);
-        var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
-
-        var hasAccess = accessClient switch
-        {
-            AccessClientType.NoAccessCheck => true,
-            AccessClientType.User => await _projectRepository.UserHasWriteAccessToProject(updatedProject.Id, userId),
-            _ => false,
-        };
-
-        if (!hasAccess)
-        {
-            throw new NotFoundException();
-        }
-
         project.Name = updatedProject.Name;
         project.RevisionDate = DateTime.UtcNow;
 

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/CreateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/CreateSecretCommand.cs
@@ -1,7 +1,4 @@
-﻿using Bit.Core.Context;
-using Bit.Core.Enums;
-using Bit.Core.Exceptions;
-using Bit.Core.SecretsManager.Commands.Secrets.Interfaces;
+﻿using Bit.Core.SecretsManager.Commands.Secrets.Interfaces;
 using Bit.Core.SecretsManager.Entities;
 using Bit.Core.SecretsManager.Repositories;
 
@@ -10,39 +7,14 @@ namespace Bit.Commercial.Core.SecretsManager.Commands.Secrets;
 public class CreateSecretCommand : ICreateSecretCommand
 {
     private readonly ISecretRepository _secretRepository;
-    private readonly IProjectRepository _projectRepository;
-    private readonly ICurrentContext _currentContext;
 
-    public CreateSecretCommand(ISecretRepository secretRepository, IProjectRepository projectRepository, ICurrentContext currentContext)
+    public CreateSecretCommand(ISecretRepository secretRepository)
     {
         _secretRepository = secretRepository;
-        _projectRepository = projectRepository;
-        _currentContext = currentContext;
     }
 
-    public async Task<Secret> CreateAsync(Secret secret, Guid userId)
+    public async Task<Secret> CreateAsync(Secret secret)
     {
-        var orgAdmin = await _currentContext.OrganizationAdmin(secret.OrganizationId);
-        var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
-        var project = secret.Projects?.FirstOrDefault();
-
-        if (project == null)
-        {
-            throw new NotFoundException();
-        }
-
-        var hasAccess = accessClient switch
-        {
-            AccessClientType.NoAccessCheck => true,
-            AccessClientType.User => await _projectRepository.UserHasWriteAccessToProject(project.Id, userId),
-            _ => false,
-        };
-
-        if (!hasAccess)
-        {
-            throw new NotFoundException();
-        }
-
         return await _secretRepository.CreateAsync(secret);
     }
 }

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
@@ -1,7 +1,4 @@
-﻿using Bit.Core.Context;
-using Bit.Core.Enums;
-using Bit.Core.Exceptions;
-using Bit.Core.SecretsManager.Commands.Secrets.Interfaces;
+﻿using Bit.Core.SecretsManager.Commands.Secrets.Interfaces;
 using Bit.Core.SecretsManager.Entities;
 using Bit.Core.SecretsManager.Repositories;
 
@@ -10,32 +7,14 @@ namespace Bit.Commercial.Core.SecretsManager.Commands.Secrets;
 public class UpdateSecretCommand : IUpdateSecretCommand
 {
     private readonly ISecretRepository _secretRepository;
-    private readonly IProjectRepository _projectRepository;
-    private readonly ICurrentContext _currentContext;
 
-    public UpdateSecretCommand(ISecretRepository secretRepository, IProjectRepository projectRepository, ICurrentContext currentContext)
+    public UpdateSecretCommand(ISecretRepository secretRepository)
     {
         _secretRepository = secretRepository;
-        _projectRepository = projectRepository;
-        _currentContext = currentContext;
     }
 
-    public async Task<Secret> UpdateAsync(Secret updatedSecret, Guid userId)
+    public async Task<Secret> UpdateAsync(Secret secret, Secret updatedSecret)
     {
-        var secret = await _secretRepository.GetByIdAsync(updatedSecret.Id);
-        if (secret == null || !_currentContext.AccessSecretsManager(secret.OrganizationId))
-        {
-            throw new NotFoundException();
-        }
-
-        var orgAdmin = await _currentContext.OrganizationAdmin(secret.OrganizationId);
-        var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
-
-        if (!await HasAccessToOriginalAndUpdatedProject(accessClient, secret, updatedSecret, userId))
-        {
-            throw new NotFoundException();
-        }
-
         secret.Key = updatedSecret.Key;
         secret.Value = updatedSecret.Value;
         secret.Note = updatedSecret.Note;
@@ -44,22 +23,5 @@ public class UpdateSecretCommand : IUpdateSecretCommand
 
         await _secretRepository.UpdateAsync(secret);
         return secret;
-    }
-
-    public async Task<bool> HasAccessToOriginalAndUpdatedProject(AccessClientType accessClient, Secret secret, Secret updatedSecret, Guid userId)
-    {
-        switch (accessClient)
-        {
-            case AccessClientType.NoAccessCheck:
-                return true;
-            case AccessClientType.User:
-                var oldProject = secret.Projects?.FirstOrDefault();
-                var newProject = updatedSecret.Projects?.FirstOrDefault();
-                var accessToOld = oldProject != null && await _projectRepository.UserHasWriteAccessToProject(oldProject.Id, userId);
-                var accessToNew = newProject != null && await _projectRepository.UserHasWriteAccessToProject(newProject.Id, userId);
-                return accessToOld && accessToNew;
-            default:
-                return false;
-        }
     }
 }

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.SecretsManager.Commands.Secrets.Interfaces;
+﻿using Bit.Core.Exceptions;
+using Bit.Core.SecretsManager.Commands.Secrets.Interfaces;
 using Bit.Core.SecretsManager.Entities;
 using Bit.Core.SecretsManager.Repositories;
 
@@ -13,8 +14,14 @@ public class UpdateSecretCommand : IUpdateSecretCommand
         _secretRepository = secretRepository;
     }
 
-    public async Task<Secret> UpdateAsync(Secret secret, Secret updatedSecret)
+    public async Task<Secret> UpdateAsync(Secret updatedSecret)
     {
+        var secret = await _secretRepository.GetByIdAsync(updatedSecret.Id);
+        if (secret == null)
+        {
+            throw new NotFoundException();
+        }
+
         secret.Key = updatedSecret.Key;
         secret.Value = updatedSecret.Value;
         secret.Note = updatedSecret.Note;

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/ServiceAccounts/DeleteServiceAccountsCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/ServiceAccounts/DeleteServiceAccountsCommand.cs
@@ -54,14 +54,9 @@ public class DeleteServiceAccountsCommand : IDeleteServiceAccountsCommand
 
         foreach (var sa in serviceAccounts)
         {
-            var hasAccess = accessClient switch
-            {
-                AccessClientType.NoAccessCheck => true,
-                AccessClientType.User => await _serviceAccountRepository.UserHasWriteAccessToServiceAccount(sa.Id, userId),
-                _ => false,
-            };
+            var access = await _serviceAccountRepository.AccessToServiceAccountAsync(sa.Id, userId, accessClient);
 
-            if (!hasAccess)
+            if (!access.Write)
             {
                 results.Add(new Tuple<ServiceAccount, string>(sa, "access denied"));
             }

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/ServiceAccounts/UpdateServiceAccountCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/ServiceAccounts/UpdateServiceAccountCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Core.Context;
+using Bit.Core.Exceptions;
 using Bit.Core.SecretsManager.Commands.ServiceAccounts.Interfaces;
 using Bit.Core.SecretsManager.Entities;
 using Bit.Core.SecretsManager.Repositories;
@@ -16,8 +17,14 @@ public class UpdateServiceAccountCommand : IUpdateServiceAccountCommand
         _currentContext = currentContext;
     }
 
-    public async Task<ServiceAccount> UpdateAsync(ServiceAccount serviceAccount, ServiceAccount updatedServiceAccount)
+    public async Task<ServiceAccount> UpdateAsync(ServiceAccount updatedServiceAccount)
     {
+        var serviceAccount = await _serviceAccountRepository.GetByIdAsync(updatedServiceAccount.Id);
+        if (serviceAccount == null)
+        {
+            throw new NotFoundException();
+        }
+
         serviceAccount.Name = updatedServiceAccount.Name;
         serviceAccount.RevisionDate = DateTime.UtcNow;
 

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/ServiceAccounts/UpdateServiceAccountCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/ServiceAccounts/UpdateServiceAccountCommand.cs
@@ -1,6 +1,4 @@
 ﻿using Bit.Core.Context;
-using Bit.Core.Enums;
-using Bit.Core.Exceptions;
 using Bit.Core.SecretsManager.Commands.ServiceAccounts.Interfaces;
 using Bit.Core.SecretsManager.Entities;
 using Bit.Core.SecretsManager.Repositories;
@@ -18,34 +16,8 @@ public class UpdateServiceAccountCommand : IUpdateServiceAccountCommand
         _currentContext = currentContext;
     }
 
-    public async Task<ServiceAccount> UpdateAsync(ServiceAccount updatedServiceAccount, Guid userId)
+    public async Task<ServiceAccount> UpdateAsync(ServiceAccount serviceAccount, ServiceAccount updatedServiceAccount)
     {
-        var serviceAccount = await _serviceAccountRepository.GetByIdAsync(updatedServiceAccount.Id);
-        if (serviceAccount == null)
-        {
-            throw new NotFoundException();
-        }
-
-        if (!_currentContext.AccessSecretsManager(serviceAccount.OrganizationId))
-        {
-            throw new NotFoundException();
-        }
-
-        var orgAdmin = await _currentContext.OrganizationAdmin(serviceAccount.OrganizationId);
-        var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
-
-        var hasAccess = accessClient switch
-        {
-            AccessClientType.NoAccessCheck => true,
-            AccessClientType.User => await _serviceAccountRepository.UserHasWriteAccessToServiceAccount(updatedServiceAccount.Id, userId),
-            _ => false,
-        };
-
-        if (!hasAccess)
-        {
-            throw new NotFoundException();
-        }
-
         serviceAccount.Name = updatedServiceAccount.Name;
         serviceAccount.RevisionDate = DateTime.UtcNow;
 

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Queries/Access/AccessPolicyAccessQuery.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Queries/Access/AccessPolicyAccessQuery.cs
@@ -1,0 +1,149 @@
+﻿using Bit.Core.Context;
+using Bit.Core.Enums;
+using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Queries.Access.Interfaces;
+using Bit.Core.SecretsManager.Repositories;
+
+namespace Bit.Commercial.Core.SecretsManager.Queries.Access;
+
+public class AccessPolicyAccessQuery : IAccessPolicyAccessQuery
+{
+    private readonly ICurrentContext _currentContext;
+    private readonly IProjectRepository _projectRepository;
+    private readonly IServiceAccountRepository _serviceAccountRepository;
+
+    public AccessPolicyAccessQuery(ICurrentContext currentContext, IProjectRepository projectRepository, IServiceAccountRepository serviceAccountRepository)
+    {
+        _currentContext = currentContext;
+        _projectRepository = projectRepository;
+        _serviceAccountRepository = serviceAccountRepository;
+    }
+
+    private static IEnumerable<Guid?> GetDistinctGrantedProjectIds(List<BaseAccessPolicy> accessPolicies)
+    {
+        var userGrantedIds = accessPolicies.OfType<UserProjectAccessPolicy>().Select(ap => ap.GrantedProjectId);
+        var groupGrantedIds = accessPolicies.OfType<GroupProjectAccessPolicy>().Select(ap => ap.GrantedProjectId);
+        var saGrantedIds = accessPolicies.OfType<ServiceAccountProjectAccessPolicy>().Select(ap => ap.GrantedProjectId);
+        return userGrantedIds.Concat(groupGrantedIds).Concat(saGrantedIds).Distinct();
+    }
+
+    private static IEnumerable<Guid?> GetDistinctGrantedServiceAccountIds(List<BaseAccessPolicy> accessPolicies)
+    {
+        var userGrantedIds = accessPolicies.OfType<UserServiceAccountAccessPolicy>().Select(ap => ap.GrantedServiceAccountId);
+        var groupGrantedIds = accessPolicies.OfType<GroupServiceAccountAccessPolicy>()
+            .Select(ap => ap.GrantedServiceAccountId);
+        return userGrantedIds.Concat(groupGrantedIds).Distinct();
+    }
+
+    public async Task<bool> HasAccess(BaseAccessPolicy baseAccessPolicy, Guid userId)
+    {
+        return baseAccessPolicy switch
+        {
+            UserProjectAccessPolicy ap => await HasPermissionsAsync(ap.GrantedProject!.OrganizationId, userId,
+                ap.GrantedProjectId),
+            GroupProjectAccessPolicy ap => await HasPermissionsAsync(ap.GrantedProject!.OrganizationId, userId,
+                ap.GrantedProjectId),
+            ServiceAccountProjectAccessPolicy ap => await HasPermissionsAsync(ap.GrantedProject!.OrganizationId, userId,
+                ap.GrantedProjectId),
+            UserServiceAccountAccessPolicy ap => await HasPermissionsAsync(ap.GrantedServiceAccount!.OrganizationId,
+                userId, serviceAccountIdToCheck: ap.GrantedServiceAccountId),
+            GroupServiceAccountAccessPolicy ap => await HasPermissionsAsync(ap.GrantedServiceAccount!.OrganizationId,
+                userId, serviceAccountIdToCheck: ap.GrantedServiceAccountId),
+            _ => throw new ArgumentException("Unsupported access policy type provided.")
+        };
+    }
+
+    public async Task<bool> HasAccess(List<BaseAccessPolicy> accessPolicies, Guid organizationId, Guid userId)
+    {
+        if (!_currentContext.AccessSecretsManager(organizationId))
+        {
+            return false;
+        }
+
+        var orgAdmin = await _currentContext.OrganizationAdmin(organizationId);
+        var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
+
+        var projectIds = GetDistinctGrantedProjectIds(accessPolicies).ToList();
+        var serviceAccountIds = GetDistinctGrantedServiceAccountIds(accessPolicies).ToList();
+
+        if (!projectIds.Any() && !serviceAccountIds.Any())
+        {
+            return false;
+        }
+
+        if (projectIds.Any())
+        {
+            foreach (var projectId in projectIds)
+            {
+                if (!await HasPermissionToIdAsync(accessClient, userId, projectId))
+                {
+                    return false;
+                }
+            }
+        }
+
+        if (serviceAccountIds.Any())
+        {
+            foreach (var serviceAccountId in serviceAccountIds)
+            {
+                if (!await HasPermissionToIdAsync(accessClient, userId, serviceAccountIdToCheck: serviceAccountId))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private async Task<bool> HasPermissionsAsync(
+        Guid organizationId,
+        Guid userId,
+        Guid? projectIdToCheck = null,
+        Guid? serviceAccountIdToCheck = null)
+    {
+        if (!_currentContext.AccessSecretsManager(organizationId))
+        {
+            return false;
+        }
+
+        var orgAdmin = await _currentContext.OrganizationAdmin(organizationId);
+        var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
+        return await HasPermissionToIdAsync(accessClient, userId, projectIdToCheck, serviceAccountIdToCheck);
+    }
+
+    private async Task<bool> HasPermissionToIdAsync(AccessClientType accessClient, Guid userId,
+        Guid? projectIdToCheck = null,
+        Guid? serviceAccountIdToCheck = null)
+    {
+        bool hasAccess;
+        switch (accessClient)
+        {
+            case AccessClientType.NoAccessCheck:
+                hasAccess = true;
+                break;
+            case AccessClientType.User:
+                if (projectIdToCheck.HasValue)
+                {
+                    hasAccess = await _projectRepository.UserHasWriteAccessToProject(projectIdToCheck.Value, userId);
+                }
+                else if (serviceAccountIdToCheck.HasValue)
+                {
+                    hasAccess =
+                        await _serviceAccountRepository.UserHasWriteAccessToServiceAccount(
+                            serviceAccountIdToCheck.Value, userId);
+                }
+                else
+                {
+                    throw new ArgumentException("No ID to check provided.");
+                }
+
+                break;
+            default:
+                hasAccess = false;
+                break;
+        }
+
+        return hasAccess;
+    }
+}

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Queries/Access/AccessPolicyAccessQuery.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Queries/Access/AccessPolicyAccessQuery.cs
@@ -129,9 +129,8 @@ public class AccessPolicyAccessQuery : IAccessPolicyAccessQuery
                 }
                 else if (serviceAccountIdToCheck.HasValue)
                 {
-                    hasAccess =
-                        await _serviceAccountRepository.UserHasWriteAccessToServiceAccount(
-                            serviceAccountIdToCheck.Value, userId);
+                    hasAccess = (await _serviceAccountRepository.AccessToServiceAccountAsync(
+                        serviceAccountIdToCheck.Value, userId, accessClient)).Write;
                 }
                 else
                 {

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Queries/Access/AccessQuery.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Queries/Access/AccessQuery.cs
@@ -1,0 +1,164 @@
+﻿using Bit.Core.Context;
+using Bit.Core.Enums;
+using Bit.Core.SecretsManager.Models.Data;
+using Bit.Core.SecretsManager.Queries.Access.Interfaces;
+using Bit.Core.SecretsManager.Repositories;
+
+namespace Bit.Commercial.Core.SecretsManager.Queries.Access;
+
+public class AccessQuery : IAccessQuery
+{
+    private readonly ICurrentContext _currentContext;
+    private readonly IProjectRepository _projectRepository;
+    private readonly ISecretRepository _secretRepository;
+    private readonly IServiceAccountRepository _serviceAccountRepository;
+
+    public AccessQuery(ICurrentContext currentContext, IProjectRepository projectRepository, ISecretRepository secretRepository, IServiceAccountRepository serviceAccountRepository)
+    {
+        _currentContext = currentContext;
+        _projectRepository = projectRepository;
+        _secretRepository = secretRepository;
+        _serviceAccountRepository = serviceAccountRepository;
+    }
+
+    public async Task<bool> HasAccess(AccessCheck accessCheck)
+    {
+        if (!_currentContext.AccessSecretsManager(accessCheck.OrganizationId))
+        {
+            return false;
+        }
+
+        var orgAdmin = await _currentContext.OrganizationAdmin(accessCheck.OrganizationId);
+        var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
+
+        return accessCheck.OperationType switch
+        {
+            OperationType.RevokeAccessToken => await HasAccessToRevokeAccessTokenAsync(accessCheck, accessClient),
+            OperationType.CreateAccessToken => await HasAccessToCreateAccessTokenAsync(accessCheck, accessClient),
+            OperationType.CreateServiceAccount => HasAccessToCreateServiceAccount(accessClient),
+            OperationType.UpdateServiceAccount => await HasAccessToUpdateServiceAccountAsync(accessCheck, accessClient),
+            OperationType.CreateProject => HasAccessToCreateProject(accessClient),
+            OperationType.UpdateProject => await HasAccessToUpdateProjectAsync(accessCheck, accessClient),
+            _ => false,
+        };
+    }
+
+    public async Task<bool> HasAccess(SecretAccessCheck secretAccessCheck)
+    {
+        if (!_currentContext.AccessSecretsManager(secretAccessCheck.OrganizationId))
+        {
+            return false;
+        }
+
+        var orgAdmin = await _currentContext.OrganizationAdmin(secretAccessCheck.OrganizationId);
+        var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
+
+        return secretAccessCheck.OperationType switch
+        {
+            OperationType.UpdateSecret => await HasAccessToUpdateSecretAsync(secretAccessCheck, accessClient),
+            OperationType.CreateSecret => await HasAccessToCreateSecretAsync(secretAccessCheck, accessClient),
+            _ => false,
+        };
+    }
+
+    private async Task<bool> HasAccessToCreateSecretAsync(SecretAccessCheck accessCheck, AccessClientType accessClient)
+    {
+        var hasAccess = accessClient switch
+        {
+            AccessClientType.NoAccessCheck => true,
+            AccessClientType.User => accessCheck.TargetProjectId != null && (await _projectRepository.AccessToProjectAsync(accessCheck.TargetProjectId.Value, accessCheck.UserId, accessClient)).Write,
+            _ => false,
+        };
+        return hasAccess;
+    }
+
+    private async Task<bool> HasAccessToUpdateSecretAsync(SecretAccessCheck accessCheck, AccessClientType accessClient)
+    {
+        switch (accessClient)
+        {
+            case AccessClientType.NoAccessCheck:
+                return true;
+            case AccessClientType.User:
+                var accessToOld = accessCheck.CurrentSecretId != null &&
+                                  (await _secretRepository.AccessToSecretAsync(accessCheck.CurrentSecretId.Value,
+                                      accessCheck.UserId, accessClient)).Write;
+                var accessToNew = accessCheck.TargetProjectId != null &&
+                                  (await _projectRepository.AccessToProjectAsync(accessCheck.TargetProjectId.Value,
+                                      accessCheck.UserId, accessClient)).Write;
+                return accessToOld && accessToNew;
+            default:
+                return false;
+        }
+    }
+
+    private bool HasAccessToCreateProject(AccessClientType accessClient) =>
+        accessClient != AccessClientType.ServiceAccount;
+
+    private async Task<bool> HasAccessToUpdateProjectAsync(AccessCheck accessCheck, AccessClientType accessClient)
+    {
+        if (accessClient == AccessClientType.ServiceAccount)
+        {
+            return false;
+        }
+
+        var access =
+            await _projectRepository.AccessToProjectAsync(accessCheck.TargetId, accessCheck.UserId,
+                accessClient);
+        return access.Write;
+    }
+
+    private bool HasAccessToCreateServiceAccount(AccessClientType accessClient) =>
+        accessClient != AccessClientType.ServiceAccount;
+
+    private async Task<bool> HasAccessToUpdateServiceAccountAsync(AccessCheck accessCheck, AccessClientType accessClient)
+    {
+        if (accessClient == AccessClientType.ServiceAccount)
+        {
+            return false;
+        }
+
+        var hasAccess = accessClient switch
+        {
+            AccessClientType.NoAccessCheck => true,
+            AccessClientType.User => await _serviceAccountRepository.UserHasWriteAccessToServiceAccount(accessCheck.TargetId, accessCheck.UserId),
+            _ => false,
+        };
+        return hasAccess;
+    }
+
+    private async Task<bool> HasAccessToCreateAccessTokenAsync(AccessCheck accessCheck, AccessClientType accessClient)
+    {
+        if (accessClient == AccessClientType.ServiceAccount)
+        {
+            return false;
+        }
+
+        var hasAccess = accessClient switch
+        {
+            AccessClientType.NoAccessCheck => true,
+            AccessClientType.User => await _serviceAccountRepository.UserHasWriteAccessToServiceAccount(
+                accessCheck.TargetId, accessCheck.UserId),
+            _ => false,
+        };
+        return hasAccess;
+    }
+
+    private async Task<bool> HasAccessToRevokeAccessTokenAsync(AccessCheck accessCheck, AccessClientType accessClient)
+    {
+        if (accessClient == AccessClientType.ServiceAccount)
+        {
+            return false;
+        }
+
+
+        var hasAccess = accessClient switch
+        {
+            AccessClientType.NoAccessCheck => true,
+            AccessClientType.User => await _serviceAccountRepository.UserHasWriteAccessToServiceAccount(accessCheck.TargetId, accessCheck.UserId),
+            _ => false,
+        };
+
+        return hasAccess;
+    }
+
+}

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Queries/Access/AccessQuery.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Queries/Access/AccessQuery.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Core.Context;
 using Bit.Core.Enums;
+using Bit.Core.SecretsManager.Enums;
 using Bit.Core.SecretsManager.Models.Data;
 using Bit.Core.SecretsManager.Queries.Access.Interfaces;
 using Bit.Core.SecretsManager.Repositories;
@@ -10,14 +11,12 @@ public class AccessQuery : IAccessQuery
 {
     private readonly ICurrentContext _currentContext;
     private readonly IProjectRepository _projectRepository;
-    private readonly ISecretRepository _secretRepository;
     private readonly IServiceAccountRepository _serviceAccountRepository;
 
-    public AccessQuery(ICurrentContext currentContext, IProjectRepository projectRepository, ISecretRepository secretRepository, IServiceAccountRepository serviceAccountRepository)
+    public AccessQuery(ICurrentContext currentContext, IProjectRepository projectRepository, IServiceAccountRepository serviceAccountRepository)
     {
         _currentContext = currentContext;
         _projectRepository = projectRepository;
-        _secretRepository = secretRepository;
         _serviceAccountRepository = serviceAccountRepository;
     }
 
@@ -31,68 +30,28 @@ public class AccessQuery : IAccessQuery
         var orgAdmin = await _currentContext.OrganizationAdmin(accessCheck.OrganizationId);
         var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
 
-        return accessCheck.OperationType switch
+        return accessCheck.AccessOperationType switch
         {
-            OperationType.RevokeAccessToken => await HasAccessToRevokeAccessTokenAsync(accessCheck, accessClient),
-            OperationType.CreateAccessToken => await HasAccessToCreateAccessTokenAsync(accessCheck, accessClient),
-            OperationType.CreateServiceAccount => HasAccessToCreateServiceAccount(accessClient),
-            OperationType.UpdateServiceAccount => await HasAccessToUpdateServiceAccountAsync(accessCheck, accessClient),
-            OperationType.CreateProject => HasAccessToCreateProject(accessClient),
-            OperationType.UpdateProject => await HasAccessToUpdateProjectAsync(accessCheck, accessClient),
+            AccessOperationType.RevokeAccessToken => await HasAccessToRevokeAccessTokenAsync(accessCheck, accessClient),
+            AccessOperationType.CreateAccessToken => await HasAccessToCreateAccessTokenAsync(accessCheck, accessClient),
+            AccessOperationType.CreateServiceAccount => HasAccessToCreateServiceAccount(accessClient),
+            AccessOperationType.UpdateServiceAccount => await HasAccessToUpdateServiceAccountAsync(accessCheck, accessClient),
+            AccessOperationType.CreateProject => HasAccessToCreateProject(accessClient),
+            AccessOperationType.UpdateProject => await HasAccessToUpdateProjectAsync(accessCheck, accessClient),
             _ => false,
         };
     }
 
-    public async Task<bool> HasAccess(SecretAccessCheck secretAccessCheck)
+    private bool HasAccessToCreateProject(AccessClientType accessClient)
     {
-        if (!_currentContext.AccessSecretsManager(secretAccessCheck.OrganizationId))
-        {
-            return false;
-        }
-
-        var orgAdmin = await _currentContext.OrganizationAdmin(secretAccessCheck.OrganizationId);
-        var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
-
-        return secretAccessCheck.OperationType switch
-        {
-            OperationType.UpdateSecret => await HasAccessToUpdateSecretAsync(secretAccessCheck, accessClient),
-            OperationType.CreateSecret => await HasAccessToCreateSecretAsync(secretAccessCheck, accessClient),
-            _ => false,
-        };
-    }
-
-    private async Task<bool> HasAccessToCreateSecretAsync(SecretAccessCheck accessCheck, AccessClientType accessClient)
-    {
-        var hasAccess = accessClient switch
+        return accessClient switch
         {
             AccessClientType.NoAccessCheck => true,
-            AccessClientType.User => accessCheck.TargetProjectId != null && (await _projectRepository.AccessToProjectAsync(accessCheck.TargetProjectId.Value, accessCheck.UserId, accessClient)).Write,
+            AccessClientType.User => true,
+            AccessClientType.ServiceAccount => false,
             _ => false,
         };
-        return hasAccess;
     }
-
-    private async Task<bool> HasAccessToUpdateSecretAsync(SecretAccessCheck accessCheck, AccessClientType accessClient)
-    {
-        switch (accessClient)
-        {
-            case AccessClientType.NoAccessCheck:
-                return true;
-            case AccessClientType.User:
-                var accessToOld = accessCheck.CurrentSecretId != null &&
-                                  (await _secretRepository.AccessToSecretAsync(accessCheck.CurrentSecretId.Value,
-                                      accessCheck.UserId, accessClient)).Write;
-                var accessToNew = accessCheck.TargetProjectId != null &&
-                                  (await _projectRepository.AccessToProjectAsync(accessCheck.TargetProjectId.Value,
-                                      accessCheck.UserId, accessClient)).Write;
-                return accessToOld && accessToNew;
-            default:
-                return false;
-        }
-    }
-
-    private bool HasAccessToCreateProject(AccessClientType accessClient) =>
-        accessClient != AccessClientType.ServiceAccount;
 
     private async Task<bool> HasAccessToUpdateProjectAsync(AccessCheck accessCheck, AccessClientType accessClient)
     {
@@ -107,58 +66,39 @@ public class AccessQuery : IAccessQuery
         return access.Write;
     }
 
-    private bool HasAccessToCreateServiceAccount(AccessClientType accessClient) =>
-        accessClient != AccessClientType.ServiceAccount;
-
-    private async Task<bool> HasAccessToUpdateServiceAccountAsync(AccessCheck accessCheck, AccessClientType accessClient)
+    private bool HasAccessToCreateServiceAccount(AccessClientType accessClient)
     {
-        if (accessClient == AccessClientType.ServiceAccount)
-        {
-            return false;
-        }
-
-        var hasAccess = accessClient switch
+        return accessClient switch
         {
             AccessClientType.NoAccessCheck => true,
-            AccessClientType.User => await _serviceAccountRepository.UserHasWriteAccessToServiceAccount(accessCheck.TargetId, accessCheck.UserId),
+            AccessClientType.User => true,
+            AccessClientType.ServiceAccount => false,
             _ => false,
         };
-        return hasAccess;
+    }
+
+    private async Task<bool> HasAccessToUpdateServiceAccountAsync(AccessCheck accessCheck,
+        AccessClientType accessClient)
+    {
+        var access =
+            await _serviceAccountRepository.AccessToServiceAccountAsync(accessCheck.TargetId, accessCheck.UserId,
+                accessClient);
+        return access.Write;
     }
 
     private async Task<bool> HasAccessToCreateAccessTokenAsync(AccessCheck accessCheck, AccessClientType accessClient)
     {
-        if (accessClient == AccessClientType.ServiceAccount)
-        {
-            return false;
-        }
-
-        var hasAccess = accessClient switch
-        {
-            AccessClientType.NoAccessCheck => true,
-            AccessClientType.User => await _serviceAccountRepository.UserHasWriteAccessToServiceAccount(
-                accessCheck.TargetId, accessCheck.UserId),
-            _ => false,
-        };
-        return hasAccess;
+        var access =
+            await _serviceAccountRepository.AccessToServiceAccountAsync(accessCheck.TargetId, accessCheck.UserId,
+                accessClient);
+        return access.Write;
     }
 
     private async Task<bool> HasAccessToRevokeAccessTokenAsync(AccessCheck accessCheck, AccessClientType accessClient)
     {
-        if (accessClient == AccessClientType.ServiceAccount)
-        {
-            return false;
-        }
-
-
-        var hasAccess = accessClient switch
-        {
-            AccessClientType.NoAccessCheck => true,
-            AccessClientType.User => await _serviceAccountRepository.UserHasWriteAccessToServiceAccount(accessCheck.TargetId, accessCheck.UserId),
-            _ => false,
-        };
-
-        return hasAccess;
+        var access =
+            await _serviceAccountRepository.AccessToServiceAccountAsync(accessCheck.TargetId, accessCheck.UserId,
+                accessClient);
+        return access.Write;
     }
-
 }

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Queries/Access/SecretAccessQuery.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Queries/Access/SecretAccessQuery.cs
@@ -1,0 +1,108 @@
+﻿using Bit.Core.Context;
+using Bit.Core.Enums;
+using Bit.Core.SecretsManager.Enums;
+using Bit.Core.SecretsManager.Models.Data;
+using Bit.Core.SecretsManager.Queries.Access.Interfaces;
+using Bit.Core.SecretsManager.Repositories;
+
+namespace Bit.Commercial.Core.SecretsManager.Queries.Access;
+
+public class SecretAccessQuery : ISecretAccessQuery
+{
+    private readonly ICurrentContext _currentContext;
+    private readonly IProjectRepository _projectRepository;
+    private readonly ISecretRepository _secretRepository;
+
+    public SecretAccessQuery(ICurrentContext currentContext, IProjectRepository projectRepository, ISecretRepository secretRepository)
+    {
+        _currentContext = currentContext;
+        _projectRepository = projectRepository;
+        _secretRepository = secretRepository;
+    }
+
+    public async Task<bool> HasAccess(SecretAccessCheck secretAccessCheck)
+    {
+        if (!_currentContext.AccessSecretsManager(secretAccessCheck.OrganizationId))
+        {
+            return false;
+        }
+
+        var orgAdmin = await _currentContext.OrganizationAdmin(secretAccessCheck.OrganizationId);
+        var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
+
+        return secretAccessCheck.AccessOperationType switch
+        {
+            AccessOperationType.UpdateSecret => await HasAccessToUpdateSecretAsync(secretAccessCheck, accessClient),
+            AccessOperationType.CreateSecret => await HasAccessToCreateSecretAsync(secretAccessCheck, accessClient),
+            _ => false,
+        };
+    }
+
+    private async Task<bool> HasAccessToCreateSecretAsync(SecretAccessCheck accessCheck, AccessClientType accessClient)
+    {
+        // FIXME can we clean this up?
+        if (accessClient == AccessClientType.NoAccessCheck && accessCheck.TargetProjectId == null)
+        {
+            return true;
+        }
+
+        if (accessCheck.TargetProjectId == null)
+        {
+            return false;
+        }
+
+        var project = await _projectRepository.GetByIdAsync(accessCheck.TargetProjectId.Value);
+
+        if (project == null || project.OrganizationId != accessCheck.OrganizationId)
+        {
+            return false;
+        }
+
+        return accessClient switch
+        {
+            AccessClientType.NoAccessCheck => true,
+            AccessClientType.User => accessCheck.TargetProjectId != null && (await _projectRepository.AccessToProjectAsync(accessCheck.TargetProjectId.Value, accessCheck.UserId, accessClient)).Write,
+            AccessClientType.ServiceAccount => false,
+            _ => false,
+        };
+    }
+
+    private async Task<bool> HasAccessToUpdateSecretAsync(SecretAccessCheck accessCheck, AccessClientType accessClient)
+    {
+
+        // FIXME can we clean this up? 
+        if (accessClient == AccessClientType.NoAccessCheck && accessCheck.TargetProjectId == null)
+        {
+            return true;
+        }
+
+        if (accessCheck.TargetProjectId == null)
+        {
+            return false;
+        }
+
+        var project = await _projectRepository.GetByIdAsync(accessCheck.TargetProjectId.Value);
+
+        if (project == null || project.OrganizationId != accessCheck.OrganizationId)
+        {
+            return false;
+        }
+
+
+        switch (accessClient)
+        {
+            case AccessClientType.NoAccessCheck:
+                return true;
+            case AccessClientType.User:
+                var accessToOld = accessCheck.CurrentSecretId != null &&
+                                  (await _secretRepository.AccessToSecretAsync(accessCheck.CurrentSecretId.Value,
+                                      accessCheck.UserId, accessClient)).Write;
+                var accessToNew = accessCheck.TargetProjectId != null &&
+                                  (await _projectRepository.AccessToProjectAsync(accessCheck.TargetProjectId.Value,
+                                      accessCheck.UserId, accessClient)).Write;
+                return accessToOld && accessToNew;
+            default:
+                return false;
+        }
+    }
+}

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/SecretsManagerCollectionExtensions.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/SecretsManagerCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Bit.Commercial.Core.SecretsManager.Commands.Projects;
 using Bit.Commercial.Core.SecretsManager.Commands.Secrets;
 using Bit.Commercial.Core.SecretsManager.Commands.ServiceAccounts;
 using Bit.Commercial.Core.SecretsManager.Commands.Trash;
+using Bit.Commercial.Core.SecretsManager.Queries.Access;
 using Bit.Core.SecretsManager.Commands.AccessPolicies.Interfaces;
 using Bit.Core.SecretsManager.Commands.AccessTokens.Interfaces;
 using Bit.Core.SecretsManager.Commands.Porting.Interfaces;
@@ -12,6 +13,7 @@ using Bit.Core.SecretsManager.Commands.Projects.Interfaces;
 using Bit.Core.SecretsManager.Commands.Secrets.Interfaces;
 using Bit.Core.SecretsManager.Commands.ServiceAccounts.Interfaces;
 using Bit.Core.SecretsManager.Commands.Trash.Interfaces;
+using Bit.Core.SecretsManager.Queries.Access.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Bit.Commercial.Core.SecretsManager;
@@ -20,6 +22,8 @@ public static class SecretsManagerCollectionExtensions
 {
     public static void AddSecretsManagerServices(this IServiceCollection services)
     {
+        services.AddScoped<IAccessQuery, AccessQuery>();
+        services.AddScoped<IAccessPolicyAccessQuery, AccessPolicyAccessQuery>();
         services.AddScoped<ICreateSecretCommand, CreateSecretCommand>();
         services.AddScoped<IUpdateSecretCommand, UpdateSecretCommand>();
         services.AddScoped<IDeleteSecretCommand, DeleteSecretCommand>();

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/SecretsManagerCollectionExtensions.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/SecretsManagerCollectionExtensions.cs
@@ -23,6 +23,7 @@ public static class SecretsManagerCollectionExtensions
     public static void AddSecretsManagerServices(this IServiceCollection services)
     {
         services.AddScoped<IAccessQuery, AccessQuery>();
+        services.AddScoped<ISecretAccessQuery, SecretAccessQuery>();
         services.AddScoped<IAccessPolicyAccessQuery, AccessPolicyAccessQuery>();
         services.AddScoped<ICreateSecretCommand, CreateSecretCommand>();
         services.AddScoped<IUpdateSecretCommand, UpdateSecretCommand>();

--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/ProjectRepository.cs
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/ProjectRepository.cs
@@ -188,6 +188,6 @@ public class ProjectRepository : Repository<Core.SecretsManager.Entities.Project
 
         var policy = await query.FirstOrDefaultAsync();
 
-        return (policy.Read, policy.Write);
+        return policy == null ? (false, false) : (policy.Read, policy.Write);
     }
 }

--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/SecretRepository.cs
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/SecretRepository.cs
@@ -290,7 +290,7 @@ public class SecretRepository : Repository<Core.SecretsManager.Entities.Secret, 
 
         var policy = await query.FirstOrDefaultAsync();
 
-        return (policy.Read, policy.Write);
+        return policy == null ? (false, false) : (policy.Read, policy.Write);
     }
 
     private IQueryable<SecretPermissionDetails> SecretToPermissionDetails(IQueryable<Secret> query, Guid userId, AccessClientType accessType)

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/AccessPolicies/UpdateAccessPolicyCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/AccessPolicies/UpdateAccessPolicyCommandTests.cs
@@ -1,6 +1,5 @@
 ﻿using Bit.Commercial.Core.SecretsManager.Commands.AccessPolicies;
 using Bit.Commercial.Core.Test.SecretsManager.Enums;
-using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Exceptions;
 using Bit.Core.SecretsManager.Entities;
@@ -18,43 +17,6 @@ namespace Bit.Commercial.Core.Test.SecretsManager.AccessPolicies;
 [ProjectCustomize]
 public class UpdateAccessPolicyCommandTests
 {
-    private static void SetupPermission(SutProvider<UpdateAccessPolicyCommand> sutProvider,
-        PermissionType permissionType, Project grantedProject, Guid userId)
-    {
-        switch (permissionType)
-        {
-            case PermissionType.RunAsAdmin:
-                sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(grantedProject.OrganizationId)
-                    .Returns(true);
-                break;
-            case PermissionType.RunAsUserWithPermission:
-                sutProvider.GetDependency<IProjectRepository>().UserHasWriteAccessToProject(grantedProject.Id, userId)
-                    .Returns(true);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(permissionType), permissionType, null);
-        }
-    }
-
-    private static void SetupPermission(SutProvider<UpdateAccessPolicyCommand> sutProvider,
-        PermissionType permissionType, ServiceAccount grantedServiceAccount, Guid userId)
-    {
-        switch (permissionType)
-        {
-            case PermissionType.RunAsAdmin:
-                sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(grantedServiceAccount.OrganizationId)
-                    .Returns(true);
-                break;
-            case PermissionType.RunAsUserWithPermission:
-                sutProvider.GetDependency<IServiceAccountRepository>()
-                    .UserHasWriteAccessToServiceAccount(grantedServiceAccount.Id, userId)
-                    .Returns(true);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(permissionType), permissionType, null);
-        }
-    }
-
     private static BaseAccessPolicy CreatePolicyToReturn(AccessPolicyType accessPolicyType,
         ServiceAccount grantedServiceAccount, Guid data, Group mockGroup)
     {
@@ -131,104 +93,32 @@ public class UpdateAccessPolicyCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task UpdateAsync_Throws_NotFoundException(Guid data, bool read, bool write, Guid userId,
+    public async Task UpdateAsync_Throws_NotFoundException(Guid data, bool read, bool write,
         SutProvider<UpdateAccessPolicyCommand> sutProvider)
     {
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(Arg.Any<Guid>()).Returns(true);
-        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.UpdateAsync(data, read, write, userId));
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.UpdateAsync(data, read, write));
         await sutProvider.GetDependency<IAccessPolicyRepository>().DidNotReceiveWithAnyArgs().ReplaceAsync(default);
-    }
-
-    [Theory]
-    [BitAutoData]
-    public async Task UpdateAsync_SmNotEnabled_Throws_NotFoundException(Guid data, bool read, bool write, Guid userId,
-        SutProvider<UpdateAccessPolicyCommand> sutProvider)
-    {
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(Arg.Any<Guid>()).Returns(false);
-        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.UpdateAsync(data, read, write, userId));
-        await sutProvider.GetDependency<IAccessPolicyRepository>().DidNotReceiveWithAnyArgs().ReplaceAsync(default);
-    }
-
-    [Theory]
-    [BitAutoData(AccessPolicyType.UserProjectAccessPolicy, PermissionType.RunAsAdmin)]
-    [BitAutoData(AccessPolicyType.UserProjectAccessPolicy, PermissionType.RunAsUserWithPermission)]
-    [BitAutoData(AccessPolicyType.GroupProjectAccessPolicy, PermissionType.RunAsAdmin)]
-    [BitAutoData(AccessPolicyType.GroupProjectAccessPolicy, PermissionType.RunAsUserWithPermission)]
-    [BitAutoData(AccessPolicyType.ServiceAccountProjectAccessPolicy, PermissionType.RunAsAdmin)]
-    [BitAutoData(AccessPolicyType.ServiceAccountProjectAccessPolicy, PermissionType.RunAsUserWithPermission)]
-    public async Task UpdateAsync_ProjectGrants_PermissionsCheck_Success(
-        AccessPolicyType accessPolicyType,
-        PermissionType permissionType,
-        Guid data,
-        bool read,
-        bool write,
-        Guid userId,
-        Project grantedProject,
-        Group mockGroup,
-        ServiceAccount mockServiceAccount,
-        SutProvider<UpdateAccessPolicyCommand> sutProvider)
-    {
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(Arg.Any<Guid>()).Returns(true);
-        var policyToReturn =
-            CreatePolicyToReturn(accessPolicyType, data, grantedProject, mockGroup, mockServiceAccount);
-        SetupPermission(sutProvider, permissionType, grantedProject, userId);
-
-        sutProvider.GetDependency<IAccessPolicyRepository>().GetByIdAsync(data).Returns(policyToReturn);
-        var result = await sutProvider.Sut.UpdateAsync(data, read, write, userId);
-        await sutProvider.GetDependency<IAccessPolicyRepository>().Received(1).ReplaceAsync(policyToReturn);
-
-        AssertHelper.AssertRecent(result.RevisionDate);
-        Assert.Equal(read, result.Read);
-        Assert.Equal(write, result.Write);
     }
 
     [Theory]
     [BitAutoData(AccessPolicyType.UserProjectAccessPolicy)]
     [BitAutoData(AccessPolicyType.GroupProjectAccessPolicy)]
     [BitAutoData(AccessPolicyType.ServiceAccountProjectAccessPolicy)]
-    public async Task UpdateAsync_ProjectGrants_PermissionsCheck_Throws(
+    public async Task UpdateAsync_ProjectGrants_Success(
         AccessPolicyType accessPolicyType,
         Guid data,
         bool read,
         bool write,
-        Guid userId,
         Project grantedProject,
         Group mockGroup,
         ServiceAccount mockServiceAccount,
         SutProvider<UpdateAccessPolicyCommand> sutProvider)
     {
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(Arg.Any<Guid>()).Returns(true);
         var policyToReturn =
             CreatePolicyToReturn(accessPolicyType, data, grantedProject, mockGroup, mockServiceAccount);
-        sutProvider.GetDependency<IAccessPolicyRepository>().GetByIdAsync(data).Returns(policyToReturn);
-
-        await Assert.ThrowsAsync<NotFoundException>(() =>
-            sutProvider.Sut.UpdateAsync(data, read, write, userId));
-        await sutProvider.GetDependency<IAccessPolicyRepository>().DidNotReceiveWithAnyArgs().ReplaceAsync(default);
-    }
-
-    [Theory]
-    [BitAutoData(AccessPolicyType.UserServiceAccountAccessPolicy, PermissionType.RunAsAdmin)]
-    [BitAutoData(AccessPolicyType.UserServiceAccountAccessPolicy, PermissionType.RunAsUserWithPermission)]
-    [BitAutoData(AccessPolicyType.GroupServiceAccountAccessPolicy, PermissionType.RunAsAdmin)]
-    [BitAutoData(AccessPolicyType.GroupServiceAccountAccessPolicy, PermissionType.RunAsUserWithPermission)]
-    public async Task UpdateAsync_ServiceAccountGrants_PermissionsCheck_Success(
-        AccessPolicyType accessPolicyType,
-        PermissionType permissionType,
-        Guid data,
-        bool read,
-        bool write,
-        Guid userId,
-        ServiceAccount grantedServiceAccount,
-        Group mockGroup,
-        SutProvider<UpdateAccessPolicyCommand> sutProvider)
-    {
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(Arg.Any<Guid>()).Returns(true);
-        var policyToReturn = CreatePolicyToReturn(accessPolicyType, grantedServiceAccount, data, mockGroup);
-        SetupPermission(sutProvider, permissionType, grantedServiceAccount, userId);
 
         sutProvider.GetDependency<IAccessPolicyRepository>().GetByIdAsync(data).Returns(policyToReturn);
-        var result = await sutProvider.Sut.UpdateAsync(data, read, write, userId);
+        var result = await sutProvider.Sut.UpdateAsync(data, read, write);
         await sutProvider.GetDependency<IAccessPolicyRepository>().Received(1).ReplaceAsync(policyToReturn);
 
         AssertHelper.AssertRecent(result.RevisionDate);
@@ -239,22 +129,23 @@ public class UpdateAccessPolicyCommandTests
     [Theory]
     [BitAutoData(AccessPolicyType.UserServiceAccountAccessPolicy)]
     [BitAutoData(AccessPolicyType.GroupServiceAccountAccessPolicy)]
-    public async Task UpdateAsync_ServiceAccountGrants_PermissionsCheck_Throws(
+    public async Task UpdateAsync_ServiceAccountGrants_PermissionsCheck_Success(
         AccessPolicyType accessPolicyType,
         Guid data,
         bool read,
         bool write,
-        Guid userId,
         ServiceAccount grantedServiceAccount,
         Group mockGroup,
         SutProvider<UpdateAccessPolicyCommand> sutProvider)
     {
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(Arg.Any<Guid>()).Returns(true);
         var policyToReturn = CreatePolicyToReturn(accessPolicyType, grantedServiceAccount, data, mockGroup);
-        sutProvider.GetDependency<IAccessPolicyRepository>().GetByIdAsync(data).Returns(policyToReturn);
 
-        await Assert.ThrowsAsync<NotFoundException>(() =>
-            sutProvider.Sut.UpdateAsync(data, read, write, userId));
-        await sutProvider.GetDependency<IAccessPolicyRepository>().DidNotReceiveWithAnyArgs().ReplaceAsync(default);
+        sutProvider.GetDependency<IAccessPolicyRepository>().GetByIdAsync(data).Returns(policyToReturn);
+        var result = await sutProvider.Sut.UpdateAsync(data, read, write);
+        await sutProvider.GetDependency<IAccessPolicyRepository>().Received(1).ReplaceAsync(policyToReturn);
+
+        AssertHelper.AssertRecent(result.RevisionDate);
+        Assert.Equal(read, result.Read);
+        Assert.Equal(write, result.Write);
     }
 }

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/AccessTokens/CreateAccessTokenCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/AccessTokens/CreateAccessTokenCommandTests.cs
@@ -1,6 +1,4 @@
 ﻿using Bit.Commercial.Core.SecretsManager.Commands.AccessTokens;
-using Bit.Core.Context;
-using Bit.Core.Exceptions;
 using Bit.Core.SecretsManager.Entities;
 using Bit.Core.SecretsManager.Repositories;
 using Bit.Test.Common.AutoFixture;
@@ -16,59 +14,12 @@ public class CreateServiceAccountCommandTests
 {
     [Theory]
     [BitAutoData]
-    public async Task CreateAsync_NoServiceAccountId_ThrowsBadRequestException(ApiKey data, Guid userId,
-        SutProvider<CreateAccessTokenCommand> sutProvider)
-    {
-        data.ServiceAccountId = null;
-
-        await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.CreateAsync(data, userId));
-
-        await sutProvider.GetDependency<IApiKeyRepository>().DidNotReceiveWithAnyArgs().CreateAsync(default);
-    }
-
-    [Theory]
-    [BitAutoData]
-    public async Task CreateAsync_User_NoAccess(ApiKey data, Guid userId, ServiceAccount saData,
+    public async Task CreateAsync_Success(ApiKey data, ServiceAccount saData,
         SutProvider<CreateAccessTokenCommand> sutProvider)
     {
         data.ServiceAccountId = saData.Id;
 
-        sutProvider.GetDependency<IServiceAccountRepository>().GetByIdAsync(saData.Id).Returns(saData);
-        sutProvider.GetDependency<IServiceAccountRepository>().UserHasWriteAccessToServiceAccount(saData.Id, userId).Returns(false);
-
-        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.CreateAsync(data, userId));
-
-        await sutProvider.GetDependency<IApiKeyRepository>().DidNotReceiveWithAnyArgs().CreateAsync(default);
-    }
-
-    [Theory]
-    [BitAutoData]
-    public async Task CreateAsync_User_Success(ApiKey data, Guid userId, ServiceAccount saData,
-        SutProvider<CreateAccessTokenCommand> sutProvider)
-    {
-        data.ServiceAccountId = saData.Id;
-        sutProvider.GetDependency<IServiceAccountRepository>().GetByIdAsync(saData.Id).Returns(saData);
-        sutProvider.GetDependency<IServiceAccountRepository>().UserHasWriteAccessToServiceAccount(saData.Id, userId).Returns(true);
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(saData.OrganizationId).Returns(true);
-
-        await sutProvider.Sut.CreateAsync(data, userId);
-
-        await sutProvider.GetDependency<IApiKeyRepository>().Received(1)
-            .CreateAsync(Arg.Is(AssertHelper.AssertPropertyEqual(data)));
-    }
-
-    [Theory]
-    [BitAutoData]
-    public async Task CreateAsync_Admin_Succeeds(ApiKey data, Guid userId, ServiceAccount saData,
-        SutProvider<CreateAccessTokenCommand> sutProvider)
-    {
-        data.ServiceAccountId = saData.Id;
-
-        sutProvider.GetDependency<IServiceAccountRepository>().GetByIdAsync(saData.Id).Returns(saData);
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(saData.OrganizationId).Returns(true);
-        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(saData.OrganizationId).Returns(true);
-
-        await sutProvider.Sut.CreateAsync(data, userId);
+        await sutProvider.Sut.CreateAsync(data);
 
         await sutProvider.GetDependency<IApiKeyRepository>().Received(1)
             .CreateAsync(Arg.Is(AssertHelper.AssertPropertyEqual(data)));

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/AccessPolicies/CreateAccessPoliciesCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/AccessPolicies/CreateAccessPoliciesCommandTests.cs
@@ -10,7 +10,7 @@ using Bit.Test.Common.Helpers;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Commercial.Core.Test.SecretsManager.AccessPolicies;
+namespace Bit.Commercial.Core.Test.SecretsManager.Commands.AccessPolicies;
 
 [SutProviderCustomize]
 [ProjectCustomize]

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/AccessPolicies/DeleteAccessPolicyCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/AccessPolicies/DeleteAccessPolicyCommandTests.cs
@@ -12,7 +12,7 @@ using NSubstitute;
 using NSubstitute.ReturnsExtensions;
 using Xunit;
 
-namespace Bit.Commercial.Core.Test.SecretsManager.AccessPolicies;
+namespace Bit.Commercial.Core.Test.SecretsManager.Commands.AccessPolicies;
 
 [SutProviderCustomize]
 [ProjectCustomize]
@@ -47,8 +47,8 @@ public class DeleteAccessPolicyCommandTests
                 break;
             case PermissionType.RunAsUserWithPermission:
                 sutProvider.GetDependency<IServiceAccountRepository>()
-                    .UserHasWriteAccessToServiceAccount(grantedServiceAccount.Id, userId)
-                    .Returns(true);
+                    .AccessToServiceAccountAsync(grantedServiceAccount.Id, userId, default)
+                    .Returns((true, true));
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(permissionType), permissionType, null);

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/AccessPolicies/UpdateAccessPolicyCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/AccessPolicies/UpdateAccessPolicyCommandTests.cs
@@ -11,7 +11,7 @@ using Bit.Test.Common.Helpers;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Commercial.Core.Test.SecretsManager.AccessPolicies;
+namespace Bit.Commercial.Core.Test.SecretsManager.Commands.AccessPolicies;
 
 [SutProviderCustomize]
 [ProjectCustomize]

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/AccessTokens/CreateAccessTokenCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/AccessTokens/CreateAccessTokenCommandTests.cs
@@ -7,7 +7,7 @@ using Bit.Test.Common.Helpers;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Commercial.Core.Test.SecretsManager.AccessTokens;
+namespace Bit.Commercial.Core.Test.SecretsManager.Commands.AccessTokens;
 
 [SutProviderCustomize]
 public class CreateServiceAccountCommandTests

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/Projects/CreateProjectCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/Projects/CreateProjectCommandTests.cs
@@ -9,7 +9,7 @@ using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Commercial.Core.Test.SecretsManager.Projects;
+namespace Bit.Commercial.Core.Test.SecretsManager.Commands.Projects;
 
 [SutProviderCustomize]
 [ProjectCustomize]

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/Projects/DeleteProjectCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/Projects/DeleteProjectCommandTests.cs
@@ -9,7 +9,7 @@ using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Commercial.Core.Test.SecretsManager.Projects;
+namespace Bit.Commercial.Core.Test.SecretsManager.Commands.Projects;
 
 [SutProviderCustomize]
 public class DeleteProjectCommandTests

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/Projects/UpdateProjectCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/Projects/UpdateProjectCommandTests.cs
@@ -9,7 +9,7 @@ using NSubstitute;
 using NSubstitute.ReturnsExtensions;
 using Xunit;
 
-namespace Bit.Commercial.Core.Test.SecretsManager.Projects;
+namespace Bit.Commercial.Core.Test.SecretsManager.Commands.Projects;
 
 [SutProviderCustomize]
 [ProjectCustomize]

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/Secrets/CreateSecretCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/Secrets/CreateSecretCommandTests.cs
@@ -7,7 +7,7 @@ using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Commercial.Core.Test.SecretsManager.Secrets;
+namespace Bit.Commercial.Core.Test.SecretsManager.Commands.Secrets;
 
 [SutProviderCustomize]
 [SecretCustomize]

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/Secrets/DeleteSecretCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/Secrets/DeleteSecretCommandTests.cs
@@ -11,7 +11,7 @@ using Bit.Test.Common.Helpers;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Commercial.Core.Test.SecretsManager.Secrets;
+namespace Bit.Commercial.Core.Test.SecretsManager.Commands.Secrets;
 
 [SutProviderCustomize]
 [ProjectCustomize]

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/Secrets/UpdateSecretCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/Secrets/UpdateSecretCommandTests.cs
@@ -10,7 +10,7 @@ using Bit.Test.Common.Helpers;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Commercial.Core.Test.SecretsManager.Secrets;
+namespace Bit.Commercial.Core.Test.SecretsManager.Commands.Secrets;
 
 [SutProviderCustomize]
 [SecretCustomize]

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/ServiceAccounts/CreateServiceAccountCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/ServiceAccounts/CreateServiceAccountCommandTests.cs
@@ -9,7 +9,7 @@ using Bit.Test.Common.Helpers;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Commercial.Core.Test.SecretsManager.ServiceAccounts;
+namespace Bit.Commercial.Core.Test.SecretsManager.Commands.ServiceAccounts;
 
 [SutProviderCustomize]
 public class CreateServiceAccountCommandTests

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/ServiceAccounts/RevokeAccessTokenCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/ServiceAccounts/RevokeAccessTokenCommandTests.cs
@@ -6,7 +6,7 @@ using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Commercial.Core.Test.SecretsManager.ServiceAccounts;
+namespace Bit.Commercial.Core.Test.SecretsManager.Commands.ServiceAccounts;
 
 [SutProviderCustomize]
 public class RevokeAccessTokenCommandTests

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/ServiceAccounts/UpdateServiceAccountCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/ServiceAccounts/UpdateServiceAccountCommandTests.cs
@@ -8,7 +8,7 @@ using Bit.Test.Common.Helpers;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Commercial.Core.Test.SecretsManager.ServiceAccounts;
+namespace Bit.Commercial.Core.Test.SecretsManager.Commands.ServiceAccounts;
 
 [SutProviderCustomize]
 public class UpdateServiceAccountCommandTests

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/Trash/EmptyTrashCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/Trash/EmptyTrashCommandTests.cs
@@ -8,15 +8,15 @@ using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Commercial.Core.Test.SecretsManager.Trash;
+namespace Bit.Commercial.Core.Test.SecretsManager.Commands.Trash;
 
 [SutProviderCustomize]
 [ProjectCustomize]
-public class RestoreTrashCommandTests
+public class EmptyTrashCommandTests
 {
     [Theory]
     [BitAutoData]
-    public async Task RestoreTrash_Throws_NotFoundException(Guid orgId, Secret s1, Secret s2, SutProvider<RestoreTrashCommand> sutProvider)
+    public async Task EmptyTrash_Throws_NotFoundException(Guid orgId, Secret s1, Secret s2, SutProvider<EmptyTrashCommand> sutProvider)
     {
         s1.DeletedDate = DateTime.Now;
 
@@ -25,14 +25,14 @@ public class RestoreTrashCommandTests
             .GetManyByOrganizationIdInTrashByIdsAsync(orgId, ids)
             .Returns(new List<Secret> { s1 });
 
-        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.RestoreTrash(orgId, ids));
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.EmptyTrash(orgId, ids));
 
         await sutProvider.GetDependency<ISecretRepository>().DidNotReceiveWithAnyArgs().RestoreManyByIdAsync(default);
     }
 
     [Theory]
     [BitAutoData]
-    public async Task RestoreTrash_Success(Guid orgId, Secret s1, Secret s2, SutProvider<RestoreTrashCommand> sutProvider)
+    public async Task EmptyTrash_Success(Guid orgId, Secret s1, Secret s2, SutProvider<EmptyTrashCommand> sutProvider)
     {
         s1.DeletedDate = DateTime.Now;
 
@@ -41,8 +41,8 @@ public class RestoreTrashCommandTests
             .GetManyByOrganizationIdInTrashByIdsAsync(orgId, ids)
             .Returns(new List<Secret> { s1, s2 });
 
-        await sutProvider.Sut.RestoreTrash(orgId, ids);
+        await sutProvider.Sut.EmptyTrash(orgId, ids);
 
-        await sutProvider.GetDependency<ISecretRepository>().Received(1).RestoreManyByIdAsync(ids);
+        await sutProvider.GetDependency<ISecretRepository>().Received(1).HardDeleteManyByIdAsync(ids);
     }
 }

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/Trash/RestoreTrashCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Commands/Trash/RestoreTrashCommandTests.cs
@@ -8,15 +8,15 @@ using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Commercial.Core.Test.SecretsManager.Trash;
+namespace Bit.Commercial.Core.Test.SecretsManager.Commands.Trash;
 
 [SutProviderCustomize]
 [ProjectCustomize]
-public class EmptyTrashCommandTests
+public class RestoreTrashCommandTests
 {
     [Theory]
     [BitAutoData]
-    public async Task EmptyTrash_Throws_NotFoundException(Guid orgId, Secret s1, Secret s2, SutProvider<EmptyTrashCommand> sutProvider)
+    public async Task RestoreTrash_Throws_NotFoundException(Guid orgId, Secret s1, Secret s2, SutProvider<RestoreTrashCommand> sutProvider)
     {
         s1.DeletedDate = DateTime.Now;
 
@@ -25,14 +25,14 @@ public class EmptyTrashCommandTests
             .GetManyByOrganizationIdInTrashByIdsAsync(orgId, ids)
             .Returns(new List<Secret> { s1 });
 
-        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.EmptyTrash(orgId, ids));
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.RestoreTrash(orgId, ids));
 
         await sutProvider.GetDependency<ISecretRepository>().DidNotReceiveWithAnyArgs().RestoreManyByIdAsync(default);
     }
 
     [Theory]
     [BitAutoData]
-    public async Task EmptyTrash_Success(Guid orgId, Secret s1, Secret s2, SutProvider<EmptyTrashCommand> sutProvider)
+    public async Task RestoreTrash_Success(Guid orgId, Secret s1, Secret s2, SutProvider<RestoreTrashCommand> sutProvider)
     {
         s1.DeletedDate = DateTime.Now;
 
@@ -41,8 +41,8 @@ public class EmptyTrashCommandTests
             .GetManyByOrganizationIdInTrashByIdsAsync(orgId, ids)
             .Returns(new List<Secret> { s1, s2 });
 
-        await sutProvider.Sut.EmptyTrash(orgId, ids);
+        await sutProvider.Sut.RestoreTrash(orgId, ids);
 
-        await sutProvider.GetDependency<ISecretRepository>().Received(1).HardDeleteManyByIdAsync(ids);
+        await sutProvider.GetDependency<ISecretRepository>().Received(1).RestoreManyByIdAsync(ids);
     }
 }

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Projects/UpdateProjectCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Projects/UpdateProjectCommandTests.cs
@@ -1,12 +1,10 @@
 ﻿using Bit.Commercial.Core.SecretsManager.Commands.Projects;
-using Bit.Core.Context;
 using Bit.Core.Exceptions;
 using Bit.Core.SecretsManager.Entities;
 using Bit.Core.SecretsManager.Repositories;
 using Bit.Core.Test.SecretsManager.AutoFixture.ProjectsFixture;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
-using Bit.Test.Common.Helpers;
 using NSubstitute;
 using NSubstitute.ReturnsExtensions;
 using Xunit;
@@ -19,56 +17,23 @@ public class UpdateProjectCommandTests
 {
     [Theory]
     [BitAutoData]
-    public async Task UpdateAsync_Throws_NotFoundException(Project project, Guid userId, SutProvider<UpdateProjectCommand> sutProvider)
+    public async Task UpdateAsync_Throws_NotFoundException(Project project, SutProvider<UpdateProjectCommand> sutProvider)
     {
         sutProvider.GetDependency<IProjectRepository>().GetByIdAsync(project.Id).ReturnsNull();
 
-        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.UpdateAsync(project, userId));
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.UpdateAsync(project));
 
         await sutProvider.GetDependency<IProjectRepository>().DidNotReceiveWithAnyArgs().ReplaceAsync(default);
     }
 
     [Theory]
     [BitAutoData]
-    public async Task UpdateAsync_Admin_Succeeds(Project project, Guid userId, SutProvider<UpdateProjectCommand> sutProvider)
+    public async Task UpdateAsync_Success(Project project, SutProvider<UpdateProjectCommand> sutProvider)
     {
         sutProvider.GetDependency<IProjectRepository>().GetByIdAsync(project.Id).Returns(project);
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(project.OrganizationId).Returns(true);
-        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(project.OrganizationId).Returns(true);
 
-        var project2 = new Project { Id = project.Id, Name = "newName" };
-        var result = await sutProvider.Sut.UpdateAsync(project2, userId);
-
-        Assert.NotNull(result);
-        Assert.Equal("newName", result.Name);
-        AssertHelper.AssertRecent(result.RevisionDate);
-
-        await sutProvider.GetDependency<IProjectRepository>().ReceivedWithAnyArgs(1).ReplaceAsync(default);
-    }
-
-    [Theory]
-    [BitAutoData]
-    public async Task UpdateAsync_User_NoAccess(Project project, Guid userId, SutProvider<UpdateProjectCommand> sutProvider)
-    {
-        sutProvider.GetDependency<IProjectRepository>().GetByIdAsync(project.Id).Returns(project);
-        sutProvider.GetDependency<IProjectRepository>().UserHasWriteAccessToProject(project.Id, userId).Returns(false);
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(project.OrganizationId).Returns(true);
-
-        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.UpdateAsync(project, userId));
-
-        await sutProvider.GetDependency<IProjectRepository>().DidNotReceiveWithAnyArgs().ReplaceAsync(default);
-    }
-
-    [Theory]
-    [BitAutoData]
-    public async Task UpdateAsync_User_Success(Project project, Guid userId, SutProvider<UpdateProjectCommand> sutProvider)
-    {
-        sutProvider.GetDependency<IProjectRepository>().GetByIdAsync(project.Id).Returns(project);
-        sutProvider.GetDependency<IProjectRepository>().UserHasWriteAccessToProject(project.Id, userId).Returns(true);
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(project.OrganizationId).Returns(true);
-
-        var project2 = new Project { Id = project.Id, Name = "newName" };
-        var result = await sutProvider.Sut.UpdateAsync(project2, userId);
+        var updatedProject = new Project { Id = project.Id, Name = "newName" };
+        var result = await sutProvider.Sut.UpdateAsync(updatedProject);
 
         Assert.NotNull(result);
         Assert.Equal("newName", result.Name);

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Queries/Access/AccessQueryTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Queries/Access/AccessQueryTests.cs
@@ -1,0 +1,274 @@
+﻿using Bit.Commercial.Core.SecretsManager.Queries.Access;
+using Bit.Commercial.Core.Test.SecretsManager.Enums;
+using Bit.Core.Context;
+using Bit.Core.Enums;
+using Bit.Core.Identity;
+using Bit.Core.SecretsManager.Enums;
+using Bit.Core.SecretsManager.Models.Data;
+using Bit.Core.SecretsManager.Repositories;
+using Bit.Core.Test.SecretsManager.AutoFixture.ProjectsFixture;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
+using Xunit;
+
+
+namespace Bit.Commercial.Core.Test.SecretsManager.Queries.Access;
+
+[SutProviderCustomize]
+[ProjectCustomize]
+public class AccessQueryTests
+{
+    private static void SetupPermission(SutProvider<AccessQuery> sutProvider, PermissionType permissionType, Guid organizationId)
+    {
+        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(organizationId)
+            .Returns(true);
+
+        switch (permissionType)
+        {
+            case PermissionType.RunAsAdmin:
+                sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(organizationId).Returns(true);
+                break;
+            case PermissionType.RunAsUserWithPermission:
+                sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(organizationId).Returns(false);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(permissionType), permissionType, null);
+        }
+    }
+
+    [Theory]
+    [BitAutoData(AccessOperationType.CreateAccessToken)]
+    [BitAutoData(AccessOperationType.RevokeAccessToken)]
+    [BitAutoData(AccessOperationType.CreateServiceAccount)]
+    [BitAutoData(AccessOperationType.UpdateServiceAccount)]
+    [BitAutoData(AccessOperationType.CreateProject)]
+    [BitAutoData(AccessOperationType.UpdateProject)]
+    [BitAutoData(AccessOperationType.CreateSecret)]
+    [BitAutoData(AccessOperationType.UpdateSecret)]
+    public async Task HasAccess_AccessSecretsManagerFalse_ReturnsFalse(AccessOperationType accessOperationType, SutProvider<AccessQuery> sutProvider, AccessCheck data)
+    {
+        data.AccessOperationType = accessOperationType;
+        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(data.OrganizationId)
+            .Returns(false);
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, true, false)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, false, false)]
+    public async Task HasAccess_RevokeAccessToken_ShouldReturnFalse(PermissionType permissionType, bool read, bool write, SutProvider<AccessQuery> sutProvider, AccessCheck data)
+    {
+        data.AccessOperationType = AccessOperationType.RevokeAccessToken;
+        SetupPermission(sutProvider, permissionType, data.OrganizationId);
+        sutProvider.GetDependency<IServiceAccountRepository>().AccessToServiceAccountAsync(data.TargetId, data.UserId, Arg.Any<AccessClientType>())
+            .Returns((read, write));
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [BitAutoData(PermissionType.RunAsAdmin, true, true)]
+    [BitAutoData(PermissionType.RunAsAdmin, false, true)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, true, true)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, false, true)]
+    public async Task HasAccess_RevokeAccessToken_ShouldReturnTrue(PermissionType permissionType, bool read, bool write, SutProvider<AccessQuery> sutProvider, AccessCheck data)
+    {
+        data.AccessOperationType = AccessOperationType.RevokeAccessToken;
+        SetupPermission(sutProvider, permissionType, data.OrganizationId);
+        sutProvider.GetDependency<IServiceAccountRepository>().AccessToServiceAccountAsync(data.TargetId, data.UserId, Arg.Any<AccessClientType>())
+            .Returns((read, write));
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.True(result);
+    }
+
+    [Theory]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, true, false)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, false, false)]
+    public async Task HasAccess_CreateAccessToken_ShouldReturnFalse(PermissionType permissionType, bool read, bool write, SutProvider<AccessQuery> sutProvider, AccessCheck data)
+    {
+        data.AccessOperationType = AccessOperationType.CreateAccessToken;
+        SetupPermission(sutProvider, permissionType, data.OrganizationId);
+        sutProvider.GetDependency<IServiceAccountRepository>().AccessToServiceAccountAsync(data.TargetId, data.UserId, Arg.Any<AccessClientType>())
+            .Returns((read, write));
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [BitAutoData(PermissionType.RunAsAdmin, true, true)]
+    [BitAutoData(PermissionType.RunAsAdmin, false, true)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, true, true)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, false, true)]
+    public async Task HasAccess_CreateAccessToken_ShouldReturnTrue(PermissionType permissionType, bool read, bool write, SutProvider<AccessQuery> sutProvider, AccessCheck data)
+    {
+        data.AccessOperationType = AccessOperationType.CreateAccessToken;
+        SetupPermission(sutProvider, permissionType, data.OrganizationId);
+        sutProvider.GetDependency<IServiceAccountRepository>().AccessToServiceAccountAsync(data.TargetId, data.UserId, Arg.Any<AccessClientType>())
+            .Returns((read, write));
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.True(result);
+    }
+
+    [Theory]
+    [BitAutoData(ClientType.ServiceAccount)]
+    [BitAutoData(ClientType.Organization)]
+    public async Task HasAccess_CreateServiceAccount_ShouldReturnFalse(ClientType clientType, SutProvider<AccessQuery> sutProvider, AccessCheck data)
+    {
+        data.AccessOperationType = AccessOperationType.CreateServiceAccount;
+        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(data.OrganizationId)
+            .Returns(true);
+        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(data.OrganizationId)
+            .Returns(false);
+        sutProvider.GetDependency<ICurrentContext>().ClientType
+            .Returns(clientType);
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [BitAutoData(PermissionType.RunAsAdmin)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission)]
+    public async Task HasAccess_CreateServiceAccount_ShouldReturnTrue(PermissionType permissionType, SutProvider<AccessQuery> sutProvider, AccessCheck data)
+    {
+        data.AccessOperationType = AccessOperationType.CreateServiceAccount;
+        SetupPermission(sutProvider, permissionType, data.OrganizationId);
+        sutProvider.GetDependency<ICurrentContext>().ClientType
+            .Returns(ClientType.User);
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.True(result);
+    }
+
+    [Theory]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, true, false)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, false, false)]
+    public async Task HasAccess_UpdateServiceAccount_ShouldReturnFalse(PermissionType permissionType, bool read, bool write, SutProvider<AccessQuery> sutProvider, AccessCheck data)
+    {
+        data.AccessOperationType = AccessOperationType.UpdateServiceAccount;
+        SetupPermission(sutProvider, permissionType, data.OrganizationId);
+        sutProvider.GetDependency<IServiceAccountRepository>().AccessToServiceAccountAsync(data.TargetId, data.UserId, Arg.Any<AccessClientType>())
+            .Returns((read, write));
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [BitAutoData(PermissionType.RunAsAdmin, true, true)]
+    [BitAutoData(PermissionType.RunAsAdmin, false, true)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, true, true)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, false, true)]
+    public async Task HasAccess_UpdateServiceAccount_ShouldReturnTrue(PermissionType permissionType, bool read, bool write, SutProvider<AccessQuery> sutProvider, AccessCheck data)
+    {
+        data.AccessOperationType = AccessOperationType.UpdateServiceAccount;
+        SetupPermission(sutProvider, permissionType, data.OrganizationId);
+        sutProvider.GetDependency<IServiceAccountRepository>().AccessToServiceAccountAsync(data.TargetId, data.UserId, Arg.Any<AccessClientType>())
+            .Returns((read, write));
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.True(result);
+    }
+
+    [Theory]
+    [BitAutoData(ClientType.ServiceAccount)]
+    [BitAutoData(ClientType.Organization)]
+    public async Task HasAccess_CreateProject_ShouldReturnFalse(ClientType clientType, SutProvider<AccessQuery> sutProvider, AccessCheck data)
+    {
+        data.AccessOperationType = AccessOperationType.CreateProject;
+        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(data.OrganizationId)
+            .Returns(true);
+        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(data.OrganizationId)
+            .Returns(false);
+        sutProvider.GetDependency<ICurrentContext>().ClientType
+            .Returns(clientType);
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [BitAutoData(PermissionType.RunAsAdmin)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission)]
+    public async Task HasAccess_CreateProject_ShouldReturnTrue(PermissionType permissionType, SutProvider<AccessQuery> sutProvider, AccessCheck data)
+    {
+        data.AccessOperationType = AccessOperationType.CreateProject;
+        SetupPermission(sutProvider, permissionType, data.OrganizationId);
+        sutProvider.GetDependency<ICurrentContext>().ClientType
+            .Returns(ClientType.User);
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.True(result);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task HasAccess_UpdateProject_SaAccessClient_ShouldReturnFalse(SutProvider<AccessQuery> sutProvider, AccessCheck data)
+    {
+        data.AccessOperationType = AccessOperationType.UpdateProject;
+        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(data.OrganizationId)
+            .Returns(true);
+        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(data.OrganizationId)
+            .Returns(false);
+        sutProvider.GetDependency<ICurrentContext>().ClientType
+            .Returns(ClientType.ServiceAccount);
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, true, false)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, false, false)]
+    public async Task HasAccess_UpdateProject_ShouldReturnFalse(PermissionType permissionType, bool read, bool write, SutProvider<AccessQuery> sutProvider, AccessCheck data)
+    {
+        data.AccessOperationType = AccessOperationType.UpdateProject;
+        SetupPermission(sutProvider, permissionType, data.OrganizationId);
+        sutProvider.GetDependency<ICurrentContext>().ClientType
+            .Returns(ClientType.User);
+        sutProvider.GetDependency<IProjectRepository>().AccessToProjectAsync(data.TargetId, data.UserId, Arg.Any<AccessClientType>())
+            .Returns((read, write));
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [BitAutoData(PermissionType.RunAsAdmin, true, true)]
+    [BitAutoData(PermissionType.RunAsAdmin, false, true)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, true, true)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, false, true)]
+    public async Task HasAccess_UpdateProject_ShouldReturnTrue(PermissionType permissionType, bool read, bool write, SutProvider<AccessQuery> sutProvider, AccessCheck data)
+    {
+        data.AccessOperationType = AccessOperationType.UpdateProject;
+        SetupPermission(sutProvider, permissionType, data.OrganizationId);
+        sutProvider.GetDependency<ICurrentContext>().ClientType
+            .Returns(ClientType.User);
+        sutProvider.GetDependency<IProjectRepository>().AccessToProjectAsync(data.TargetId, data.UserId, Arg.Any<AccessClientType>())
+            .Returns((read, write));
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.True(result);
+    }
+}

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Queries/Access/SecretAccessQueryTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Queries/Access/SecretAccessQueryTests.cs
@@ -1,0 +1,155 @@
+﻿using Bit.Commercial.Core.SecretsManager.Queries.Access;
+using Bit.Commercial.Core.Test.SecretsManager.Enums;
+using Bit.Core.Context;
+using Bit.Core.Enums;
+using Bit.Core.Identity;
+using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Enums;
+using Bit.Core.SecretsManager.Models.Data;
+using Bit.Core.SecretsManager.Repositories;
+using Bit.Core.Test.SecretsManager.AutoFixture.ProjectsFixture;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Commercial.Core.Test.SecretsManager.Queries.Access;
+
+[SutProviderCustomize]
+[ProjectCustomize]
+public class SecretAccessQueryTests
+{
+    private static void SetupPermission(SutProvider<SecretAccessQuery> sutProvider, PermissionType permissionType, Guid organizationId)
+    {
+        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(organizationId)
+            .Returns(true);
+
+        switch (permissionType)
+        {
+            case PermissionType.RunAsAdmin:
+                sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(organizationId).Returns(true);
+                break;
+            case PermissionType.RunAsUserWithPermission:
+                sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(organizationId).Returns(false);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(permissionType), permissionType, null);
+        }
+    }
+
+    [Theory]
+    [BitAutoData(AccessOperationType.CreateAccessToken)]
+    [BitAutoData(AccessOperationType.RevokeAccessToken)]
+    [BitAutoData(AccessOperationType.CreateServiceAccount)]
+    [BitAutoData(AccessOperationType.UpdateServiceAccount)]
+    [BitAutoData(AccessOperationType.CreateProject)]
+    [BitAutoData(AccessOperationType.UpdateProject)]
+    [BitAutoData(AccessOperationType.CreateSecret)]
+    [BitAutoData(AccessOperationType.UpdateSecret)]
+    public async Task HasAccess_SecretAccessCheck_AccessSecretsManagerFalse_ReturnsFalse(AccessOperationType accessOperationType, SutProvider<SecretAccessQuery> sutProvider, SecretAccessCheck data)
+    {
+        data.AccessOperationType = accessOperationType;
+        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(data.OrganizationId)
+            .Returns(false);
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [BitAutoData(PermissionType.RunAsAdmin)]
+    public async Task HasAccess_SecretAccessCheck_UpdateSecret_AdminNoProject_ReturnsTrue(PermissionType permissionType, SutProvider<SecretAccessQuery> sutProvider, SecretAccessCheck data)
+    {
+        data.AccessOperationType = AccessOperationType.UpdateSecret;
+        data.TargetProjectId = null;
+        SetupPermission(sutProvider, permissionType, data.OrganizationId);
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.True(result);
+    }
+
+    [Theory]
+    [BitAutoData(PermissionType.RunAsUserWithPermission)]
+    public async Task HasAccess_SecretAccessCheck_UpdateSecret_NotAdminNoProject_ReturnsFalse(PermissionType permissionType, SutProvider<SecretAccessQuery> sutProvider, SecretAccessCheck data)
+    {
+        data.AccessOperationType = AccessOperationType.UpdateSecret;
+        data.TargetProjectId = null;
+        SetupPermission(sutProvider, permissionType, data.OrganizationId);
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [BitAutoData(PermissionType.RunAsUserWithPermission)]
+    public async Task HasAccess_SecretAccessCheck_UpdateSecret_ProjectOrgMismatch_ReturnsFalse(PermissionType permissionType, SutProvider<SecretAccessQuery> sutProvider, SecretAccessCheck data, Project mockProject)
+    {
+        mockProject.Id = data.TargetProjectId!.Value;
+        data.AccessOperationType = AccessOperationType.UpdateSecret;
+        SetupPermission(sutProvider, permissionType, data.OrganizationId);
+        sutProvider.GetDependency<IProjectRepository>().GetByIdAsync(data.TargetProjectId.Value)
+            .Returns(mockProject);
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, true, true, true, false)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, true, true, false, false)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, false, true, true, false)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, false, true, false, false)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, false, false, true, true)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, false, false, false, true)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, true, false, true, true)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, true, false, false, true)]
+    public async Task HasAccess_SecretAccessCheck_UpdateSecret_ReturnsFalse(PermissionType permissionType, bool currentRead, bool currentWrite, bool read, bool write, SutProvider<SecretAccessQuery> sutProvider, SecretAccessCheck data, Project mockProject)
+    {
+        mockProject.Id = data.TargetProjectId!.Value;
+        mockProject.OrganizationId = data.OrganizationId;
+        data.AccessOperationType = AccessOperationType.UpdateSecret;
+        SetupPermission(sutProvider, permissionType, data.OrganizationId);
+        sutProvider.GetDependency<IProjectRepository>().GetByIdAsync(data.TargetProjectId.Value)
+            .Returns(mockProject);
+        sutProvider.GetDependency<ICurrentContext>().ClientType
+            .Returns(ClientType.User);
+        sutProvider.GetDependency<ISecretRepository>().AccessToSecretAsync(data.CurrentSecretId!.Value, data.UserId, Arg.Any<AccessClientType>())
+            .Returns((currentRead, currentWrite));
+        sutProvider.GetDependency<IProjectRepository>().AccessToProjectAsync(data.TargetProjectId.Value, data.UserId, Arg.Any<AccessClientType>())
+            .Returns((read, write));
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [BitAutoData(PermissionType.RunAsAdmin, true, true)]
+    [BitAutoData(PermissionType.RunAsAdmin, false, true)]
+    [BitAutoData(PermissionType.RunAsAdmin, false, false)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, true, true)]
+    [BitAutoData(PermissionType.RunAsUserWithPermission, false, true)]
+    public async Task HasAccess_SecretAccessCheck_UpdateSecret_ReturnsTrue(PermissionType permissionType, bool read, bool write, SutProvider<SecretAccessQuery> sutProvider, SecretAccessCheck data, Project mockProject)
+    {
+        mockProject.Id = data.TargetProjectId!.Value;
+        mockProject.OrganizationId = data.OrganizationId;
+        data.AccessOperationType = AccessOperationType.UpdateSecret;
+        SetupPermission(sutProvider, permissionType, data.OrganizationId);
+        sutProvider.GetDependency<IProjectRepository>().GetByIdAsync(data.TargetProjectId.Value)
+            .Returns(mockProject);
+        sutProvider.GetDependency<ICurrentContext>().ClientType
+            .Returns(ClientType.User);
+        sutProvider.GetDependency<ISecretRepository>().AccessToSecretAsync(data.CurrentSecretId!.Value, data.UserId, Arg.Any<AccessClientType>())
+            .Returns((read, write));
+        sutProvider.GetDependency<IProjectRepository>().AccessToProjectAsync(data.TargetProjectId.Value, data.UserId, Arg.Any<AccessClientType>())
+            .Returns((read, write));
+
+        var result = await sutProvider.Sut.HasAccess(data);
+
+        Assert.True(result);
+    }
+}

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Secrets/CreateSecretCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Secrets/CreateSecretCommandTests.cs
@@ -1,7 +1,4 @@
 ﻿using Bit.Commercial.Core.SecretsManager.Commands.Secrets;
-using Bit.Commercial.Core.Test.SecretsManager.Enums;
-using Bit.Core.Context;
-using Bit.Core.Exceptions;
 using Bit.Core.SecretsManager.Entities;
 using Bit.Core.SecretsManager.Repositories;
 using Bit.Core.Test.SecretsManager.AutoFixture.SecretsFixture;
@@ -17,54 +14,16 @@ namespace Bit.Commercial.Core.Test.SecretsManager.Secrets;
 public class CreateSecretCommandTests
 {
     [Theory]
-    [BitAutoData(PermissionType.RunAsAdmin)]
-    [BitAutoData(PermissionType.RunAsUserWithPermission)]
-    public async Task CreateAsync_Success(PermissionType permissionType, Secret data,
-      SutProvider<CreateSecretCommand> sutProvider, Guid userId, Project mockProject)
+    [BitAutoData]
+    public async Task CreateAsync_Success(Secret data,
+      SutProvider<CreateSecretCommand> sutProvider, Project mockProject)
     {
         data.Projects = new List<Project>() { mockProject };
 
-        if (permissionType == PermissionType.RunAsAdmin)
-        {
-            sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(data.OrganizationId).Returns(true);
-        }
-        else
-        {
-            sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(data.OrganizationId).Returns(false);
-            sutProvider.GetDependency<IProjectRepository>().UserHasWriteAccessToProject((Guid)(data.Projects?.First().Id), userId).Returns(true);
-        }
-
-        await sutProvider.Sut.CreateAsync(data, userId);
+        await sutProvider.Sut.CreateAsync(data);
 
         await sutProvider.GetDependency<ISecretRepository>().Received(1)
             .CreateAsync(data);
-    }
-
-
-    [Theory]
-    [BitAutoData]
-    public async Task CreateAsync_UserWithoutPermission_ThrowsNotFound(Secret data,
-    SutProvider<CreateSecretCommand> sutProvider, Guid userId, Project mockProject)
-    {
-        data.Projects = new List<Project>() { mockProject };
-
-        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(data.OrganizationId).Returns(false);
-        sutProvider.GetDependency<IProjectRepository>().UserHasWriteAccessToProject((Guid)(data.Projects?.First().Id), userId).Returns(false);
-
-        await Assert.ThrowsAsync<NotFoundException>(() =>
-            sutProvider.Sut.CreateAsync(data, userId));
-    }
-
-    [Theory]
-    [BitAutoData]
-    public async Task CreateAsync_NoProjects_User_ThrowsNotFound(Secret data,
-    SutProvider<CreateSecretCommand> sutProvider, Guid userId)
-    {
-        data.Projects = null;
-        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(data.OrganizationId).Returns(false);
-
-        await Assert.ThrowsAsync<NotFoundException>(() =>
-            sutProvider.Sut.CreateAsync(data, userId));
     }
 }
 

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Secrets/UpdateSecretCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Secrets/UpdateSecretCommandTests.cs
@@ -1,6 +1,4 @@
 ﻿using Bit.Commercial.Core.SecretsManager.Commands.Secrets;
-using Bit.Commercial.Core.Test.SecretsManager.Enums;
-using Bit.Core.Context;
 using Bit.Core.Exceptions;
 using Bit.Core.SecretsManager.Entities;
 using Bit.Core.SecretsManager.Repositories;
@@ -23,31 +21,20 @@ public class UpdateSecretCommandTests
     [BitAutoData]
     public async Task UpdateAsync_SecretDoesNotExist_ThrowsNotFound(Secret data, SutProvider<UpdateSecretCommand> sutProvider)
     {
-        var exception = await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.UpdateAsync(data, default));
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.UpdateAsync(data));
 
         await sutProvider.GetDependency<ISecretRepository>().DidNotReceiveWithAnyArgs().UpdateAsync(default);
     }
 
     [Theory]
-    [BitAutoData(PermissionType.RunAsAdmin)]
-    [BitAutoData(PermissionType.RunAsUserWithPermission)]
-    public async Task UpdateAsync_Success(PermissionType permissionType, Secret data, SutProvider<UpdateSecretCommand> sutProvider, Guid userId, Project mockProject)
+    [BitAutoData]
+    public async Task UpdateAsync_Success(Secret existingSecret, Secret data, SutProvider<UpdateSecretCommand> sutProvider, Project mockProject)
     {
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(data.OrganizationId).Returns(true);
+        sutProvider.GetDependency<ISecretRepository>().GetByIdAsync(existingSecret.Id).Returns(existingSecret);
         data.Projects = new List<Project>() { mockProject };
 
-        if (permissionType == PermissionType.RunAsAdmin)
-        {
-            sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(data.OrganizationId).Returns(true);
-        }
-        else
-        {
-            sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(data.OrganizationId).Returns(false);
-            sutProvider.GetDependency<IProjectRepository>().UserHasWriteAccessToProject((Guid)(data.Projects?.First().Id), userId).Returns(true);
-        }
-
         sutProvider.GetDependency<ISecretRepository>().GetByIdAsync(data.Id).Returns(data);
-        await sutProvider.Sut.UpdateAsync(data, userId);
+        await sutProvider.Sut.UpdateAsync(data);
 
         await sutProvider.GetDependency<ISecretRepository>().Received(1)
             .UpdateAsync(data);
@@ -55,13 +42,10 @@ public class UpdateSecretCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task UpdateAsync_DoesNotModifyOrganizationId(Secret existingSecret, SutProvider<UpdateSecretCommand> sutProvider, Guid userId)
+    public async Task UpdateAsync_DoesNotModifyOrganizationId(Secret existingSecret, SutProvider<UpdateSecretCommand> sutProvider)
     {
         var updatedOrgId = Guid.NewGuid();
-        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(existingSecret.OrganizationId).Returns(true);
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(existingSecret.OrganizationId).Returns(true);
         sutProvider.GetDependency<ISecretRepository>().GetByIdAsync(existingSecret.Id).Returns(existingSecret);
-        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(updatedOrgId).Returns(true);
 
         var secretUpdate = new Secret()
         {
@@ -70,7 +54,7 @@ public class UpdateSecretCommandTests
             Key = existingSecret.Key,
         };
 
-        var result = await sutProvider.Sut.UpdateAsync(secretUpdate, userId);
+        var result = await sutProvider.Sut.UpdateAsync(secretUpdate);
 
         Assert.Equal(existingSecret.OrganizationId, result.OrganizationId);
         Assert.NotEqual(existingSecret.OrganizationId, updatedOrgId);
@@ -78,11 +62,9 @@ public class UpdateSecretCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task UpdateAsync_DoesNotModifyCreationDate(Secret existingSecret, SutProvider<UpdateSecretCommand> sutProvider, Guid userId)
+    public async Task UpdateAsync_DoesNotModifyCreationDate(Secret existingSecret, SutProvider<UpdateSecretCommand> sutProvider)
     {
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(existingSecret.OrganizationId).Returns(true);
         sutProvider.GetDependency<ISecretRepository>().GetByIdAsync(existingSecret.Id).Returns(existingSecret);
-        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(existingSecret.OrganizationId).Returns(true);
 
         var updatedCreationDate = DateTime.UtcNow;
         var secretUpdate = new Secret()
@@ -93,7 +75,7 @@ public class UpdateSecretCommandTests
             OrganizationId = existingSecret.OrganizationId
         };
 
-        var result = await sutProvider.Sut.UpdateAsync(secretUpdate, userId);
+        var result = await sutProvider.Sut.UpdateAsync(secretUpdate);
 
         Assert.Equal(existingSecret.CreationDate, result.CreationDate);
         Assert.NotEqual(existingSecret.CreationDate, updatedCreationDate);
@@ -101,11 +83,9 @@ public class UpdateSecretCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task UpdateAsync_DoesNotModifyDeletionDate(Secret existingSecret, SutProvider<UpdateSecretCommand> sutProvider, Guid userId)
+    public async Task UpdateAsync_DoesNotModifyDeletionDate(Secret existingSecret, SutProvider<UpdateSecretCommand> sutProvider)
     {
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(existingSecret.OrganizationId).Returns(true);
         sutProvider.GetDependency<ISecretRepository>().GetByIdAsync(existingSecret.Id).Returns(existingSecret);
-        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(existingSecret.OrganizationId).Returns(true);
 
         var updatedDeletionDate = DateTime.UtcNow;
         var secretUpdate = new Secret()
@@ -116,7 +96,7 @@ public class UpdateSecretCommandTests
             OrganizationId = existingSecret.OrganizationId
         };
 
-        var result = await sutProvider.Sut.UpdateAsync(secretUpdate, userId);
+        var result = await sutProvider.Sut.UpdateAsync(secretUpdate);
 
         Assert.Equal(existingSecret.DeletedDate, result.DeletedDate);
         Assert.NotEqual(existingSecret.DeletedDate, updatedDeletionDate);
@@ -125,12 +105,9 @@ public class UpdateSecretCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task UpdateAsync_RevisionDateIsUpdatedToUtcNow(Secret existingSecret, SutProvider<UpdateSecretCommand> sutProvider, Guid userId)
+    public async Task UpdateAsync_RevisionDateIsUpdatedToUtcNow(Secret existingSecret, SutProvider<UpdateSecretCommand> sutProvider)
     {
-        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(existingSecret.OrganizationId).Returns(true);
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(existingSecret.OrganizationId).Returns(true);
         sutProvider.GetDependency<ISecretRepository>().GetByIdAsync(existingSecret.Id).Returns(existingSecret);
-        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(existingSecret.OrganizationId).Returns(true);
 
         var updatedRevisionDate = DateTime.UtcNow.AddDays(10);
         var secretUpdate = new Secret()
@@ -141,7 +118,7 @@ public class UpdateSecretCommandTests
             OrganizationId = existingSecret.OrganizationId
         };
 
-        var result = await sutProvider.Sut.UpdateAsync(secretUpdate, userId);
+        var result = await sutProvider.Sut.UpdateAsync(secretUpdate);
 
         Assert.NotEqual(secretUpdate.RevisionDate, result.RevisionDate);
         AssertHelper.AssertRecent(result.RevisionDate);

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/ServiceAccounts/UpdateServiceAccountCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/ServiceAccounts/UpdateServiceAccountCommandTests.cs
@@ -1,5 +1,4 @@
 ﻿using Bit.Commercial.Core.SecretsManager.Commands.ServiceAccounts;
-using Bit.Core.Context;
 using Bit.Core.Exceptions;
 using Bit.Core.SecretsManager.Entities;
 using Bit.Core.SecretsManager.Repositories;
@@ -16,49 +15,20 @@ public class UpdateServiceAccountCommandTests
 {
     [Theory]
     [BitAutoData]
-    public async Task UpdateAsync_ServiceAccountDoesNotExist_ThrowsNotFound(ServiceAccount data, Guid userId, SutProvider<UpdateServiceAccountCommand> sutProvider)
+    public async Task UpdateAsync_ServiceAccountDoesNotExist_ThrowsNotFound(ServiceAccount data, SutProvider<UpdateServiceAccountCommand> sutProvider)
     {
-        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.UpdateAsync(data, userId));
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.UpdateAsync(data));
 
         await sutProvider.GetDependency<IServiceAccountRepository>().DidNotReceiveWithAnyArgs().ReplaceAsync(default);
     }
 
     [Theory]
     [BitAutoData]
-    public async Task UpdateAsync_User_NoAccess(ServiceAccount data, Guid userId, SutProvider<UpdateServiceAccountCommand> sutProvider)
+    public async Task UpdateAsync_Success(ServiceAccount data, SutProvider<UpdateServiceAccountCommand> sutProvider)
     {
         sutProvider.GetDependency<IServiceAccountRepository>().GetByIdAsync(data.Id).Returns(data);
-        sutProvider.GetDependency<IServiceAccountRepository>().UserHasWriteAccessToServiceAccount(data.Id, userId).Returns(false);
 
-        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.UpdateAsync(data, userId));
-
-        await sutProvider.GetDependency<IServiceAccountRepository>().DidNotReceiveWithAnyArgs().ReplaceAsync(default);
-    }
-
-    [Theory]
-    [BitAutoData]
-    public async Task UpdateAsync_User_Success(ServiceAccount data, Guid userId, SutProvider<UpdateServiceAccountCommand> sutProvider)
-    {
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(data.OrganizationId).Returns(true);
-        sutProvider.GetDependency<IServiceAccountRepository>().GetByIdAsync(data.Id).Returns(data);
-        sutProvider.GetDependency<IServiceAccountRepository>().UserHasWriteAccessToServiceAccount(data.Id, userId).Returns(true);
-
-        await sutProvider.Sut.UpdateAsync(data, userId);
-
-        await sutProvider.GetDependency<IServiceAccountRepository>().Received(1)
-            .ReplaceAsync(Arg.Is(AssertHelper.AssertPropertyEqual(data)));
-    }
-
-
-    [Theory]
-    [BitAutoData]
-    public async Task UpdateAsync_Admin_Success(ServiceAccount data, Guid userId, SutProvider<UpdateServiceAccountCommand> sutProvider)
-    {
-        sutProvider.GetDependency<IServiceAccountRepository>().GetByIdAsync(data.Id).Returns(data);
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(data.OrganizationId).Returns(true);
-        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(data.OrganizationId).Returns(true);
-
-        await sutProvider.Sut.UpdateAsync(data, userId);
+        await sutProvider.Sut.UpdateAsync(data);
 
         await sutProvider.GetDependency<IServiceAccountRepository>().Received(1)
             .ReplaceAsync(Arg.Is(AssertHelper.AssertPropertyEqual(data)));
@@ -66,11 +36,9 @@ public class UpdateServiceAccountCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task UpdateAsync_DoesNotModifyOrganizationId(ServiceAccount existingServiceAccount, Guid userId, SutProvider<UpdateServiceAccountCommand> sutProvider)
+    public async Task UpdateAsync_DoesNotModifyOrganizationId(ServiceAccount existingServiceAccount, SutProvider<UpdateServiceAccountCommand> sutProvider)
     {
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(existingServiceAccount.OrganizationId).Returns(true);
         sutProvider.GetDependency<IServiceAccountRepository>().GetByIdAsync(existingServiceAccount.Id).Returns(existingServiceAccount);
-        sutProvider.GetDependency<IServiceAccountRepository>().UserHasWriteAccessToServiceAccount(existingServiceAccount.Id, userId).Returns(true);
 
         var updatedOrgId = Guid.NewGuid();
         var serviceAccountUpdate = new ServiceAccount()
@@ -80,7 +48,7 @@ public class UpdateServiceAccountCommandTests
             Name = existingServiceAccount.Name,
         };
 
-        var result = await sutProvider.Sut.UpdateAsync(serviceAccountUpdate, userId);
+        var result = await sutProvider.Sut.UpdateAsync(serviceAccountUpdate);
 
         Assert.Equal(existingServiceAccount.OrganizationId, result.OrganizationId);
         Assert.NotEqual(existingServiceAccount.OrganizationId, updatedOrgId);
@@ -88,11 +56,9 @@ public class UpdateServiceAccountCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task UpdateAsync_DoesNotModifyCreationDate(ServiceAccount existingServiceAccount, Guid userId, SutProvider<UpdateServiceAccountCommand> sutProvider)
+    public async Task UpdateAsync_DoesNotModifyCreationDate(ServiceAccount existingServiceAccount, SutProvider<UpdateServiceAccountCommand> sutProvider)
     {
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(existingServiceAccount.OrganizationId).Returns(true);
         sutProvider.GetDependency<IServiceAccountRepository>().GetByIdAsync(existingServiceAccount.Id).Returns(existingServiceAccount);
-        sutProvider.GetDependency<IServiceAccountRepository>().UserHasWriteAccessToServiceAccount(existingServiceAccount.Id, userId).Returns(true);
 
         var updatedCreationDate = DateTime.UtcNow;
         var serviceAccountUpdate = new ServiceAccount()
@@ -102,7 +68,7 @@ public class UpdateServiceAccountCommandTests
             Name = existingServiceAccount.Name,
         };
 
-        var result = await sutProvider.Sut.UpdateAsync(serviceAccountUpdate, userId);
+        var result = await sutProvider.Sut.UpdateAsync(serviceAccountUpdate);
 
         Assert.Equal(existingServiceAccount.CreationDate, result.CreationDate);
         Assert.NotEqual(existingServiceAccount.CreationDate, updatedCreationDate);
@@ -110,11 +76,9 @@ public class UpdateServiceAccountCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task UpdateAsync_RevisionDateIsUpdatedToUtcNow(ServiceAccount existingServiceAccount, Guid userId, SutProvider<UpdateServiceAccountCommand> sutProvider)
+    public async Task UpdateAsync_RevisionDateIsUpdatedToUtcNow(ServiceAccount existingServiceAccount, SutProvider<UpdateServiceAccountCommand> sutProvider)
     {
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(existingServiceAccount.OrganizationId).Returns(true);
         sutProvider.GetDependency<IServiceAccountRepository>().GetByIdAsync(existingServiceAccount.Id).Returns(existingServiceAccount);
-        sutProvider.GetDependency<IServiceAccountRepository>().UserHasWriteAccessToServiceAccount(existingServiceAccount.Id, userId).Returns(true);
 
         var updatedRevisionDate = DateTime.UtcNow.AddDays(10);
         var serviceAccountUpdate = new ServiceAccount()
@@ -124,7 +88,7 @@ public class UpdateServiceAccountCommandTests
             Name = existingServiceAccount.Name,
         };
 
-        var result = await sutProvider.Sut.UpdateAsync(serviceAccountUpdate, userId);
+        var result = await sutProvider.Sut.UpdateAsync(serviceAccountUpdate);
 
         Assert.NotEqual(serviceAccountUpdate.RevisionDate, result.RevisionDate);
         AssertHelper.AssertRecent(result.RevisionDate);

--- a/src/Api/SecretsManager/Controllers/AccessPoliciesController.cs
+++ b/src/Api/SecretsManager/Controllers/AccessPoliciesController.cs
@@ -183,6 +183,7 @@ public class AccessPoliciesController : Controller
     public async Task<BaseAccessPolicyResponseModel> UpdateAccessPolicyAsync([FromRoute] Guid id,
         [FromBody] AccessPolicyUpdateRequest request)
     {
+        // FIXME pass orgID with request?
         var ap = await _accessPolicyRepository.GetByIdAsync(id);
         if (ap == null)
         {
@@ -195,7 +196,7 @@ public class AccessPoliciesController : Controller
             throw new NotFoundException();
         }
 
-        var result = await _updateAccessPolicyCommand.UpdateAsync(ap, request.Read, request.Write);
+        var result = await _updateAccessPolicyCommand.UpdateAsync(id, request.Read, request.Write);
         return result switch
         {
             UserProjectAccessPolicy accessPolicy => new UserProjectAccessPolicyResponseModel(accessPolicy),

--- a/src/Api/SecretsManager/Controllers/ProjectsController.cs
+++ b/src/Api/SecretsManager/Controllers/ProjectsController.cs
@@ -5,6 +5,7 @@ using Bit.Core.Context;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.SecretsManager.Commands.Projects.Interfaces;
+using Bit.Core.SecretsManager.Queries.Access.Interfaces;
 using Bit.Core.SecretsManager.Repositories;
 using Bit.Core.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -22,6 +23,7 @@ public class ProjectsController : Controller
     private readonly ICreateProjectCommand _createProjectCommand;
     private readonly IUpdateProjectCommand _updateProjectCommand;
     private readonly IDeleteProjectCommand _deleteProjectCommand;
+    private readonly IAccessQuery _accessQuery;
 
     public ProjectsController(
         ICurrentContext currentContext,
@@ -29,7 +31,8 @@ public class ProjectsController : Controller
         IProjectRepository projectRepository,
         ICreateProjectCommand createProjectCommand,
         IUpdateProjectCommand updateProjectCommand,
-        IDeleteProjectCommand deleteProjectCommand)
+        IDeleteProjectCommand deleteProjectCommand,
+        IAccessQuery accessQuery)
     {
         _currentContext = currentContext;
         _userService = userService;
@@ -37,6 +40,7 @@ public class ProjectsController : Controller
         _createProjectCommand = createProjectCommand;
         _updateProjectCommand = updateProjectCommand;
         _deleteProjectCommand = deleteProjectCommand;
+        _accessQuery = accessQuery;
     }
 
     [HttpGet("organizations/{organizationId}/projects")]
@@ -60,7 +64,7 @@ public class ProjectsController : Controller
     [HttpPost("organizations/{organizationId}/projects")]
     public async Task<ProjectResponseModel> CreateAsync([FromRoute] Guid organizationId, [FromBody] ProjectCreateRequestModel createRequest)
     {
-        if (!_currentContext.AccessSecretsManager(organizationId))
+        if (!await _accessQuery.HasAccess(createRequest.ToAccessCheck(organizationId)))
         {
             throw new NotFoundException();
         }
@@ -73,9 +77,19 @@ public class ProjectsController : Controller
     [HttpPut("projects/{id}")]
     public async Task<ProjectResponseModel> UpdateAsync([FromRoute] Guid id, [FromBody] ProjectUpdateRequestModel updateRequest)
     {
-        var userId = _userService.GetProperUserId(User).Value;
+        var project = await _projectRepository.GetByIdAsync(id);
+        if (project == null)
+        {
+            throw new NotFoundException();
+        }
 
-        var result = await _updateProjectCommand.UpdateAsync(updateRequest.ToProject(id), userId);
+        var userId = _userService.GetProperUserId(User).Value;
+        if (!await _accessQuery.HasAccess(updateRequest.ToAccessCheck(project.OrganizationId, id, userId)))
+        {
+            throw new NotFoundException();
+        }
+
+        var result = await _updateProjectCommand.UpdateAsync(project, updateRequest.ToProject(id));
         return new ProjectResponseModel(result);
     }
 

--- a/src/Api/SecretsManager/Controllers/ProjectsController.cs
+++ b/src/Api/SecretsManager/Controllers/ProjectsController.cs
@@ -77,6 +77,7 @@ public class ProjectsController : Controller
     [HttpPut("projects/{id}")]
     public async Task<ProjectResponseModel> UpdateAsync([FromRoute] Guid id, [FromBody] ProjectUpdateRequestModel updateRequest)
     {
+        //FIX me should we pass org id with request?
         var project = await _projectRepository.GetByIdAsync(id);
         if (project == null)
         {
@@ -89,7 +90,7 @@ public class ProjectsController : Controller
             throw new NotFoundException();
         }
 
-        var result = await _updateProjectCommand.UpdateAsync(project, updateRequest.ToProject(id));
+        var result = await _updateProjectCommand.UpdateAsync(updateRequest.ToProject(id));
         return new ProjectResponseModel(result);
     }
 

--- a/src/Api/SecretsManager/Controllers/ProjectsController.cs
+++ b/src/Api/SecretsManager/Controllers/ProjectsController.cs
@@ -77,7 +77,6 @@ public class ProjectsController : Controller
     [HttpPut("projects/{id}")]
     public async Task<ProjectResponseModel> UpdateAsync([FromRoute] Guid id, [FromBody] ProjectUpdateRequestModel updateRequest)
     {
-        //FIX me should we pass org id with request?
         var project = await _projectRepository.GetByIdAsync(id);
         if (project == null)
         {

--- a/src/Api/SecretsManager/Controllers/SecretsController.cs
+++ b/src/Api/SecretsManager/Controllers/SecretsController.cs
@@ -11,7 +11,6 @@ using Bit.Core.SecretsManager.Commands.Secrets.Interfaces;
 using Bit.Core.SecretsManager.Queries.Access.Interfaces;
 using Bit.Core.SecretsManager.Repositories;
 using Bit.Core.Services;
-using LinqToDB;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -152,6 +151,7 @@ public class SecretsController : Controller
     [HttpPut("secrets/{id}")]
     public async Task<SecretResponseModel> UpdateSecretAsync([FromRoute] Guid id, [FromBody] SecretUpdateRequestModel updateRequest)
     {
+        // FIXME pass in orgID 
         var secret = await _secretRepository.GetByIdAsync(id);
         if (secret == null)
         {
@@ -164,7 +164,7 @@ public class SecretsController : Controller
             throw new NotFoundException();
         }
 
-        var result = await _updateSecretCommand.UpdateAsync(secret, updateRequest.ToSecret(id));
+        var result = await _updateSecretCommand.UpdateAsync(updateRequest.ToSecret(id));
 
         // Updating a secret means you have read & write permission.
         return new SecretResponseModel(result, true, true);

--- a/src/Api/SecretsManager/Controllers/ServiceAccountsController.cs
+++ b/src/Api/SecretsManager/Controllers/ServiceAccountsController.cs
@@ -127,6 +127,7 @@ public class ServiceAccountsController : Controller
     public async Task<ServiceAccountResponseModel> UpdateAsync([FromRoute] Guid id,
         [FromBody] ServiceAccountUpdateRequestModel updateRequest)
     {
+        // FIX ME should we pass orgID in request? 
         var serviceAccount = await _serviceAccountRepository.GetByIdAsync(id);
         if (serviceAccount == null)
         {
@@ -139,7 +140,7 @@ public class ServiceAccountsController : Controller
             throw new NotFoundException();
         }
 
-        var result = await _updateServiceAccountCommand.UpdateAsync(serviceAccount, updateRequest.ToServiceAccount(id));
+        var result = await _updateServiceAccountCommand.UpdateAsync(updateRequest.ToServiceAccount(id));
         return new ServiceAccountResponseModel(result);
     }
 

--- a/src/Api/SecretsManager/Models/Request/AccessTokenCreateRequestModel.cs
+++ b/src/Api/SecretsManager/Models/Request/AccessTokenCreateRequestModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Enums;
 using Bit.Core.SecretsManager.Models.Data;
 using Bit.Core.Utilities;
 
@@ -40,7 +41,7 @@ public class AccessTokenCreateRequestModel
     {
         return new AccessCheck
         {
-            OperationType = OperationType.CreateAccessToken,
+            AccessOperationType = AccessOperationType.CreateAccessToken,
             TargetId = id,
             OrganizationId = organizationId,
             UserId = userId,

--- a/src/Api/SecretsManager/Models/Request/AccessTokenCreateRequestModel.cs
+++ b/src/Api/SecretsManager/Models/Request/AccessTokenCreateRequestModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Models.Data;
 using Bit.Core.Utilities;
 
 namespace Bit.Api.SecretsManager.Models.Request;
@@ -32,6 +33,17 @@ public class AccessTokenCreateRequestModel
             ExpireAt = ExpireAt,
             Scope = "[\"api.secrets\"]",
             EncryptedPayload = EncryptedPayload,
+        };
+    }
+
+    public AccessCheck ToAccessCheck(Guid id, Guid organizationId, Guid userId)
+    {
+        return new AccessCheck
+        {
+            OperationType = OperationType.CreateAccessToken,
+            TargetId = id,
+            OrganizationId = organizationId,
+            UserId = userId,
         };
     }
 }

--- a/src/Api/SecretsManager/Models/Request/ProjectCreateRequestModel.cs
+++ b/src/Api/SecretsManager/Models/Request/ProjectCreateRequestModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Enums;
 using Bit.Core.SecretsManager.Models.Data;
 using Bit.Core.Utilities;
 
@@ -22,6 +23,10 @@ public class ProjectCreateRequestModel
 
     public AccessCheck ToAccessCheck(Guid organizationId)
     {
-        return new AccessCheck() { OperationType = OperationType.CreateProject, OrganizationId = organizationId, };
+        return new AccessCheck()
+        {
+            AccessOperationType = AccessOperationType.CreateProject,
+            OrganizationId = organizationId,
+        };
     }
 }

--- a/src/Api/SecretsManager/Models/Request/ProjectCreateRequestModel.cs
+++ b/src/Api/SecretsManager/Models/Request/ProjectCreateRequestModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Models.Data;
 using Bit.Core.Utilities;
 
 namespace Bit.Api.SecretsManager.Models.Request;
@@ -17,5 +18,10 @@ public class ProjectCreateRequestModel
             OrganizationId = organizationId,
             Name = Name,
         };
+    }
+
+    public AccessCheck ToAccessCheck(Guid organizationId)
+    {
+        return new AccessCheck() { OperationType = OperationType.CreateProject, OrganizationId = organizationId, };
     }
 }

--- a/src/Api/SecretsManager/Models/Request/ProjectUpdateRequestModel.cs
+++ b/src/Api/SecretsManager/Models/Request/ProjectUpdateRequestModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Enums;
 using Bit.Core.SecretsManager.Models.Data;
 using Bit.Core.Utilities;
 
@@ -24,7 +25,7 @@ public class ProjectUpdateRequestModel
     {
         return new AccessCheck
         {
-            OperationType = OperationType.UpdateProject,
+            AccessOperationType = AccessOperationType.UpdateProject,
             OrganizationId = organizationId,
             TargetId = id,
             UserId = userId,

--- a/src/Api/SecretsManager/Models/Request/ProjectUpdateRequestModel.cs
+++ b/src/Api/SecretsManager/Models/Request/ProjectUpdateRequestModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Models.Data;
 using Bit.Core.Utilities;
 
 namespace Bit.Api.SecretsManager.Models.Request;
@@ -16,6 +17,17 @@ public class ProjectUpdateRequestModel
         {
             Id = id,
             Name = Name,
+        };
+    }
+
+    public AccessCheck ToAccessCheck(Guid organizationId, Guid id, Guid userId)
+    {
+        return new AccessCheck
+        {
+            OperationType = OperationType.UpdateProject,
+            OrganizationId = organizationId,
+            TargetId = id,
+            UserId = userId,
         };
     }
 }

--- a/src/Api/SecretsManager/Models/Request/RevokeAccessTokensRequest.cs
+++ b/src/Api/SecretsManager/Models/Request/RevokeAccessTokensRequest.cs
@@ -1,5 +1,8 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.SecretsManager.Enums;
 using Bit.Core.SecretsManager.Models.Data;
+
+namespace Bit.Api.SecretsManager.Models.Request;
 
 public class RevokeAccessTokensRequest
 {
@@ -10,7 +13,7 @@ public class RevokeAccessTokensRequest
     {
         return new AccessCheck
         {
-            OperationType = OperationType.RevokeAccessToken,
+            AccessOperationType = AccessOperationType.RevokeAccessToken,
             TargetId = targetId,
             OrganizationId = organizationId,
             UserId = userId,

--- a/src/Api/SecretsManager/Models/Request/RevokeAccessTokensRequest.cs
+++ b/src/Api/SecretsManager/Models/Request/RevokeAccessTokensRequest.cs
@@ -1,7 +1,19 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.SecretsManager.Models.Data;
 
 public class RevokeAccessTokensRequest
 {
     [Required]
     public Guid[] Ids { get; set; }
+
+    public AccessCheck ToAccessCheck(Guid targetId, Guid organizationId, Guid userId)
+    {
+        return new AccessCheck
+        {
+            OperationType = OperationType.RevokeAccessToken,
+            TargetId = targetId,
+            OrganizationId = organizationId,
+            UserId = userId,
+        };
+    }
 }

--- a/src/Api/SecretsManager/Models/Request/SecretCreateRequestModel.cs
+++ b/src/Api/SecretsManager/Models/Request/SecretCreateRequestModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Enums;
 using Bit.Core.SecretsManager.Models.Data;
 using Bit.Core.Utilities;
 
@@ -38,7 +39,7 @@ public class SecretCreateRequestModel
     {
         return new SecretAccessCheck
         {
-            OperationType = OperationType.CreateSecret,
+            AccessOperationType = AccessOperationType.CreateSecret,
             OrganizationId = organizationId,
             TargetProjectId = ProjectIds?.FirstOrDefault(),
             UserId = userId,

--- a/src/Api/SecretsManager/Models/Request/SecretCreateRequestModel.cs
+++ b/src/Api/SecretsManager/Models/Request/SecretCreateRequestModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Models.Data;
 using Bit.Core.Utilities;
 
 namespace Bit.Api.SecretsManager.Models.Request;
@@ -30,6 +31,17 @@ public class SecretCreateRequestModel
             Note = Note,
             DeletedDate = null,
             Projects = ProjectIds != null && ProjectIds.Any() ? ProjectIds.Select(x => new Project() { Id = x }).ToList() : null,
+        };
+    }
+
+    public SecretAccessCheck ToSecretAccessCheck(Guid organizationId, Guid userId)
+    {
+        return new SecretAccessCheck
+        {
+            OperationType = OperationType.CreateSecret,
+            OrganizationId = organizationId,
+            TargetProjectId = ProjectIds?.FirstOrDefault(),
+            UserId = userId,
         };
     }
 }

--- a/src/Api/SecretsManager/Models/Request/SecretUpdateRequestModel.cs
+++ b/src/Api/SecretsManager/Models/Request/SecretUpdateRequestModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Enums;
 using Bit.Core.SecretsManager.Models.Data;
 using Bit.Core.Utilities;
 
@@ -39,7 +40,7 @@ public class SecretUpdateRequestModel
         var projectId = ProjectIds?.FirstOrDefault();
         return new SecretAccessCheck()
         {
-            OperationType = OperationType.UpdateSecret,
+            AccessOperationType = AccessOperationType.UpdateSecret,
             OrganizationId = organizationId,
             UserId = userId,
             TargetProjectId = projectId,

--- a/src/Api/SecretsManager/Models/Request/SecretUpdateRequestModel.cs
+++ b/src/Api/SecretsManager/Models/Request/SecretUpdateRequestModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Models.Data;
 using Bit.Core.Utilities;
 
 namespace Bit.Api.SecretsManager.Models.Request;
@@ -30,6 +31,19 @@ public class SecretUpdateRequestModel
             Note = Note,
             DeletedDate = null,
             Projects = ProjectIds != null && ProjectIds.Any() ? ProjectIds.Select(x => new Project() { Id = x }).ToList() : null,
+        };
+    }
+
+    public SecretAccessCheck ToSecretAccessCheck(Guid organizationId, Guid userId, Guid? currentSecretId)
+    {
+        var projectId = ProjectIds?.FirstOrDefault();
+        return new SecretAccessCheck()
+        {
+            OperationType = OperationType.UpdateSecret,
+            OrganizationId = organizationId,
+            UserId = userId,
+            TargetProjectId = projectId,
+            CurrentSecretId = currentSecretId,
         };
     }
 }

--- a/src/Api/SecretsManager/Models/Request/SerivceAccountUpdateRequestModel.cs
+++ b/src/Api/SecretsManager/Models/Request/SerivceAccountUpdateRequestModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Models.Data;
 using Bit.Core.Utilities;
 
 namespace Bit.Api.SecretsManager.Models.Request;
@@ -16,6 +17,17 @@ public class ServiceAccountUpdateRequestModel
         {
             Id = id,
             Name = Name,
+        };
+    }
+
+    public AccessCheck ToAccessCheck(Guid id, Guid organizationId, Guid userId)
+    {
+        return new AccessCheck
+        {
+            OperationType = OperationType.UpdateServiceAccount,
+            OrganizationId = organizationId,
+            TargetId = id,
+            UserId = userId,
         };
     }
 }

--- a/src/Api/SecretsManager/Models/Request/SerivceAccountUpdateRequestModel.cs
+++ b/src/Api/SecretsManager/Models/Request/SerivceAccountUpdateRequestModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Enums;
 using Bit.Core.SecretsManager.Models.Data;
 using Bit.Core.Utilities;
 
@@ -24,7 +25,7 @@ public class ServiceAccountUpdateRequestModel
     {
         return new AccessCheck
         {
-            OperationType = OperationType.UpdateServiceAccount,
+            AccessOperationType = AccessOperationType.UpdateServiceAccount,
             OrganizationId = organizationId,
             TargetId = id,
             UserId = userId,

--- a/src/Api/SecretsManager/Models/Request/ServiceAccountCreateRequestModel.cs
+++ b/src/Api/SecretsManager/Models/Request/ServiceAccountCreateRequestModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Enums;
 using Bit.Core.SecretsManager.Models.Data;
 using Bit.Core.Utilities;
 
@@ -24,7 +25,7 @@ public class ServiceAccountCreateRequestModel
     {
         return new AccessCheck
         {
-            OperationType = OperationType.CreateServiceAccount,
+            AccessOperationType = AccessOperationType.CreateServiceAccount,
             OrganizationId = organizationId,
             UserId = userId,
         };

--- a/src/Api/SecretsManager/Models/Request/ServiceAccountCreateRequestModel.cs
+++ b/src/Api/SecretsManager/Models/Request/ServiceAccountCreateRequestModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Models.Data;
 using Bit.Core.Utilities;
 
 namespace Bit.Api.SecretsManager.Models.Request;
@@ -16,6 +17,16 @@ public class ServiceAccountCreateRequestModel
         {
             OrganizationId = organizationId,
             Name = Name,
+        };
+    }
+
+    public AccessCheck ToAccessCheck(Guid organizationId, Guid userId)
+    {
+        return new AccessCheck
+        {
+            OperationType = OperationType.CreateServiceAccount,
+            OrganizationId = organizationId,
+            UserId = userId,
         };
     }
 }

--- a/src/Core/SecretsManager/Commands/AccessPolicies/Interfaces/ICreateAccessPoliciesCommand.cs
+++ b/src/Core/SecretsManager/Commands/AccessPolicies/Interfaces/ICreateAccessPoliciesCommand.cs
@@ -1,9 +1,8 @@
-﻿using Bit.Core.Enums;
-using Bit.Core.SecretsManager.Entities;
+﻿using Bit.Core.SecretsManager.Entities;
 
 namespace Bit.Core.SecretsManager.Commands.AccessPolicies.Interfaces;
 
 public interface ICreateAccessPoliciesCommand
 {
-    Task<IEnumerable<BaseAccessPolicy>> CreateManyAsync(List<BaseAccessPolicy> accessPolicies, Guid userId, AccessClientType accessType);
+    Task<IEnumerable<BaseAccessPolicy>> CreateManyAsync(List<BaseAccessPolicy> accessPolicies);
 }

--- a/src/Core/SecretsManager/Commands/AccessPolicies/Interfaces/IDeleteAccessPolicyCommand.cs
+++ b/src/Core/SecretsManager/Commands/AccessPolicies/Interfaces/IDeleteAccessPolicyCommand.cs
@@ -2,5 +2,5 @@
 
 public interface IDeleteAccessPolicyCommand
 {
-    Task DeleteAsync(Guid id, Guid userId);
+    Task DeleteAsync(Guid id);
 }

--- a/src/Core/SecretsManager/Commands/AccessPolicies/Interfaces/IUpdateAccessPolicyCommand.cs
+++ b/src/Core/SecretsManager/Commands/AccessPolicies/Interfaces/IUpdateAccessPolicyCommand.cs
@@ -4,5 +4,5 @@ namespace Bit.Core.SecretsManager.Commands.AccessPolicies.Interfaces;
 
 public interface IUpdateAccessPolicyCommand
 {
-    public Task<BaseAccessPolicy> UpdateAsync(BaseAccessPolicy accessPolicy, bool read, bool write);
+    public Task<BaseAccessPolicy> UpdateAsync(Guid id, bool read, bool write);
 }

--- a/src/Core/SecretsManager/Commands/AccessPolicies/Interfaces/IUpdateAccessPolicyCommand.cs
+++ b/src/Core/SecretsManager/Commands/AccessPolicies/Interfaces/IUpdateAccessPolicyCommand.cs
@@ -4,5 +4,5 @@ namespace Bit.Core.SecretsManager.Commands.AccessPolicies.Interfaces;
 
 public interface IUpdateAccessPolicyCommand
 {
-    public Task<BaseAccessPolicy> UpdateAsync(Guid id, bool read, bool write, Guid userId);
+    public Task<BaseAccessPolicy> UpdateAsync(BaseAccessPolicy accessPolicy, bool read, bool write);
 }

--- a/src/Core/SecretsManager/Commands/AccessTokens/Interfaces/ICreateAccessTokenCommand.cs
+++ b/src/Core/SecretsManager/Commands/AccessTokens/Interfaces/ICreateAccessTokenCommand.cs
@@ -4,5 +4,5 @@ namespace Bit.Core.SecretsManager.Commands.AccessTokens.Interfaces;
 
 public interface ICreateAccessTokenCommand
 {
-    Task<ApiKey> CreateAsync(ApiKey apiKey, Guid userId);
+    Task<ApiKey> CreateAsync(ApiKey apiKey);
 }

--- a/src/Core/SecretsManager/Commands/Projects/Interfaces/IUpdateProjectCommand.cs
+++ b/src/Core/SecretsManager/Commands/Projects/Interfaces/IUpdateProjectCommand.cs
@@ -4,5 +4,5 @@ namespace Bit.Core.SecretsManager.Commands.Projects.Interfaces;
 
 public interface IUpdateProjectCommand
 {
-    Task<Project> UpdateAsync(Project project, Project updatedProject);
+    Task<Project> UpdateAsync(Project updatedProject);
 }

--- a/src/Core/SecretsManager/Commands/Projects/Interfaces/IUpdateProjectCommand.cs
+++ b/src/Core/SecretsManager/Commands/Projects/Interfaces/IUpdateProjectCommand.cs
@@ -4,5 +4,5 @@ namespace Bit.Core.SecretsManager.Commands.Projects.Interfaces;
 
 public interface IUpdateProjectCommand
 {
-    Task<Project> UpdateAsync(Project updatedProject, Guid userId);
+    Task<Project> UpdateAsync(Project project, Project updatedProject);
 }

--- a/src/Core/SecretsManager/Commands/Secrets/Interfaces/ICreateSecretCommand.cs
+++ b/src/Core/SecretsManager/Commands/Secrets/Interfaces/ICreateSecretCommand.cs
@@ -4,5 +4,5 @@ namespace Bit.Core.SecretsManager.Commands.Secrets.Interfaces;
 
 public interface ICreateSecretCommand
 {
-    Task<Secret> CreateAsync(Secret secret, Guid userId);
+    Task<Secret> CreateAsync(Secret secret);
 }

--- a/src/Core/SecretsManager/Commands/Secrets/Interfaces/IUpdateSecretCommand.cs
+++ b/src/Core/SecretsManager/Commands/Secrets/Interfaces/IUpdateSecretCommand.cs
@@ -4,5 +4,5 @@ namespace Bit.Core.SecretsManager.Commands.Secrets.Interfaces;
 
 public interface IUpdateSecretCommand
 {
-    Task<Secret> UpdateAsync(Secret secret, Secret updatedSecret);
+    Task<Secret> UpdateAsync(Secret updatedSecret);
 }

--- a/src/Core/SecretsManager/Commands/Secrets/Interfaces/IUpdateSecretCommand.cs
+++ b/src/Core/SecretsManager/Commands/Secrets/Interfaces/IUpdateSecretCommand.cs
@@ -4,5 +4,5 @@ namespace Bit.Core.SecretsManager.Commands.Secrets.Interfaces;
 
 public interface IUpdateSecretCommand
 {
-    Task<Secret> UpdateAsync(Secret secret, Guid userId);
+    Task<Secret> UpdateAsync(Secret secret, Secret updatedSecret);
 }

--- a/src/Core/SecretsManager/Commands/ServiceAccounts/Interfaces/IUpdateServiceAccountCommand.cs
+++ b/src/Core/SecretsManager/Commands/ServiceAccounts/Interfaces/IUpdateServiceAccountCommand.cs
@@ -4,5 +4,5 @@ namespace Bit.Core.SecretsManager.Commands.ServiceAccounts.Interfaces;
 
 public interface IUpdateServiceAccountCommand
 {
-    Task<ServiceAccount> UpdateAsync(ServiceAccount serviceAccount, ServiceAccount updatedServiceAccount);
+    Task<ServiceAccount> UpdateAsync(ServiceAccount updatedServiceAccount);
 }

--- a/src/Core/SecretsManager/Commands/ServiceAccounts/Interfaces/IUpdateServiceAccountCommand.cs
+++ b/src/Core/SecretsManager/Commands/ServiceAccounts/Interfaces/IUpdateServiceAccountCommand.cs
@@ -4,5 +4,5 @@ namespace Bit.Core.SecretsManager.Commands.ServiceAccounts.Interfaces;
 
 public interface IUpdateServiceAccountCommand
 {
-    Task<ServiceAccount> UpdateAsync(ServiceAccount serviceAccount, Guid userId);
+    Task<ServiceAccount> UpdateAsync(ServiceAccount serviceAccount, ServiceAccount updatedServiceAccount);
 }

--- a/src/Core/SecretsManager/Enums/AccessOperationType.cs
+++ b/src/Core/SecretsManager/Enums/AccessOperationType.cs
@@ -1,0 +1,13 @@
+﻿namespace Bit.Core.SecretsManager.Enums;
+
+public enum AccessOperationType
+{
+    CreateAccessToken,
+    RevokeAccessToken,
+    CreateServiceAccount,
+    UpdateServiceAccount,
+    CreateProject,
+    UpdateProject,
+    CreateSecret,
+    UpdateSecret,
+}

--- a/src/Core/SecretsManager/Models/Data/AccessCheck.cs
+++ b/src/Core/SecretsManager/Models/Data/AccessCheck.cs
@@ -1,20 +1,10 @@
-﻿namespace Bit.Core.SecretsManager.Models.Data;
+﻿using Bit.Core.SecretsManager.Enums;
 
-public enum OperationType
-{
-    CreateAccessToken,
-    RevokeAccessToken,
-    CreateServiceAccount,
-    UpdateServiceAccount,
-    CreateProject,
-    UpdateProject,
-    CreateSecret,
-    UpdateSecret,
-}
+namespace Bit.Core.SecretsManager.Models.Data;
 
 public class AccessCheck
 {
-    public OperationType OperationType { get; set; }
+    public AccessOperationType AccessOperationType { get; set; }
     public Guid OrganizationId { get; set; }
     public Guid TargetId { get; set; }
     public Guid UserId { get; set; }
@@ -22,7 +12,7 @@ public class AccessCheck
 
 public class SecretAccessCheck
 {
-    public OperationType OperationType { get; set; }
+    public AccessOperationType AccessOperationType { get; set; }
     public Guid OrganizationId { get; set; }
     public Guid? CurrentSecretId { get; set; }
     public Guid? TargetProjectId { get; set; }

--- a/src/Core/SecretsManager/Models/Data/AccessCheck.cs
+++ b/src/Core/SecretsManager/Models/Data/AccessCheck.cs
@@ -1,0 +1,30 @@
+﻿namespace Bit.Core.SecretsManager.Models.Data;
+
+public enum OperationType
+{
+    CreateAccessToken,
+    RevokeAccessToken,
+    CreateServiceAccount,
+    UpdateServiceAccount,
+    CreateProject,
+    UpdateProject,
+    CreateSecret,
+    UpdateSecret,
+}
+
+public class AccessCheck
+{
+    public OperationType OperationType { get; set; }
+    public Guid OrganizationId { get; set; }
+    public Guid TargetId { get; set; }
+    public Guid UserId { get; set; }
+}
+
+public class SecretAccessCheck
+{
+    public OperationType OperationType { get; set; }
+    public Guid OrganizationId { get; set; }
+    public Guid? CurrentSecretId { get; set; }
+    public Guid? TargetProjectId { get; set; }
+    public Guid UserId { get; set; }
+}

--- a/src/Core/SecretsManager/Queries/Access/Interfaces/IAccessPolicyAccessQuery.cs
+++ b/src/Core/SecretsManager/Queries/Access/Interfaces/IAccessPolicyAccessQuery.cs
@@ -1,0 +1,9 @@
+﻿using Bit.Core.SecretsManager.Entities;
+
+namespace Bit.Core.SecretsManager.Queries.Access.Interfaces;
+
+public interface IAccessPolicyAccessQuery
+{
+    Task<bool> HasAccess(BaseAccessPolicy baseAccessPolicy, Guid userId);
+    Task<bool> HasAccess(List<BaseAccessPolicy> baseAccessPolicies, Guid organizationId, Guid userId);
+}

--- a/src/Core/SecretsManager/Queries/Access/Interfaces/IAccessQuery.cs
+++ b/src/Core/SecretsManager/Queries/Access/Interfaces/IAccessQuery.cs
@@ -1,0 +1,9 @@
+﻿using Bit.Core.SecretsManager.Models.Data;
+
+namespace Bit.Core.SecretsManager.Queries.Access.Interfaces;
+
+public interface IAccessQuery
+{
+    Task<bool> HasAccess(AccessCheck accessCheck);
+    Task<bool> HasAccess(SecretAccessCheck accessCheck);
+}

--- a/src/Core/SecretsManager/Queries/Access/Interfaces/ISecretAccessQuery.cs
+++ b/src/Core/SecretsManager/Queries/Access/Interfaces/ISecretAccessQuery.cs
@@ -2,7 +2,7 @@
 
 namespace Bit.Core.SecretsManager.Queries.Access.Interfaces;
 
-public interface IAccessQuery
+public interface ISecretAccessQuery
 {
-    Task<bool> HasAccess(AccessCheck accessCheck);
+    Task<bool> HasAccess(SecretAccessCheck accessCheck);
 }

--- a/src/Core/SecretsManager/Repositories/IServiceAccountRepository.cs
+++ b/src/Core/SecretsManager/Repositories/IServiceAccountRepository.cs
@@ -11,7 +11,6 @@ public interface IServiceAccountRepository
     Task<ServiceAccount> CreateAsync(ServiceAccount serviceAccount);
     Task ReplaceAsync(ServiceAccount serviceAccount);
     Task DeleteManyByIdAsync(IEnumerable<Guid> ids);
-    Task<bool> UserHasReadAccessToServiceAccount(Guid id, Guid userId);
-    Task<bool> UserHasWriteAccessToServiceAccount(Guid id, Guid userId);
     Task<IEnumerable<ServiceAccount>> GetManyByOrganizationIdWriteAccessAsync(Guid organizationId, Guid userId, AccessClientType accessType);
+    Task<(bool Read, bool Write)> AccessToServiceAccountAsync(Guid id, Guid userId, AccessClientType accessType);
 }

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/SecretsControllerTests.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/SecretsControllerTests.cs
@@ -148,11 +148,8 @@ public class SecretsControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
         var (org, _) = await _organizationHelper.Initialize(true, true);
         await LoginAsync(_email);
 
-        var project = await _projectRepository.CreateAsync(new Project { Name = "123" });
-
         var request = new SecretCreateRequestModel
         {
-            ProjectIds = new Guid[] { project.Id },
             Key = _mockEncryptedString,
             Value = _mockEncryptedString,
             Note = _mockEncryptedString,

--- a/test/Api.Test/SecretsManager/Controllers/AccessPoliciesControllerTests.cs
+++ b/test/Api.Test/SecretsManager/Controllers/AccessPoliciesControllerTests.cs
@@ -211,12 +211,15 @@ public class AccessPoliciesControllerTests
         {
             case PermissionType.RunAsAdmin:
                 SetupAdmin(sutProvider, data.OrganizationId);
+                sutProvider.GetDependency<IServiceAccountRepository>()
+                    .AccessToServiceAccountAsync(default, default, default)
+                    .ReturnsForAnyArgs((true, true));
                 break;
             case PermissionType.RunAsUserWithPermission:
                 SetupUserWithPermission(sutProvider, data.OrganizationId);
                 sutProvider.GetDependency<IServiceAccountRepository>()
-                    .UserHasWriteAccessToServiceAccount(default, default)
-                    .ReturnsForAnyArgs(true);
+                    .AccessToServiceAccountAsync(default, default, default)
+                    .ReturnsForAnyArgs((true, true));
                 break;
         }
 
@@ -238,8 +241,8 @@ public class AccessPoliciesControllerTests
     {
         SetupUserWithoutPermission(sutProvider, data.OrganizationId);
         sutProvider.GetDependency<IServiceAccountRepository>().GetByIdAsync(default).ReturnsForAnyArgs(data);
-        sutProvider.GetDependency<IServiceAccountRepository>().UserHasWriteAccessToServiceAccount(default, default)
-            .ReturnsForAnyArgs(false);
+        sutProvider.GetDependency<IServiceAccountRepository>().AccessToServiceAccountAsync(default, default, default)
+            .ReturnsForAnyArgs((false, false));
 
         await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.GetServiceAccountAccessPoliciesAsync(id));
 
@@ -262,12 +265,15 @@ public class AccessPoliciesControllerTests
         {
             case PermissionType.RunAsAdmin:
                 SetupAdmin(sutProvider, data.OrganizationId);
+                sutProvider.GetDependency<IServiceAccountRepository>()
+                    .AccessToServiceAccountAsync(default, default, default)
+                    .ReturnsForAnyArgs((true, true));
                 break;
             case PermissionType.RunAsUserWithPermission:
                 SetupUserWithPermission(sutProvider, data.OrganizationId);
                 sutProvider.GetDependency<IServiceAccountRepository>()
-                    .UserHasWriteAccessToServiceAccount(default, default)
-                    .ReturnsForAnyArgs(true);
+                    .AccessToServiceAccountAsync(default, default, default)
+                    .ReturnsForAnyArgs((true, true));
                 break;
         }
 
@@ -293,8 +299,8 @@ public class AccessPoliciesControllerTests
     {
         SetupUserWithoutPermission(sutProvider, data.OrganizationId);
         sutProvider.GetDependency<IServiceAccountRepository>().GetByIdAsync(default).ReturnsForAnyArgs(data);
-        sutProvider.GetDependency<IServiceAccountRepository>().UserHasWriteAccessToServiceAccount(default, default)
-            .ReturnsForAnyArgs(false);
+        sutProvider.GetDependency<IServiceAccountRepository>().AccessToServiceAccountAsync(default, default, default)
+            .ReturnsForAnyArgs((false, false));
 
         sutProvider.GetDependency<IAccessPolicyRepository>().GetManyByGrantedServiceAccountIdAsync(default, default)
             .ReturnsForAnyArgs(new List<BaseAccessPolicy> { resultAccessPolicy });
@@ -323,8 +329,8 @@ public class AccessPoliciesControllerTests
             case PermissionType.RunAsUserWithPermission:
                 SetupUserWithPermission(sutProvider, data.OrganizationId);
                 sutProvider.GetDependency<IServiceAccountRepository>()
-                    .UserHasWriteAccessToServiceAccount(default, default)
-                    .ReturnsForAnyArgs(true);
+                    .AccessToServiceAccountAsync(default, default, default)
+                    .ReturnsForAnyArgs((true, true));
                 break;
         }
 

--- a/test/Api.Test/SecretsManager/Controllers/ProjectsControllerTests.cs
+++ b/test/Api.Test/SecretsManager/Controllers/ProjectsControllerTests.cs
@@ -6,6 +6,7 @@ using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.SecretsManager.Commands.Projects.Interfaces;
 using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Queries.Access.Interfaces;
 using Bit.Core.SecretsManager.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Test.SecretsManager.AutoFixture.ProjectsFixture;
@@ -101,10 +102,16 @@ public class ProjectsControllerTests
 
     [Theory]
     [BitAutoData]
-    public async void Create_SmNotEnabled_Throws(SutProvider<ProjectsController> sutProvider, Guid orgId,
-        ProjectCreateRequestModel data)
+    public async void Create_NoAccess_Throws(SutProvider<ProjectsController> sutProvider,
+        Guid orgId, ProjectCreateRequestModel data)
     {
-        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(orgId).Returns(false);
+        sutProvider.GetDependency<IAccessQuery>().HasAccess(data.ToAccessCheck(orgId)).ReturnsForAnyArgs(false);
+        sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(Guid.NewGuid());
+
+        var resultProject = data.ToProject(orgId);
+
+        sutProvider.GetDependency<ICreateProjectCommand>().CreateAsync(default, default)
+            .ReturnsForAnyArgs(resultProject);
 
         await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.CreateAsync(orgId, data));
         await sutProvider.GetDependency<ICreateProjectCommand>().DidNotReceiveWithAnyArgs()
@@ -112,22 +119,15 @@ public class ProjectsControllerTests
     }
 
     [Theory]
-    [BitAutoData(PermissionType.RunAsAdmin)]
-    [BitAutoData(PermissionType.RunAsUserWithPermission)]
-    public async void Create_Success(PermissionType permissionType, SutProvider<ProjectsController> sutProvider,
+    [BitAutoData]
+    public async void Create_Success(SutProvider<ProjectsController> sutProvider,
         Guid orgId, ProjectCreateRequestModel data)
     {
-        switch (permissionType)
-        {
-            case PermissionType.RunAsAdmin:
-                SetupAdmin(sutProvider, orgId);
-                break;
-            case PermissionType.RunAsUserWithPermission:
-                SetupUserWithPermission(sutProvider, orgId);
-                break;
-        }
+        sutProvider.GetDependency<IAccessQuery>().HasAccess(data.ToAccessCheck(orgId)).ReturnsForAnyArgs(true);
+        sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(Guid.NewGuid());
 
         var resultProject = data.ToProject(orgId);
+
         sutProvider.GetDependency<ICreateProjectCommand>().CreateAsync(default, default)
             .ReturnsForAnyArgs(resultProject);
 
@@ -138,29 +138,40 @@ public class ProjectsControllerTests
     }
 
     [Theory]
-    [BitAutoData(PermissionType.RunAsAdmin)]
-    [BitAutoData(PermissionType.RunAsUserWithPermission)]
-    public async void Update_Success(PermissionType permissionType, SutProvider<ProjectsController> sutProvider,
-        Guid orgId, ProjectUpdateRequestModel data)
+    [BitAutoData]
+    public async void Update_NoAccess_Throws(SutProvider<ProjectsController> sutProvider,
+        Guid userId, ProjectUpdateRequestModel data, Project existingProject)
     {
-        switch (permissionType)
-        {
-            case PermissionType.RunAsAdmin:
-                SetupAdmin(sutProvider, orgId);
-                break;
-            case PermissionType.RunAsUserWithPermission:
-                SetupUserWithPermission(sutProvider, orgId);
-                break;
-        }
+        sutProvider.GetDependency<IAccessQuery>().HasAccess(data.ToAccessCheck(existingProject.OrganizationId, existingProject.Id, userId)).ReturnsForAnyArgs(false);
+        sutProvider.GetDependency<IProjectRepository>().GetByIdAsync(existingProject.Id).ReturnsForAnyArgs(existingProject);
+        sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(userId);
 
-        var resultProject = data.ToProject(orgId);
-        sutProvider.GetDependency<IUpdateProjectCommand>().UpdateAsync(default, default)
+        var resultProject = data.ToProject(existingProject.Id);
+        sutProvider.GetDependency<IUpdateProjectCommand>().UpdateAsync(default)
             .ReturnsForAnyArgs(resultProject);
 
-        await sutProvider.Sut.UpdateAsync(orgId, data);
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.UpdateAsync(existingProject.Id, data));
+        await sutProvider.GetDependency<IUpdateProjectCommand>().DidNotReceiveWithAnyArgs()
+            .UpdateAsync(Arg.Any<Project>());
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async void Update_Success(SutProvider<ProjectsController> sutProvider,
+        Guid userId, ProjectUpdateRequestModel data, Project existingProject)
+    {
+        sutProvider.GetDependency<IAccessQuery>().HasAccess(data.ToAccessCheck(existingProject.OrganizationId, existingProject.Id, userId)).ReturnsForAnyArgs(true);
+        sutProvider.GetDependency<IProjectRepository>().GetByIdAsync(existingProject.Id).ReturnsForAnyArgs(existingProject);
+        sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(userId);
+
+        var resultProject = data.ToProject(existingProject.Id);
+        sutProvider.GetDependency<IUpdateProjectCommand>().UpdateAsync(default)
+            .ReturnsForAnyArgs(resultProject);
+
+        await sutProvider.Sut.UpdateAsync(existingProject.Id, data);
 
         await sutProvider.GetDependency<IUpdateProjectCommand>().Received(1)
-            .UpdateAsync(Arg.Any<Project>(), Arg.Any<Guid>());
+            .UpdateAsync(Arg.Any<Project>());
     }
 
     [Theory]

--- a/test/Api.Test/SecretsManager/Controllers/SecretsControllerTests.cs
+++ b/test/Api.Test/SecretsManager/Controllers/SecretsControllerTests.cs
@@ -126,7 +126,7 @@ public class SecretsControllerTests
     public async void CreateSecret_NoAccess_Throws(SutProvider<SecretsController> sutProvider, SecretCreateRequestModel data, Guid organizationId, Secret existingSecret, Guid userId)
     {
 
-        sutProvider.GetDependency<IAccessQuery>().HasAccess(data.ToSecretAccessCheck(organizationId, userId)).ReturnsForAnyArgs(false);
+        sutProvider.GetDependency<ISecretAccessQuery>().HasAccess(data.ToSecretAccessCheck(organizationId, userId)).ReturnsForAnyArgs(false);
         sutProvider.GetDependency<ISecretRepository>().GetByIdAsync(existingSecret.Id).ReturnsForAnyArgs(existingSecret);
         sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(userId);
 
@@ -143,7 +143,7 @@ public class SecretsControllerTests
     [BitAutoData]
     public async void CreateSecret_Success(SutProvider<SecretsController> sutProvider, SecretCreateRequestModel data, Guid organizationId, Secret existingSecret, Guid userId)
     {
-        sutProvider.GetDependency<IAccessQuery>().HasAccess(data.ToSecretAccessCheck(organizationId, userId)).ReturnsForAnyArgs(true);
+        sutProvider.GetDependency<ISecretAccessQuery>().HasAccess(data.ToSecretAccessCheck(organizationId, userId)).ReturnsForAnyArgs(true);
         sutProvider.GetDependency<ISecretRepository>().GetByIdAsync(existingSecret.Id).ReturnsForAnyArgs(existingSecret);
         sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(userId);
 
@@ -160,7 +160,7 @@ public class SecretsControllerTests
     [BitAutoData]
     public async void UpdateSecret_NoAccess_Throws(SutProvider<SecretsController> sutProvider, SecretUpdateRequestModel data, Guid organizationId, Guid userId, Secret existingSecret)
     {
-        sutProvider.GetDependency<IAccessQuery>().HasAccess(data.ToSecretAccessCheck(organizationId, userId, existingSecret.Id)).ReturnsForAnyArgs(false);
+        sutProvider.GetDependency<ISecretAccessQuery>().HasAccess(data.ToSecretAccessCheck(organizationId, userId, existingSecret.Id)).ReturnsForAnyArgs(false);
         sutProvider.GetDependency<ISecretRepository>().GetByIdAsync(existingSecret.Id).ReturnsForAnyArgs(existingSecret);
         sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(userId);
 
@@ -176,7 +176,7 @@ public class SecretsControllerTests
     [BitAutoData]
     public async void UpdateSecret_Success(SutProvider<SecretsController> sutProvider, SecretUpdateRequestModel data, Guid organizationId, Guid userId, Secret existingSecret)
     {
-        sutProvider.GetDependency<IAccessQuery>().HasAccess(data.ToSecretAccessCheck(organizationId, userId, existingSecret.Id)).ReturnsForAnyArgs(true);
+        sutProvider.GetDependency<ISecretAccessQuery>().HasAccess(data.ToSecretAccessCheck(organizationId, userId, existingSecret.Id)).ReturnsForAnyArgs(true);
         sutProvider.GetDependency<ISecretRepository>().GetByIdAsync(existingSecret.Id).ReturnsForAnyArgs(existingSecret);
         sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(userId);
 

--- a/test/Api.Test/SecretsManager/Controllers/ServiceAccountsControllerTests.cs
+++ b/test/Api.Test/SecretsManager/Controllers/ServiceAccountsControllerTests.cs
@@ -179,6 +179,8 @@ public class ServiceAccountsControllerTests
         sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(data.OrganizationId).Returns(true);
         sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(data.OrganizationId).Returns(true);
         sutProvider.GetDependency<IServiceAccountRepository>().GetByIdAsync(default).ReturnsForAnyArgs(data);
+        sutProvider.GetDependency<IServiceAccountRepository>().AccessToServiceAccountAsync(default, default, default)
+            .ReturnsForAnyArgs((true, true));
         foreach (var apiKey in resultApiKeys)
         {
             apiKey.Scope = "[\"api.secrets\"]";
@@ -198,7 +200,8 @@ public class ServiceAccountsControllerTests
         sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(userId);
         sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(data.OrganizationId).Returns(true);
         sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(data.OrganizationId).Returns(false);
-        sutProvider.GetDependency<IServiceAccountRepository>().UserHasReadAccessToServiceAccount(default, default).ReturnsForAnyArgs(true);
+        sutProvider.GetDependency<IServiceAccountRepository>().AccessToServiceAccountAsync(default, default, default).ReturnsForAnyArgs(
+            (true, true));
         sutProvider.GetDependency<IServiceAccountRepository>().GetByIdAsync(default).ReturnsForAnyArgs(data);
         foreach (var apiKey in resultApiKeys)
         {
@@ -218,7 +221,8 @@ public class ServiceAccountsControllerTests
     {
         sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(userId);
         sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(data.OrganizationId).Returns(false);
-        sutProvider.GetDependency<IServiceAccountRepository>().UserHasReadAccessToServiceAccount(default, default).ReturnsForAnyArgs(false);
+        sutProvider.GetDependency<IServiceAccountRepository>().AccessToServiceAccountAsync(default, default, default).ReturnsForAnyArgs(
+            (false, false));
         sutProvider.GetDependency<IServiceAccountRepository>().GetByIdAsync(default).ReturnsForAnyArgs(data);
         foreach (var apiKey in resultApiKeys)
         {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The purpose of this PR is to separate out access policy checks from commands for secrets manager.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
