### PR TITLE
Change DomainsResponseModel to use byte instead of GlobalEvalentDomainsType

### DIFF
--- a/src/Api/Models/Response/DomainsResponseModel.cs
+++ b/src/Api/Models/Response/DomainsResponseModel.cs
@@ -43,12 +43,12 @@ public class DomainsResponseModel : ResponseModel
             IEnumerable<GlobalEquivalentDomainsType> excludedDomains,
             bool excluded)
         {
-            Type = globalDomain;
+            Type = (byte)globalDomain;
             Domains = domains;
             Excluded = excluded && (excludedDomains?.Contains(globalDomain) ?? false);
         }
 
-        public GlobalEquivalentDomainsType Type { get; set; }
+        public byte Type { get; set; }
         public IEnumerable<string> Domains { get; set; }
         public bool Excluded { get; set; }
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Generating API bindings from the Swagger Docs drags in all the `GlobalEvalentDomainsType` which may be frequently updated on the server. When the server returns a domain that is unknown to the client they will throw an error which is undesired.

This changes the `DomainsResponseModel` to use the inner `byte` value of the `GlobalEquivalentDomainsType` instead.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
