### PR TITLE
Shrink the database transaction logs after backup

### DIFF
--- a/util/MsSql/backup-db.sh
+++ b/util/MsSql/backup-db.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+export DATABASE_NAME=${DATABASE_NAME:-vault}
 BACKUP_INTERVAL=${BACKUP_INTERVAL:-next day}
 BACKUP_INTERVAL_FORMAT=${BACKUP_INTERVAL_FORMAT:-%Y-%m-%d 00:00:00}
 
@@ -14,7 +15,7 @@ do
   export now=$(date +%Y%m%d_%H%M%S)
 
   # Do a new backup
-  /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -i /backup-db.sql
+  /opt/mssql-tools/bin/sqlcmd -S localhost -d ${DATABASE_NAME} -U sa -P ${SA_PASSWORD} -i /backup-db.sql
 
   # Delete backup files older than 30 days
   grep -B1 "BACKUP DATABASE successfully" /var/opt/mssql/log/errorlog | grep -q _$now.BAK &&

--- a/util/MsSql/backup-db.sql
+++ b/util/MsSql/backup-db.sql
@@ -1,10 +1,10 @@
 -- Database name which is set from the backup-db.sh script.
 DECLARE @DatabaseName varchar(100)
-SET @DatabaseName = 'vault'
+SET @DatabaseName = '$(DATABASE_NAME)'
 
 -- Database name without spaces for saving the backup files.
 DECLARE @DatabaseNameSafe varchar(100)
-SET @DatabaseNameSafe = 'vault'
+SET @DatabaseNameSafe = '$(DATABASE_NAME)'
 
 DECLARE @BackupFile varchar(100)
 SET @BackupFile = '/etc/bitwarden/mssql/backups/' + @DatabaseNameSafe + '_FULL_$(now).BAK'
@@ -16,3 +16,6 @@ DECLARE @BackupCommand NVARCHAR(1000)
 SET @BackupCommand = 'BACKUP DATABASE [' + @DatabaseName + '] TO DISK = ''' + @BackupFile + ''' WITH INIT, NAME= ''' + @BackupName + ''', NOSKIP, NOFORMAT'
 
 EXEC(@BackupCommand)
+
+-- Shrink the transaction log after the backup
+DBCC SHRINKFILE ('$(DATABASE_NAME)_log', EMPTYFILE);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Without shrinking the transaction logs, mssql will keep them indefinitely.
This would generate a huge log file after some time. In my case this is 27GB


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Most important change is adding

* **backup-db.sh**: DBCC SHRINKFILE ('$(DATABASE_NAME)_log', EMPTYFILE);

According to https://learn.microsoft.com/de-de/sql/t-sql/database-console-commands/dbcc-shrinkfile-transact-sql?view=sql-server-ver16

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
