### PR TITLE
fix: Fix null handling in SendLicenseExpiredAsync method

### DIFF
--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -335,10 +335,11 @@ public class HandlebarsMailService : IMailService
     public async Task SendLicenseExpiredAsync(IEnumerable<string> emails, string organizationName = null)
     {
         var message = CreateDefaultMessage("License Expired", emails);
-        var model = new LicenseExpiredViewModel
+        var model = new LicenseExpiredViewModel();
+        if (organizationName != null)
         {
-            OrganizationName = CoreHelpers.SanitizeForEmail(organizationName, false),
-        };
+            model.OrganizationName = CoreHelpers.SanitizeForEmail(organizationName, false);
+        }
         await AddMessageContentAsync(message, "LicenseExpired", model);
         message.Category = "LicenseExpired";
         await _mailDeliveryService.SendEmailAsync(message);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fixed that when the user license is not available, there may be an error when logging in to Bitwarden, and the user may not receive the license expiration reminder email



## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **HandlebarsMailService.cs:** A null check has been added to prevent an exception when passing an empty organizationName to the `CoreHelpers.SanitizeForEmail()` method. Without this change, the specific location in the code (at [this link](https://github.com/bitwarden/server/blob/1fe2f0fb5738d69e4f214e4f6b6cec49df1dd836/src/Core/Utilities/CoreHelpers.cs#L438)) would throw an exception.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
