### PR TITLE
Revert changes to ReferenceEvent code

### DIFF
--- a/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs
@@ -284,9 +284,7 @@ public class UpgradeOrganizationPlanCommand : IUpgradeOrganizationPlanCommand
                     OldPlanType = existingPasswordManagerPlan.Type,
                     Seats = organization.Seats,
                     Storage = organization.MaxStorageGb,
-                    SmSeats = organization.SmSeats,
-                    ServiceAccounts = organization.SmServiceAccounts,
-                    UseSecretsManager = organization.UseSecretsManager
+                    // TODO: add reference events for SmSeats and Service Accounts - see AC-1481
                 });
         }
 

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -481,9 +481,7 @@ public class OrganizationService : IOrganizationService
                 PlanType = passwordManagerPlan.Type,
                 Seats = returnValue.Item1.Seats,
                 Storage = returnValue.Item1.MaxStorageGb,
-                SmSeats = returnValue.Item1.SmSeats,
-                ServiceAccounts = returnValue.Item1.SmServiceAccounts,
-                UseSecretsManager = returnValue.Item1.UseSecretsManager
+                // TODO: add reference events for SmSeats and Service Accounts - see AC-1481
             });
         return returnValue;
     }

--- a/src/Core/Tools/Models/Business/ReferenceEvent.cs
+++ b/src/Core/Tools/Models/Business/ReferenceEvent.cs
@@ -52,7 +52,6 @@ public class ReferenceEvent
 
     public int? Seats { get; set; }
     public int? PreviousSeats { get; set; }
-    public int? PreviousServiceAccounts { get; set; }
 
     public short? Storage { get; set; }
 
@@ -71,7 +70,4 @@ public class ReferenceEvent
 
     public string ClientId { get; set; }
     public Version ClientVersion { get; set; }
-    public int? SmSeats { get; set; }
-    public int? ServiceAccounts { get; set; }
-    public bool UseSecretsManager { get; set; }
 }

--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -184,7 +184,7 @@ public class OrganizationServiceTests
                 referenceEvent.PlanType == purchaseOrganizationPlan[0].Type &&
                 referenceEvent.Seats == result.Item1.Seats &&
                 referenceEvent.Storage == result.Item1.MaxStorageGb));
-                // TODO: add reference events for SmSeats and Service Accounts - see AC-1481
+        // TODO: add reference events for SmSeats and Service Accounts - see AC-1481
 
         Assert.NotNull(result);
         Assert.NotNull(result.Item1);

--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -183,10 +183,8 @@ public class OrganizationServiceTests
                 referenceEvent.PlanName == purchaseOrganizationPlan[0].Name &&
                 referenceEvent.PlanType == purchaseOrganizationPlan[0].Type &&
                 referenceEvent.Seats == result.Item1.Seats &&
-                referenceEvent.SmSeats == result.Item1.SmSeats &&
-                referenceEvent.ServiceAccounts == result.Item1.SmServiceAccounts &&
-                referenceEvent.UseSecretsManager == result.Item1.UseSecretsManager &&
                 referenceEvent.Storage == result.Item1.MaxStorageGb));
+                // TODO: add reference events for SmSeats and Service Accounts - see AC-1481
 
         Assert.NotNull(result);
         Assert.NotNull(result.Item1);


### PR DESCRIPTION
This will be done in AC-1481

## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

We decided to do the ReferenceEvent changes to AC-1481, as it requires more than just changing the enum.

I have reverted the few changes we made so far, so that we don't merge code that doesn't do anything. It should also drop `team-tools-dev` off the code reviewers, so they can just review AC-1481 when we get to it.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
