### PR TITLE
[AC-1504] Allow SM max autoscale limits to be disabled

### DIFF
--- a/src/Api/Models/Request/Organizations/SecretsManagerSubscriptionUpdateRequestModel.cs
+++ b/src/Api/Models/Request/Organizations/SecretsManagerSubscriptionUpdateRequestModel.cs
@@ -17,11 +17,6 @@ public class SecretsManagerSubscriptionUpdateRequestModel
     {
         var newTotalSeats = organization.SmSeats.GetValueOrDefault() + SeatAdjustment;
         var newTotalServiceAccounts = organization.SmServiceAccounts.GetValueOrDefault() + ServiceAccountAdjustment;
-        var autoscaleSeats = MaxAutoscaleSeats.HasValue && MaxAutoscaleSeats !=
-                             organization.MaxAutoscaleSmSeats.GetValueOrDefault();
-        var autoscaleServiceAccounts = MaxAutoscaleServiceAccounts.HasValue &&
-                                       MaxAutoscaleServiceAccounts !=
-                                       organization.MaxAutoscaleSmServiceAccounts.GetValueOrDefault();
 
         var orgUpdate = new SecretsManagerSubscriptionUpdate
         {
@@ -39,8 +34,10 @@ public class SecretsManagerSubscriptionUpdateRequestModel
 
             MaxAutoscaleSmServiceAccounts = MaxAutoscaleServiceAccounts,
 
-            MaxAutoscaleSmSeatsChanged = autoscaleSeats,
-            MaxAutoscaleSmServiceAccountsChanged = autoscaleServiceAccounts
+            MaxAutoscaleSmSeatsChanged = 
+                MaxAutoscaleSeats.GetValueOrDefault() != organization.MaxAutoscaleSmSeats.GetValueOrDefault(),
+            MaxAutoscaleSmServiceAccountsChanged = 
+                MaxAutoscaleServiceAccounts.GetValueOrDefault() != organization.MaxAutoscaleSmServiceAccounts.GetValueOrDefault()
         };
 
         return orgUpdate;

--- a/src/Api/Models/Request/Organizations/SecretsManagerSubscriptionUpdateRequestModel.cs
+++ b/src/Api/Models/Request/Organizations/SecretsManagerSubscriptionUpdateRequestModel.cs
@@ -34,9 +34,9 @@ public class SecretsManagerSubscriptionUpdateRequestModel
 
             MaxAutoscaleSmServiceAccounts = MaxAutoscaleServiceAccounts,
 
-            MaxAutoscaleSmSeatsChanged = 
+            MaxAutoscaleSmSeatsChanged =
                 MaxAutoscaleSeats.GetValueOrDefault() != organization.MaxAutoscaleSmSeats.GetValueOrDefault(),
-            MaxAutoscaleSmServiceAccountsChanged = 
+            MaxAutoscaleSmServiceAccountsChanged =
                 MaxAutoscaleServiceAccounts.GetValueOrDefault() != organization.MaxAutoscaleSmServiceAccounts.GetValueOrDefault()
         };
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Server code was not allowing a `null` value for the max autoscale limits. We need to allow this because `null` indicates that autoscale limits have been disabled, which is a valid state.

Goes with https://github.com/bitwarden/clients/pull/5781

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
