### PR TITLE
[PM-2300] Add Linux script to create dev certificates 

### DIFF
--- a/dev/create_certificates_linux.sh
+++ b/dev/create_certificates_linux.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Script for generating and installing the Bitwarden development certificates on Linux.
+
+IDENTITY_SERVER_KEY=identity_server_dev.key
+IDENTITY_SERVER_CERT=identity_server_dev.crt
+IDENTITY_SERVER_CN="Bitwarden Identity Server Dev"
+DATA_PROTECTION_KEY=data_protection_dev.key
+DATA_PROTECTION_CERT=data_protection_dev.crt
+DATA_PROTECTION_CN="Bitwarden Data Protection Dev"
+
+# Detect management command to trust generated certificates.
+if [ -x "$(command -v update-ca-certificates)" ]; then
+  # Debian based
+  CA_CERT_DIR=/usr/local/share/ca-certificates/
+  UPDATE_CA_CMD=update-ca-certificates
+elif [ -x "$(command -v update-ca-trust)" ]; then
+  # Redhat based
+  CA_CERT_DIR=/etc/pki/ca-trust/source/anchors/
+  UPDATE_CA_CMD=update-ca-trust
+else
+  echo 'Error: Update manager for CA certificates not found!'
+  exit 1
+fi
+
+
+openssl req -x509 -newkey rsa:4096 -sha256 -nodes -days 3650 \
+    -keyout $IDENTITY_SERVER_KEY \
+    -out $IDENTITY_SERVER_CERT \
+    -subj "/CN=$IDENTITY_SERVER_CN"
+
+sudo cp $IDENTITY_SERVER_CERT $CA_CERT_DIR
+
+openssl req -x509 -newkey rsa:4096 -sha256 -nodes -days 3650 \
+    -keyout $DATA_PROTECTION_KEY \
+    -out $DATA_PROTECTION_CERT \
+    -subj "/CN=$DATA_PROTECTION_CN"
+
+sudo cp $DATA_PROTECTION_CERT $CA_CERT_DIR
+
+sudo $UPDATE_CA_CMD
+
+identity=($(openssl x509 -in $IDENTITY_SERVER_CERT -outform der | sha1sum | tr a-z A-Z))
+data=($(openssl x509 -in $DATA_PROTECTION_CERT -outform der | sha1sum | tr a-z A-Z))
+
+echo "Certificate fingerprints:"
+
+echo "Identity Server Dev: ${identity}"
+echo "Data Protection Dev: ${data}"

--- a/dev/secrets.json.example
+++ b/dev/secrets.json.example
@@ -8,7 +8,7 @@
       "connectionString": "Server=localhost;Database=vault_dev;User Id=SA;Password=SET_A_PASSWORD_HERE_123;Encrypt=True;TrustServerCertificate=True"
     },
     "postgreSql": {
-      "connectionString": "Host=localhost;Username=postgres;Password=SET_A_PASSWORD_HERE_123;Database=vault_dev;Include Error Detail=true",
+      "connectionString": "Host=localhost;Username=postgres;Password=SET_A_PASSWORD_HERE_123;Database=vault_dev;Include Error Detail=true"
     },
     "mySql": {
       "connectionString": "server=localhost;uid=root;pwd=SET_A_PASSWORD_HERE_123;database=vault_dev"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective

To be able to quickly generate the self-signed certificates for local development on Linux.

## Code changes

* Add a script based on the macOS script that can be used on Linux, either Debian or Red-hat derived distros.
* Trivial fix for json sample file

This may require a documentation update in to [getting-started](https://contributing.bitwarden.com/getting-started/server/guide/#generate-certificates). Please advise who should make those changes.