### PR TITLE
[PM-2471] adjust captcha requirement to include user creation date

### DIFF
--- a/src/Core/Auth/Services/Implementations/HCaptchaValidationService.cs
+++ b/src/Core/Auth/Services/Implementations/HCaptchaValidationService.cs
@@ -98,10 +98,11 @@ public class HCaptchaValidationService : ICaptchaValidationService
 
         var failedLoginCeiling = _globalSettings.Captcha.MaximumFailedLoginAttempts;
         var failedLoginCount = user?.FailedLoginCount ?? 0;
-        var cloudEmailUnverified = !_globalSettings.SelfHosted && !user.EmailVerified;
+        var requireOnCloud = !_globalSettings.SelfHosted && !user.EmailVerified &&
+            user.CreationDate < DateTime.UtcNow.AddHours(-24);
         return currentContext.IsBot ||
                _globalSettings.Captcha.ForceCaptchaRequired ||
-               cloudEmailUnverified ||
+               requireOnCloud ||
                failedLoginCeiling > 0 && failedLoginCount >= failedLoginCeiling;
     }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Users get prompted for captcha on new devices just after creating their account.

For the sake of user experience, I think we can forego captcha requirements on brand new accounts for a certain time.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **HCaptchaValidationService.cs:** Add a check to user creation date to the existing `requireOnCloud` check.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
