### PR TITLE
Fix flaky UpdateSecretsManagerSubscriptionCommandTest

### DIFF
--- a/test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/UpdateSecretsManagerSubscriptionCommandTests.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/UpdateSecretsManagerSubscriptionCommandTests.cs
@@ -375,6 +375,7 @@ public class UpdateSecretsManagerSubscriptionCommandTests
         Organization organization,
         SutProvider<UpdateSecretsManagerSubscriptionCommand> sutProvider)
     {
+        organization.SmSeats = 8;
         var update = new SecretsManagerSubscriptionUpdate(organization, false)
         {
             SmSeats = 7,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

@Thomas-Avery reported that the `UpdateSubscriptionAsync_ThrowsBadRequestException_WhenOccupiedSeatsExceedNewSeatTotal` test sometimes fails for no reason, because an exception is expected but not thrown: https://github.com/bitwarden/server/actions/runs/6539171183/job/17756678563

My guess is that this occurs when autodata generates `organization.SmSeats = 7`. That would be equal to the new `SmSeat` value in the update model, so it won't be considered a change and [validation will be skipped by the sut](https://github.com/bitwarden/server/blob/45e883cc185093e4b9cf53a57f8a3c2058912948/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpdateSecretsManagerSubscriptionCommand.cs#L138-L142).

Fix this by expressly setting this value.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
