### PR TITLE
[AC-1509] PayPal changes for the EU datacenter

### DIFF
--- a/src/Admin/Controllers/ToolsController.cs
+++ b/src/Admin/Controllers/ToolsController.cs
@@ -95,12 +95,13 @@ public class ToolsController : Controller
                     SubmitForSettlement = true,
                     PayPal = new Braintree.TransactionOptionsPayPalRequest
                     {
-                        CustomField = $"{btObjIdField}:{btObjId}"
+                        CustomField = $"{btObjIdField}:{btObjId},region:{_globalSettings.BaseServiceUri.CloudRegion}"
                     }
                 },
                 CustomFields = new Dictionary<string, string>
                 {
-                    [btObjIdField] = btObjId.ToString()
+                    [btObjIdField] = btObjId.ToString(),
+                    ["region"] = _globalSettings.BaseServiceUri.CloudRegion
                 }
             });
 

--- a/src/Billing/Controllers/StripeController.cs
+++ b/src/Billing/Controllers/StripeController.cs
@@ -746,12 +746,13 @@ public class StripeController : Controller
                     SubmitForSettlement = true,
                     PayPal = new Braintree.TransactionOptionsPayPalRequest
                     {
-                        CustomField = $"{btObjIdField}:{btObjId}"
+                        CustomField = $"{btObjIdField}:{btObjId},region:{_globalSettings.BaseServiceUri.CloudRegion}"
                     }
                 },
                 CustomFields = new Dictionary<string, string>
                 {
-                    [btObjIdField] = btObjId.ToString()
+                    [btObjIdField] = btObjId.ToString(),
+                    ["region"] = _globalSettings.BaseServiceUri.CloudRegion
                 }
             });
 

--- a/src/Core/Entities/ISubscriber.cs
+++ b/src/Core/Entities/ISubscriber.cs
@@ -13,6 +13,7 @@ public interface ISubscriber
     string SubscriberName();
     string BraintreeCustomerIdPrefix();
     string BraintreeIdField();
+    string BraintreeCloudRegionField();
     string GatewayIdField();
     bool IsUser();
     string SubscriberType();

--- a/src/Core/Entities/Organization.cs
+++ b/src/Core/Entities/Organization.cs
@@ -111,6 +111,11 @@ public class Organization : ITableObject<Guid>, ISubscriber, IStorable, IStorabl
         return "organization_id";
     }
 
+    public string BraintreeCloudRegionField()
+    {
+        return "region";
+    }
+
     public string GatewayIdField()
     {
         return "organizationId";

--- a/src/Core/Entities/User.cs
+++ b/src/Core/Entities/User.cs
@@ -101,6 +101,11 @@ public class User : ITableObject<Guid>, ISubscriber, IStorable, IStorableSubscri
         return "user_id";
     }
 
+    public string BraintreeCloudRegionField()
+    {
+        return "region";
+    }
+
     public string GatewayIdField()
     {
         return "userId";

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -83,7 +83,8 @@ public class StripePaymentService : IPaymentService
                 Id = org.BraintreeCustomerIdPrefix() + org.Id.ToString("N").ToLower() + randomSuffix,
                 CustomFields = new Dictionary<string, string>
                 {
-                    [org.BraintreeIdField()] = org.Id.ToString()
+                    [org.BraintreeIdField()] = org.Id.ToString(),
+                    [org.BraintreeCloudRegionField()] = _globalSettings.BaseServiceUri.CloudRegion
                 }
             });
 
@@ -406,7 +407,8 @@ public class StripePaymentService : IPaymentService
                     Id = user.BraintreeCustomerIdPrefix() + user.Id.ToString("N").ToLower() + randomSuffix,
                     CustomFields = new Dictionary<string, string>
                     {
-                        [user.BraintreeIdField()] = user.Id.ToString()
+                        [user.BraintreeIdField()] = user.Id.ToString(),
+                        [user.BraintreeCloudRegionField()] = _globalSettings.BaseServiceUri.CloudRegion
                     }
                 });
 
@@ -602,12 +604,13 @@ public class StripePaymentService : IPaymentService
                                     SubmitForSettlement = true,
                                     PayPal = new Braintree.TransactionOptionsPayPalRequest
                                     {
-                                        CustomField = $"{subscriber.BraintreeIdField()}:{subscriber.Id}"
+                                        CustomField = $"{subscriber.BraintreeIdField()}:{subscriber.Id},{subscriber.BraintreeCloudRegionField()}:{_globalSettings.BaseServiceUri.CloudRegion}"
                                     }
                                 },
                                 CustomFields = new Dictionary<string, string>
                                 {
-                                    [subscriber.BraintreeIdField()] = subscriber.Id.ToString()
+                                    [subscriber.BraintreeIdField()] = subscriber.Id.ToString(),
+                                    [subscriber.BraintreeCloudRegionField()] = _globalSettings.BaseServiceUri.CloudRegion
                                 }
                             });
 
@@ -991,12 +994,13 @@ public class StripePaymentService : IPaymentService
                             SubmitForSettlement = true,
                             PayPal = new Braintree.TransactionOptionsPayPalRequest
                             {
-                                CustomField = $"{subscriber.BraintreeIdField()}:{subscriber.Id}"
+                                CustomField = $"{subscriber.BraintreeIdField()}:{subscriber.Id},{subscriber.BraintreeCloudRegionField()}:{_globalSettings.BaseServiceUri.CloudRegion}"
                             }
                         },
                         CustomFields = new Dictionary<string, string>
                         {
-                            [subscriber.BraintreeIdField()] = subscriber.Id.ToString()
+                            [subscriber.BraintreeIdField()] = subscriber.Id.ToString(),
+                            [subscriber.BraintreeCloudRegionField()] = _globalSettings.BaseServiceUri.CloudRegion
                         }
                     });
 
@@ -1290,7 +1294,8 @@ public class StripePaymentService : IPaymentService
                         Utilities.CoreHelpers.RandomString(3, upper: false, numeric: false),
                     CustomFields = new Dictionary<string, string>
                     {
-                        [subscriber.BraintreeIdField()] = subscriber.Id.ToString()
+                        [subscriber.BraintreeIdField()] = subscriber.Id.ToString(),
+                        [subscriber.BraintreeCloudRegionField()] = _globalSettings.BaseServiceUri.CloudRegion
                     }
                 });
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Deploying to the new data center broke our PayPal IPN webhook given that PayPal only supports the configuration of a single webhook endpoint in their portal. In order to enable both IPN endpoints in each data center to receive events for their respective users, I've added a new custom field, `region` on all PayPal objects. This will allow the new mothership service to know how to route the IPN traffic to the correct data center.

Mothership pull request: https://github.com/bitwarden/mothership/pull/9


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src\Core\Services\Implementations\StripePaymentService.cs:** Updated all calls to create Paypal objects to include the new `region` custom field
* **src\Billing\Controllers\StripeController.cs:** Updated all calls to create Paypal objects to include the new `region` custom field
* **src\Admin\Controllers\ToolsController.cs:** Updated all calls to create Paypal objects to include the new `region` custom field
* **src\Core\Entities\ISubscriber.cs:** Updated the interface to include a new value for the Braintree "region" custom field
* **src\Core\Entities\Organization.cs:** Updated implementation to contain the new value for the Braintree "region" custom field
* **src\Core\Entities\User.cs:** Updated implementation to contain the new value for the Braintree "region" custom field

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
