### PR TITLE
[PM-1381] Add Trusted Device Keys to Auth Response

### DIFF
--- a/src/Core/Auth/Models/Api/Response/UserDecryptionOptions.cs
+++ b/src/Core/Auth/Models/Api/Response/UserDecryptionOptions.cs
@@ -32,13 +32,13 @@ public class UserDecryptionOptions : ResponseModel
 public class TrustedDeviceUserDecryptionOption
 {
     public bool HasAdminApproval { get; }
-    public string? EncryptedPublicKey { get; }
+    public string? EncryptedPrivateKey { get; }
     public string? EncryptedUserKey { get; }
 
-    public TrustedDeviceUserDecryptionOption(bool hasAdminApproval, string? encryptedPublicKey, string? encryptedUserKey)
+    public TrustedDeviceUserDecryptionOption(bool hasAdminApproval, string? encryptedPrivateKey, string? encryptedUserKey)
     {
         HasAdminApproval = hasAdminApproval;
-        EncryptedPublicKey = encryptedPublicKey;
+        EncryptedPrivateKey = encryptedPrivateKey;
         EncryptedUserKey = encryptedUserKey;
     }
 }

--- a/src/Core/Auth/Models/Api/Response/UserDecryptionOptions.cs
+++ b/src/Core/Auth/Models/Api/Response/UserDecryptionOptions.cs
@@ -32,10 +32,14 @@ public class UserDecryptionOptions : ResponseModel
 public class TrustedDeviceUserDecryptionOption
 {
     public bool HasAdminApproval { get; }
+    public string? EncryptedPublicKey { get; }
+    public string? EncryptedUserKey { get; }
 
-    public TrustedDeviceUserDecryptionOption(bool hasAdminApproval)
+    public TrustedDeviceUserDecryptionOption(bool hasAdminApproval, string? encryptedPublicKey, string? encryptedUserKey)
     {
         HasAdminApproval = hasAdminApproval;
+        EncryptedPublicKey = encryptedPublicKey;
+        EncryptedUserKey = encryptedUserKey;
     }
 }
 

--- a/src/Core/Auth/Utilities/DeviceExtensions.cs
+++ b/src/Core/Auth/Utilities/DeviceExtensions.cs
@@ -9,6 +9,11 @@ public static class DeviceExtensions
     /// <summary>
     /// Gets a boolean representing if the device has enough information on it to determine whether or not it is trusted.
     /// </summary>
+    /// <remarks>
+    /// It is possible for a device to be un-trusted client side and not notify the server side. This should not be
+    /// the source of truth for whether a device is fully trusted and should just be considered that, to the server,
+    /// a device has the necessary information to be "trusted".
+    /// </remarks>
     public static bool IsTrusted(this Device device)
     {
         return !string.IsNullOrEmpty(device.EncryptedUserKey) &&

--- a/src/Core/Auth/Utilities/DeviceExtensions.cs
+++ b/src/Core/Auth/Utilities/DeviceExtensions.cs
@@ -1,0 +1,18 @@
+using Bit.Core.Entities;
+
+#nullable enable
+
+namespace Bit.Core.Auth.Utilities;
+
+public static class DeviceExtensions
+{
+    /// <summary>
+    /// Gets a boolean representing if the device has enough information on it to determine whether or not it is trusted.
+    /// </summary>
+    public static bool IsTrusted(this Device device)
+    {
+        return !string.IsNullOrEmpty(device.EncryptedUserKey) &&
+            !string.IsNullOrEmpty(device.EncryptedPublicKey) &&
+            !string.IsNullOrEmpty(device.EncryptedPrivateKey);
+    }
+}

--- a/src/Core/Auth/Utilities/DeviceExtensions.cs
+++ b/src/Core/Auth/Utilities/DeviceExtensions.cs
@@ -1,4 +1,4 @@
-using Bit.Core.Entities;
+﻿using Bit.Core.Entities;
 
 #nullable enable
 

--- a/src/Identity/IdentityServer/BaseRequestValidator.cs
+++ b/src/Identity/IdentityServer/BaseRequestValidator.cs
@@ -607,17 +607,17 @@ public abstract class BaseRequestValidator<T> where T : class
         // Only add the trusted device specific option when the flag is turned on
         if (FeatureService.IsEnabled(FeatureFlagKeys.TrustedDeviceEncryption, CurrentContext) && ssoConfigurationData is { MemberDecryptionType: MemberDecryptionType.TrustedDeviceEncryption })
         {
-            string? encryptedPublicKey = null;
+            string? encryptedPrivateKey = null;
             string? encryptedUserKey = null;
             if (device.IsTrusted())
             {
-                encryptedPublicKey = device.EncryptedPublicKey;
+                encryptedPrivateKey = device.EncryptedPrivateKey;
                 encryptedUserKey = device.EncryptedUserKey;
             }
             var hasAdminApproval = await PolicyService.AnyPoliciesApplicableToUserAsync(user.Id, PolicyType.ResetPassword);
             // TrustedDeviceEncryption only exists for SSO, but if that ever changes this value won't always be true
             userDecryptionOption.TrustedDeviceOption = new TrustedDeviceUserDecryptionOption(hasAdminApproval,
-                encryptedPublicKey, encryptedUserKey);
+                encryptedPrivateKey, encryptedUserKey);
         }
 
         return userDecryptionOption;

--- a/test/Identity.IntegrationTest/Endpoints/IdentityServerSsoTests.cs
+++ b/test/Identity.IntegrationTest/Endpoints/IdentityServerSsoTests.cs
@@ -243,6 +243,11 @@ public class IdentityServerSsoTests
 
         var trustedDeviceOption = AssertHelper.AssertJsonProperty(userDecryptionOptions, "TrustedDeviceOption", JsonValueKind.Object);
         AssertHelper.AssertJsonProperty(trustedDeviceOption, "HasAdminApproval", JsonValueKind.False);
+
+        // This asserts that device keys are not coming back in the response because this should be a new device.
+        // if we ever add new properties that come back from here it is fine to change the expected number of properties
+        // but it should still be asserted in some way that keys are not amongst them.
+        Assert.Single(trustedDeviceOption.EnumerateObject());
     }
 
     /// <summary>
@@ -267,7 +272,7 @@ public class IdentityServerSsoTests
 
         var user = await factory.Services.GetRequiredService<IUserRepository>().GetByEmailAsync(TestEmail);
 
-        const string expectedPublicKey = "2.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA==";
+        const string expectedPrivateKey = "2.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA==";
         const string expectedUserKey = "2.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA==";
 
         var device = await deviceRepository.CreateAsync(new Device
@@ -276,8 +281,8 @@ public class IdentityServerSsoTests
             Identifier = deviceIdentifier,
             Name = "Thing",
             UserId = user.Id,
-            EncryptedPrivateKey = "2.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA==",
-            EncryptedPublicKey = expectedPublicKey,
+            EncryptedPrivateKey = expectedPrivateKey,
+            EncryptedPublicKey = "2.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA==",
             EncryptedUserKey = expectedUserKey,
         });
 
@@ -313,7 +318,7 @@ public class IdentityServerSsoTests
         //   "HasMasterPassword": false,
         //   "TrustedDeviceOption": {
         //     "HasAdminApproval": true,
-        //     "EncryptedPublicKey": "2.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA==",
+        //     "EncryptedPrivateKey": "2.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA==",
         //     "EncryptedUserKey": "2.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA=="
         //   }
         // }
@@ -321,8 +326,8 @@ public class IdentityServerSsoTests
         var trustedDeviceOption = AssertHelper.AssertJsonProperty(userDecryptionOptions, "TrustedDeviceOption", JsonValueKind.Object);
         AssertHelper.AssertJsonProperty(trustedDeviceOption, "HasAdminApproval", JsonValueKind.False);
 
-        var actualPublickKey = AssertHelper.AssertJsonProperty(trustedDeviceOption, "EncryptedPublicKey", JsonValueKind.String).GetString();
-        Assert.Equal(expectedPublicKey, actualPublickKey);
+        var actualPrivateKey = AssertHelper.AssertJsonProperty(trustedDeviceOption, "EncryptedPrivateKey", JsonValueKind.String).GetString();
+        Assert.Equal(expectedPrivateKey, actualPrivateKey);
         var actualUserKey = AssertHelper.AssertJsonProperty(trustedDeviceOption, "EncryptedUserKey", JsonValueKind.String).GetString();
         Assert.Equal(expectedUserKey, actualUserKey);
     }

--- a/test/Identity.IntegrationTest/Endpoints/IdentityServerSsoTests.cs
+++ b/test/Identity.IntegrationTest/Endpoints/IdentityServerSsoTests.cs
@@ -245,6 +245,88 @@ public class IdentityServerSsoTests
         AssertHelper.AssertJsonProperty(trustedDeviceOption, "HasAdminApproval", JsonValueKind.False);
     }
 
+    /// <summary>
+    /// Story: When a user signs in with SSO on a device they have already signed in with we need to return the keys
+    /// back to them for the current device if it has been trusted before.
+    /// </summary>
+    [Fact]
+    public async Task SsoLogin_TrustedDeviceEncryptionAndNoMasterPassword_DeviceAlreadyTrusted_ReturnsOneOption()
+    {
+        // Arrange
+        var challenge = new string('c', 50);
+        var factory = await CreateFactoryAsync(new SsoConfigurationData
+        {
+            MemberDecryptionType = MemberDecryptionType.TrustedDeviceEncryption,
+        }, challenge);
+
+        await UpdateUserAsync(factory, user => user.MasterPassword = null);
+
+        var deviceRepository = factory.Services.GetRequiredService<IDeviceRepository>();
+
+        var deviceIdentifier = $"test_id_{Guid.NewGuid()}";
+
+        var user = await factory.Services.GetRequiredService<IUserRepository>().GetByEmailAsync(TestEmail);
+
+        const string expectedPublicKey = "2.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA==";
+        const string expectedUserKey = "2.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA==";
+
+        var device = await deviceRepository.CreateAsync(new Device
+        {
+            Type = DeviceType.FirefoxBrowser,
+            Identifier = deviceIdentifier,
+            Name = "Thing",
+            UserId = user.Id,
+            EncryptedPrivateKey = "2.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA==",
+            EncryptedPublicKey = expectedPublicKey,
+            EncryptedUserKey = expectedUserKey,
+        });
+
+        // Act
+        var context = await factory.Server.PostAsync("/connect/token", new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            { "scope", "api offline_access" },
+            { "client_id", "web" },
+            { "deviceType", "10" },
+            { "deviceIdentifier", deviceIdentifier },
+            { "deviceName", "firefox" },
+            { "twoFactorToken", "TEST"},
+            { "twoFactorProvider", "5" }, // RememberMe Provider
+            { "twoFactorRemember", "0" },
+            { "grant_type", "authorization_code" },
+            { "code", "test_code" },
+            { "code_verifier", challenge },
+            { "redirect_uri", "https://localhost:8080/sso-connector.html" }
+        }));
+
+        // Assert
+        // If the organization has selected TrustedDeviceEncryption but the user still has their master password
+        // they can decrypt with either option
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        using var responseBody = await AssertHelper.AssertResponseTypeIs<JsonDocument>(context);
+        var root = responseBody.RootElement;
+        AssertHelper.AssertJsonProperty(root, "access_token", JsonValueKind.String);
+        var userDecryptionOptions = AssertHelper.AssertJsonProperty(root, "UserDecryptionOptions", JsonValueKind.Object);
+
+        // Expected to look like:
+        // "UserDecryptionOptions": {
+        //   "Object": "userDecryptionOptions"
+        //   "HasMasterPassword": false,
+        //   "TrustedDeviceOption": {
+        //     "HasAdminApproval": true,
+        //     "EncryptedPublicKey": "2.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA==",
+        //     "EncryptedUserKey": "2.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA=="
+        //   }
+        // }
+
+        var trustedDeviceOption = AssertHelper.AssertJsonProperty(userDecryptionOptions, "TrustedDeviceOption", JsonValueKind.Object);
+        AssertHelper.AssertJsonProperty(trustedDeviceOption, "HasAdminApproval", JsonValueKind.False);
+
+        var actualPublickKey = AssertHelper.AssertJsonProperty(trustedDeviceOption, "EncryptedPublicKey", JsonValueKind.String).GetString();
+        Assert.Equal(expectedPublicKey, actualPublickKey);
+        var actualUserKey = AssertHelper.AssertJsonProperty(trustedDeviceOption, "EncryptedUserKey", JsonValueKind.String).GetString();
+        Assert.Equal(expectedUserKey, actualUserKey);
+    }
+
     [Fact]
     public async Task SsoLogin_TrustedDeviceEncryption_FlagTurnedOff_DoesNotReturnOption()
     {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add the keys from a device when a user is logging in on a device that has previously been trusted.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/Auth/Models/Api/Response/UserDecryptionOptions.cs:** Create optional properties for the `EncryptedPublicKey` & `EncryptedUserKey` for when the device being signed into has been trusted. They will be `null` when the device signing in has not been trusted yet.
* **src/Core/Auth/Utilities/DeviceExtensions.cs:** Added an extension method for determining if a device contains the necessary values to consider itself trusted (as far as the server knows). I put it in an extension method so that Auth team can own the logic of what that means without needing to own the full device.
* **src/Identity/IdentityServer/BaseRequestValidator.cs:** Pass `Device` into `CreateUserDecryptionOptionsAsync` so that I can test whether or not it's trusted and if it is pass along the needed details so that the requester can continue trying to decrypt their vault.
* **test/Identity.IntegrationTest/Endpoints/IdentityServerSsoTests.cs:** Added a test validating that when a device is trusted it will respond with the needed keys.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
