### PR TITLE
[PM-2115] Add notion's equivalent domains

### DIFF
--- a/src/Core/Utilities/StaticStore.cs
+++ b/src/Core/Utilities/StaticStore.cs
@@ -101,6 +101,7 @@ public class StaticStore
         GlobalDomains.Add(GlobalEquivalentDomainsType.TransferWise, new List<string> { "transferwise.com", "wise.com" });
         GlobalDomains.Add(GlobalEquivalentDomainsType.TakeawayEU, new List<string> { "takeaway.com", "just-eat.dk", "just-eat.no", "just-eat.fr", "just-eat.ch", "lieferando.de", "lieferando.at", "thuisbezorgd.nl", "pyszne.pl" });
         GlobalDomains.Add(GlobalEquivalentDomainsType.Atlassian, new List<string> { "atlassian.com", "bitbucket.org", "trello.com", "statuspage.io", "atlassian.net", "jira.com" });
+        GlobalDomains.Add(GlobalEquivalentDomainsType.Atlassian, new List<string> { "notion.so", "androidapp://notion.id" });
         #endregion
 
         #region Plans


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
There is no auto-suggest of a password in Notion's Android app.
I have added the domain to my vault, but I think it would be nice to have out of the box.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Not sure that I could use `androidapp://` in the list, correct me if there is another way.
We can't use just `notion.id` because under this domain there is different website not belonging to Notion.
Also, it should cover IOS too, the app url is `https://apps.apple.com/us/app/notion-notes-docs-tasks/id1232780281`. But I have no idea how it should be written.