### PR TITLE
[PM-2697] Return `UserDecryptionOptions` Always

### DIFF
--- a/src/Core/Auth/Models/Api/Response/UserDecryptionOptions.cs
+++ b/src/Core/Auth/Models/Api/Response/UserDecryptionOptions.cs
@@ -12,18 +12,18 @@ public class UserDecryptionOptions : ResponseModel
     }
 
     /// <summary>
-    /// 
+    /// Gets or sets whether the current user has a master password that can be used to decrypt their vault.
     /// </summary>
     public bool HasMasterPassword { get; set; }
 
     /// <summary>
-    /// 
+    /// Gets or sets information regarding this users trusted device decryption setup.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public TrustedDeviceUserDecryptionOption? TrustedDeviceOption { get; set; }
 
     /// <summary>
-    /// 
+    /// Gets or set information about the current users KeyConnector setup.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public KeyConnectorUserDecryptionOption? KeyConnectorOption { get; set; }

--- a/src/Identity/IdentityServer/CustomTokenRequestValidator.cs
+++ b/src/Identity/IdentityServer/CustomTokenRequestValidator.cs
@@ -1,14 +1,11 @@
 ﻿using System.Security.Claims;
-using Bit.Core;
 using Bit.Core.Auth.Enums;
 using Bit.Core.Auth.Identity;
 using Bit.Core.Auth.Models.Api.Response;
 using Bit.Core.Auth.Models.Business.Tokenables;
-using Bit.Core.Auth.Models.Data;
 using Bit.Core.Auth.Repositories;
 using Bit.Core.Context;
 using Bit.Core.Entities;
-using Bit.Core.Enums;
 using Bit.Core.IdentityServer;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
@@ -27,8 +24,6 @@ public class CustomTokenRequestValidator : BaseRequestValidator<CustomTokenReque
     ICustomTokenRequestValidator
 {
     private readonly UserManager<User> _userManager;
-    private readonly ISsoConfigRepository _ssoConfigRepository;
-    private readonly IFeatureService _featureService;
 
     public CustomTokenRequestValidator(
         UserManager<User> userManager,
@@ -44,7 +39,6 @@ public class CustomTokenRequestValidator : BaseRequestValidator<CustomTokenReque
         ILogger<CustomTokenRequestValidator> logger,
         ICurrentContext currentContext,
         GlobalSettings globalSettings,
-        IPolicyRepository policyRepository,
         ISsoConfigRepository ssoConfigRepository,
         IUserRepository userRepository,
         IPolicyService policyService,
@@ -52,12 +46,10 @@ public class CustomTokenRequestValidator : BaseRequestValidator<CustomTokenReque
         IFeatureService featureService)
         : base(userManager, deviceRepository, deviceService, userService, eventService,
             organizationDuoWebTokenProvider, organizationRepository, organizationUserRepository,
-            applicationCacheService, mailService, logger, currentContext, globalSettings, policyRepository,
-            userRepository, policyService, tokenDataFactory)
+            applicationCacheService, mailService, logger, currentContext, globalSettings,
+            userRepository, policyService, tokenDataFactory, featureService, ssoConfigRepository)
     {
         _userManager = userManager;
-        _ssoConfigRepository = ssoConfigRepository;
-        _featureService = featureService;
     }
 
     public async Task ValidateAsync(CustomTokenRequestValidationContext context)
@@ -110,17 +102,6 @@ public class CustomTokenRequestValidator : BaseRequestValidator<CustomTokenReque
             }
         }
 
-        // Attempts to find ssoConfigData for a given validate request subject
-        // this is actually guarenteed to pretty often be null, because more than just sso login requests will come
-        // through here
-        var ssoConfigData = await GetSsoConfigurationDataAsync(context.Result.ValidatedRequest.Subject);
-
-        // You can't put this below the user.MasterPassword != null check because TDE users can still have a MasterPassword
-        // It's worth noting that CurrentContext here will build a user in LaunchDarkly that is anonymous but DOES belong
-        // to an organization. So we will not be able to turn this feature on for only a single user, only for an entire 
-        // organization at a time.
-        context.Result.CustomResponse["UserDecryptionOptions"] = await CreateUserDecryptionOptionsAsync(ssoConfigData, user);
-
         if (context.Result.CustomResponse == null || user.MasterPassword != null)
         {
             return;
@@ -141,33 +122,25 @@ public class CustomTokenRequestValidator : BaseRequestValidator<CustomTokenReque
             return;
         }
 
-        // SSO login
-        // This does a double check, that ssoConfigData is not null and that it has the KeyConnector member decryption type
-        if (ssoConfigData is { MemberDecryptionType: MemberDecryptionType.KeyConnector } && !string.IsNullOrEmpty(ssoConfigData.KeyConnectorUrl))
+        // Key connector data should have already been set in the decryption options
+        // for backwards compatibility we set them this way too. We can eventually get rid of this
+        // when all clients don't read them from the existing locations.
+        if (!context.Result.CustomResponse.TryGetValue("UserDecryptionOptions", out var userDecryptionOptionsObj) ||
+            userDecryptionOptionsObj is not UserDecryptionOptions userDecryptionOptions)
         {
-            // TODO: Can be removed in the future
-            context.Result.CustomResponse["KeyConnectorUrl"] = ssoConfigData.KeyConnectorUrl;
-            // Prevent clients redirecting to set-password
+            return;
+        }
+
+        if (userDecryptionOptions is { KeyConnectorOption: { } })
+        {
+            context.Result.CustomResponse["KeyConnectorUrl"] = userDecryptionOptions.KeyConnectorOption.KeyConnectorUrl;
             context.Result.CustomResponse["ResetMasterPassword"] = false;
         }
     }
 
-    private async Task<SsoConfigurationData?> GetSsoConfigurationDataAsync(ClaimsPrincipal? subject)
+    protected override ClaimsPrincipal GetSubject(CustomTokenRequestValidationContext context)
     {
-        var organizationClaim = subject?.FindFirstValue("organizationId");
-
-        if (organizationClaim == null || !Guid.TryParse(organizationClaim, out var organizationId))
-        {
-            return null;
-        }
-
-        var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(organizationId);
-        if (ssoConfig == null)
-        {
-            return null;
-        }
-
-        return ssoConfig.GetData();
+        return context.Result.ValidatedRequest.Subject;
     }
 
     protected override void SetTwoFactorResult(CustomTokenRequestValidationContext context,
@@ -194,33 +167,5 @@ public class CustomTokenRequestValidator : BaseRequestValidator<CustomTokenReque
         context.Result.Error = "invalid_grant";
         context.Result.IsError = true;
         context.Result.CustomResponse = customResponse;
-    }
-
-    /// <summary>
-    /// Used to create a list of all possible ways the newly authenticated user can decrypt their vault contents
-    /// </summary>
-    private async Task<UserDecryptionOptions> CreateUserDecryptionOptionsAsync(SsoConfigurationData? ssoConfigurationData, User user)
-    {
-        var userDecryptionOption = new UserDecryptionOptions
-        {
-            HasMasterPassword = !string.IsNullOrEmpty(user.MasterPassword)
-        };
-
-        if (ssoConfigurationData is { MemberDecryptionType: MemberDecryptionType.KeyConnector } && !string.IsNullOrEmpty(ssoConfigurationData.KeyConnectorUrl))
-        {
-            // KeyConnector makes it mutually exclusive
-            userDecryptionOption.KeyConnectorOption = new KeyConnectorUserDecryptionOption(ssoConfigurationData.KeyConnectorUrl);
-            return userDecryptionOption;
-        }
-
-        // Only add the trusted device specific option when the flag is turned on
-        if (_featureService.IsEnabled(FeatureFlagKeys.TrustedDeviceEncryption, CurrentContext) && ssoConfigurationData is { MemberDecryptionType: MemberDecryptionType.TrustedDeviceEncryption })
-        {
-            var hasAdminApproval = await PolicyService.AnyPoliciesApplicableToUserAsync(user.Id, PolicyType.ResetPassword);
-            // TrustedDeviceEncryption only exists for SSO, but if that ever changes this value won't always be true
-            userDecryptionOption.TrustedDeviceOption = new TrustedDeviceUserDecryptionOption(hasAdminApproval);
-        }
-
-        return userDecryptionOption;
     }
 }

--- a/src/Identity/IdentityServer/CustomTokenRequestValidator.cs
+++ b/src/Identity/IdentityServer/CustomTokenRequestValidator.cs
@@ -1,5 +1,4 @@
 ﻿using System.Security.Claims;
-using Bit.Core.Auth.Enums;
 using Bit.Core.Auth.Identity;
 using Bit.Core.Auth.Models.Api.Response;
 using Bit.Core.Auth.Models.Business.Tokenables;
@@ -88,7 +87,7 @@ public class CustomTokenRequestValidator : BaseRequestValidator<CustomTokenReque
         return validatorContext.User != null;
     }
 
-    protected override async Task SetSuccessResult(CustomTokenRequestValidationContext context, User user,
+    protected override Task SetSuccessResult(CustomTokenRequestValidationContext context, User user,
         List<Claim> claims, Dictionary<string, object> customResponse)
     {
         context.Result.CustomResponse = customResponse;
@@ -104,7 +103,7 @@ public class CustomTokenRequestValidator : BaseRequestValidator<CustomTokenReque
 
         if (context.Result.CustomResponse == null || user.MasterPassword != null)
         {
-            return;
+            return Task.CompletedTask;
         }
 
         // KeyConnector responses below
@@ -119,7 +118,7 @@ public class CustomTokenRequestValidator : BaseRequestValidator<CustomTokenReque
                 context.Result.CustomResponse["ResetMasterPassword"] = false;
             }
 
-            return;
+            return Task.CompletedTask;
         }
 
         // Key connector data should have already been set in the decryption options
@@ -128,7 +127,7 @@ public class CustomTokenRequestValidator : BaseRequestValidator<CustomTokenReque
         if (!context.Result.CustomResponse.TryGetValue("UserDecryptionOptions", out var userDecryptionOptionsObj) ||
             userDecryptionOptionsObj is not UserDecryptionOptions userDecryptionOptions)
         {
-            return;
+            return Task.CompletedTask;
         }
 
         if (userDecryptionOptions is { KeyConnectorOption: { } })
@@ -136,6 +135,8 @@ public class CustomTokenRequestValidator : BaseRequestValidator<CustomTokenReque
             context.Result.CustomResponse["KeyConnectorUrl"] = userDecryptionOptions.KeyConnectorOption.KeyConnectorUrl;
             context.Result.CustomResponse["ResetMasterPassword"] = false;
         }
+
+        return Task.CompletedTask;
     }
 
     protected override ClaimsPrincipal GetSubject(CustomTokenRequestValidationContext context)

--- a/src/Identity/IdentityServer/CustomTokenRequestValidator.cs
+++ b/src/Identity/IdentityServer/CustomTokenRequestValidator.cs
@@ -119,10 +119,7 @@ public class CustomTokenRequestValidator : BaseRequestValidator<CustomTokenReque
         // It's worth noting that CurrentContext here will build a user in LaunchDarkly that is anonymous but DOES belong
         // to an organization. So we will not be able to turn this feature on for only a single user, only for an entire 
         // organization at a time.
-        if (ssoConfigData != null)
-        {
-            context.Result.CustomResponse["UserDecryptionOptions"] = await CreateUserDecryptionOptionsAsync(ssoConfigData, user);
-        }
+        context.Result.CustomResponse["UserDecryptionOptions"] = await CreateUserDecryptionOptionsAsync(ssoConfigData, user);
 
         if (context.Result.CustomResponse == null || user.MasterPassword != null)
         {
@@ -202,7 +199,7 @@ public class CustomTokenRequestValidator : BaseRequestValidator<CustomTokenReque
     /// <summary>
     /// Used to create a list of all possible ways the newly authenticated user can decrypt their vault contents
     /// </summary>
-    private async Task<UserDecryptionOptions> CreateUserDecryptionOptionsAsync(SsoConfigurationData ssoConfigurationData, User user)
+    private async Task<UserDecryptionOptions> CreateUserDecryptionOptionsAsync(SsoConfigurationData? ssoConfigurationData, User user)
     {
         var userDecryptionOption = new UserDecryptionOptions
         {

--- a/src/Identity/IdentityServer/ResourceOwnerPasswordValidator.cs
+++ b/src/Identity/IdentityServer/ResourceOwnerPasswordValidator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Security.Claims;
 using Bit.Core.Auth.Identity;
 using Bit.Core.Auth.Models.Business.Tokenables;
+using Bit.Core.Auth.Repositories;
 using Bit.Core.Auth.Services;
 using Bit.Core.Context;
 using Bit.Core.Entities;
@@ -37,16 +38,17 @@ public class ResourceOwnerPasswordValidator : BaseRequestValidator<ResourceOwner
         ILogger<ResourceOwnerPasswordValidator> logger,
         ICurrentContext currentContext,
         GlobalSettings globalSettings,
-        IPolicyRepository policyRepository,
         ICaptchaValidationService captchaValidationService,
         IAuthRequestRepository authRequestRepository,
         IUserRepository userRepository,
         IPolicyService policyService,
-        IDataProtectorTokenFactory<SsoEmail2faSessionTokenable> tokenDataFactory)
+        IDataProtectorTokenFactory<SsoEmail2faSessionTokenable> tokenDataFactory,
+        IFeatureService featureService,
+        ISsoConfigRepository ssoConfigRepository)
         : base(userManager, deviceRepository, deviceService, userService, eventService,
               organizationDuoWebTokenProvider, organizationRepository, organizationUserRepository,
-              applicationCacheService, mailService, logger, currentContext, globalSettings, policyRepository,
-              userRepository, policyService, tokenDataFactory)
+              applicationCacheService, mailService, logger, currentContext, globalSettings, userRepository, policyService,
+              tokenDataFactory, featureService, ssoConfigRepository)
     {
         _userManager = userManager;
         _userService = userService;
@@ -164,6 +166,11 @@ public class ResourceOwnerPasswordValidator : BaseRequestValidator<ResourceOwner
         Dictionary<string, object> customResponse)
     {
         context.Result = new GrantValidationResult(TokenRequestErrors.InvalidGrant, customResponse: customResponse);
+    }
+
+    protected override ClaimsPrincipal GetSubject(ResourceOwnerPasswordValidationContext context)
+    {
+        return context.Result.Subject;
     }
 
     private bool AuthEmailHeaderIsValid(ResourceOwnerPasswordValidationContext context)

--- a/test/Identity.IntegrationTest/Endpoints/IdentityServerSsoTests.cs
+++ b/test/Identity.IntegrationTest/Endpoints/IdentityServerSsoTests.cs
@@ -246,6 +246,59 @@ public class IdentityServerSsoTests
     }
 
     [Fact]
+    public async Task SsoLogin_TrustedDeviceEncryption_FlagTurnedOff_DoesNotReturnOption()
+    {
+        // Arrange
+        var challenge = new string('c', 50);
+
+        // This creates SsoConfig that HAS enabled trusted device encryption which should have only been
+        // done with the feature flag turned on but we are testing that even if they have done that, this will turn off
+        // if returning as an option if the flag has later been turned off.  We should be very careful turning the flag
+        // back off.
+        var factory = await CreateFactoryAsync(new SsoConfigurationData
+        {
+            MemberDecryptionType = MemberDecryptionType.TrustedDeviceEncryption,
+        }, challenge, trustedDeviceEnabled: false);
+
+        await UpdateUserAsync(factory, user => user.MasterPassword = null);
+
+        // Act
+        var context = await factory.Server.PostAsync("/connect/token", new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            { "scope", "api offline_access" },
+            { "client_id", "web" },
+            { "deviceType", "10" },
+            { "deviceIdentifier", "test_id" },
+            { "deviceName", "firefox" },
+            { "twoFactorToken", "TEST"},
+            { "twoFactorProvider", "5" }, // RememberMe Provider
+            { "twoFactorRemember", "0" },
+            { "grant_type", "authorization_code" },
+            { "code", "test_code" },
+            { "code_verifier", challenge },
+            { "redirect_uri", "https://localhost:8080/sso-connector.html" }
+        }));
+
+        // Assert
+        // If the organization has selected TrustedDeviceEncryption but the user still has their master password
+        // they can decrypt with either option
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        using var responseBody = await AssertHelper.AssertResponseTypeIs<JsonDocument>(context);
+        var root = responseBody.RootElement;
+        AssertHelper.AssertJsonProperty(root, "access_token", JsonValueKind.String);
+        var userDecryptionOptions = AssertHelper.AssertJsonProperty(root, "UserDecryptionOptions", JsonValueKind.Object);
+
+        // Expected to look like:
+        // "UserDecryptionOptions": {
+        //   "Object": "userDecryptionOptions"
+        //   "HasMasterPassword": false
+        // }
+
+        // Should only have 2 properties
+        Assert.Equal(2, userDecryptionOptions.EnumerateObject().Count());
+    }
+
+    [Fact]
     public async Task SsoLogin_KeyConnector_ReturnsOptions()
     {
         // Arrange
@@ -301,7 +354,7 @@ public class IdentityServerSsoTests
         Assert.Equal("https://key_connector.com", keyConnectorUrl);
     }
 
-    private static async Task<IdentityApplicationFactory> CreateFactoryAsync(SsoConfigurationData ssoConfigurationData, string challenge)
+    private static async Task<IdentityApplicationFactory> CreateFactoryAsync(SsoConfigurationData ssoConfigurationData, string challenge, bool trustedDeviceEnabled = true)
     {
         var factory = new IdentityApplicationFactory();
 
@@ -327,7 +380,7 @@ public class IdentityServerSsoTests
         factory.SubstitueService<IFeatureService>(service =>
         {
             service.IsEnabled(FeatureFlagKeys.TrustedDeviceEncryption, Arg.Any<ICurrentContext>())
-                .Returns(true);
+                .Returns(trustedDeviceEnabled);
         });
 
         // This starts the server and finalizes services

--- a/test/Identity.IntegrationTest/Endpoints/IdentityServerTests.cs
+++ b/test/Identity.IntegrationTest/Endpoints/IdentityServerTests.cs
@@ -65,6 +65,7 @@ public class IdentityServerTests : IClassFixture<IdentityApplicationFactory>
         Assert.Equal(0, kdf);
         var kdfIterations = AssertHelper.AssertJsonProperty(root, "KdfIterations", JsonValueKind.Number).GetInt32();
         Assert.Equal(5000, kdfIterations);
+        AssertUserDecryptionOptions(root);
     }
 
     [Theory, BitAutoData]
@@ -633,6 +634,16 @@ public class IdentityServerTests : IClassFixture<IdentityApplicationFactory>
         Assert.Equal("invalid_grant", error);
         var errorDescription = AssertHelper.AssertJsonProperty(root, "error_description", JsonValueKind.String).GetString();
         Assert.StartsWith("sso authentication", errorDescription.ToLowerInvariant());
+    }
+
+    private static void AssertUserDecryptionOptions(JsonElement tokenResponse)
+    {
+        var userDecryptionOptions = AssertHelper.AssertJsonProperty(tokenResponse, "UserDecryptionOptions", JsonValueKind.Object)
+            .EnumerateObject();
+
+        Assert.Collection(userDecryptionOptions,
+            (prop) => { Assert.Equal("HasMasterPassword", prop.Name); Assert.Equal(JsonValueKind.True, prop.Value.ValueKind); },
+            (prop) => { Assert.Equal("Object", prop.Name); Assert.Equal("userDecryptionOptions", prop.Value.GetString()); });
     }
 
     private void ReinitializeDbForTests()


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Changes to always returning `UserDecryptionOptions` and only feature flagging the trusted device section. This way the return can be stored and saved and trusted for other purposes beyond TDE.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/Auth/Models/Api/Response/UserDecryptionOptions.cs:** Added some comments that were left blank in the previous PR.
* **src/Identity/IdentityServer/CustomTokenRequestValidator.cs:** Change legacy KeyConnector settings to come from the already exist user decryption options.
* **test/Identity.IntegrationTest/Endpoints/IdentityServerSsoTests.cs:** Added a test for when the feature is off but you may have turned on the feature before.
* **test/Identity.IntegrationTest/Endpoints/IdentityServerTests.cs:** Added test for making sure decryption options come back on password authentication.
* **src/Identity/IdentityServer/BaseRequestValidator.cs:** Moved Decryption option creation here so that it can be done on every successful authentication.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
