### PR TITLE
[PM-2427] Added back alias that was accidentally introduced

### DIFF
--- a/src/Identity/Controllers/SsoController.cs
+++ b/src/Identity/Controllers/SsoController.cs
@@ -14,6 +14,8 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Bit.Identity.Controllers;
 
+// TODO: 2023-10-16, Remove account alias (https://bitwarden.atlassian.net/browse/PM-1247)
+[Route("account/[action]")]
 [Route("sso/[action]")]
 public class SsoController : Controller
 {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

In https://github.com/bitwarden/server/pull/3118/, we accidentally introduced a change that was meant to be part of PM-1247, which is still in review.

This commit adds back the alias with an additional note referencing the issue that will remove it.  We cannot remove it yet as clients need to be fixed.

## Code changes

* **SsoController.cs:** Added back the `account` alias and added a note referencing the Jira ticket currently in progress to fix it.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
