### PR TITLE
[AC-1585] Automatically verify managed members on an organization with a verified domain

### DIFF
--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -50,20 +50,20 @@ public static class CoreHelpers
     {
         var guidArray = startingGuid.ToByteArray();
 
-        // Get the days and milliseconds which will be used to build the byte string 
+        // Get the days and milliseconds which will be used to build the byte string
         var days = new TimeSpan(time.Ticks - _baseDateTicks);
         var msecs = time.TimeOfDay;
 
-        // Convert to a byte array 
-        // Note that SQL Server is accurate to 1/300th of a millisecond so we divide by 3.333333 
+        // Convert to a byte array
+        // Note that SQL Server is accurate to 1/300th of a millisecond so we divide by 3.333333
         var daysArray = BitConverter.GetBytes(days.Days);
         var msecsArray = BitConverter.GetBytes((long)(msecs.TotalMilliseconds / 3.333333));
 
-        // Reverse the bytes to match SQL Servers ordering 
+        // Reverse the bytes to match SQL Servers ordering
         Array.Reverse(daysArray);
         Array.Reverse(msecsArray);
 
-        // Copy the bytes into the guid 
+        // Copy the bytes into the guid
         Array.Copy(daysArray, daysArray.Length - 2, guidArray, guidArray.Length - 6, 2);
         Array.Copy(msecsArray, msecsArray.Length - 4, guidArray, guidArray.Length - 4, 4);
 
@@ -816,5 +816,20 @@ public static class CoreHelpers
             .Append(emailParts[1])
             .ToString();
 
+    }
+
+    public static string GetEmailDomain(string email)
+    {
+        if (!string.IsNullOrWhiteSpace(email))
+        {
+            var emailParts = email.Split('@', StringSplitOptions.RemoveEmptyEntries);
+
+            if (emailParts.Length == 2)
+            {
+                return emailParts[1].Trim();
+            }
+        }
+
+        return null;
     }
 }

--- a/test/Core.Test/Utilities/CoreHelpersTests.cs
+++ b/test/Core.Test/Utilities/CoreHelpersTests.cs
@@ -416,4 +416,25 @@ public class CoreHelpersTests
     {
         Assert.Equal(expected, CoreHelpers.ObfuscateEmail(input));
     }
+
+    [Theory]
+    [InlineData("user@example.com")]
+    [InlineData("user@example.com ")]
+    [InlineData("user.name@example.com")]
+    public void GetEmailDomain_Success(string email)
+    {
+        Assert.Equal("example.com", CoreHelpers.GetEmailDomain(email));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("userexample.com")]
+    [InlineData("user@")]
+    [InlineData("@example.com")]
+    [InlineData("user@ex@ample.com")]
+    public void GetEmailDomain_ReturnsNull(string wrongEmail)
+    {
+        Assert.Null(CoreHelpers.GetEmailDomain(wrongEmail));
+    }
 }


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
If an organization has verified a domain, any members joining the organization from that domain should be automatically considered verified.


## Code changes

* **bitwarden_license/src/Sso/Controllers/AccountController.cs:** Added `IOrganizationDomainRepository` to retrieve the domains for the user's organization and if there are any verified then we mark the user's email as verified
* **src/Core/Utilities/CoreHelpers.cs:** Added a method to retrieve the domain from an email address
* **test/Core.Test/Utilities/CoreHelpersTests.cs:** Added unit tests for the new static method

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
