### PR TITLE
[PM-4252] Change attachment Size to be represented as a string

### DIFF
--- a/src/Api/Vault/Models/Response/AttachmentResponseModel.cs
+++ b/src/Api/Vault/Models/Response/AttachmentResponseModel.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Serialization;
-using Bit.Core.Models.Api;
+﻿using Bit.Core.Models.Api;
 using Bit.Core.Settings;
 using Bit.Core.Utilities;
 using Bit.Core.Vault.Entities;
@@ -15,7 +14,7 @@ public class AttachmentResponseModel : ResponseModel
         Url = data.Url;
         FileName = data.Data.FileName;
         Key = data.Data.Key;
-        Size = data.Data.Size;
+        Size = data.Data.Size.ToString();
         SizeName = CoreHelpers.ReadableBytesSize(data.Data.Size);
     }
 
@@ -27,7 +26,7 @@ public class AttachmentResponseModel : ResponseModel
         Url = $"{globalSettings.Attachment.BaseUrl}/{cipher.Id}/{id}";
         FileName = data.FileName;
         Key = data.Key;
-        Size = data.Size;
+        Size = data.Size.ToString();
         SizeName = CoreHelpers.ReadableBytesSize(data.Size);
     }
 
@@ -35,8 +34,7 @@ public class AttachmentResponseModel : ResponseModel
     public string Url { get; set; }
     public string FileName { get; set; }
     public string Key { get; set; }
-    [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString)]
-    public long Size { get; set; }
+    public string Size { get; set; }
     public string SizeName { get; set; }
 
     public static IEnumerable<AttachmentResponseModel> FromCipher(Cipher cipher, IGlobalSettings globalSettings)


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

We use `JsonNumberHandling.WriteAsString)` for Size in AttachmentResponse, unfortunately this isn't understood by the Open API generation we use and the generated rust code attempts to cast int to string which is an invalid operation.

Changes it to be an actual string in code, which should functionality be equivalent to existing behavior.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
