### PR TITLE
Fix github.ref comparison in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -357,14 +357,18 @@ jobs:
           github.ref == 'refs/heads/rc' ||
           github.ref == 'refs/heads/hotfix-rc'
         run: |
-          # Set proper image based on branch
-          if [[ "${{ github.ref }}" == "master" ]]; then
-            SETUP_IMAGE="$_AZ_REGISTRY/setup:dev"
-          elif [[ "${{ github.ref }}" == "rc" ]]; then
-            SETUP_IMAGE="$_AZ_REGISTRY/setup:rc"
-          elif [[ "${{ github.ref }}" == "hotfix-rc" ]]; then
-            SETUP_IMAGE="$_AZ_REGISTRY/setup:hotfix-rc"
-          fi
+          # Set proper setup image based on branch
+          case "${{ github.ref }}" in
+            "refs/heads/master")
+                SETUP_IMAGE="$_AZ_REGISTRY/setup:dev"
+                ;;
+            "refs/heads/rc")
+                SETUP_IMAGE="$_AZ_REGISTRY/setup:rc"
+                ;;
+            "refs/heads/hotfix-rc")
+                SETUP_IMAGE="$_AZ_REGISTRY/setup:hotfix-rc"
+                ;;
+          esac
 
           STUB_OUTPUT=$(pwd)/docker-stub
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fixes the comparison of `${{github.ref}}` by using the branch ref's full path.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **.github/workflows/build.yml:** Convert setup image tag setup to case statement and fix comparision values.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
