### PR TITLE
[AC-244] Consider a user's email as verified when they accept an organization invitation via the email link

### DIFF
--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1180,6 +1180,9 @@ public class OrganizationService : IOrganizationService
 
         await _organizationUserRepository.ReplaceAsync(orgUser);
 
+        user.EmailVerified = true;
+        await _userRepository.ReplaceAsync(user);
+
         var admins = await _organizationUserRepository.GetManyByMinimumRoleAsync(orgUser.OrganizationId, OrganizationUserType.Admin);
         var adminEmails = admins.Select(a => a.Email).Distinct().ToList();
 

--- a/test/Core.Test/AutoFixture/OrganizationFixtures.cs
+++ b/test/Core.Test/AutoFixture/OrganizationFixtures.cs
@@ -10,6 +10,7 @@ using Bit.Core.Models.Data;
 using Bit.Core.Utilities;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
+using Microsoft.AspNetCore.DataProtection;
 
 namespace Bit.Core.Test.AutoFixture.OrganizationFixtures;
 
@@ -161,4 +162,32 @@ internal class OrganizationInviteCustomizeAttribute : BitCustomizeAttribute
         InvitorUserType = InvitorUserType,
         PermissionsBlob = PermissionsBlob,
     };
+}
+
+internal class EphemeralDataProtectionCustomization : ICustomization
+{
+    public void Customize(IFixture fixture)
+    {
+        fixture.Customizations.Add(new EphemeralDataProtectionProviderBuilder());
+    }
+
+    private class EphemeralDataProtectionProviderBuilder : ISpecimenBuilder
+    {
+        public object Create(object request, ISpecimenContext context)
+        {
+            var type = request as Type;
+            if (type == null || type != typeof(IDataProtectionProvider))
+            {
+                return new NoSpecimen();
+            }
+
+            return new EphemeralDataProtectionProvider();
+        }
+    }
+}
+
+internal class EphemeralDataProtectionAutoDataAttribute : CustomAutoDataAttribute
+{
+    public EphemeralDataProtectionAutoDataAttribute() : base(new SutProviderCustomization(), new EphemeralDataProtectionCustomization())
+    { }
 }

--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -1835,7 +1835,7 @@ public class OrganizationServiceTests
     }
 
     [Theory]
-    [EphemeralDataProtectionAutoData, BitAutoData]
+    [BitAutoData]
     public async Task AcceptUserAsync_Success([OrganizationUser(OrganizationUserStatusType.Invited)] OrganizationUser organizationUser, User user)
     {
         var fixture = new Fixture();


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
If a user is invited to an organization and accepts the email invite, the member record should be considered automatically verified.


## Code changes

* **src/Core/Services/Implementations/OrganizationService.cs:** Set `User.EmailVerified` as true and save the changes.
* **test/Core.Test/AutoFixture/OrganizationFixtures.cs:** Created `EphemeralDataProtectionAutoDataAttribute` to use an instance of `EphemeralDataProtectionProvider` for testing
* **test/Core.Test/Services/OrganizationServiceTests.cs:** Added a unit test to verify the expected behaviour of `OrganizationService.AcceptUserAsync` for a valid input

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
