### PR TITLE
Reverting TOTP changes from rc branch

### DIFF
--- a/src/Identity/IdentityServer/BaseRequestValidator.cs
+++ b/src/Identity/IdentityServer/BaseRequestValidator.cs
@@ -163,10 +163,7 @@ public abstract class BaseRequestValidator<T> where T : class
                 }
                 return;
             }
-            if (twoFactorProviderType != TwoFactorProviderType.Remember)
-            {
-                await Core.Utilities.DistributedCacheExtensions.SetAsync(_distributedCache, cacheKey, twoFactorToken, _cacheEntryOptions);
-            }
+            await Core.Utilities.DistributedCacheExtensions.SetAsync(_distributedCache, cacheKey, twoFactorToken, _cacheEntryOptions);
         }
         else
         {

--- a/src/Identity/IdentityServer/BaseRequestValidator.cs
+++ b/src/Identity/IdentityServer/BaseRequestValidator.cs
@@ -147,20 +147,26 @@ public abstract class BaseRequestValidator<T> where T : class
             var verified = await VerifyTwoFactor(user, twoFactorOrganization,
                 twoFactorProviderType, twoFactorToken);
 
-            var cacheKey = "TOTP_" + user.Email + "_" + twoFactorToken;
+            var cacheKey = "TOTP_" + user.Email;
 
             var isOtpCached = Core.Utilities.DistributedCacheExtensions.TryGetValue(_distributedCache, cacheKey, out string _);
-            if (!verified || isBot || isOtpCached)
+            if (isOtpCached)
             {
-                if (twoFactorProviderType != TwoFactorProviderType.Remember)
-                {
-                    await UpdateFailedAuthDetailsAsync(user, true, !validatorContext.KnownDevice);
-                    await BuildErrorResultAsync("Two-step token is invalid. Try again.", true, context, user);
-                }
-                else if (twoFactorProviderType == TwoFactorProviderType.Remember)
-                {
-                    await BuildTwoFactorResultAsync(user, twoFactorOrganization, context);
-                }
+                await BuildErrorResultAsync("Two-step token is invalid. Try again.", true, context, user);
+                return;
+            }
+
+            if ((!verified || isBot) && twoFactorProviderType != TwoFactorProviderType.Remember)
+            {
+                await UpdateFailedAuthDetailsAsync(user, true, !validatorContext.KnownDevice);
+                await BuildErrorResultAsync("Two-step token is invalid. Try again.", true, context, user);
+                return;
+            }
+            else if ((!verified || isBot) && twoFactorProviderType == TwoFactorProviderType.Remember)
+            {
+                // Delay for brute force.
+                await Task.Delay(2000);
+                await BuildTwoFactorResultAsync(user, twoFactorOrganization, context);
                 return;
             }
             await Core.Utilities.DistributedCacheExtensions.SetAsync(_distributedCache, cacheKey, twoFactorToken, _cacheEntryOptions);

--- a/src/Identity/IdentityServer/BaseRequestValidator.cs
+++ b/src/Identity/IdentityServer/BaseRequestValidator.cs
@@ -26,7 +26,6 @@ using Bit.Core.Utilities;
 using Bit.Identity.Utilities;
 using IdentityServer4.Validation;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace Bit.Identity.IdentityServer;
 
@@ -46,8 +45,6 @@ public abstract class BaseRequestValidator<T> where T : class
     private readonly GlobalSettings _globalSettings;
     private readonly IUserRepository _userRepository;
     private readonly IDataProtectorTokenFactory<SsoEmail2faSessionTokenable> _tokenDataFactory;
-    private readonly IDistributedCache _distributedCache;
-    private readonly DistributedCacheEntryOptions _cacheEntryOptions;
 
     protected ICurrentContext CurrentContext { get; }
     protected IPolicyService PolicyService { get; }
@@ -72,8 +69,7 @@ public abstract class BaseRequestValidator<T> where T : class
         IPolicyService policyService,
         IDataProtectorTokenFactory<SsoEmail2faSessionTokenable> tokenDataFactory,
         IFeatureService featureService,
-        ISsoConfigRepository ssoConfigRepository,
-        IDistributedCache distributedCache)
+        ISsoConfigRepository ssoConfigRepository)
     {
         _userManager = userManager;
         _deviceRepository = deviceRepository;
@@ -93,14 +89,6 @@ public abstract class BaseRequestValidator<T> where T : class
         _tokenDataFactory = tokenDataFactory;
         FeatureService = featureService;
         SsoConfigRepository = ssoConfigRepository;
-        _distributedCache = distributedCache;
-        _cacheEntryOptions = new DistributedCacheEntryOptions
-        {
-            // This sets the time an item is cached to 15 minutes. This value is hard coded 
-            // to 15 because to it covers all time-out windows for both Authenticators and
-            // Email TOTP.
-            AbsoluteExpirationRelativeToNow = new TimeSpan(0, 15, 0)
-        };
     }
 
     protected async Task ValidateAsync(T context, ValidatedTokenRequest request,
@@ -147,15 +135,6 @@ public abstract class BaseRequestValidator<T> where T : class
             var verified = await VerifyTwoFactor(user, twoFactorOrganization,
                 twoFactorProviderType, twoFactorToken);
 
-            var cacheKey = "TOTP_" + user.Email;
-
-            var isOtpCached = Core.Utilities.DistributedCacheExtensions.TryGetValue(_distributedCache, cacheKey, out string _);
-            if (isOtpCached)
-            {
-                await BuildErrorResultAsync("Two-step token is invalid. Try again.", true, context, user);
-                return;
-            }
-
             if ((!verified || isBot) && twoFactorProviderType != TwoFactorProviderType.Remember)
             {
                 await UpdateFailedAuthDetailsAsync(user, true, !validatorContext.KnownDevice);
@@ -169,7 +148,6 @@ public abstract class BaseRequestValidator<T> where T : class
                 await BuildTwoFactorResultAsync(user, twoFactorOrganization, context);
                 return;
             }
-            await Core.Utilities.DistributedCacheExtensions.SetAsync(_distributedCache, cacheKey, twoFactorToken, _cacheEntryOptions);
         }
         else
         {

--- a/src/Identity/IdentityServer/CustomTokenRequestValidator.cs
+++ b/src/Identity/IdentityServer/CustomTokenRequestValidator.cs
@@ -14,7 +14,6 @@ using IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Validation;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.Caching.Distributed;
 
 #nullable enable
 
@@ -43,13 +42,11 @@ public class CustomTokenRequestValidator : BaseRequestValidator<CustomTokenReque
         IUserRepository userRepository,
         IPolicyService policyService,
         IDataProtectorTokenFactory<SsoEmail2faSessionTokenable> tokenDataFactory,
-        IFeatureService featureService,
-        IDistributedCache distributedCache)
+        IFeatureService featureService)
         : base(userManager, deviceRepository, deviceService, userService, eventService,
             organizationDuoWebTokenProvider, organizationRepository, organizationUserRepository,
             applicationCacheService, mailService, logger, currentContext, globalSettings,
-            userRepository, policyService, tokenDataFactory, featureService, ssoConfigRepository,
-            distributedCache)
+            userRepository, policyService, tokenDataFactory, featureService, ssoConfigRepository)
     {
         _userManager = userManager;
     }

--- a/src/Identity/IdentityServer/ResourceOwnerPasswordValidator.cs
+++ b/src/Identity/IdentityServer/ResourceOwnerPasswordValidator.cs
@@ -13,7 +13,6 @@ using Bit.Core.Utilities;
 using IdentityServer4.Models;
 using IdentityServer4.Validation;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace Bit.Identity.IdentityServer;
 
@@ -45,12 +44,11 @@ public class ResourceOwnerPasswordValidator : BaseRequestValidator<ResourceOwner
         IPolicyService policyService,
         IDataProtectorTokenFactory<SsoEmail2faSessionTokenable> tokenDataFactory,
         IFeatureService featureService,
-        ISsoConfigRepository ssoConfigRepository,
-        IDistributedCache distributedCache)
+        ISsoConfigRepository ssoConfigRepository)
         : base(userManager, deviceRepository, deviceService, userService, eventService,
               organizationDuoWebTokenProvider, organizationRepository, organizationUserRepository,
               applicationCacheService, mailService, logger, currentContext, globalSettings, userRepository, policyService,
-              tokenDataFactory, featureService, ssoConfigRepository, distributedCache)
+              tokenDataFactory, featureService, ssoConfigRepository)
     {
         _userManager = userManager;
         _userService = userService;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Reverting 3 commits that implement PM-2128.  The initial implementation of this work assumed that we needed to cache all types of 2FA tokens, not just TOTP tokens.  Rather than try to patch this for the release, we are reverting it so that we can have a more complete solution in the next release.  The changes will stay in `master` and be iterated upon there in preparation for the November release.

## Code change

- Reverted changes from 3 commits.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
