### PR TITLE
[PM-153] Add missing appsettings for FreshDesk extension

### DIFF
--- a/src/Billing/appsettings.json
+++ b/src/Billing/appsettings.json
@@ -73,6 +73,7 @@
     "freshdesk": {
       "apiKey": "SECRET",
       "webhookKey": "SECRET",
+      "region": "US",
       "userFieldName": "cf_user",
       "orgFieldName": "cf_org"
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Quick fix for the appsettings which got extended with https://github.com/bitwarden/server/pull/2939

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Billing/appsettings.json:** Add `region`-property with default set to US

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
