### PR TITLE
[SG-497] Prevent registering health check on self hosted

### DIFF
--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -225,7 +225,7 @@ public class Startup
                 endpoints.MapHealthChecks("/healthz/extended", new HealthCheckOptions
                 {
                     ResponseWriter = HealthCheckServiceExtensions.WriteResponse
-                });   
+                });
             }
         });
 

--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -136,7 +136,10 @@ public class Startup
         services.AddCoreLocalizationServices();
 
         //health check
-        services.AddHealthChecks(globalSettings);
+        if (!globalSettings.SelfHosted)
+        {
+            services.AddHealthChecks(globalSettings);   
+        }
 
 #if OSS
         services.AddOosServices();

--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -138,7 +138,7 @@ public class Startup
         //health check
         if (!globalSettings.SelfHosted)
         {
-            services.AddHealthChecks(globalSettings);   
+            services.AddHealthChecks(globalSettings);
         }
 
 #if OSS

--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -218,12 +218,15 @@ public class Startup
         {
             endpoints.MapDefaultControllerRoute();
 
-            endpoints.MapHealthChecks("/healthz");
-
-            endpoints.MapHealthChecks("/healthz/extended", new HealthCheckOptions
+            if (!globalSettings.SelfHosted)
             {
-                ResponseWriter = HealthCheckServiceExtensions.WriteResponse
-            });
+                endpoints.MapHealthChecks("/healthz");
+
+                endpoints.MapHealthChecks("/healthz/extended", new HealthCheckOptions
+                {
+                    ResponseWriter = HealthCheckServiceExtensions.WriteResponse
+                });   
+            }
         });
 
         // Add Swagger

--- a/src/Api/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Api/Utilities/ServiceCollectionExtensions.cs
@@ -80,7 +80,7 @@ public static class ServiceCollectionExtensions
                                       + "/.well-known/openid-configuration");
 
             builder.AddUrlGroup(identityUri, "identity");
-    
+
             if (CoreHelpers.SettingHasValue(globalSettings.SqlServer.ConnectionString))
             {
                 builder.AddSqlServer(globalSettings.SqlServer.ConnectionString);

--- a/src/Api/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Api/Utilities/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Core.IdentityServer;
 using Bit.Core.Settings;
+using Bit.Core.Utilities;
 using Bit.SharedWeb.Health;
 using Microsoft.OpenApi.Models;
 
@@ -79,36 +80,36 @@ public static class ServiceCollectionExtensions
                                       + "/.well-known/openid-configuration");
 
             builder.AddUrlGroup(identityUri, "identity");
-
-            if (!string.IsNullOrEmpty(globalSettings.SqlServer.ConnectionString))
+    
+            if (CoreHelpers.SettingHasValue(globalSettings.SqlServer.ConnectionString))
             {
                 builder.AddSqlServer(globalSettings.SqlServer.ConnectionString);
             }
 
-            if (!string.IsNullOrEmpty(globalSettings.Redis.ConnectionString))
+            if (CoreHelpers.SettingHasValue(globalSettings.Redis.ConnectionString))
             {
                 builder.AddRedis(globalSettings.Redis.ConnectionString);
             }
 
-            if (!string.IsNullOrEmpty(globalSettings.Storage.ConnectionString))
+            if (CoreHelpers.SettingHasValue(globalSettings.Storage.ConnectionString))
             {
                 builder.AddAzureQueueStorage(globalSettings.Storage.ConnectionString, name: "storage_queue")
                     .AddAzureQueueStorage(globalSettings.Events.ConnectionString, name: "events_queue");
             }
 
-            if (!string.IsNullOrEmpty(globalSettings.Notifications.ConnectionString))
+            if (CoreHelpers.SettingHasValue(globalSettings.Notifications.ConnectionString))
             {
                 builder.AddAzureQueueStorage(globalSettings.Notifications.ConnectionString,
                     name: "notifications_queue");
             }
 
-            if (!string.IsNullOrEmpty(globalSettings.ServiceBus.ConnectionString))
+            if (CoreHelpers.SettingHasValue(globalSettings.ServiceBus.ConnectionString))
             {
                 builder.AddAzureServiceBusTopic(_ => globalSettings.ServiceBus.ConnectionString,
                     _ => globalSettings.ServiceBus.ApplicationCacheTopicName, name: "service_bus");
             }
 
-            if (!string.IsNullOrEmpty(globalSettings.Mail.SendGridApiKey))
+            if (CoreHelpers.SettingHasValue(globalSettings.Mail.SendGridApiKey))
             {
                 builder.AddSendGrid(globalSettings.Mail.SendGridApiKey);
             }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Due to ongoing discussions, it would make sense not to allow the health check endpoint on `self-hosted`.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->
I've updated the health checks to not register when the application is self-hosted. Additionally, I replaced the usage of `string.IsNullOrEmpty` with `CoreHelpers.SettingHasValue` for a more reliable way to check if a setting has been provided.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
