### PR TITLE
[PM-3246] Check the user directly if they have the ResetPasswordKey

### DIFF
--- a/test/Common/Helpers/AssertHelper.cs
+++ b/test/Common/Helpers/AssertHelper.cs
@@ -103,6 +103,7 @@ public static class AssertHelper
     public static Expression<Predicate<T>> AssertEqualExpected<T>(T expected) =>
         (T actual) => AssertEqualExpectedPredicate(expected)(actual);
 
+    [StackTraceHidden]
     public static JsonElement AssertJsonProperty(JsonElement element, string propertyName, JsonValueKind jsonValueKind)
     {
         if (!element.TryGetProperty(propertyName, out var subElement))


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Check the `OrganizationUser` directly for if they have the reset password key which is the better identifier for if the org has the policy and they have enrolled in that policy since that is what is needed for admin approval to work.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Identity/IdentityServer/BaseRequestValidator.cs:** Grab the user from `IOrganizationUserRepository` so that we can check their `ResetPasswordKey` value.
* **test/Common/Helpers/AssertHelper.cs:** Usability improvement so that when an exception comes from this assertion helper the first line in the stack trace is user code and can be clicked on to find the actual problem in the test code.
* **test/Identity.IntegrationTest/Endpoints/IdentityServerSsoTests.cs:** Refactored tests for reuse of code, and fixed the has admin approval test.
## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
