### PR TITLE
[PM-1966] Fix typos in comments

### DIFF
--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -308,8 +308,8 @@ public class AccountController : Controller
             await HttpContext.SignOutAsync();
         }
 
-        // HACK: Temporary workaroud for the time being that doesn't try to sign out of OneLogin schemes,
-        // which doesnt support SLO
+        // HACK: Temporary workaround for the time being that doesn't try to sign out of OneLogin schemes,
+        // which doesn't support SLO
         if (externalAuthenticationScheme != null && !externalAuthenticationScheme.Contains("onelogin"))
         {
             // Build a return URL so the upstream provider will redirect back

--- a/bitwarden_license/src/Sso/Utilities/ClaimsExtensions.cs
+++ b/bitwarden_license/src/Sso/Utilities/ClaimsExtensions.cs
@@ -12,7 +12,7 @@ public static class ClaimsExtensions
     {
         var normalizedClaims = claims.Select(c => (Normalize(c.Type), c.Value)).ToList();
 
-        // Order of prescendence is by passed in names
+        // Order of precedence is by passed in names
         foreach (var name in possibleNames.Select(Normalize))
         {
             // Second by order of claims (find claim by name)

--- a/dev/reverse-proxy.conf.example
+++ b/dev/reverse-proxy.conf.example
@@ -26,7 +26,7 @@ upstream identity_loadbalancer {
 }
 
 server {
-    listen 33756; # The port clients will connect to for the Identiy, must be exposed via Docker
+    listen 33756; # The port clients will connect to for the Identity, must be exposed via Docker
     location / {
         proxy_pass http://identity_loadbalancer;
     }

--- a/src/Admin/Controllers/ToolsController.cs
+++ b/src/Admin/Controllers/ToolsController.cs
@@ -508,7 +508,7 @@ public class ToolsController : Controller
     }
 
     // This requires a redundant API call to Stripe because of the way they handle pagination.
-    // The StartingBefore value has to be infered from the list we get, and isn't supplied by Stripe.
+    // The StartingBefore value has to be inferred from the list we get, and isn't supplied by Stripe.
     private async Task<bool> StripeSubscriptionsGetHasPreviousPage(List<Stripe.Subscription> subscriptions, StripeSubscriptionListOptions options)
     {
         var hasPreviousPage = false;

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -140,7 +140,7 @@ public class StripePaymentService : IPaymentService
                 {
                     Country = taxInfo.BillingAddressCountry,
                     PostalCode = taxInfo.BillingAddressPostalCode,
-                    // Line1 is required in Stripe's API, suggestion in Docs is to use Business Name intead.
+                    // Line1 is required in Stripe's API, suggestion in Docs is to use Business Name instead.
                     Line1 = taxInfo.BillingAddressLine1 ?? string.Empty,
                     Line2 = taxInfo.BillingAddressLine2,
                     City = taxInfo.BillingAddressCity,

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -390,7 +390,7 @@ public class GlobalSettings : IGlobalSettings
         /// </summary>
         /// <remarks>
         /// The certificate path and <see cref="CertificatePassword"/> are passed into the <see cref="System.Security.Cryptography.X509Certificates.X509Certificate2.X509Certificate2(string, string)" />.
-        /// The file format of the certificate may be binary encded (DER) or base64. If the private key is encrypted, provide the password in <see cref="CertificatePassword"/>,
+        /// The file format of the certificate may be binary encoded (DER) or base64. If the private key is encrypted, provide the password in <see cref="CertificatePassword"/>,
         /// </remarks>
         public string CertificatePath { get; set; }
         /// <summary>

--- a/src/Core/Utilities/CustomRedisProcessingStrategy.cs
+++ b/src/Core/Utilities/CustomRedisProcessingStrategy.cs
@@ -50,7 +50,7 @@ public class CustomRedisProcessingStrategy : RedisProcessingStrategy
             return SkipRateLimitResult();
         }
 
-        // Check if any Redis timeouts have occured recently
+        // Check if any Redis timeouts have occurred recently
         if (_memoryCache.TryGetValue<TimeoutCounter>(_redisTimeoutCacheKey, out var timeoutCounter))
         {
             // We've exceeded threshold, backoff Redis and skip rate limiting for now

--- a/src/Core/Utilities/LoggerFactoryExtensions.cs
+++ b/src/Core/Utilities/LoggerFactoryExtensions.cs
@@ -77,7 +77,7 @@ public static class LoggerFactoryExtensions
         }
         else if (CoreHelpers.SettingHasValue(globalSettings?.Syslog.Destination))
         {
-            // appending sitename to project name to allow eaiser identification in syslog.
+            // appending sitename to project name to allow easier identification in syslog.
             var appName = $"{globalSettings.SiteName}-{globalSettings.ProjectName}";
             if (globalSettings.Syslog.Destination.Equals("local", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Infrastructure.EntityFramework/Repositories/CollectionCipherRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CollectionCipherRepository.cs
@@ -110,7 +110,7 @@ public class CollectionCipherRepository : BaseEntityFrameworkRepository, ICollec
 
             foreach (var requestedCollectionId in collectionIds)
             {
-                // I don't totally agree with t.CipherId = cipherId here because that should have been guarenteed by
+                // I don't totally agree with t.CipherId = cipherId here because that should have been guaranteed by
                 // the WHERE above but the SQL Server CTE has it
                 var existingCollectionCipher = collectionCiphers
                     .FirstOrDefault(t => t.CollectionId == requestedCollectionId && t.CipherId == cipherId);

--- a/test/Core.Test/Services/HandlebarsMailServiceTests.cs
+++ b/test/Core.Test/Services/HandlebarsMailServiceTests.cs
@@ -39,7 +39,7 @@ public class HandlebarsMailServiceTests
         // This will send all emails to the test email address so that they can be viewed.
         var namedParameters = new Dictionary<(string, Type), object>
         {
-            // TODO: Swith to use env variable
+            // TODO: Switch to use env variable
             { ("email", typeof(string)), "test@bitwarden.com" },
             { ("user", typeof(User)), new User
             {

--- a/test/Infrastructure.EFIntegration.Test/Vault/AutoFixture/CipherFixtures.cs
+++ b/test/Infrastructure.EFIntegration.Test/Vault/AutoFixture/CipherFixtures.cs
@@ -37,7 +37,7 @@ internal class CipherBuilder : ISpecimenBuilder
                     .Without(c => c.OrganizationId));
         }
 
-        // Can't test valid Favorites and Folders without creating those values inide each test,
+        // Can't test valid Favorites and Folders without creating those values inside each test,
         // since we won't have any UserIds until the test is running & creating data
         fixture.Customize<Cipher>(c => c
             .Without(e => e.Favorites)

--- a/util/Migrator/DbScripts/2020-10-28_00_UserApiKey.sql
+++ b/util/Migrator/DbScripts/2020-10-28_00_UserApiKey.sql
@@ -55,7 +55,7 @@ WHERE
     [ApiKey] IS NULL
 GO
 
--- Change dbo.User.ApiKey to not null to enforece all future users to have one on create
+-- Change dbo.User.ApiKey to not null to enforce all future users to have one on create
 ALTER TABLE
     [dbo].[User]
 ALTER COLUMN


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Fixes several typos in comments found by running CSpell locally.  Changes that fix bugs or affect code have been split into a separate PR.

## Code changes
None

Let me know if I should drop the change to the old migration script:
```util/Migrator/DbScripts/2020-10-28_00_UserApiKey.sql```