### PR TITLE
[AC-1601] Added RequireSso policy as a dependency of TDE

### DIFF
--- a/src/Core/Auth/Services/Implementations/SsoConfigService.cs
+++ b/src/Core/Auth/Services/Implementations/SsoConfigService.cs
@@ -84,7 +84,7 @@ public class SsoConfigService : ISsoConfigService
                               new Policy { OrganizationId = config.OrganizationId, Type = PolicyType.RequireSso, };
 
             ssoRequiredPolicy.Enabled = true;
-            await _policyService.SaveAsync(resetPolicy, _userService, _organizationService, null);
+            await _policyService.SaveAsync(ssoRequiredPolicy, _userService, _organizationService, null);
         }
 
         await LogEventsAsync(config, oldConfig);

--- a/src/Core/Auth/Services/Implementations/SsoConfigService.cs
+++ b/src/Core/Auth/Services/Implementations/SsoConfigService.cs
@@ -84,7 +84,7 @@ public class SsoConfigService : ISsoConfigService
                               new Policy { OrganizationId = config.OrganizationId, Type = PolicyType.RequireSso, };
 
             ssoRequiredPolicy.Enabled = true;
-
+            await _policyService.SaveAsync(resetPolicy, _userService, _organizationService, null);
         }
 
         await LogEventsAsync(config, oldConfig);

--- a/src/Core/Auth/Services/Implementations/SsoConfigService.cs
+++ b/src/Core/Auth/Services/Implementations/SsoConfigService.cs
@@ -63,7 +63,7 @@ public class SsoConfigService : ISsoConfigService
             throw new BadRequestException("Key Connector cannot be disabled at this moment.");
         }
 
-        // Automatically enable account recovery and single org policies if trusted device encryption is selected
+        // Automatically enable account recovery, SSO required, and single org policies if trusted device encryption is selected
         if (config.GetData().MemberDecryptionType == MemberDecryptionType.TrustedDeviceEncryption)
         {
             var singleOrgPolicy = await _policyRepository.GetByOrganizationIdTypeAsync(config.OrganizationId, PolicyType.SingleOrg) ??
@@ -78,8 +78,13 @@ public class SsoConfigService : ISsoConfigService
 
             resetPolicy.Enabled = true;
             resetPolicy.SetDataModel(new ResetPasswordDataModel { AutoEnrollEnabled = true });
-
             await _policyService.SaveAsync(resetPolicy, _userService, _organizationService, null);
+
+            var ssoRequiredPolicy = await _policyRepository.GetByOrganizationIdTypeAsync(config.OrganizationId, PolicyType.RequireSso) ??
+                              new Policy { OrganizationId = config.OrganizationId, Type = PolicyType.RequireSso, };
+
+            ssoRequiredPolicy.Enabled = true;
+
         }
 
         await LogEventsAsync(config, oldConfig);

--- a/src/Core/Services/Implementations/PolicyService.cs
+++ b/src/Core/Services/Implementations/PolicyService.cs
@@ -75,6 +75,7 @@ public class PolicyService : IPolicyService
                 else
                 {
                     await RequiredByKeyConnectorAsync(org);
+                    await RequiredBySsoTrustedDeviceEncryptionAsync(org);
                 }
                 break;
 

--- a/test/Core.Test/Services/PolicyServiceTests.cs
+++ b/test/Core.Test/Services/PolicyServiceTests.cs
@@ -406,7 +406,7 @@ public class PolicyServiceTests
     [BitAutoData(true, false)]
     [BitAutoData(false, true)]
     [BitAutoData(false, false)]
-    public async Task SaveAsync_PolicyRequiredByTrustedDeviceEncryption_DisablePolicyOrDisableAutomaticEnrollment_ThrowsBadRequest(
+    public async Task SaveAsync_ResetPasswordPolicyRequiredByTrustedDeviceEncryption_DisablePolicyOrDisableAutomaticEnrollment_ThrowsBadRequest(
         bool policyEnabled,
         bool autoEnrollEnabled,
         [PolicyFixtures.Policy(PolicyType.ResetPassword)] Policy policy,
@@ -417,6 +417,43 @@ public class PolicyServiceTests
         {
             AutoEnrollEnabled = autoEnrollEnabled
         });
+
+        SetupOrg(sutProvider, policy.OrganizationId, new Organization
+        {
+            Id = policy.OrganizationId,
+            UsePolicies = true,
+        });
+
+        var ssoConfig = new SsoConfig { Enabled = true };
+        ssoConfig.SetData(new SsoConfigurationData { MemberDecryptionType = MemberDecryptionType.TrustedDeviceEncryption });
+
+        sutProvider.GetDependency<ISsoConfigRepository>()
+            .GetByOrganizationIdAsync(policy.OrganizationId)
+            .Returns(ssoConfig);
+
+        var badRequestException = await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.SaveAsync(policy,
+                Substitute.For<IUserService>(),
+                Substitute.For<IOrganizationService>(),
+                Guid.NewGuid()));
+
+        Assert.Contains("Trusted device encryption is on and requires this policy.", badRequestException.Message, StringComparison.OrdinalIgnoreCase);
+
+        await sutProvider.GetDependency<IPolicyRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .UpsertAsync(default);
+
+        await sutProvider.GetDependency<IEventService>()
+            .DidNotReceiveWithAnyArgs()
+            .LogPolicyEventAsync(default, default, default);
+    }
+
+    [Theory, BitAutoData]
+    public async Task SaveAsync_RequireSsoPolicyRequiredByTrustedDeviceEncryption_DisablePolicy_ThrowsBadRequest(
+        [PolicyFixtures.Policy(PolicyType.RequireSso)] Policy policy,
+        SutProvider<PolicyService> sutProvider)
+    {
+        policy.Enabled = false;
 
         SetupOrg(sutProvider, policy.OrganizationId, new Organization
         {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

We are making the RequireSSO policy a prerequisite for enabling TDE.  This is because allowing users to use Login with Device puts users in a bad state that was unanticipated during implementation.

This change in policy application has been discussed and approved by Product as well.

## Code changes
* **SsoConfigService.cs:** Added code to set RequireSso policy when TDE is enabled.
* **PolicyService.cs:** Added code to prevent disabling RequireSso policy when TDE is enabled.
* **PolicyServiceTests.cs:** Added test to ensure that the RequireSso not enabled when TDE is enabled throws an error.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
