### PR TITLE
[PM-2196] Improvements to the Swagger generator

### DIFF
--- a/bitwarden_license/src/Scim/Models/ScimGroupResponseModel.cs
+++ b/bitwarden_license/src/Scim/Models/ScimGroupResponseModel.cs
@@ -13,13 +13,13 @@ public class ScimGroupResponseModel : BaseScimGroupModel
     public ScimGroupResponseModel(Group group)
         : this()
     {
-        Id = group.Id.ToString();
+        Id = group.Id;
         DisplayName = group.Name;
         ExternalId = group.ExternalId;
         Meta.Created = group.CreationDate;
         Meta.LastModified = group.RevisionDate;
     }
 
-    public string Id { get; set; }
+    public Guid Id { get; set; }
     public ScimMetaModel Meta { get; private set; }
 }

--- a/bitwarden_license/src/Scim/Models/ScimUserResponseModel.cs
+++ b/bitwarden_license/src/Scim/Models/ScimUserResponseModel.cs
@@ -14,7 +14,7 @@ public class ScimUserResponseModel : BaseScimUserModel
     public ScimUserResponseModel(OrganizationUserUserDetails orgUser)
         : this()
     {
-        Id = orgUser.Id.ToString();
+        Id = orgUser.Id;
         ExternalId = orgUser.ExternalId;
         UserName = orgUser.Email;
         DisplayName = orgUser.Name;
@@ -23,6 +23,6 @@ public class ScimUserResponseModel : BaseScimUserModel
         Active = orgUser.Status != Core.Enums.OrganizationUserStatusType.Revoked;
     }
 
-    public string Id { get; set; }
+    public Guid Id { get; set; }
     public ScimMetaModel Meta { get; private set; }
 }

--- a/bitwarden_license/test/Scim.IntegrationTest/Controllers/v2/GroupsControllerTests.cs
+++ b/bitwarden_license/test/Scim.IntegrationTest/Controllers/v2/GroupsControllerTests.cs
@@ -36,7 +36,7 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
         var groupId = ScimApplicationFactory.TestGroupId1;
         var expectedResponse = new ScimGroupResponseModel
         {
-            Id = groupId,
+            Id = Guid.Parse(groupId),
             DisplayName = "Test Group 1",
             ExternalId = "A",
             Schemas = new List<string> { ScimConstants.Scim2SchemaGroup }
@@ -86,14 +86,14 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
             {
                 new ScimGroupResponseModel
                 {
-                    Id = ScimApplicationFactory.TestGroupId1,
+                    Id = Guid.Parse(ScimApplicationFactory.TestGroupId1),
                     DisplayName = "Test Group 1",
                     ExternalId = "A",
                     Schemas = new List<string> { ScimConstants.Scim2SchemaGroup }
                 },
                 new ScimGroupResponseModel
                 {
-                    Id = ScimApplicationFactory.TestGroupId2,
+                    Id = Guid.Parse(ScimApplicationFactory.TestGroupId2),
                     DisplayName = "Test Group 2",
                     ExternalId = "B",
                     Schemas = new List<string> { ScimConstants.Scim2SchemaGroup }
@@ -126,7 +126,7 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
             {
                 new ScimGroupResponseModel
                 {
-                    Id = ScimApplicationFactory.TestGroupId2,
+                    Id = Guid.Parse(ScimApplicationFactory.TestGroupId2),
                     DisplayName = "Test Group 2",
                     ExternalId = "B",
                     Schemas = new List<string> { ScimConstants.Scim2SchemaGroup }
@@ -159,7 +159,7 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
             {
                 new ScimGroupResponseModel
                 {
-                    Id = ScimApplicationFactory.TestGroupId3,
+                    Id = Guid.Parse(ScimApplicationFactory.TestGroupId3),
                     DisplayName = "Test Group 3",
                     ExternalId = "C",
                     Schemas = new List<string> { ScimConstants.Scim2SchemaGroup }
@@ -234,14 +234,13 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
 
         var responseModel = JsonSerializer.Deserialize<ScimGroupResponseModel>(context.Response.Body, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
         AssertHelper.AssertPropertyEqual(expectedResponse, responseModel, "Id");
-        Assert.NotNull(responseModel.Id);
 
         var databaseContext = _factory.GetDatabaseContext();
         Assert.Equal(_initialGroupCount + 1, databaseContext.Groups.Count());
         Assert.True(databaseContext.Groups.Any(g => g.Name == displayName && g.ExternalId == externalId));
 
         Assert.Equal(_initialGroupUsersCount + 1, databaseContext.GroupUsers.Count());
-        Assert.True(databaseContext.GroupUsers.Any(gu => gu.GroupId.ToString() == responseModel.Id && gu.OrganizationUserId.ToString() == ScimApplicationFactory.TestOrganizationUserId1));
+        Assert.True(databaseContext.GroupUsers.Any(gu => gu.GroupId == responseModel.Id && gu.OrganizationUserId.ToString() == ScimApplicationFactory.TestOrganizationUserId1));
     }
 
     [Theory]
@@ -304,7 +303,7 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
         };
         var expectedResponse = new ScimGroupResponseModel
         {
-            Id = groupId,
+            Id = Guid.Parse(groupId),
             DisplayName = newGroupName,
             ExternalId = "A",
             Schemas = new List<string>() { ScimConstants.Scim2SchemaGroup }

--- a/bitwarden_license/test/Scim.IntegrationTest/Controllers/v2/GroupsControllerTests.cs
+++ b/bitwarden_license/test/Scim.IntegrationTest/Controllers/v2/GroupsControllerTests.cs
@@ -36,7 +36,7 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
         var groupId = ScimApplicationFactory.TestGroupId1;
         var expectedResponse = new ScimGroupResponseModel
         {
-            Id = Guid.Parse(groupId),
+            Id = groupId,
             DisplayName = "Test Group 1",
             ExternalId = "A",
             Schemas = new List<string> { ScimConstants.Scim2SchemaGroup }
@@ -54,7 +54,7 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
     public async Task Get_NotFound()
     {
         var organizationId = ScimApplicationFactory.TestOrganizationId1;
-        var groupId = Guid.NewGuid().ToString();
+        var groupId = Guid.NewGuid();
         var expectedResponse = new ScimErrorResponseModel
         {
             Status = StatusCodes.Status404NotFound,
@@ -86,14 +86,14 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
             {
                 new ScimGroupResponseModel
                 {
-                    Id = Guid.Parse(ScimApplicationFactory.TestGroupId1),
+                    Id = ScimApplicationFactory.TestGroupId1,
                     DisplayName = "Test Group 1",
                     ExternalId = "A",
                     Schemas = new List<string> { ScimConstants.Scim2SchemaGroup }
                 },
                 new ScimGroupResponseModel
                 {
-                    Id = Guid.Parse(ScimApplicationFactory.TestGroupId2),
+                    Id = ScimApplicationFactory.TestGroupId2,
                     DisplayName = "Test Group 2",
                     ExternalId = "B",
                     Schemas = new List<string> { ScimConstants.Scim2SchemaGroup }
@@ -126,7 +126,7 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
             {
                 new ScimGroupResponseModel
                 {
-                    Id = Guid.Parse(ScimApplicationFactory.TestGroupId2),
+                    Id = ScimApplicationFactory.TestGroupId2,
                     DisplayName = "Test Group 2",
                     ExternalId = "B",
                     Schemas = new List<string> { ScimConstants.Scim2SchemaGroup }
@@ -159,7 +159,7 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
             {
                 new ScimGroupResponseModel
                 {
-                    Id = Guid.Parse(ScimApplicationFactory.TestGroupId3),
+                    Id = ScimApplicationFactory.TestGroupId3,
                     DisplayName = "Test Group 3",
                     ExternalId = "C",
                     Schemas = new List<string> { ScimConstants.Scim2SchemaGroup }
@@ -214,7 +214,7 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
             ExternalId = externalId.ToString(),
             Members = new List<ScimGroupRequestModel.GroupMembersModel>
             {
-                new ScimGroupRequestModel.GroupMembersModel { Display = "user1@example.com", Value = ScimApplicationFactory.TestOrganizationUserId1 }
+                new ScimGroupRequestModel.GroupMembersModel { Display = "user1@example.com", Value = ScimApplicationFactory.TestOrganizationUserId1.ToString() }
             },
             Schemas = new List<string>() { ScimConstants.Scim2SchemaGroup }
         };
@@ -240,7 +240,7 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
         Assert.True(databaseContext.Groups.Any(g => g.Name == displayName && g.ExternalId == externalId));
 
         Assert.Equal(_initialGroupUsersCount + 1, databaseContext.GroupUsers.Count());
-        Assert.True(databaseContext.GroupUsers.Any(gu => gu.GroupId == responseModel.Id && gu.OrganizationUserId.ToString() == ScimApplicationFactory.TestOrganizationUserId1));
+        Assert.True(databaseContext.GroupUsers.Any(gu => gu.GroupId == responseModel.Id && gu.OrganizationUserId == ScimApplicationFactory.TestOrganizationUserId1));
     }
 
     [Theory]
@@ -296,14 +296,14 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
             ExternalId = "A",
             Members = new List<ScimGroupRequestModel.GroupMembersModel>
             {
-                new ScimGroupRequestModel.GroupMembersModel { Display = "user2@example.com", Value = ScimApplicationFactory.TestOrganizationUserId2 },
-                new ScimGroupRequestModel.GroupMembersModel { Display = "user3@example.com", Value = ScimApplicationFactory.TestOrganizationUserId3 }
+                new ScimGroupRequestModel.GroupMembersModel { Display = "user2@example.com", Value = ScimApplicationFactory.TestOrganizationUserId2.ToString() },
+                new ScimGroupRequestModel.GroupMembersModel { Display = "user3@example.com", Value = ScimApplicationFactory.TestOrganizationUserId3.ToString() }
             },
             Schemas = new List<string>() { ScimConstants.Scim2SchemaGroup }
         };
         var expectedResponse = new ScimGroupResponseModel
         {
-            Id = Guid.Parse(groupId),
+            Id = groupId,
             DisplayName = newGroupName,
             ExternalId = "A",
             Schemas = new List<string>() { ScimConstants.Scim2SchemaGroup }
@@ -317,12 +317,12 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
         AssertHelper.AssertPropertyEqual(expectedResponse, responseModel);
 
         var databaseContext = _factory.GetDatabaseContext();
-        var firstGroup = databaseContext.Groups.FirstOrDefault(g => g.Id.ToString() == groupId);
+        var firstGroup = databaseContext.Groups.FirstOrDefault(g => g.Id == groupId);
         Assert.Equal(newGroupName, firstGroup.Name);
 
-        Assert.Equal(2, databaseContext.GroupUsers.Count(gu => gu.GroupId.ToString() == groupId));
-        Assert.NotNull(databaseContext.GroupUsers.FirstOrDefault(gu => gu.GroupId.ToString() == groupId && gu.OrganizationUserId.ToString() == ScimApplicationFactory.TestOrganizationUserId2));
-        Assert.NotNull(databaseContext.GroupUsers.FirstOrDefault(gu => gu.GroupId.ToString() == groupId && gu.OrganizationUserId.ToString() == ScimApplicationFactory.TestOrganizationUserId3));
+        Assert.Equal(2, databaseContext.GroupUsers.Count(gu => gu.GroupId == groupId));
+        Assert.NotNull(databaseContext.GroupUsers.FirstOrDefault(gu => gu.GroupId == groupId && gu.OrganizationUserId == ScimApplicationFactory.TestOrganizationUserId2));
+        Assert.NotNull(databaseContext.GroupUsers.FirstOrDefault(gu => gu.GroupId == groupId && gu.OrganizationUserId == ScimApplicationFactory.TestOrganizationUserId3));
     }
 
     [Fact]
@@ -330,7 +330,7 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
     {
         var newGroupName = "Test Group 1 New Name";
         var organizationId = ScimApplicationFactory.TestOrganizationId1;
-        var groupId = Guid.NewGuid().ToString();
+        var groupId = Guid.NewGuid();
         var inputModel = new ScimGroupRequestModel
         {
             DisplayName = newGroupName,
@@ -377,12 +377,12 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
         Assert.Equal(StatusCodes.Status204NoContent, context.Response.StatusCode);
 
         var databaseContext = _factory.GetDatabaseContext();
-        var group = databaseContext.Groups.FirstOrDefault(g => g.Id.ToString() == groupId);
+        var group = databaseContext.Groups.FirstOrDefault(g => g.Id == groupId);
         Assert.Equal(newDisplayName, group.Name);
 
         Assert.Equal(_initialGroupUsersCount, databaseContext.GroupUsers.Count());
-        Assert.True(databaseContext.GroupUsers.Any(gu => gu.OrganizationUserId.ToString() == ScimApplicationFactory.TestOrganizationUserId1));
-        Assert.True(databaseContext.GroupUsers.Any(gu => gu.OrganizationUserId.ToString() == ScimApplicationFactory.TestOrganizationUserId4));
+        Assert.True(databaseContext.GroupUsers.Any(gu => gu.OrganizationUserId == ScimApplicationFactory.TestOrganizationUserId1));
+        Assert.True(databaseContext.GroupUsers.Any(gu => gu.OrganizationUserId == ScimApplicationFactory.TestOrganizationUserId4));
     }
 
     [Fact]
@@ -413,7 +413,7 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
 
         Assert.Equal(_initialGroupUsersCount - 1, databaseContext.GroupUsers.Count());
         var groupUser = databaseContext.GroupUsers.FirstOrDefault();
-        Assert.Equal(ScimApplicationFactory.TestOrganizationUserId2, groupUser.OrganizationUserId.ToString());
+        Assert.Equal(ScimApplicationFactory.TestOrganizationUserId2, groupUser.OrganizationUserId);
     }
 
     [Fact]
@@ -441,9 +441,9 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
 
         var databaseContext = _factory.GetDatabaseContext();
         Assert.Equal(_initialGroupUsersCount + 1, databaseContext.GroupUsers.Count());
-        Assert.True(databaseContext.GroupUsers.Any(gu => gu.GroupId.ToString() == groupId && gu.OrganizationUserId.ToString() == ScimApplicationFactory.TestOrganizationUserId1));
-        Assert.True(databaseContext.GroupUsers.Any(gu => gu.GroupId.ToString() == groupId && gu.OrganizationUserId.ToString() == ScimApplicationFactory.TestOrganizationUserId2));
-        Assert.True(databaseContext.GroupUsers.Any(gu => gu.GroupId.ToString() == groupId && gu.OrganizationUserId.ToString() == ScimApplicationFactory.TestOrganizationUserId4));
+        Assert.True(databaseContext.GroupUsers.Any(gu => gu.GroupId == groupId && gu.OrganizationUserId == ScimApplicationFactory.TestOrganizationUserId1));
+        Assert.True(databaseContext.GroupUsers.Any(gu => gu.GroupId == groupId && gu.OrganizationUserId == ScimApplicationFactory.TestOrganizationUserId2));
+        Assert.True(databaseContext.GroupUsers.Any(gu => gu.GroupId == groupId && gu.OrganizationUserId == ScimApplicationFactory.TestOrganizationUserId4));
     }
 
     [Fact]
@@ -470,8 +470,8 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
         Assert.Equal(StatusCodes.Status204NoContent, context.Response.StatusCode);
 
         var databaseContext = _factory.GetDatabaseContext();
-        Assert.True(databaseContext.GroupUsers.Any(gu => gu.GroupId.ToString() == groupId && gu.OrganizationUserId.ToString() == ScimApplicationFactory.TestOrganizationUserId2));
-        Assert.True(databaseContext.GroupUsers.Any(gu => gu.GroupId.ToString() == groupId && gu.OrganizationUserId.ToString() == ScimApplicationFactory.TestOrganizationUserId3));
+        Assert.True(databaseContext.GroupUsers.Any(gu => gu.GroupId == groupId && gu.OrganizationUserId == ScimApplicationFactory.TestOrganizationUserId2));
+        Assert.True(databaseContext.GroupUsers.Any(gu => gu.GroupId == groupId && gu.OrganizationUserId == ScimApplicationFactory.TestOrganizationUserId3));
     }
 
     [Fact]
@@ -507,7 +507,7 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
         Assert.Equal(_initialGroupUsersCount - 1, databaseContext.GroupUsers.Count());
         Assert.Equal(_initialGroupCount, databaseContext.Groups.Count());
 
-        var group = databaseContext.Groups.FirstOrDefault(g => g.Id.ToString() == groupId);
+        var group = databaseContext.Groups.FirstOrDefault(g => g.Id == groupId);
         Assert.Equal(newDisplayName, group.Name);
     }
 
@@ -542,7 +542,7 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
     public async Task Patch_NotFound()
     {
         var organizationId = ScimApplicationFactory.TestOrganizationId1;
-        var groupId = Guid.NewGuid().ToString();
+        var groupId = Guid.NewGuid();
         var inputModel = new Models.ScimPatchModel
         {
             Operations = new List<ScimPatchModel.OperationModel>(),
@@ -575,14 +575,14 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
 
         var databaseContext = _factory.GetDatabaseContext();
         Assert.Equal(_initialGroupCount - 1, databaseContext.Groups.Count());
-        Assert.True(databaseContext.Groups.FirstOrDefault(g => g.Id.ToString() == groupId) == null);
+        Assert.True(databaseContext.Groups.FirstOrDefault(g => g.Id == groupId) == null);
     }
 
     [Fact]
     public async Task Delete_NotFound()
     {
         var organizationId = ScimApplicationFactory.TestOrganizationId1;
-        var groupId = Guid.NewGuid().ToString();
+        var groupId = Guid.NewGuid();
         var expectedResponse = new ScimErrorResponseModel
         {
             Status = StatusCodes.Status404NotFound,

--- a/bitwarden_license/test/Scim.IntegrationTest/Controllers/v2/UsersControllerTests.cs
+++ b/bitwarden_license/test/Scim.IntegrationTest/Controllers/v2/UsersControllerTests.cs
@@ -35,7 +35,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
         var organizationUserId = ScimApplicationFactory.TestOrganizationUserId1;
         var expectedResponse = new ScimUserResponseModel
         {
-            Id = ScimApplicationFactory.TestOrganizationUserId1,
+            Id = Guid.Parse(ScimApplicationFactory.TestOrganizationUserId1),
             DisplayName = "Test User 1",
             ExternalId = "UA",
             Active = true,
@@ -92,7 +92,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
             {
                 new ScimUserResponseModel
                 {
-                    Id = ScimApplicationFactory.TestOrganizationUserId1,
+                    Id = Guid.Parse(ScimApplicationFactory.TestOrganizationUserId1),
                     DisplayName = "Test User 1",
                     ExternalId = "UA",
                     Active = true,
@@ -107,7 +107,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
                 },
                 new ScimUserResponseModel
                 {
-                    Id = ScimApplicationFactory.TestOrganizationUserId2,
+                    Id = Guid.Parse(ScimApplicationFactory.TestOrganizationUserId2),
                     DisplayName = "Test User 2",
                     ExternalId = "UB",
                     Active = true,
@@ -147,7 +147,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
             {
                 new ScimUserResponseModel
                 {
-                    Id = ScimApplicationFactory.TestOrganizationUserId2,
+                    Id = Guid.Parse(ScimApplicationFactory.TestOrganizationUserId2),
                     DisplayName = "Test User 2",
                     ExternalId = "UB",
                     Active = true,
@@ -187,7 +187,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
             {
                 new ScimUserResponseModel
                 {
-                    Id = ScimApplicationFactory.TestOrganizationUserId3,
+                    Id = Guid.Parse(ScimApplicationFactory.TestOrganizationUserId3),
                     DisplayName = "Test User 3",
                     ExternalId = "UC",
                     Active = false,
@@ -274,7 +274,6 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
 
         var responseModel = JsonSerializer.Deserialize<ScimUserResponseModel>(context.Response.Body, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
         AssertHelper.AssertPropertyEqual(expectedResponse, responseModel, "Id");
-        Assert.NotNull(responseModel.Id);
 
         var databaseContext = _factory.GetDatabaseContext();
         Assert.Equal(_initialUserCount + 1, databaseContext.OrganizationUsers.Count());
@@ -352,7 +351,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
         };
         var expectedResponse = new ScimUserResponseModel
         {
-            Id = ScimApplicationFactory.TestOrganizationUserId2,
+            Id = Guid.Parse(ScimApplicationFactory.TestOrganizationUserId2),
             DisplayName = "Test User 2",
             ExternalId = "UB",
             Active = false,
@@ -387,7 +386,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
         };
         var expectedResponse = new ScimUserResponseModel
         {
-            Id = ScimApplicationFactory.TestOrganizationUserId3,
+            Id = Guid.Parse(ScimApplicationFactory.TestOrganizationUserId3),
             DisplayName = "Test User 3",
             ExternalId = "UC",
             Active = true,

--- a/bitwarden_license/test/Scim.IntegrationTest/Controllers/v2/UsersControllerTests.cs
+++ b/bitwarden_license/test/Scim.IntegrationTest/Controllers/v2/UsersControllerTests.cs
@@ -35,7 +35,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
         var organizationUserId = ScimApplicationFactory.TestOrganizationUserId1;
         var expectedResponse = new ScimUserResponseModel
         {
-            Id = Guid.Parse(ScimApplicationFactory.TestOrganizationUserId1),
+            Id = ScimApplicationFactory.TestOrganizationUserId1,
             DisplayName = "Test User 1",
             ExternalId = "UA",
             Active = true,
@@ -60,7 +60,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
     [Fact]
     public async Task Get_NotFound()
     {
-        var organizationUserId = Guid.NewGuid().ToString();
+        var organizationUserId = Guid.NewGuid();
         var expectedResponse = new ScimErrorResponseModel
         {
             Status = StatusCodes.Status404NotFound,
@@ -92,7 +92,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
             {
                 new ScimUserResponseModel
                 {
-                    Id = Guid.Parse(ScimApplicationFactory.TestOrganizationUserId1),
+                    Id = ScimApplicationFactory.TestOrganizationUserId1,
                     DisplayName = "Test User 1",
                     ExternalId = "UA",
                     Active = true,
@@ -107,7 +107,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
                 },
                 new ScimUserResponseModel
                 {
-                    Id = Guid.Parse(ScimApplicationFactory.TestOrganizationUserId2),
+                    Id = ScimApplicationFactory.TestOrganizationUserId2,
                     DisplayName = "Test User 2",
                     ExternalId = "UB",
                     Active = true,
@@ -147,7 +147,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
             {
                 new ScimUserResponseModel
                 {
-                    Id = Guid.Parse(ScimApplicationFactory.TestOrganizationUserId2),
+                    Id = ScimApplicationFactory.TestOrganizationUserId2,
                     DisplayName = "Test User 2",
                     ExternalId = "UB",
                     Active = true,
@@ -187,7 +187,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
             {
                 new ScimUserResponseModel
                 {
-                    Id = Guid.Parse(ScimApplicationFactory.TestOrganizationUserId3),
+                    Id = ScimApplicationFactory.TestOrganizationUserId3,
                     DisplayName = "Test User 3",
                     ExternalId = "UC",
                     Active = false,
@@ -351,7 +351,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
         };
         var expectedResponse = new ScimUserResponseModel
         {
-            Id = Guid.Parse(ScimApplicationFactory.TestOrganizationUserId2),
+            Id = ScimApplicationFactory.TestOrganizationUserId2,
             DisplayName = "Test User 2",
             ExternalId = "UB",
             Active = false,
@@ -372,7 +372,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
         AssertHelper.AssertPropertyEqual(expectedResponse, responseModel);
 
         var databaseContext = _factory.GetDatabaseContext();
-        var revokedUser = databaseContext.OrganizationUsers.FirstOrDefault(g => g.Id.ToString() == organizationUserId);
+        var revokedUser = databaseContext.OrganizationUsers.FirstOrDefault(g => g.Id == organizationUserId);
         Assert.Equal(OrganizationUserStatusType.Revoked, revokedUser.Status);
     }
 
@@ -386,7 +386,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
         };
         var expectedResponse = new ScimUserResponseModel
         {
-            Id = Guid.Parse(ScimApplicationFactory.TestOrganizationUserId3),
+            Id = ScimApplicationFactory.TestOrganizationUserId3,
             DisplayName = "Test User 3",
             ExternalId = "UC",
             Active = true,
@@ -407,7 +407,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
         AssertHelper.AssertPropertyEqual(expectedResponse, responseModel);
 
         var databaseContext = _factory.GetDatabaseContext();
-        var revokedUser = databaseContext.OrganizationUsers.FirstOrDefault(g => g.Id.ToString() == organizationUserId);
+        var revokedUser = databaseContext.OrganizationUsers.FirstOrDefault(g => g.Id == organizationUserId);
         Assert.NotEqual(OrganizationUserStatusType.Revoked, revokedUser.Status);
     }
 
@@ -428,7 +428,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
             Schemas = new List<string> { ScimConstants.Scim2SchemaError }
         };
 
-        var context = await _factory.UsersPutAsync(ScimApplicationFactory.TestOrganizationId1, organizationUserId.ToString(), inputModel);
+        var context = await _factory.UsersPutAsync(ScimApplicationFactory.TestOrganizationId1, organizationUserId, inputModel);
 
         Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
 
@@ -455,7 +455,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
 
         var databaseContext = _factory.GetDatabaseContext();
 
-        var organizationUser = databaseContext.OrganizationUsers.FirstOrDefault(g => g.Id.ToString() == organizationUserId);
+        var organizationUser = databaseContext.OrganizationUsers.FirstOrDefault(g => g.Id == organizationUserId);
         Assert.Equal(OrganizationUserStatusType.Revoked, organizationUser.Status);
     }
 
@@ -478,14 +478,14 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
 
         var databaseContext = _factory.GetDatabaseContext();
 
-        var organizationUser = databaseContext.OrganizationUsers.FirstOrDefault(g => g.Id.ToString() == organizationUserId);
+        var organizationUser = databaseContext.OrganizationUsers.FirstOrDefault(g => g.Id == organizationUserId);
         Assert.NotEqual(OrganizationUserStatusType.Revoked, organizationUser.Status);
     }
 
     [Fact]
     public async Task Patch_NotFound()
     {
-        var organizationUserId = Guid.NewGuid().ToString();
+        var organizationUserId = Guid.NewGuid();
         var inputModel = new Models.ScimPatchModel
         {
             Operations = new List<ScimPatchModel.OperationModel>(),
@@ -518,13 +518,13 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
 
         var databaseContext = _factory.GetDatabaseContext();
         Assert.Equal(_initialUserCount - 1, databaseContext.OrganizationUsers.Count());
-        Assert.False(databaseContext.OrganizationUsers.Any(g => g.Id.ToString() == organizationUserId));
+        Assert.False(databaseContext.OrganizationUsers.Any(g => g.Id == organizationUserId));
     }
 
     [Fact]
     public async Task Delete_NotFound()
     {
-        var organizationUserId = Guid.NewGuid().ToString();
+        var organizationUserId = Guid.NewGuid();
         var inputModel = new ScimUserRequestModel();
         var expectedResponse = new ScimErrorResponseModel
         {

--- a/bitwarden_license/test/Scim.IntegrationTest/Factories/ScimApplicationFactory.cs
+++ b/bitwarden_license/test/Scim.IntegrationTest/Factories/ScimApplicationFactory.cs
@@ -19,18 +19,18 @@ public class ScimApplicationFactory : WebApplicationFactoryBase<Startup>
 {
     public readonly new TestServer Server;
 
-    public const string TestUserId1 = "2e8173db-8e8d-4de1-ac38-91b15c6d8dcb";
-    public const string TestUserId2 = "b57846fc-0e94-4c93-9de5-9d0389eeadfb";
-    public const string TestUserId3 = "20713eb8-d0c5-4655-b855-1a0f3472ccb5";
-    public const string TestUserId4 = "cee613af-d0cb-4db9-ab9d-579bb120fd2a";
-    public const string TestGroupId1 = "dcb232e8-761d-4152-a510-be2778d037cb";
-    public const string TestGroupId2 = "562e5371-7020-40b6-b092-099ac66dbdf9";
-    public const string TestGroupId3 = "362c2782-0f1f-4c86-95dd-edbdf7d6040b";
-    public const string TestOrganizationId1 = "fb98e04f-0303-4914-9b37-a983943bf1ca";
-    public const string TestOrganizationUserId1 = "5d421196-8c59-485b-8926-2d6d0101e05f";
-    public const string TestOrganizationUserId2 = "3a63d520-0d84-4679-b887-13fe2058d53b";
-    public const string TestOrganizationUserId3 = "be2f9045-e2b6-4173-ad44-4c69c3ea8140";
-    public const string TestOrganizationUserId4 = "1f5689b7-e96e-4840-b0b1-eb3d5b5fd514";
+    public static readonly Guid TestUserId1 = Guid.Parse("2e8173db-8e8d-4de1-ac38-91b15c6d8dcb");
+    public static readonly Guid TestUserId2 = Guid.Parse("b57846fc-0e94-4c93-9de5-9d0389eeadfb");
+    public static readonly Guid TestUserId3 = Guid.Parse("20713eb8-d0c5-4655-b855-1a0f3472ccb5");
+    public static readonly Guid TestUserId4 = Guid.Parse("cee613af-d0cb-4db9-ab9d-579bb120fd2a");
+    public static readonly Guid TestGroupId1 = Guid.Parse("dcb232e8-761d-4152-a510-be2778d037cb");
+    public static readonly Guid TestGroupId2 = Guid.Parse("562e5371-7020-40b6-b092-099ac66dbdf9");
+    public static readonly Guid TestGroupId3 = Guid.Parse("362c2782-0f1f-4c86-95dd-edbdf7d6040b");
+    public static readonly Guid TestOrganizationId1 = Guid.Parse("fb98e04f-0303-4914-9b37-a983943bf1ca");
+    public static readonly Guid TestOrganizationUserId1 = Guid.Parse("5d421196-8c59-485b-8926-2d6d0101e05f");
+    public static readonly Guid TestOrganizationUserId2 = Guid.Parse("3a63d520-0d84-4679-b887-13fe2058d53b");
+    public static readonly Guid TestOrganizationUserId3 = Guid.Parse("be2f9045-e2b6-4173-ad44-4c69c3ea8140");
+    public static readonly Guid TestOrganizationUserId4 = Guid.Parse("1f5689b7-e96e-4840-b0b1-eb3d5b5fd514");
 
     public ScimApplicationFactory()
     {
@@ -60,12 +60,12 @@ public class ScimApplicationFactory : WebApplicationFactoryBase<Startup>
         Server = webApplicationFactory.Server;
     }
 
-    public async Task<HttpContext> GroupsGetAsync(string organizationId, string id)
+    public async Task<HttpContext> GroupsGetAsync(Guid organizationId, Guid id)
     {
         return await Server.GetAsync($"/v2/{organizationId}/groups/{id}");
     }
 
-    public async Task<HttpContext> GroupsGetListAsync(string organizationId, string filter, int? count, int? startIndex)
+    public async Task<HttpContext> GroupsGetListAsync(Guid organizationId, string filter, int? count, int? startIndex)
     {
         var queryString = new QueryString("?");
 
@@ -87,32 +87,32 @@ public class ScimApplicationFactory : WebApplicationFactoryBase<Startup>
         return await Server.GetAsync($"/v2/{organizationId}/groups", httpContext => httpContext.Request.QueryString = queryString);
     }
 
-    public async Task<HttpContext> GroupsPostAsync(string organizationId, ScimGroupRequestModel model)
+    public async Task<HttpContext> GroupsPostAsync(Guid organizationId, ScimGroupRequestModel model)
     {
         return await Server.PostAsync($"/v2/{organizationId}/groups", GetStringContent(model), httpContext => httpContext.Request.Headers.Add(HeaderNames.UserAgent, "Okta"));
     }
 
-    public async Task<HttpContext> GroupsPutAsync(string organizationId, string id, ScimGroupRequestModel model)
+    public async Task<HttpContext> GroupsPutAsync(Guid organizationId, Guid id, ScimGroupRequestModel model)
     {
         return await Server.PutAsync($"/v2/{organizationId}/groups/{id}", GetStringContent(model), httpContext => httpContext.Request.Headers.Add(HeaderNames.UserAgent, "Okta"));
     }
 
-    public async Task<HttpContext> GroupsPatchAsync(string organizationId, string id, ScimPatchModel model)
+    public async Task<HttpContext> GroupsPatchAsync(Guid organizationId, Guid id, ScimPatchModel model)
     {
         return await Server.PatchAsync($"/v2/{organizationId}/groups/{id}", GetStringContent(model));
     }
 
-    public async Task<HttpContext> GroupsDeleteAsync(string organizationId, string id)
+    public async Task<HttpContext> GroupsDeleteAsync(Guid organizationId, Guid id)
     {
         return await Server.DeleteAsync($"/v2/{organizationId}/groups/{id}", null);
     }
 
-    public async Task<HttpContext> UsersGetAsync(string organizationId, string id)
+    public async Task<HttpContext> UsersGetAsync(Guid organizationId, Guid id)
     {
         return await Server.GetAsync($"/v2/{organizationId}/users/{id}");
     }
 
-    public async Task<HttpContext> UsersGetListAsync(string organizationId, string filter, int? count, int? startIndex)
+    public async Task<HttpContext> UsersGetListAsync(Guid organizationId, string filter, int? count, int? startIndex)
     {
         var queryString = new QueryString("?");
 
@@ -134,22 +134,22 @@ public class ScimApplicationFactory : WebApplicationFactoryBase<Startup>
         return await Server.GetAsync($"/v2/{organizationId}/users", httpContext => httpContext.Request.QueryString = queryString);
     }
 
-    public async Task<HttpContext> UsersPostAsync(string organizationId, ScimUserRequestModel model)
+    public async Task<HttpContext> UsersPostAsync(Guid organizationId, ScimUserRequestModel model)
     {
         return await Server.PostAsync($"/v2/{organizationId}/users", GetStringContent(model));
     }
 
-    public async Task<HttpContext> UsersPutAsync(string organizationId, string id, ScimUserRequestModel model)
+    public async Task<HttpContext> UsersPutAsync(Guid organizationId, Guid id, ScimUserRequestModel model)
     {
         return await Server.PutAsync($"/v2/{organizationId}/users/{id}", GetStringContent(model));
     }
 
-    public async Task<HttpContext> UsersPatchAsync(string organizationId, string id, ScimPatchModel model)
+    public async Task<HttpContext> UsersPatchAsync(Guid organizationId, Guid id, ScimPatchModel model)
     {
         return await Server.PatchAsync($"/v2/{organizationId}/users/{id}", GetStringContent(model));
     }
 
-    public async Task<HttpContext> UsersDeleteAsync(string organizationId, string id, ScimUserRequestModel model)
+    public async Task<HttpContext> UsersDeleteAsync(Guid organizationId, Guid id, ScimUserRequestModel model)
     {
         return await Server.DeleteAsync($"/v2/{organizationId}/users/{id}", GetStringContent(model));
     }
@@ -179,10 +179,10 @@ public class ScimApplicationFactory : WebApplicationFactoryBase<Startup>
     {
         return new List<Infrastructure.EntityFramework.Models.User>()
         {
-            new Infrastructure.EntityFramework.Models.User { Id = Guid.Parse(TestUserId1), Name = "Test User 1", ApiKey = "", Email = "user1@example.com", SecurityStamp = "" },
-            new Infrastructure.EntityFramework.Models.User { Id = Guid.Parse(TestUserId2), Name = "Test User 2", ApiKey = "", Email = "user2@example.com", SecurityStamp = "" },
-            new Infrastructure.EntityFramework.Models.User { Id = Guid.Parse(TestUserId3), Name = "Test User 3", ApiKey = "", Email = "user3@example.com", SecurityStamp = "" },
-            new Infrastructure.EntityFramework.Models.User { Id = Guid.Parse(TestUserId4), Name = "Test User 4", ApiKey = "", Email = "user4@example.com", SecurityStamp = "" },
+            new Infrastructure.EntityFramework.Models.User { Id = TestUserId1, Name = "Test User 1", ApiKey = "", Email = "user1@example.com", SecurityStamp = "" },
+            new Infrastructure.EntityFramework.Models.User { Id = TestUserId2, Name = "Test User 2", ApiKey = "", Email = "user2@example.com", SecurityStamp = "" },
+            new Infrastructure.EntityFramework.Models.User { Id = TestUserId3, Name = "Test User 3", ApiKey = "", Email = "user3@example.com", SecurityStamp = "" },
+            new Infrastructure.EntityFramework.Models.User { Id = TestUserId4, Name = "Test User 4", ApiKey = "", Email = "user4@example.com", SecurityStamp = "" },
         };
     }
 
@@ -190,9 +190,9 @@ public class ScimApplicationFactory : WebApplicationFactoryBase<Startup>
     {
         return new List<Infrastructure.EntityFramework.Models.Group>()
         {
-            new Infrastructure.EntityFramework.Models.Group { Id = Guid.Parse(TestGroupId1), OrganizationId = Guid.Parse(TestOrganizationId1), Name = "Test Group 1", ExternalId = "A" },
-            new Infrastructure.EntityFramework.Models.Group { Id = Guid.Parse(TestGroupId2), OrganizationId = Guid.Parse(TestOrganizationId1), Name = "Test Group 2", ExternalId = "B" },
-            new Infrastructure.EntityFramework.Models.Group { Id = Guid.Parse(TestGroupId3), OrganizationId = Guid.Parse(TestOrganizationId1), Name = "Test Group 3", ExternalId = "C" }
+            new Infrastructure.EntityFramework.Models.Group { Id = TestGroupId1, OrganizationId = TestOrganizationId1, Name = "Test Group 1", ExternalId = "A" },
+            new Infrastructure.EntityFramework.Models.Group { Id = TestGroupId2, OrganizationId = TestOrganizationId1, Name = "Test Group 2", ExternalId = "B" },
+            new Infrastructure.EntityFramework.Models.Group { Id = TestGroupId3, OrganizationId = TestOrganizationId1, Name = "Test Group 3", ExternalId = "C" }
         };
     }
 
@@ -200,7 +200,7 @@ public class ScimApplicationFactory : WebApplicationFactoryBase<Startup>
     {
         return new List<Infrastructure.EntityFramework.Models.Organization>()
         {
-            new Infrastructure.EntityFramework.Models.Organization { Id = Guid.Parse(TestOrganizationId1), Name = "Test Organization 1", UseGroups = true }
+            new Infrastructure.EntityFramework.Models.Organization { Id = TestOrganizationId1, Name = "Test Organization 1", UseGroups = true }
         };
     }
 
@@ -208,10 +208,10 @@ public class ScimApplicationFactory : WebApplicationFactoryBase<Startup>
     {
         return new List<Infrastructure.EntityFramework.Models.OrganizationUser>()
         {
-            new Infrastructure.EntityFramework.Models.OrganizationUser { Id = Guid.Parse(TestOrganizationUserId1), OrganizationId = Guid.Parse(TestOrganizationId1), UserId = Guid.Parse(TestUserId1), Status = Core.Enums.OrganizationUserStatusType.Confirmed, ExternalId = "UA", Email = "user1@example.com" },
-            new Infrastructure.EntityFramework.Models.OrganizationUser { Id = Guid.Parse(TestOrganizationUserId2), OrganizationId = Guid.Parse(TestOrganizationId1), UserId = Guid.Parse(TestUserId2), Status = Core.Enums.OrganizationUserStatusType.Confirmed, ExternalId = "UB", Email = "user2@example.com" },
-            new Infrastructure.EntityFramework.Models.OrganizationUser { Id = Guid.Parse(TestOrganizationUserId3), OrganizationId = Guid.Parse(TestOrganizationId1), UserId = Guid.Parse(TestUserId3), Status = Core.Enums.OrganizationUserStatusType.Revoked, ExternalId = "UC", Email = "user3@example.com" },
-            new Infrastructure.EntityFramework.Models.OrganizationUser { Id = Guid.Parse(TestOrganizationUserId4), OrganizationId = Guid.Parse(TestOrganizationId1), UserId = Guid.Parse(TestUserId4), Status = Core.Enums.OrganizationUserStatusType.Confirmed, ExternalId = "UD", Email = "user4@example.com" },
+            new Infrastructure.EntityFramework.Models.OrganizationUser { Id = TestOrganizationUserId1, OrganizationId = TestOrganizationId1, UserId = TestUserId1, Status = Core.Enums.OrganizationUserStatusType.Confirmed, ExternalId = "UA", Email = "user1@example.com" },
+            new Infrastructure.EntityFramework.Models.OrganizationUser { Id = TestOrganizationUserId2, OrganizationId = TestOrganizationId1, UserId = TestUserId2, Status = Core.Enums.OrganizationUserStatusType.Confirmed, ExternalId = "UB", Email = "user2@example.com" },
+            new Infrastructure.EntityFramework.Models.OrganizationUser { Id = TestOrganizationUserId3, OrganizationId = TestOrganizationId1, UserId = TestUserId3, Status = Core.Enums.OrganizationUserStatusType.Revoked, ExternalId = "UC", Email = "user3@example.com" },
+            new Infrastructure.EntityFramework.Models.OrganizationUser { Id = TestOrganizationUserId4, OrganizationId = TestOrganizationId1, UserId = TestUserId4, Status = Core.Enums.OrganizationUserStatusType.Confirmed, ExternalId = "UD", Email = "user4@example.com" },
         };
     }
 
@@ -219,8 +219,8 @@ public class ScimApplicationFactory : WebApplicationFactoryBase<Startup>
     {
         return new List<Infrastructure.EntityFramework.Models.GroupUser>()
         {
-            new Infrastructure.EntityFramework.Models.GroupUser { GroupId = Guid.Parse(TestGroupId1), OrganizationUserId = Guid.Parse(TestOrganizationUserId1) },
-            new Infrastructure.EntityFramework.Models.GroupUser { GroupId = Guid.Parse(TestGroupId1), OrganizationUserId = Guid.Parse(TestOrganizationUserId4) }
+            new Infrastructure.EntityFramework.Models.GroupUser { GroupId = TestGroupId1, OrganizationUserId = TestOrganizationUserId1 },
+            new Infrastructure.EntityFramework.Models.GroupUser { GroupId = TestGroupId1, OrganizationUserId = TestOrganizationUserId4 }
         };
     }
 
@@ -239,7 +239,7 @@ public class ScimApplicationFactory : WebApplicationFactoryBase<Startup>
             var claims = new[]
             {
                 new Claim(ClaimTypes.Name, "Test user"),
-                new Claim("orgadmin", TestOrganizationId1)
+                new Claim("orgadmin", TestOrganizationId1.ToString())
             };
             var identity = new ClaimsIdentity(claims, "Test");
             var principal = new ClaimsPrincipal(identity);

--- a/src/Api/Auth/Models/Response/AuthRequestResponseModel.cs
+++ b/src/Api/Auth/Models/Response/AuthRequestResponseModel.cs
@@ -15,7 +15,7 @@ public class AuthRequestResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(authRequest));
         }
 
-        Id = authRequest.Id.ToString();
+        Id = authRequest.Id;
         PublicKey = authRequest.PublicKey;
         RequestDeviceType = authRequest.RequestDeviceType.GetType().GetMember(authRequest.RequestDeviceType.ToString())
             .FirstOrDefault()?.GetCustomAttribute<DisplayAttribute>()?.GetName();
@@ -28,7 +28,7 @@ public class AuthRequestResponseModel : ResponseModel
         ResponseDate = authRequest.ResponseDate;
     }
 
-    public string Id { get; set; }
+    public Guid Id { get; set; }
     public string PublicKey { get; set; }
     public string RequestDeviceType { get; set; }
     public string RequestIpAddress { get; set; }

--- a/src/Api/Auth/Models/Response/EmergencyAccessResponseModel.cs
+++ b/src/Api/Auth/Models/Response/EmergencyAccessResponseModel.cs
@@ -19,7 +19,7 @@ public class EmergencyAccessResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(emergencyAccess));
         }
 
-        Id = emergencyAccess.Id.ToString();
+        Id = emergencyAccess.Id;
         Status = emergencyAccess.Status;
         Type = emergencyAccess.Type;
         WaitTimeDays = emergencyAccess.WaitTimeDays;
@@ -32,13 +32,13 @@ public class EmergencyAccessResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(emergencyAccess));
         }
 
-        Id = emergencyAccess.Id.ToString();
+        Id = emergencyAccess.Id;
         Status = emergencyAccess.Status;
         Type = emergencyAccess.Type;
         WaitTimeDays = emergencyAccess.WaitTimeDays;
     }
 
-    public string Id { get; private set; }
+    public Guid Id { get; private set; }
     public EmergencyAccessStatusType Status { get; private set; }
     public EmergencyAccessType Type { get; private set; }
     public int WaitTimeDays { get; private set; }
@@ -54,13 +54,13 @@ public class EmergencyAccessGranteeDetailsResponseModel : EmergencyAccessRespons
             throw new ArgumentNullException(nameof(emergencyAccess));
         }
 
-        GranteeId = emergencyAccess.GranteeId.ToString();
+        GranteeId = emergencyAccess.GranteeId;
         Email = emergencyAccess.GranteeEmail;
         Name = emergencyAccess.GranteeName;
         AvatarColor = emergencyAccess.GranteeAvatarColor;
     }
 
-    public string GranteeId { get; private set; }
+    public Guid? GranteeId { get; private set; }
     public string Name { get; private set; }
     public string Email { get; private set; }
     public string AvatarColor { get; private set; }
@@ -76,13 +76,13 @@ public class EmergencyAccessGrantorDetailsResponseModel : EmergencyAccessRespons
             throw new ArgumentNullException(nameof(emergencyAccess));
         }
 
-        GrantorId = emergencyAccess.GrantorId.ToString();
+        GrantorId = emergencyAccess.GrantorId;
         Email = emergencyAccess.GrantorEmail;
         Name = emergencyAccess.GrantorName;
         AvatarColor = emergencyAccess.GrantorAvatarColor;
     }
 
-    public string GrantorId { get; private set; }
+    public Guid GrantorId { get; private set; }
     public string Name { get; private set; }
     public string Email { get; private set; }
     public string AvatarColor { get; private set; }

--- a/src/Api/Models/Response/CollectionResponseModel.cs
+++ b/src/Api/Models/Response/CollectionResponseModel.cs
@@ -14,14 +14,14 @@ public class CollectionResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(collection));
         }
 
-        Id = collection.Id.ToString();
-        OrganizationId = collection.OrganizationId.ToString();
+        Id = collection.Id;
+        OrganizationId = collection.OrganizationId;
         Name = collection.Name;
         ExternalId = collection.ExternalId;
     }
 
-    public string Id { get; set; }
-    public string OrganizationId { get; set; }
+    public Guid Id { get; set; }
+    public Guid OrganizationId { get; set; }
     public string Name { get; set; }
     public string ExternalId { get; set; }
 }

--- a/src/Api/Models/Response/DeviceResponseModel.cs
+++ b/src/Api/Models/Response/DeviceResponseModel.cs
@@ -14,14 +14,14 @@ public class DeviceResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(device));
         }
 
-        Id = device.Id.ToString();
+        Id = device.Id;
         Name = device.Name;
         Type = device.Type;
         Identifier = device.Identifier;
         CreationDate = device.CreationDate;
     }
 
-    public string Id { get; set; }
+    public Guid Id { get; set; }
     public string Name { get; set; }
     public DeviceType Type { get; set; }
     public string Identifier { get; set; }

--- a/src/Api/Models/Response/GroupResponseModel.cs
+++ b/src/Api/Models/Response/GroupResponseModel.cs
@@ -14,15 +14,15 @@ public class GroupResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(group));
         }
 
-        Id = group.Id.ToString();
-        OrganizationId = group.OrganizationId.ToString();
+        Id = group.Id;
+        OrganizationId = group.OrganizationId;
         Name = group.Name;
         AccessAll = group.AccessAll;
         ExternalId = group.ExternalId;
     }
 
-    public string Id { get; set; }
-    public string OrganizationId { get; set; }
+    public Guid Id { get; set; }
+    public Guid OrganizationId { get; set; }
     public string Name { get; set; }
     public bool AccessAll { get; set; }
     public string ExternalId { get; set; }

--- a/src/Api/Models/Response/InstallationResponseModel.cs
+++ b/src/Api/Models/Response/InstallationResponseModel.cs
@@ -8,12 +8,12 @@ public class InstallationResponseModel : ResponseModel
     public InstallationResponseModel(Installation installation, bool withKey)
         : base("installation")
     {
-        Id = installation.Id.ToString();
+        Id = installation.Id;
         Key = withKey ? installation.Key : null;
         Enabled = installation.Enabled;
     }
 
-    public string Id { get; set; }
+    public Guid Id { get; set; }
     public string Key { get; set; }
     public bool Enabled { get; set; }
 }

--- a/src/Api/Models/Response/Organizations/OrganizationAutoEnrollStatusResponseModel.cs
+++ b/src/Api/Models/Response/Organizations/OrganizationAutoEnrollStatusResponseModel.cs
@@ -6,10 +6,10 @@ public class OrganizationAutoEnrollStatusResponseModel : ResponseModel
 {
     public OrganizationAutoEnrollStatusResponseModel(Guid orgId, bool resetPasswordEnabled) : base("organizationAutoEnrollStatus")
     {
-        Id = orgId.ToString();
+        Id = orgId;
         ResetPasswordEnabled = resetPasswordEnabled;
     }
 
-    public string Id { get; set; }
+    public Guid Id { get; set; }
     public bool ResetPasswordEnabled { get; set; }
 }

--- a/src/Api/Models/Response/Organizations/OrganizationDomainResponseModel.cs
+++ b/src/Api/Models/Response/Organizations/OrganizationDomainResponseModel.cs
@@ -13,8 +13,8 @@ public class OrganizationDomainResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(organizationDomain));
         }
 
-        Id = organizationDomain.Id.ToString();
-        OrganizationId = organizationDomain.OrganizationId.ToString();
+        Id = organizationDomain.Id;
+        OrganizationId = organizationDomain.OrganizationId;
         Txt = organizationDomain.Txt;
         DomainName = organizationDomain.DomainName;
         CreationDate = organizationDomain.CreationDate;
@@ -24,8 +24,8 @@ public class OrganizationDomainResponseModel : ResponseModel
         LastCheckedDate = organizationDomain.LastCheckedDate;
     }
 
-    public string Id { get; set; }
-    public string OrganizationId { get; set; }
+    public Guid Id { get; set; }
+    public Guid OrganizationId { get; set; }
     public string Txt { get; set; }
     public string DomainName { get; set; }
     public DateTime CreationDate { get; set; }

--- a/src/Api/Models/Response/Organizations/OrganizationResponseModel.cs
+++ b/src/Api/Models/Response/Organizations/OrganizationResponseModel.cs
@@ -16,7 +16,7 @@ public class OrganizationResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(organization));
         }
 
-        Id = organization.Id.ToString();
+        Id = organization.Id;
         Name = organization.Name;
         BusinessName = organization.BusinessName;
         BusinessAddress1 = organization.BusinessAddress1;
@@ -49,7 +49,7 @@ public class OrganizationResponseModel : ResponseModel
         HasPublicAndPrivateKeys = organization.PublicKey != null && organization.PrivateKey != null;
     }
 
-    public string Id { get; set; }
+    public Guid Id { get; set; }
     public string Name { get; set; }
     public string BusinessName { get; set; }
     public string BusinessAddress1 { get; set; }

--- a/src/Api/Models/Response/Organizations/OrganizationUserResponseModel.cs
+++ b/src/Api/Models/Response/Organizations/OrganizationUserResponseModel.cs
@@ -18,8 +18,8 @@ public class OrganizationUserResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(organizationUser));
         }
 
-        Id = organizationUser.Id.ToString();
-        UserId = organizationUser.UserId?.ToString();
+        Id = organizationUser.Id;
+        UserId = organizationUser.UserId;
         Type = organizationUser.Type;
         Status = organizationUser.Status;
         AccessAll = organizationUser.AccessAll;
@@ -37,8 +37,8 @@ public class OrganizationUserResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(organizationUser));
         }
 
-        Id = organizationUser.Id.ToString();
-        UserId = organizationUser.UserId?.ToString();
+        Id = organizationUser.Id;
+        UserId = organizationUser.UserId;
         Type = organizationUser.Type;
         Status = organizationUser.Status;
         AccessAll = organizationUser.AccessAll;
@@ -49,8 +49,8 @@ public class OrganizationUserResponseModel : ResponseModel
         UsesKeyConnector = organizationUser.UsesKeyConnector;
     }
 
-    public string Id { get; set; }
-    public string UserId { get; set; }
+    public Guid Id { get; set; }
+    public Guid? UserId { get; set; }
     public OrganizationUserType Type { get; set; }
     public OrganizationUserStatusType Status { get; set; }
     public bool AccessAll { get; set; }

--- a/src/Api/Models/Response/ProfileOrganizationResponseModel.cs
+++ b/src/Api/Models/Response/ProfileOrganizationResponseModel.cs
@@ -14,7 +14,7 @@ public class ProfileOrganizationResponseModel : ResponseModel
 
     public ProfileOrganizationResponseModel(OrganizationUserOrganizationDetails organization) : this("profileOrganization")
     {
-        Id = organization.OrganizationId.ToString();
+        Id = organization.OrganizationId;
         Name = organization.Name;
         UsePolicies = organization.UsePolicies;
         UseSso = organization.UseSso;
@@ -45,8 +45,8 @@ public class ProfileOrganizationResponseModel : ResponseModel
         Identifier = organization.Identifier;
         Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(organization.Permissions);
         ResetPasswordEnrolled = organization.ResetPasswordKey != null;
-        UserId = organization.UserId?.ToString();
-        ProviderId = organization.ProviderId?.ToString();
+        UserId = organization.UserId;
+        ProviderId = organization.ProviderId;
         ProviderName = organization.ProviderName;
         ProviderType = organization.ProviderType;
         FamilySponsorshipFriendlyName = organization.FamilySponsorshipFriendlyName;
@@ -67,7 +67,7 @@ public class ProfileOrganizationResponseModel : ResponseModel
         }
     }
 
-    public string Id { get; set; }
+    public Guid Id { get; set; }
     public string Name { get; set; }
     public bool UsePolicies { get; set; }
     public bool UseSso { get; set; }
@@ -96,9 +96,9 @@ public class ProfileOrganizationResponseModel : ResponseModel
     public string Identifier { get; set; }
     public Permissions Permissions { get; set; }
     public bool ResetPasswordEnrolled { get; set; }
-    public string UserId { get; set; }
+    public Guid? UserId { get; set; }
     public bool HasPublicAndPrivateKeys { get; set; }
-    public string ProviderId { get; set; }
+    public Guid? ProviderId { get; set; }
     public string ProviderName { get; set; }
     public ProviderType? ProviderType { get; set; }
     public string FamilySponsorshipFriendlyName { get; set; }

--- a/src/Api/Models/Response/ProfileProviderOrganizationResponseModel.cs
+++ b/src/Api/Models/Response/ProfileProviderOrganizationResponseModel.cs
@@ -9,7 +9,7 @@ public class ProfileProviderOrganizationResponseModel : ProfileOrganizationRespo
     public ProfileProviderOrganizationResponseModel(ProviderUserOrganizationDetails organization)
         : base("profileProviderOrganization")
     {
-        Id = organization.OrganizationId.ToString();
+        Id = organization.OrganizationId;
         Name = organization.Name;
         UsePolicies = organization.UsePolicies;
         UseSso = organization.UseSso;
@@ -39,8 +39,8 @@ public class ProfileProviderOrganizationResponseModel : ProfileOrganizationRespo
         Identifier = organization.Identifier;
         Permissions = new Permissions();
         ResetPasswordEnrolled = false;
-        UserId = organization.UserId?.ToString();
-        ProviderId = organization.ProviderId?.ToString();
+        UserId = organization.UserId;
+        ProviderId = organization.ProviderId;
         ProviderName = organization.ProviderName;
         PlanProductType = StaticStore.GetPlan(organization.PlanType).Product;
     }

--- a/src/Api/Models/Response/ProfileResponseModel.cs
+++ b/src/Api/Models/Response/ProfileResponseModel.cs
@@ -20,7 +20,7 @@ public class ProfileResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(user));
         }
 
-        Id = user.Id.ToString();
+        Id = user.Id;
         Name = user.Name;
         Email = user.Email;
         EmailVerified = user.EmailVerified;
@@ -45,7 +45,7 @@ public class ProfileResponseModel : ResponseModel
     {
     }
 
-    public string Id { get; set; }
+    public Guid Id { get; set; }
     public string Name { get; set; }
     public string Email { get; set; }
     public bool EmailVerified { get; set; }

--- a/src/Api/Models/Response/Providers/ProfileProviderResponseModel.cs
+++ b/src/Api/Models/Response/Providers/ProfileProviderResponseModel.cs
@@ -10,24 +10,24 @@ public class ProfileProviderResponseModel : ResponseModel
     public ProfileProviderResponseModel(ProviderUserProviderDetails provider)
         : base("profileProvider")
     {
-        Id = provider.ProviderId.ToString();
+        Id = provider.ProviderId;
         Name = provider.Name;
         Key = provider.Key;
         Status = provider.Status;
         Type = provider.Type;
         Enabled = provider.Enabled;
         Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(provider.Permissions);
-        UserId = provider.UserId?.ToString();
+        UserId = provider.UserId;
         UseEvents = provider.UseEvents;
     }
 
-    public string Id { get; set; }
+    public Guid Id { get; set; }
     public string Name { get; set; }
     public string Key { get; set; }
     public ProviderUserStatusType Status { get; set; }
     public ProviderUserType Type { get; set; }
     public bool Enabled { get; set; }
     public Permissions Permissions { get; set; }
-    public string UserId { get; set; }
+    public Guid? UserId { get; set; }
     public bool UseEvents { get; set; }
 }

--- a/src/Api/Models/Response/Providers/ProviderUserResponseModel.cs
+++ b/src/Api/Models/Response/Providers/ProviderUserResponseModel.cs
@@ -16,8 +16,8 @@ public class ProviderUserResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(providerUser));
         }
 
-        Id = providerUser.Id.ToString();
-        UserId = providerUser.UserId?.ToString();
+        Id = providerUser.Id;
+        UserId = providerUser.UserId;
         Type = providerUser.Type;
         Status = providerUser.Status;
         Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(providerUser.Permissions);
@@ -31,15 +31,15 @@ public class ProviderUserResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(providerUser));
         }
 
-        Id = providerUser.Id.ToString();
-        UserId = providerUser.UserId?.ToString();
+        Id = providerUser.Id;
+        UserId = providerUser.UserId;
         Type = providerUser.Type;
         Status = providerUser.Status;
         Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(providerUser.Permissions);
     }
 
-    public string Id { get; set; }
-    public string UserId { get; set; }
+    public Guid Id { get; set; }
+    public Guid? UserId { get; set; }
     public ProviderUserType Type { get; set; }
     public ProviderUserStatusType Status { get; set; }
     public Permissions Permissions { get; set; }

--- a/src/Api/Models/Response/SelectionReadOnlyResponseModel.cs
+++ b/src/Api/Models/Response/SelectionReadOnlyResponseModel.cs
@@ -11,12 +11,12 @@ public class SelectionReadOnlyResponseModel
             throw new ArgumentNullException(nameof(selection));
         }
 
-        Id = selection.Id.ToString();
+        Id = selection.Id;
         ReadOnly = selection.ReadOnly;
         HidePasswords = selection.HidePasswords;
     }
 
-    public string Id { get; set; }
+    public Guid Id { get; set; }
     public bool ReadOnly { get; set; }
     public bool HidePasswords { get; set; }
 }

--- a/src/Api/Models/Response/UserKeyResponseModel.cs
+++ b/src/Api/Models/Response/UserKeyResponseModel.cs
@@ -7,10 +7,10 @@ public class UserKeyResponseModel : ResponseModel
     public UserKeyResponseModel(Guid id, string key)
         : base("userKey")
     {
-        UserId = id.ToString();
+        UserId = id;
         PublicKey = key;
     }
 
-    public string UserId { get; set; }
+    public Guid UserId { get; set; }
     public string PublicKey { get; set; }
 }

--- a/src/Api/SecretsManager/Controllers/SecretsManagerPortingController.cs
+++ b/src/Api/SecretsManager/Controllers/SecretsManagerPortingController.cs
@@ -31,7 +31,7 @@ public class SecretsManagerPortingController : Controller
     }
 
     [HttpGet("sm/{organizationId}/export")]
-    public async Task<SMExportResponseModel> Export([FromRoute] Guid organizationId, [FromRoute] string format = "json")
+    public async Task<SMExportResponseModel> Export([FromRoute] Guid organizationId)
     {
         if (!await _currentContext.OrganizationAdmin(organizationId) || !_currentContext.AccessSecretsManager(organizationId))
         {

--- a/src/Api/SecretsManager/Models/Response/PotentialGranteeResponseModel.cs
+++ b/src/Api/SecretsManager/Models/Response/PotentialGranteeResponseModel.cs
@@ -17,7 +17,7 @@ public class PotentialGranteeResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(group));
         }
 
-        Id = group.Id.ToString();
+        Id = group.Id;
         Name = group.Name;
         Type = "group";
     }
@@ -30,7 +30,7 @@ public class PotentialGranteeResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(user));
         }
 
-        Id = user.Id.ToString();
+        Id = user.Id;
         Name = user.Name;
         Email = user.Email;
         Type = "user";
@@ -44,7 +44,7 @@ public class PotentialGranteeResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(serviceAccount));
         }
 
-        Id = serviceAccount.Id.ToString();
+        Id = serviceAccount.Id;
         Name = serviceAccount.Name;
         Type = "serviceAccount";
     }
@@ -57,7 +57,7 @@ public class PotentialGranteeResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(project));
         }
 
-        Id = project.Id.ToString();
+        Id = project.Id;
         Name = project.Name;
         Type = "project";
     }
@@ -66,7 +66,7 @@ public class PotentialGranteeResponseModel : ResponseModel
     {
     }
 
-    public string Id { get; set; }
+    public Guid Id { get; set; }
 
     public string Name { get; set; }
 

--- a/src/Api/SecretsManager/Models/Response/ProjectResponseModel.cs
+++ b/src/Api/SecretsManager/Models/Response/ProjectResponseModel.cs
@@ -16,8 +16,8 @@ public class ProjectResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(project));
         }
 
-        Id = project.Id.ToString();
-        OrganizationId = project.OrganizationId.ToString();
+        Id = project.Id;
+        OrganizationId = project.OrganizationId;
         Name = project.Name;
         CreationDate = project.CreationDate;
         RevisionDate = project.RevisionDate;
@@ -33,8 +33,8 @@ public class ProjectResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(projectDetails));
         }
 
-        Id = projectDetails.Project.Id.ToString();
-        OrganizationId = projectDetails.Project.OrganizationId.ToString();
+        Id = projectDetails.Project.Id;
+        OrganizationId = projectDetails.Project.OrganizationId;
         Name = projectDetails.Project.Name;
         CreationDate = projectDetails.Project.CreationDate;
         RevisionDate = projectDetails.Project.RevisionDate;
@@ -46,9 +46,9 @@ public class ProjectResponseModel : ResponseModel
     {
     }
 
-    public string Id { get; set; }
+    public Guid Id { get; set; }
 
-    public string OrganizationId { get; set; }
+    public Guid OrganizationId { get; set; }
 
     public string Name { get; set; }
 

--- a/src/Api/SecretsManager/Models/Response/SecretResponseModel.cs
+++ b/src/Api/SecretsManager/Models/Response/SecretResponseModel.cs
@@ -21,7 +21,7 @@ public class SecretResponseModel : ResponseModel
         Note = secret.Note;
         CreationDate = secret.CreationDate;
         RevisionDate = secret.RevisionDate;
-        Projects = secret.Projects?.Select(p => new InnerProject(p));
+        Projects = secret.Projects?.Select(p => new SecretResponseInnerProject(p));
 
         Read = read;
         Write = write;
@@ -45,21 +45,21 @@ public class SecretResponseModel : ResponseModel
 
     public DateTime RevisionDate { get; set; }
 
-    public IEnumerable<InnerProject> Projects { get; set; }
+    public IEnumerable<SecretResponseInnerProject> Projects { get; set; }
 
     public bool Read { get; set; }
 
     public bool Write { get; set; }
 
-    public class InnerProject
+    public class SecretResponseInnerProject
     {
-        public InnerProject(Project project)
+        public SecretResponseInnerProject(Project project)
         {
             Id = project.Id;
             Name = project.Name;
         }
 
-        public InnerProject()
+        public SecretResponseInnerProject()
         {
         }
 

--- a/src/Api/SecretsManager/Models/Response/SecretResponseModel.cs
+++ b/src/Api/SecretsManager/Models/Response/SecretResponseModel.cs
@@ -14,8 +14,8 @@ public class SecretResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(secret));
         }
 
-        Id = secret.Id.ToString();
-        OrganizationId = secret.OrganizationId.ToString();
+        Id = secret.Id;
+        OrganizationId = secret.OrganizationId;
         Key = secret.Key;
         Value = secret.Value;
         Note = secret.Note;
@@ -31,9 +31,9 @@ public class SecretResponseModel : ResponseModel
     {
     }
 
-    public string Id { get; set; }
+    public Guid Id { get; set; }
 
-    public string OrganizationId { get; set; }
+    public Guid OrganizationId { get; set; }
 
     public string Key { get; set; }
 

--- a/src/Api/SecretsManager/Models/Response/SecretWithProjectsListResponseModel.cs
+++ b/src/Api/SecretsManager/Models/Response/SecretWithProjectsListResponseModel.cs
@@ -10,26 +10,26 @@ public class SecretWithProjectsListResponseModel : ResponseModel
 
     public SecretWithProjectsListResponseModel(IEnumerable<SecretPermissionDetails> secrets) : base(_objectName)
     {
-        Secrets = secrets.Select(s => new InnerSecret(s));
-        Projects = secrets.SelectMany(s => s.Secret.Projects).DistinctBy(p => p.Id).Select(p => new InnerProject(p));
+        Secrets = secrets.Select(s => new SecretsWithProjectsInnerSecret(s));
+        Projects = secrets.SelectMany(s => s.Secret.Projects).DistinctBy(p => p.Id).Select(p => new SecretWithProjectsInnerProject(p));
     }
 
     public SecretWithProjectsListResponseModel() : base(_objectName)
     {
     }
 
-    public IEnumerable<InnerSecret> Secrets { get; set; }
-    public IEnumerable<InnerProject> Projects { get; set; }
+    public IEnumerable<SecretsWithProjectsInnerSecret> Secrets { get; set; }
+    public IEnumerable<SecretWithProjectsInnerProject> Projects { get; set; }
 
-    public class InnerProject
+    public class SecretWithProjectsInnerProject
     {
-        public InnerProject(Project project)
+        public SecretWithProjectsInnerProject(Project project)
         {
             Id = project.Id;
             Name = project.Name;
         }
 
-        public InnerProject()
+        public SecretWithProjectsInnerProject()
         {
         }
 
@@ -37,27 +37,27 @@ public class SecretWithProjectsListResponseModel : ResponseModel
         public string Name { get; set; }
     }
 
-    public class InnerSecret
+    public class SecretsWithProjectsInnerSecret
     {
-        public InnerSecret(SecretPermissionDetails secret)
+        public SecretsWithProjectsInnerSecret(SecretPermissionDetails secret)
         {
-            Id = secret.Secret.Id.ToString();
-            OrganizationId = secret.Secret.OrganizationId.ToString();
+            Id = secret.Secret.Id;
+            OrganizationId = secret.Secret.OrganizationId;
             Key = secret.Secret.Key;
             CreationDate = secret.Secret.CreationDate;
             RevisionDate = secret.Secret.RevisionDate;
-            Projects = secret.Secret.Projects?.Select(p => new InnerProject(p));
+            Projects = secret.Secret.Projects?.Select(p => new SecretWithProjectsInnerProject(p));
             Read = secret.Read;
             Write = secret.Write;
         }
 
-        public InnerSecret()
+        public SecretsWithProjectsInnerSecret()
         {
         }
 
-        public string Id { get; set; }
+        public Guid Id { get; set; }
 
-        public string OrganizationId { get; set; }
+        public Guid OrganizationId { get; set; }
 
         public string Key { get; set; }
 
@@ -65,7 +65,7 @@ public class SecretWithProjectsListResponseModel : ResponseModel
 
         public DateTime RevisionDate { get; set; }
 
-        public IEnumerable<InnerProject> Projects { get; set; }
+        public IEnumerable<SecretWithProjectsInnerProject> Projects { get; set; }
         public bool Read { get; set; }
         public bool Write { get; set; }
     }

--- a/src/Api/SecretsManager/Models/Response/ServiceAccountResponseModel.cs
+++ b/src/Api/SecretsManager/Models/Response/ServiceAccountResponseModel.cs
@@ -14,8 +14,8 @@ public class ServiceAccountResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(serviceAccount));
         }
 
-        Id = serviceAccount.Id.ToString();
-        OrganizationId = serviceAccount.OrganizationId.ToString();
+        Id = serviceAccount.Id;
+        OrganizationId = serviceAccount.OrganizationId;
         Name = serviceAccount.Name;
         CreationDate = serviceAccount.CreationDate;
         RevisionDate = serviceAccount.RevisionDate;
@@ -25,9 +25,9 @@ public class ServiceAccountResponseModel : ResponseModel
     {
     }
 
-    public string Id { get; set; }
+    public Guid Id { get; set; }
 
-    public string OrganizationId { get; set; }
+    public Guid OrganizationId { get; set; }
 
     public string Name { get; set; }
 

--- a/src/Api/Tools/Models/Response/SendResponseModel.cs
+++ b/src/Api/Tools/Models/Response/SendResponseModel.cs
@@ -18,7 +18,7 @@ public class SendResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(send));
         }
 
-        Id = send.Id.ToString();
+        Id = send.Id;
         AccessId = CoreHelpers.Base64UrlEncode(send.Id.ToByteArray());
         Type = send.Type;
         Key = send.Key;
@@ -52,7 +52,7 @@ public class SendResponseModel : ResponseModel
         Notes = sendData.Notes;
     }
 
-    public string Id { get; set; }
+    public Guid Id { get; set; }
     public string AccessId { get; set; }
     public SendType Type { get; set; }
     public string Name { get; set; }

--- a/src/Api/Vault/Models/Response/CipherResponseModel.cs
+++ b/src/Api/Vault/Models/Response/CipherResponseModel.cs
@@ -18,7 +18,7 @@ public class CipherMiniResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(cipher));
         }
 
-        Id = cipher.Id.ToString();
+        Id = cipher.Id;
         Type = cipher.Type;
 
         CipherData cipherData;
@@ -57,7 +57,7 @@ public class CipherMiniResponseModel : ResponseModel
         Fields = cipherData.Fields?.Select(f => new CipherFieldModel(f));
         PasswordHistory = cipherData.PasswordHistory?.Select(ph => new CipherPasswordHistoryModel(ph));
         RevisionDate = cipher.RevisionDate;
-        OrganizationId = cipher.OrganizationId?.ToString();
+        OrganizationId = cipher.OrganizationId;
         Attachments = AttachmentResponseModel.FromCipher(cipher, globalSettings);
         OrganizationUseTotp = orgUseTotp;
         CreationDate = cipher.CreationDate;
@@ -65,8 +65,8 @@ public class CipherMiniResponseModel : ResponseModel
         Reprompt = cipher.Reprompt.GetValueOrDefault(CipherRepromptType.None);
     }
 
-    public string Id { get; set; }
-    public string OrganizationId { get; set; }
+    public Guid Id { get; set; }
+    public Guid? OrganizationId { get; set; }
     public CipherType Type { get; set; }
     public dynamic Data { get; set; }
     public string Name { get; set; }
@@ -90,13 +90,13 @@ public class CipherResponseModel : CipherMiniResponseModel
     public CipherResponseModel(CipherDetails cipher, IGlobalSettings globalSettings, string obj = "cipher")
         : base(cipher, globalSettings, cipher.OrganizationUseTotp, obj)
     {
-        FolderId = cipher.FolderId?.ToString();
+        FolderId = cipher.FolderId;
         Favorite = cipher.Favorite;
         Edit = cipher.Edit;
         ViewPassword = cipher.ViewPassword;
     }
 
-    public string FolderId { get; set; }
+    public Guid? FolderId { get; set; }
     public bool Favorite { get; set; }
     public bool Edit { get; set; }
     public bool ViewPassword { get; set; }

--- a/src/Api/Vault/Models/Response/FolderResponseModel.cs
+++ b/src/Api/Vault/Models/Response/FolderResponseModel.cs
@@ -13,12 +13,12 @@ public class FolderResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(folder));
         }
 
-        Id = folder.Id.ToString();
+        Id = folder.Id;
         Name = folder.Name;
         RevisionDate = folder.RevisionDate;
     }
 
-    public string Id { get; set; }
+    public Guid Id { get; set; }
     public string Name { get; set; }
     public DateTime RevisionDate { get; set; }
 }

--- a/src/Core/Models/Api/Response/PolicyResponseModel.cs
+++ b/src/Core/Models/Api/Response/PolicyResponseModel.cs
@@ -14,8 +14,8 @@ public class PolicyResponseModel : ResponseModel
             throw new ArgumentNullException(nameof(policy));
         }
 
-        Id = policy.Id.ToString();
-        OrganizationId = policy.OrganizationId.ToString();
+        Id = policy.Id;
+        OrganizationId = policy.OrganizationId;
         Type = policy.Type;
         Enabled = policy.Enabled;
         if (!string.IsNullOrWhiteSpace(policy.Data))
@@ -24,8 +24,8 @@ public class PolicyResponseModel : ResponseModel
         }
     }
 
-    public string Id { get; set; }
-    public string OrganizationId { get; set; }
+    public Guid Id { get; set; }
+    public Guid OrganizationId { get; set; }
     public PolicyType Type { get; set; }
     public Dictionary<string, object> Data { get; set; }
     public bool Enabled { get; set; }

--- a/test/Api.IntegrationTest/Controllers/AccountsControllerTest.cs
+++ b/test/Api.IntegrationTest/Controllers/AccountsControllerTest.cs
@@ -24,8 +24,6 @@ public class AccountsControllerTest : IClassFixture<ApiApplicationFactory>
         response.EnsureSuccessStatusCode();
 
         var content = await response.Content.ReadFromJsonAsync<ProfileResponseModel>();
-
-        Assert.NotEmpty(content!.Id);
         Assert.Equal("integration-test@bitwarden.com", content.Email);
         Assert.Null(content.Name);
         Assert.False(content.EmailVerified);

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/AccessPoliciesControllerTests.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/AccessPoliciesControllerTests.cs
@@ -532,7 +532,7 @@ public class AccessPoliciesControllerTests : IClassFixture<ApiApplicationFactory
 
         Assert.NotNull(result?.Data);
         Assert.NotEmpty(result!.Data);
-        Assert.Equal(serviceAccount.Id.ToString(), result.Data.First(x => x.Id == serviceAccount.Id.ToString()).Id);
+        Assert.Equal(serviceAccount.Id, result.Data.First(x => x.Id == serviceAccount.Id).Id);
     }
 
     [Theory]
@@ -610,7 +610,7 @@ public class AccessPoliciesControllerTests : IClassFixture<ApiApplicationFactory
 
         Assert.NotNull(result?.Data);
         Assert.NotEmpty(result!.Data);
-        Assert.Equal(project.Id.ToString(), result.Data.First(x => x.Id == project.Id.ToString()).Id);
+        Assert.Equal(project.Id, result.Data.First(x => x.Id == project.Id).Id);
     }
 
     [Theory]

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/ProjectsControllerTests.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/ProjectsControllerTests.cs
@@ -144,7 +144,7 @@ public class ProjectsControllerTests : IClassFixture<ApiApplicationFactory>, IAs
         AssertHelper.AssertRecent(result.RevisionDate);
         AssertHelper.AssertRecent(result.CreationDate);
 
-        var createdProject = await _projectRepository.GetByIdAsync(new Guid(result.Id));
+        var createdProject = await _projectRepository.GetByIdAsync(result.Id);
         Assert.NotNull(result);
         Assert.Equal(request.Name, createdProject.Name);
         AssertHelper.AssertRecent(createdProject.RevisionDate);
@@ -205,7 +205,7 @@ public class ProjectsControllerTests : IClassFixture<ApiApplicationFactory>, IAs
         AssertHelper.AssertRecent(result.RevisionDate);
         Assert.NotEqual(initialProject.RevisionDate, result.RevisionDate);
 
-        var updatedProject = await _projectRepository.GetByIdAsync(new Guid(result.Id));
+        var updatedProject = await _projectRepository.GetByIdAsync(result.Id);
         Assert.NotNull(result);
         Assert.Equal(request.Name, updatedProject.Name);
         AssertHelper.AssertRecent(updatedProject.RevisionDate);

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/SecretsControllerTests.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/SecretsControllerTests.cs
@@ -169,7 +169,7 @@ public class SecretsControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
         AssertHelper.AssertRecent(result.RevisionDate);
         AssertHelper.AssertRecent(result.CreationDate);
 
-        var createdSecret = await _secretRepository.GetByIdAsync(new Guid(result.Id));
+        var createdSecret = await _secretRepository.GetByIdAsync(result.Id);
         Assert.NotNull(result);
         Assert.Equal(request.Key, createdSecret.Key);
         Assert.Equal(request.Value, createdSecret.Value);
@@ -289,8 +289,8 @@ public class SecretsControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
         var secret = result.Secret;
 
         Assert.NotNull(secretResult);
-        Assert.Equal(secret.Id.ToString(), secretResult!.Id);
-        Assert.Equal(secret.OrganizationId.ToString(), secretResult.OrganizationId);
+        Assert.Equal(secret.Id, secretResult!.Id);
+        Assert.Equal(secret.OrganizationId, secretResult.OrganizationId);
         Assert.Equal(secret.Key, secretResult.Key);
         Assert.Equal(secret.Value, secretResult.Value);
         Assert.Equal(secret.Note, secretResult.Note);
@@ -466,8 +466,8 @@ public class SecretsControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
         response.EnsureSuccessStatusCode();
         var result = await response.Content.ReadFromJsonAsync<SecretWithProjectsListResponseModel>();
         Assert.NotEmpty(result!.Secrets);
-        Assert.Equal(secret.Id.ToString(), result.Secrets.First().Id);
-        Assert.Equal(secret.OrganizationId.ToString(), result.Secrets.First().OrganizationId);
+        Assert.Equal(secret.Id, result.Secrets.First().Id);
+        Assert.Equal(secret.OrganizationId, result.Secrets.First().OrganizationId);
         Assert.Equal(secret.Key, result.Secrets.First().Key);
         Assert.Equal(secret.CreationDate, result.Secrets.First().CreationDate);
         Assert.Equal(secret.RevisionDate, result.Secrets.First().RevisionDate);
@@ -560,7 +560,7 @@ public class SecretsControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
         AssertHelper.AssertRecent(result.RevisionDate);
         Assert.NotEqual(secret.RevisionDate, result.RevisionDate);
 
-        var updatedSecret = await _secretRepository.GetByIdAsync(new Guid(result.Id));
+        var updatedSecret = await _secretRepository.GetByIdAsync(result.Id);
         Assert.NotNull(result);
         Assert.Equal(request.Key, updatedSecret.Key);
         Assert.Equal(request.Value, updatedSecret.Value);

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/ServiceAccountsControllerTests.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/ServiceAccountsControllerTests.cs
@@ -190,8 +190,8 @@ public class ServiceAccountsControllerTests : IClassFixture<ApiApplicationFactor
         response.EnsureSuccessStatusCode();
         var result = await response.Content.ReadFromJsonAsync<ServiceAccountResponseModel>();
         Assert.NotNull(result);
-        Assert.Equal(serviceAccount.Id.ToString(), result!.Id);
-        Assert.Equal(serviceAccount.OrganizationId.ToString(), result.OrganizationId);
+        Assert.Equal(serviceAccount.Id, result!.Id);
+        Assert.Equal(serviceAccount.OrganizationId, result.OrganizationId);
         Assert.Equal(serviceAccount.Name, result.Name);
         Assert.Equal(serviceAccount.CreationDate, result.CreationDate);
         Assert.Equal(serviceAccount.RevisionDate, result.RevisionDate);
@@ -229,7 +229,7 @@ public class ServiceAccountsControllerTests : IClassFixture<ApiApplicationFactor
         AssertHelper.AssertRecent(result.RevisionDate);
         AssertHelper.AssertRecent(result.CreationDate);
 
-        var createdServiceAccount = await _serviceAccountRepository.GetByIdAsync(new Guid(result.Id));
+        var createdServiceAccount = await _serviceAccountRepository.GetByIdAsync(result.Id);
         Assert.NotNull(result);
         Assert.Equal(request.Name, createdServiceAccount.Name);
         AssertHelper.AssertRecent(createdServiceAccount.RevisionDate);

--- a/test/Api.Test/Controllers/GroupsControllerTests.cs
+++ b/test/Api.Test/Controllers/GroupsControllerTests.cs
@@ -33,10 +33,8 @@ public class GroupsControllerTests
             organization,
             Arg.Any<IEnumerable<CollectionAccessSelection>>(),
             Arg.Any<IEnumerable<Guid>>());
-
-        Assert.NotNull(response.Id);
         Assert.Equal(groupRequestModel.Name, response.Name);
-        Assert.Equal(organization.Id.ToString(), response.OrganizationId);
+        Assert.Equal(organization.Id, response.OrganizationId);
         Assert.Equal(groupRequestModel.AccessAll, response.AccessAll);
     }
 
@@ -60,10 +58,8 @@ public class GroupsControllerTests
             Arg.Is<Organization>(o => o.Id == organization.Id),
             Arg.Any<IEnumerable<CollectionAccessSelection>>(),
             Arg.Any<IEnumerable<Guid>>());
-
-        Assert.NotNull(response.Id);
         Assert.Equal(groupRequestModel.Name, response.Name);
-        Assert.Equal(organization.Id.ToString(), response.OrganizationId);
+        Assert.Equal(organization.Id, response.OrganizationId);
         Assert.Equal(groupRequestModel.AccessAll, response.AccessAll);
     }
 }

--- a/test/Api.Test/Controllers/OrganizationDomainControllerTests.cs
+++ b/test/Api.Test/Controllers/OrganizationDomainControllerTests.cs
@@ -67,7 +67,7 @@ public class OrganizationDomainControllerTests
         var result = await sutProvider.Sut.Get(orgId.ToString());
 
         Assert.IsType<ListResponseModel<OrganizationDomainResponseModel>>(result);
-        Assert.Equal(orgId.ToString(), result.Data.Select(x => x.OrganizationId).FirstOrDefault());
+        Assert.Equal(orgId, result.Data.Select(x => x.OrganizationId).FirstOrDefault());
     }
 
     [Theory, BitAutoData]
@@ -125,7 +125,7 @@ public class OrganizationDomainControllerTests
         var result = await sutProvider.Sut.Get(orgId.ToString(), id.ToString());
 
         Assert.IsType<OrganizationDomainResponseModel>(result);
-        Assert.Equal(orgId.ToString(), result.OrganizationId);
+        Assert.Equal(orgId, result.OrganizationId);
     }
 
     [Theory, BitAutoData]

--- a/test/Api.Test/Vault/Controllers/CiphersControllerTests.cs
+++ b/test/Api.Test/Vault/Controllers/CiphersControllerTests.cs
@@ -39,7 +39,7 @@ public class CiphersControllerTests
 
         var result = await sutProvider.Sut.PutPartial(cipherId.ToString(), new CipherPartialRequestModel { Favorite = isFavorite, FolderId = folderId.ToString() });
 
-        Assert.Equal(folderId.ToString(), result.FolderId);
+        Assert.Equal(folderId, result.FolderId);
         Assert.Equal(isFavorite, result.Favorite);
     }
 }

--- a/test/Api.Test/Vault/Controllers/SyncControllerTests.cs
+++ b/test/Api.Test/Vault/Controllers/SyncControllerTests.cs
@@ -301,7 +301,7 @@ public class SyncControllerTests
         foreach (var profProviderOrg in result.Profile.ProviderOrganizations)
         {
             var matchedProviderUserOrgDetails =
-                providerUserOrganizationDetails.FirstOrDefault(p => p.OrganizationId.ToString() == profProviderOrg.Id);
+                providerUserOrganizationDetails.FirstOrDefault(p => p.OrganizationId == profProviderOrg.Id);
 
             if (matchedProviderUserOrgDetails != null)
             {


### PR DESCRIPTION
## Type of change
```
- [x] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
- Changed all the IDs in the response models to return an actual `Guid` instead of a `string` representation, this helps the code generator use the correct `Uuid` type in the SDK. Seems to work the exact same way than using string in my tests.
- Also rebased PR #2722 from @Hinton to solve the merge conflicts.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
