### PR TITLE
Return discount info in Subscription responses [AC-1657]

### DIFF
--- a/src/Api/Models/Response/Organizations/OrganizationResponseModel.cs
+++ b/src/Api/Models/Response/Organizations/OrganizationResponseModel.cs
@@ -116,6 +116,7 @@ public class OrganizationSubscriptionResponseModel : OrganizationResponseModel
     {
         Subscription = subscription.Subscription != null ? new BillingSubscription(subscription.Subscription) : null;
         UpcomingInvoice = subscription.UpcomingInvoice != null ? new BillingSubscriptionUpcomingInvoice(subscription.UpcomingInvoice) : null;
+        Discount = subscription.Discount != null ? new BillingCustomerDiscount(subscription.Discount) : null;
         Expiration = DateTime.UtcNow.AddYears(1); // Not used, so just give it a value.
 
         if (hideSensitiveData)
@@ -146,6 +147,7 @@ public class OrganizationSubscriptionResponseModel : OrganizationResponseModel
 
     public string StorageName { get; set; }
     public double? StorageGb { get; set; }
+    public BillingCustomerDiscount Discount { get; set; }
     public BillingSubscription Subscription { get; set; }
     public BillingSubscriptionUpcomingInvoice UpcomingInvoice { get; set; }
 

--- a/src/Api/Models/Response/SubscriptionResponseModel.cs
+++ b/src/Api/Models/Response/SubscriptionResponseModel.cs
@@ -14,6 +14,7 @@ public class SubscriptionResponseModel : ResponseModel
         Subscription = subscription.Subscription != null ? new BillingSubscription(subscription.Subscription) : null;
         UpcomingInvoice = subscription.UpcomingInvoice != null ?
             new BillingSubscriptionUpcomingInvoice(subscription.UpcomingInvoice) : null;
+        Discount = subscription.Discount != null ? new BillingCustomerDiscount(subscription.Discount) : null;
         StorageName = user.Storage.HasValue ? CoreHelpers.ReadableBytesSize(user.Storage.Value) : null;
         StorageGb = user.Storage.HasValue ? Math.Round(user.Storage.Value / 1073741824D, 2) : 0; // 1 GB
         MaxStorageGb = user.MaxStorageGb;
@@ -41,9 +42,22 @@ public class SubscriptionResponseModel : ResponseModel
     public short? MaxStorageGb { get; set; }
     public BillingSubscriptionUpcomingInvoice UpcomingInvoice { get; set; }
     public BillingSubscription Subscription { get; set; }
+    public BillingCustomerDiscount Discount { get; set; }
     public UserLicense License { get; set; }
     public DateTime? Expiration { get; set; }
     public bool UsingInAppPurchase { get; set; }
+}
+
+public class BillingCustomerDiscount
+{
+    public BillingCustomerDiscount(SubscriptionInfo.BillingCustomerDiscount discount)
+    {
+        Id = discount.Id;
+        Active = discount.Active;
+    }
+
+    public string Id { get; set; }
+    public bool Active { get; set; }
 }
 
 public class BillingSubscription

--- a/src/Core/Models/Business/SubscriptionInfo.cs
+++ b/src/Core/Models/Business/SubscriptionInfo.cs
@@ -5,9 +5,24 @@ namespace Bit.Core.Models.Business;
 
 public class SubscriptionInfo
 {
+    public BillingCustomerDiscount Discount { get; set; }
     public BillingSubscription Subscription { get; set; }
     public BillingUpcomingInvoice UpcomingInvoice { get; set; }
     public bool UsingInAppPurchase { get; set; }
+
+    public class BillingCustomerDiscount
+    {
+        public BillingCustomerDiscount() { }
+
+        public BillingCustomerDiscount(Discount discount)
+        {
+            Id = discount.Id;
+            Active = discount.Start != null && discount.End == null;
+        }
+
+        public string Id { get; }
+        public bool Active { get; }
+    }
 
     public class BillingSubscription
     {

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -1557,14 +1557,18 @@ public class StripePaymentService : IPaymentService
     {
         var subscriptionInfo = new SubscriptionInfo();
 
-        if (subscriber.IsUser() && !string.IsNullOrWhiteSpace(subscriber.GatewayCustomerId))
+        if (!string.IsNullOrWhiteSpace(subscriber.GatewayCustomerId))
         {
             var customer = await _stripeAdapter.CustomerGetAsync(subscriber.GatewayCustomerId);
-            subscriptionInfo.UsingInAppPurchase = customer.Metadata.ContainsKey("appleReceipt");
 
             if (customer.Discount != null)
             {
                 subscriptionInfo.Discount = new SubscriptionInfo.BillingCustomerDiscount(customer.Discount);
+            }
+
+            if (subscriber.IsUser())
+            {
+                subscriptionInfo.UsingInAppPurchase = customer.Metadata.ContainsKey("appleReceipt");
             }
         }
 

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -1561,6 +1561,11 @@ public class StripePaymentService : IPaymentService
         {
             var customer = await _stripeAdapter.CustomerGetAsync(subscriber.GatewayCustomerId);
             subscriptionInfo.UsingInAppPurchase = customer.Metadata.ContainsKey("appleReceipt");
+
+            if (customer.Discount != null)
+            {
+                subscriptionInfo.Discount = new SubscriptionInfo.BillingCustomerDiscount(customer.Discount);
+            }
         }
 
         if (!string.IsNullOrWhiteSpace(subscriber.GatewaySubscriptionId))


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
[JIRA Ticket](https://bitwarden.atlassian.net/browse/AC-1657)
As part of the ticket linked above, our API needs to inform the web client as to whether the user's Stripe Customer has any discounts applied to them. If they do, we need to display some additional copy under the user's Subscription table.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **SubscriptionInfo.cs:** Introduce a new class, `BillingCustomerDiscount`, containing information pertaining to the Stripe customer's applied discount. Add the new class as a property on the `SubscriptionInfo`.

* **StripePaymentService.cs:** If the Stripe customer has a discount, create a `BillingCustomerDiscount` and add it to the `SubscriptionInfo`.

* **SubscriptionResponseModel.cs:** Introduce another `BilingCustomerDiscount` class used in the response output and add it as a property to the `SubscriptionResponseModel`. If the incoming `SubscriptionInfo` contains a `Discount`, create a `BillingCustomerDiscount` on the response model using the `SubscriptionInfo.Discount`. 

* **OrganizationResponseModel.cs:** Add the `BillingCustomerDiscount` from the previous step as a property on the `OrganizationResponseModel`. Populate it if the incoming `SubscriptionInfo` contains a `Discount`.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
