### PR TITLE
[AC-1612] Updated CurrentContext.ViewAssignedCollections to check if the user has CreateNewCollections permission

### DIFF
--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -358,7 +358,7 @@ public class CurrentContext : ICurrentContext
 
     public async Task<bool> ViewAssignedCollections(Guid orgId)
     {
-        return await EditAssignedCollections(orgId) || await DeleteAssignedCollections(orgId);
+        return await EditAssignedCollections(orgId) || await DeleteAssignedCollections(orgId) || await CreateNewCollections(orgId);
     }
 
     public async Task<bool> ManageGroups(Guid orgId)

--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -358,7 +358,9 @@ public class CurrentContext : ICurrentContext
 
     public async Task<bool> ViewAssignedCollections(Guid orgId)
     {
-        return await EditAssignedCollections(orgId) || await DeleteAssignedCollections(orgId) || await CreateNewCollections(orgId);
+        return await CreateNewCollections(orgId) // Required to display the existing collections under which the new collection can be nested
+               || await EditAssignedCollections(orgId)
+               || await DeleteAssignedCollections(orgId);
     }
 
     public async Task<bool> ManageGroups(Guid orgId)


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
If a Custom Role org member with only Create new collections permissions navigates to the Organization vault, they run into infinite spinners along with multiple errors listed in the dev tools console.

The origin of this issue is from the change in [this PR](https://github.com/bitwarden/server/commit/95b7652ca98b2d7aafaf5bf4776d009a4abbc145#diff-a0d048d2dd3fd53b7dc8f8349cd348baf79c0ce075af29faff0a7abbc3683468) because custom users with "Create New Collections" permission used to view all collections and after that was removed they couldn't see any collection.

## Code changes

* **src/Core/Context/CurrentContext.cs:** Updated `CurrentContext.ViewAssignedCollections` to check if the user has CreateNewCollections permission.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
