### PR TITLE
Added Org_Plan_Edit permission to CS role in Bitwarden Portal

### DIFF
--- a/src/Admin/Utilities/RolePermissionMapping.cs
+++ b/src/Admin/Utilities/RolePermissionMapping.cs
@@ -114,6 +114,7 @@ public static class RolePermissionMapping
                 Permission.Org_BillingInformation_View,
                 Permission.Org_BillingInformation_DownloadInvoice,
                 Permission.Org_Plan_View,
+                Permission.Org_Plan_Edit,
                 Permission.Org_Licensing_View,
                 Permission.Org_Billing_View,
                 Permission.Org_Billing_LaunchGateway,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The CS team needs the ability to edit an organization plan.  They need this in order to set up Key Connector.  The RBAC changes previously only allowed CS to view the org plan.

## Code changes

* **RolePermissionMapping.cs** Added Org_Plan_Edit permission to the CS role.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
