### PR TITLE
[PM-2101] Added UseTcpOnly flag to setup for DNS resolution client

### DIFF
--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -184,7 +184,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ILicensingService, LicensingService>();
         services.AddSingleton<ILookupClient>(_ =>
         {
-            var options = new LookupClientOptions { Timeout = TimeSpan.FromSeconds(15) };
+            var options = new LookupClientOptions { Timeout = TimeSpan.FromSeconds(15), TcpOnly = true };
             return new LookupClient(options);
         });
         services.AddSingleton<IDnsResolverService, DnsResolverService>();

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -184,7 +184,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ILicensingService, LicensingService>();
         services.AddSingleton<ILookupClient>(_ =>
         {
-            var options = new LookupClientOptions { Timeout = TimeSpan.FromSeconds(15), TcpOnly = true };
+            var options = new LookupClientOptions { Timeout = TimeSpan.FromSeconds(15), UseTcpOnly  = true };
             return new LookupClient(options);
         });
         services.AddSingleton<IDnsResolverService, DnsResolverService>();

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -184,7 +184,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ILicensingService, LicensingService>();
         services.AddSingleton<ILookupClient>(_ =>
         {
-            var options = new LookupClientOptions { Timeout = TimeSpan.FromSeconds(15), UseTcpOnly  = true };
+            var options = new LookupClientOptions { Timeout = TimeSpan.FromSeconds(15), UseTcpOnly = true };
             return new LookupClient(options);
         });
         services.AddSingleton<IDnsResolverService, DnsResolverService>();


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
We are experiencing intermittent failures when trying to verify domains.  We have isolated this as only occurring when users have a large number of TXT records on their DNS entry.  Thanks to DevOps help, we've determined that this is due to how DNS handles switching from UDP to TCP when a response is above 512 bytes.  The way to fix this is to tell the DNS query to use TCP only.

## Code changes

* **ServiceCollectionExtensions.cs:** Added `UseTcpOnly` flag to Options object when defining the lookup client. See documentation [here](https://dnsclient.michaco.net/docs/DnsClient.DnsQueryOptions.html#DnsClient_DnsQueryOptions_UseTcpOnly) for what this flag does.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
