### PR TITLE
Remove implied default NuGet configuration

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <packageSources>
-        <!--To inherit the global NuGet package sources remove the <clear/> line below -->
         <clear />
-        <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+        <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     </packageSources>
 </configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,7 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <packageSources>
-        <clear />
-        <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-    </packageSources>
+    <!-- No configured package sources besides the default. -->
 </configuration>


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Removes the default NuGet package source config per https://github.com/renovatebot/renovate/issues/20888#issuecomment-1474255212 as we're having issues with Renovate not applying package lock updates with its changes, perhaps because of https://github.com/renovatebot/renovate/blob/2fd071cadf24e4c21a5255f25bc8b521f838d3ff/lib/manager/nuget/artifacts.ts#L73 and how it wants to use an alternative setup.

## Code changes

* **NuGet.config:** Removal with note as to why.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
