### PR TITLE
[PM-1879] Allow custom users to grant the same custom permissions that they have

### DIFF
--- a/src/Api/Models/Request/Organizations/OrganizationUserRequestModels.cs
+++ b/src/Api/Models/Request/Organizations/OrganizationUserRequestModels.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using System.Text.Json;
 using Bit.Api.Auth.Models.Request.Accounts;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
@@ -96,10 +95,7 @@ public class OrganizationUserUpdateRequestModel
     public OrganizationUser ToOrganizationUser(OrganizationUser existingUser)
     {
         existingUser.Type = Type.Value;
-        existingUser.Permissions = JsonSerializer.Serialize(Permissions, new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        });
+        existingUser.Permissions = CoreHelpers.ClassToJsonData(Permissions);
         existingUser.AccessAll = AccessAll;
         existingUser.AccessSecretsManager = AccessSecretsManager;
         return existingUser;

--- a/src/Core/Entities/OrganizationUser.cs
+++ b/src/Core/Entities/OrganizationUser.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.Enums;
 using Bit.Core.Models;
+using Bit.Core.Models.Data;
 using Bit.Core.Utilities;
 
 namespace Bit.Core.Entities;
@@ -27,5 +28,11 @@ public class OrganizationUser : ITableObject<Guid>, IExternal
     public void SetNewId()
     {
         Id = CoreHelpers.GenerateComb();
+    }
+
+    public Permissions GetPermissions()
+    {
+        return string.IsNullOrWhiteSpace(Permissions) ? null
+            : CoreHelpers.LoadClassFromJsonData<Permissions>(Permissions);
     }
 }


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The Manage Users custom permission should be updated to allow the custom user to grant the same custom permissions that they have, but not other permissions.


## Code changes
- **src/Api/Models/Request/Organizations/OrganizationUserRequestModels.cs:** Replaced `JsonSerializer.Serialize` with `CoreHelpers.ClassToJsonData`
- **src/Core/Services/Implementations/OrganizationService.cs:** Checking saving user's custom permissions
- **test/Core.Test/Services/OrganizationServiceTests.cs:** Added unit tests for saving custom permissions using a Custom saving user

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
