### PR TITLE
[PM-2548] Added validation to edit and add attachments methods

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -19,6 +19,8 @@ public static class Constants
     /// their subscription has expired.
     /// </summary>
     public const int OrganizationSelfHostSubscriptionGracePeriodDays = 60;
+
+    public const string CipherKeyEncryptionMinimumVersion = "2023.7.0";
 }
 
 public static class TokenPurposes


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Prevent users from editing or adding attachments ciphers using item-level encryption with an old client.



## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Api/Vault/Controllers/CiphersController.cs:** Throw an exception if the cipher being edited is using item-level encryption and the client version is inferior than the version with item-level decryption is released.
* **src/Core/Constants.cs:** Added the version as a constant.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
