### PR TITLE
[PM-1270] Throw error when removing master password reset policy with TDE enabled

### DIFF
--- a/src/Core/Services/Implementations/PolicyService.cs
+++ b/src/Core/Services/Implementations/PolicyService.cs
@@ -75,6 +75,13 @@ public class PolicyService : IPolicyService
                 }
                 break;
 
+            case PolicyType.ResetPassword:
+                if (!policy.Enabled || policy.GetDataModel<ResetPasswordDataModel>()?.AutoEnrollEnabled == false)
+                {
+                    await RequiredBySsoTrustedDeviceEncryptionAsync(org);
+                }
+                break;
+
             case PolicyType.MaximumVaultTimeout:
                 if (policy.Enabled)
                 {
@@ -230,7 +237,6 @@ public class PolicyService : IPolicyService
 
     private async Task RequiredByKeyConnectorAsync(Organization org)
     {
-
         var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(org.Id);
         if (ssoConfig?.GetData()?.MemberDecryptionType == MemberDecryptionType.KeyConnector)
         {
@@ -252,6 +258,15 @@ public class PolicyService : IPolicyService
         if (org.PlanType != PlanType.EnterpriseAnnually && org.PlanType != PlanType.EnterpriseMonthly)
         {
             throw new BadRequestException("This policy is only available to 2020 Enterprise plans.");
+        }
+    }
+
+    private async Task RequiredBySsoTrustedDeviceEncryptionAsync(Organization org)
+    {
+        var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(org.Id);
+        if (ssoConfig?.GetData()?.MemberDecryptionType == MemberDecryptionType.TrustedDeviceEncryption)
+        {
+            throw new BadRequestException("Trusted device encryption is on and requires this policy.");
         }
     }
 }

--- a/test/Core.Test/Services/PolicyServiceTests.cs
+++ b/test/Core.Test/Services/PolicyServiceTests.cs
@@ -209,6 +209,7 @@ public class PolicyServiceTests
         [PolicyFixtures.Policy(PolicyType.ResetPassword)] Policy policy, SutProvider<PolicyService> sutProvider)
     {
         policy.Id = default;
+        policy.Data = null;
 
         SetupOrg(sutProvider, policy.OrganizationId, new Organization
         {

--- a/test/Core.Test/Services/PolicyServiceTests.cs
+++ b/test/Core.Test/Services/PolicyServiceTests.cs
@@ -427,10 +427,6 @@ public class PolicyServiceTests
             .GetByOrganizationIdAsync(policy.OrganizationId)
             .Returns(ssoConfig);
 
-        sutProvider.GetDependency<IPolicyRepository>()
-            .GetByOrganizationIdTypeAsync(policy.OrganizationId, PolicyType.ResetPassword)
-            .Returns(Task.FromResult(new Policy { Enabled = true }));
-
         var badRequestException = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.SaveAsync(policy,
                 Substitute.For<IUserService>(),


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
If an organization has “trusted device” as their decyption method for SSO, show an error message if an admin tries to turn off the master password reset policy or tries to remove auto-enrollment. 


## Code changes

* **src/Core/Services/Implementations/PolicyService.cs:** If the saved policy is of the "Master Password" type, we verify if TDE is activated for that organization and generate an error if it is the case.
* **test/Core.Test/Services/PolicyServiceTests.cs:** Unit tests to verify the implementation

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
