### PR TITLE
[AC-1588] Fix Bitwarden Portal Secrets Manager flag not working

### DIFF
--- a/src/Admin/Views/Shared/_OrganizationForm.cshtml
+++ b/src/Admin/Views/Shared/_OrganizationForm.cshtml
@@ -83,7 +83,7 @@
                         var planTypes = Enum.GetValues<PlanType>()
                             .Where(p => Model.Provider == null || p is >= PlanType.TeamsMonthly and <= PlanType.EnterpriseAnnually)
                             .Select(e => new SelectListItem
-                            { 
+                            {
                                 Value = ((int)e).ToString(),
                                 Text = e.GetDisplayAttribute()?.GetName() ?? e.ToString()
                             })
@@ -176,7 +176,7 @@
             </div>
         </div>
     }
-    
+
     @if (canViewPlan)
     {
         <h2>Password Manager Configuration</h2>
@@ -212,7 +212,7 @@
 
     @if (canViewPlan)
     {
-        <div id="organization-secrets-configuration" hidden="@(!Model.UseSecretsManager)">
+        <div id="organization-secrets-configuration">
             <h2>Secrets Manager Configuration</h2>
             <div class="row">
                 <div class="col-sm">
@@ -265,7 +265,7 @@
     }
 
     @if (canViewBilling)
-    { 
+    {
         <h2>Billing</h2>
         <div class="row">
             <div class="col-sm">
@@ -315,7 +315,7 @@
                     <label asp-for="GatewaySubscriptionId"></label>
                     <div class="input-group">
                         <input type="text" class="form-control" asp-for="GatewaySubscriptionId" readonly='@(!canEditBilling)'>
-                        @if (canLaunchGateway) 
+                        @if (canLaunchGateway)
                         {
                             <div class="input-group-append">
                                 <button class="btn btn-secondary" type="button" id="gateway-subscription-link">

--- a/src/Admin/Views/Shared/_OrganizationForm.cshtml
+++ b/src/Admin/Views/Shared/_OrganizationForm.cshtml
@@ -83,7 +83,7 @@
                         var planTypes = Enum.GetValues<PlanType>()
                             .Where(p => Model.Provider == null || p is >= PlanType.TeamsMonthly and <= PlanType.EnterpriseAnnually)
                             .Select(e => new SelectListItem
-                            {
+                            { 
                                 Value = ((int)e).ToString(),
                                 Text = e.GetDisplayAttribute()?.GetName() ?? e.ToString()
                             })
@@ -176,7 +176,7 @@
             </div>
         </div>
     }
-
+    
     @if (canViewPlan)
     {
         <h2>Password Manager Configuration</h2>
@@ -212,7 +212,7 @@
 
     @if (canViewPlan)
     {
-        <div id="organization-secrets-configuration">
+        <div id="organization-secrets-configuration" hidden="@(!Model.UseSecretsManager)">
             <h2>Secrets Manager Configuration</h2>
             <div class="row">
                 <div class="col-sm">
@@ -265,7 +265,7 @@
     }
 
     @if (canViewBilling)
-    {
+    { 
         <h2>Billing</h2>
         <div class="row">
             <div class="col-sm">
@@ -315,7 +315,7 @@
                     <label asp-for="GatewaySubscriptionId"></label>
                     <div class="input-group">
                         <input type="text" class="form-control" asp-for="GatewaySubscriptionId" readonly='@(!canEditBilling)'>
-                        @if (canLaunchGateway)
+                        @if (canLaunchGateway) 
                         {
                             <div class="input-group-append">
                                 <button class="btn btn-secondary" type="button" id="gateway-subscription-link">

--- a/src/Admin/Views/Shared/_OrganizationFormScripts.cshtml
+++ b/src/Admin/Views/Shared/_OrganizationFormScripts.cshtml
@@ -6,7 +6,7 @@
             document.getElementById('@(nameof(Model.Plan))').value = selectText;
             togglePlanSettings(selectEl.options[selectEl.selectedIndex].value);
         });
-        document.getElementById('gateway-customer-link').addEventListener('click', () => {
+        document.getElementById('gateway-customer-link')?.addEventListener('click', () => {
             const gateway = document.getElementById('@(nameof(Model.Gateway))');
             const customerId = document.getElementById('@(nameof(Model.GatewayCustomerId))');
             if (!gateway || gateway.value === '' || !customerId || customerId.value === '') {
@@ -19,7 +19,7 @@
                     + customerId.value, '_blank');
             }
         });
-        document.getElementById('gateway-subscription-link').addEventListener('click', () => {
+        document.getElementById('gateway-subscription-link')?.addEventListener('click', () => {
             const gateway = document.getElementById('@(nameof(Model.Gateway))');
             const subId = document.getElementById('@(nameof(Model.GatewaySubscriptionId))');
             if (!gateway || gateway.value === '' || !subId || subId.value === '') {
@@ -34,24 +34,28 @@
         });
         document.getElementById('@(nameof(Model.UseSecretsManager))').addEventListener('change', (event) => {
             document.getElementById('organization-secrets-configuration').hidden  = !event.target.checked;
-            
+
             if (event.target.checked) {
                 return;
             }
-            
+
             document.getElementById('@(nameof(Model.SmSeats))').value = '';
             document.getElementById('@(nameof(Model.MaxAutoscaleSmSeats))').value = '';
             document.getElementById('@(nameof(Model.SmServiceAccounts))').value = '';
             document.getElementById('@(nameof(Model.MaxAutoscaleSmServiceAccounts))').value = '';
         });
+
+        // Set initial state
+        document.getElementById('organization-secrets-configuration').hidden  =
+            !document.getElementById('@(nameof(Model.UseSecretsManager))').checked;
     })();
-    
+
     function togglePlanSettings(planType) {
         document.getElementById('@(nameof(Model.PlanType))').value = planType;
         switch(planType) {
             case '@((byte)Bit.Core.Enums.PlanType.TeamsMonthly)':
             case '@((byte)Bit.Core.Enums.PlanType.TeamsAnnually)':
-                // Plan                
+                // Plan
                 document.getElementById('@(nameof(Model.Seats))').value = '10';
                 document.getElementById('@(nameof(Model.MaxCollections))').value = '';
                 document.getElementById('@(nameof(Model.MaxStorageGb))').value = '1';
@@ -66,7 +70,7 @@
                 document.getElementById('@(nameof(Model.UseDirectory))').checked = true;
                 document.getElementById('@(nameof(Model.UseEvents))').checked = true;
                 document.getElementById('@(nameof(Model.UsersGetPremium))').checked = true;
-                document.getElementById('@(nameof(Model.UseCustomPermissions))').checked = false;                
+                document.getElementById('@(nameof(Model.UseCustomPermissions))').checked = false;
                 document.getElementById('@(nameof(Model.UseTotp))').checked = true;
                 document.getElementById('@(nameof(Model.Use2fa))').checked = true;
                 document.getElementById('@(nameof(Model.UseApi))').checked = true;
@@ -78,7 +82,7 @@
                 document.getElementById('@(nameof(Model.ExpirationDate))').value = '@Model.FourteenDayExpirationDate';
                 document.getElementById('@(nameof(Model.SalesAssistedTrialStarted))').value = true;
             break;
-            
+
             case '@((byte)Bit.Core.Enums.PlanType.EnterpriseMonthly)':
             case '@((byte)Bit.Core.Enums.PlanType.EnterpriseAnnually)':
                 // Plan
@@ -109,6 +113,6 @@
                 document.getElementById('@(nameof(Model.SalesAssistedTrialStarted))').value = true;
             break;
         }
-        
+
     }
 </script>

--- a/src/Admin/Views/Shared/_OrganizationFormScripts.cshtml
+++ b/src/Admin/Views/Shared/_OrganizationFormScripts.cshtml
@@ -39,7 +39,7 @@
                 return;
             }
 
-            document.getElementById('@(nameof(Model.SmSeats))').value = 1;
+            document.getElementById('@(nameof(Model.SmSeats))').value = '';
             document.getElementById('@(nameof(Model.MaxAutoscaleSmSeats))').value = '';
             document.getElementById('@(nameof(Model.SmServiceAccounts))').value = '';
             document.getElementById('@(nameof(Model.MaxAutoscaleSmServiceAccounts))').value = '';

--- a/src/Admin/Views/Shared/_OrganizationFormScripts.cshtml
+++ b/src/Admin/Views/Shared/_OrganizationFormScripts.cshtml
@@ -39,15 +39,11 @@
                 return;
             }
 
-            document.getElementById('@(nameof(Model.SmSeats))').value = '';
+            document.getElementById('@(nameof(Model.SmSeats))').value = 1;
             document.getElementById('@(nameof(Model.MaxAutoscaleSmSeats))').value = '';
             document.getElementById('@(nameof(Model.SmServiceAccounts))').value = '';
             document.getElementById('@(nameof(Model.MaxAutoscaleSmServiceAccounts))').value = '';
         });
-
-        // Set initial state
-        document.getElementById('organization-secrets-configuration').hidden  =
-            !document.getElementById('@(nameof(Model.UseSecretsManager))').checked;
     })();
 
     function togglePlanSettings(planType) {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix a bug where the SM Configuration section isn't showing for Free orgs in the Bitwarden Portal. This has flow-on effects where you save the org with SM enabled but no seats, which puts the org in an invalid state.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Admin/Views/Shared/_OrganizationFormScripts.cshtml** - add optional chaining (`?`) to some of the `getElementById`, because those elements are not rendered for free orgs. This meant it was throwing an error and not executing the rest of the function, which registers the event handlers.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
