### PR TITLE
[PM-3563] Prevent org name from injecting HTML into FD notes

### DIFF
--- a/src/Billing/Controllers/FreshdeskController.cs
+++ b/src/Billing/Controllers/FreshdeskController.cs
@@ -77,7 +77,9 @@ public class FreshdeskController : Controller
 
                 foreach (var org in orgs)
                 {
-                    var orgNote = $"{org.Name} ({org.Seats.GetValueOrDefault()}): " +
+                    // Prevent org names from injecting any additional HTML
+                    var orgName = org.Name.Replace("<", string.Empty).Replace(">", string.Empty);
+                    var orgNote = $"{orgName} ({org.Seats.GetValueOrDefault()}): " +
                         $"{_globalSettings.BaseServiceUri.Admin}/organizations/edit/{org.Id}";
                     note += $"<li>Org, {orgNote}</li>";
                     if (!customFields.Any(kvp => kvp.Key == _billingSettings.FreshDesk.OrgFieldName))

--- a/src/Billing/Controllers/FreshdeskController.cs
+++ b/src/Billing/Controllers/FreshdeskController.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using System.Text;
+using System.Web;
 using Bit.Billing.Models;
 using Bit.Core.Repositories;
 using Bit.Core.Settings;
@@ -78,7 +79,7 @@ public class FreshdeskController : Controller
                 foreach (var org in orgs)
                 {
                     // Prevent org names from injecting any additional HTML
-                    var orgName = org.Name.Replace("<", string.Empty).Replace(">", string.Empty);
+                    var orgName = HttpUtility.HtmlEncode(org.Name);
                     var orgNote = $"{orgName} ({org.Seats.GetValueOrDefault()}): " +
                         $"{_globalSettings.BaseServiceUri.Admin}/organizations/edit/{org.Id}";
                     note += $"<li>Org, {orgNote}</li>";


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Prevent org name from injecting HTML into Freshdesk notes.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Billing/Controllers/FreshdeskController.cs:** Replace `<` and `>` from org names.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
