### PR TITLE
[AC-1506] Setting a license key value when creating a new organization for a provider

### DIFF
--- a/src/Admin/Models/OrganizationEditModel.cs
+++ b/src/Admin/Models/OrganizationEditModel.cs
@@ -22,6 +22,7 @@ public class OrganizationEditModel : OrganizationViewModel
         BillingEmail = provider.Type == ProviderType.Reseller ? provider.BillingEmail : string.Empty;
         PlanType = Core.Enums.PlanType.TeamsMonthly;
         Plan = Core.Enums.PlanType.TeamsMonthly.GetDisplayAttribute()?.GetName();
+        LicenseKey = RandomLicenseKey;
     }
 
     public OrganizationEditModel(Organization org, Provider provider, IEnumerable<OrganizationUserUserDetails> orgUsers,


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Organizations for a Provider were not being set a license key value on creation.


## Code changes
* **src/Admin/Models/OrganizationEditModel.cs:** Set a license key value on model creation

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
