### PR TITLE
Only log errors with LaunchDarkly

### DIFF
--- a/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
+++ b/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Core.Context;
 using Bit.Core.Settings;
+using LaunchDarkly.Logging;
 using LaunchDarkly.Sdk.Server;
 using LaunchDarkly.Sdk.Server.Integrations;
 
@@ -14,6 +15,7 @@ public class LaunchDarklyFeatureService : IFeatureService, IDisposable
         IGlobalSettings globalSettings)
     {
         var ldConfig = Configuration.Builder(globalSettings.LaunchDarkly?.SdkKey);
+        ldConfig.Logging(Components.Logging().Level(LogLevel.Error));
 
         if (string.IsNullOrEmpty(globalSettings.LaunchDarkly?.SdkKey))
         {


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Deliberately only log errors with LaunchDarkly. LD has [its own configuration](https://docs.launchdarkly.com/sdk/features/logging#net-server-side) and emits noise in our use case, especially for self-hosted installations that are offline with some warning messages. The info-level default and heavy usage by clients calling the configuration API makes this untenable and for now we can just suppress anything but errors.

## Code changes

* **src/Core/Services/Implementations/LaunchDarklyFeatureService.cs:** Logging configuration.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
