### PR TITLE
[PM-1974] Refresh OrganizationView to include Organization.Status column

### DIFF
--- a/util/Migrator/DbScripts/2023-04-26_00_FixOrganizationView.sql
+++ b/util/Migrator/DbScripts/2023-04-26_00_FixOrganizationView.sql
@@ -1,0 +1,5 @@
+IF OBJECT_ID('[dbo].[OrganizationView]') IS NOT NULL
+BEGIN
+    EXECUTE sp_refreshsqlmodule N'[dbo].[OrganizationView]';
+END
+GO


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
#2609 added the `Organization.Status` column but we forgot to refresh the `OrganizationView`. This results in a default value of 0 being returned when reading an org from the database.

This adds a migration to refresh that view, per the recommended method in the [contributing docs](https://contributing.bitwarden.com/contributing/code-style/sql#adjusting-metadata-1).

**This will be a hotfix.**

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

As above

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
