### PR TITLE
[AC-1717] Update default values for LimitCollectionCreationDeletion

### DIFF
--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -426,7 +426,7 @@ public class OrganizationService : IOrganizationService
         }
 
         var flexibleCollectionsIsEnabled =
-            !_featureService.IsEnabled(FeatureFlagKeys.FlexibleCollections, _currentContext);
+            _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollections, _currentContext);
 
         var organization = new Organization
         {

--- a/src/Sql/dbo/Stored Procedures/Organization_Create.sql
+++ b/src/Sql/dbo/Stored Procedures/Organization_Create.sql
@@ -51,7 +51,7 @@
     @MaxAutoscaleSmSeats INT= null,
     @MaxAutoscaleSmServiceAccounts INT = null,
     @SecretsManagerBeta BIT = 0,
-    @LimitCollectionCreationDeletion BIT = 0
+    @LimitCollectionCreationDeletion BIT = 1
 AS
 BEGIN
     SET NOCOUNT ON

--- a/util/Migrator/DbScripts/2023-09-26_00_LimitCollectionCreationDeletion.sql
+++ b/util/Migrator/DbScripts/2023-09-26_00_LimitCollectionCreationDeletion.sql
@@ -67,7 +67,7 @@ CREATE OR ALTER PROCEDURE [dbo].[Organization_Create]
     @MaxAutoscaleSmSeats INT= null,
     @MaxAutoscaleSmServiceAccounts INT = null,
     @SecretsManagerBeta BIT = 0,
-    @LimitCollectionCreationDeletion BIT = 0
+    @LimitCollectionCreationDeletion BIT = 1
 AS
 BEGIN
     SET NOCOUNT ON

--- a/util/Migrator/DbScripts/2023-09-26_00_LimitCollectionCreationDeletion.sql
+++ b/util/Migrator/DbScripts/2023-09-26_00_LimitCollectionCreationDeletion.sql
@@ -1,3 +1,13 @@
+--Dev cleanup: drop previous column name (never used in production but may be present on some QA instances)
+IF COL_LENGTH('[dbo].[Organization]', 'LimitCollectionCdOwnerAdmin') IS NOT NULL
+BEGIN
+    ALTER TABLE
+        [dbo].[Organization]
+    DROP COLUMN
+        [LimitCollectionCdOwnerAdmin]
+END
+GO
+
 --Add column 'LimitCollectionCreationDeletion' to 'Organization' table
 IF COL_LENGTH('[dbo].[Organization]', 'LimitCollectionCreationDeletion') IS NULL
 BEGIN


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

In the initial implementation, `LimitCollectionCreationDeletion` defaulted to 1 in the table schema but 0 in the create sproc. This makes sense when merge == release, but now that we're merging early behind feature flags, we need to adjust this.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* sql code
  * make `LimitCollectionCreationDeletion` default to 1 in the organization create sproc. This covers any rollback scenario where the server is not providing a value
  * cleanup task: delete the old column name. I didn't bother doing this initially, but thinking about it more, it's probably floating around on QA instances. It won't do anything in production because that column never existed.
* `OrganizationService` - set `LimitCollectionCreationDeletion` when an organization is created, based on the feature flag:
  * flag = OFF (pre-release) -> setting is ON for new orgs (members cannot create/delete collections, same as today)
  * flag = ON (post-release) -> setting is OFF for new orgs (members can create/delete collections)

I haven't done anything to the `SignUpAsync` method used by self-hosted instances because that'll be done when the license file is updated. I've added a note to the Jira tickets for that.

I haven't bumped dates on the migration scripts, I'll do that all at once when the feature branch is otherwise ready to go.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
