### PR TITLE
[AC-1508] Stripe changes for the EU datacenter

### DIFF
--- a/src/Billing/Constants/HandledStripeWebhook.cs
+++ b/src/Billing/Constants/HandledStripeWebhook.cs
@@ -2,12 +2,12 @@
 
 public static class HandledStripeWebhook
 {
-    public static string SubscriptionDeleted => "customer.subscription.deleted";
-    public static string SubscriptionUpdated => "customer.subscription.updated";
-    public static string UpcomingInvoice => "invoice.upcoming";
-    public static string ChargeSucceeded => "charge.succeeded";
-    public static string ChargeRefunded => "charge.refunded";
-    public static string PaymentSucceeded => "invoice.payment_succeeded";
-    public static string PaymentFailed => "invoice.payment_failed";
-    public static string InvoiceCreated => "invoice.created";
+    public const string SubscriptionDeleted = "customer.subscription.deleted";
+    public const string SubscriptionUpdated = "customer.subscription.updated";
+    public const string UpcomingInvoice = "invoice.upcoming";
+    public const string ChargeSucceeded = "charge.succeeded";
+    public const string ChargeRefunded = "charge.refunded";
+    public const string PaymentSucceeded = "invoice.payment_succeeded";
+    public const string PaymentFailed = "invoice.payment_failed";
+    public const string InvoiceCreated = "invoice.created";
 }

--- a/src/Billing/Controllers/StripeController.cs
+++ b/src/Billing/Controllers/StripeController.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Options;
 using Stripe;
+using Event = Stripe.Event;
 using TaxRate = Bit.Core.Entities.TaxRate;
 
 namespace Bit.Billing.Controllers;
@@ -41,6 +42,7 @@ public class StripeController : Controller
     private readonly ITaxRateRepository _taxRateRepository;
     private readonly IUserRepository _userRepository;
     private readonly ICurrentContext _currentContext;
+    private readonly GlobalSettings _globalSettings;
 
     public StripeController(
         GlobalSettings globalSettings,
@@ -83,6 +85,7 @@ public class StripeController : Controller
             PrivateKey = globalSettings.Braintree.PrivateKey
         };
         _currentContext = currentContext;
+        _globalSettings = globalSettings;
     }
 
     [HttpPost("webhook")]
@@ -112,6 +115,12 @@ public class StripeController : Controller
         {
             _logger.LogWarning("Getting test events in production.");
             return new BadRequestResult();
+        }
+
+        // If the customer and server cloud regions don't match, early return 200 to avoid unnecessary errors
+        if (!await ValidateCloudRegionAsync(parsedEvent))
+        {
+            return new OkResult();
         }
 
         var subDeleted = parsedEvent.Type.Equals(HandledStripeWebhook.SubscriptionDeleted);
@@ -471,6 +480,71 @@ public class StripeController : Controller
         return new OkResult();
     }
 
+    /// <summary>
+    /// Ensures that the customer associated with the parsed event's data is in the correct region for this server.
+    /// We use the customer instead of the subscription given that all subscriptions have customers, but not all
+    /// customers have subscriptions
+    /// </summary>
+    /// <param name="parsedEvent"></param>
+    /// <returns>true if the customer's region and the server's region match, otherwise false</returns>
+    /// <exception cref="Exception"></exception>
+    private async Task<bool> ValidateCloudRegionAsync(Event parsedEvent)
+    {
+        string customerRegion;
+
+        var serverRegion = _globalSettings.BaseServiceUri.CloudRegion;
+        var eventType = parsedEvent.Type;
+
+        switch (eventType)
+        {
+            case HandledStripeWebhook.SubscriptionDeleted:
+            case HandledStripeWebhook.SubscriptionUpdated:
+                {
+                    var subscription = await GetSubscriptionAsync(parsedEvent, true, new List<string>
+                {
+                    "customer"
+                });
+                    customerRegion = GetCustomerRegionFromMetadata(subscription.Customer.Metadata);
+                    break;
+                }
+            case HandledStripeWebhook.ChargeSucceeded:
+            case HandledStripeWebhook.ChargeRefunded:
+                {
+                    var charge = await GetChargeAsync(parsedEvent, true, new List<string> { "customer" });
+                    customerRegion = GetCustomerRegionFromMetadata(charge.Customer.Metadata);
+                    break;
+                }
+            case HandledStripeWebhook.UpcomingInvoice:
+            case HandledStripeWebhook.PaymentSucceeded:
+            case HandledStripeWebhook.PaymentFailed:
+            case HandledStripeWebhook.InvoiceCreated:
+                {
+                    var invoice = await GetInvoiceAsync(parsedEvent, true, new List<string> { "customer" });
+                    customerRegion = GetCustomerRegionFromMetadata(invoice.Customer.Metadata);
+                    break;
+                }
+            default:
+                {
+                    // For all Stripe events that we're not listening to, just return 200
+                    return false;
+                }
+        }
+
+        return customerRegion == serverRegion;
+    }
+
+    /// <summary>
+    /// Gets the region from the customer metadata. If no region is present, defaults to "US"
+    /// </summary>
+    /// <param name="customerMetadata"></param>
+    /// <returns></returns>
+    private static string GetCustomerRegionFromMetadata(Dictionary<string, string> customerMetadata)
+    {
+        return !customerMetadata.ContainsKey("region")
+            ? "US"
+            : customerMetadata["region"];
+    }
+
     private Tuple<Guid?, Guid?> GetIdsFromMetaData(IDictionary<string, string> metaData)
     {
         if (metaData == null || !metaData.Any())
@@ -732,7 +806,7 @@ public class StripeController : Controller
             invoice.BillingReason == "subscription_cycle" && invoice.SubscriptionId != null;
     }
 
-    private async Task<Charge> GetChargeAsync(Stripe.Event parsedEvent, bool fresh = false)
+    private async Task<Charge> GetChargeAsync(Event parsedEvent, bool fresh = false, List<string> expandOptions = null)
     {
         if (!(parsedEvent.Data.Object is Charge eventCharge))
         {
@@ -743,7 +817,8 @@ public class StripeController : Controller
             return eventCharge;
         }
         var chargeService = new ChargeService();
-        var charge = await chargeService.GetAsync(eventCharge.Id);
+        var chargeGetOptions = new ChargeGetOptions { Expand = expandOptions };
+        var charge = await chargeService.GetAsync(eventCharge.Id, chargeGetOptions);
         if (charge == null)
         {
             throw new Exception("Charge is null. " + eventCharge.Id);
@@ -751,7 +826,7 @@ public class StripeController : Controller
         return charge;
     }
 
-    private async Task<Invoice> GetInvoiceAsync(Stripe.Event parsedEvent, bool fresh = false)
+    private async Task<Invoice> GetInvoiceAsync(Stripe.Event parsedEvent, bool fresh = false, List<string> expandOptions = null)
     {
         if (!(parsedEvent.Data.Object is Invoice eventInvoice))
         {
@@ -762,7 +837,8 @@ public class StripeController : Controller
             return eventInvoice;
         }
         var invoiceService = new InvoiceService();
-        var invoice = await invoiceService.GetAsync(eventInvoice.Id);
+        var invoiceGetOptions = new InvoiceGetOptions { Expand = expandOptions };
+        var invoice = await invoiceService.GetAsync(eventInvoice.Id, invoiceGetOptions);
         if (invoice == null)
         {
             throw new Exception("Invoice is null. " + eventInvoice.Id);
@@ -770,9 +846,10 @@ public class StripeController : Controller
         return invoice;
     }
 
-    private async Task<Subscription> GetSubscriptionAsync(Stripe.Event parsedEvent, bool fresh = false)
+    private async Task<Subscription> GetSubscriptionAsync(Stripe.Event parsedEvent, bool fresh = false,
+        List<string> expandOptions = null)
     {
-        if (!(parsedEvent.Data.Object is Subscription eventSubscription))
+        if (parsedEvent.Data.Object is not Subscription eventSubscription)
         {
             throw new Exception("Subscription is null (from parsed event). " + parsedEvent.Id);
         }
@@ -781,7 +858,8 @@ public class StripeController : Controller
             return eventSubscription;
         }
         var subscriptionService = new SubscriptionService();
-        var subscription = await subscriptionService.GetAsync(eventSubscription.Id);
+        var subscriptionGetOptions = new SubscriptionGetOptions { Expand = expandOptions };
+        var subscription = await subscriptionService.GetAsync(eventSubscription.Id, subscriptionGetOptions);
         if (subscription == null)
         {
             throw new Exception("Subscription is null. " + eventSubscription.Id);

--- a/src/Billing/Controllers/StripeController.cs
+++ b/src/Billing/Controllers/StripeController.cs
@@ -500,10 +500,7 @@ public class StripeController : Controller
             case HandledStripeWebhook.SubscriptionDeleted:
             case HandledStripeWebhook.SubscriptionUpdated:
                 {
-                    var subscription = await GetSubscriptionAsync(parsedEvent, true, new List<string>
-                {
-                    "customer"
-                });
+                    var subscription = await GetSubscriptionAsync(parsedEvent, true, new List<string> { "customer" });
                     customerRegion = GetCustomerRegionFromMetadata(subscription.Customer.Metadata);
                     break;
                 }
@@ -540,9 +537,9 @@ public class StripeController : Controller
     /// <returns></returns>
     private static string GetCustomerRegionFromMetadata(Dictionary<string, string> customerMetadata)
     {
-        return !customerMetadata.ContainsKey("region")
-            ? "US"
-            : customerMetadata["region"];
+        return customerMetadata.TryGetValue("region", out var value)
+            ? value
+            : "US";
     }
 
     private Tuple<Guid?, Guid?> GetIdsFromMetaData(IDictionary<string, string> metaData)

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -26,7 +26,7 @@ public class StripePaymentService : IPaymentService
     private readonly Braintree.IBraintreeGateway _btGateway;
     private readonly ITaxRateRepository _taxRateRepository;
     private readonly IStripeAdapter _stripeAdapter;
-    private readonly GlobalSettings _globalSettings;
+    private readonly IGlobalSettings _globalSettings;
 
     public StripePaymentService(
         ITransactionRepository transactionRepository,
@@ -36,7 +36,7 @@ public class StripePaymentService : IPaymentService
         ITaxRateRepository taxRateRepository,
         IStripeAdapter stripeAdapter,
         Braintree.IBraintreeGateway braintreeGateway,
-        GlobalSettings globalSettings)
+        IGlobalSettings globalSettings)
     {
         _transactionRepository = transactionRepository;
         _userRepository = userRepository;

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -4,6 +4,7 @@ using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Business;
 using Bit.Core.Repositories;
+using Bit.Core.Settings;
 using Microsoft.Extensions.Logging;
 using StaticStore = Bit.Core.Models.StaticStore;
 using TaxRate = Bit.Core.Entities.TaxRate;
@@ -25,6 +26,7 @@ public class StripePaymentService : IPaymentService
     private readonly Braintree.IBraintreeGateway _btGateway;
     private readonly ITaxRateRepository _taxRateRepository;
     private readonly IStripeAdapter _stripeAdapter;
+    private readonly GlobalSettings _globalSettings;
 
     public StripePaymentService(
         ITransactionRepository transactionRepository,
@@ -33,7 +35,8 @@ public class StripePaymentService : IPaymentService
         ILogger<StripePaymentService> logger,
         ITaxRateRepository taxRateRepository,
         IStripeAdapter stripeAdapter,
-        Braintree.IBraintreeGateway braintreeGateway)
+        Braintree.IBraintreeGateway braintreeGateway,
+        GlobalSettings globalSettings)
     {
         _transactionRepository = transactionRepository;
         _userRepository = userRepository;
@@ -42,6 +45,7 @@ public class StripePaymentService : IPaymentService
         _taxRateRepository = taxRateRepository;
         _stripeAdapter = stripeAdapter;
         _btGateway = braintreeGateway;
+        _globalSettings = globalSettings;
     }
 
     public async Task<string> PurchaseOrganizationAsync(Organization org, PaymentMethodType paymentMethodType,
@@ -51,9 +55,12 @@ public class StripePaymentService : IPaymentService
         Braintree.Customer braintreeCustomer = null;
         string stipeCustomerSourceToken = null;
         string stipeCustomerPaymentMethodId = null;
-        var stripeCustomerMetadata = new Dictionary<string, string>();
+        var stripeCustomerMetadata = new Dictionary<string, string>
+        {
+            { "region", _globalSettings.BaseServiceUri.CloudRegion }
+        };
         var stripePaymentMethod = paymentMethodType == PaymentMethodType.Card ||
-            paymentMethodType == PaymentMethodType.BankAccount;
+                                  paymentMethodType == PaymentMethodType.BankAccount;
 
         if (stripePaymentMethod && !string.IsNullOrWhiteSpace(paymentToken))
         {
@@ -388,7 +395,7 @@ public class StripePaymentService : IPaymentService
 
         if (customer == null && !string.IsNullOrWhiteSpace(paymentToken))
         {
-            var stripeCustomerMetadata = new Dictionary<string, string>();
+            var stripeCustomerMetadata = new Dictionary<string, string> { { "region", _globalSettings.BaseServiceUri.CloudRegion } };
             if (paymentMethodType == PaymentMethodType.PayPal)
             {
                 var randomSuffix = Utilities.CoreHelpers.RandomString(3, upper: false, numeric: false);
@@ -1185,9 +1192,12 @@ public class StripePaymentService : IPaymentService
         Braintree.Customer braintreeCustomer = null;
         string stipeCustomerSourceToken = null;
         string stipeCustomerPaymentMethodId = null;
-        var stripeCustomerMetadata = new Dictionary<string, string>();
+        var stripeCustomerMetadata = new Dictionary<string, string>
+        {
+            { "region", _globalSettings.BaseServiceUri.CloudRegion }
+        };
         var stripePaymentMethod = paymentMethodType == PaymentMethodType.Card ||
-            paymentMethodType == PaymentMethodType.BankAccount;
+                                  paymentMethodType == PaymentMethodType.BankAccount;
         var inAppPurchase = paymentMethodType == PaymentMethodType.AppleInApp ||
             paymentMethodType == PaymentMethodType.GoogleInApp;
 

--- a/test/Core.Test/Services/StripePaymentServiceTests.cs
+++ b/test/Core.Test/Services/StripePaymentServiceTests.cs
@@ -4,6 +4,7 @@ using Bit.Core.Exceptions;
 using Bit.Core.Models.Business;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
+using Bit.Core.Settings;
 using Bit.Core.Utilities;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
@@ -51,6 +52,9 @@ public class StripePaymentServiceTests
             Id = "S-1",
             CurrentPeriodEnd = DateTime.Today.AddDays(10),
         });
+        sutProvider.GetDependency<IGlobalSettings>()
+            .BaseServiceUri.CloudRegion
+            .Returns("US");
 
         var result = await sutProvider.Sut.PurchaseOrganizationAsync(organization, PaymentMethodType.Card, paymentToken, plan, 0, 0, false, taxInfo, provider);
 
@@ -67,7 +71,8 @@ public class StripePaymentServiceTests
             c.Source == paymentToken &&
             c.PaymentMethod == null &&
             c.Coupon == "msp-discount-35" &&
-            !c.Metadata.Any() &&
+            c.Metadata.Count == 1 &&
+            c.Metadata["region"] == "US" &&
             c.InvoiceSettings.DefaultPaymentMethod == null &&
             c.Address.Country == taxInfo.BillingAddressCountry &&
             c.Address.PostalCode == taxInfo.BillingAddressPostalCode &&
@@ -101,6 +106,9 @@ public class StripePaymentServiceTests
             Id = "S-1",
             CurrentPeriodEnd = DateTime.Today.AddDays(10),
         });
+        sutProvider.GetDependency<IGlobalSettings>()
+            .BaseServiceUri.CloudRegion
+            .Returns("US");
 
         var result = await sutProvider.Sut.PurchaseOrganizationAsync(organization, PaymentMethodType.Card, paymentToken, plan, 0, 0, false, taxInfo);
 
@@ -116,7 +124,8 @@ public class StripePaymentServiceTests
             c.Email == organization.BillingEmail &&
             c.Source == paymentToken &&
             c.PaymentMethod == null &&
-            !c.Metadata.Any() &&
+            c.Metadata.Count == 1 &&
+            c.Metadata["region"] == "US" &&
             c.InvoiceSettings.DefaultPaymentMethod == null &&
             c.InvoiceSettings.CustomFields != null &&
             c.InvoiceSettings.CustomFields[0].Name == "Organization" &&
@@ -154,6 +163,9 @@ public class StripePaymentServiceTests
             Id = "S-1",
             CurrentPeriodEnd = DateTime.Today.AddDays(10),
         });
+        sutProvider.GetDependency<IGlobalSettings>()
+            .BaseServiceUri.CloudRegion
+            .Returns("US");
 
         var result = await sutProvider.Sut.PurchaseOrganizationAsync(organization, PaymentMethodType.Card, paymentToken, plan, 0, 0, false, taxInfo);
 
@@ -169,7 +181,8 @@ public class StripePaymentServiceTests
             c.Email == organization.BillingEmail &&
             c.Source == null &&
             c.PaymentMethod == paymentToken &&
-            !c.Metadata.Any() &&
+            c.Metadata.Count == 1 &&
+            c.Metadata["region"] == "US" &&
             c.InvoiceSettings.DefaultPaymentMethod == paymentToken &&
             c.InvoiceSettings.CustomFields != null &&
             c.InvoiceSettings.CustomFields[0].Name == "Organization" &&
@@ -300,6 +313,10 @@ public class StripePaymentServiceTests
             CurrentPeriodEnd = DateTime.Today.AddDays(10),
         });
 
+        sutProvider.GetDependency<IGlobalSettings>()
+            .BaseServiceUri.CloudRegion
+            .Returns("US");
+
         var customer = Substitute.For<Customer>();
         customer.Id.ReturnsForAnyArgs("Braintree-Id");
         customer.PaymentMethods.ReturnsForAnyArgs(new[] { Substitute.For<PaymentMethod>() });
@@ -323,8 +340,9 @@ public class StripePaymentServiceTests
             c.Description == organization.BusinessName &&
             c.Email == organization.BillingEmail &&
             c.PaymentMethod == null &&
-            c.Metadata.Count == 1 &&
+            c.Metadata.Count == 2 &&
             c.Metadata["btCustomerId"] == "Braintree-Id" &&
+            c.Metadata["region"] == "US" &&
             c.InvoiceSettings.DefaultPaymentMethod == null &&
             c.Address.Country == taxInfo.BillingAddressCountry &&
             c.Address.PostalCode == taxInfo.BillingAddressPostalCode &&


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The launch of the EU data center brought up some issues around the Stripe webhook. With the current implementation, The `"webhook"` endpoints in both data centers will each receive all events sent out by Stripe. To combat this in the short term, and to avoid needless errors around looking up entities that exist in another datacenter, we've added a `region` value to the Stripe customer object. Using that value, we're able to determine if a given event is intended for the current instance's webhook or that of another data center.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **StripePaymentService.cs:** Added logic to supply the configured region value to Stripe when creating or updating a Customer. This will occur when purchasing an organization, purchasing a premium subscription, or when updating a payment method
* **StripeController.cs:** Added logic to check the current instance's region (`"US"` or `"EU"`), and match it with the customer's region. If they match, execution continues as normal. Otherwise, the webhook returns `200 OK` to Stripe.
* **HandledStripeWebhook.cs:** Updated the webhook event type strings to be compile-time constants instead of read-only properties with a single expression. This is to allow them to be used in the switch statement in StripeController.cs.
