### PR TITLE
[AC-1276] Billing Obfuscation: client email address is missing when the org is in pending status

### DIFF
--- a/src/Admin/Models/OrganizationViewModel.cs
+++ b/src/Admin/Models/OrganizationViewModel.cs
@@ -26,13 +26,16 @@ public class OrganizationViewModel
         CollectionCount = collections.Count();
         GroupCount = groups?.Count() ?? 0;
         PolicyCount = policies?.Count() ?? 0;
+        var organizationUserStatus = org.Status == OrganizationStatusType.Pending
+            ? OrganizationUserStatusType.Invited
+            : OrganizationUserStatusType.Confirmed;
         Owners = string.Join(", ",
             orgUsers
-            .Where(u => u.Type == OrganizationUserType.Owner && u.Status == OrganizationUserStatusType.Confirmed)
+            .Where(u => u.Type == OrganizationUserType.Owner && u.Status == organizationUserStatus)
             .Select(u => u.Email));
         Admins = string.Join(", ",
             orgUsers
-            .Where(u => u.Type == OrganizationUserType.Admin && u.Status == OrganizationUserStatusType.Confirmed)
+            .Where(u => u.Type == OrganizationUserType.Admin && u.Status == organizationUserStatus)
             .Select(u => u.Email));
     }
 


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
If the organization is in a Pending status then the Owners field should display Owners with a Pending status


## Code changes

* **src/Admin/Models/OrganizationViewModel.cs:** Filter the Owners status depending on the Org status

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
