### PR TITLE
[PM-1675] Timeout or transient error when verifying domains

### DIFF
--- a/src/Core/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs
@@ -60,7 +60,8 @@ public class VerifyOrganizationDomainCommand : IVerifyOrganizationDomainCommand
         }
         catch (Exception e)
         {
-            _logger.LogError("Error verifying Organization domain. {errorMessage}", e.Message);
+            _logger.LogError("Error verifying Organization domain: {domain}. {errorMessage}", 
+                domain.DomainName, e.Message);
         }
 
         domain.SetLastCheckedDate();

--- a/src/Core/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs
@@ -60,7 +60,7 @@ public class VerifyOrganizationDomainCommand : IVerifyOrganizationDomainCommand
         }
         catch (Exception e)
         {
-            _logger.LogError("Error verifying Organization domain: {domain}. {errorMessage}", 
+            _logger.LogError("Error verifying Organization domain: {domain}. {errorMessage}",
                 domain.DomainName, e.Message);
         }
 

--- a/src/Core/Services/Implementations/DnsResolverService.cs
+++ b/src/Core/Services/Implementations/DnsResolverService.cs
@@ -7,7 +7,10 @@ public class DnsResolverService : IDnsResolverService
 {
     public async Task<bool> ResolveAsync(string domain, string txtRecord, CancellationToken cancellationToken = default)
     {
-        var lookup = new LookupClient();
+        //increased timeout to 15 seconds to avoid timeouts
+        var options = new LookupClientOptions {Timeout = TimeSpan.FromSeconds(15)};
+        var lookup = new LookupClient(options);
+        
         var result = await lookup.QueryAsync(new DnsQuestion(domain, QueryType.TXT), cancellationToken);
         if (!result.HasError)
         {

--- a/src/Core/Services/Implementations/DnsResolverService.cs
+++ b/src/Core/Services/Implementations/DnsResolverService.cs
@@ -5,15 +5,15 @@ namespace Bit.Core.Services;
 
 public class DnsResolverService : IDnsResolverService
 {
-    private readonly LookupClient _lookupClient;
+    private readonly ILookupClient _client;
 
-    public DnsResolverService(LookupClient lookupClient)
+    public DnsResolverService(ILookupClient client)
     {
-        _lookupClient = lookupClient;
+        _client = client;
     }
     public async Task<bool> ResolveAsync(string domain, string txtRecord, CancellationToken cancellationToken = default)
     {
-        var result = await _lookupClient.QueryAsync(new DnsQuestion(domain, QueryType.TXT), cancellationToken);
+        var result = await _client.QueryAsync(new DnsQuestion(domain, QueryType.TXT), cancellationToken);
         if (!result.HasError)
         {
             return result.Answers.TxtRecords()

--- a/src/Core/Services/Implementations/DnsResolverService.cs
+++ b/src/Core/Services/Implementations/DnsResolverService.cs
@@ -5,13 +5,15 @@ namespace Bit.Core.Services;
 
 public class DnsResolverService : IDnsResolverService
 {
+    private readonly LookupClient _lookupClient;
+
+    public DnsResolverService(LookupClient lookupClient)
+    {
+        _lookupClient = lookupClient;
+    }
     public async Task<bool> ResolveAsync(string domain, string txtRecord, CancellationToken cancellationToken = default)
     {
-        //increased timeout to 15 seconds to avoid timeouts
-        var options = new LookupClientOptions {Timeout = TimeSpan.FromSeconds(15)};
-        var lookup = new LookupClient(options);
-        
-        var result = await lookup.QueryAsync(new DnsQuestion(domain, QueryType.TXT), cancellationToken);
+        var result = await _lookupClient.QueryAsync(new DnsQuestion(domain, QueryType.TXT), cancellationToken);
         if (!result.HasError)
         {
             return result.Answers.TxtRecords()

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -177,7 +177,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IStripeSyncService, StripeSyncService>();
         services.AddSingleton<IMailService, HandlebarsMailService>();
         services.AddSingleton<ILicensingService, LicensingService>();
-        services.AddSingleton(provider =>
+        services.AddSingleton<ILookupClient>((serviceProvider) =>
         {
             var options = new LookupClientOptions { Timeout = TimeSpan.FromSeconds(15) };
             return new LookupClient(options);

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -177,7 +177,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IStripeSyncService, StripeSyncService>();
         services.AddSingleton<IMailService, HandlebarsMailService>();
         services.AddSingleton<ILicensingService, LicensingService>();
-        services.AddSingleton<ILookupClient>((serviceProvider) =>
+        services.AddSingleton<ILookupClient>(_ =>
         {
             var options = new LookupClientOptions { Timeout = TimeSpan.FromSeconds(15) };
             return new LookupClient(options);

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ using Bit.Core.Utilities;
 using Bit.Core.Vault.Services;
 using Bit.Infrastructure.Dapper;
 using Bit.Infrastructure.EntityFramework;
+using DnsClient;
 using IdentityModel;
 using IdentityServer4.AccessTokenValidation;
 using IdentityServer4.Configuration;
@@ -176,7 +177,12 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IStripeSyncService, StripeSyncService>();
         services.AddSingleton<IMailService, HandlebarsMailService>();
         services.AddSingleton<ILicensingService, LicensingService>();
-        services.AddScoped<IDnsResolverService, DnsResolverService>();
+        services.AddSingleton(provider =>
+        {
+            var options = new LookupClientOptions { Timeout = TimeSpan.FromSeconds(15) };
+            return new LookupClient(options);
+        });
+        services.AddSingleton<IDnsResolverService, DnsResolverService>();
         services.AddSingleton<IFeatureService, LaunchDarklyFeatureService>();
         services.AddTokenizers();
 

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -176,7 +176,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IStripeSyncService, StripeSyncService>();
         services.AddSingleton<IMailService, HandlebarsMailService>();
         services.AddSingleton<ILicensingService, LicensingService>();
-        services.AddSingleton<IDnsResolverService, DnsResolverService>();
+        services.AddScoped<IDnsResolverService, DnsResolverService>();
         services.AddSingleton<IFeatureService, LaunchDarklyFeatureService>();
         services.AddTokenizers();
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Timeout or Transient error gets thrown when verifying domains for some organizations. The default timeout is `5` seconds, which has been increased to `15` seconds.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
Registered the `LookupClient` as a singleton, recommended in the docs for better performance and increased the timeout from 5 seconds to 15 seconds.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
