### PR TITLE
[AC-1508] Stripe fix for invoice.upcoming event

### DIFF
--- a/src/Billing/Controllers/StripeController.cs
+++ b/src/Billing/Controllers/StripeController.cs
@@ -512,6 +512,10 @@ public class StripeController : Controller
                     break;
                 }
             case HandledStripeWebhook.UpcomingInvoice:
+                var eventInvoice = await GetInvoiceAsync(parsedEvent);
+                var customer = await GetCustomerAsync(eventInvoice.CustomerId);
+                customerRegion = GetCustomerRegionFromMetadata(customer.Metadata);
+                break;
             case HandledStripeWebhook.PaymentSucceeded:
             case HandledStripeWebhook.PaymentFailed:
             case HandledStripeWebhook.InvoiceCreated:
@@ -862,6 +866,23 @@ public class StripeController : Controller
             throw new Exception("Subscription is null. " + eventSubscription.Id);
         }
         return subscription;
+    }
+
+    private async Task<Customer> GetCustomerAsync(string customerId)
+    {
+        if (string.IsNullOrWhiteSpace(customerId))
+        {
+            throw new Exception("Customer ID cannot be empty when attempting to get a customer from Stripe");
+        }
+
+        var customerService = new CustomerService();
+        var customer = await customerService.GetAsync(customerId);
+        if (customer == null)
+        {
+            throw new Exception($"Customer is null. {customerId}");
+        }
+
+        return customer;
     }
 
     private async Task<Subscription> VerifyCorrectTaxRateForCharge(Invoice invoice, Subscription subscription)


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Stripe was reporting a high number of failures when sending us webhook events. We found that this was because, for the event `invoice.upcoming` has a unique feature where they don't send us the Invoice ID, and the code to validate the region was depending on that ID. I updated the code that handles that event to not require the Invoice ID


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **StripeController.cs:** Modified the code for the event `invoice.upcoming` to not depend on `parsedEvent.Data.Object.Id` since it wasn't being sent to us. Instead, I used the `parsedEvent.Data.Object.CustomerId` which was available to fetch the customer's metadata.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
