### PR TITLE
[AC-1669] Bug - Remove obsolete assignUserId from CollectionService.SaveAsync(...)

### DIFF
--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -161,7 +161,7 @@ public class CollectionsController : Controller
         var groups = model.Groups?.Select(g => g.ToSelectionReadOnly());
         var users = model.Users?.Select(g => g.ToSelectionReadOnly());
 
-        await _collectionService.SaveAsync(collection, groups, users, _currentContext.UserId);
+        await _collectionService.SaveAsync(collection, groups, users);
         return new CollectionResponseModel(collection);
     }
 

--- a/src/Core/Services/ICollectionService.cs
+++ b/src/Core/Services/ICollectionService.cs
@@ -5,7 +5,7 @@ namespace Bit.Core.Services;
 
 public interface ICollectionService
 {
-    Task SaveAsync(Collection collection, IEnumerable<CollectionAccessSelection> groups = null, IEnumerable<CollectionAccessSelection> users = null, Guid? assignUserId = null);
+    Task SaveAsync(Collection collection, IEnumerable<CollectionAccessSelection> groups = null, IEnumerable<CollectionAccessSelection> users = null);
     Task DeleteUserAsync(Collection collection, Guid organizationUserId);
     Task<IEnumerable<Collection>> GetOrganizationCollectionsAsync(Guid organizationId);
 }

--- a/src/Core/Services/Implementations/CollectionService.cs
+++ b/src/Core/Services/Implementations/CollectionService.cs
@@ -56,7 +56,7 @@ public class CollectionService : ICollectionService
         if (!groupHasManageAccess && !userHasManageAccess)
         {
             throw new BadRequestException(
-                "At least one User or Group must have Manage access to the newly created collection.");
+                "At least one member or group must have can manage permission.");
         }
 
         if (collection.Id == default(Guid))

--- a/test/Api.Test/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.Test/Controllers/CollectionsControllerTests.cs
@@ -40,7 +40,7 @@ public class CollectionsControllerTests
         await sutProvider.GetDependency<ICollectionService>()
             .Received(1)
             .SaveAsync(Arg.Any<Collection>(), Arg.Any<IEnumerable<CollectionAccessSelection>>(),
-                Arg.Any<IEnumerable<CollectionAccessSelection>>(), null);
+                Arg.Any<IEnumerable<CollectionAccessSelection>>());
     }
 
     [Theory, BitAutoData]

--- a/test/Core.Test/AutoFixture/CollectionAccessSelectionFixtures.cs
+++ b/test/Core.Test/AutoFixture/CollectionAccessSelectionFixtures.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using AutoFixture;
+using AutoFixture.Xunit2;
+using Bit.Core.Models.Data;
+
+namespace Bit.Core.Test.AutoFixture;
+
+public class CollectionAccessSelectionCustomization : ICustomization
+{
+    public bool Manage { get; set; }
+
+    public CollectionAccessSelectionCustomization(bool manage)
+    {
+        Manage = manage;
+    }
+
+    public void Customize(IFixture fixture)
+    {
+        fixture.Customize<CollectionAccessSelection>(composer => composer
+            .With(o => o.Manage, Manage));
+    }
+}
+
+public class CollectionAccessSelectionAttribute : CustomizeAttribute
+{
+    private readonly bool _manage;
+
+    public CollectionAccessSelectionAttribute(bool manage = false)
+    {
+        _manage = manage;
+    }
+
+    public override ICustomization GetCustomization(ParameterInfo parameter)
+    {
+        return new CollectionAccessSelectionCustomization(_manage);
+    }
+}

--- a/test/Core.Test/AutoFixture/CollectionAccessSelectionFixtures.cs
+++ b/test/Core.Test/AutoFixture/CollectionAccessSelectionFixtures.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using AutoFixture;
 using AutoFixture.Xunit2;
 using Bit.Core.Models.Data;

--- a/test/Core.Test/AutoFixture/CollectionAccessSelectionFixtures.cs
+++ b/test/Core.Test/AutoFixture/CollectionAccessSelectionFixtures.cs
@@ -21,11 +21,11 @@ public class CollectionAccessSelectionCustomization : ICustomization
     }
 }
 
-public class CollectionAccessSelectionAttribute : CustomizeAttribute
+public class CollectionAccessSelectionCustomizeAttribute : CustomizeAttribute
 {
     private readonly bool _manage;
 
-    public CollectionAccessSelectionAttribute(bool manage = false)
+    public CollectionAccessSelectionCustomizeAttribute(bool manage = false)
     {
         _manage = manage;
     }

--- a/test/Core.Test/Services/CollectionServiceTests.cs
+++ b/test/Core.Test/Services/CollectionServiceTests.cs
@@ -28,8 +28,8 @@ public class CollectionServiceTest
         await sutProvider.Sut.SaveAsync(collection, null, users);
 
         await sutProvider.GetDependency<ICollectionRepository>().Received()
-            .CreateAsync(collection, null,
-                Arg.Is<List<CollectionAccessSelection>>(list => list.Any(item => item.Manage == true)));
+            .CreateAsync(collection, Arg.Is<List<CollectionAccessSelection>>(l => l == null),
+                Arg.Is<List<CollectionAccessSelection>>(l => l.Any(i => i.Manage == true)));
         await sutProvider.GetDependency<IEventService>().Received()
             .LogCollectionEventAsync(collection, EventType.Collection_Created);
         Assert.True(collection.CreationDate - utcNow < TimeSpan.FromSeconds(1));
@@ -48,7 +48,7 @@ public class CollectionServiceTest
         await sutProvider.Sut.SaveAsync(collection, groups, users);
 
         await sutProvider.GetDependency<ICollectionRepository>().Received()
-            .CreateAsync(collection, Arg.Is<List<CollectionAccessSelection>>(list => list.Any(item => item.Manage == true)),
+            .CreateAsync(collection, Arg.Is<List<CollectionAccessSelection>>(l => l.Any(i => i.Manage == true)),
                 Arg.Any<List<CollectionAccessSelection>>());
         await sutProvider.GetDependency<IEventService>().Received()
             .LogCollectionEventAsync(collection, EventType.Collection_Created);
@@ -66,8 +66,8 @@ public class CollectionServiceTest
         await sutProvider.Sut.SaveAsync(collection, null, users);
 
         await sutProvider.GetDependency<ICollectionRepository>().Received().ReplaceAsync(collection,
-            Arg.Any<List<CollectionAccessSelection>>(),
-            Arg.Is<List<CollectionAccessSelection>>(list => list.Any(item => item.Manage == true)));
+            Arg.Is<List<CollectionAccessSelection>>(l => l == null),
+            Arg.Is<List<CollectionAccessSelection>>(l => l.Any(i => i.Manage == true)));
         await sutProvider.GetDependency<IEventService>().Received()
             .LogCollectionEventAsync(collection, EventType.Collection_Updated);
         Assert.Equal(collection.CreationDate, creationDate);
@@ -87,8 +87,8 @@ public class CollectionServiceTest
         await sutProvider.Sut.SaveAsync(collection, groups, users);
 
         await sutProvider.GetDependency<ICollectionRepository>().Received().CreateAsync(collection,
-            Arg.Any<List<CollectionAccessSelection>>(),
-            Arg.Is<List<CollectionAccessSelection>>(list => list.Any(item => item.Manage == true)));
+            Arg.Is<List<CollectionAccessSelection>>(l => l == null),
+            Arg.Is<List<CollectionAccessSelection>>(l => l.Any(i => i.Manage == true)));
         await sutProvider.GetDependency<IEventService>().Received()
             .LogCollectionEventAsync(collection, EventType.Collection_Created);
         Assert.True(collection.CreationDate - utcNow < TimeSpan.FromSeconds(1));

--- a/test/Core.Test/Services/CollectionServiceTests.cs
+++ b/test/Core.Test/Services/CollectionServiceTests.cs
@@ -18,15 +18,20 @@ namespace Bit.Core.Test.Services;
 public class CollectionServiceTest
 {
     [Theory, BitAutoData]
-    public async Task SaveAsync_DefaultId_CreatesCollectionInTheRepository(Collection collection, Organization organization, SutProvider<CollectionService> sutProvider)
+    public async Task SaveAsync_DefaultId_CreatesCollectionInTheRepository(Collection collection, Organization organization, CollectionAccessSelection userAccess, SutProvider<CollectionService> sutProvider)
     {
         collection.Id = default;
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
         var utcNow = DateTime.UtcNow;
+        // Grant the user manage access
+        userAccess.Manage = true;
+        List<CollectionAccessSelection> userList = new() { userAccess };
 
-        await sutProvider.Sut.SaveAsync(collection);
+        await sutProvider.Sut.SaveAsync(collection, users: userList);
 
-        await sutProvider.GetDependency<ICollectionRepository>().Received().CreateAsync(collection, null, null);
+        await sutProvider.GetDependency<ICollectionRepository>().Received()
+            .CreateAsync(collection, Arg.Any<List<CollectionAccessSelection>>(),
+                Arg.Is<List<CollectionAccessSelection>>(list => list.Any(item => item.Manage == true)));
         await sutProvider.GetDependency<IEventService>().Received()
             .LogCollectionEventAsync(collection, EventType.Collection_Created);
         Assert.True(collection.CreationDate - utcNow < TimeSpan.FromSeconds(1));
@@ -39,10 +44,15 @@ public class CollectionServiceTest
         collection.Id = default;
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
         var utcNow = DateTime.UtcNow;
+        // Grant the user manage access
+        var userList = users.ToList();
+        userList.First().Manage = true;
 
-        await sutProvider.Sut.SaveAsync(collection, null, users);
+        await sutProvider.Sut.SaveAsync(collection, null, userList);
 
-        await sutProvider.GetDependency<ICollectionRepository>().Received().CreateAsync(collection, null, users);
+        await sutProvider.GetDependency<ICollectionRepository>().Received()
+            .CreateAsync(collection, Arg.Any<List<CollectionAccessSelection>>(),
+                Arg.Is<List<CollectionAccessSelection>>(list => list.Any(item => item.Manage == true)));
         await sutProvider.GetDependency<IEventService>().Received()
             .LogCollectionEventAsync(collection, EventType.Collection_Created);
         Assert.True(collection.CreationDate - utcNow < TimeSpan.FromSeconds(1));
@@ -57,10 +67,16 @@ public class CollectionServiceTest
         organization.UseGroups = true;
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
         var utcNow = DateTime.UtcNow;
+        var userList = users.ToList();
+        var groupList = groups.ToList();
+        userList.First().Manage = true;
 
-        await sutProvider.Sut.SaveAsync(collection, groups, users);
 
-        await sutProvider.GetDependency<ICollectionRepository>().Received().CreateAsync(collection, groups, users);
+        await sutProvider.Sut.SaveAsync(collection, groupList, userList);
+
+        await sutProvider.GetDependency<ICollectionRepository>().Received()
+            .CreateAsync(collection, Arg.Any<List<CollectionAccessSelection>>(),
+                Arg.Is<List<CollectionAccessSelection>>(list => list.Any(item => item.Manage == true)));
         await sutProvider.GetDependency<IEventService>().Received()
             .LogCollectionEventAsync(collection, EventType.Collection_Created);
         Assert.True(collection.CreationDate - utcNow < TimeSpan.FromSeconds(1));
@@ -68,15 +84,19 @@ public class CollectionServiceTest
     }
 
     [Theory, BitAutoData]
-    public async Task SaveAsync_NonDefaultId_ReplacesCollectionInRepository(Collection collection, Organization organization, SutProvider<CollectionService> sutProvider)
+    public async Task SaveAsync_NonDefaultId_ReplacesCollectionInRepository(Collection collection, Organization organization, CollectionAccessSelection userAccess, SutProvider<CollectionService> sutProvider)
     {
         var creationDate = collection.CreationDate;
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
         var utcNow = DateTime.UtcNow;
+        userAccess.Manage = true;
+        List<CollectionAccessSelection> userList = new() { userAccess };
 
-        await sutProvider.Sut.SaveAsync(collection);
+        await sutProvider.Sut.SaveAsync(collection, null, userList);
 
-        await sutProvider.GetDependency<ICollectionRepository>().Received().ReplaceAsync(collection, null, null);
+        await sutProvider.GetDependency<ICollectionRepository>().Received().ReplaceAsync(collection,
+            Arg.Any<List<CollectionAccessSelection>>(),
+            Arg.Is<List<CollectionAccessSelection>>(list => list.Any(item => item.Manage == true)));
         await sutProvider.GetDependency<IEventService>().Received()
             .LogCollectionEventAsync(collection, EventType.Collection_Updated);
         Assert.Equal(collection.CreationDate, creationDate);
@@ -101,29 +121,6 @@ public class CollectionServiceTest
     }
 
     [Theory, BitAutoData]
-    public async Task SaveAsync_DefaultIdWithUserId_UpdateUserInCollectionRepository(Collection collection,
-        Organization organization, OrganizationUser organizationUser, SutProvider<CollectionService> sutProvider)
-    {
-        collection.Id = default;
-        organizationUser.Status = OrganizationUserStatusType.Confirmed;
-        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
-        sutProvider.GetDependency<IOrganizationUserRepository>().GetByOrganizationAsync(organization.Id, organizationUser.Id)
-            .Returns(organizationUser);
-        var utcNow = DateTime.UtcNow;
-
-        await sutProvider.Sut.SaveAsync(collection, null, null, organizationUser.Id);
-
-        await sutProvider.GetDependency<ICollectionRepository>().Received().CreateAsync(collection, null, null);
-        await sutProvider.GetDependency<IOrganizationUserRepository>().Received()
-            .GetByOrganizationAsync(organization.Id, organizationUser.Id);
-        await sutProvider.GetDependency<ICollectionRepository>().Received().UpdateUsersAsync(collection.Id, Arg.Any<List<CollectionAccessSelection>>());
-        await sutProvider.GetDependency<IEventService>().Received()
-            .LogCollectionEventAsync(collection, EventType.Collection_Created);
-        Assert.True(collection.CreationDate - utcNow < TimeSpan.FromSeconds(1));
-        Assert.True(collection.RevisionDate - utcNow < TimeSpan.FromSeconds(1));
-    }
-
-    [Theory, BitAutoData]
     public async Task SaveAsync_NonExistingOrganizationId_ThrowsBadRequest(Collection collection, SutProvider<CollectionService> sutProvider)
     {
         var ex = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.SaveAsync(collection));
@@ -135,14 +132,32 @@ public class CollectionServiceTest
     }
 
     [Theory, BitAutoData]
-    public async Task SaveAsync_ExceedsOrganizationMaxCollections_ThrowsBadRequest(Collection collection, Organization organization, SutProvider<CollectionService> sutProvider)
+    public async Task SaveAsync_NoManageAccess_ThrowsBadRequest(Collection collection, Organization organization, CollectionAccessSelection userAccess, SutProvider<CollectionService> sutProvider)
     {
         collection.Id = default;
+        userAccess.Manage = false;
+        List<CollectionAccessSelection> userList = new() { userAccess };
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
+
+        var ex = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.SaveAsync(collection, null, userList));
+        Assert.Contains("At least one User or Group must have Manage access to the newly created collection", ex.Message);
+        await sutProvider.GetDependency<ICollectionRepository>().DidNotReceiveWithAnyArgs().CreateAsync(default);
+        await sutProvider.GetDependency<ICollectionRepository>().DidNotReceiveWithAnyArgs().CreateAsync(default, default, default);
+        await sutProvider.GetDependency<ICollectionRepository>().DidNotReceiveWithAnyArgs().ReplaceAsync(default);
+        await sutProvider.GetDependency<IEventService>().DidNotReceiveWithAnyArgs().LogCollectionEventAsync(default, default);
+    }
+
+    [Theory, BitAutoData]
+    public async Task SaveAsync_ExceedsOrganizationMaxCollections_ThrowsBadRequest(Collection collection, Organization organization, CollectionAccessSelection userAccess, SutProvider<CollectionService> sutProvider)
+    {
+        collection.Id = default;
+        userAccess.Manage = true;
+        List<CollectionAccessSelection> userList = new() { userAccess };
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
         sutProvider.GetDependency<ICollectionRepository>().GetCountByOrganizationIdAsync(organization.Id)
             .Returns(organization.MaxCollections.Value);
 
-        var ex = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.SaveAsync(collection));
+        var ex = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.SaveAsync(collection, null, userList));
         Assert.Equal($@"You have reached the maximum number of collections ({organization.MaxCollections.Value}) for this organization.", ex.Message);
         await sutProvider.GetDependency<ICollectionRepository>().DidNotReceiveWithAnyArgs().CreateAsync(default);
         await sutProvider.GetDependency<ICollectionRepository>().DidNotReceiveWithAnyArgs().CreateAsync(default, default, default);

--- a/test/Core.Test/Services/CollectionServiceTests.cs
+++ b/test/Core.Test/Services/CollectionServiceTests.cs
@@ -24,11 +24,11 @@ public class CollectionServiceTest
         collection.Id = default;
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
         var utcNow = DateTime.UtcNow;
-        
+
         await sutProvider.Sut.SaveAsync(collection, null, users);
 
         await sutProvider.GetDependency<ICollectionRepository>().Received()
-            .CreateAsync(collection, Arg.Any<List<CollectionAccessSelection>>(),
+            .CreateAsync(collection, null,
                 Arg.Is<List<CollectionAccessSelection>>(list => list.Any(item => item.Manage == true)));
         await sutProvider.GetDependency<IEventService>().Received()
             .LogCollectionEventAsync(collection, EventType.Collection_Created);
@@ -44,7 +44,7 @@ public class CollectionServiceTest
         organization.UseGroups = true;
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
         var utcNow = DateTime.UtcNow;
-        
+
         await sutProvider.Sut.SaveAsync(collection, groups, users);
 
         await sutProvider.GetDependency<ICollectionRepository>().Received()
@@ -75,7 +75,7 @@ public class CollectionServiceTest
     }
 
     [Theory, BitAutoData]
-    public async Task SaveAsync_OrganizationNotUseGroup_CreateCollectionWithoutGroupsInRepository(Collection collection, 
+    public async Task SaveAsync_OrganizationNotUseGroup_CreateCollectionWithoutGroupsInRepository(Collection collection,
         IEnumerable<CollectionAccessSelection> groups, [CollectionAccessSelection(true)] IEnumerable<CollectionAccessSelection> users,
         Organization organization, SutProvider<CollectionService> sutProvider)
     {
@@ -107,7 +107,7 @@ public class CollectionServiceTest
     }
 
     [Theory, BitAutoData]
-    public async Task SaveAsync_NoManageAccess_ThrowsBadRequest(Collection collection, Organization organization, 
+    public async Task SaveAsync_NoManageAccess_ThrowsBadRequest(Collection collection, Organization organization,
         [CollectionAccessSelection] IEnumerable<CollectionAccessSelection> users, SutProvider<CollectionService> sutProvider)
     {
         collection.Id = default;
@@ -122,7 +122,7 @@ public class CollectionServiceTest
     }
 
     [Theory, BitAutoData]
-    public async Task SaveAsync_ExceedsOrganizationMaxCollections_ThrowsBadRequest(Collection collection, 
+    public async Task SaveAsync_ExceedsOrganizationMaxCollections_ThrowsBadRequest(Collection collection,
         Organization organization, [CollectionAccessSelection(true)] IEnumerable<CollectionAccessSelection> users,
         SutProvider<CollectionService> sutProvider)
     {

--- a/test/Core.Test/Services/CollectionServiceTests.cs
+++ b/test/Core.Test/Services/CollectionServiceTests.cs
@@ -19,7 +19,7 @@ namespace Bit.Core.Test.Services;
 public class CollectionServiceTest
 {
     [Theory, BitAutoData]
-    public async Task SaveAsync_DefaultIdWithUsers_CreatesCollectionInTheRepository(Collection collection, Organization organization, [CollectionAccessSelection(true)] IEnumerable<CollectionAccessSelection> users, SutProvider<CollectionService> sutProvider)
+    public async Task SaveAsync_DefaultIdWithUsers_CreatesCollectionInTheRepository(Collection collection, Organization organization, [CollectionAccessSelectionCustomize(true)] IEnumerable<CollectionAccessSelection> users, SutProvider<CollectionService> sutProvider)
     {
         collection.Id = default;
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
@@ -38,7 +38,7 @@ public class CollectionServiceTest
 
     [Theory, BitAutoData]
     public async Task SaveAsync_DefaultIdWithGroupsAndUsers_CreateCollectionWithGroupsAndUsersInRepository(Collection collection,
-        [CollectionAccessSelection(true)] IEnumerable<CollectionAccessSelection> groups, IEnumerable<CollectionAccessSelection> users, Organization organization, SutProvider<CollectionService> sutProvider)
+        [CollectionAccessSelectionCustomize(true)] IEnumerable<CollectionAccessSelection> groups, IEnumerable<CollectionAccessSelection> users, Organization organization, SutProvider<CollectionService> sutProvider)
     {
         collection.Id = default;
         organization.UseGroups = true;
@@ -57,7 +57,7 @@ public class CollectionServiceTest
     }
 
     [Theory, BitAutoData]
-    public async Task SaveAsync_NonDefaultId_ReplacesCollectionInRepository(Collection collection, Organization organization, [CollectionAccessSelection(true)] IEnumerable<CollectionAccessSelection> users, SutProvider<CollectionService> sutProvider)
+    public async Task SaveAsync_NonDefaultId_ReplacesCollectionInRepository(Collection collection, Organization organization, [CollectionAccessSelectionCustomize(true)] IEnumerable<CollectionAccessSelection> users, SutProvider<CollectionService> sutProvider)
     {
         var creationDate = collection.CreationDate;
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
@@ -76,7 +76,7 @@ public class CollectionServiceTest
 
     [Theory, BitAutoData]
     public async Task SaveAsync_OrganizationNotUseGroup_CreateCollectionWithoutGroupsInRepository(Collection collection,
-        IEnumerable<CollectionAccessSelection> groups, [CollectionAccessSelection(true)] IEnumerable<CollectionAccessSelection> users,
+        IEnumerable<CollectionAccessSelection> groups, [CollectionAccessSelectionCustomize(true)] IEnumerable<CollectionAccessSelection> users,
         Organization organization, SutProvider<CollectionService> sutProvider)
     {
         collection.Id = default;
@@ -108,7 +108,7 @@ public class CollectionServiceTest
 
     [Theory, BitAutoData]
     public async Task SaveAsync_NoManageAccess_ThrowsBadRequest(Collection collection, Organization organization,
-        [CollectionAccessSelection] IEnumerable<CollectionAccessSelection> users, SutProvider<CollectionService> sutProvider)
+        [CollectionAccessSelectionCustomize] IEnumerable<CollectionAccessSelection> users, SutProvider<CollectionService> sutProvider)
     {
         collection.Id = default;
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
@@ -123,7 +123,7 @@ public class CollectionServiceTest
 
     [Theory, BitAutoData]
     public async Task SaveAsync_ExceedsOrganizationMaxCollections_ThrowsBadRequest(Collection collection,
-        Organization organization, [CollectionAccessSelection(true)] IEnumerable<CollectionAccessSelection> users,
+        Organization organization, [CollectionAccessSelectionCustomize(true)] IEnumerable<CollectionAccessSelection> users,
         SutProvider<CollectionService> sutProvider)
     {
         collection.Id = default;


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Fix issues where creating a collection removes other users sent with request

## Code changes
* **src/Api/Controllers/CollectionsController.cs**: Removed parameter
* **src/Core/Services/ICollectionService.cs**: Removed parameter
* **src/Core/Services/Implementations/CollectionService.cs**: Removed parameter. Added conditionals around making sure either a group or user have the `manage` access

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
