### PR TITLE
[AC-1418] Add SecretsManagerPlan property to OrganizationResponseModel

### DIFF
--- a/src/Api/Models/Response/Organizations/OrganizationResponseModel.cs
+++ b/src/Api/Models/Response/Organizations/OrganizationResponseModel.cs
@@ -27,6 +27,7 @@ public class OrganizationResponseModel : ResponseModel
         BusinessTaxNumber = organization.BusinessTaxNumber;
         BillingEmail = organization.BillingEmail;
         Plan = new PlanResponseModel(StaticStore.PasswordManagerPlans.FirstOrDefault(plan => plan.Type == organization.PlanType));
+        SecretsManagerPlan = new PlanResponseModel(StaticStore.SecretManagerPlans.FirstOrDefault(plan => plan.Type == organization.PlanType));
         PlanType = organization.PlanType;
         Seats = organization.Seats;
         MaxAutoscaleSeats = organization.MaxAutoscaleSeats;
@@ -65,6 +66,7 @@ public class OrganizationResponseModel : ResponseModel
     public string BusinessTaxNumber { get; set; }
     public string BillingEmail { get; set; }
     public PlanResponseModel Plan { get; set; }
+    public PlanResponseModel SecretsManagerPlan { get; set; }
     public PlanType PlanType { get; set; }
     public int? Seats { get; set; }
     public int? MaxAutoscaleSeats { get; set; } = null;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Add missing `SecretsManagerPlan` to the `OrganizationResponseModel` so that the SM subscription components have access to the correct SM plan details.

Fixes the issue mentioned in Clients PR: https://github.com/bitwarden/clients/pull/5661 (see [this comment](https://github.com/bitwarden/clients/pull/5661#discussion_r1244624073) for more details)

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
