### PR TITLE
[AC-1510] Enable access to Secrets Manager to Organization owner for new Subscription

### DIFF
--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -604,6 +604,7 @@ public class OrganizationService : IOrganizationService
                     OrganizationId = organization.Id,
                     UserId = ownerId,
                     Key = ownerKey,
+                    AccessSecretsManager = organization.UseSecretsManager,
                     Type = OrganizationUserType.Owner,
                     Status = OrganizationUserStatusType.Confirmed,
                     AccessAll = true,

--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -174,10 +174,8 @@ public class OrganizationServiceTests
                 o.Seats == passwordManagerPlan.BaseSeats + signup.AdditionalSeats
                 && o.SmSeats == secretsManagerPlan.BaseSeats + signup.AdditionalSmSeats
                 && o.SmServiceAccounts == secretsManagerPlan.BaseServiceAccount + signup.AdditionalServiceAccounts));
-
         await sutProvider.GetDependency<IOrganizationUserRepository>().Received(1).CreateAsync(
-            Arg.Is<OrganizationUser>(o =>
-                o.AccessSecretsManager == signup.UseSecretsManager));
+            Arg.Is<OrganizationUser>(o => o.AccessSecretsManager == signup.UseSecretsManager));
 
         await sutProvider.GetDependency<IReferenceEventService>().Received(1)
             .RaiseEventAsync(Arg.Is<ReferenceEvent>(referenceEvent =>

--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -174,7 +174,7 @@ public class OrganizationServiceTests
                 o.Seats == passwordManagerPlan.BaseSeats + signup.AdditionalSeats
                 && o.SmSeats == secretsManagerPlan.BaseSeats + signup.AdditionalSmSeats
                 && o.SmServiceAccounts == secretsManagerPlan.BaseServiceAccount + signup.AdditionalServiceAccounts));
-        
+
         await sutProvider.GetDependency<IOrganizationUserRepository>().Received(1).CreateAsync(
             Arg.Is<OrganizationUser>(o =>
                 o.AccessSecretsManager == signup.UseSecretsManager));

--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -174,6 +174,10 @@ public class OrganizationServiceTests
                 o.Seats == passwordManagerPlan.BaseSeats + signup.AdditionalSeats
                 && o.SmSeats == secretsManagerPlan.BaseSeats + signup.AdditionalSmSeats
                 && o.SmServiceAccounts == secretsManagerPlan.BaseServiceAccount + signup.AdditionalServiceAccounts));
+        
+        await sutProvider.GetDependency<IOrganizationUserRepository>().Received(1).CreateAsync(
+            Arg.Is<OrganizationUser>(o =>
+                o.AccessSecretsManager == signup.UseSecretsManager));
 
         await sutProvider.GetDependency<IReferenceEventService>().Received(1)
             .RaiseEventAsync(Arg.Is<ReferenceEvent>(referenceEvent =>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Enable or Disable AccessSecretsManager owner user base on the value of UseSecretsManager


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/Services/Implementations/OrganizationService.cs:**  set the AccessSecretsManager owner user during subscription base on UseSecretsManager value

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
