### PR TITLE
[Ac 1563] Unable to load billing and subscription related pages for non-enterprise organizations

### DIFF
--- a/src/Api/Models/Response/Organizations/OrganizationResponseModel.cs
+++ b/src/Api/Models/Response/Organizations/OrganizationResponseModel.cs
@@ -27,7 +27,11 @@ public class OrganizationResponseModel : ResponseModel
         BusinessTaxNumber = organization.BusinessTaxNumber;
         BillingEmail = organization.BillingEmail;
         Plan = new PlanResponseModel(StaticStore.PasswordManagerPlans.FirstOrDefault(plan => plan.Type == organization.PlanType));
-        SecretsManagerPlan = new PlanResponseModel(StaticStore.SecretManagerPlans.FirstOrDefault(plan => plan.Type == organization.PlanType));
+        var matchingPlan = StaticStore.SecretManagerPlans.FirstOrDefault(plan => plan.Type == organization.PlanType);
+        if (matchingPlan != null)
+        {
+            SecretsManagerPlan = new PlanResponseModel(matchingPlan);
+        }
         PlanType = organization.PlanType;
         Seats = organization.Seats;
         MaxAutoscaleSeats = organization.MaxAutoscaleSeats;

--- a/src/Api/Models/Response/Organizations/OrganizationResponseModel.cs
+++ b/src/Api/Models/Response/Organizations/OrganizationResponseModel.cs
@@ -27,7 +27,7 @@ public class OrganizationResponseModel : ResponseModel
         BusinessTaxNumber = organization.BusinessTaxNumber;
         BillingEmail = organization.BillingEmail;
         Plan = new PlanResponseModel(StaticStore.PasswordManagerPlans.FirstOrDefault(plan => plan.Type == organization.PlanType));
-        var matchingPlan = StaticStore.SecretManagerPlans.FirstOrDefault(plan => plan.Type == organization.PlanType);
+        var matchingPlan = StaticStore.GetSecretsManagerPlan(organization.PlanType);
         if (matchingPlan != null)
         {
             SecretsManagerPlan = new PlanResponseModel(matchingPlan);

--- a/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs
@@ -267,13 +267,13 @@ public class UpgradeOrganizationPlanCommand : IUpgradeOrganizationPlanCommand
         organization.PublicKey = upgrade.PublicKey;
         organization.PrivateKey = upgrade.PrivateKey;
         organization.UsePasswordManager = true;
+        organization.UseSecretsManager = upgrade.UseSecretsManager;
 
         if (upgrade.UseSecretsManager)
         {
             organization.SmSeats = newSecretsManagerPlan.BaseSeats + upgrade.AdditionalSmSeats.GetValueOrDefault();
             organization.SmServiceAccounts = newSecretsManagerPlan.BaseServiceAccount.GetValueOrDefault() +
                                              upgrade.AdditionalServiceAccounts.GetValueOrDefault();
-            organization.UseSecretsManager = upgrade.UseSecretsManager;
         }
 
         await _organizationService.ReplaceAndUpdateCacheAsync(organization);

--- a/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs
@@ -267,8 +267,8 @@ public class UpgradeOrganizationPlanCommand : IUpgradeOrganizationPlanCommand
         organization.PublicKey = upgrade.PublicKey;
         organization.PrivateKey = upgrade.PrivateKey;
         organization.UsePasswordManager = true;
-        organization.SmSeats = (short)(newSecretsManagerPlan.BaseSeats + upgrade.AdditionalSmSeats.GetValueOrDefault());
-        organization.SmServiceAccounts = newSecretsManagerPlan.BaseServiceAccount + upgrade.AdditionalServiceAccounts.GetValueOrDefault();
+        organization.SmSeats = newSecretsManagerPlan?.BaseSeats + upgrade.AdditionalSmSeats.GetValueOrDefault();
+        organization.SmServiceAccounts = newSecretsManagerPlan?.BaseServiceAccount + upgrade.AdditionalServiceAccounts.GetValueOrDefault();
         organization.UseSecretsManager = upgrade.UseSecretsManager;
 
         await _organizationService.ReplaceAndUpdateCacheAsync(organization);

--- a/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs
@@ -267,9 +267,14 @@ public class UpgradeOrganizationPlanCommand : IUpgradeOrganizationPlanCommand
         organization.PublicKey = upgrade.PublicKey;
         organization.PrivateKey = upgrade.PrivateKey;
         organization.UsePasswordManager = true;
-        organization.SmSeats = newSecretsManagerPlan?.BaseSeats + upgrade.AdditionalSmSeats.GetValueOrDefault();
-        organization.SmServiceAccounts = newSecretsManagerPlan?.BaseServiceAccount + upgrade.AdditionalServiceAccounts.GetValueOrDefault();
-        organization.UseSecretsManager = upgrade.UseSecretsManager;
+
+        if (upgrade.UseSecretsManager)
+        {
+            organization.SmSeats = newSecretsManagerPlan.BaseSeats + upgrade.AdditionalSmSeats.GetValueOrDefault();
+            organization.SmServiceAccounts = newSecretsManagerPlan.BaseServiceAccount.GetValueOrDefault() +
+                                             upgrade.AdditionalServiceAccounts.GetValueOrDefault();
+            organization.UseSecretsManager = upgrade.UseSecretsManager;
+        }
 
         await _organizationService.ReplaceAndUpdateCacheAsync(organization);
 

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -446,6 +446,7 @@ public class OrganizationService : IOrganizationService
             RevisionDate = DateTime.UtcNow,
             Status = OrganizationStatusType.Created,
             UsePasswordManager = true,
+            UseSecretsManager = signup.UseSecretsManager,
         };
 
         if (signup.UseSecretsManager)
@@ -453,7 +454,6 @@ public class OrganizationService : IOrganizationService
             organization.SmSeats = secretsManagerPlan.BaseSeats + signup.AdditionalSmSeats.GetValueOrDefault();
             organization.SmServiceAccounts = secretsManagerPlan.BaseServiceAccount.GetValueOrDefault() +
                                              signup.AdditionalServiceAccounts.GetValueOrDefault();
-            organization.UseSecretsManager = signup.UseSecretsManager;
         }
 
         if (passwordManagerPlan.Type == PlanType.Free && !provider)

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -446,8 +446,8 @@ public class OrganizationService : IOrganizationService
             RevisionDate = DateTime.UtcNow,
             Status = OrganizationStatusType.Created,
             UsePasswordManager = true,
-            SmSeats = (short)(secretsManagerPlan.BaseSeats + signup.AdditionalSmSeats.GetValueOrDefault()),
-            SmServiceAccounts = secretsManagerPlan.BaseServiceAccount + signup.AdditionalServiceAccounts.GetValueOrDefault(),
+            SmSeats = secretsManagerPlan?.BaseSeats + signup.AdditionalSmSeats.GetValueOrDefault(),
+            SmServiceAccounts = secretsManagerPlan?.BaseServiceAccount + signup.AdditionalServiceAccounts.GetValueOrDefault(),
             UseSecretsManager = signup.UseSecretsManager
         };
 

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -446,10 +446,15 @@ public class OrganizationService : IOrganizationService
             RevisionDate = DateTime.UtcNow,
             Status = OrganizationStatusType.Created,
             UsePasswordManager = true,
-            SmSeats = secretsManagerPlan?.BaseSeats + signup.AdditionalSmSeats.GetValueOrDefault(),
-            SmServiceAccounts = secretsManagerPlan?.BaseServiceAccount + signup.AdditionalServiceAccounts.GetValueOrDefault(),
-            UseSecretsManager = signup.UseSecretsManager
         };
+
+        if (signup.UseSecretsManager)
+        {
+            organization.SmSeats = secretsManagerPlan.BaseSeats + signup.AdditionalSmSeats.GetValueOrDefault();
+            organization.SmServiceAccounts = secretsManagerPlan.BaseServiceAccount.GetValueOrDefault() +
+                                             signup.AdditionalServiceAccounts.GetValueOrDefault();
+            organization.UseSecretsManager = signup.UseSecretsManager;
+        }
 
         if (passwordManagerPlan.Type == PlanType.Free && !provider)
         {

--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -156,6 +156,7 @@ public class OrganizationServiceTests
         signup.AdditionalSeats = 0;
         signup.PaymentMethodType = PaymentMethodType.Card;
         signup.PremiumAccessAddon = false;
+        signup.UseSecretsManager = false;
 
         var purchaseOrganizationPlan = StaticStore.Plans.Where(x => x.Type == signup.Plan).ToList();
 
@@ -172,8 +173,8 @@ public class OrganizationServiceTests
         await sutProvider.GetDependency<IReferenceEventService>().Received(1)
             .RaiseEventAsync(Arg.Is<ReferenceEvent>(referenceEvent =>
                 referenceEvent.Type == ReferenceEventType.Signup &&
-                referenceEvent.PlanName == purchaseOrganizationPlan[0].Name &&
-                referenceEvent.PlanType == purchaseOrganizationPlan[0].Type &&
+                referenceEvent.PlanName == passwordManagerPlan.Name &&
+                referenceEvent.PlanType == passwordManagerPlan.Type &&
                 referenceEvent.Seats == result.Item1.Seats &&
                 referenceEvent.Storage == result.Item1.MaxStorageGb));
         // TODO: add reference events for SmSeats and Service Accounts - see AC-1481
@@ -187,7 +188,7 @@ public class OrganizationServiceTests
             Arg.Any<Organization>(),
             signup.PaymentMethodType.Value,
             signup.PaymentToken,
-            Arg.Is<List<Plan>>(plan => plan.All(p => purchaseOrganizationPlan.Contains(p))),
+            Arg.Is<List<Plan>>(plan => plan.Single() == passwordManagerPlan),
             signup.AdditionalStorageGb,
             signup.AdditionalSeats,
             signup.PremiumAccessAddon,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
In CloudQA-US and CloudQA-EU, the following pages will not load when the subscription is not enterprise:

Organization Info

Subscription

Payment Method


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
