### PR TITLE
[AC-1666] Removed EditAnyCollection from Create/Delete permission checks

### DIFF
--- a/src/Api/Vault/AuthorizationHandlers/Collections/CollectionAuthorizationHandler.cs
+++ b/src/Api/Vault/AuthorizationHandlers/Collections/CollectionAuthorizationHandler.cs
@@ -77,7 +77,7 @@ public class CollectionAuthorizationHandler : BulkAuthorizationHandler<Collectio
             return;
         }
 
-        // Owners, Admins, Providers, and users with CreateNewCollections or EditAnyCollection permission can always create collections
+        // Owners, Admins, Providers, and users with CreateNewCollections permission can always create collections
         if (
             org.Type is OrganizationUserType.Owner or OrganizationUserType.Admin ||
             org.Permissions is { CreateNewCollections: true } ||
@@ -93,7 +93,7 @@ public class CollectionAuthorizationHandler : BulkAuthorizationHandler<Collectio
     private async Task CanDeleteAsync(AuthorizationHandlerContext context, CollectionOperationRequirement requirement,
         ICollection<Collection> resources, CurrentContextOrganization org)
     {
-        // Owners, Admins, Providers, and users with DeleteAnyCollection or EditAnyCollection permission can always delete collections
+        // Owners, Admins, Providers, and users with DeleteAnyCollection permission can always delete collections
         if (
             org.Type is OrganizationUserType.Owner or OrganizationUserType.Admin ||
             org.Permissions is { DeleteAnyCollection: true } ||

--- a/src/Api/Vault/AuthorizationHandlers/Collections/CollectionAuthorizationHandler.cs
+++ b/src/Api/Vault/AuthorizationHandlers/Collections/CollectionAuthorizationHandler.cs
@@ -80,7 +80,7 @@ public class CollectionAuthorizationHandler : BulkAuthorizationHandler<Collectio
         // Owners, Admins, Providers, and users with CreateNewCollections or EditAnyCollection permission can always create collections
         if (
             org.Type is OrganizationUserType.Owner or OrganizationUserType.Admin ||
-            org.Permissions.CreateNewCollections || org.Permissions.EditAnyCollection ||
+            org.Permissions is { CreateNewCollections: true } ||
             await _currentContext.ProviderUserForOrgAsync(org.Id))
         {
             context.Succeed(requirement);
@@ -96,7 +96,7 @@ public class CollectionAuthorizationHandler : BulkAuthorizationHandler<Collectio
         // Owners, Admins, Providers, and users with DeleteAnyCollection or EditAnyCollection permission can always delete collections
         if (
             org.Type is OrganizationUserType.Owner or OrganizationUserType.Admin ||
-            org.Permissions.DeleteAnyCollection || org.Permissions.EditAnyCollection ||
+            org.Permissions is { DeleteAnyCollection: true } ||
             await _currentContext.ProviderUserForOrgAsync(org.Id))
         {
             context.Succeed(requirement);


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Remove `EditAnyCollections` from the permission checks for `Create` and `Delete` collections

## Code changes
* **src/Api/Vault/AuthorizationHandlers/Collections/CollectionAuthorizationHandler.cs** Removed `EditAnyCollections` from the permission checks for `Create` and `Delete`

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
