### PR TITLE
SM-718: Delete appropriate Access Policies on Org deletion

### DIFF
--- a/src/Sql/dbo/Stored Procedures/Organization_DeleteById.sql
+++ b/src/Sql/dbo/Stored Procedures/Organization_DeleteById.sql
@@ -45,6 +45,14 @@ BEGIN
     WHERE 
         [OU].[OrganizationId] = @Id
 
+    DELETE AP
+    FROM
+        [dbo].[AccessPolicy] AP
+    INNER JOIN
+        [dbo].[OrganizationUser] OU ON [AP].[OrganizationUserId] = [OU].[Id]
+    WHERE
+        [OU].[OrganizationId] = @Id
+
     DELETE
     FROM 
         [dbo].[OrganizationUser]
@@ -79,6 +87,14 @@ BEGIN
         [dbo].[ApiKey] AK
     INNER JOIN
         [dbo].[ServiceAccount] SA ON [AK].[ServiceAccountId] = [SA].[Id]
+    WHERE
+        [SA].[OrganizationId] = @Id
+
+    DELETE AP
+    FROM
+        [dbo].[AccessPolicy] AP
+    INNER JOIN
+        [dbo].[ServiceAccount] SA ON [AP].[GrantedServiceAccountId] = [SA].[Id]
     WHERE
         [SA].[OrganizationId] = @Id
 

--- a/src/Sql/dbo/Stored Procedures/Organization_DeleteById.sql
+++ b/src/Sql/dbo/Stored Procedures/Organization_DeleteById.sql
@@ -53,6 +53,14 @@ BEGIN
     WHERE
         [OU].[OrganizationId] = @Id
 
+    DELETE GU
+    FROM
+        [dbo].[GroupUser] GU
+    INNER JOIN
+        [dbo].[OrganizationUser] OU ON [GU].[OrganizationUserId] = [OU].[Id]
+    WHERE
+        [OU].[OrganizationId] = @Id
+
     DELETE
     FROM 
         [dbo].[OrganizationUser]

--- a/util/Migrator/DbScripts/2023-04-21_00_DeleteAccessPoliciesOnOrganizationDelete.sql
+++ b/util/Migrator/DbScripts/2023-04-21_00_DeleteAccessPoliciesOnOrganizationDelete.sql
@@ -1,0 +1,114 @@
+CREATE OR ALTER PROCEDURE [dbo].[Organization_DeleteById]
+    @Id UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    EXEC [dbo].[User_BumpAccountRevisionDateByOrganizationId] @Id
+
+    DECLARE @BatchSize INT = 100
+    WHILE @BatchSize > 0
+    BEGIN
+        BEGIN TRANSACTION Organization_DeleteById_Ciphers
+
+        DELETE TOP(@BatchSize)
+        FROM
+            [dbo].[Cipher]
+        WHERE
+            [UserId] IS NULL
+            AND [OrganizationId] = @Id
+
+        SET @BatchSize = @@ROWCOUNT
+
+        COMMIT TRANSACTION Organization_DeleteById_Ciphers
+    END
+
+    BEGIN TRANSACTION Organization_DeleteById
+
+    DELETE
+    FROM
+        [dbo].[SsoUser]
+    WHERE
+        [OrganizationId] = @Id
+
+    DELETE
+    FROM
+        [dbo].[SsoConfig]
+    WHERE
+        [OrganizationId] = @Id
+
+    DELETE CU
+    FROM 
+        [dbo].[CollectionUser] CU
+    INNER JOIN 
+        [dbo].[OrganizationUser] OU ON [CU].[OrganizationUserId] = [OU].[Id]
+    WHERE 
+        [OU].[OrganizationId] = @Id
+
+    DELETE AP
+    FROM
+        [dbo].[AccessPolicy] AP
+    INNER JOIN
+        [dbo].[OrganizationUser] OU ON [AP].[OrganizationUserId] = [OU].[Id]
+    WHERE
+        [OU].[OrganizationId] = @Id
+
+    DELETE
+    FROM 
+        [dbo].[OrganizationUser]
+    WHERE 
+        [OrganizationId] = @Id
+
+    DELETE
+    FROM
+         [dbo].[ProviderOrganization]
+    WHERE
+        [OrganizationId] = @Id
+
+    EXEC [dbo].[OrganizationApiKey_OrganizationDeleted] @Id
+    EXEC [dbo].[OrganizationConnection_OrganizationDeleted] @Id
+    EXEC [dbo].[OrganizationSponsorship_OrganizationDeleted] @Id
+    EXEC [dbo].[OrganizationDomain_OrganizationDeleted] @Id
+
+    DELETE
+    FROM
+        [dbo].[Project]
+    WHERE
+        [OrganizationId] = @Id
+
+    DELETE
+    FROM
+        [dbo].[Secret]
+    WHERE
+        [OrganizationId] = @Id
+
+    DELETE AK
+    FROM
+        [dbo].[ApiKey] AK
+    INNER JOIN
+        [dbo].[ServiceAccount] SA ON [AK].[ServiceAccountId] = [SA].[Id]
+    WHERE
+        [SA].[OrganizationId] = @Id
+
+    DELETE AP
+    FROM
+        [dbo].[AccessPolicy] AP
+    INNER JOIN
+        [dbo].[ServiceAccount] SA ON [AP].[GrantedServiceAccountId] = [SA].[Id]
+    WHERE
+        [SA].[OrganizationId] = @Id
+
+    DELETE
+    FROM
+        [dbo].[ServiceAccount]
+    WHERE
+        [OrganizationId] = @Id
+
+    DELETE
+    FROM
+        [dbo].[Organization]
+    WHERE
+        [Id] = @Id
+
+    COMMIT TRANSACTION Organization_DeleteById
+END

--- a/util/Migrator/DbScripts/2023-04-21_00_DeleteAccessPoliciesOnOrganizationDelete.sql
+++ b/util/Migrator/DbScripts/2023-04-21_00_DeleteAccessPoliciesOnOrganizationDelete.sql
@@ -112,3 +112,4 @@ BEGIN
 
     COMMIT TRANSACTION Organization_DeleteById
 END
+GO

--- a/util/Migrator/DbScripts/2023-04-21_00_DeleteAccessPoliciesOnOrganizationDelete.sql
+++ b/util/Migrator/DbScripts/2023-04-21_00_DeleteAccessPoliciesOnOrganizationDelete.sql
@@ -53,6 +53,14 @@ BEGIN
     WHERE
         [OU].[OrganizationId] = @Id
 
+    DELETE GU
+    FROM
+        [dbo].[GroupUser] GU
+    INNER JOIN
+        [dbo].[OrganizationUser] OU ON [GU].[OrganizationUserId] = [OU].[Id]
+    WHERE
+        [OU].[OrganizationId] = @Id
+
     DELETE
     FROM 
         [dbo].[OrganizationUser]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This PR covers two issues. First, it covers the issues listed in SM-718. Secondly, it addresses a second bug that was found. Details on both are below.

### SM-718

Currently there is an error occurring when an organization is deleted and secrets manager is enabled. Access policies are not properly being deleted when an organization is deleted. During the deletion of an organization, we need to delete access policies where there are access policies associated with:
- The org's organization users
- The org's service accounts

Other access policies associated with other entities should be deleted via cascade deletes.

### Second Bug

Additionally, when testing, @Thomas-Avery found a second error message that was being thrown:

```
The DELETE statement conflicted with the REFERENCE constraint "FK_GroupUser_OrganizationUser". The conflict occurred in database "vault_dev", table "dbo.GroupUser", column 'OrganizationUserId'.
The statement has been terminated.
```

This occurs regardless if secrets manager is on or off- when an org has a group and a user in the group, the above issue occurs when that org is being deleted. This is solved by adding a delete on the GroupUser table associated with OrganizationUsers in the org on org deletion. Thankfully, all groups and group users are still being deleted due to ON DELETE CASCADE effects from statements later in the stored procedure.

#### More Information

The error is being thrown because when `OrganizationUser` rows are being deleted, rows in `GroupUser` still have `FK` references to the `OrganizationUserId` in the `OrganizationUser` table.

The error was thrown, but as subsequent commands in the sproc are processed, the delete for rows in the `GroupUser` table still occur, as they are covered by `ON DELETE CASCADE`. When a row from the `Organization` table is deleted, the rows from the `Group` table are deleted, and then rows from the `GroupUser` table are deleted, all thanks to `ON DELETE CASCADE`.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Organization_DeleteById.sql:** Add deletion code for Access Policies and Group Users
* **2023-04-21_00_DeleteAccessPoliciesOnOrganizationDelete.sql:** Migration script for the `Organization_DeleteById` sproc updates

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
