### PR TITLE
Remove website instance id from launch env

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -101,7 +101,6 @@
             "stopAtEntry": false,
             "env": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
-                "WEBSITE_INSTANCE_ID": "dev",
             },
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"
@@ -124,7 +123,6 @@
             "stopAtEntry": false,
             "env": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
-                "WEBSITE_INSTANCE_ID": "dev",
             },
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"
@@ -147,7 +145,6 @@
             "stopAtEntry": false,
             "env": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
-                "WEBSITE_INSTANCE_ID": "dev",
             },
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"
@@ -172,7 +169,6 @@
             "OS-COMMENT5": "Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser",
             "env": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
-                "WEBSITE_INSTANCE_ID": "dev",
             },
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"
@@ -195,7 +191,6 @@
             "stopAtEntry": false,
             "env": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
-                "WEBSITE_INSTANCE_ID": "dev",
             },
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"
@@ -218,7 +213,6 @@
             "stopAtEntry": false,
             "env": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
-                "WEBSITE_INSTANCE_ID": "dev",
             },
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"
@@ -241,7 +235,6 @@
             "stopAtEntry": false,
             "env": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
-                "WEBSITE_INSTANCE_ID": "dev",
             },
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"
@@ -264,7 +257,6 @@
             "stopAtEntry": false,
             "env": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
-                "WEBSITE_INSTANCE_ID": "dev",
             },
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"
@@ -289,7 +281,6 @@
                 "ASPNETCORE_ENVIRONMENT": "Development",
                 "ASPNETCORE_URLS": "http://localhost:33657",
                 "developSelfHosted": "true",
-                "WEBSITE_INSTANCE_ID": "dev",
             },
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"
@@ -314,7 +305,6 @@
                 "ASPNETCORE_ENVIRONMENT": "Development",
                 "ASPNETCORE_URLS": "http://localhost:4001",
                 "developSelfHosted": "true",
-                "WEBSITE_INSTANCE_ID": "dev",
             },
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"
@@ -341,7 +331,6 @@
                 "ASPNETCORE_ENVIRONMENT": "Development",
                 "ASPNETCORE_URLS": "http://localhost:62912",
                 "developSelfHosted": "true",
-                "WEBSITE_INSTANCE_ID": "dev",
             },
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"
@@ -366,7 +355,6 @@
                 "ASPNETCORE_ENVIRONMENT": "Development",
                 "ASPNETCORE_URLS": "http://localhost:51822",
                 "developSelfHosted": "true",
-                "WEBSITE_INSTANCE_ID": "dev",
             },
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"
@@ -391,7 +379,6 @@
                 "ASPNETCORE_ENVIRONMENT": "Development",
                 "ASPNETCORE_URLS": "http://localhost:61841",
                 "developSelfHosted": "true",
-                "WEBSITE_INSTANCE_ID": "dev",
             },
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"
@@ -416,7 +403,6 @@
                 "ASPNETCORE_ENVIRONMENT": "Development",
                 "ASPNETCORE_URLS": "http://localhost:46274",
                 "developSelfHosted": "true",
-                "WEBSITE_INSTANCE_ID": "dev",
             },
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
#3102 added `WEBSITE_INSTANCE_ID` to launch.json, but that has the side effect of moving your data protection keys. This removes those since it's not widely relevant AND that PR adds a way to set instance ID through globalsettings, which lacks the side effect

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
