### PR TITLE
Remove Secrets Manager LaunchDarkly feature flag

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -27,7 +27,6 @@ public static class AuthenticationSchemes
 
 public static class FeatureFlagKeys
 {
-    public const string SecretsManager = "secrets-manager";
     public const string DisplayEuEnvironment = "display-eu-environment";
     public const string DisplayLowKdfIterationWarning = "display-kdf-iteration-warning";
     public const string TrustedDeviceEncryption = "trusted-device-encryption";

--- a/test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs
+++ b/test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs
@@ -47,7 +47,7 @@ public class LaunchDarklyFeatureServiceTests
         var currentContext = Substitute.For<ICurrentContext>();
         currentContext.UserId.Returns(Guid.NewGuid());
 
-        Assert.False(sutProvider.Sut.IsEnabled(FeatureFlagKeys.SecretsManager, currentContext));
+        Assert.False(sutProvider.Sut.IsEnabled("somekey", currentContext));
     }
 
     [Fact(Skip = "For local development")]
@@ -61,7 +61,7 @@ public class LaunchDarklyFeatureServiceTests
         var currentContext = Substitute.For<ICurrentContext>();
         currentContext.UserId.Returns(Guid.NewGuid());
 
-        Assert.False(sutProvider.Sut.IsEnabled(FeatureFlagKeys.SecretsManager, currentContext));
+        Assert.False(sutProvider.Sut.IsEnabled("somekey", currentContext));
     }
 
     [Fact(Skip = "For local development")]
@@ -75,7 +75,7 @@ public class LaunchDarklyFeatureServiceTests
         var currentContext = Substitute.For<ICurrentContext>();
         currentContext.UserId.Returns(Guid.NewGuid());
 
-        Assert.Equal(0, sutProvider.Sut.GetIntVariation(FeatureFlagKeys.SecretsManager, currentContext));
+        Assert.Equal(0, sutProvider.Sut.GetIntVariation("somekey", currentContext));
     }
 
     [Fact(Skip = "For local development")]
@@ -89,7 +89,7 @@ public class LaunchDarklyFeatureServiceTests
         var currentContext = Substitute.For<ICurrentContext>();
         currentContext.UserId.Returns(Guid.NewGuid());
 
-        Assert.Null(sutProvider.Sut.GetStringVariation(FeatureFlagKeys.SecretsManager, currentContext));
+        Assert.Null(sutProvider.Sut.GetStringVariation("somekey", currentContext));
     }
 
     [Fact(Skip = "For local development")]


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Removes the never-used LaunchDarkly version of the Secrets Manager feature flag.

## Code changes

* **src/Core/Constants.cs:** Constant removal.
* **test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs:** Constant replacement with a string value for ad hoc testing. We don't want to use the constants since they should be short-lived.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
