### PR TITLE
[AC-621] Added possibility of adding users through SCIM to an Organization without a confirmed Owner

### DIFF
--- a/src/Core/Services/IOrganizationService.cs
+++ b/src/Core/Services/IOrganizationService.cs
@@ -60,7 +60,7 @@ public interface IOrganizationService
         bool overwriteExisting);
     Task DeleteSsoUserAsync(Guid userId, Guid? organizationId);
     Task<Organization> UpdateOrganizationKeysAsync(Guid orgId, string publicKey, string privateKey);
-    Task<bool> HasConfirmedOwnersExceptAsync(Guid organizationId, IEnumerable<Guid> organizationUsersId, bool includeProvider = true);
+    Task<bool> HasConfirmedOwnersExceptAsync(Guid organizationId, IEnumerable<Guid> organizationUsersId, bool includeProvider = true, EventSystemUser? systemUser = null);
     Task RevokeUserAsync(OrganizationUser organizationUser, Guid? revokingUserId);
     Task RevokeUserAsync(OrganizationUser organizationUser, EventSystemUser systemUser);
     Task<List<Tuple<OrganizationUser, string>>> RevokeUsersAsync(Guid organizationId,


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
SCIM User provisioning fails in a MSP managed Org if no Owner Type User exists prior to provisioning.
This PR addresses this by bypassing the requirement and checking if the request is done through SCIM and if the Organization is managed by a Provider.

## Code changes

* **src/Core/Services/IOrganizationService.cs:** Added parameter for the EventSystemUser
* **src/Core/Services/Implementations/OrganizationService.cs:** Added a check on inviting a user to verify that the EventSystemUser is SCIM and if the Organization is managed by a Provider

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
