### PR TITLE
[SM-911] Remove indexing from data migration

### DIFF
--- a/util/Migrator/DbScripts/2023-08-10_00_ClientSecretHashDataMigration.sql
+++ b/util/Migrator/DbScripts/2023-08-10_00_ClientSecretHashDataMigration.sql
@@ -6,14 +6,6 @@ The final migration is in util/Migrator/DbScripts/2023-08-10_01_RemoveClientSecr
 IF COL_LENGTH('[dbo].[ApiKey]', 'ClientSecretHash') IS NOT NULL AND COL_LENGTH('[dbo].[ApiKey]', 'ClientSecret')  IS NOT NULL
 BEGIN
 
-  -- Add index
-  IF NOT EXISTS(SELECT name FROM sys.indexes WHERE name = 'IX_ApiKey_ClientSecretHash')
-  BEGIN
-   CREATE NONCLUSTERED INDEX [IX_ApiKey_ClientSecretHash]
-   ON [dbo].[ApiKey]([ClientSecretHash] ASC)
-   WITH (ONLINE = ON)
-  END
-
   -- Data Migration
   DECLARE @BatchSize INT = 10000
   WHILE @BatchSize > 0
@@ -33,10 +25,6 @@ BEGIN
 
     COMMIT TRANSACTION Migrate_ClientSecretHash
   END
-
-  -- Drop index
-  DROP INDEX IF EXISTS [IX_ApiKey_ClientSecretHash]
-      ON [dbo].[ApiKey];
 
 END
 GO


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The purpose of this PR is to remove the temporary indexing from the client secret hash data migration that has already been run in production. The version of MS SQL Server used for self-hosted instances doesn't support `ONLINE = ON`


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **util/Migrator/DbScripts/2023-08-10_00_ClientSecretHashDataMigration.sql:** 
Removing temporary indexing.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
