### PR TITLE
[PM-1198] Modify `AuthRequest` Purge Job

### DIFF
--- a/src/Admin/Auth/Jobs/DeleteAuthRequestsJob.cs
+++ b/src/Admin/Auth/Jobs/DeleteAuthRequestsJob.cs
@@ -24,7 +24,6 @@ public class DeleteAuthRequestsJob : BaseJob
     protected async override Task ExecuteJobAsync(IJobExecutionContext context)
     {
         _logger.LogInformation(Constants.BypassFiltersEventId, "Execute job task: DeleteAuthRequestsJob: Start");
-        // TODO: Replace with global settings
         var count = await _authRepo.DeleteExpiredAsync(
             _globalSettings.PasswordlessAuth.UserRequestExpiration,
             _globalSettings.PasswordlessAuth.AdminRequestExpiration,

--- a/src/Admin/Auth/Jobs/DeleteAuthRequestsJob.cs
+++ b/src/Admin/Auth/Jobs/DeleteAuthRequestsJob.cs
@@ -1,6 +1,7 @@
 ﻿using Bit.Core;
 using Bit.Core.Jobs;
 using Bit.Core.Repositories;
+using Bit.Core.Settings;
 using Quartz;
 
 namespace Bit.Admin.Auth.Jobs;
@@ -8,20 +9,27 @@ namespace Bit.Admin.Auth.Jobs;
 public class DeleteAuthRequestsJob : BaseJob
 {
     private readonly IAuthRequestRepository _authRepo;
+    private readonly IGlobalSettings _globalSettings;
 
     public DeleteAuthRequestsJob(
         IAuthRequestRepository authrepo,
+        IGlobalSettings globalSettings,
         ILogger<DeleteAuthRequestsJob> logger)
         : base(logger)
     {
         _authRepo = authrepo;
+        _globalSettings = globalSettings;
     }
 
     protected async override Task ExecuteJobAsync(IJobExecutionContext context)
     {
         _logger.LogInformation(Constants.BypassFiltersEventId, "Execute job task: DeleteAuthRequestsJob: Start");
-        var count = await _authRepo.DeleteExpiredAsync();
-        _logger.LogInformation(Constants.BypassFiltersEventId, $"{count} records deleted from AuthRequests.");
+        // TODO: Replace with global settings
+        var count = await _authRepo.DeleteExpiredAsync(
+            _globalSettings.PasswordlessAuth.UserRequestExpiration,
+            _globalSettings.PasswordlessAuth.AdminRequestExpiration,
+            _globalSettings.PasswordlessAuth.AfterAdminApprovalExpiration);
+        _logger.LogInformation(Constants.BypassFiltersEventId, "{Count} records deleted from AuthRequests.", count);
         _logger.LogInformation(Constants.BypassFiltersEventId, "Execute job task: DeleteAuthRequestsJob: End");
     }
 }

--- a/src/Core/Auth/Repositories/IAuthRequestRepository.cs
+++ b/src/Core/Auth/Repositories/IAuthRequestRepository.cs
@@ -5,7 +5,7 @@ namespace Bit.Core.Repositories;
 
 public interface IAuthRequestRepository : IRepository<AuthRequest, Guid>
 {
-    Task<int> DeleteExpiredAsync(TimeSpan userExpiration, TimeSpan adminExpiration, TimeSpan adminApprovalExpiration);
+    Task<int> DeleteExpiredAsync(TimeSpan userRequestExpiration, TimeSpan adminRequestExpiration, TimeSpan afterAdminApprovalExpiration);
     Task<ICollection<AuthRequest>> GetManyByUserIdAsync(Guid userId);
     Task<ICollection<OrganizationAdminAuthRequest>> GetManyPendingByOrganizationIdAsync(Guid organizationId);
     Task<ICollection<OrganizationAdminAuthRequest>> GetManyAdminApprovalRequestsByManyIdsAsync(Guid organizationId, IEnumerable<Guid> ids);

--- a/src/Core/Auth/Repositories/IAuthRequestRepository.cs
+++ b/src/Core/Auth/Repositories/IAuthRequestRepository.cs
@@ -5,7 +5,7 @@ namespace Bit.Core.Repositories;
 
 public interface IAuthRequestRepository : IRepository<AuthRequest, Guid>
 {
-    Task<int> DeleteExpiredAsync();
+    Task<int> DeleteExpiredAsync(TimeSpan userExpiration, TimeSpan adminExpiration, TimeSpan adminApprovalExpiration);
     Task<ICollection<AuthRequest>> GetManyByUserIdAsync(Guid userId);
     Task<ICollection<OrganizationAdminAuthRequest>> GetManyPendingByOrganizationIdAsync(Guid organizationId);
     Task<ICollection<OrganizationAdminAuthRequest>> GetManyAdminApprovalRequestsByManyIdsAsync(Guid organizationId, IEnumerable<Guid> ids);

--- a/src/Core/Auth/Settings/IPasswordlessAuthSettings.cs
+++ b/src/Core/Auth/Settings/IPasswordlessAuthSettings.cs
@@ -3,4 +3,7 @@
 public interface IPasswordlessAuthSettings
 {
     bool KnownDevicesOnly { get; set; }
+    TimeSpan UserRequestExpiration { get; set; }
+    TimeSpan AdminRequestExpiration { get; set; }
+    TimeSpan AfterAdminApprovalExpiration { get; set; }
 }

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -534,6 +534,9 @@ public class GlobalSettings : IGlobalSettings
     public class PasswordlessAuthSettings : IPasswordlessAuthSettings
     {
         public bool KnownDevicesOnly { get; set; } = true;
+        public TimeSpan UserRequestExpiration { get; set; } = TimeSpan.FromMinutes(15);
+        public TimeSpan AdminRequestExpiration { get; set; } = TimeSpan.FromDays(7);
+        public TimeSpan AfterAdminApprovalExpiration { get; set; } = TimeSpan.FromHours(12);
     }
 
     public class DomainVerificationSettings : IDomainVerificationSettings

--- a/src/Infrastructure.Dapper/Auth/Repositories/AuthRequestRepository.cs
+++ b/src/Infrastructure.Dapper/Auth/Repositories/AuthRequestRepository.cs
@@ -19,7 +19,8 @@ public class AuthRequestRepository : Repository<AuthRequest, Guid>, IAuthRequest
         : base(connectionString, readOnlyConnectionString)
     { }
 
-    public async Task<int> DeleteExpiredAsync(TimeSpan userExpiration, TimeSpan adminExpiration, TimeSpan adminApprovalExpiration)
+    public async Task<int> DeleteExpiredAsync(
+        TimeSpan userRequestExpiration, TimeSpan adminRequestExpiration, TimeSpan afterAdminApprovalExpiration)
     {
         using (var connection = new SqlConnection(ConnectionString))
         {
@@ -27,9 +28,9 @@ public class AuthRequestRepository : Repository<AuthRequest, Guid>, IAuthRequest
                 $"[{Schema}].[AuthRequest_DeleteIfExpired]",
                 new
                 {
-                    UserExpirationSeconds = (int)userExpiration.TotalSeconds,
-                    AdminExpirationSeconds = (int)adminExpiration.TotalSeconds,
-                    AdminApprovalExpirationSeconds = (int)adminApprovalExpiration.TotalSeconds,
+                    UserExpirationSeconds = (int)userRequestExpiration.TotalSeconds,
+                    AdminExpirationSeconds = (int)adminRequestExpiration.TotalSeconds,
+                    AdminApprovalExpirationSeconds = (int)afterAdminApprovalExpiration.TotalSeconds,
                 },
                 commandType: CommandType.StoredProcedure);
         }

--- a/src/Infrastructure.Dapper/Auth/Repositories/AuthRequestRepository.cs
+++ b/src/Infrastructure.Dapper/Auth/Repositories/AuthRequestRepository.cs
@@ -19,13 +19,18 @@ public class AuthRequestRepository : Repository<AuthRequest, Guid>, IAuthRequest
         : base(connectionString, readOnlyConnectionString)
     { }
 
-    public async Task<int> DeleteExpiredAsync()
+    public async Task<int> DeleteExpiredAsync(TimeSpan userExpiration, TimeSpan adminExpiration, TimeSpan adminApprovalExpiration)
     {
         using (var connection = new SqlConnection(ConnectionString))
         {
             return await connection.ExecuteAsync(
                 $"[{Schema}].[AuthRequest_DeleteIfExpired]",
-                null,
+                new
+                {
+                    UserExpirationSeconds = (int)userExpiration.TotalSeconds,
+                    AdminExpirationSeconds = (int)adminExpiration.TotalSeconds,
+                    AdminApprovalExpirationSeconds = (int)adminApprovalExpiration.TotalSeconds,
+                },
                 commandType: CommandType.StoredProcedure);
         }
     }

--- a/src/Infrastructure.EntityFramework/Auth/Repositories/AuthRequestRepository.cs
+++ b/src/Infrastructure.EntityFramework/Auth/Repositories/AuthRequestRepository.cs
@@ -15,16 +15,17 @@ public class AuthRequestRepository : Repository<Core.Auth.Entities.AuthRequest, 
     public AuthRequestRepository(IServiceScopeFactory serviceScopeFactory, IMapper mapper)
         : base(serviceScopeFactory, mapper, (DatabaseContext context) => context.AuthRequests)
     { }
-    public async Task<int> DeleteExpiredAsync(TimeSpan userExpiration, TimeSpan adminExpiration, TimeSpan adminApprovalExpiration)
+    public async Task<int> DeleteExpiredAsync(
+        TimeSpan userRequestExpiration, TimeSpan adminRequestExpiration, TimeSpan afterAdminApprovalExpiration)
     {
 
         using (var scope = ServiceScopeFactory.CreateScope())
         {
             var dbContext = GetDatabaseContext(scope);
             var expiredRequests = await dbContext.AuthRequests
-                .Where(a => (a.Type != AuthRequestType.AdminApproval && a.CreationDate.AddSeconds(userExpiration.TotalSeconds) < DateTime.UtcNow)
-                    || (a.Type == AuthRequestType.AdminApproval && a.Approved != true && a.CreationDate.AddSeconds(adminExpiration.TotalSeconds) < DateTime.UtcNow)
-                    || (a.Type == AuthRequestType.AdminApproval && a.Approved == true && a.ResponseDate.Value.AddSeconds(adminApprovalExpiration.TotalSeconds) < DateTime.UtcNow))
+                .Where(a => (a.Type != AuthRequestType.AdminApproval && a.CreationDate.AddSeconds(userRequestExpiration.TotalSeconds) < DateTime.UtcNow)
+                    || (a.Type == AuthRequestType.AdminApproval && a.Approved != true && a.CreationDate.AddSeconds(adminRequestExpiration.TotalSeconds) < DateTime.UtcNow)
+                    || (a.Type == AuthRequestType.AdminApproval && a.Approved == true && a.ResponseDate.Value.AddSeconds(afterAdminApprovalExpiration.TotalSeconds) < DateTime.UtcNow))
                 .ToListAsync();
             dbContext.AuthRequests.RemoveRange(expiredRequests);
             return await dbContext.SaveChangesAsync();

--- a/src/Infrastructure.EntityFramework/Auth/Repositories/AuthRequestRepository.cs
+++ b/src/Infrastructure.EntityFramework/Auth/Repositories/AuthRequestRepository.cs
@@ -23,7 +23,7 @@ public class AuthRequestRepository : Repository<Core.Auth.Entities.AuthRequest, 
             var dbContext = GetDatabaseContext(scope);
             var expiredRequests = await dbContext.AuthRequests
                 .Where(a => (a.Type != AuthRequestType.AdminApproval && a.CreationDate.AddSeconds(userExpiration.TotalSeconds) < DateTime.UtcNow)
-                    || (a.Type == AuthRequestType.AdminApproval && a.Approved != false && a.CreationDate.AddSeconds(adminExpiration.TotalSeconds) < DateTime.UtcNow)
+                    || (a.Type == AuthRequestType.AdminApproval && a.Approved != true && a.CreationDate.AddSeconds(adminExpiration.TotalSeconds) < DateTime.UtcNow)
                     || (a.Type == AuthRequestType.AdminApproval && a.Approved == true && a.ResponseDate.Value.AddSeconds(adminApprovalExpiration.TotalSeconds) < DateTime.UtcNow))
                 .ToListAsync();
             dbContext.AuthRequests.RemoveRange(expiredRequests);

--- a/test/Infrastructure.IntegrationTest/Auth/Repositories/AuthRequestRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/Auth/Repositories/AuthRequestRepositoryTests.cs
@@ -1,4 +1,4 @@
-using Bit.Core.Auth.Entities;
+﻿using Bit.Core.Auth.Entities;
 using Bit.Core.Auth.Enums;
 using Bit.Core.Entities;
 using Bit.Core.Repositories;
@@ -63,7 +63,7 @@ public class AuthRequestRepositoryTests
         Assert.NotNull(await authRequestRepository.GetByIdAsync(notExpiredUserAuthRequest.Id));
         Assert.NotNull(await authRequestRepository.GetByIdAsync(notExpiredAdminApprovalRequest.Id));
         Assert.NotNull(await authRequestRepository.GetByIdAsync(notExpiredApprovedAdminApprovalRequest.Id));
-        
+
         // Ensure the repository responds with the amount of items it deleted and it deleted the right amount.
         // NOTE: On local development this might fail on it's first run because the developer could have expired AuthRequests
         // on their machine but aren't running the job that would delete them. The second run of this test should succeed.

--- a/test/Infrastructure.IntegrationTest/Auth/Repositories/AuthRequestRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/Auth/Repositories/AuthRequestRepositoryTests.cs
@@ -1,0 +1,94 @@
+using Bit.Core.Auth.Entities;
+using Bit.Core.Auth.Enums;
+using Bit.Core.Entities;
+using Bit.Core.Repositories;
+using Xunit;
+
+namespace Bit.Infrastructure.IntegrationTest.Auth.Repositories;
+
+public class AuthRequestRepositoryTests
+{
+    private readonly static TimeSpan _userExpiration = TimeSpan.FromMinutes(15);
+    private readonly static TimeSpan _adminExpiration = TimeSpan.FromDays(6);
+    private readonly static TimeSpan _adminApprovalExpiration = TimeSpan.FromHours(12);
+
+    [DatabaseTheory, DatabaseData]
+    public async Task DeleteExpiredAsync_Works(
+        IAuthRequestRepository authRequestRepository,
+        IUserRepository userRepository,
+        ITestDatabaseHelper helper)
+    {
+        var user = await userRepository.CreateAsync(new User
+        {
+            Name = "Test User",
+            Email = $"test+{Guid.NewGuid()}@email.com",
+            ApiKey = "TEST",
+            SecurityStamp = "stamp",
+        });
+
+        // A user auth request type that has passed it's expiration time, should be deleted.
+        var userExpiredAuthRequest = await authRequestRepository.CreateAsync(
+            CreateAuthRequest(user.Id, AuthRequestType.AuthenticateAndUnlock, CreateExpiredDate(_userExpiration)));
+
+        // An AdminApproval request that hasn't had any action taken on it and has passed it's expiration time, should be deleted.
+        var adminApprovalExpiredAuthRequest = await authRequestRepository.CreateAsync(
+            CreateAuthRequest(user.Id, AuthRequestType.AdminApproval, CreateExpiredDate(_adminExpiration)));
+
+        // An AdminApproval request that was approved before it expired but the user has been approved for too long, should be deleted.
+        var adminApprovedExpiredAuthRequest = await authRequestRepository.CreateAsync(
+            CreateAuthRequest(user.Id, AuthRequestType.AdminApproval, DateTime.UtcNow.AddDays(-6), true, CreateExpiredDate(_adminApprovalExpiration)));
+
+        // A User AuthRequest that was created just a minute ago.
+        var notExpiredUserAuthRequest = await authRequestRepository.CreateAsync(
+            CreateAuthRequest(user.Id, AuthRequestType.Unlock, DateTime.UtcNow.AddMinutes(-1)));
+
+        // An AdminApproval AuthRequest that was create 6 days 23 hours 59 minutes 59 seconds ago which is right on the edge of still being valid
+        var notExpiredAdminApprovalRequest = await authRequestRepository.CreateAsync(
+            CreateAuthRequest(user.Id, AuthRequestType.AdminApproval, DateTime.UtcNow.Add(new TimeSpan(days: 6, hours: 23, minutes: 59, seconds: 59))));
+
+        // An AdminApproval AuthRequest that was created a week ago but just approved 11 hours ago.
+        var notExpiredApprovedAdminApprovalRequest = await authRequestRepository.CreateAsync(
+            CreateAuthRequest(user.Id, AuthRequestType.AdminApproval, DateTime.UtcNow.AddDays(7), true, DateTime.UtcNow.AddHours(11)));
+
+        helper.ClearTracker();
+
+        var numberOfDeleted = await authRequestRepository.DeleteExpiredAsync(_userExpiration, _adminExpiration, _adminApprovalExpiration);
+
+        // Ensure all the AuthRequests that should have been deleted, have been deleted.
+        Assert.Null(await authRequestRepository.GetByIdAsync(userExpiredAuthRequest.Id));
+        Assert.Null(await authRequestRepository.GetByIdAsync(adminApprovalExpiredAuthRequest.Id));
+        Assert.Null(await authRequestRepository.GetByIdAsync(adminApprovedExpiredAuthRequest.Id));
+
+        // Ensure that all the AuthRequests that should have been left alone, were.
+        Assert.NotNull(await authRequestRepository.GetByIdAsync(notExpiredUserAuthRequest.Id));
+        Assert.NotNull(await authRequestRepository.GetByIdAsync(notExpiredAdminApprovalRequest.Id));
+        Assert.NotNull(await authRequestRepository.GetByIdAsync(notExpiredApprovedAdminApprovalRequest.Id));
+        
+        // Ensure the repository responds with the amount of items it deleted and it deleted the right amount.
+        // NOTE: On local development this might fail on it's first run because the developer could have expired AuthRequests
+        // on their machine but aren't running the job that would delete them. The second run of this test should succeed.
+        Assert.Equal(3, numberOfDeleted);
+    }
+
+    private static AuthRequest CreateAuthRequest(Guid userId, AuthRequestType authRequestType, DateTime creationDate, bool? approved = null, DateTime? responseDate = null)
+    {
+        return new AuthRequest
+        {
+            UserId = userId,
+            Type = authRequestType,
+            Approved = approved,
+            RequestDeviceIdentifier = "something", // TODO: EF Doesn't enforce this as not null
+            RequestIpAddress = "1.1.1.1", // TODO: EF Doesn't enforce this as not null
+            AccessCode = "test_access_code", // TODO: EF Doesn't enforce this as not null
+            PublicKey = "test_public_key", // TODO: EF Doesn't enforce this as not null
+            CreationDate = creationDate,
+            ResponseDate = responseDate,
+        };
+    }
+
+    private static DateTime CreateExpiredDate(TimeSpan expirationPeriod)
+    {
+        var exp = expirationPeriod + TimeSpan.FromMinutes(1);
+        return DateTime.UtcNow.Add(exp.Negate());
+    }
+}

--- a/util/Migrator/DbScripts/2023-06-27_00_AuthRequestExpirationUpdates.sql
+++ b/util/Migrator/DbScripts/2023-06-27_00_AuthRequestExpirationUpdates.sql
@@ -1,4 +1,10 @@
-﻿-- UserExpirationSeconds to 15 minutes (15 * 60)
+IF OBJECT_ID('[dbo].[AuthRequest_DeleteIfExpired]') IS NOT NULL
+    BEGIN
+        DROP PROCEDURE [dbo].[AuthRequest_DeleteIfExpired]
+    END
+GO
+
+-- UserExpirationSeconds to 15 minutes (15 * 60)
 -- AdminExpirationSeconds to 7 days (7 * 24 * 60 * 60)
 -- AdminApprovalExpirationSeconds to 12 hour (12 * 60 * 60)
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
`AuthRequestType.AdminApproval` has different rules for what is considered expired compared to the the other, existing, types. This updates the stored procedure to handle the new type as well as allow it to be configurable from settings with defaults for evolutionary database design. 


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Admin/Auth/Jobs/DeleteAuthRequestsJob.cs:** Change the call to `DeleteExpiredAsync` to include customizable settings.
* **src/Core/Settings/GlobalSettings.cs:** Add new settings for customizing expiration time periods. Will conflict with them also being added #3046 but they are in one commit that I could pick out of here or just deal with a merge request depending on what merges first.
* **src/Infrastructure.Dapper/Auth/Repositories/AuthRequestRepository.cs:** Pass in the seconds to an `int` of the `TotalSeconds` in the `TimeSpan`s. This will lose the precision of any microseconds/nanoseconds that someone could have customized but I think that is more than enough precision that someone might want for these settings.
* **src/Infrastructure.EntityFramework/Auth/Repositories/AuthRequestRepository.cs:** Update EF logic for AdminApproval type.
* **util/Migrator/DbScripts/2023-06-27_00_AuthRequestExpirationUpdates.sql:** Migration for updating the logic of `AuthRequest_DeleteIfExpired` to handle AdminApproval rules.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
