### PR TITLE
SM-695: Block Create & Update for Admins on Secrets Outside of the Org

### DIFF
--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/CreateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/CreateSecretCommand.cs
@@ -31,6 +31,11 @@ public class CreateSecretCommand : ICreateSecretCommand
             throw new NotFoundException();
         }
 
+        if (orgAdmin && secret.Projects != null && secret.Projects.Any() && !(await _projectRepository.ProjectsAreInOrganization(secret.Projects.Select(p => p.Id).ToList(), secret.OrganizationId)))
+        {
+            throw new NotFoundException();
+        }
+
         var hasAccess = accessClient switch
         {
             AccessClientType.NoAccessCheck => true,

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/CreateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/CreateSecretCommand.cs
@@ -31,7 +31,7 @@ public class CreateSecretCommand : ICreateSecretCommand
             throw new NotFoundException();
         }
 
-        if (orgAdmin && secret.Projects != null && secret.Projects.Any() && !(await _projectRepository.ProjectsAreInOrganization(secret.Projects.Select(p => p.Id).ToList(), secret.OrganizationId)))
+        if (secret.Projects != null && secret.Projects.Any() && !(await _projectRepository.ProjectsAreInOrganization(secret.Projects.Select(p => p.Id).ToList(), secret.OrganizationId)))
         {
             throw new NotFoundException();
         }

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
@@ -28,13 +28,13 @@ public class UpdateSecretCommand : IUpdateSecretCommand
             throw new NotFoundException();
         }
 
-        var orgAdmin = await _currentContext.OrganizationAdmin(secret.OrganizationId);
-        var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
-
-        if (orgAdmin && updatedSecret.Projects != null && updatedSecret.Projects.Any() && !(await _projectRepository.ProjectsAreInOrganization(updatedSecret.Projects.Select(p => p.Id).ToList(), secret.OrganizationId)))
+        if (updatedSecret.Projects != null && updatedSecret.Projects.Any() && !(await _projectRepository.ProjectsAreInOrganization(updatedSecret.Projects.Select(p => p.Id).ToList(), secret.OrganizationId)))
         {
             throw new NotFoundException();
         }
+
+        var orgAdmin = await _currentContext.OrganizationAdmin(secret.OrganizationId);
+        var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
 
         if (!await HasAccessToOriginalAndUpdatedProject(accessClient, secret, updatedSecret, userId))
         {

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Commands/Secrets/UpdateSecretCommand.cs
@@ -31,6 +31,11 @@ public class UpdateSecretCommand : IUpdateSecretCommand
         var orgAdmin = await _currentContext.OrganizationAdmin(secret.OrganizationId);
         var accessClient = AccessClientHelper.ToAccessClient(_currentContext.ClientType, orgAdmin);
 
+        if (orgAdmin && updatedSecret.Projects != null && updatedSecret.Projects.Any() && !(await _projectRepository.ProjectsAreInOrganization(updatedSecret.Projects.Select(p => p.Id).ToList(), secret.OrganizationId)))
+        {
+            throw new NotFoundException();
+        }
+
         if (!await HasAccessToOriginalAndUpdatedProject(accessClient, secret, updatedSecret, userId))
         {
             throw new NotFoundException();

--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/ProjectRepository.cs
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/ProjectRepository.cs
@@ -190,4 +190,13 @@ public class ProjectRepository : Repository<Core.SecretsManager.Entities.Project
 
         return (policy.Read, policy.Write);
     }
+
+    public async Task<bool> ProjectsAreInOrganization(List<Guid> projectIds, Guid organizationId)
+    {
+        using var scope = ServiceScopeFactory.CreateScope();
+        var dbContext = GetDatabaseContext(scope);
+        var results = await dbContext.Project.Where(p => p.OrganizationId == organizationId && projectIds.Contains(p.Id)).ToListAsync();
+
+        return projectIds.Count == results.Count;
+    }
 }

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Secrets/CreateSecretCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Secrets/CreateSecretCommandTests.cs
@@ -22,6 +22,9 @@ public class CreateSecretCommandTests
     public async Task CreateAsync_Success(PermissionType permissionType, Secret data,
       SutProvider<CreateSecretCommand> sutProvider, Guid userId, Project mockProject)
     {
+        sutProvider.GetDependency<IProjectRepository>().ProjectsAreInOrganization(default, default).ReturnsForAnyArgs(true);
+
+        mockProject.OrganizationId = data.OrganizationId;
         data.Projects = new List<Project>() { mockProject };
 
         if (permissionType == PermissionType.RunAsAdmin)

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Secrets/UpdateSecretCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Secrets/UpdateSecretCommandTests.cs
@@ -34,6 +34,9 @@ public class UpdateSecretCommandTests
     public async Task UpdateAsync_Success(PermissionType permissionType, Secret data, SutProvider<UpdateSecretCommand> sutProvider, Guid userId, Project mockProject)
     {
         sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(data.OrganizationId).Returns(true);
+        sutProvider.GetDependency<IProjectRepository>().ProjectsAreInOrganization(default, default).ReturnsForAnyArgs(true);
+
+        mockProject.OrganizationId = data.OrganizationId;
         data.Projects = new List<Project>() { mockProject };
 
         if (permissionType == PermissionType.RunAsAdmin)

--- a/src/Api/SecretsManager/Controllers/SecretsController.cs
+++ b/src/Api/SecretsManager/Controllers/SecretsController.cs
@@ -80,6 +80,11 @@ public class SecretsController : Controller
             throw new NotFoundException();
         }
 
+        if (createRequest.ProjectIds != null && createRequest.ProjectIds.Length > 1)
+        {
+            throw new BadRequestException();
+        }
+
         var userId = _userService.GetProperUserId(User).Value;
         var result = await _createSecretCommand.CreateAsync(createRequest.ToSecret(organizationId), userId);
 
@@ -140,6 +145,11 @@ public class SecretsController : Controller
     [HttpPut("secrets/{id}")]
     public async Task<SecretResponseModel> UpdateSecretAsync([FromRoute] Guid id, [FromBody] SecretUpdateRequestModel updateRequest)
     {
+        if (updateRequest.ProjectIds != null && updateRequest.ProjectIds.Length > 1)
+        {
+            throw new BadRequestException();
+        }
+
         var userId = _userService.GetProperUserId(User).Value;
         var secret = updateRequest.ToSecret(id);
         var result = await _updateSecretCommand.UpdateAsync(secret, userId);

--- a/src/Core/SecretsManager/Repositories/IProjectRepository.cs
+++ b/src/Core/SecretsManager/Repositories/IProjectRepository.cs
@@ -18,4 +18,5 @@ public interface IProjectRepository
     Task<bool> ServiceAccountHasWriteAccessToProject(Guid id, Guid userId);
     Task<bool> ServiceAccountHasReadAccessToProject(Guid id, Guid userId);
     Task<(bool Read, bool Write)> AccessToProjectAsync(Guid id, Guid userId, AccessClientType accessType);
+    Task<bool> ProjectsAreInOrganization(List<Guid> projectIds, Guid organizationId);
 }

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/SecretsControllerTests.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/SecretsControllerTests.cs
@@ -180,6 +180,47 @@ public class SecretsControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
     }
 
     [Fact]
+    public async Task CreateWithDifferentProjectOrgId_RunAsAdmin_NotFound()
+    {
+        var (org, _) = await _organizationHelper.Initialize(true, true);
+        await LoginAsync(_email);
+
+        var project = await _projectRepository.CreateAsync(new Project { Name = "123" });
+
+        var request = new SecretCreateRequestModel
+        {
+            ProjectIds = new Guid[] { project.Id },
+            Key = _mockEncryptedString,
+            Value = _mockEncryptedString,
+            Note = _mockEncryptedString,
+        };
+
+        var response = await _client.PostAsJsonAsync($"/organizations/{org.Id}/secrets", request);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateWithMultipleProjects_RunAsAdmin_BadRequest()
+    {
+        var (org, _) = await _organizationHelper.Initialize(true, true);
+        await LoginAsync(_email);
+
+        var projectA = await _projectRepository.CreateAsync(new Project { OrganizationId = org.Id, Name = "123A" });
+        var projectB = await _projectRepository.CreateAsync(new Project { OrganizationId = org.Id, Name = "123B" });
+
+        var request = new SecretCreateRequestModel
+        {
+            ProjectIds = new Guid[] { projectA.Id, projectB.Id },
+            Key = _mockEncryptedString,
+            Value = _mockEncryptedString,
+            Note = _mockEncryptedString,
+        };
+
+        var response = await _client.PostAsJsonAsync($"/organizations/{org.Id}/secrets", request);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
     public async Task CreateWithoutProject_RunAsUser_NotFound()
     {
         var (org, _) = await _organizationHelper.Initialize(true, true);
@@ -529,6 +570,63 @@ public class SecretsControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
         Assert.Null(updatedSecret.DeletedDate);
         Assert.NotEqual(secret.Value, updatedSecret.Value);
         Assert.NotEqual(secret.RevisionDate, updatedSecret.RevisionDate);
+    }
+
+    [Fact]
+    public async Task UpdateWithDifferentProjectOrgId_RunAsAdmin_NotFound()
+    {
+        var (org, _) = await _organizationHelper.Initialize(true, true);
+        await LoginAsync(_email);
+
+        var project = await _projectRepository.CreateAsync(new Project { Name = "123" });
+
+        var secret = await _secretRepository.CreateAsync(new Secret
+        {
+            OrganizationId = org.Id,
+            Key = _mockEncryptedString,
+            Value = _mockEncryptedString,
+            Note = _mockEncryptedString
+        });
+
+        var request = new SecretUpdateRequestModel
+        {
+            Key = _mockEncryptedString,
+            Value = "2.3Uk+WNBIoU5xzmVFNcoWzz==|1MsPIYuRfdOHfu/0uY6H2Q==|/98xy4wb6pHP1VTZ9JcNCYgQjEUMFPlqJgCwRk1YXKg=",
+            Note = _mockEncryptedString,
+            ProjectIds = new Guid[] { project.Id },
+        };
+
+        var response = await _client.PutAsJsonAsync($"/secrets/{secret.Id}", request);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateWithMultipleProjects_BadRequest()
+    {
+        var (org, _) = await _organizationHelper.Initialize(true, true);
+        await LoginAsync(_email);
+
+        var projectA = await _projectRepository.CreateAsync(new Project { OrganizationId = org.Id, Name = "123A" });
+        var projectB = await _projectRepository.CreateAsync(new Project { OrganizationId = org.Id, Name = "123B" });
+
+        var secret = await _secretRepository.CreateAsync(new Secret
+        {
+            OrganizationId = org.Id,
+            Key = _mockEncryptedString,
+            Value = _mockEncryptedString,
+            Note = _mockEncryptedString
+        });
+
+        var request = new SecretUpdateRequestModel
+        {
+            Key = _mockEncryptedString,
+            Value = "2.3Uk+WNBIoU5xzmVFNcoWzz==|1MsPIYuRfdOHfu/0uY6H2Q==|/98xy4wb6pHP1VTZ9JcNCYgQjEUMFPlqJgCwRk1YXKg=",
+            Note = _mockEncryptedString,
+            ProjectIds = new Guid[] { projectA.Id, projectB.Id },
+        };
+
+        var response = await _client.PutAsJsonAsync($"/secrets/{secret.Id}", request);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Theory]

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/SecretsControllerTests.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/SecretsControllerTests.cs
@@ -148,7 +148,7 @@ public class SecretsControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
         var (org, _) = await _organizationHelper.Initialize(true, true);
         await LoginAsync(_email);
 
-        var project = await _projectRepository.CreateAsync(new Project { Name = "123" });
+        var project = await _projectRepository.CreateAsync(new Project { OrganizationId = org.Id, Name = "123" });
 
         var request = new SecretCreateRequestModel
         {

--- a/test/Api.Test/SecretsManager/Controllers/SecretsControllerTests.cs
+++ b/test/Api.Test/SecretsManager/Controllers/SecretsControllerTests.cs
@@ -125,6 +125,12 @@ public class SecretsControllerTests
     [BitAutoData(PermissionType.RunAsUserWithPermission)]
     public async void CreateSecret_Success(PermissionType permissionType, SutProvider<SecretsController> sutProvider, SecretCreateRequestModel data, Guid organizationId, Project mockProject, Guid userId)
     {
+        // We currently only allow a secret to be in one project at a time
+        if (data.ProjectIds != null && data.ProjectIds.Length > 1)
+        {
+            data.ProjectIds = new Guid[] { data.ProjectIds.ElementAt(0) };
+        }
+
         var resultSecret = data.ToSecret(organizationId);
         sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(userId);
 
@@ -152,6 +158,12 @@ public class SecretsControllerTests
     [BitAutoData(PermissionType.RunAsUserWithPermission)]
     public async void UpdateSecret_Success(PermissionType permissionType, SutProvider<SecretsController> sutProvider, SecretUpdateRequestModel data, Guid secretId, Guid organizationId, Guid userId, Project mockProject)
     {
+        // We currently only allow a secret to be in one project at a time
+        if (data.ProjectIds != null && data.ProjectIds.Length > 1)
+        {
+            data.ProjectIds = new Guid[] { data.ProjectIds.ElementAt(0) };
+        }
+
         sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(userId);
 
         if (permissionType == PermissionType.RunAsAdmin)


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This PR stops admins from being able to create or update secrets into projects that are not within their organization.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **CreateSecretCommand.cs:** Verify all projects on the secret being created are in the org
* **UpdateSecretCommand.cs:** Verify all projects on the secret being updated are in the org
* **ProjectRepository.cs:** Add the `ProjectsAreInOrganization` method
* **CreateSecretCommandTests.cs:** OrgId is required for a project being attached to a secret
* **UpdateSecretCommandTests.cs:**  OrgId is required for a project being attached to a secret
* **SecretsController.cs:** Add project count check
* **IProjectRepository.cs:** Add the `ProjectsAreInOrganization` method
* **SecretsControllerTests.cs:** (Api.IntegrationTest) OrgId is required for a project being attached to a secret, add additional tests
* **SecretsControllerTests.cs:** (Api.Test) Edit tests to only allow a secret to be in one project at a time

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
