### PR TITLE
[PM-2633] Warnings cleanup

### DIFF
--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/SecretRepository.cs
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/SecretRepository.cs
@@ -139,22 +139,16 @@ public class SecretRepository : Repository<Core.SecretsManager.Entities.Secret, 
                 .Include("Projects")
                 .FirstAsync(s => s.Id == secret.Id);
 
-            if (entity.Projects != null)
+            foreach (var p in entity.Projects.Where(p => mappedEntity.Projects.All(mp => mp.Id != p.Id)))
             {
-                foreach (var p in entity.Projects.Where(p => mappedEntity.Projects.All(mp => mp.Id != p.Id)))
-                {
-                    entity.Projects.Remove(p);
-                }
+                entity.Projects.Remove(p);
+            }
 
-                if (mappedEntity.Projects != null)
-                {
-                    // Add new relationships
-                    foreach (var project in mappedEntity.Projects.Where(p => entity.Projects.All(ep => ep.Id != p.Id)))
-                    {
-                        var p = dbContext.AttachToOrGet<Project>(_ => _.Id == project.Id, () => project);
-                        entity.Projects.Add(p);
-                    }
-                }
+            // Add new relationships
+            foreach (var project in mappedEntity.Projects.Where(p => entity.Projects.All(ep => ep.Id != p.Id)))
+            {
+                var p = dbContext.AttachToOrGet<Project>(_ => _.Id == project.Id, () => project);
+                entity.Projects.Add(p);
             }
 
             dbContext.Entry(entity).CurrentValues.SetValues(mappedEntity);

--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/SecretRepository.cs
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/SecretRepository.cs
@@ -295,10 +295,8 @@ public class SecretRepository : Repository<Core.SecretsManager.Entities.Secret, 
         };
 
         var policy = await query.FirstOrDefaultAsync();
-        if (policy == null)
-            return (false, false);
 
-        return (policy.Read, policy.Write);
+return policy == null ? (false, false) : (policy.Read, policy.Write);
     }
 
     private IQueryable<SecretPermissionDetails> SecretToPermissionDetails(IQueryable<Secret> query, Guid userId, AccessClientType accessType)

--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/SecretRepository.cs
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/SecretRepository.cs
@@ -290,7 +290,7 @@ public class SecretRepository : Repository<Core.SecretsManager.Entities.Secret, 
 
         var policy = await query.FirstOrDefaultAsync();
 
-return policy == null ? (false, false) : (policy.Read, policy.Write);
+        return policy == null ? (false, false) : (policy.Read, policy.Write);
     }
 
     private IQueryable<SecretPermissionDetails> SecretToPermissionDetails(IQueryable<Secret> query, Guid userId, AccessClientType accessType)

--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/SecretRepository.cs
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/SecretRepository.cs
@@ -139,16 +139,22 @@ public class SecretRepository : Repository<Core.SecretsManager.Entities.Secret, 
                 .Include("Projects")
                 .FirstAsync(s => s.Id == secret.Id);
 
-            foreach (var p in entity.Projects?.Where(p => mappedEntity.Projects.All(mp => mp.Id != p.Id)))
+            if (entity.Projects != null)
             {
-                entity.Projects.Remove(p);
-            }
+                foreach (var p in entity.Projects.Where(p => mappedEntity.Projects.All(mp => mp.Id != p.Id)))
+                {
+                    entity.Projects.Remove(p);
+                }
 
-            // Add new relationships
-            foreach (var project in mappedEntity.Projects?.Where(p => entity.Projects.All(ep => ep.Id != p.Id)))
-            {
-                var p = dbContext.AttachToOrGet<Project>(_ => _.Id == project.Id, () => project);
-                entity.Projects.Add(p);
+                if (mappedEntity.Projects != null)
+                {
+                    // Add new relationships
+                    foreach (var project in mappedEntity.Projects.Where(p => entity.Projects.All(ep => ep.Id != p.Id)))
+                    {
+                        var p = dbContext.AttachToOrGet<Project>(_ => _.Id == project.Id, () => project);
+                        entity.Projects.Add(p);
+                    }
+                }
             }
 
             dbContext.Entry(entity).CurrentValues.SetValues(mappedEntity);
@@ -289,6 +295,8 @@ public class SecretRepository : Repository<Core.SecretsManager.Entities.Secret, 
         };
 
         var policy = await query.FirstOrDefaultAsync();
+        if (policy == null)
+            return (false, false);
 
         return (policy.Read, policy.Write);
     }

--- a/src/Api/SecretsManager/Models/Response/AccessTokenCreationResponseModel.cs
+++ b/src/Api/SecretsManager/Models/Response/AccessTokenCreationResponseModel.cs
@@ -23,8 +23,8 @@ public class AccessTokenCreationResponseModel : ResponseModel
     }
 
     public Guid Id { get; set; }
-    public string Name { get; set; }
-    public string ClientSecret { get; set; }
+    public string? Name { get; set; }
+    public string? ClientSecret { get; set; }
     public DateTime? ExpireAt { get; set; }
     public DateTime CreationDate { get; set; }
     public DateTime RevisionDate { get; set; }

--- a/src/Api/SecretsManager/Models/Response/PotentialGranteeResponseModel.cs
+++ b/src/Api/SecretsManager/Models/Response/PotentialGranteeResponseModel.cs
@@ -71,5 +71,5 @@ public class PotentialGranteeResponseModel : ResponseModel
     public string Name { get; set; }
 
     public string Type { get; set; }
-    public string? Email { get; set; }
+    public string Email { get; set; }
 }

--- a/src/Billing/Controllers/StripeController.cs
+++ b/src/Billing/Controllers/StripeController.cs
@@ -131,12 +131,12 @@ public class StripeController : Controller
             if (subCanceled || subUnpaid || subIncompleteExpired)
             {
                 // org
-                if (organizationId != null && organizationId != Guid.Empty)
+                if (organizationId != Guid.Empty)
                 {
                     await _organizationService.DisableAsync(organizationId, subscription.CurrentPeriodEnd);
                 }
                 // user
-                else if (userId != null && userId != Guid.Empty)
+                else if (userId != Guid.Empty)
                 {
                     await _userService.DisablePremiumAsync(userId, subscription.CurrentPeriodEnd);
                 }
@@ -145,11 +145,11 @@ public class StripeController : Controller
             if (subActive)
             {
 
-                if (organizationId != null && organizationId != Guid.Empty)
+                if (organizationId != Guid.Empty)
                 {
                     await _organizationService.EnableAsync(organizationId);
                 }
-                else if (userId != null && userId != Guid.Empty)
+                else if (userId != Guid.Empty)
                 {
                     await _userService.EnablePremiumAsync(userId,
                         subscription.CurrentPeriodEnd);
@@ -159,7 +159,7 @@ public class StripeController : Controller
             if (subUpdated)
             {
                 // org
-                if (organizationId != null && organizationId != Guid.Empty)
+                if (organizationId != Guid.Empty)
                 {
                     await _organizationService.UpdateExpirationDateAsync(organizationId,
                         subscription.CurrentPeriodEnd);
@@ -169,7 +169,7 @@ public class StripeController : Controller
                     }
                 }
                 // user
-                else if (userId != null && userId != Guid.Empty)
+                else if (userId != Guid.Empty)
                 {
                     await _userService.UpdatePremiumExpirationAsync(userId,
                         subscription.CurrentPeriodEnd);

--- a/src/Core/Tools/Models/Business/ReferenceEvent.cs
+++ b/src/Core/Tools/Models/Business/ReferenceEvent.cs
@@ -69,5 +69,5 @@ public class ReferenceEvent
     public bool? SalesAssistedTrialStarted { get; set; }
 
     public string ClientId { get; set; }
-    public Version? ClientVersion { get; set; }
+    public Version ClientVersion { get; set; }
 }

--- a/src/Infrastructure.EntityFramework/Repositories/OrganizationDomainRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/OrganizationDomainRepository.cs
@@ -111,11 +111,11 @@ public class OrganizationDomainRepository : Repository<Core.Entities.Organizatio
         var dbContext = GetDatabaseContext(scope);
 
         //Get domains that have not been verified after 72 hours
-        var domains = dbContext.OrganizationDomains
-            .AsEnumerable()
+        var domains = await dbContext.OrganizationDomains
             .Where(x => (DateTime.UtcNow - x.CreationDate).Days == 4
                         && x.VerifiedDate == null)
-            .ToList();
+            .AsNoTracking()
+            .ToListAsync();
 
         return Mapper.Map<List<Core.Entities.OrganizationDomain>>(domains);
     }

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/SecretsManagerPortingControllerTests.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/SecretsManagerPortingControllerTests.cs
@@ -9,9 +9,6 @@ namespace Bit.Api.IntegrationTest.SecretsManager.Controllers;
 
 public class SecretsManagerPortingControllerTests : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
 {
-    private readonly string _mockEncryptedString =
-        "2.3Uk+WNBIoU5xzmVFNcoWzz==|1MsPIYuRfdOHfu/0uY6H2Q==|/98sp4wb6pHP1VTZ9JcNCYgQjEUMFPlqJgCwRk1YXKg=";
-
     private readonly HttpClient _client;
     private readonly ApiApplicationFactory _factory;
     private readonly IProjectRepository _projectRepository;

--- a/test/Api.Test/Controllers/OrganizationsControllerTests.cs
+++ b/test/Api.Test/Controllers/OrganizationsControllerTests.cs
@@ -38,7 +38,6 @@ public class OrganizationsControllerTests : IDisposable
     private readonly ICloudGetOrganizationLicenseQuery _cloudGetOrganizationLicenseQuery;
     private readonly ICreateOrganizationApiKeyCommand _createOrganizationApiKeyCommand;
     private readonly IUpdateOrganizationLicenseCommand _updateOrganizationLicenseCommand;
-    private readonly IOrganizationDomainRepository _organizationDomainRepository;
     private readonly IFeatureService _featureService;
     private readonly ILicensingService _licensingService;
 

--- a/test/Core.Test/Models/Data/SelfHostedOrganizationDetailsTests.cs
+++ b/test/Core.Test/Models/Data/SelfHostedOrganizationDetailsTests.cs
@@ -17,7 +17,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_Success(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_Success(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);
@@ -31,7 +31,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_OccupiedSeatCount_ExceedsLicense_Fail(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_OccupiedSeatCount_ExceedsLicense_Fail(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);
@@ -46,7 +46,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_MaxCollections_ExceedsLicense_Fail(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_MaxCollections_ExceedsLicense_Fail(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);
@@ -61,7 +61,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_Groups_NotAllowedByLicense_Fail(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_Groups_NotAllowedByLicense_Fail(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);
@@ -76,7 +76,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_Policies_NotAllowedByLicense_Fail(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_Policies_NotAllowedByLicense_Fail(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);
@@ -91,7 +91,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_DisabledPolicies_NotAllowedByLicense_Success(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_DisabledPolicies_NotAllowedByLicense_Success(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);
@@ -107,7 +107,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_Sso_NotAllowedByLicense_Fail(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_Sso_NotAllowedByLicense_Fail(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);
@@ -122,7 +122,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_DisabledSso_NotAllowedByLicense_Success(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_DisabledSso_NotAllowedByLicense_Success(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);
@@ -138,7 +138,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_NoSso_NotAllowedByLicense_Success(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_NoSso_NotAllowedByLicense_Success(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);
@@ -154,7 +154,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_KeyConnector_NotAllowedByLicense_Fail(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_KeyConnector_NotAllowedByLicense_Fail(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);
@@ -169,7 +169,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_DisabledKeyConnector_NotAllowedByLicense_Success(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_DisabledKeyConnector_NotAllowedByLicense_Success(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);
@@ -185,7 +185,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_NoSsoKeyConnector_NotAllowedByLicense_Success(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_NoSsoKeyConnector_NotAllowedByLicense_Success(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);
@@ -201,7 +201,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_Scim_NotAllowedByLicense_Fail(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_Scim_NotAllowedByLicense_Fail(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);
@@ -216,7 +216,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_DisabledScim_NotAllowedByLicense_Success(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_DisabledScim_NotAllowedByLicense_Success(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);
@@ -233,7 +233,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_NoScimConfig_NotAllowedByLicense_Success(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_NoScimConfig_NotAllowedByLicense_Success(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);
@@ -249,7 +249,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_CustomPermissions_NotAllowedByLicense_Fail(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_CustomPermissions_NotAllowedByLicense_Fail(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);
@@ -264,7 +264,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_NoCustomPermissions_NotAllowedByLicense_Success(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_NoCustomPermissions_NotAllowedByLicense_Success(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);
@@ -280,7 +280,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_ResetPassword_NotAllowedByLicense_Fail(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_ResetPassword_NotAllowedByLicense_Fail(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);
@@ -295,7 +295,7 @@ public class SelfHostedOrganizationDetailsTests
     [Theory]
     [BitAutoData]
     [OrganizationLicenseCustomize]
-    public async Task ValidateForOrganization_DisabledResetPassword_NotAllowedByLicense_Success(List<OrganizationUser> orgUsers,
+    public void ValidateForOrganization_DisabledResetPassword_NotAllowedByLicense_Success(List<OrganizationUser> orgUsers,
         List<Policy> policies, SsoConfig ssoConfig, List<OrganizationConnection<ScimConfig>> scimConnections, OrganizationLicense license)
     {
         var (orgDetails, orgLicense) = GetOrganizationAndLicense(orgUsers, policies, ssoConfig, scimConnections, license);

--- a/test/Infrastructure.EFIntegration.Test/Vault/Repositories/CipherRepositoryTests.cs
+++ b/test/Infrastructure.EFIntegration.Test/Vault/Repositories/CipherRepositoryTests.cs
@@ -180,18 +180,14 @@ public class CipherRepositoryTests
         List<EfRepo.OrganizationRepository> efOrgRepos
             ) => await DeleteAsync_CipherIsDeleted(cipher, user, org, suts, efUserRepos, efOrgRepos);
     [CiSkippedTheory, EfOrganizationCipherCustomize, BitAutoData]
-    public Task OrganizationCipher_DeleteAsync_CipherIsDeleted(
+    public async Task OrganizationCipher_DeleteAsync_CipherIsDeleted(
         Cipher cipher,
         User user,
         Organization org,
         List<EfVaultRepo.CipherRepository> suts,
         List<EfRepo.UserRepository> efUserRepos,
         List<EfRepo.OrganizationRepository> efOrgRepos
-            )
-    {
-        DeleteAsync_CipherIsDeleted(cipher, user, org, suts, efUserRepos, efOrgRepos);
-        return Task.CompletedTask;
-    }
+            ) => await DeleteAsync_CipherIsDeleted(cipher, user, org, suts, efUserRepos, efOrgRepos);
 
     private async Task DeleteAsync_CipherIsDeleted(
         Cipher cipher,

--- a/test/IntegrationTestCommon/Factories/WebApplicationFactoryBase.cs
+++ b/test/IntegrationTestCommon/Factories/WebApplicationFactoryBase.cs
@@ -154,9 +154,9 @@ public abstract class WebApplicationFactoryBase<T> : WebApplicationFactory<T>
         return scope.ServiceProvider.GetRequiredService<DatabaseContext>();
     }
 
-    public T GetService<T>()
+    public TS GetService<TS>()
     {
         var scope = Services.CreateScope();
-        return scope.ServiceProvider.GetRequiredService<T>();
+        return scope.ServiceProvider.GetRequiredService<TS>();
     }
 }

--- a/util/EfShared/MigrationBuilderExtensions.cs
+++ b/util/EfShared/MigrationBuilderExtensions.cs
@@ -14,12 +14,12 @@ namespace Bit.EfShared;
 public static class MigrationBuilderExtensions
 {
     /// <summary>
-    /// Reads an embedded resource for it's SQL contents and formats it with the specified direction for easier custom migration steps
+    /// Reads an embedded resource for its SQL contents and formats it with the specified direction for easier custom migration steps
     /// </summary>
     /// <param name="migrationBuilder">The MigrationBuilder instance the sql should be applied to</param>
     /// <param name="resourceName">The file name portion of the resource name, it is assumed to be in a Scripts folder</param>
     /// <param name="dir">The direction of the migration taking place</param>
-    public static void SqlResource(this MigrationBuilder migrationBuilder, string resourceName, [CallerMemberName] string dir = null)
+    public static void SqlResource(this MigrationBuilder migrationBuilder, string resourceName, [CallerMemberName] string dir = "")
     {
         var formattedResourceName = string.IsNullOrEmpty(dir) ? resourceName : string.Format(resourceName, dir);
 


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Cleans up some miscellaneous warnings found in the solution.

## Code changes

* **bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/SecretRepository.cs:** Couple null checks to make the compiler happy, instead of the coalescing that was there before.
* **src/Api/SecretsManager/Models/Response/AccessTokenCreationResponseModel.cs:** Null markers given the use of `#nullable`; I don't really see the need to use that but it seems to be in a lot of places.
* **src/Api/SecretsManager/Models/Response/PotentialGranteeResponseModel.cs:** Opposite of the above.
* **src/Billing/Controllers/StripeController.cs:** Null checks for when a nullable is actually in use. The need for `Guid.Empty` checks is a little scary to me and potentially misguided, but they've been there a while.
* **src/Core/Tools/Models/Business/ReferenceEvent.cs:** More null markers.
* **src/Infrastructure.EntityFramework/Repositories/OrganizationDomainRepository.cs:** Use an `await` and follow the pattern used in the other methods.
* **test/Api.IntegrationTest/SecretsManager/Controllers/SecretsManagerPortingControllerTests.cs:** Unused variable.
* **test/Api.Test/Controllers/OrganizationsControllerTests.cs:** Unused repository.
* **test/Core.Test/Models/Data/SelfHostedOrganizationDetailsTests.cs:** Proper method return type since they're not asynchronous.
* **test/Infrastructure.EFIntegration.Test/Vault/Repositories/CipherRepositoryTests.cs:** Same.
* **test/IntegrationTestCommon/Factories/WebApplicationFactoryBase.cs:** Avoid clashing generic references.
* **util/EfShared/MigrationBuilderExtensions.cs:** Use an empty constant string given the use of a reference type and the subsequent operations. This is a rather fancy method to detect the up and down operations, but maintaining functionality.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
