### PR TITLE
[AC-1659] Add CanCreateNewCollections to ProfileOrganizationResponse

### DIFF
--- a/src/Api/Models/Response/ProfileOrganizationResponseModel.cs
+++ b/src/Api/Models/Response/ProfileOrganizationResponseModel.cs
@@ -115,4 +115,8 @@ public class ProfileOrganizationResponseModel : ResponseModel
     public bool? FamilySponsorshipToDelete { get; set; }
     public bool AccessSecretsManager { get; set; }
     public bool LimitCollectionCdOwnerAdmin { get; set; }
+    public bool CanCreateNewCollections => !LimitCollectionCdOwnerAdmin
+                                           || Type is OrganizationUserType.Owner or OrganizationUserType.Admin
+                                           || Permissions is { CreateNewCollections: true }
+                                           || ProviderId is not null;
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other


## Objective
> Add `CanCreateNewCollections` property to the `ProfileOrganizationResponseModel` for passing to the clients during sync. This will be the new source of truth instead of relying on the clients to replicate and re-run the permission check.


## Code changes
* **src/Api/Models/Response/ProfileOrganizationResponseModel.cs**: Added `CanCreateNewCollections` property and emulated the same permission structure found in the `CollectionAuthorizationHandler => CanCreateAsync`

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
