### PR TITLE
[AC-1488] Store service account max as total not additional

### DIFF
--- a/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs
@@ -268,7 +268,7 @@ public class UpgradeOrganizationPlanCommand : IUpgradeOrganizationPlanCommand
         organization.PrivateKey = upgrade.PrivateKey;
         organization.UsePasswordManager = true;
         organization.SmSeats = (short)(newSecretsManagerPlan.BaseSeats + upgrade.AdditionalSmSeats.GetValueOrDefault());
-        organization.SmServiceAccounts = upgrade.AdditionalServiceAccounts.GetValueOrDefault();
+        organization.SmServiceAccounts = newSecretsManagerPlan.BaseServiceAccount + upgrade.AdditionalServiceAccounts.GetValueOrDefault();
         organization.UseSecretsManager = upgrade.UseSecretsManager;
 
         await _organizationService.ReplaceAndUpdateCacheAsync(organization);

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -447,7 +447,7 @@ public class OrganizationService : IOrganizationService
             Status = OrganizationStatusType.Created,
             UsePasswordManager = true,
             SmSeats = (short)(secretsManagerPlan.BaseSeats + signup.AdditionalSmSeats.GetValueOrDefault()),
-            SmServiceAccounts = signup.AdditionalServiceAccounts.GetValueOrDefault(),
+            SmServiceAccounts = secretsManagerPlan.BaseServiceAccount + signup.AdditionalServiceAccounts.GetValueOrDefault(),
             UseSecretsManager = signup.UseSecretsManager
         };
 


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The service account field was storing just the additional value and this PR changes it to include the plans BaseServiceAccount value.


## Code changes
 - **src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs:** Added the value from the plans BaseServiceAccount
 - **src/Core/Services/Implementations/OrganizationService.cs:** Added the value from the plans BaseServiceAccount
 - **test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/UpdateSecretsManagerSubscriptionCommandTests.cs:** Testing that the value in SmServiceAccounts is incremented
 - **test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/UpgradeOrganizationPlanCommandTests.cs:** esting that the value in SmServiceAccounts is incremented and includes the BaseServiceAccount from the plan - **test/Core.Test/Services/OrganizationServiceTests.cs:** Testing that the value in SmServiceAccounts is incremented and includes the BaseServiceAccount from the plan

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
