### PR TITLE
Migration to remove WebAuthn 2FA method from Free users

### DIFF
--- a/util/Migrator/DbScripts/2023-09-14_00_Remove_WebAuthn_For_Free_Users.sql
+++ b/util/Migrator/DbScripts/2023-09-14_00_Remove_WebAuthn_For_Free_Users.sql
@@ -33,7 +33,7 @@ from @TwoFactorByUser t1
 where t1.TwoFactorType = 7
 AND NOT EXISTS (SELECT * FROM @TwoFactorByUser t2 WHERE t2.Id = t1.Id and t2.TwoFactorType <> 7)
 
-UPDATE [User]
-SET TwoFactorProviders = NULL
-FROM @TwoFactorByUser tf
-WHERE tf.Id = [User].Id
+-- UPDATE [User]
+-- SET TwoFactorProviders = NULL
+-- FROM @TwoFactorByUser tf
+-- WHERE tf.Id = [User].Id

--- a/util/Migrator/DbScripts/2023-09-14_00_Remove_WebAuthn_For_Free_Users.sql
+++ b/util/Migrator/DbScripts/2023-09-14_00_Remove_WebAuthn_For_Free_Users.sql
@@ -1,0 +1,38 @@
+-- Assumptions:
+-- When a 2FA method is disabled, it is removed from the TwoFactorProviders array
+
+-- Problem statement:
+-- We have users who currently do not have any 2FA method, with the only one being
+-- WebAuthn, which is effectively disabled by a server-side permission check for Premium status.
+-- With WebAuthn being made free, we want to avoid these users suddenly being forced
+-- to provide 2FA using a key that they haven't used in a long time, by deleting that key from their TwoFactorProviders.
+declare @TwoFactorByUser TABLE
+(
+    Id UNIQUEIDENTIFIER,
+    Email NVARCHAR(256),
+    TwoFactorType INT,
+    TypeEnabled BIT
+)
+
+INSERT INTO @TwoFactorByUser
+SELECT  u.Id, 
+        u.Email,
+        tfp1.[key] as TwoFactorType, 
+        CASE [Enabled] WHEN 'true' THEN 1 ELSE 0 END as TypeEnabled
+FROM [User] u
+CROSS APPLY OPENJSON(u.TwoFactorProviders) tfp1
+CROSS APPLY OPENJSON(tfp1.[value]) WITH (
+   [Enabled] nvarchar(10) '$.Enabled'
+) tfp2
+WHERE [Enabled] = 'true'
+AND Premium = 0
+
+select *
+from @TwoFactorByUser t1
+where t1.TwoFactorType = 7 and t1.TypeEnabled = 1
+AND NOT EXISTS (SELECT * FROM @TwoFactorByUser t2 WHERE t2.Id = t1.Id and t2.TwoFactorType <> 7)
+
+UPDATE [User]
+SET TwoFactorProviders = NULL
+FROM @TwoFactorByUser tf
+WHERE tf.Id = [User].Id

--- a/util/Migrator/DbScripts/2023-09-14_00_Remove_WebAuthn_For_Free_Users.sql
+++ b/util/Migrator/DbScripts/2023-09-14_00_Remove_WebAuthn_For_Free_Users.sql
@@ -16,7 +16,7 @@ DECLARE @UsersWithoutPremium TABLE
 DECLARE @TwoFactorMethodsForUsersWithoutPremium TABLE
 (
     Id UNIQUEIDENTIFIER,
-    TwoFactorType INT
+    TwoFactorType NVARCHAR(50)
 )
 
 DECLARE @UsersToAdjust TABLE
@@ -55,7 +55,7 @@ WHERE t1.TwoFactorType = 7
 AND NOT EXISTS 
     (SELECT * 
     FROM @TwoFactorMethodsForUsersWithoutPremium t2 
-    WHERE t2.Id = t1.Id AND t2.TwoFactorType <> 7 AND t2.TwoFactorType <> 4)
+    WHERE t2.Id = t1.Id AND t2.TwoFactorType <> '7' AND t2.TwoFactorType <> '4')
 
 SELECT *
 FROM @UsersToAdjust

--- a/util/Migrator/DbScripts/2023-09-14_00_Remove_WebAuthn_For_Free_Users.sql
+++ b/util/Migrator/DbScripts/2023-09-14_00_Remove_WebAuthn_For_Free_Users.sql
@@ -51,7 +51,7 @@ WHERE [Enabled] = 1 -- We only want enabled 2FA methods
 INSERT INTO @UsersToAdjust
 SELECT t1.Id
 FROM @TwoFactorMethodsForUsersWithoutPremium t1
-WHERE t1.TwoFactorType = 7
+WHERE t1.TwoFactorType = '7'
 AND NOT EXISTS 
     (SELECT * 
     FROM @TwoFactorMethodsForUsersWithoutPremium t2 
@@ -60,7 +60,9 @@ AND NOT EXISTS
 SELECT *
 FROM @UsersToAdjust
 
--- UPDATE [User]
--- SET TwoFactorProviders = NULL
--- FROM @UsersToAdjust ua
--- WHERE ua.Id = [User].Id
+DECLARE @revisionDate DATETIME2(7) = GETUTCDATE();
+
+UPDATE [User]
+SET TwoFactorProviders = NULL, RevisionDate = @revisionDate
+FROM @UsersToAdjust ua
+WHERE ua.Id = [User].Id

--- a/util/Migrator/DbScripts/2023-09-14_00_Remove_WebAuthn_For_Free_Users.sql
+++ b/util/Migrator/DbScripts/2023-09-14_00_Remove_WebAuthn_For_Free_Users.sql
@@ -10,26 +10,27 @@ declare @TwoFactorByUser TABLE
 (
     Id UNIQUEIDENTIFIER,
     Email NVARCHAR(256),
-    TwoFactorType INT,
-    TypeEnabled BIT
+    TwoFactorType INT
 )
 
 INSERT INTO @TwoFactorByUser
 SELECT  u.Id, 
         u.Email,
-        tfp1.[key] as TwoFactorType, 
-        CASE [Enabled] WHEN 'true' THEN 1 ELSE 0 END as TypeEnabled
+        tfp1.[key] as TwoFactorType
 FROM [User] u
+LEFT OUTER JOIN [OrganizationUser] ou on ou.UserId = u.Id
+LEFT OUTER JOIN [Organization] o on o.Id = ou.OrganizationId
 CROSS APPLY OPENJSON(u.TwoFactorProviders) tfp1
 CROSS APPLY OPENJSON(tfp1.[value]) WITH (
    [Enabled] nvarchar(10) '$.Enabled'
 ) tfp2
-WHERE [Enabled] = 'true'
-AND Premium = 0
+WHERE [Enabled] = 'true' -- We only want enabled 2FA methods
+AND Premium = 0 -- User isn't Premium
+AND (o IS NULL OR (o IS NOT NULL AND o.Enabled = 1 AND o.UsersGetPremium = 0)) -- User doesn't have Premium from their org
 
 select *
 from @TwoFactorByUser t1
-where t1.TwoFactorType = 7 and t1.TypeEnabled = 1
+where t1.TwoFactorType = 7
 AND NOT EXISTS (SELECT * FROM @TwoFactorByUser t2 WHERE t2.Id = t1.Id and t2.TwoFactorType <> 7)
 
 UPDATE [User]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other (migration script)
```

## Objective

We have users who currently do not have any 2FA method, with the only one being WebAuthn, which is effectively disabled by a server-side permission check for Premium status.

With WebAuthn being made free, we want to avoid these users suddenly being forced to provide 2FA using a key that they haven't used in a long time, by deleting that key from their TwoFactorProviders.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
