### PR TITLE
Allow self-hosted notifications to work for Login with Device approval

### DIFF
--- a/docker-unified/hbs/nginx-config.hbs
+++ b/docker-unified/hbs/nginx-config.hbs
@@ -134,6 +134,13 @@ server {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $http_connection;
   }
+
+  location /notifications/anonymous-hub {
+    proxy_pass http://localhost:5006/anonymous-hub;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $http_connection;
+  }
+  
 {{/if}}
 {{#if (String.Equal env.BW_ENABLE_EVENTS "true")}}
 

--- a/src/Notifications/Controllers/SendController.cs
+++ b/src/Notifications/Controllers/SendController.cs
@@ -10,10 +10,12 @@ namespace Bit.Notifications;
 public class SendController : Controller
 {
     private readonly IHubContext<NotificationsHub> _hubContext;
+    private readonly IHubContext<AnonymousNotificationsHub> _anonymousHubContext;
 
-    public SendController(IHubContext<NotificationsHub> hubContext)
+    public SendController(IHubContext<NotificationsHub> hubContext, IHubContext<AnonymousNotificationsHub> anonymousHubContext)
     {
         _hubContext = hubContext;
+        _anonymousHubContext = anonymousHubContext;
     }
 
     [HttpPost("~/send")]
@@ -25,7 +27,7 @@ public class SendController : Controller
             var notificationJson = await reader.ReadToEndAsync();
             if (!string.IsNullOrWhiteSpace(notificationJson))
             {
-                await HubHelpers.SendNotificationToHubAsync(notificationJson, _hubContext, null);
+                await HubHelpers.SendNotificationToHubAsync(notificationJson, _hubContext, _anonymousHubContext);
             }
         }
     }

--- a/src/Notifications/HubHelpers.cs
+++ b/src/Notifications/HubHelpers.cs
@@ -17,7 +17,7 @@ public static class HubHelpers
         CancellationToken cancellationToken = default(CancellationToken)
     )
     {
-        var notification = JsonSerializer.Deserialize<PushNotificationData<object>>(notificationJson);
+        var notification = JsonSerializer.Deserialize<PushNotificationData<object>>(notificationJson, _deserializerOptions);
         switch (notification.Type)
         {
             case PushType.SyncCipherUpdate:

--- a/util/Setup/Templates/NginxConfig.hbs
+++ b/util/Setup/Templates/NginxConfig.hbs
@@ -132,6 +132,12 @@ server {
     proxy_set_header Connection $http_connection;
   }
 
+  location /notifications/anonymous-hub {
+    proxy_pass http://notifications:5000/anonymous-hub;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $http_connection;
+  }
+
   location /events/ {
     proxy_pass http://events:5000/;
   }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Self-hosted customers cannot use Login with Device, as they don't receive the approval notification on their requesting device.

## Code changes

**SendController.cs:** Injected the `AnonymousHubContext` into the `Send` method on the Notifications Service so that self-hosted customers receive notifications.  It was being passed in as `null` to the `HubHelper` which resulted in a null reference exception when trying to send the message.  The equivalent initialization for the `AzureQueueHostedService` does initialize it correctly, which is why cloud-hosted customers have no issues.
**nginx-config.hbs / NginxConfig.hbs:** Added configuration for anonymous hub to nginx configuration for self-hosted.
**HubHelpers.cs:** Deserialized the message contents using the `deserializationOptions` used at all other places in the method, to ensure that we are case-insensitive in our deserialization.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
