### PR TITLE
[PM-3203] Renamed the "cloudVaultRegion" variable to "cloudRegion" in EnvironmentFileBuilder

### DIFF
--- a/util/Setup/EnvironmentFileBuilder.cs
+++ b/util/Setup/EnvironmentFileBuilder.cs
@@ -73,7 +73,7 @@ public class EnvironmentFileBuilder
         _globalOverrideValues = new Dictionary<string, string>
         {
             ["globalSettings__baseServiceUri__vault"] = _context.Config.Url,
-            ["globalSettings__baseServiceUri__cloudVaultRegion"] = "US",
+            ["globalSettings__baseServiceUri__cloudRegion"] = "US",
             ["globalSettings__sqlServer__connectionString"] = $"\"{dbConnectionString.Replace("\"", "\\\"")}\"",
             ["globalSettings__identityServer__certificatePassword"] = _context.Install?.IdentityCertPassword,
             ["globalSettings__internalIdentityKey"] = _context.Stub ? "RANDOM_IDENTITY_KEY" :


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
EnvironmentFileBuilder was adding the region variable as "cloudVaultRegion" when it should have been "cloudRegion".


## Code changes

* **util/Setup/EnvironmentFileBuilder.cs:** Renamed the environment variable

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
