### PR TITLE
Added RBAC to secrets.json.example

### DIFF
--- a/dev/secrets.json.example
+++ b/dev/secrets.json.example
@@ -1,6 +1,13 @@
 {
   "adminSettings": {
-    "admins": "admin@localhost"
+    "admins": "admin@localhost,owner@localhost,cs@localhost,billing@localhost,sales@localhost",
+    "role": {
+        "owner": "owner@localhost",
+        "admin": "admin@localhost",
+        "cs": "cs@localhost",
+        "billing": "billing@localhost",
+        "sales": "sales@localhost"
+    }
   },
   "globalSettings": {
     "selfHosted": true,


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

As part of #2853, we added RBAC for Bitwarden Portal. This added additional configuration for specifying role membership in the `adminSettings` section of the `secrets.json`.  This updates the example JSON to include the RBAC membership defaults.

## Code changes

* **secrets.json.example:** Added RBAC default accounts.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
