### PR TITLE
[PM-3708] Allow local overrides for flag values

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -46,4 +46,13 @@ public static class FeatureFlagKeys
             .Select(x => (string)x.GetRawConstantValue())
             .ToList();
     }
+
+    public static Dictionary<string, string> GetLocalOverrideFlagValues()
+    {
+        // place overriding values when needed locally (offline), or return null
+        return new Dictionary<string, string>()
+        {
+            { TrustedDeviceEncryption, "true" }
+        };
+    }
 }

--- a/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
+++ b/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
@@ -29,24 +29,12 @@ public class LaunchDarklyFeatureService : IFeatureService, IDisposable
             // support configuration directly from settings
             else if (globalSettings.LaunchDarkly?.FlagValues?.Any() is true)
             {
-                var source = TestData.DataSource();
-                foreach (var kvp in globalSettings.LaunchDarkly.FlagValues)
-                {
-                    if (bool.TryParse(kvp.Value, out bool boolValue))
-                    {
-                        source.Update(source.Flag(kvp.Key).ValueForAll(LaunchDarkly.Sdk.LdValue.Of(boolValue)));
-                    }
-                    else if (int.TryParse(kvp.Value, out int intValue))
-                    {
-                        source.Update(source.Flag(kvp.Key).ValueForAll(LaunchDarkly.Sdk.LdValue.Of(intValue)));
-                    }
-                    else
-                    {
-                        source.Update(source.Flag(kvp.Key).ValueForAll(LaunchDarkly.Sdk.LdValue.Of(kvp.Value)));
-                    }
-                }
-
-                ldConfig.DataSource(source);
+                ldConfig.DataSource(GetTestData(globalSettings.LaunchDarkly.FlagValues));
+            }
+            // support local overrides
+            else if (FeatureFlagKeys.GetLocalOverrideFlagValues()?.Any() is true)
+            {
+                ldConfig.DataSource(GetTestData(FeatureFlagKeys.GetLocalOverrideFlagValues()));
             }
             else
             {
@@ -186,5 +174,27 @@ public class LaunchDarklyFeatureService : IFeatureService, IDisposable
         }
 
         return builder.Build();
+    }
+
+    private TestData GetTestData(Dictionary<string, string> values)
+    {
+        var source = TestData.DataSource();
+        foreach (var kvp in values)
+        {
+            if (bool.TryParse(kvp.Value, out bool boolValue))
+            {
+                source.Update(source.Flag(kvp.Key).ValueForAll(LaunchDarkly.Sdk.LdValue.Of(boolValue)));
+            }
+            else if (int.TryParse(kvp.Value, out int intValue))
+            {
+                source.Update(source.Flag(kvp.Key).ValueForAll(LaunchDarkly.Sdk.LdValue.Of(intValue)));
+            }
+            else
+            {
+                source.Update(source.Flag(kvp.Key).ValueForAll(LaunchDarkly.Sdk.LdValue.Of(kvp.Value)));
+            }
+        }
+
+        return source;
     }
 }

--- a/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
+++ b/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
@@ -29,12 +29,12 @@ public class LaunchDarklyFeatureService : IFeatureService, IDisposable
             // support configuration directly from settings
             else if (globalSettings.LaunchDarkly?.FlagValues?.Any() is true)
             {
-                ldConfig.DataSource(GetTestData(globalSettings.LaunchDarkly.FlagValues));
+                ldConfig.DataSource(BuildDataSource(globalSettings.LaunchDarkly.FlagValues));
             }
             // support local overrides
             else if (FeatureFlagKeys.GetLocalOverrideFlagValues()?.Any() is true)
             {
-                ldConfig.DataSource(GetTestData(FeatureFlagKeys.GetLocalOverrideFlagValues()));
+                ldConfig.DataSource(BuildDataSource(FeatureFlagKeys.GetLocalOverrideFlagValues()));
             }
             else
             {
@@ -176,7 +176,7 @@ public class LaunchDarklyFeatureService : IFeatureService, IDisposable
         return builder.Build();
     }
 
-    private TestData GetTestData(Dictionary<string, string> values)
+    private TestData BuildDataSource(Dictionary<string, string> values)
     {
         var source = TestData.DataSource();
         foreach (var kvp in values)

--- a/test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs
+++ b/test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs
@@ -20,14 +20,6 @@ public class LaunchDarklyFeatureServiceTests
             .Create();
     }
 
-    [Fact]
-    public void Offline_WhenSelfHost()
-    {
-        var sutProvider = GetSutProvider(new Core.Settings.GlobalSettings() { SelfHosted = true });
-
-        Assert.False(sutProvider.Sut.IsOnline());
-    }
-
     [Theory, BitAutoData]
     public void DefaultFeatureValue_WhenSelfHost(string key)
     {


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Adds the ability to utilize another data source for flag values referred to as a "local override". When we desire to leave feature flag checks and configuration in place e.g. returning a value to clients but need the value to be fixed, use a new dictionary where flag constants are stored to allow for overrides. All the existing data store capabilities:

1. Online with LaunchDarkly
2. Local file
3. Local app settings or environment variables

are maintained in that order, with the last being the new constants check for local overrides. This maintains customizations and is a final fallback before considering flag retrieval to be totally offline (and therefore use only default values).

Supersedes https://github.com/bitwarden/server/pull/3240.

## Code changes

* **src/Core/Constants.cs:** New method `GetLocalOverrideFlagValues` and an initial use case for TDE that's needed. This will `return null;` when not in use.
* **src/Core/Services/Implementations/LaunchDarklyFeatureService.cs:** Additional check for local override presence and extraction to a helper method the process of mapping said values for both local overrides and configuration / environment variables.
* **test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs:** Removal of a test that assumed self-host is offline. This never really meant anything for us to begin and self-host still isn't sending anything to LaunchDarkly's cloud.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
