### PR TITLE
[PM-153] Extend Freshdesk integration

### DIFF
--- a/src/Billing/BillingSettings.cs
+++ b/src/Billing/BillingSettings.cs
@@ -8,8 +8,7 @@ public class BillingSettings
     public virtual bool StripeEventParseThrowMismatch { get; set; } = true;
     public virtual string BitPayWebhookKey { get; set; }
     public virtual string AppleWebhookKey { get; set; }
-    public virtual string FreshdeskWebhookKey { get; set; }
-    public virtual string FreshdeskApiKey { get; set; }
+    public virtual FreshDeskSettings FreshDesk { get; set; } = new FreshDeskSettings();
     public virtual string FreshsalesApiKey { get; set; }
     public virtual PayPalSettings PayPal { get; set; } = new PayPalSettings();
 
@@ -17,6 +16,12 @@ public class BillingSettings
     {
         public virtual bool Production { get; set; }
         public virtual string BusinessId { get; set; }
+        public virtual string WebhookKey { get; set; }
+    }
+
+    public class FreshDeskSettings
+    {
+        public virtual string ApiKey { get; set; }
         public virtual string WebhookKey { get; set; }
     }
 }

--- a/src/Billing/BillingSettings.cs
+++ b/src/Billing/BillingSettings.cs
@@ -23,5 +23,7 @@ public class BillingSettings
     {
         public virtual string ApiKey { get; set; }
         public virtual string WebhookKey { get; set; }
+        public virtual string UserFieldName { get; set; }
+        public virtual string OrgFieldName { get; set; }
     }
 }

--- a/src/Billing/Controllers/FreshdeskController.cs
+++ b/src/Billing/Controllers/FreshdeskController.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using System.Text;
 using Bit.Billing.Models;
@@ -43,7 +43,7 @@ public class FreshdeskController : Controller
     public async Task<IActionResult> PostWebhook([FromQuery, Required] string key,
         [FromBody, Required] FreshdeskWebhookModel model)
     {
-        if (string.IsNullOrWhiteSpace(key) || !CoreHelpers.FixedTimeEquals(key, _billingSettings.FreshdeskWebhookKey))
+        if (string.IsNullOrWhiteSpace(key) || !CoreHelpers.FixedTimeEquals(key, _billingSettings.FreshDesk.WebhookKey))
         {
             return new BadRequestResult();
         }
@@ -145,7 +145,7 @@ public class FreshdeskController : Controller
     {
         try
         {
-            var freshdeskAuthkey = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{_billingSettings.FreshdeskApiKey}:X"));
+            var freshdeskAuthkey = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{_billingSettings.FreshDesk.ApiKey}:X"));
             var httpClient = _httpClientFactory.CreateClient("FreshdeskApi");
             request.Headers.Add("Authorization", $"Basic {freshdeskAuthkey}");
             var response = await httpClient.SendAsync(request);

--- a/src/Billing/Controllers/FreshdeskController.cs
+++ b/src/Billing/Controllers/FreshdeskController.cs
@@ -66,7 +66,7 @@ public class FreshdeskController : Controller
             {
                 var userLink = $"{_globalSettings.BaseServiceUri.Admin}/users/edit/{user.Id}";
                 note += $"<li>User, {user.Email}: {userLink}</li>";
-                customFields.Add("cf_user", userLink);
+                customFields.Add(_billingSettings.FreshDesk.UserFieldName, userLink);
                 var tags = new HashSet<string>();
                 if (user.Premium)
                 {
@@ -81,11 +81,11 @@ public class FreshdeskController : Controller
                     note += $"<li>Org, {orgNote}</li>";
                     if (!customFields.Any(kvp => kvp.Key == "cf_org"))
                     {
-                        customFields.Add("cf_org", orgNote);
+                        customFields.Add(_billingSettings.FreshDesk.OrgFieldName, orgNote);
                     }
                     else
                     {
-                        customFields["cf_org"] += $"\n{orgNote}";
+                        customFields[_billingSettings.FreshDesk.OrgFieldName] += $"\n{orgNote}";
                     }
 
                     var planName = GetAttribute<DisplayAttribute>(org.PlanType).Name.Split(" ").FirstOrDefault();

--- a/src/Billing/appsettings.json
+++ b/src/Billing/appsettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "globalSettings": {
     "selfHosted": false,
     "siteName": "Bitwarden",
@@ -68,6 +68,10 @@
     "payPal": {
       "production": false,
       "businessId": "AD3LAUZSNVPJY",
+      "webhookKey": "SECRET"
+    },
+    "freshdesk": {
+      "apiKey": "SECRET",
       "webhookKey": "SECRET"
     }
   }

--- a/src/Billing/appsettings.json
+++ b/src/Billing/appsettings.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "globalSettings": {
     "selfHosted": false,
     "siteName": "Bitwarden",
@@ -72,7 +72,9 @@
     },
     "freshdesk": {
       "apiKey": "SECRET",
-      "webhookKey": "SECRET"
+      "webhookKey": "SECRET",
+      "userFieldName": "cf_user",
+      "orgFieldName": "cf_org"
     }
   }
 }

--- a/test/Billing.Test/Controllers/FreshdeskControllerTests.cs
+++ b/test/Billing.Test/Controllers/FreshdeskControllerTests.cs
@@ -1,4 +1,4 @@
-using Bit.Billing.Controllers;
+﻿using Bit.Billing.Controllers;
 using Bit.Billing.Models;
 using Bit.Core.Entities;
 using Bit.Core.Repositories;
@@ -18,6 +18,9 @@ public class FreshdeskControllerTests
 {
     private const string ApiKey = "TESTFRESHDESKAPIKEY";
     private const string WebhookKey = "TESTKEY";
+
+    private const string UserFieldName = "cf_user";
+    private const string OrgFieldName = "cf_org";
 
     [Theory]
     [BitAutoData((string)null, null)]
@@ -54,6 +57,8 @@ public class FreshdeskControllerTests
 
         sutProvider.GetDependency<IOptions<BillingSettings>>().Value.FreshDesk.WebhookKey.Returns(WebhookKey);
         sutProvider.GetDependency<IOptions<BillingSettings>>().Value.FreshDesk.ApiKey.Returns(ApiKey);
+        sutProvider.GetDependency<IOptions<BillingSettings>>().Value.FreshDesk.UserFieldName.Returns(UserFieldName);
+        sutProvider.GetDependency<IOptions<BillingSettings>>().Value.FreshDesk.OrgFieldName.Returns(OrgFieldName);
 
         var response = await sutProvider.Sut.PostWebhook(WebhookKey, model);
 

--- a/test/Billing.Test/Controllers/FreshdeskControllerTests.cs
+++ b/test/Billing.Test/Controllers/FreshdeskControllerTests.cs
@@ -1,4 +1,4 @@
-﻿using Bit.Billing.Controllers;
+using Bit.Billing.Controllers;
 using Bit.Billing.Models;
 using Bit.Core.Entities;
 using Bit.Core.Repositories;
@@ -26,7 +26,7 @@ public class FreshdeskControllerTests
     public async Task PostWebhook_NullRequiredParameters_BadRequest(string freshdeskWebhookKey, FreshdeskWebhookModel model,
         BillingSettings billingSettings, SutProvider<FreshdeskController> sutProvider)
     {
-        sutProvider.GetDependency<IOptions<BillingSettings>>().Value.FreshdeskWebhookKey.Returns(billingSettings.FreshdeskWebhookKey);
+        sutProvider.GetDependency<IOptions<BillingSettings>>().Value.FreshDesk.WebhookKey.Returns(billingSettings.FreshDesk.WebhookKey);
 
         var response = await sutProvider.Sut.PostWebhook(freshdeskWebhookKey, model);
 
@@ -52,8 +52,8 @@ public class FreshdeskControllerTests
 
         sutProvider.GetDependency<IHttpClientFactory>().CreateClient("FreshdeskApi").Returns(httpClient);
 
-        sutProvider.GetDependency<IOptions<BillingSettings>>().Value.FreshdeskWebhookKey.Returns(WebhookKey);
-        sutProvider.GetDependency<IOptions<BillingSettings>>().Value.FreshdeskApiKey.Returns(ApiKey);
+        sutProvider.GetDependency<IOptions<BillingSettings>>().Value.FreshDesk.WebhookKey.Returns(WebhookKey);
+        sutProvider.GetDependency<IOptions<BillingSettings>>().Value.FreshDesk.ApiKey.Returns(ApiKey);
 
         var response = await sutProvider.Sut.PostWebhook(WebhookKey, model);
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
For CS to differentiate where customers are registered (US/EU) we need to enrich the Freshdesk tickets with user/org ids including the region

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **Move keys into FreshDeskSettings class -** https://github.com/bitwarden/server/commit/df2f8f1f2a9d662f5494f2232416b4568652f0d7
* **Add configurable custom fields for user and org -** https://github.com/bitwarden/server/commit/0dc8ead1e304c234ba7c2b9aee61dcc2af4ec5b2
  * In FreshDesk we currently use the custom fields `cf_user` and `cf_org`.
    * For the US instance these will be set to those values.
    * For the EU instance these will likely be configured to `cf_user_eu` and `cf_org_eu`

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
