### PR TITLE
nginx preserve upstream header values, fix ip

### DIFF
--- a/docker-unified/nginx/proxy.conf
+++ b/docker-unified/nginx/proxy.conf
@@ -1,9 +1,21 @@
 proxy_redirect          off;
-proxy_set_header        Host              $host;
+
+map $http_host $upstream_host {
+    default "$host";
+    ~. "$http_host";
+}
+proxy_set_header        Host              $upstream_host;
+
 proxy_set_header        X-Real-IP         $remote_addr;
 proxy_set_header        X-Forwarded-For   $proxy_add_x_forwarded_for;
-proxy_set_header        X-Url-Scheme      $scheme;
-proxy_set_header        X-Forwarded-Proto $scheme;
+
+map $http_x_forwarded_proto $upstream_scheme {
+    default "$scheme";
+    ~. "$http_x_forwarded_proto";
+}
+proxy_set_header        X-Url-Scheme      $upstream_scheme;
+proxy_set_header        X-Forwarded-Proto $upstream_scheme;
+
 client_max_body_size    505m;
 client_body_buffer_size 128k;
 proxy_connect_timeout   90;

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -29,7 +29,6 @@ public static class CoreHelpers
     private static readonly DateTime _max = new DateTime(9999, 1, 1, 0, 0, 0, DateTimeKind.Utc);
     private static readonly Random _random = new Random();
     private static readonly string CloudFlareConnectingIp = "CF-Connecting-IP";
-    private static readonly string RealIp = "X-Real-IP";
 
     /// <summary>
     /// Generate sequential Guid for Sql Server.
@@ -559,10 +558,6 @@ public static class CoreHelpers
         if (!globalSettings.SelfHosted && httpContext.Request.Headers.ContainsKey(CloudFlareConnectingIp))
         {
             return httpContext.Request.Headers[CloudFlareConnectingIp].ToString();
-        }
-        if (globalSettings.SelfHosted && httpContext.Request.Headers.ContainsKey(RealIp))
-        {
-            return httpContext.Request.Headers[RealIp].ToString();
         }
 
         return httpContext.Connection?.RemoteIpAddress?.ToString();

--- a/util/Nginx/proxy.conf
+++ b/util/Nginx/proxy.conf
@@ -1,9 +1,21 @@
 proxy_redirect          off;
-proxy_set_header        Host              $host;
+
+map $http_host $upstream_host {
+    default "$host";
+    ~. "$http_host";
+}
+proxy_set_header        Host              $upstream_host;
+
 proxy_set_header        X-Real-IP         $remote_addr;
 proxy_set_header        X-Forwarded-For   $proxy_add_x_forwarded_for;
-proxy_set_header        X-Url-Scheme      $scheme;
-proxy_set_header        X-Forwarded-Proto $scheme;
+
+map $http_x_forwarded_proto $upstream_scheme {
+    default "$scheme";
+    ~. "$http_x_forwarded_proto";
+}
+proxy_set_header        X-Url-Scheme      $upstream_scheme;
+proxy_set_header        X-Forwarded-Proto $upstream_scheme;
+
 client_max_body_size    505m;
 client_body_buffer_size 128k;
 proxy_connect_timeout   90;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Resolves https://github.com/bitwarden/server/issues/2500

Fix improper protocol and host header from persisting across proxy jumps.

Also, remove `X-Real-IP` header from being evaluated for `GetIpAddress` since it will always be the value of the last connecting client, which could be a proxy whenever there is a chain of multiple proxies.  `X-Forwarded-For` will properly chain proxy IP addresses in a CSV string, and ASP.NET Core will load the correct value in `httpContext.Connection.RemoteIpAddress`.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **proxy.conf:** Null coalesce previously set header values and default back to standard values.
* **CoreHelpers.cs:** Remove `X-Real-IP` from being evaluated from self hosted servers for client ip address.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
