### PR TITLE
[AC-1438] Updated SCIM controllers to respond with "content-Type: application/scim+json"

### DIFF
--- a/bitwarden_license/src/Scim/Controllers/v2/GroupsController.cs
+++ b/bitwarden_license/src/Scim/Controllers/v2/GroupsController.cs
@@ -12,6 +12,7 @@ namespace Bit.Scim.Controllers.v2;
 
 [Authorize("Scim")]
 [Route("v2/{organizationId}/groups")]
+[Produces("application/scim+json")]
 [ExceptionHandlerFilter]
 public class GroupsController : Controller
 {

--- a/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
+++ b/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
@@ -13,6 +13,7 @@ namespace Bit.Scim.Controllers.v2;
 
 [Authorize("Scim")]
 [Route("v2/{organizationId}/users")]
+[Produces("application/scim+json")]
 [ExceptionHandlerFilter]
 public class UsersController : Controller
 {

--- a/bitwarden_license/test/Scim.IntegrationTest/Controllers/v2/GroupsControllerTests.cs
+++ b/bitwarden_license/test/Scim.IntegrationTest/Controllers/v2/GroupsControllerTests.cs
@@ -48,6 +48,8 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
 
         var responseModel = JsonSerializer.Deserialize<ScimGroupResponseModel>(context.Response.Body, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
         AssertHelper.AssertPropertyEqual(expectedResponse, responseModel);
+
+        Assert.Contains("application/scim+json", context.Response.Headers.ContentType.ToString());
     }
 
     [Fact]

--- a/bitwarden_license/test/Scim.IntegrationTest/Controllers/v2/UsersControllerTests.cs
+++ b/bitwarden_license/test/Scim.IntegrationTest/Controllers/v2/UsersControllerTests.cs
@@ -55,6 +55,8 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
 
         var responseModel = JsonSerializer.Deserialize<ScimUserResponseModel>(context.Response.Body, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
         AssertHelper.AssertPropertyEqual(expectedResponse, responseModel);
+
+        Assert.Contains("application/scim+json", context.Response.Headers.ContentType.ToString());
     }
 
     [Fact]


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective
Microsoft reviewed our integration and provided the following feedback, as it is a requirement to add our integration to their catalog.

The `content-Type: application/scim+json` should be in the response header of all of our SCIM responses.


## Code changes

* **bitwarden_license/src/Scim/Controllers/v2/GroupsController.cs:** Added `content-Type: application/scim+json` to responses
* **bitwarden_license/src/Scim/Controllers/v2/UsersController.cs:** Added `content-Type: application/scim+json` to responses
* **bitwarden_license/test/Scim.IntegrationTest/Controllers/v2/GroupsControllerTests.cs:** Asserting the response content type
* **bitwarden_license/test/Scim.IntegrationTest/Controllers/v2/UsersControllerTests.cs:** Asserting the response content type

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
