### PR TITLE
Feature/auth/pm 2759/add can reset password to user decryption options fix jit users

### DIFF
--- a/src/Identity/IdentityServer/BaseRequestValidator.cs
+++ b/src/Identity/IdentityServer/BaseRequestValidator.cs
@@ -633,8 +633,7 @@ public abstract class BaseRequestValidator<T> where T : class
             if (org != null)
             {
                 // TDE requires single org so grabbing first org & id is fine.
-                var orgId = org.Id;
-                hasManageResetPasswordPermission = await CurrentContext.ManageResetPassword(orgId);
+                hasManageResetPasswordPermission = await CurrentContext.ManageResetPassword(org.Id);
             }
 
             var hasAdminApproval = await PolicyService.AnyPoliciesApplicableToUserAsync(user.Id, PolicyType.ResetPassword);

--- a/src/Identity/IdentityServer/BaseRequestValidator.cs
+++ b/src/Identity/IdentityServer/BaseRequestValidator.cs
@@ -630,7 +630,7 @@ public abstract class BaseRequestValidator<T> where T : class
             // when a user is being created via JIT provisioning, they will not have any orgs so we can't assume we will have orgs here
             var org = CurrentContext.Organizations.FirstOrDefault();
 
-            if(org != null)
+            if (org != null)
             {
                 // TDE requires single org so grabbing first org & id is fine.
                 var orgId = org.Id;

--- a/src/Identity/IdentityServer/BaseRequestValidator.cs
+++ b/src/Identity/IdentityServer/BaseRequestValidator.cs
@@ -352,7 +352,7 @@ public abstract class BaseRequestValidator<T> where T : class
             return true;
         }
 
-        // Check if user belongs to any organization with an active SSO policy 
+        // Check if user belongs to any organization with an active SSO policy
         var anySsoPoliciesApplicableToUser = await PolicyService.AnyPoliciesApplicableToUserAsync(user.Id, PolicyType.RequireSso, OrganizationUserStatusType.Confirmed);
         if (anySsoPoliciesApplicableToUser)
         {
@@ -625,9 +625,17 @@ public abstract class BaseRequestValidator<T> where T : class
                 .Any();
 
             // Determine if user has manage reset password permission as post sso logic requires it for forcing users with this permission to set a MP
-            // TDE requires single org so grab first id. 
-            var orgId = CurrentContext.Organizations.First().Id;
-            var hasManageResetPasswordPermission = await CurrentContext.ManageResetPassword(orgId);
+            var hasManageResetPasswordPermission = false;
+
+            // when a user is being created via JIT provisioning, they will not have any orgs so we can't assume we will have orgs here
+            var org = CurrentContext.Organizations.FirstOrDefault();
+
+            if(org != null)
+            {
+                // TDE requires single org so grabbing first org & id is fine.
+                var orgId = org.Id;
+                hasManageResetPasswordPermission = await CurrentContext.ManageResetPassword(orgId);
+            }
 
             var hasAdminApproval = await PolicyService.AnyPoliciesApplicableToUserAsync(user.Id, PolicyType.ResetPassword);
             // TrustedDeviceEncryption only exists for SSO, but if that ever changes this value won't always be true

--- a/test/Identity.IntegrationTest/Endpoints/IdentityServerSsoTests.cs
+++ b/test/Identity.IntegrationTest/Endpoints/IdentityServerSsoTests.cs
@@ -441,6 +441,9 @@ public class IdentityServerSsoTests
         Assert.Equal(expectedUserKey, actualUserKey);
     }
 
+    // we should add a test case for JIT provisioned users. They don't have any orgs which caused
+    // an error in the UserHasManageResetPasswordPermission set logic.
+
     /// <summary>
     /// Story: When a user with TDE and the manage reset password permission signs in with SSO, we should return
     ///  TrustedDeviceEncryption.HasManageResetPasswordPermission as true
@@ -620,7 +623,7 @@ public class IdentityServerSsoTests
             RedirectUri = "https://localhost:8080/sso-connector.html",
             RequestedScopes = new[] { "api", "offline_access" },
             CodeChallenge = challenge.Sha256(),
-            CodeChallengeMethod = "plain", // 
+            CodeChallengeMethod = "plain", //
             Subject = null, // Temporarily set it to null
         };
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
[PM-2759](https://bitwarden.atlassian.net/browse/PM-2759) - `IdentityServer` - `CreateUserDecryptionOptionsAsync` - `hasManageResetPasswordPermission` set logic was broken for JIT provisioned users as I assumed we would always have a list of at least 1 org during the SSO process. Added TODO for future test addition but getting this out there now as QA is blocked by being unable to create JIT provisioned users.

This resolves bug [PM-3073](https://bitwarden.atlassian.net/browse/PM-3073)


## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team


[PM-2759]: https://bitwarden.atlassian.net/browse/PM-2759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-3073]: https://bitwarden.atlassian.net/browse/PM-3073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ