### PR TITLE
[AC-1522] Fix service account check on upgrading

### DIFF
--- a/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs
@@ -311,19 +311,16 @@ public class UpgradeOrganizationPlanCommand : IUpgradeOrganizationPlanCommand
             }
         }
 
-        if (newSecretsManagerPlan.BaseServiceAccount != null)
+        if (!organization.SmServiceAccounts.HasValue ||
+            organization.SmServiceAccounts.Value > newSecretsManagerPlan.MaxServiceAccounts)
         {
-            if (!organization.SmServiceAccounts.HasValue ||
-                organization.SmServiceAccounts.Value > newSecretsManagerPlan.MaxServiceAccounts)
+            var currentServiceAccounts =
+                await _serviceAccountRepository.GetServiceAccountCountByOrganizationIdAsync(organization.Id);
+            if (currentServiceAccounts > newSecretsManagerPlan.MaxServiceAccounts)
             {
-                var currentServiceAccounts =
-                    await _serviceAccountRepository.GetServiceAccountCountByOrganizationIdAsync(organization.Id);
-                if (currentServiceAccounts > newSecretsManagerPlan.MaxServiceAccounts)
-                {
-                    throw new BadRequestException(
-                        $"Your organization currently has {currentServiceAccounts} service account seats filled. " +
-                        $"Your new plan only has ({newSecretsManagerPlan.MaxServiceAccounts}) service accounts. Remove some service accounts.");
-                }
+                throw new BadRequestException(
+                    $"Your organization currently has {currentServiceAccounts} service accounts. " +
+                    $"Your new plan only allows {newSecretsManagerPlan.MaxServiceAccounts} service accounts. Remove some service accounts.");
             }
         }
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

I noticed that the logic to check service accounts on upgrade is wrong. It was gated behind a `newSecretsManagerPlan.BaseServiceAccount != null` check, which is irrelevant, and it wasn't calculating the new plan total correctly. It basically needs to mirror the seats logic, i.e. if the new total is less than the current total, check current usage and throw if the new total is less than the current usage.

Also added unit tests.

Also added "or increase your subscription" to the end of the error messages, because that's another (and better) way of solving the problem.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
