### PR TITLE
[PM-294] Add Database to MSSQL Environment File

### DIFF
--- a/util/MsSql/entrypoint.sh
+++ b/util/MsSql/entrypoint.sh
@@ -43,8 +43,8 @@ fi
 # Replace database name in backup-db.sql
 if [ ! -z "$DATABASE" ]
 then
-  sed -i -e "/@DatabaseName /s/vault/$DATABASE/" backup-db.sql
-  sed -i -e "/@DatabaseNameSafe /s/vault/${DATABASE// /-}/" backup-db.sql
+  sed -i "/^SET @DatabaseName =/s/'[^']*'/'$DATABASE'/" backup-db.sql
+  sed -i "/^SET @DatabaseNameSafe =/s/'[^']*'/'${DATABASE// /-}'/" backup-db.sql
 fi
 
 # The rest...

--- a/util/Setup/EnvironmentFileBuilder.cs
+++ b/util/Setup/EnvironmentFileBuilder.cs
@@ -104,6 +104,7 @@ public class EnvironmentFileBuilder
         _mssqlOverrideValues = new Dictionary<string, string>
         {
             ["SA_PASSWORD"] = dbPassword,
+            ["DATABASE"] = _context.Install?.Database ?? "vault"
         };
 
         _keyConnectorOverrideValues = new Dictionary<string, string>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add the custom database name into the MSSQL override environment file so that 
https://github.com/bitwarden/server/blob/e5a22524fc6b7afd7e51eae2a3a482275f4717a5/util/MsSql/entrypoint.sh#L44-L48

will properly edit the `backup-db.sql` file and backups of the correct database will be made.

Fixes #1811

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **util/Setup/EnvironmentFileBuilder.cs:** Check if a custom database name was given, if it was, add it to the `_mssqlOverrideValues` dictionary. If not, add the default value of `vault`.
* **util/MsSql/entrypoint.sh:** Updates `sed` commands to replace any value found inside single quotes for `DatabaseName` and `DatabaseNameSafe` instead of looking specifically for `vault`.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
