### PR TITLE
Added key and forceKeyRotation to BuildCiphersTable method

### DIFF
--- a/src/Infrastructure.Dapper/Vault/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.Dapper/Vault/Repositories/CipherRepository.cs
@@ -714,6 +714,10 @@ public class CipherRepository : Repository<Cipher, Guid>, ICipherRepository
         ciphersTable.Columns.Add(deletedDateColumn);
         var repromptColumn = new DataColumn(nameof(c.Reprompt), typeof(short));
         ciphersTable.Columns.Add(repromptColumn);
+        var keyColummn = new DataColumn(nameof(c.Key), typeof(string));
+        ciphersTable.Columns.Add(keyColummn);
+        var forceKeyRotationColumn = new DataColumn(nameof(c.ForceKeyRotation), typeof(bool));
+        ciphersTable.Columns.Add(forceKeyRotationColumn);
 
         foreach (DataColumn col in ciphersTable.Columns)
         {
@@ -740,6 +744,8 @@ public class CipherRepository : Repository<Cipher, Guid>, ICipherRepository
             row[revisionDateColumn] = cipher.RevisionDate;
             row[deletedDateColumn] = cipher.DeletedDate.HasValue ? (object)cipher.DeletedDate : DBNull.Value;
             row[repromptColumn] = cipher.Reprompt;
+            row[keyColummn] = cipher.Key;
+            row[forceKeyRotationColumn] = cipher.ForceKeyRotation;
 
             ciphersTable.Rows.Add(row);
         }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
`Key` and `ForceKeyRotation` properties were not added to the `BuildCiphersTable` method in the `CiphersRepository` during the original server work for individual vault items. Adding these properties ensures import ciphers work for the individual vault items feature.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
