### PR TITLE
[SM-918] Enforce project maximums on import

### DIFF
--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Queries/Projects/MaxProjectsQuery.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Queries/Projects/MaxProjectsQuery.cs
@@ -20,7 +20,7 @@ public class MaxProjectsQuery : IMaxProjectsQuery
         _projectRepository = projectRepository;
     }
 
-    public async Task<(short? max, bool? atMax)> GetByOrgIdAsync(Guid organizationId)
+    public async Task<(short? max, bool? overMax)> GetByOrgIdAsync(Guid organizationId, int projectsToAdd)
     {
         var org = await _organizationRepository.GetByIdAsync(organizationId);
         if (org == null)
@@ -37,7 +37,7 @@ public class MaxProjectsQuery : IMaxProjectsQuery
         if (plan.Type == PlanType.Free)
         {
             var projects = await _projectRepository.GetProjectCountByOrganizationIdAsync(organizationId);
-            return projects >= plan.MaxProjects ? (plan.MaxProjects, true) : (plan.MaxProjects, false);
+            return projects + projectsToAdd > plan.MaxProjects ? (plan.MaxProjects, true) : (plan.MaxProjects, false);
         }
 
         return (null, null);

--- a/src/Api/SecretsManager/Controllers/ProjectsController.cs
+++ b/src/Api/SecretsManager/Controllers/ProjectsController.cs
@@ -79,8 +79,8 @@ public class ProjectsController : Controller
             throw new NotFoundException();
         }
 
-        var (max, atMax) = await _maxProjectsQuery.GetByOrgIdAsync(organizationId);
-        if (atMax != null && atMax.Value)
+        var (max, overMax) = await _maxProjectsQuery.GetByOrgIdAsync(organizationId, 1);
+        if (overMax != null && overMax.Value)
         {
             throw new BadRequestException($"You have reached the maximum number of projects ({max}) for this plan.");
         }

--- a/src/Core/SecretsManager/Queries/Projects/Interfaces/IMaxProjectsQuery.cs
+++ b/src/Core/SecretsManager/Queries/Projects/Interfaces/IMaxProjectsQuery.cs
@@ -2,5 +2,5 @@
 
 public interface IMaxProjectsQuery
 {
-    Task<(short? max, bool? atMax)> GetByOrgIdAsync(Guid organizationId);
+    Task<(short? max, bool? overMax)> GetByOrgIdAsync(Guid organizationId, int projectsToAdd);
 }

--- a/test/Api.Test/SecretsManager/Controllers/ProjectsControllerTests.cs
+++ b/test/Api.Test/SecretsManager/Controllers/ProjectsControllerTests.cs
@@ -132,7 +132,7 @@ public class ProjectsControllerTests
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), data.ToProject(orgId),
                 Arg.Any<IEnumerable<IAuthorizationRequirement>>()).ReturnsForAnyArgs(AuthorizationResult.Success());
         sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(Guid.NewGuid());
-        sutProvider.GetDependency<IMaxProjectsQuery>().GetByOrgIdAsync(orgId).Returns(((short)3, true));
+        sutProvider.GetDependency<IMaxProjectsQuery>().GetByOrgIdAsync(orgId, 1).Returns(((short)3, true));
 
 
         await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.CreateAsync(orgId, data));


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The purpose of this PR is to enforce Secrets Manager project maximums when using the import tool.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **bitwarden_license/src/Commercial.Core/SecretsManager/Queries/Projects/MaxProjectsQuery.cs:** 
**src/Core/SecretsManager/Queries/Projects/Interfaces/IMaxProjectsQuery.cs:** 
Alter `MaxProjectsQuery` to take a count of projects to add as a parameter.
This will return a boolean `overMax` indicating if adding the provided number of projects would put the organization over the maximum allowed. 

* **bitwarden_license/test/Commercial.Core.Test/SecretsManager/Queries/Projects/MaxProjectsQueryTests.cs:**
Update unit tests with alterations.

* **src/Api/SecretsManager/Controllers/ProjectsController.cs:**
Update to use the altered `MaxProjectQuery`.

* **src/Api/SecretsManager/Controllers/SecretsManagerPortingController.cs:**
Add project maximum enforcement on import.

* **test/Api.Test/SecretsManager/Controllers/ProjectsControllerTests.cs:**
Update unit test with `MaxProjectQuery` alterations.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
