### PR TITLE
Add server version compatibility check for Fido2Credentials on sharing with org

### DIFF
--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -540,7 +540,7 @@ public class CiphersController : Controller
 
             ValidateClientVersionForItemLevelEncryptionSupport(existingCipher);
             ValidateClientVersionForFido2CredentialSupport(existingCipher);
-         
+
             shareCiphers.Add((cipher.ToCipher(existingCipher), cipher.LastKnownRevisionDate));
         }
 
@@ -816,7 +816,7 @@ public class CiphersController : Controller
         }
     }
 
-     private void ValidateClientVersionForItemLevelEncryptionSupport(Cipher cipher)
+    private void ValidateClientVersionForItemLevelEncryptionSupport(Cipher cipher)
     {
         if (cipher.Key != null && _currentContext.ClientVersion < _cipherKeyEncryptionMinimumVersion)
         {

--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -537,10 +537,10 @@ public class CiphersController : Controller
             }
 
             var existingCipher = ciphersDict[cipher.Id.Value];
-            
-            ValidateClientVersionForFido2CredentialSupport(existingCipher);
-            ValidateClientVersionForItemLevelEncryptionSupport(existingCipher);
 
+            ValidateClientVersionForItemLevelEncryptionSupport(existingCipher);
+            ValidateClientVersionForFido2CredentialSupport(existingCipher);
+         
             shareCiphers.Add((cipher.ToCipher(existingCipher), cipher.LastKnownRevisionDate));
         }
 

--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -536,7 +536,12 @@ public class CiphersController : Controller
                 throw new BadRequestException("Trying to move ciphers that you do not own.");
             }
 
-            shareCiphers.Add((cipher.ToCipher(ciphersDict[cipher.Id.Value]), cipher.LastKnownRevisionDate));
+            var existingCipher = ciphersDict[cipher.Id.Value];
+            
+            ValidateClientVersionForFido2CredentialSupport(existingCipher);
+            ValidateClientVersionForItemLevelEncryptionSupport(existingCipher);
+
+            shareCiphers.Add((cipher.ToCipher(existingCipher), cipher.LastKnownRevisionDate));
         }
 
         await _cipherService.ShareManyAsync(shareCiphers, organizationId,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

We need to ensure that a Login cipher that is updated from an old client doesn't overwrite a `Fido2Credential` that exists in the `Data` property from a newer client.

This should be done:
- When updating a cipher
- When moving a cipher to an org 
- When moving multiple ciphers to an org

## Code changes

**CiphersController.cs:** 
- Refactored `Fido2Credential` version check into a separate method for reuse on multiple methods.
- Added check to additional methods.
- Added missing check for vault item encryption on `PutShareMany()` as well.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
