### PR TITLE
[AC-1435] Single Organization policy prerequisite for Account Recovery policy

### DIFF
--- a/src/Core/Auth/Services/Implementations/SsoConfigService.cs
+++ b/src/Core/Auth/Services/Implementations/SsoConfigService.cs
@@ -63,9 +63,16 @@ public class SsoConfigService : ISsoConfigService
             throw new BadRequestException("Key Connector cannot be disabled at this moment.");
         }
 
-        // Automatically enable reset password policy if trusted device encryption is selected
+        // Automatically enable account recovery and single org policies if trusted device encryption is selected
         if (config.GetData().MemberDecryptionType == MemberDecryptionType.TrustedDeviceEncryption)
         {
+            var singleOrgPolicy = await _policyRepository.GetByOrganizationIdTypeAsync(config.OrganizationId, PolicyType.SingleOrg) ??
+                                  new Policy { OrganizationId = config.OrganizationId, Type = PolicyType.SingleOrg };
+
+            singleOrgPolicy.Enabled = true;
+
+            await _policyService.SaveAsync(singleOrgPolicy, _userService, _organizationService, null);
+
             var resetPolicy = await _policyRepository.GetByOrganizationIdTypeAsync(config.OrganizationId, PolicyType.ResetPassword) ??
                               new Policy { OrganizationId = config.OrganizationId, Type = PolicyType.ResetPassword, };
 

--- a/src/Core/Services/Implementations/PolicyService.cs
+++ b/src/Core/Services/Implementations/PolicyService.cs
@@ -61,6 +61,7 @@ public class PolicyService : IPolicyService
                     await RequiredBySsoAsync(org);
                     await RequiredByVaultTimeoutAsync(org);
                     await RequiredByKeyConnectorAsync(org);
+                    await RequiredByAccountRecoveryAsync(org);
                 }
                 break;
 
@@ -241,6 +242,15 @@ public class PolicyService : IPolicyService
         if (ssoConfig?.GetData()?.MemberDecryptionType == MemberDecryptionType.KeyConnector)
         {
             throw new BadRequestException("Key Connector is enabled.");
+        }
+    }
+
+    private async Task RequiredByAccountRecoveryAsync(Organization org)
+    {
+        var requireSso = await _policyRepository.GetByOrganizationIdTypeAsync(org.Id, PolicyType.ResetPassword);
+        if (requireSso?.Enabled == true)
+        {
+            throw new BadRequestException("Account recovery policy is enabled.");
         }
     }
 

--- a/src/Core/Services/Implementations/PolicyService.cs
+++ b/src/Core/Services/Implementations/PolicyService.cs
@@ -81,6 +81,11 @@ public class PolicyService : IPolicyService
                 {
                     await RequiredBySsoTrustedDeviceEncryptionAsync(org);
                 }
+
+                if (policy.Enabled)
+                {
+                    await DependsOnSingleOrgAsync(org);
+                }
                 break;
 
             case PolicyType.MaximumVaultTimeout:

--- a/test/Core.Test/Services/PolicyServiceTests.cs
+++ b/test/Core.Test/Services/PolicyServiceTests.cs
@@ -217,6 +217,10 @@ public class PolicyServiceTests
             UsePolicies = true,
         });
 
+        sutProvider.GetDependency<IPolicyRepository>()
+            .GetByOrganizationIdTypeAsync(policy.OrganizationId, Enums.PolicyType.SingleOrg)
+            .Returns(Task.FromResult(new Policy { Enabled = true }));
+
         var utcNow = DateTime.UtcNow;
 
         await sutProvider.Sut.SaveAsync(policy, Substitute.For<IUserService>(), Substitute.For<IOrganizationService>(), Guid.NewGuid());


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Make the Single Organization policy a prerequisite for the Account Recovery policy and by extension Trusted Device Encryption.

See related copy/UI changes in Clients repo: https://github.com/bitwarden/clients/pull/5774

## Code changes

- **src/Core/Auth/Services/Implementations/SsoConfigService.cs:** Whenever TDE is enabled, automatically turn on the Single Organization policy.
- **src/Core/Services/Implementations/PolicyService.cs:** Add new dependency checks when modifying the Single Org and/or Account Recovery policies.
- **SsoConfigServiceTests and PolicyServiceTests:** Add unit tests to ensure desired functionality
## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
