### PR TITLE
Add check for api-key on custom plan

### DIFF
--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -486,11 +486,13 @@ public class OrganizationsController : Controller
 
         if (model.Type == OrganizationApiKeyType.BillingSync || model.Type == OrganizationApiKeyType.Scim)
         {
-            // Non-enterprise orgs should not be able to create or view an apikey of billing sync/scim key types
-            var plan = StaticStore.GetPasswordManagerPlan(organization.PlanType);
-            if (plan.Product != ProductType.Enterprise)
-            {
-                throw new NotFoundException();
+            if (organization.PlanType == PlanType.Custom) {
+                // Non-enterprise orgs should not be able to create or view an apikey of billing sync/scim key types
+                var plan = StaticStore.GetPasswordManagerPlan(organization.PlanType);
+                if (plan.Product != ProductType.Enterprise)
+                {
+                    throw new NotFoundException();
+                }
             }
         }
 

--- a/src/Api/Controllers/OrganizationsController.cs
+++ b/src/Api/Controllers/OrganizationsController.cs
@@ -486,7 +486,8 @@ public class OrganizationsController : Controller
 
         if (model.Type == OrganizationApiKeyType.BillingSync || model.Type == OrganizationApiKeyType.Scim)
         {
-            if (organization.PlanType == PlanType.Custom) {
+            if (organization.PlanType == PlanType.Custom) 
+            {
                 // Non-enterprise orgs should not be able to create or view an apikey of billing sync/scim key types
                 var plan = StaticStore.GetPasswordManagerPlan(organization.PlanType);
                 if (plan.Product != ProductType.Enterprise)


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

There is a bug where custom plan users cannot access the SCIM page of the organization. It may seem like it is a 404 at first glance, but deep down it is actually due to license checking problem. Custom plan organization are implicitly enterprise based anyway.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **[OrganizationsController.cs](https://github.com/bitwarden/server/commit/70cc4e6cfe285c3226d1a356ed0cd1e183896973):** Ignore custom plan for `api-key` organization

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
