### PR TITLE
[AC-362] Remove deprecated activate/deactivate endpoints

### DIFF
--- a/src/Api/Controllers/OrganizationUsersController.cs
+++ b/src/Api/Controllers/OrganizationUsersController.cs
@@ -392,38 +392,6 @@ public class OrganizationUsersController : Controller
             new OrganizationUserBulkResponseModel(r.Item1.Id, r.Item2)));
     }
 
-    [Obsolete("2022-07-22 Moved to {id}/revoke endpoint")]
-    [HttpPatch("{id}/deactivate")]
-    [HttpPut("{id}/deactivate")]
-    public async Task Deactivate(Guid orgId, Guid id)
-    {
-        await RevokeAsync(orgId, id);
-    }
-
-    [Obsolete("2022-07-22 Moved to /revoke endpoint")]
-    [HttpPatch("deactivate")]
-    [HttpPut("deactivate")]
-    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkDeactivate(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
-    {
-        return await BulkRevokeAsync(orgId, model);
-    }
-
-    [Obsolete("2022-07-22 Moved to {id}/restore endpoint")]
-    [HttpPatch("{id}/activate")]
-    [HttpPut("{id}/activate")]
-    public async Task Activate(Guid orgId, Guid id)
-    {
-        await RestoreAsync(orgId, id);
-    }
-
-    [Obsolete("2022-07-22 Moved to /restore endpoint")]
-    [HttpPatch("activate")]
-    [HttpPut("activate")]
-    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkActivate(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
-    {
-        return await BulkRestoreAsync(orgId, model);
-    }
-
     [HttpPatch("{id}/revoke")]
     [HttpPut("{id}/revoke")]
     public async Task RevokeAsync(Guid orgId, Guid id)


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Removed the deprecated activate and deactivate endpoints after they were previously renamed from activate and deactivate to restore and revoked, respectively.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **OrganizationUsersController.cs:** Deleted the endpoints `Deactivate`, `BulkDeactivate`, `Activate`, `BulkActivate` from this controller as they were previously renamed to use the restore/revoke terminology as a part of https://bitwarden.atlassian.net/browse/AC-338.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
