### PR TITLE
[AC-1487] Fix missing Admin Auth Request emails

### DIFF
--- a/src/Sql/Auth/dbo/Stored Procedures/AuthRequest_ReadAdminApprovalsByIds.sql
+++ b/src/Sql/Auth/dbo/Stored Procedures/AuthRequest_ReadAdminApprovalsByIds.sql
@@ -6,11 +6,13 @@ BEGIN
     SET NOCOUNT ON
 
 SELECT
-    ar.*, ou.[Email], ou.[Id] AS [OrganizationUserId]
+    ar.*, u.[Email], ou.[Id] AS [OrganizationUserId]
 FROM
     [dbo].[AuthRequestView] ar
     INNER JOIN
         [dbo].[OrganizationUser] ou ON ou.[UserId] = ar.[UserId] AND ou.[OrganizationId] = ar.[OrganizationId]
+    INNER JOIN
+        [dbo].[User] u ON u.[Id] = ar.[UserId]
     WHERE
         ar.[OrganizationId] = @OrganizationId
     AND

--- a/src/Sql/Auth/dbo/Stored Procedures/AuthRequest_ReadPendingByOrganizationId.sql
+++ b/src/Sql/Auth/dbo/Stored Procedures/AuthRequest_ReadPendingByOrganizationId.sql
@@ -5,11 +5,13 @@ BEGIN
     SET NOCOUNT ON
 
 SELECT
-    ar.*, ou.[Email], ou.[OrganizationId], ou.[Id] AS [OrganizationUserId]
+    ar.*, u.[Email], ou.[Id] AS [OrganizationUserId]
 FROM
     [dbo].[AuthRequestView] ar
     INNER JOIN
         [dbo].[OrganizationUser] ou ON ou.[UserId] = ar.[UserId] AND ou.[OrganizationId] = ar.[OrganizationId]
+    INNER JOIN
+        [dbo].[User] u ON u.[Id] = ar.[UserId]
     WHERE
         ar.[OrganizationId] = @OrganizationId 
     AND 

--- a/util/Migrator/DbScripts/2023-07-10_00_FixTdeAdminApprovalEmail.sql
+++ b/util/Migrator/DbScripts/2023-07-10_00_FixTdeAdminApprovalEmail.sql
@@ -1,0 +1,46 @@
+CREATE OR ALTER PROCEDURE [dbo].[AuthRequest_ReadAdminApprovalsByIds]
+	@OrganizationId UNIQUEIDENTIFIER,
+	@Ids AS [dbo].[GuidIdArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+SELECT
+    ar.*, u.[Email], ou.[Id] AS [OrganizationUserId]
+FROM
+    [dbo].[AuthRequestView] ar
+    INNER JOIN
+        [dbo].[OrganizationUser] ou ON ou.[UserId] = ar.[UserId] AND ou.[OrganizationId] = ar.[OrganizationId]
+    INNER JOIN
+        [dbo].[User] u ON u.[Id] = ar.[UserId]
+    WHERE
+        ar.[OrganizationId] = @OrganizationId
+    AND
+        ar.[Type] = 2 -- AdminApproval
+    AND
+        ar.[Id] IN (SELECT [Id] FROM @Ids)
+END
+GO
+
+CREATE OR ALTER PROCEDURE [dbo].[AuthRequest_ReadPendingByOrganizationId]
+    @OrganizationId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+SELECT
+    ar.*, u.[Email], ou.[Id] AS [OrganizationUserId]
+FROM
+    [dbo].[AuthRequestView] ar
+    INNER JOIN
+        [dbo].[OrganizationUser] ou ON ou.[UserId] = ar.[UserId] AND ou.[OrganizationId] = ar.[OrganizationId]
+    INNER JOIN
+        [dbo].[User] u ON u.[Id] = ar.[UserId]
+    WHERE
+        ar.[OrganizationId] = @OrganizationId 
+    AND 
+        ar.[ResponseDate] IS NULL
+    AND
+        ar.[Type] = 2 -- AdminApproval
+END
+GO


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Update the TDE admin auth request SQL queries to use the `[User]` table for the email address instead of the `[OrganizationUser]` table, which does not always have an email available.


## Code changes

Update the `AuthRequest_ReadAdminApprovalsbyIds.sql` and `AuthRequest_ReadPendingByOrganizationId.sql` scripts to join on the `[User]` table in order to retrieve the user's email address.

Also adds the necessary migration script.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
