### PR TITLE
[AC-1174] Bulk Collection Management (targeting master)

### DIFF
--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -211,8 +211,8 @@ public class CollectionsController : Controller
 
         await _bulkAddCollectionAccessCommand.AddAccessAsync(orgId,
             collections,
-            model.Users.Select(u => u.ToSelectionReadOnly()).ToList(),
-            model.Groups.Select(g => g.ToSelectionReadOnly()).ToList());
+            model.Users?.Select(u => u.ToSelectionReadOnly()).ToList(),
+            model.Groups?.Select(g => g.ToSelectionReadOnly()).ToList());
     }
 
     [HttpDelete("{id}")]

--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -22,6 +22,7 @@ public class CollectionsController : Controller
     private readonly IUserService _userService;
     private readonly IAuthorizationService _authorizationService;
     private readonly ICurrentContext _currentContext;
+    private readonly IBulkAddCollectionAccessCommand _bulkAddCollectionAccessCommand;
 
     public CollectionsController(
         ICollectionRepository collectionRepository,
@@ -29,7 +30,7 @@ public class CollectionsController : Controller
         IDeleteCollectionCommand deleteCollectionCommand,
         IUserService userService,
         IAuthorizationService authorizationService,
-        ICurrentContext currentContext)
+        ICurrentContext currentContext, IBulkAddCollectionAccessCommand bulkAddCollectionAccessCommand)
     {
         _collectionRepository = collectionRepository;
         _collectionService = collectionService;
@@ -37,6 +38,7 @@ public class CollectionsController : Controller
         _userService = userService;
         _authorizationService = authorizationService;
         _currentContext = currentContext;
+        _bulkAddCollectionAccessCommand = bulkAddCollectionAccessCommand;
     }
 
     [HttpGet("{id}")]
@@ -207,7 +209,10 @@ public class CollectionsController : Controller
             throw new NotFoundException();
         }
 
-        // TODO: Perform operation
+        await _bulkAddCollectionAccessCommand.AddAccessAsync(orgId,
+            collections,
+            model.Users.Select(u => u.ToSelectionReadOnly()).ToList(),
+            model.Groups.Select(g => g.ToSelectionReadOnly()).ToList());
     }
 
     [HttpDelete("{id}")]

--- a/src/Api/Models/Request/BulkCollectionAccessRequestModel.cs
+++ b/src/Api/Models/Request/BulkCollectionAccessRequestModel.cs
@@ -17,6 +17,11 @@ public class BulkCollectionAccessRequestModel
     /// </summary>
     public IEnumerable<CollectionUser> ToAllCollectionUsers()
     {
+        if (Users == null)
+        {
+            return new List<CollectionUser>();
+        }
+
         return CollectionIds.SelectMany(collectionId => Users.Select(u => new CollectionUser
         {
             CollectionId = collectionId,
@@ -33,6 +38,11 @@ public class BulkCollectionAccessRequestModel
     /// </summary>
     public IEnumerable<CollectionGroup> ToAllCollectionGroups()
     {
+        if (Groups == null)
+        {
+            return new List<CollectionGroup>();
+        }
+
         return CollectionIds.SelectMany(collectionId => Groups.Select(u => new CollectionGroup
         {
             CollectionId = collectionId,

--- a/src/Api/Models/Request/BulkCollectionAccessRequestModel.cs
+++ b/src/Api/Models/Request/BulkCollectionAccessRequestModel.cs
@@ -1,55 +1,13 @@
 ﻿
 
 using Bit.Core.Entities;
+using Bit.Core.Exceptions;
 
 namespace Bit.Api.Models.Request;
 
 public class BulkCollectionAccessRequestModel
 {
     public IEnumerable<Guid> CollectionIds { get; set; }
-
     public IEnumerable<SelectionReadOnlyRequestModel> Groups { get; set; }
     public IEnumerable<SelectionReadOnlyRequestModel> Users { get; set; }
-
-    /// <summary>
-    /// Build a list of <see cref="CollectionUser"/> entities from combinations of every
-    /// <see cref="CollectionIds"/> and <see cref="Users"/>.
-    /// </summary>
-    public IEnumerable<CollectionUser> ToAllCollectionUsers()
-    {
-        if (Users == null)
-        {
-            return new List<CollectionUser>();
-        }
-
-        return CollectionIds.SelectMany(collectionId => Users.Select(u => new CollectionUser
-        {
-            CollectionId = collectionId,
-            OrganizationUserId = u.Id,
-            Manage = u.Manage,
-            HidePasswords = u.HidePasswords,
-            ReadOnly = u.ReadOnly
-        }));
-    }
-
-    /// <summary>
-    /// Build a list of <see cref="CollectionGroup"/> entities from combinations of every
-    /// <see cref="CollectionIds"/> and <see cref="Groups"/>.
-    /// </summary>
-    public IEnumerable<CollectionGroup> ToAllCollectionGroups()
-    {
-        if (Groups == null)
-        {
-            return new List<CollectionGroup>();
-        }
-
-        return CollectionIds.SelectMany(collectionId => Groups.Select(u => new CollectionGroup
-        {
-            CollectionId = collectionId,
-            GroupId = u.Id,
-            Manage = u.Manage,
-            HidePasswords = u.HidePasswords,
-            ReadOnly = u.ReadOnly
-        }));
-    }
 }

--- a/src/Api/Models/Request/BulkCollectionAccessRequestModel.cs
+++ b/src/Api/Models/Request/BulkCollectionAccessRequestModel.cs
@@ -1,0 +1,45 @@
+﻿
+
+using Bit.Core.Entities;
+
+namespace Bit.Api.Models.Request;
+
+public class BulkCollectionAccessRequestModel
+{
+    public IEnumerable<Guid> CollectionIds { get; set; }
+
+    public IEnumerable<SelectionReadOnlyRequestModel> Groups { get; set; }
+    public IEnumerable<SelectionReadOnlyRequestModel> Users { get; set; }
+
+    /// <summary>
+    /// Build a list of <see cref="CollectionUser"/> entities from combinations of every
+    /// <see cref="CollectionIds"/> and <see cref="Users"/>.
+    /// </summary>
+    public IEnumerable<CollectionUser> ToAllCollectionUsers()
+    {
+        return CollectionIds.SelectMany(collectionId => Users.Select(u => new CollectionUser
+        {
+            CollectionId = collectionId,
+            OrganizationUserId = u.Id,
+            Manage = u.Manage,
+            HidePasswords = u.HidePasswords,
+            ReadOnly = u.ReadOnly
+        }));
+    }
+
+    /// <summary>
+    /// Build a list of <see cref="CollectionGroup"/> entities from combinations of every
+    /// <see cref="CollectionIds"/> and <see cref="Groups"/>.
+    /// </summary>
+    public IEnumerable<CollectionGroup> ToAllCollectionGroups()
+    {
+        return CollectionIds.SelectMany(collectionId => Groups.Select(u => new CollectionGroup
+        {
+            CollectionId = collectionId,
+            GroupId = u.Id,
+            Manage = u.Manage,
+            HidePasswords = u.HidePasswords,
+            ReadOnly = u.ReadOnly
+        }));
+    }
+}

--- a/src/Api/Models/Request/BulkCollectionAccessRequestModel.cs
+++ b/src/Api/Models/Request/BulkCollectionAccessRequestModel.cs
@@ -1,9 +1,4 @@
-﻿
-
-using Bit.Core.Entities;
-using Bit.Core.Exceptions;
-
-namespace Bit.Api.Models.Request;
+﻿namespace Bit.Api.Models.Request;
 
 public class BulkCollectionAccessRequestModel
 {

--- a/src/Api/Models/Request/SelectionReadOnlyRequestModel.cs
+++ b/src/Api/Models/Request/SelectionReadOnlyRequestModel.cs
@@ -6,7 +6,7 @@ namespace Bit.Api.Models.Request;
 public class SelectionReadOnlyRequestModel
 {
     [Required]
-    public string Id { get; set; }
+    public Guid Id { get; set; }
     public bool ReadOnly { get; set; }
     public bool HidePasswords { get; set; }
 
@@ -14,7 +14,7 @@ public class SelectionReadOnlyRequestModel
     {
         return new CollectionAccessSelection
         {
-            Id = new Guid(Id),
+            Id = Id,
             ReadOnly = ReadOnly,
             HidePasswords = HidePasswords,
         };

--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -137,6 +137,9 @@ public class Startup
         services.AddOrganizationSubscriptionServices();
         services.AddCoreLocalizationServices();
 
+        // Authorization Handlers
+        services.AddAuthorizationHandlers();
+
         //health check
         if (!globalSettings.SelfHosted)
         {

--- a/src/Api/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Api/Utilities/ServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
-﻿using Bit.Core.IdentityServer;
+﻿using Bit.Api.Vault.AuthorizationHandlers;
+using Bit.Core.IdentityServer;
 using Bit.Core.Settings;
 using Bit.Core.Utilities;
 using Bit.SharedWeb.Health;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.OpenApi.Models;
 
 namespace Bit.Api.Utilities;
@@ -114,5 +116,10 @@ public static class ServiceCollectionExtensions
                 builder.AddSendGrid(globalSettings.Mail.SendGridApiKey);
             }
         });
+    }
+
+    public static void AddAuthorizationHandlers(this IServiceCollection services)
+    {
+        services.AddScoped<IAuthorizationHandler, CollectionAuthorizationHandler>();
     }
 }

--- a/src/Api/Vault/AuthorizationHandlers/CollectionAuthorizationHandler.cs
+++ b/src/Api/Vault/AuthorizationHandlers/CollectionAuthorizationHandler.cs
@@ -71,10 +71,17 @@ public class CollectionAuthorizationHandler : BulkAuthorizationHandler<Collectio
             return;
         }
 
-        // List of collection Ids the acting user is allowed to manage
+        // Acting user does not have permission to edit assigned collections, fail
+        if (!org.Permissions.EditAssignedCollections)
+        {
+            context.Fail();
+            return;
+        }
+
+        // List of assigned collection Ids for the acting user
         var manageableCollectionIds =
             (await _collectionRepository.GetManyByUserIdAsync(_currentContext.UserId.Value))
-            .Where(c => c.Manage && c.OrganizationId == targetOrganizationId)
+            .Where(c => c.OrganizationId == targetOrganizationId)
             .Select(c => c.Id)
             .ToHashSet();
 

--- a/src/Api/Vault/AuthorizationHandlers/CollectionAuthorizationHandler.cs
+++ b/src/Api/Vault/AuthorizationHandlers/CollectionAuthorizationHandler.cs
@@ -1,0 +1,90 @@
+﻿using Bit.Core.Context;
+using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Exceptions;
+using Bit.Core.Repositories;
+using Bit.Core.Utilities;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Bit.Api.Vault.AuthorizationHandlers;
+
+public class CollectionAuthorizationHandler : BulkAuthorizationHandler<CollectionOperationRequirement, Collection>
+{
+    private readonly ICurrentContext _currentContext;
+    private readonly ICollectionRepository _collectionRepository;
+    private readonly IOrganizationUserRepository _organizationUserRepository;
+
+    public CollectionAuthorizationHandler(ICurrentContext currentContext, ICollectionRepository collectionRepository, IOrganizationUserRepository organizationUserRepository)
+    {
+        _currentContext = currentContext;
+        _collectionRepository = collectionRepository;
+        _organizationUserRepository = organizationUserRepository;
+    }
+
+    protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, CollectionOperationRequirement requirement,
+        ICollection<Collection> resources)
+    {
+        switch (requirement)
+        {
+            case not null when requirement == CollectionOperation.ModifyAccess:
+                await CanManageCollectionAccessAsync(context, requirement, resources);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Ensures the acting user is allowed to manage access permissions for the target collections.
+    /// </summary>
+    private async Task CanManageCollectionAccessAsync(AuthorizationHandlerContext context, IAuthorizationRequirement requirement, ICollection<Collection> targetCollections)
+    {
+        if (!_currentContext.UserId.HasValue)
+        {
+            context.Fail();
+            return;
+        }
+
+        var targetOrganizationId = targetCollections.First().OrganizationId;
+
+        // Ensure all target collections belong to the same organization
+        if (targetCollections.Any(tc => tc.OrganizationId != targetOrganizationId))
+        {
+            throw new BadRequestException("Requested collections must belong to the same organization.");
+        }
+
+        var org = (await _currentContext.OrganizationMembershipAsync(_organizationUserRepository, _currentContext.UserId.Value))
+            .FirstOrDefault(o => targetOrganizationId == o.Id);
+
+        // Acting user is not a member of the target organization, fail
+        if (org == null)
+        {
+            context.Fail();
+            return;
+        }
+
+        // Owners, Admins, Providers, and users with EditAnyCollection permission can always manage collection access
+        if (
+            org.Permissions is { EditAnyCollection: true } ||
+            org.Type is OrganizationUserType.Admin or OrganizationUserType.Owner ||
+            await _currentContext.ProviderUserForOrgAsync(org.Id))
+        {
+            context.Succeed(requirement);
+            return;
+        }
+
+        // List of collection Ids the acting user is allowed to manage
+        var manageableCollectionIds =
+            (await _collectionRepository.GetManyByUserIdAsync(_currentContext.UserId.Value))
+            .Where(c => c.Manage && c.OrganizationId == targetOrganizationId)
+            .Select(c => c.Id)
+            .ToHashSet();
+
+        // The acting user does not have permission to manage all target collections, fail
+        if (targetCollections.Any(tc => !manageableCollectionIds.Contains(tc.Id)))
+        {
+            context.Fail();
+            return;
+        }
+
+        context.Succeed(requirement);
+    }
+}

--- a/src/Api/Vault/AuthorizationHandlers/CollectionOperation.cs
+++ b/src/Api/Vault/AuthorizationHandlers/CollectionOperation.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Authorization.Infrastructure;
+
+namespace Bit.Api.Vault.AuthorizationHandlers;
+
+public class CollectionOperationRequirement : OperationAuthorizationRequirement { }
+
+public static class CollectionOperation
+{
+    /// <summary>
+    /// The operation that represents creating, updating, or removing collection access.
+    /// Combined together to allow for a single requirement to be used for each operation
+    /// as they all currently share the same underlying authorization logic.
+    /// </summary>
+    public static readonly CollectionOperationRequirement ModifyAccess = new() { Name = nameof(ModifyAccess) };
+}

--- a/src/Core/OrganizationFeatures/OrganizationCollections/BulkAddCollectionAccessCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationCollections/BulkAddCollectionAccessCommand.cs
@@ -41,7 +41,7 @@ public class BulkAddCollectionAccessCommand : IBulkAddCollectionAccessCommand
 
     private async Task ValidateRequestAsync(Guid orgId, ICollection<Collection> collections, ICollection<CollectionAccessSelection> usersAccess, ICollection<CollectionAccessSelection> groupsAccess)
     {
-        if (collections.Count == 0)
+        if (collections == null || collections.Count == 0)
         {
             throw new BadRequestException("No collections were provided.");
         }
@@ -51,9 +51,9 @@ public class BulkAddCollectionAccessCommand : IBulkAddCollectionAccessCommand
             throw new BadRequestException("All collections must belong to the same organization.");
         }
 
-        var collectionUserIds = usersAccess.Select(u => u.Id).ToList();
+        var collectionUserIds = usersAccess?.Select(u => u.Id).ToList();
 
-        if (collectionUserIds.Count > 0)
+        if (collectionUserIds is { Count: > 0 })
         {
             var users = await _organizationUserRepository.GetManyAsync(collectionUserIds);
 
@@ -68,9 +68,9 @@ public class BulkAddCollectionAccessCommand : IBulkAddCollectionAccessCommand
             }
         }
 
-        var collectionGroupIds = groupsAccess.Select(g => g.Id).ToList();
+        var collectionGroupIds = groupsAccess?.Select(g => g.Id).ToList();
 
-        if (collectionGroupIds.Count > 0)
+        if (collectionGroupIds is { Count: > 0 })
         {
             var groups = await _groupRepository.GetManyByManyIds(collectionGroupIds);
 

--- a/src/Core/OrganizationFeatures/OrganizationCollections/BulkAddCollectionAccessCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationCollections/BulkAddCollectionAccessCommand.cs
@@ -28,7 +28,9 @@ public class BulkAddCollectionAccessCommand : IBulkAddCollectionAccessCommand
     {
         await ValidateRequestAsync(organizationId, collections, users, groups);
 
-        // TODO: Add repository call and Event logs
+        await _collectionRepository.CreateOrUpdateAccessForManyAsync(organizationId, collections.Select(c => c.Id), users, groups);
+
+        // TODO: Add Event logs
     }
 
     private async Task ValidateRequestAsync(Guid orgId, ICollection<Collection> collections, ICollection<CollectionAccessSelection> usersAccess, ICollection<CollectionAccessSelection> groupsAccess)

--- a/src/Core/OrganizationFeatures/OrganizationCollections/BulkAddCollectionAccessCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationCollections/BulkAddCollectionAccessCommand.cs
@@ -1,0 +1,80 @@
+﻿using Bit.Core.Entities;
+using Bit.Core.Exceptions;
+using Bit.Core.Models.Data;
+using Bit.Core.OrganizationFeatures.OrganizationCollections.Interfaces;
+using Bit.Core.Repositories;
+
+namespace Bit.Core.OrganizationFeatures.OrganizationCollections;
+
+public class BulkAddCollectionAccessCommand : IBulkAddCollectionAccessCommand
+{
+    private readonly ICollectionRepository _collectionRepository;
+    private readonly IOrganizationUserRepository _organizationUserRepository;
+    private readonly IGroupRepository _groupRepository;
+
+    public BulkAddCollectionAccessCommand(
+        ICollectionRepository collectionRepository,
+        IOrganizationUserRepository organizationUserRepository,
+        IGroupRepository groupRepository)
+    {
+        _collectionRepository = collectionRepository;
+        _organizationUserRepository = organizationUserRepository;
+        _groupRepository = groupRepository;
+    }
+
+    public async Task AddAccessAsync(Guid organizationId, ICollection<Collection> collections,
+        ICollection<CollectionAccessSelection> users,
+        ICollection<CollectionAccessSelection> groups)
+    {
+        await ValidateRequestAsync(organizationId, collections, users, groups);
+
+        // TODO: Add repository call and Event logs
+    }
+
+    private async Task ValidateRequestAsync(Guid orgId, ICollection<Collection> collections, ICollection<CollectionAccessSelection> usersAccess, ICollection<CollectionAccessSelection> groupsAccess)
+    {
+        if (collections.Count == 0)
+        {
+            throw new BadRequestException("No collections were provided.");
+        }
+
+        if (collections.Any(c => c.OrganizationId != orgId))
+        {
+            throw new BadRequestException("All collections must belong to the same organization.");
+        }
+
+        var collectionUserIds = usersAccess.Select(u => u.Id).ToList();
+
+        if (collectionUserIds.Count > 0)
+        {
+            var users = await _organizationUserRepository.GetManyAsync(collectionUserIds);
+
+            if (users.Count != collectionUserIds.Count)
+            {
+                throw new BadRequestException("One or more users do not exist.");
+            }
+
+            if (users.Any(u => u.OrganizationId != orgId))
+            {
+                throw new BadRequestException("One or more users do not belong to the same organization as the collection being assigned.");
+            }
+        }
+
+        var collectionGroupIds = groupsAccess.Select(g => g.Id).ToList();
+
+        if (collectionGroupIds.Count > 0)
+        {
+            var groups = await _groupRepository.GetManyByManyIds(collectionGroupIds);
+
+            if (groups.Count != collectionGroupIds.Count)
+            {
+                throw new BadRequestException("One or more groups do not exist.");
+            }
+
+            if (groups.Any(g => g.OrganizationId != orgId))
+            {
+                throw new BadRequestException("One or more groups do not belong to the same organization as the collection being assigned.");
+            }
+        }
+    }
+}

--- a/src/Core/OrganizationFeatures/OrganizationCollections/Interfaces/IBulkAddCollectionAccessCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationCollections/Interfaces/IBulkAddCollectionAccessCommand.cs
@@ -1,0 +1,10 @@
+﻿using Bit.Core.Entities;
+using Bit.Core.Models.Data;
+
+namespace Bit.Core.OrganizationFeatures.OrganizationCollections.Interfaces;
+
+public interface IBulkAddCollectionAccessCommand
+{
+    Task AddAccessAsync(Guid organizationId, ICollection<Collection> collections,
+        ICollection<CollectionAccessSelection> users, ICollection<CollectionAccessSelection> groups);
+}

--- a/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
+++ b/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
@@ -98,6 +98,7 @@ public static class OrganizationServiceCollectionExtensions
     public static void AddOrganizationCollectionCommands(this IServiceCollection services)
     {
         services.AddScoped<IDeleteCollectionCommand, DeleteCollectionCommand>();
+        services.AddScoped<IBulkAddCollectionAccessCommand, BulkAddCollectionAccessCommand>();
     }
 
     private static void AddOrganizationGroupCommands(this IServiceCollection services)

--- a/src/Core/Repositories/ICollectionRepository.cs
+++ b/src/Core/Repositories/ICollectionRepository.cs
@@ -20,4 +20,6 @@ public interface ICollectionRepository : IRepository<Collection, Guid>
     Task UpdateUsersAsync(Guid id, IEnumerable<CollectionAccessSelection> users);
     Task<ICollection<CollectionAccessSelection>> GetManyUsersByIdAsync(Guid id);
     Task DeleteManyAsync(IEnumerable<Guid> collectionIds);
+    Task CreateOrUpdateAccessForManyAsync(Guid organizationId, IEnumerable<Guid> collectionIds,
+        IEnumerable<CollectionAccessSelection> users, IEnumerable<CollectionAccessSelection> groups);
 }

--- a/src/Core/Utilities/BulkAuthorizationHandler.cs
+++ b/src/Core/Utilities/BulkAuthorizationHandler.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace Bit.Core.Utilities;
+
+/// <summary>
+/// Allows a single authorization handler implementation to handle requirements for
+/// both singular or bulk operations on single or multiple resources.
+/// </summary>
+/// <typeparam name="TRequirement">The type of the requirement to evaluate.</typeparam>
+/// <typeparam name="TResource">The type of the resource(s) that will be evaluated.</typeparam>
+public abstract class BulkAuthorizationHandler<TRequirement, TResource> : AuthorizationHandler<TRequirement>
+    where TRequirement : IAuthorizationRequirement
+{
+    protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, TRequirement requirement)
+    {
+        // Attempt to get the resource(s) from the context
+        var bulkResources = GetBulkResourceFromContext(context);
+
+        // No resources of the expected type were found in the context, nothing to evaluate
+        if (bulkResources == null)
+        {
+            return;
+        }
+
+        await HandleRequirementAsync(context, requirement, bulkResources);
+    }
+
+    private static ICollection<TResource> GetBulkResourceFromContext(AuthorizationHandlerContext context)
+    {
+        return context.Resource switch
+        {
+            TResource resource => new List<TResource> { resource },
+            IEnumerable<TResource> resources => resources.ToList(),
+            _ => null
+        };
+    }
+
+    protected abstract Task HandleRequirementAsync(AuthorizationHandlerContext context, TRequirement requirement,
+        ICollection<TResource> resources);
+}

--- a/src/Infrastructure.Dapper/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.Dapper/Repositories/CollectionRepository.cs
@@ -253,9 +253,12 @@ public class CollectionRepository : Repository<Collection, Guid>, ICollectionRep
     {
         using (var connection = new SqlConnection(ConnectionString))
         {
+            var usersArray = users != null ? users.ToArrayTVP() : Enumerable.Empty<CollectionAccessSelection>().ToArrayTVP();
+            var groupsArray = groups != null ? groups.ToArrayTVP() : Enumerable.Empty<CollectionAccessSelection>().ToArrayTVP();
+
             var results = await connection.ExecuteAsync(
                 $"[{Schema}].[Collection_CreateOrUpdateAccessForMany]",
-                new { OrganizationId = organizationId, CollectionIds = collectionIds.ToGuidIdArrayTVP(), Users = users.ToArrayTVP(), Groups = groups.ToArrayTVP() },
+                new { OrganizationId = organizationId, CollectionIds = collectionIds.ToGuidIdArrayTVP(), Users = usersArray, Groups = groupsArray },
                 commandType: CommandType.StoredProcedure);
         }
     }

--- a/src/Infrastructure.Dapper/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.Dapper/Repositories/CollectionRepository.cs
@@ -248,6 +248,18 @@ public class CollectionRepository : Repository<Collection, Guid>, ICollectionRep
         }
     }
 
+    public async Task CreateOrUpdateAccessForManyAsync(Guid organizationId, IEnumerable<Guid> collectionIds,
+        IEnumerable<CollectionAccessSelection> users, IEnumerable<CollectionAccessSelection> groups)
+    {
+        using (var connection = new SqlConnection(ConnectionString))
+        {
+            var results = await connection.ExecuteAsync(
+                $"[{Schema}].[Collection_CreateOrUpdateAccessForMany]",
+                new { OrganizationId = organizationId, CollectionIds = collectionIds.ToGuidIdArrayTVP(), Users = users.ToArrayTVP(), Groups = groups.ToArrayTVP() },
+                commandType: CommandType.StoredProcedure);
+        }
+    }
+
     public async Task CreateUserAsync(Guid collectionId, Guid organizationUserId)
     {
         using (var connection = new SqlConnection(ConnectionString))

--- a/src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs
@@ -458,6 +458,11 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
         }
     }
 
+    public async Task CreateOrUpdateAccessForManyAsync(Guid organizationId, IEnumerable<Guid> collectionIds,
+        IEnumerable<CollectionAccessSelection> users, IEnumerable<CollectionAccessSelection> groups)
+    {
+    }
+
     private async Task ReplaceCollectionGroupsAsync(DatabaseContext dbContext, Core.Entities.Collection collection, IEnumerable<CollectionAccessSelection> groups)
     {
         var groupsInOrg = dbContext.Groups.Where(g => g.OrganizationId == collection.OrganizationId);

--- a/src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs
@@ -491,7 +491,6 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                                 OrganizationUserId = requestedUser.Id,
                                 HidePasswords = requestedUser.HidePasswords,
                                 ReadOnly = requestedUser.ReadOnly,
-                                Manage = requestedUser.Manage
                             });
                             continue;
                         }
@@ -499,7 +498,6 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                         // It already exists, update it
                         existingCollectionUser.HidePasswords = requestedUser.HidePasswords;
                         existingCollectionUser.ReadOnly = requestedUser.ReadOnly;
-                        existingCollectionUser.Manage = requestedUser.Manage;
                         dbContext.CollectionUsers.Update(existingCollectionUser);
                     }
                 }
@@ -528,8 +526,7 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                                 CollectionId = collectionId,
                                 GroupId = requestedGroup.Id,
                                 HidePasswords = requestedGroup.HidePasswords,
-                                ReadOnly = requestedGroup.ReadOnly,
-                                Manage = requestedGroup.Manage
+                                ReadOnly = requestedGroup.ReadOnly
                             });
                             continue;
                         }
@@ -537,7 +534,6 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                         // It already exists, update it
                         existingCollectionGroup.HidePasswords = requestedGroup.HidePasswords;
                         existingCollectionGroup.ReadOnly = requestedGroup.ReadOnly;
-                        existingCollectionGroup.Manage = requestedGroup.Manage;
                         dbContext.CollectionGroups.Update(existingCollectionGroup);
                     }
                 }

--- a/src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs
@@ -461,6 +461,92 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
     public async Task CreateOrUpdateAccessForManyAsync(Guid organizationId, IEnumerable<Guid> collectionIds,
         IEnumerable<CollectionAccessSelection> users, IEnumerable<CollectionAccessSelection> groups)
     {
+        using (var scope = ServiceScopeFactory.CreateScope())
+        {
+            var dbContext = GetDatabaseContext(scope);
+
+            var collectionIdsList = collectionIds.ToList();
+
+            if (users != null)
+            {
+                var existingCollectionUsers = await dbContext.CollectionUsers
+                    .Where(cu => collectionIdsList.Contains(cu.CollectionId))
+                    .ToDictionaryAsync(x => (x.CollectionId, x.OrganizationUserId));
+
+                var requestedUsers = users.ToList();
+
+                foreach (var collectionId in collectionIdsList)
+                {
+                    foreach (var requestedUser in requestedUsers)
+                    {
+                        if (!existingCollectionUsers.TryGetValue(
+                                (collectionId, requestedUser.Id),
+                                out var existingCollectionUser)
+                            )
+                        {
+                            // This is a brand new entry
+                            dbContext.CollectionUsers.Add(new CollectionUser
+                            {
+                                CollectionId = collectionId,
+                                OrganizationUserId = requestedUser.Id,
+                                HidePasswords = requestedUser.HidePasswords,
+                                ReadOnly = requestedUser.ReadOnly,
+                                Manage = requestedUser.Manage
+                            });
+                            continue;
+                        }
+
+                        // It already exists, update it
+                        existingCollectionUser.HidePasswords = requestedUser.HidePasswords;
+                        existingCollectionUser.ReadOnly = requestedUser.ReadOnly;
+                        existingCollectionUser.Manage = requestedUser.Manage;
+                        dbContext.CollectionUsers.Update(existingCollectionUser);
+                    }
+                }
+            }
+
+            if (groups != null)
+            {
+                var existingCollectionGroups = await dbContext.CollectionGroups
+                    .Where(cu => collectionIdsList.Contains(cu.CollectionId))
+                    .ToDictionaryAsync(x => (x.CollectionId, x.GroupId));
+
+                var requestedGroups = groups.ToList();
+
+                foreach (var collectionId in collectionIdsList)
+                {
+                    foreach (var requestedGroup in requestedGroups)
+                    {
+                        if (!existingCollectionGroups.TryGetValue(
+                                (collectionId, requestedGroup.Id),
+                                out var existingCollectionGroup)
+                           )
+                        {
+                            // This is a brand new entry
+                            dbContext.CollectionGroups.Add(new CollectionGroup()
+                            {
+                                CollectionId = collectionId,
+                                GroupId = requestedGroup.Id,
+                                HidePasswords = requestedGroup.HidePasswords,
+                                ReadOnly = requestedGroup.ReadOnly,
+                                Manage = requestedGroup.Manage
+                            });
+                            continue;
+                        }
+
+                        // It already exists, update it
+                        existingCollectionGroup.HidePasswords = requestedGroup.HidePasswords;
+                        existingCollectionGroup.ReadOnly = requestedGroup.ReadOnly;
+                        existingCollectionGroup.Manage = requestedGroup.Manage;
+                        dbContext.CollectionGroups.Update(existingCollectionGroup);
+                    }
+                }
+            }
+
+            await dbContext.SaveChangesAsync();
+            await dbContext.UserBumpAccountRevisionDateByCollectionIdsAsync(collectionIdsList, organizationId);
+            await dbContext.SaveChangesAsync();
+        }
     }
 
     private async Task ReplaceCollectionGroupsAsync(DatabaseContext dbContext, Core.Entities.Collection collection, IEnumerable<CollectionAccessSelection> groups)

--- a/src/Sql/dbo/Stored Procedures/Collection_CreateOrUpdateAccessForMany.sql
+++ b/src/Sql/dbo/Stored Procedures/Collection_CreateOrUpdateAccessForMany.sql
@@ -1,0 +1,93 @@
+CREATE PROCEDURE [dbo].[Collection_CreateOrUpdateAccessForMany]
+	@OrganizationId UNIQUEIDENTIFIER,
+	@CollectionIds AS [dbo].[GuidIdArray] READONLY,
+    @Groups AS [dbo].[SelectionReadOnlyArray] READONLY,
+    @Users AS [dbo].[SelectionReadOnlyArray] READONLY
+AS
+BEGIN
+	SET NOCOUNT ON
+
+	 -- Groups
+	;WITH [NewCollectionGroups] AS (
+		SELECT
+			cId.[Id] AS [CollectionId],
+			gu.[Id] AS [GroupId],
+			gu.[ReadOnly],
+			gu.[HidePasswords],
+			gu.[Manage]
+		FROM
+			@Groups AS gu
+		CROSS JOIN
+			@CollectionIds cId
+		INNER JOIN
+			[dbo].[Group] g ON gu.[Id] = g.[Id]
+		WHERE
+			g.[OrganizationId] = @OrganizationId
+	)
+    MERGE
+    	[dbo].[CollectionGroup] as [Target]
+	USING
+		[NewCollectionGroups] AS [Source]
+	ON
+		[Target].[CollectionId] = [Source].[CollectionId]
+		AND [Target].[GroupId] = [Source].[GroupId]
+	WHEN MATCHED AND EXISTS(
+		SELECT [Source].[ReadOnly], [Source].[HidePasswords], [Source].[Manage]
+		EXCEPT
+		SELECT [Target].[ReadOnly], [Target].[HidePasswords], [Target].[Manage]
+	) THEN UPDATE SET
+		[Target].[ReadOnly] = [Source].[ReadOnly],
+		[Target].[HidePasswords] = [Source].[HidePasswords],
+		[Target].[Manage] = [Source].[Manage]
+	WHEN NOT MATCHED BY TARGET
+		THEN INSERT VALUES
+		(
+			[Source].[CollectionId],
+			[Source].[GroupId],
+			[Source].[ReadOnly],
+			[Source].[HidePasswords],
+			[Source].[Manage]
+		);
+
+	-- Users
+	;WITH [NewCollectionUsers] AS (
+		SELECT
+			cId.[Id] AS [CollectionId],
+			cu.[Id] AS [OrganizationUserId],
+			cu.[ReadOnly],
+			cu.[HidePasswords],
+			cu.[Manage]
+		FROM
+			@Users AS cu
+		CROSS JOIN
+			@CollectionIds cId
+		INNER JOIN
+			[dbo].[OrganizationUser] u ON cu.[Id] = u.[Id]
+		WHERE
+			u.[OrganizationId] = @OrganizationId
+	)
+    MERGE
+    	[dbo].[CollectionUser] as [Target]
+	USING
+		[NewCollectionUsers] AS [Source]
+	ON
+		[Target].[CollectionId] = [Source].[CollectionId]
+		AND [Target].[OrganizationUserId] = [Source].[OrganizationUserId]
+	WHEN MATCHED AND EXISTS(
+		SELECT [Source].[ReadOnly], [Source].[HidePasswords], [Source].[Manage]
+		EXCEPT
+		SELECT [Target].[ReadOnly], [Target].[HidePasswords], [Target].[Manage]
+	) THEN UPDATE SET
+		[Target].[ReadOnly] = [Source].[ReadOnly],
+		[Target].[HidePasswords] = [Source].[HidePasswords],
+		[Target].[Manage] = [Source].[Manage]
+	WHEN NOT MATCHED BY TARGET
+		THEN INSERT VALUES
+		(
+			[Source].[CollectionId],
+			[Source].[OrganizationUserId],
+			[Source].[ReadOnly],
+			[Source].[HidePasswords],
+			[Source].[Manage]
+		);
+END

--- a/src/Sql/dbo/Stored Procedures/Collection_CreateOrUpdateAccessForMany.sql
+++ b/src/Sql/dbo/Stored Procedures/Collection_CreateOrUpdateAccessForMany.sql
@@ -13,8 +13,7 @@ BEGIN
 			cId.[Id] AS [CollectionId],
 			gu.[Id] AS [GroupId],
 			gu.[ReadOnly],
-			gu.[HidePasswords],
-			gu.[Manage]
+			gu.[HidePasswords]
 		FROM
 			@Groups AS gu
 		CROSS JOIN
@@ -32,21 +31,19 @@ BEGIN
 		[Target].[CollectionId] = [Source].[CollectionId]
 		AND [Target].[GroupId] = [Source].[GroupId]
 	WHEN MATCHED AND EXISTS(
-		SELECT [Source].[ReadOnly], [Source].[HidePasswords], [Source].[Manage]
+		SELECT [Source].[ReadOnly], [Source].[HidePasswords]
 		EXCEPT
-		SELECT [Target].[ReadOnly], [Target].[HidePasswords], [Target].[Manage]
+		SELECT [Target].[ReadOnly], [Target].[HidePasswords]
 	) THEN UPDATE SET
 		[Target].[ReadOnly] = [Source].[ReadOnly],
-		[Target].[HidePasswords] = [Source].[HidePasswords],
-		[Target].[Manage] = [Source].[Manage]
+		[Target].[HidePasswords] = [Source].[HidePasswords]
 	WHEN NOT MATCHED BY TARGET
 		THEN INSERT VALUES
 		(
 			[Source].[CollectionId],
 			[Source].[GroupId],
 			[Source].[ReadOnly],
-			[Source].[HidePasswords],
-			[Source].[Manage]
+			[Source].[HidePasswords]
 		);
 
 	-- Users
@@ -55,8 +52,7 @@ BEGIN
 			cId.[Id] AS [CollectionId],
 			cu.[Id] AS [OrganizationUserId],
 			cu.[ReadOnly],
-			cu.[HidePasswords],
-			cu.[Manage]
+			cu.[HidePasswords]
 		FROM
 			@Users AS cu
 		CROSS JOIN
@@ -74,21 +70,19 @@ BEGIN
 		[Target].[CollectionId] = [Source].[CollectionId]
 		AND [Target].[OrganizationUserId] = [Source].[OrganizationUserId]
 	WHEN MATCHED AND EXISTS(
-		SELECT [Source].[ReadOnly], [Source].[HidePasswords], [Source].[Manage]
+		SELECT [Source].[ReadOnly], [Source].[HidePasswords]
 		EXCEPT
-		SELECT [Target].[ReadOnly], [Target].[HidePasswords], [Target].[Manage]
+		SELECT [Target].[ReadOnly], [Target].[HidePasswords]
 	) THEN UPDATE SET
 		[Target].[ReadOnly] = [Source].[ReadOnly],
-		[Target].[HidePasswords] = [Source].[HidePasswords],
-		[Target].[Manage] = [Source].[Manage]
+		[Target].[HidePasswords] = [Source].[HidePasswords]
 	WHEN NOT MATCHED BY TARGET
 		THEN INSERT VALUES
 		(
 			[Source].[CollectionId],
 			[Source].[OrganizationUserId],
 			[Source].[ReadOnly],
-			[Source].[HidePasswords],
-			[Source].[Manage]
+			[Source].[HidePasswords]
 		);
 
     EXEC [dbo].[User_BumpAccountRevisionDateByCollectionIds] @CollectionIds, @OrganizationId

--- a/src/Sql/dbo/Stored Procedures/User_BumpAccountRevisionDateByCollectionIds.sql
+++ b/src/Sql/dbo/Stored Procedures/User_BumpAccountRevisionDateByCollectionIds.sql
@@ -1,0 +1,35 @@
+CREATE PROCEDURE [dbo].[User_BumpAccountRevisionDateByCollectionIds]
+	@CollectionIds AS [dbo].[GuidIdArray] READONLY,
+	@OrganizationId UNIQUEIDENTIFIER
+AS
+BEGIN
+	SET NOCOUNT ON
+
+UPDATE
+    U
+SET
+    U.[AccountRevisionDate] = GETUTCDATE()
+    FROM
+        [dbo].[User] U
+    INNER JOIN
+    	[dbo].[Collection] C ON C.[Id] IN (SELECT [Id] FROM @CollectionIds)
+    INNER JOIN
+    [dbo].[OrganizationUser] OU ON OU.[UserId] = U.[Id]
+    LEFT JOIN
+    [dbo].[CollectionUser] CU ON OU.[AccessAll] = 0 AND CU.[OrganizationUserId] = OU.[Id] AND CU.[CollectionId] = C.[Id]
+    LEFT JOIN
+    [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND OU.[AccessAll] = 0 AND GU.[OrganizationUserId] = OU.[Id]
+    LEFT JOIN
+    [dbo].[Group] G ON G.[Id] = GU.[GroupId]
+    LEFT JOIN
+    [dbo].[CollectionGroup] CG ON G.[AccessAll] = 0 AND CG.[GroupId] = GU.[GroupId] AND CG.[CollectionId] = C.[Id]
+WHERE
+    OU.[OrganizationId] = @OrganizationId
+  AND OU.[Status] = 2 -- 2 = Confirmed
+  AND (
+    CU.[CollectionId] IS NOT NULL
+   OR CG.[CollectionId] IS NOT NULL
+   OR OU.[AccessAll] = 1
+   OR G.[AccessAll] = 1
+    )
+END

--- a/test/Api.Test/Vault/AuthorizationHandlers/CollectionAuthorizationHandlerTests.cs
+++ b/test/Api.Test/Vault/AuthorizationHandlers/CollectionAuthorizationHandlerTests.cs
@@ -1,0 +1,163 @@
+﻿using System.Security.Claims;
+using Bit.Api.Vault.AuthorizationHandlers;
+using Bit.Core.Context;
+using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Exceptions;
+using Bit.Core.Models.Data;
+using Bit.Core.Repositories;
+using Bit.Core.Test.Vault.AutoFixture;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Microsoft.AspNetCore.Authorization;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Api.Test.Vault.AuthorizationHandlers;
+
+[SutProviderCustomize]
+public class CollectionAuthorizationHandlerTests
+{
+    [Theory, CollectionCustomization]
+    [BitAutoData(OrganizationUserType.User, false, true)]
+    [BitAutoData(OrganizationUserType.Admin, false, false)]
+    [BitAutoData(OrganizationUserType.Owner, false, false)]
+    [BitAutoData(OrganizationUserType.Custom, true, false)]
+    [BitAutoData(OrganizationUserType.Owner, true, true)]
+    public async Task CanManageCollectionAccessAsync_Success(
+        OrganizationUserType userType, bool editAnyCollection, bool manageCollections,
+        SutProvider<CollectionAuthorizationHandler> sutProvider,
+        ICollection<Collection> collections,
+        ICollection<CollectionDetails> collectionDetails,
+        CurrentContentOrganization organization)
+    {
+        var actingUserId = Guid.NewGuid();
+        foreach (var collectionDetail in collectionDetails)
+        {
+            collectionDetail.Manage = manageCollections;
+        }
+
+        organization.Type = userType;
+        organization.Permissions.EditAnyCollection = editAnyCollection;
+
+        var context = new AuthorizationHandlerContext(
+            new[] { CollectionOperation.ModifyAccess },
+            new ClaimsPrincipal(),
+            collections);
+
+        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
+        sutProvider.GetDependency<ICurrentContext>().OrganizationMembershipAsync(Arg.Any<IOrganizationUserRepository>(), actingUserId).Returns(new[] { organization });
+        sutProvider.GetDependency<ICollectionRepository>().GetManyByUserIdAsync(actingUserId).Returns(collectionDetails);
+
+        await sutProvider.Sut.HandleAsync(context);
+
+        Assert.True(context.HasSucceeded);
+    }
+
+
+    [Theory, BitAutoData, CollectionCustomization]
+    public async Task CanManageCollectionAccessAsync_MissingUserId_Failure(
+        SutProvider<CollectionAuthorizationHandler> sutProvider,
+        ICollection<Collection> collections)
+    {
+        var context = new AuthorizationHandlerContext(
+            new[] { CollectionOperation.ModifyAccess },
+            new ClaimsPrincipal(),
+            collections
+        );
+
+        // Simulate missing user id
+        sutProvider.GetDependency<ICurrentContext>().UserId.Returns((Guid?)null);
+
+        await sutProvider.Sut.HandleAsync(context);
+        Assert.True(context.HasFailed);
+        sutProvider.GetDependency<ICollectionRepository>().DidNotReceiveWithAnyArgs();
+    }
+
+    [Theory, BitAutoData, CollectionCustomization]
+    public async Task CanManageCollectionAccessAsync_TargetCollectionsMultipleOrgs_Failure(
+        SutProvider<CollectionAuthorizationHandler> sutProvider,
+        IList<Collection> collections)
+    {
+        var actingUserId = Guid.NewGuid();
+
+        // Simulate a collection in a different organization
+        collections.First().OrganizationId = Guid.NewGuid();
+
+        var context = new AuthorizationHandlerContext(
+            new[] { CollectionOperation.ModifyAccess },
+            new ClaimsPrincipal(),
+            collections
+        );
+
+        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.HandleAsync(context));
+        Assert.Equal("Requested collections must belong to the same organization.", exception.Message);
+        await sutProvider.GetDependency<ICurrentContext>().DidNotReceiveWithAnyArgs()
+            .OrganizationMembershipAsync(default, default);
+    }
+
+    [Theory, BitAutoData, CollectionCustomization]
+    public async Task CanManageCollectionAccessAsync_MissingOrgMembership_Failure(
+        SutProvider<CollectionAuthorizationHandler> sutProvider,
+        ICollection<Collection> collections,
+        CurrentContentOrganization organization)
+    {
+        var actingUserId = Guid.NewGuid();
+
+        var context = new AuthorizationHandlerContext(
+            new[] { CollectionOperation.ModifyAccess },
+            new ClaimsPrincipal(),
+            collections
+        );
+
+        // Simulate a missing org membership
+        organization.Id = Guid.NewGuid();
+
+        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
+        sutProvider.GetDependency<ICurrentContext>().OrganizationMembershipAsync(Arg.Any<IOrganizationUserRepository>(), actingUserId).Returns(new[] { organization });
+
+        await sutProvider.Sut.HandleAsync(context);
+        Assert.True(context.HasFailed);
+        await sutProvider.GetDependency<ICollectionRepository>().DidNotReceiveWithAnyArgs()
+            .GetManyByUserIdAsync(default);
+    }
+
+    [Theory, BitAutoData, CollectionCustomization]
+    public async Task CanManageCollectionAccessAsync_MissingManageCollectionPermission_Failure(
+        SutProvider<CollectionAuthorizationHandler> sutProvider,
+        ICollection<Collection> collections,
+        ICollection<CollectionDetails> collectionDetails,
+        CurrentContentOrganization organization)
+    {
+        var actingUserId = Guid.NewGuid();
+
+        foreach (var collectionDetail in collectionDetails)
+        {
+            collectionDetail.Manage = true;
+        }
+        // Simulate one collection missing the manage permission
+        collectionDetails.First().Manage = false;
+
+        // Ensure the user is not an owner/admin and does not have edit any collection permission
+        organization.Type = OrganizationUserType.User;
+        organization.Permissions.EditAnyCollection = false;
+
+        var context = new AuthorizationHandlerContext(
+            new[] { CollectionOperation.ModifyAccess },
+            new ClaimsPrincipal(),
+            collections
+        );
+
+        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
+        sutProvider.GetDependency<ICurrentContext>().OrganizationMembershipAsync(Arg.Any<IOrganizationUserRepository>(), actingUserId).Returns(new[] { organization });
+        sutProvider.GetDependency<ICollectionRepository>().GetManyByUserIdAsync(actingUserId).Returns(collectionDetails);
+
+        await sutProvider.Sut.HandleAsync(context);
+        Assert.True(context.HasFailed);
+        await sutProvider.GetDependency<ICurrentContext>().ReceivedWithAnyArgs().OrganizationMembershipAsync(default, default);
+        await sutProvider.GetDependency<ICollectionRepository>().ReceivedWithAnyArgs()
+            .GetManyByUserIdAsync(default);
+    }
+}

--- a/test/Core.Test/AutoFixture/AutoFixtureExtensions.cs
+++ b/test/Core.Test/AutoFixture/AutoFixtureExtensions.cs
@@ -1,0 +1,54 @@
+﻿using System.Linq.Expressions;
+using AutoFixture.Dsl;
+
+namespace Bit.Core.Test.AutoFixture;
+
+public static class AutoFixtureExtensions
+{
+    /// <summary>
+    /// Registers that a writable Guid property should be assigned a random value that is derived from the given seed.
+    /// </summary>
+    /// <remarks>
+    /// This can be used to generate random Guids that are deterministic based on the seed and thus can be re-used for
+    /// different entities that share the same identifiers. e.g. Collections, CollectionUsers, and CollectionGroups can
+    /// all have the same Guids generate for their "collection id" properties.
+    /// </remarks>
+    /// <param name="composer"></param>
+    /// <param name="propertyPicker">The Guid property to register</param>
+    /// <param name="seed">The random seed to use for random Guid generation</param>
+    public static IPostprocessComposer<T> WithGuidFromSeed<T>(this IPostprocessComposer<T> composer, Expression<Func<T, Guid>> propertyPicker, int seed)
+    {
+        var rnd = new Random(seed);
+        return composer.With(propertyPicker, () =>
+        {
+            // While not as random/unique as Guid.NewGuid(), this is works well enough for testing purposes.
+            var bytes = new byte[16];
+            rnd.NextBytes(bytes);
+            return new Guid(bytes);
+        });
+    }
+
+    /// <summary>
+    /// Registers that a writable property should be assigned a value from the given list.
+    /// </summary>
+    /// <remarks>
+    /// The value will be assigned in the order that the list is enumerated. Values will wrap around to the beginning
+    /// should the end of the list be reached.
+    /// </remarks>
+    /// <param name="composer"></param>
+    /// <param name="propertyPicker"></param>
+    /// <param name="values"></param>
+    public static IPostprocessComposer<T> WithValueFromList<T, TValue>(
+        this IPostprocessComposer<T> composer,
+        Expression<Func<T, TValue>> propertyPicker,
+        ICollection<TValue> values)
+    {
+        var index = 0;
+        return composer.With(propertyPicker, () =>
+        {
+            var value = values.ElementAt(index);
+            index = (index + 1) % values.Count;
+            return value;
+        });
+    }
+}

--- a/test/Core.Test/OrganizationFeatures/OrganizationCollections/BulkAddCollectionAccessCommandTests.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationCollections/BulkAddCollectionAccessCommandTests.cs
@@ -1,0 +1,211 @@
+﻿using Bit.Core.Entities;
+using Bit.Core.Exceptions;
+using Bit.Core.Models.Data;
+using Bit.Core.OrganizationFeatures.OrganizationCollections;
+using Bit.Core.Repositories;
+using Bit.Core.Test.Vault.AutoFixture;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.OrganizationFeatures.OrganizationCollections;
+
+[SutProviderCustomize]
+public class BulkAddCollectionAccessCommandTests
+{
+    [Theory, BitAutoData, CollectionCustomization]
+    public async Task ValidateRequestAsync_Success(SutProvider<BulkAddCollectionAccessCommand> sutProvider,
+        Organization org,
+        ICollection<Collection> collections,
+        ICollection<OrganizationUser> users,
+        ICollection<Group> groups,
+        IEnumerable<CollectionUser> collectionUsers,
+        IEnumerable<CollectionGroup> collectionGroups)
+    {
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetManyAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns(users);
+
+        sutProvider.GetDependency<IGroupRepository>()
+            .GetManyByManyIds(Arg.Any<IEnumerable<Guid>>())
+            .Returns(groups);
+
+        await sutProvider.Sut.AddAccessAsync(org.Id, collections,
+            ToAccessSelection(collectionUsers),
+            ToAccessSelection(collectionGroups)
+        );
+
+        await sutProvider.GetDependency<IOrganizationUserRepository>().ReceivedWithAnyArgs().GetManyAsync(default);
+        await sutProvider.GetDependency<IGroupRepository>().ReceivedWithAnyArgs().GetManyByManyIds(default);
+    }
+
+
+    [Theory, BitAutoData, CollectionCustomization]
+    public async Task ValidateRequestAsync_NoCollection_Failure(SutProvider<BulkAddCollectionAccessCommand> sutProvider,
+        Organization org,
+        IEnumerable<CollectionUser> collectionUsers,
+        IEnumerable<CollectionGroup> collectionGroups)
+    {
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.AddAccessAsync(org.Id, Enumerable.Empty<Collection>().ToList(),
+            ToAccessSelection(collectionUsers),
+            ToAccessSelection(collectionGroups)
+        ));
+
+        Assert.Contains("No collections were provided.", exception.Message);
+
+        await sutProvider.GetDependency<IOrganizationUserRepository>().DidNotReceiveWithAnyArgs().GetManyAsync(default);
+        await sutProvider.GetDependency<IGroupRepository>().DidNotReceiveWithAnyArgs().GetManyByManyIds(default);
+    }
+
+    [Theory, BitAutoData, CollectionCustomization]
+    public async Task ValidateRequestAsync_DifferentOrgs_Failure(SutProvider<BulkAddCollectionAccessCommand> sutProvider,
+        Organization org,
+        ICollection<Collection> collections,
+        IEnumerable<CollectionUser> collectionUsers,
+        IEnumerable<CollectionGroup> collectionGroups)
+    {
+        collections.First().OrganizationId = Guid.NewGuid();
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.AddAccessAsync(org.Id, collections,
+            ToAccessSelection(collectionUsers),
+            ToAccessSelection(collectionGroups)
+        ));
+
+        Assert.Contains("All collections must belong to the same organization.", exception.Message);
+
+        await sutProvider.GetDependency<IOrganizationUserRepository>().DidNotReceiveWithAnyArgs().GetManyAsync(default);
+        await sutProvider.GetDependency<IGroupRepository>().DidNotReceiveWithAnyArgs().GetManyByManyIds(default);
+    }
+
+    [Theory, BitAutoData, CollectionCustomization]
+    public async Task ValidateRequestAsync_MissingUser_Failure(SutProvider<BulkAddCollectionAccessCommand> sutProvider,
+        Organization org,
+        IList<Collection> collections,
+        IList<OrganizationUser> users,
+        IEnumerable<CollectionUser> collectionUsers,
+        IEnumerable<CollectionGroup> collectionGroups)
+    {
+        users.RemoveAt(0);
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetManyAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns(users);
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.AddAccessAsync(org.Id, collections,
+            ToAccessSelection(collectionUsers),
+            ToAccessSelection(collectionGroups)
+        ));
+
+        Assert.Contains("One or more users do not exist.", exception.Message);
+
+        await sutProvider.GetDependency<IOrganizationUserRepository>().ReceivedWithAnyArgs().GetManyAsync(default);
+        await sutProvider.GetDependency<IGroupRepository>().DidNotReceiveWithAnyArgs().GetManyByManyIds(default);
+    }
+
+    [Theory, BitAutoData, CollectionCustomization]
+    public async Task ValidateRequestAsync_UserWrongOrg_Failure(SutProvider<BulkAddCollectionAccessCommand> sutProvider,
+        Organization org,
+        IList<Collection> collections,
+        IList<OrganizationUser> users,
+        IEnumerable<CollectionUser> collectionUsers,
+        IEnumerable<CollectionGroup> collectionGroups)
+    {
+        users.First().OrganizationId = Guid.NewGuid();
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetManyAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns(users);
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.AddAccessAsync(org.Id, collections,
+            ToAccessSelection(collectionUsers),
+            ToAccessSelection(collectionGroups)
+        ));
+
+        Assert.Contains("One or more users do not belong to the same organization as the collection being assigned.", exception.Message);
+
+        await sutProvider.GetDependency<IOrganizationUserRepository>().ReceivedWithAnyArgs().GetManyAsync(default);
+        await sutProvider.GetDependency<IGroupRepository>().DidNotReceiveWithAnyArgs().GetManyByManyIds(default);
+    }
+
+    [Theory, BitAutoData, CollectionCustomization]
+    public async Task ValidateRequestAsync_MissingGroup_Failure(SutProvider<BulkAddCollectionAccessCommand> sutProvider,
+        Organization org,
+        IList<Collection> collections,
+        IList<OrganizationUser> users,
+        IList<Group> groups,
+        IEnumerable<CollectionUser> collectionUsers,
+        IEnumerable<CollectionGroup> collectionGroups)
+    {
+        groups.RemoveAt(0);
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetManyAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns(users);
+
+        sutProvider.GetDependency<IGroupRepository>()
+            .GetManyByManyIds(Arg.Any<IEnumerable<Guid>>())
+            .Returns(groups);
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.AddAccessAsync(org.Id, collections,
+            ToAccessSelection(collectionUsers),
+            ToAccessSelection(collectionGroups)
+        ));
+
+        Assert.Contains("One or more groups do not exist.", exception.Message);
+
+        await sutProvider.GetDependency<IOrganizationUserRepository>().ReceivedWithAnyArgs().GetManyAsync(default);
+        await sutProvider.GetDependency<IGroupRepository>().ReceivedWithAnyArgs().GetManyByManyIds(default);
+    }
+
+    [Theory, BitAutoData, CollectionCustomization]
+    public async Task ValidateRequestAsync_GroupWrongOrg_Failure(SutProvider<BulkAddCollectionAccessCommand> sutProvider,
+        Organization org,
+        IList<Collection> collections,
+        IList<OrganizationUser> users,
+        IList<Group> groups,
+        IEnumerable<CollectionUser> collectionUsers,
+        IEnumerable<CollectionGroup> collectionGroups)
+    {
+        groups.First().OrganizationId = Guid.NewGuid();
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetManyAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns(users);
+
+        sutProvider.GetDependency<IGroupRepository>()
+            .GetManyByManyIds(Arg.Any<IEnumerable<Guid>>())
+            .Returns(groups);
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.AddAccessAsync(org.Id, collections,
+            ToAccessSelection(collectionUsers),
+            ToAccessSelection(collectionGroups)
+        ));
+
+        Assert.Contains("One or more groups do not belong to the same organization as the collection being assigned.", exception.Message);
+
+        await sutProvider.GetDependency<IOrganizationUserRepository>().ReceivedWithAnyArgs().GetManyAsync(default);
+        await sutProvider.GetDependency<IGroupRepository>().ReceivedWithAnyArgs().GetManyByManyIds(default);
+    }
+
+    private static ICollection<CollectionAccessSelection> ToAccessSelection(IEnumerable<CollectionUser> collectionUsers)
+    {
+        return collectionUsers.Select(cu => new CollectionAccessSelection
+        {
+            Id = cu.OrganizationUserId,
+            Manage = cu.Manage,
+            HidePasswords = cu.HidePasswords,
+            ReadOnly = cu.ReadOnly
+        }).ToList();
+    }
+    private static ICollection<CollectionAccessSelection> ToAccessSelection(IEnumerable<CollectionGroup> collectionGroups)
+    {
+        return collectionGroups.Select(cg => new CollectionAccessSelection
+        {
+            Id = cg.GroupId,
+            Manage = cg.Manage,
+            HidePasswords = cg.HidePasswords,
+            ReadOnly = cg.ReadOnly
+        }).ToList();
+    }
+}

--- a/test/Core.Test/OrganizationFeatures/OrganizationCollections/BulkAddCollectionAccessCommandTests.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationCollections/BulkAddCollectionAccessCommandTests.cs
@@ -60,6 +60,21 @@ public class BulkAddCollectionAccessCommandTests
         );
     }
 
+    [Theory, BitAutoData, CollectionCustomization]
+    public async Task ValidateRequestAsync_NoCollectionsProvided_Failure(SutProvider<BulkAddCollectionAccessCommand> sutProvider,
+        Organization org)
+    {
+        var exception =
+            await Assert.ThrowsAsync<BadRequestException>(
+                () => sutProvider.Sut.AddAccessAsync(org.Id, null, null, null));
+
+        Assert.Contains("No collections were provided.", exception.Message);
+
+        await sutProvider.GetDependency<ICollectionRepository>().DidNotReceiveWithAnyArgs().GetManyByManyIdsAsync(default);
+        await sutProvider.GetDependency<IOrganizationUserRepository>().DidNotReceiveWithAnyArgs().GetManyAsync(default);
+        await sutProvider.GetDependency<IGroupRepository>().DidNotReceiveWithAnyArgs().GetManyByManyIds(default);
+    }
+
 
     [Theory, BitAutoData, CollectionCustomization]
     public async Task ValidateRequestAsync_NoCollection_Failure(SutProvider<BulkAddCollectionAccessCommand> sutProvider,

--- a/test/Core.Test/OrganizationFeatures/OrganizationCollections/BulkAddCollectionAccessCommandTests.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationCollections/BulkAddCollectionAccessCommandTests.cs
@@ -228,7 +228,6 @@ public class BulkAddCollectionAccessCommandTests
         return collectionUsers.Select(cu => new CollectionAccessSelection
         {
             Id = cu.OrganizationUserId,
-            Manage = cu.Manage,
             HidePasswords = cu.HidePasswords,
             ReadOnly = cu.ReadOnly
         }).ToList();
@@ -238,7 +237,6 @@ public class BulkAddCollectionAccessCommandTests
         return collectionGroups.Select(cg => new CollectionAccessSelection
         {
             Id = cg.GroupId,
-            Manage = cg.Manage,
             HidePasswords = cg.HidePasswords,
             ReadOnly = cg.ReadOnly
         }).ToList();

--- a/test/Core.Test/OrganizationFeatures/OrganizationCollections/BulkAddCollectionAccessCommandTests.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationCollections/BulkAddCollectionAccessCommandTests.cs
@@ -1,8 +1,10 @@
 ﻿using Bit.Core.Entities;
+using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Data;
 using Bit.Core.OrganizationFeatures.OrganizationCollections;
 using Bit.Core.Repositories;
+using Bit.Core.Services;
 using Bit.Core.Test.Vault.AutoFixture;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
@@ -15,7 +17,7 @@ namespace Bit.Core.Test.OrganizationFeatures.OrganizationCollections;
 public class BulkAddCollectionAccessCommandTests
 {
     [Theory, BitAutoData, CollectionCustomization]
-    public async Task ValidateRequestAsync_Success(SutProvider<BulkAddCollectionAccessCommand> sutProvider,
+    public async Task AddAccessAsync_Success(SutProvider<BulkAddCollectionAccessCommand> sutProvider,
         Organization org,
         ICollection<Collection> collections,
         ICollection<OrganizationUser> users,
@@ -31,13 +33,31 @@ public class BulkAddCollectionAccessCommandTests
             .GetManyByManyIds(Arg.Any<IEnumerable<Guid>>())
             .Returns(groups);
 
+        var userAccessSelections = ToAccessSelection(collectionUsers);
+        var groupAccessSelections = ToAccessSelection(collectionGroups);
         await sutProvider.Sut.AddAccessAsync(org.Id, collections,
-            ToAccessSelection(collectionUsers),
-            ToAccessSelection(collectionGroups)
+            userAccessSelections,
+            groupAccessSelections
         );
 
         await sutProvider.GetDependency<IOrganizationUserRepository>().ReceivedWithAnyArgs().GetManyAsync(default);
         await sutProvider.GetDependency<IGroupRepository>().ReceivedWithAnyArgs().GetManyByManyIds(default);
+
+        await sutProvider.GetDependency<ICollectionRepository>().Received().CreateOrUpdateAccessForManyAsync(
+            org.Id,
+            Arg.Is<IEnumerable<Guid>>(ids => ids.SequenceEqual(collections.Select(c => c.Id))),
+            userAccessSelections,
+            groupAccessSelections);
+
+        await sutProvider.GetDependency<IEventService>().Received().LogCollectionEventsAsync(
+            Arg.Is<IEnumerable<(Collection, EventType, DateTime?)>>(
+                events => events.All(e =>
+                    collections.Contains(e.Item1) &&
+                    e.Item2 == EventType.Collection_Updated &&
+                    e.Item3.HasValue
+                )
+            )
+        );
     }
 
 

--- a/test/Core.Test/Utilities/BulkAuthorizationHandlerTests.cs
+++ b/test/Core.Test/Utilities/BulkAuthorizationHandlerTests.cs
@@ -1,0 +1,72 @@
+﻿using System.Security.Claims;
+using Bit.Core.Utilities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
+using Xunit;
+
+namespace Bit.Core.Test.Utilities;
+
+public class BulkAuthorizationHandlerTests
+{
+    [Fact]
+    public async Task HandleRequirementAsync_SingleResource_Success()
+    {
+        var handler = new TestBulkAuthorizationHandler();
+        var context = new AuthorizationHandlerContext(
+            new[] { new TestOperationRequirement() },
+            new ClaimsPrincipal(),
+            new TestResource());
+        await handler.HandleAsync(context);
+        Assert.True(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task HandleRequirementAsync_BulkResource_Success()
+    {
+        var handler = new TestBulkAuthorizationHandler();
+        var context = new AuthorizationHandlerContext(
+            new[] { new TestOperationRequirement() },
+            new ClaimsPrincipal(),
+            new[] { new TestResource(), new TestResource() });
+        await handler.HandleAsync(context);
+        Assert.True(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task HandleRequirementAsync_NoResources_Failure()
+    {
+        var handler = new TestBulkAuthorizationHandler();
+        var context = new AuthorizationHandlerContext(
+            new[] { new TestOperationRequirement() },
+            new ClaimsPrincipal(),
+            null);
+        await handler.HandleAsync(context);
+        Assert.False(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task HandleRequirementAsync_WrongResourceType_Failure()
+    {
+        var handler = new TestBulkAuthorizationHandler();
+        var context = new AuthorizationHandlerContext(
+            new[] { new TestOperationRequirement() },
+            new ClaimsPrincipal(),
+            new object());
+        await handler.HandleAsync(context);
+        Assert.False(context.HasSucceeded);
+    }
+
+    private class TestOperationRequirement : OperationAuthorizationRequirement { }
+
+    private class TestResource { }
+
+    private class TestBulkAuthorizationHandler : BulkAuthorizationHandler<TestOperationRequirement, TestResource>
+    {
+        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context,
+            TestOperationRequirement requirement,
+            ICollection<TestResource> resources)
+        {
+            context.Succeed(requirement);
+        }
+    }
+}

--- a/test/Core.Test/Vault/AutoFixture/CollectionFixture.cs
+++ b/test/Core.Test/Vault/AutoFixture/CollectionFixture.cs
@@ -20,7 +20,7 @@ public class CollectionCustomization : ICustomization
         fixture.Customize<Organization>(composer => composer
             .With(o => o.Id, orgId));
 
-        fixture.Customize<CurrentContentOrganization>(composer => composer
+        fixture.Customize<CurrentContextOrganization>(composer => composer
             .With(o => o.Id, orgId));
 
         fixture.Customize<OrganizationUser>(composer => composer

--- a/test/Core.Test/Vault/AutoFixture/CollectionFixture.cs
+++ b/test/Core.Test/Vault/AutoFixture/CollectionFixture.cs
@@ -1,0 +1,52 @@
+﻿using AutoFixture;
+using Bit.Core.Context;
+using Bit.Core.Entities;
+using Bit.Core.Models.Data;
+using Bit.Core.Test.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+
+namespace Bit.Core.Test.Vault.AutoFixture;
+
+public class CollectionCustomization : ICustomization
+{
+    private const int _collectionIdSeed = 1;
+    private const int _userIdSeed = 2;
+    private const int _groupIdSeed = 3;
+
+    public void Customize(IFixture fixture)
+    {
+        var orgId = Guid.NewGuid();
+
+        fixture.Customize<CurrentContentOrganization>(composer => composer
+            .With(o => o.Id, orgId));
+
+        fixture.Customize<OrganizationUser>(composer => composer
+            .With(o => o.OrganizationId, orgId)
+            .WithGuidFromSeed(o => o.Id, _userIdSeed));
+
+        fixture.Customize<Collection>(composer => composer
+            .With(o => o.OrganizationId, orgId)
+            .WithGuidFromSeed(c => c.Id, _collectionIdSeed));
+
+        fixture.Customize<CollectionDetails>(composer => composer
+            .With(o => o.OrganizationId, orgId)
+            .WithGuidFromSeed(cd => cd.Id, _collectionIdSeed));
+
+        fixture.Customize<CollectionUser>(c => c
+            .WithGuidFromSeed(cu => cu.OrganizationUserId, _userIdSeed)
+            .WithGuidFromSeed(cu => cu.CollectionId, _collectionIdSeed));
+
+        fixture.Customize<Group>(composer => composer
+            .With(o => o.OrganizationId, orgId)
+            .WithGuidFromSeed(o => o.Id, _groupIdSeed));
+
+        fixture.Customize<CollectionGroup>(c => c
+            .WithGuidFromSeed(cu => cu.GroupId, _groupIdSeed)
+            .WithGuidFromSeed(cu => cu.CollectionId, _collectionIdSeed));
+    }
+}
+
+public class CollectionCustomizationAttribute : BitCustomizeAttribute
+{
+    public override ICustomization GetCustomization() => new CollectionCustomization();
+}

--- a/test/Core.Test/Vault/AutoFixture/CollectionFixture.cs
+++ b/test/Core.Test/Vault/AutoFixture/CollectionFixture.cs
@@ -17,6 +17,9 @@ public class CollectionCustomization : ICustomization
     {
         var orgId = Guid.NewGuid();
 
+        fixture.Customize<Organization>(composer => composer
+            .With(o => o.Id, orgId));
+
         fixture.Customize<CurrentContentOrganization>(composer => composer
             .With(o => o.Id, orgId));
 

--- a/util/Migrator/DbScripts/2023-08-25_00_BulkAddCollectionAccess.sql
+++ b/util/Migrator/DbScripts/2023-08-25_00_BulkAddCollectionAccess.sql
@@ -50,8 +50,7 @@ BEGIN
 			cId.[Id] AS [CollectionId],
 			gu.[Id] AS [GroupId],
 			gu.[ReadOnly],
-			gu.[HidePasswords],
-			gu.[Manage]
+			gu.[HidePasswords]
 		FROM
 			@Groups AS gu
 		CROSS JOIN
@@ -69,21 +68,19 @@ BEGIN
 		[Target].[CollectionId] = [Source].[CollectionId]
 		AND [Target].[GroupId] = [Source].[GroupId]
 	WHEN MATCHED AND EXISTS(
-		SELECT [Source].[ReadOnly], [Source].[HidePasswords], [Source].[Manage]
+		SELECT [Source].[ReadOnly], [Source].[HidePasswords]
 		EXCEPT
-		SELECT [Target].[ReadOnly], [Target].[HidePasswords], [Target].[Manage]
+		SELECT [Target].[ReadOnly], [Target].[HidePasswords]
 	) THEN UPDATE SET
 		[Target].[ReadOnly] = [Source].[ReadOnly],
-		[Target].[HidePasswords] = [Source].[HidePasswords],
-		[Target].[Manage] = [Source].[Manage]
+		[Target].[HidePasswords] = [Source].[HidePasswords]
 	WHEN NOT MATCHED BY TARGET
 		THEN INSERT VALUES
 		(
 			[Source].[CollectionId],
 			[Source].[GroupId],
 			[Source].[ReadOnly],
-			[Source].[HidePasswords],
-			[Source].[Manage]
+			[Source].[HidePasswords]
 		);
 
 	-- Users
@@ -92,8 +89,7 @@ BEGIN
 			cId.[Id] AS [CollectionId],
 			cu.[Id] AS [OrganizationUserId],
 			cu.[ReadOnly],
-			cu.[HidePasswords],
-			cu.[Manage]
+			cu.[HidePasswords]
 		FROM
 			@Users AS cu
 		CROSS JOIN
@@ -111,21 +107,19 @@ BEGIN
 		[Target].[CollectionId] = [Source].[CollectionId]
 		AND [Target].[OrganizationUserId] = [Source].[OrganizationUserId]
 	WHEN MATCHED AND EXISTS(
-		SELECT [Source].[ReadOnly], [Source].[HidePasswords], [Source].[Manage]
+		SELECT [Source].[ReadOnly], [Source].[HidePasswords]
 		EXCEPT
-		SELECT [Target].[ReadOnly], [Target].[HidePasswords], [Target].[Manage]
+		SELECT [Target].[ReadOnly], [Target].[HidePasswords]
 	) THEN UPDATE SET
 		[Target].[ReadOnly] = [Source].[ReadOnly],
-		[Target].[HidePasswords] = [Source].[HidePasswords],
-		[Target].[Manage] = [Source].[Manage]
+		[Target].[HidePasswords] = [Source].[HidePasswords]
 	WHEN NOT MATCHED BY TARGET
 		THEN INSERT VALUES
 		(
 			[Source].[CollectionId],
 			[Source].[OrganizationUserId],
 			[Source].[ReadOnly],
-			[Source].[HidePasswords],
-			[Source].[Manage]
+			[Source].[HidePasswords]
 		);
 
     EXEC [dbo].[User_BumpAccountRevisionDateByCollectionIds] @CollectionIds, @OrganizationId

--- a/util/Migrator/DbScripts/2023-08-25_00_BulkAddCollectionAccess.sql
+++ b/util/Migrator/DbScripts/2023-08-25_00_BulkAddCollectionAccess.sql
@@ -1,4 +1,41 @@
-CREATE PROCEDURE [dbo].[Collection_CreateOrUpdateAccessForMany]
+CREATE OR ALTER PROCEDURE [dbo].[User_BumpAccountRevisionDateByCollectionIds]
+	@CollectionIds AS [dbo].[GuidIdArray] READONLY,
+	@OrganizationId UNIQUEIDENTIFIER
+AS
+BEGIN
+	SET NOCOUNT ON
+
+UPDATE
+    U
+SET
+    U.[AccountRevisionDate] = GETUTCDATE()
+    FROM
+        [dbo].[User] U
+    INNER JOIN
+    	[dbo].[Collection] C ON C.[Id] IN (SELECT [Id] FROM @CollectionIds)
+    INNER JOIN
+    [dbo].[OrganizationUser] OU ON OU.[UserId] = U.[Id]
+    LEFT JOIN
+    [dbo].[CollectionUser] CU ON OU.[AccessAll] = 0 AND CU.[OrganizationUserId] = OU.[Id] AND CU.[CollectionId] = C.[Id]
+    LEFT JOIN
+    [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND OU.[AccessAll] = 0 AND GU.[OrganizationUserId] = OU.[Id]
+    LEFT JOIN
+    [dbo].[Group] G ON G.[Id] = GU.[GroupId]
+    LEFT JOIN
+    [dbo].[CollectionGroup] CG ON G.[AccessAll] = 0 AND CG.[GroupId] = GU.[GroupId] AND CG.[CollectionId] = C.[Id]
+WHERE
+    OU.[OrganizationId] = @OrganizationId
+  AND OU.[Status] = 2 -- 2 = Confirmed
+  AND (
+    CU.[CollectionId] IS NOT NULL
+   OR CG.[CollectionId] IS NOT NULL
+   OR OU.[AccessAll] = 1
+   OR G.[AccessAll] = 1
+    )
+END
+GO
+
+CREATE OR ALTER PROCEDURE [dbo].[Collection_CreateOrUpdateAccessForMany]
 	@OrganizationId UNIQUEIDENTIFIER,
 	@CollectionIds AS [dbo].[GuidIdArray] READONLY,
     @Groups AS [dbo].[SelectionReadOnlyArray] READONLY,
@@ -93,3 +130,4 @@ BEGIN
 
     EXEC [dbo].[User_BumpAccountRevisionDateByCollectionIds] @CollectionIds, @OrganizationId
 END
+GO


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Add support for bulk adding access to multiple collections at once.

Also introduces the concept of authorization handlers for Collections. Discussion / previous reviews can be found around this can be found in: https://github.com/bitwarden/server/pull/3194

Related client changes: https://github.com/bitwarden/clients/pull/6133

## Code changes

- `src/Api/Controllers/CollectionsController.cs`
  -  Add the new endpoint and make use of the new `CollectionAuthorizationHandler` introduced in #3194

- `src/Core/OrganizationFeatures/OrganizationCollections/BulkAddCollectionAccessCommand.cs`
  - Add a new `BulkAddCollectionAccessCommand`
  - Validates that all collections, users, and groups exist and belong to the same organization
  - Creates `Collection_Updated` event logs for every collection modified
  - Command is registered in the `OrganizationServiceCollectionExtensions.cs`

- `src/Infrastructure.Dapper/Repositories/CollectionRepository.cs`
  - Add new repository method `CreateOrUpdateAccessForManyAsync()`
  - **Note: This new method only adds or updates collection access, it does not remove any existing access relationships.**

- `src/Infrastructure.EntityFramework/Repositories/DatabaseContextExtensions.cs`
  - Add a new extension method to bump user account revision dates by _multiple_ collection ids at once.
  - A similar sproc was also created `User_BumpAccountRevisionDateByCollectionIds.sql`

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
