### PR TITLE
[PM-1339] Allow Rotating Device Keys

### DIFF
--- a/src/Api/Auth/Models/Request/UpdateDevicesTrustRequestModel.cs
+++ b/src/Api/Auth/Models/Request/UpdateDevicesTrustRequestModel.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+using Bit.Api.Auth.Models.Request.Accounts;
+using Bit.Core.Auth.Models.Api.Request;
+
+#nullable enable
+
+namespace Bit.Api.Auth.Models.Request;
+
+public class UpdateDevicesTrustRequestModel : SecretVerificationRequestModel
+{
+    [Required]
+    public DeviceKeysUpdateRequestModel CurrentDevice { get; set; } = null!;
+    public IEnumerable<OtherDeviceKeysUpdateRequestModel>? OtherDevices { get; set; }
+}

--- a/src/Api/Auth/Models/Request/UpdateDevicesTrustRequestModel.cs
+++ b/src/Api/Auth/Models/Request/UpdateDevicesTrustRequestModel.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Bit.Api.Auth.Models.Request.Accounts;
 using Bit.Core.Auth.Models.Api.Request;
 

--- a/src/Api/Controllers/DevicesController.cs
+++ b/src/Api/Controllers/DevicesController.cs
@@ -1,5 +1,10 @@
-﻿using Bit.Api.Models.Request;
+﻿using Bit.Api.Auth.Models.Request;
+using Bit.Api.Auth.Models.Request.Accounts;
+using Bit.Api.Models.Request;
 using Bit.Api.Models.Response;
+using Bit.Core.Auth.Models.Api.Request;
+using Bit.Core.Auth.Models.Api.Response;
+using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
@@ -19,17 +24,20 @@ public class DevicesController : Controller
     private readonly IDeviceService _deviceService;
     private readonly IUserService _userService;
     private readonly IUserRepository _userRepository;
+    private readonly ICurrentContext _currentContext;
 
     public DevicesController(
         IDeviceRepository deviceRepository,
         IDeviceService deviceService,
         IUserService userService,
-        IUserRepository userRepository)
+        IUserRepository userRepository,
+        ICurrentContext currentContext)
     {
         _deviceRepository = deviceRepository;
         _deviceService = deviceService;
         _userService = userService;
         _userRepository = userRepository;
+        _currentContext = currentContext;
     }
 
     [HttpGet("{id}")]
@@ -115,6 +123,55 @@ public class DevicesController : Controller
 
         var response = new DeviceResponseModel(device);
         return response;
+    }
+
+    [HttpPost("{identifier}/retrieve-keys")]
+    public async Task<ProtectedDeviceResponseModel> GetDeviceKeys(string identifier, [FromBody] SecretVerificationRequestModel model)
+    {
+        var user = await _userService.GetUserByPrincipalAsync(User);
+
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
+        if (!await _userService.VerifySecretAsync(user, model.Secret))
+        {
+            await Task.Delay(2000);
+            throw new BadRequestException(string.Empty, "User verification failed.");
+        }
+
+        var device = await _deviceRepository.GetByIdentifierAsync(identifier, user.Id);
+
+        if (device == null)
+        {
+            throw new NotFoundException();
+        }
+
+        return new ProtectedDeviceResponseModel(device);
+    }
+
+    [HttpPost("update-trust")]
+    public async Task PostUpdateTrust([FromBody] UpdateDevicesTrustRequestModel model)
+    {
+        var user = await _userService.GetUserByPrincipalAsync(User);
+
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
+        if (!await _userService.VerifySecretAsync(user, model.Secret))
+        {
+            await Task.Delay(2000);
+            throw new BadRequestException(string.Empty, "User verification failed.");
+        }
+
+        await _deviceService.UpdateDevicesTrustAsync(
+            _currentContext.DeviceIdentifier,
+            user.Id,
+            model.CurrentDevice,
+            model.OtherDevices ?? Enumerable.Empty<OtherDeviceKeysUpdateRequestModel>());
     }
 
     [HttpPut("identifier/{identifier}/token")]

--- a/src/Api/Models/Response/DeviceResponseModel.cs
+++ b/src/Api/Models/Response/DeviceResponseModel.cs
@@ -19,9 +19,10 @@ public class DeviceResponseModel : ResponseModel
         Type = device.Type;
         Identifier = device.Identifier;
         CreationDate = device.CreationDate;
-        EncryptedUserKey = device.EncryptedUserKey;
-        EncryptedPublicKey = device.EncryptedPublicKey;
-        EncryptedPrivateKey = device.EncryptedPrivateKey;
+        // TODO: Use helper added in another PR
+        IsTrusted = !string.IsNullOrEmpty(device.EncryptedUserKey) &&
+            !string.IsNullOrEmpty(device.EncryptedPublicKey) &&
+            !string.IsNullOrEmpty(device.EncryptedPrivateKey);
     }
 
     public string Id { get; set; }
@@ -29,7 +30,5 @@ public class DeviceResponseModel : ResponseModel
     public DeviceType Type { get; set; }
     public string Identifier { get; set; }
     public DateTime CreationDate { get; set; }
-    public string EncryptedUserKey { get; }
-    public string EncryptedPublicKey { get; }
-    public string EncryptedPrivateKey { get; }
+    public bool IsTrusted { get; set; }
 }

--- a/src/Core/Auth/Models/Api/Request/DeviceKeysUpdateRequestModel.cs
+++ b/src/Core/Auth/Models/Api/Request/DeviceKeysUpdateRequestModel.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.Utilities;
+
+namespace Bit.Core.Auth.Models.Api.Request;
+
+public class OtherDeviceKeysUpdateRequestModel : DeviceKeysUpdateRequestModel
+{
+    [Required]
+    public Guid DeviceId { get; set; }
+}
+
+public class DeviceKeysUpdateRequestModel
+{
+    [Required]
+    [EncryptedString]
+    public string EncryptedPublicKey { get; set; }
+
+    [Required]
+    [EncryptedString]
+    public string EncryptedUserKey { get; set; }
+}

--- a/src/Core/Auth/Models/Api/Response/ProtectedDeviceResponseModel.cs
+++ b/src/Core/Auth/Models/Api/Response/ProtectedDeviceResponseModel.cs
@@ -1,4 +1,4 @@
-using Bit.Core.Entities;
+﻿using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Models.Api;
 

--- a/src/Core/Auth/Models/Api/Response/ProtectedDeviceResponseModel.cs
+++ b/src/Core/Auth/Models/Api/Response/ProtectedDeviceResponseModel.cs
@@ -1,0 +1,30 @@
+using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Models.Api;
+
+namespace Bit.Core.Auth.Models.Api.Response;
+
+public class ProtectedDeviceResponseModel : ResponseModel
+{
+    public ProtectedDeviceResponseModel(Device device)
+        : base("protectedDevice")
+    {
+        ArgumentNullException.ThrowIfNull(device);
+
+        Id = device.Id;
+        Name = device.Name;
+        Type = device.Type;
+        Identifier = device.Identifier;
+        CreationDate = device.CreationDate;
+        EncryptedUserKey = device.EncryptedUserKey;
+        EncryptedPublicKey = device.EncryptedPublicKey;
+    }
+
+    public Guid Id { get; set; }
+    public string Name { get; set; }
+    public DeviceType Type { get; set; }
+    public string Identifier { get; set; }
+    public DateTime CreationDate { get; set; }
+    public string EncryptedUserKey { get; set; }
+    public string EncryptedPublicKey { get; set; }
+}

--- a/src/Core/Services/IDeviceService.cs
+++ b/src/Core/Services/IDeviceService.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.Entities;
+﻿using Bit.Core.Auth.Models.Api.Request;
+using Bit.Core.Entities;
 
 namespace Bit.Core.Services;
 
@@ -7,4 +8,8 @@ public interface IDeviceService
     Task SaveAsync(Device device);
     Task ClearTokenAsync(Device device);
     Task DeleteAsync(Device device);
+    Task UpdateDevicesTrustAsync(string currentDeviceIdentifier,
+        Guid currentUserId,
+        DeviceKeysUpdateRequestModel currentDeviceUpdate,
+        IEnumerable<OtherDeviceKeysUpdateRequestModel> alteredDevices);
 }

--- a/src/Core/Services/Implementations/DeviceService.cs
+++ b/src/Core/Services/Implementations/DeviceService.cs
@@ -1,4 +1,6 @@
-﻿using Bit.Core.Entities;
+﻿using Bit.Core.Auth.Models.Api.Request;
+using Bit.Core.Entities;
+using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 
 namespace Bit.Core.Services;
@@ -42,5 +44,65 @@ public class DeviceService : IDeviceService
     {
         await _deviceRepository.DeleteAsync(device);
         await _pushRegistrationService.DeleteRegistrationAsync(device.Id.ToString());
+    }
+
+    public async Task UpdateDevicesTrustAsync(string currentDeviceIdentifier,
+        Guid currentUserId,
+        DeviceKeysUpdateRequestModel currentDeviceUpdate,
+        IEnumerable<OtherDeviceKeysUpdateRequestModel> alteredDevices)
+    {
+        var existingDevices = await _deviceRepository.GetManyByUserIdAsync(currentUserId);
+
+        var currentDevice = existingDevices.FirstOrDefault(d => d.Identifier == currentDeviceIdentifier);
+
+        if (currentDevice == null)
+        {
+            throw new NotFoundException();
+        }
+
+        existingDevices.Remove(currentDevice);
+
+        var alterDeviceKeysDict = alteredDevices.ToDictionary(d => d.DeviceId);
+
+        if (alterDeviceKeysDict.ContainsKey(currentDevice.Id))
+        {
+            throw new BadRequestException("Current device can not be an optional rotation.");
+        }
+
+        currentDevice.EncryptedPublicKey = currentDeviceUpdate.EncryptedPublicKey;
+        currentDevice.EncryptedUserKey = currentDeviceUpdate.EncryptedUserKey;
+
+        await _deviceRepository.UpsertAsync(currentDevice);
+
+        foreach (var device in existingDevices)
+        {
+            // TODO: Use extension method
+            if (string.IsNullOrEmpty(device.EncryptedPrivateKey) ||
+                string.IsNullOrEmpty(device.EncryptedPublicKey) ||
+                string.IsNullOrEmpty(device.EncryptedUserKey))
+            {
+                // You can't update the trust of a device that isn't trusted to begin with
+                // should we throw and consider this a BadRequest? If we want to consider it a invalid request
+                // we need to check that information before we enter this foreach, we don't want to partially complete
+                // this process.
+                continue;
+            }
+
+            if (alterDeviceKeysDict.TryGetValue(device.Id, out var updateRequest))
+            {
+                // An update to this device was requested
+                device.EncryptedPublicKey = updateRequest.EncryptedPublicKey;
+                device.EncryptedUserKey = updateRequest.EncryptedUserKey;
+            }
+            else
+            {
+                // No update to this device requested, just untrust it
+                device.EncryptedUserKey = null;
+                device.EncryptedPublicKey = null;
+                device.EncryptedPrivateKey = null;
+            }
+
+            await _deviceRepository.UpsertAsync(device);
+        }
     }
 }

--- a/test/Core.Test/Services/DeviceServiceTests.cs
+++ b/test/Core.Test/Services/DeviceServiceTests.cs
@@ -1,12 +1,16 @@
-﻿using Bit.Core.Entities;
+﻿using Bit.Core.Auth.Models.Api.Request;
+using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
 using Xunit;
 
 namespace Bit.Core.Test.Services;
 
+[SutProviderCustomize]
 public class DeviceServiceTests
 {
     [Fact]
@@ -32,5 +36,62 @@ public class DeviceServiceTests
         Assert.True(device.RevisionDate - DateTime.UtcNow < TimeSpan.FromSeconds(1));
         await pushRepo.Received().CreateOrUpdateRegistrationAsync("testtoken", id.ToString(),
             userId.ToString(), "testid", DeviceType.Android);
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    [Theory, BitAutoData]
+    public async Task UpdateDevicesTrustAsync_Works(
+        SutProvider<DeviceService> sutProvider,
+        Guid currentUserId,
+        Device deviceOne,
+        Device deviceTwo,
+        Device deviceThree)
+    {
+        deviceOne.Identifier = "current_device";
+
+        sutProvider.GetDependency<IDeviceRepository>()
+            .GetManyByUserIdAsync(currentUserId)
+            .Returns(new List<Device>
+            {
+                deviceOne,
+                deviceTwo,
+                deviceThree,
+            });
+
+        var currentDeviceModel = new DeviceKeysUpdateRequestModel
+        {
+            EncryptedPublicKey = "current_encrypted_public_key",
+            EncryptedUserKey = "current_encrypted_user_key",
+        };
+
+        var alteredDeviceModels = new List<OtherDeviceKeysUpdateRequestModel>
+        {
+            new OtherDeviceKeysUpdateRequestModel
+            {
+                DeviceId = deviceTwo.Id,
+                EncryptedPublicKey = "encrypted_public_key_two",
+                EncryptedUserKey = "encrypted_user_key_two",
+            },
+        };
+
+        await sutProvider.Sut.UpdateDevicesTrustAsync("current_device", currentUserId, currentDeviceModel, alteredDeviceModels);
+
+        await sutProvider.GetDependency<IDeviceRepository>()
+            .Received(1)
+            .UpsertAsync(Arg.Is<Device>(d => d.Id == deviceOne.Id && d.EncryptedPublicKey == "current_encrypted_public_key"));
+
+        await sutProvider.GetDependency<IDeviceRepository>()
+            .Received(1)
+            .UpsertAsync(Arg.Is<Device>(d => d.Id == deviceTwo.Id && d.EncryptedPublicKey == "encrypted_public_key_two"));
+
+        await sutProvider.GetDependency<IDeviceRepository>()
+            .Received(1)
+            .UpsertAsync(Arg.Is<Device>(d => d.Id == deviceThree.Id && d.EncryptedPublicKey == null));
+
+        await sutProvider.GetDependency<IDeviceRepository>()
+            .Received(3)
+            .UpsertAsync(Arg.Any<Device>());
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Add server side components for facilitating the rotation of the current devices keys alongside any other chosen device keys. This makes it so that when a user rotates their user key they are not locked out of all their devices.

TODO: Add Clients PR


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **UpdateDevicesTrustRequestModel.cs:** A model that requires the inclusion of at least new keys for the current device and optionally allows `n` number of other devices the user wants rotated.
* **DevicesController.cs:** Added two new endpoints for retrieving the rotation specific keys for a device by it's ID behind a user verification check and for updating the trust of the users devices, also behind a user verification check.
* **DeviceResponseModel.cs:** Updated default device model to only respond that a device is trusted or not, and to not include the keys. Although they are encrypted with a key owned by the user, they should not be needlessly shared.
* **DeviceService.cs:** Added method for facilitating the rotation of all devices keys requested by the user.
* **DeviceServiceTests.cs:** Added tests asserting expected behavior from rotating trust.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
