### PR TITLE
SM-631: Allow creation of unassigned secrets for admins

### DIFF
--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/CreateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/CreateSecretCommand.cs
@@ -26,7 +26,7 @@ public class CreateSecretCommand : ICreateSecretCommand
         var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
         var project = secret.Projects?.FirstOrDefault();
 
-        if (project == null)
+        if (project == null && !orgAdmin)
         {
             throw new NotFoundException();
         }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This PR is associated with this clients PR: [https://github.com/bitwarden/clients/pull/5052](https://github.com/bitwarden/clients/pull/5052)

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CreateSecretCommand.cs:** Allow creation of unassigned secrets if the user is an org admin

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
