### PR TITLE
[PM-3487] prevent account enumeration on auth request endpoint

### DIFF
--- a/test/Core.Test/Auth/Services/AuthRequestServiceTests.cs
+++ b/test/Core.Test/Auth/Services/AuthRequestServiceTests.cs
@@ -142,15 +142,19 @@ public class AuthRequestServiceTests
     }
 
     [Theory, BitAutoData]
-    public async Task CreateAuthRequestAsync_NoUser_ThrowsNotFound(
+    public async Task CreateAuthRequestAsync_NoUser_ThrowsBadRequest(
         SutProvider<AuthRequestService> sutProvider,
         AuthRequestCreateRequestModel createModel)
     {
+        sutProvider.GetDependency<ICurrentContext>()
+            .DeviceType
+            .Returns(DeviceType.Android);
+
         sutProvider.GetDependency<IUserRepository>()
             .GetByEmailAsync(createModel.Email)
             .Returns((User?)null);
 
-        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.CreateAuthRequestAsync(createModel));
+        await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.CreateAuthRequestAsync(createModel));
     }
 
     [Theory, BitAutoData]
@@ -253,7 +257,7 @@ public class AuthRequestServiceTests
 
     /// <summary>
     /// Story: If a user happens to exist to more than one organization, we will send the device approval request to
-    /// each of them. 
+    /// each of them.
     /// </summary>
     [Theory, BitAutoData]
     public async Task CreateAuthRequestAsync_AdminApproval_CreatesForEachOrganization(
@@ -627,8 +631,8 @@ public class AuthRequestServiceTests
     }
 
     /// <summary>
-    /// Story: An admin approves a request for one of their org users. For auditing purposes we need to 
-    /// log an event that correlates the action for who the request was approved for. On approval we also need to 
+    /// Story: An admin approves a request for one of their org users. For auditing purposes we need to
+    /// log an event that correlates the action for who the request was approved for. On approval we also need to
     /// push the notification to the user.
     /// </summary>
     [Theory, BitAutoData]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The create auth request endpoint was returning different errors based on if the user existed or not. We can't leak that information on anonymous endpoint due to account enumeration.

The solution here is to return the same error message for if the user or device isn't found.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
