### PR TITLE
Allow feature flag state configuration via application settings

### DIFF
--- a/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
+++ b/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
@@ -42,7 +42,7 @@ public class LaunchDarklyFeatureService : IFeatureService, IDisposable
                     }
                     else
                     {
-                        source.Update(source.Flag(kvp.Key).ValueForAll(LaunchDarkly.Sdk.LdValue.Of(kvp.Value.ToString())));
+                        source.Update(source.Flag(kvp.Key).ValueForAll(LaunchDarkly.Sdk.LdValue.Of(kvp.Value)));
                     }
                 }
 

--- a/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
+++ b/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
@@ -25,15 +25,37 @@ public class LaunchDarklyFeatureService : IFeatureService, IDisposable
                         .FilePaths(globalSettings.LaunchDarkly?.FlagDataFilePath)
                         .AutoUpdate(true)
                 );
+            }
+            // support configuration directly from settings
+            else if (globalSettings.LaunchDarkly?.FlagValues?.Any() is true)
+            {
+                var source = TestData.DataSource();
+                foreach (var kvp in globalSettings.LaunchDarkly.FlagValues)
+                {
+                    if (bool.TryParse(kvp.Value, out bool boolValue))
+                    {
+                        source.Update(source.Flag(kvp.Key).ValueForAll(LaunchDarkly.Sdk.LdValue.Of(boolValue)));
+                    }
+                    else if (int.TryParse(kvp.Value, out int intValue))
+                    {
+                        source.Update(source.Flag(kvp.Key).ValueForAll(LaunchDarkly.Sdk.LdValue.Of(intValue)));
+                    }
+                    else
+                    {
+                        source.Update(source.Flag(kvp.Key).ValueForAll(LaunchDarkly.Sdk.LdValue.Of(kvp.Value.ToString())));
+                    }
+                }
 
-                // do not provide analytics events
-                ldConfig.Events(Components.NoEvents);
+                ldConfig.DataSource(source);
             }
             else
             {
-                // when a file-based fallback isn't available, work offline
+                // when fallbacks aren't available, work offline
                 ldConfig.Offline(true);
             }
+
+            // do not provide analytics events
+            ldConfig.Events(Components.NoEvents);
         }
         else if (globalSettings.SelfHosted)
         {

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -545,5 +545,6 @@ public class GlobalSettings : IGlobalSettings
     {
         public string SdkKey { get; set; }
         public string FlagDataFilePath { get; set; } = "flags.json";
+        public Dictionary<string, dynamic> FlagValues { get; set; } = new Dictionary<string, dynamic>();
     }
 }

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -545,6 +545,6 @@ public class GlobalSettings : IGlobalSettings
     {
         public string SdkKey { get; set; }
         public string FlagDataFilePath { get; set; } = "flags.json";
-        public Dictionary<string, dynamic> FlagValues { get; set; } = new Dictionary<string, dynamic>();
+        public Dictionary<string, string> FlagValues { get; set; } = new Dictionary<string, string>();
     }
 }

--- a/src/Core/Settings/ILaunchDarklySettings.cs
+++ b/src/Core/Settings/ILaunchDarklySettings.cs
@@ -4,4 +4,5 @@ public interface ILaunchDarklySettings
 {
     public string SdkKey { get; set; }
     public string FlagDataFilePath { get; set; }
+    public Dictionary<string, dynamic> FlagValues { get; set; }
 }

--- a/src/Core/Settings/ILaunchDarklySettings.cs
+++ b/src/Core/Settings/ILaunchDarklySettings.cs
@@ -4,5 +4,5 @@ public interface ILaunchDarklySettings
 {
     public string SdkKey { get; set; }
     public string FlagDataFilePath { get; set; }
-    public Dictionary<string, dynamic> FlagValues { get; set; }
+    public Dictionary<string, string> FlagValues { get; set; }
 }


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Extends configuration capabilities to read flag values not just from online or a local file but also application settings. A config like:

```json
"launchDarkly": {
  "flagValues": {
    "somekey1": true,
    "somekey2": 52,
    "somekey3": "value"
  }
}
```

will successfully be parsed on app startup. Since this uses the capabilities that ASP.NET Core provides there's a lot of power unlocked to set feature states e.g. via environment variables.

## Code changes
* **src/Core/Services/Implementations/LaunchDarklyFeatureService.cs:** Parsing of the provided configuration, albeit rather manually since the flag type is dynamic. Loads a [special data source built for testing](https://docs.launchdarkly.com/sdk/features/test-data-sources).
* **src/Core/Settings/GlobalSettings.cs:** Property definition modeled after the file-based approach.
* **src/Core/Settings/ILaunchDarklySettings.cs:** Passthrough implementation.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
