### PR TITLE
PM-3327 - UserService.UpdateKeyAsync Must Exclude Current Device from Log out

### DIFF
--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -892,7 +892,7 @@ public class UserService : UserManager<User>, IUserService, IDisposable
                 await _userRepository.ReplaceAsync(user);
             }
 
-            await _pushService.PushLogOutAsync(user.Id);
+            await _pushService.PushLogOutAsync(user.Id, excludeCurrentContextFromPush: true);
             return IdentityResult.Success;
         }
 


### PR DESCRIPTION
[PM-3327](https://bitwarden.atlassian.net/browse/PM-3327)

`UserService's` `UpdateKeyAsync` must exempt the currently calling device from the logout notification in order to prevent prematurely logging the user out before the client side key rotation process can complete. The calling device will log itself out once it is done.

## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/Services/Implementations/UserService.cs:** `UserService's` `UpdateKeyAsync` must exempt current device from logout notification

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team


[PM-3327]: https://bitwarden.atlassian.net/browse/PM-3327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ