### PR TITLE
[AC-1649] Remove OrganizationId from CollectionBulkDeleteRequest

### DIFF
--- a/src/Api/Models/Request/CollectionRequestModel.cs
+++ b/src/Api/Models/Request/CollectionRequestModel.cs
@@ -35,8 +35,6 @@ public class CollectionBulkDeleteRequestModel
 {
     [Required]
     public IEnumerable<Guid> Ids { get; set; }
-    [Obsolete("OrganizationId is no longer required and will be removed in a future release")]
-    public string OrganizationId { get; set; }
 }
 
 public class CollectionWithIdRequestModel : CollectionRequestModel


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other


## Objective
> Tech Debt - cleaning up out of scope changes from a previous PR.  Removing the `OrganizationId` property from the `CollectionBulkDeleteRequest` model as it is no longer necessary for the controller operations.

## Code changes
* **src/Api/Models/Request/CollectionRequestModel.cs** Removed `OrganizationId` from the request model

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
