### PR TITLE
 [PM-4054] Rename Fido2Key to Fido2Credential

### DIFF
--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -194,7 +194,7 @@ public class CiphersController : Controller
         // Temporary protection against old clients overwriting and deleting Fido2Keys
         // Response model used to re-use logic for parsing 'data' property
         var cipherModel = new CipherResponseModel(cipher, _globalSettings);
-        if (cipherModel.Login?.Fido2Keys != null && _currentContext.ClientVersion < _fido2KeyCipherMinimumVersion)
+        if (cipherModel.Login?.Fido2Credentials != null && _currentContext.ClientVersion < _fido2KeyCipherMinimumVersion)
         {
             throw new BadRequestException("Please update your client to edit this item.");
         }

--- a/src/Api/Vault/Models/CipherFido2CredentialModel.cs
+++ b/src/Api/Vault/Models/CipherFido2CredentialModel.cs
@@ -4,11 +4,11 @@ using Bit.Core.Vault.Models.Data;
 
 namespace Bit.Api.Vault.Models;
 
-public class CipherFido2KeyModel
+public class CipherFido2CredentialModel
 {
-    public CipherFido2KeyModel() { }
+    public CipherFido2CredentialModel() { }
 
-    public CipherFido2KeyModel(CipherLoginFido2KeyData data)
+    public CipherFido2CredentialModel(CipherLoginFido2CredentialData data)
     {
         CredentialId = data.CredentialId;
         KeyType = data.KeyType;
@@ -60,9 +60,9 @@ public class CipherFido2KeyModel
     [Required]
     public DateTime CreationDate { get; set; }
 
-    public CipherLoginFido2KeyData ToCipherLoginFido2KeyData()
+    public CipherLoginFido2CredentialData ToCipherLoginFido2CredentialData()
     {
-        return new CipherLoginFido2KeyData
+        return new CipherLoginFido2CredentialData
         {
             CredentialId = CredentialId,
             KeyType = KeyType,
@@ -80,10 +80,10 @@ public class CipherFido2KeyModel
     }
 }
 
-static class CipherFido2KeyModelExtensions
+static class CipherFido2CredentialModelExtensions
 {
-    public static CipherLoginFido2KeyData[] ToCipherLoginFido2KeyData(this CipherFido2KeyModel[] models)
+    public static CipherLoginFido2CredentialData[] ToCipherLoginFido2CredentialData(this CipherFido2CredentialModel[] models)
     {
-        return models.Select(m => m.ToCipherLoginFido2KeyData()).ToArray();
+        return models.Select(m => m.ToCipherLoginFido2CredentialData()).ToArray();
     }
 }

--- a/src/Api/Vault/Models/CipherLoginModel.cs
+++ b/src/Api/Vault/Models/CipherLoginModel.cs
@@ -16,9 +16,9 @@ public class CipherLoginModel
             Uri = data.Uri;
         }
 
-        if (data.Fido2Keys != null)
+        if (data.Fido2Credentials != null)
         {
-            Fido2Keys = data.Fido2Keys.Select(key => new CipherFido2KeyModel(key)).ToArray();
+            Fido2Credentials = data.Fido2Credentials.Select(key => new CipherFido2CredentialModel(key)).ToArray();
         }
 
         Username = data.Username;
@@ -60,7 +60,7 @@ public class CipherLoginModel
     [EncryptedStringLength(1000)]
     public string Totp { get; set; }
     public bool? AutofillOnPageLoad { get; set; }
-    public CipherFido2KeyModel[] Fido2Keys { get; set; }
+    public CipherFido2CredentialModel[] Fido2Credentials { get; set; }
 
     public class CipherLoginUriModel
     {

--- a/src/Api/Vault/Models/Request/CipherRequestModel.cs
+++ b/src/Api/Vault/Models/Request/CipherRequestModel.cs
@@ -166,7 +166,7 @@ public class CipherRequestModel
             PasswordRevisionDate = Login.PasswordRevisionDate,
             Totp = Login.Totp,
             AutofillOnPageLoad = Login.AutofillOnPageLoad,
-            Fido2Keys = Login.Fido2Keys == null ? null : Login.Fido2Keys.ToCipherLoginFido2KeyData(),
+            Fido2Credentials = Login.Fido2Credentials == null ? null : Login.Fido2Credentials.ToCipherLoginFido2CredentialData(),
         };
     }
 

--- a/src/Api/Vault/Models/Response/CipherResponseModel.cs
+++ b/src/Api/Vault/Models/Response/CipherResponseModel.cs
@@ -76,7 +76,6 @@ public class CipherMiniResponseModel : ResponseModel
     public CipherCardModel Card { get; set; }
     public CipherIdentityModel Identity { get; set; }
     public CipherSecureNoteModel SecureNote { get; set; }
-    public CipherFido2KeyModel Fido2Key { get; set; }
     public IEnumerable<CipherFieldModel> Fields { get; set; }
     public IEnumerable<CipherPasswordHistoryModel> PasswordHistory { get; set; }
     public IEnumerable<AttachmentResponseModel> Attachments { get; set; }

--- a/src/Core/Vault/Models/Data/CipherLoginData.cs
+++ b/src/Core/Vault/Models/Data/CipherLoginData.cs
@@ -19,7 +19,7 @@ public class CipherLoginData : CipherData
     public DateTime? PasswordRevisionDate { get; set; }
     public string Totp { get; set; }
     public bool? AutofillOnPageLoad { get; set; }
-    public CipherLoginFido2KeyData[] Fido2Keys { get; set; }
+    public CipherLoginFido2CredentialData[] Fido2Credentials { get; set; }
 
     public class CipherLoginUriData
     {

--- a/src/Core/Vault/Models/Data/CipherLoginFido2CredentialData.cs
+++ b/src/Core/Vault/Models/Data/CipherLoginFido2CredentialData.cs
@@ -1,8 +1,8 @@
 ﻿namespace Bit.Core.Vault.Models.Data;
 
-public class CipherLoginFido2KeyData
+public class CipherLoginFido2CredentialData
 {
-    public CipherLoginFido2KeyData() { }
+    public CipherLoginFido2CredentialData() { }
 
     public string CredentialId { get; set; }
     public string KeyType { get; set; }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Rename Fido2Key to Fido2Credential. Remove Fido2Key from Cipher since it's only available through login.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
