### PR TITLE
[ON-351] Mac Certificate Creation: Add `-legacy` flag to `openssl` exports

### DIFF
--- a/dev/create_certificates_mac.sh
+++ b/dev/create_certificates_mac.sh
@@ -2,14 +2,14 @@
 
 openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout identity_server_dev.key -out identity_server_dev.crt \
     -subj "/CN=Bitwarden Identity Server Dev" -days 3650
-openssl pkcs12 -export -out identity_server_dev.pfx -inkey identity_server_dev.key -in identity_server_dev.crt \
+openssl pkcs12 -export -legacy -out identity_server_dev.pfx -inkey identity_server_dev.key -in identity_server_dev.crt \
     -certfile identity_server_dev.crt
 
 security import ./identity_server_dev.pfx -k ~/Library/Keychains/Login.keychain
 
 openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout data_protection_dev.key -out data_protection_dev.crt \
     -subj "/CN=Bitwarden Data Protection Dev" -days 3650
-openssl pkcs12 -export -out data_protection_dev.pfx -inkey data_protection_dev.key -in data_protection_dev.crt \
+openssl pkcs12 -export -legacy -out data_protection_dev.pfx -inkey data_protection_dev.key -in data_protection_dev.crt \
     -certfile data_protection_dev.crt
 
 security import ./data_protection_dev.pfx -k ~/Library/Keychains/Login.keychain


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Ticket: [ON-351](https://bitwarden.atlassian.net/browse/ON-351)

During onboarding, I noticed that I was unable to use the `create_certificates_mac.sh` file to create my certifications as the last password prompt would never be accepted.

@cturnbull-bitwarden [uncovered an open issue](https://discussions.apple.com/thread/254518218) explaining the problem is with OpenSSL 3.x's compatibility with Mac OS' SSL libraries. The suggested resolution in the linked thread was to append the `-legacy` flag to `openssl` export invocations to avoid having to downgrade `openssl`. I tested the script and it worked as expected.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **dev/create_certificates_mac.sh:** Appended the `-legacy` flag to `openssl` `-export` operations.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team


[ON-351]: https://bitwarden.atlassian.net/browse/ON-351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ