### PR TITLE
[PM-1086] Added server-side Feature Flag enum for vault-item-encryption

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -36,6 +36,7 @@ public static class FeatureFlagKeys
     public const string DisplayEuEnvironment = "display-eu-environment";
     public const string DisplayLowKdfIterationWarning = "display-kdf-iteration-warning";
     public const string TrustedDeviceEncryption = "trusted-device-encryption";
+    public const string VaultItemEncryption = "vault-item-encryption";
 
     public static List<string> GetAllKeys()
     {


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Introduced a LaunchDarkly feature flag titled `vault-item-encryption` to enable and disable vault-item level encryption. The client use of this flag will be in https://github.com/bitwarden/clients/pull/5114.

## Code changes

* **Constants.cs:** Added a value for `vault-item-encryption`.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
