### PR TITLE
[SM-996] Fix access removal dialog bug

### DIFF
--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/AccessPolicyRepository.cs
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/AccessPolicyRepository.cs
@@ -275,7 +275,7 @@ public class AccessPolicyRepository : BaseEntityFrameworkRepository, IAccessPoli
     }
 
     public async Task<IEnumerable<Core.SecretsManager.Entities.BaseAccessPolicy>>
-        GetPeoplePoliciesByGrantedProjectIdAsync(Guid id)
+        GetPeoplePoliciesByGrantedProjectIdAsync(Guid id, Guid userId)
     {
         using var scope = ServiceScopeFactory.CreateScope();
         var dbContext = GetDatabaseContext(scope);
@@ -286,13 +286,20 @@ public class AccessPolicyRepository : BaseEntityFrameworkRepository, IAccessPoli
                  ((GroupProjectAccessPolicy)ap).GrantedProjectId == id))
             .Include(ap => ((UserProjectAccessPolicy)ap).OrganizationUser.User)
             .Include(ap => ((GroupProjectAccessPolicy)ap).Group)
+            .Select(ap => new
+            {
+                ap,
+                CurrentUserInGroup = ap is GroupProjectAccessPolicy &&
+                                     ((GroupProjectAccessPolicy)ap).Group.GroupUsers.Any(g =>
+                                         g.OrganizationUser.UserId == userId),
+            })
             .ToListAsync();
 
-        return entities.Select(MapToCore);
+        return entities.Select(e => MapToCore(e.ap, e.CurrentUserInGroup));
     }
 
     public async Task<IEnumerable<Core.SecretsManager.Entities.BaseAccessPolicy>> ReplaceProjectPeopleAsync(
-        ProjectPeopleAccessPolicies peopleAccessPolicies)
+        ProjectPeopleAccessPolicies peopleAccessPolicies, Guid userId)
     {
         using var scope = ServiceScopeFactory.CreateScope();
         var dbContext = GetDatabaseContext(scope);
@@ -337,19 +344,18 @@ public class AccessPolicyRepository : BaseEntityFrameworkRepository, IAccessPoli
             }
         }
 
-        var results = await UpsertPeoplePoliciesAsync(dbContext,
+        await UpsertPeoplePoliciesAsync(dbContext,
             peopleAccessPolicies.ToBaseAccessPolicies().Select(MapToEntity).ToList(), userPolicyEntities,
             groupPolicyEntities);
 
         await dbContext.SaveChangesAsync();
-        return results.Select(MapToCore);
+        return await GetPeoplePoliciesByGrantedProjectIdAsync(peopleAccessPolicies.Id, userId);
     }
 
-    private static async Task<List<BaseAccessPolicy>> UpsertPeoplePoliciesAsync(DatabaseContext dbContext,
+    private static async Task UpsertPeoplePoliciesAsync(DatabaseContext dbContext,
         List<BaseAccessPolicy> policies, IReadOnlyCollection<AccessPolicy> userPolicyEntities,
         IReadOnlyCollection<AccessPolicy> groupPolicyEntities)
     {
-        var results = new List<BaseAccessPolicy>();
         var currentDate = DateTime.UtcNow;
         foreach (var updatedEntity in policies)
         {
@@ -372,17 +378,13 @@ public class AccessPolicyRepository : BaseEntityFrameworkRepository, IAccessPoli
                 currentEntity.Read = updatedEntity.Read;
                 currentEntity.Write = updatedEntity.Write;
                 currentEntity.RevisionDate = currentDate;
-                results.Add(currentEntity);
             }
             else
             {
                 updatedEntity.SetNewId();
                 await dbContext.AddAsync(updatedEntity);
-                results.Add(updatedEntity);
             }
         }
-
-        return results;
     }
 
     private Core.SecretsManager.Entities.BaseAccessPolicy MapToCore(

--- a/src/Api/SecretsManager/Controllers/AccessPoliciesController.cs
+++ b/src/Api/SecretsManager/Controllers/AccessPoliciesController.cs
@@ -280,8 +280,8 @@ public class AccessPoliciesController : Controller
     {
         var project = await _projectRepository.GetByIdAsync(id);
         var (_, userId) = await CheckUserHasWriteAccessToProjectAsync(project);
-        var results = await _accessPolicyRepository.GetPeoplePoliciesByGrantedProjectIdAsync(id);
-        return new ProjectPeopleAccessPoliciesResponseModel(results);
+        var results = await _accessPolicyRepository.GetPeoplePoliciesByGrantedProjectIdAsync(id, userId);
+        return new ProjectPeopleAccessPoliciesResponseModel(results, userId);
     }
 
     [HttpPut("/projects/{id}/access-policies/people")]
@@ -303,8 +303,9 @@ public class AccessPoliciesController : Controller
             throw new NotFoundException();
         }
 
-        var results = await _accessPolicyRepository.ReplaceProjectPeopleAsync(peopleAccessPolicies);
-        return new ProjectPeopleAccessPoliciesResponseModel(results);
+        var userId = _userService.GetProperUserId(User).Value;
+        var results = await _accessPolicyRepository.ReplaceProjectPeopleAsync(peopleAccessPolicies, userId);
+        return new ProjectPeopleAccessPoliciesResponseModel(results, userId);
     }
 
 

--- a/src/Api/SecretsManager/Models/Response/AccessPolicyResponseModel.cs
+++ b/src/Api/SecretsManager/Models/Response/AccessPolicyResponseModel.cs
@@ -34,10 +34,13 @@ public class UserProjectAccessPolicyResponseModel : BaseAccessPolicyResponseMode
 
     public UserProjectAccessPolicyResponseModel(UserProjectAccessPolicy accessPolicy) : base(accessPolicy, _objectName)
     {
-        OrganizationUserId = accessPolicy.OrganizationUserId;
-        GrantedProjectId = accessPolicy.GrantedProjectId;
-        OrganizationUserName = GetUserDisplayName(accessPolicy.User);
-        UserId = accessPolicy.User?.Id;
+        SetProperties(accessPolicy);
+    }
+
+    public UserProjectAccessPolicyResponseModel(UserProjectAccessPolicy accessPolicy, Guid currentUserId) : base(accessPolicy, _objectName)
+    {
+        CurrentUser = currentUserId == accessPolicy.User?.Id;
+        SetProperties(accessPolicy);
     }
 
     public UserProjectAccessPolicyResponseModel() : base(new UserProjectAccessPolicy(), _objectName)
@@ -48,6 +51,15 @@ public class UserProjectAccessPolicyResponseModel : BaseAccessPolicyResponseMode
     public string? OrganizationUserName { get; set; }
     public Guid? UserId { get; set; }
     public Guid? GrantedProjectId { get; set; }
+    public bool? CurrentUser { get; set; }
+
+    private void SetProperties(UserProjectAccessPolicy accessPolicy)
+    {
+        OrganizationUserId = accessPolicy.OrganizationUserId;
+        GrantedProjectId = accessPolicy.GrantedProjectId;
+        OrganizationUserName = GetUserDisplayName(accessPolicy.User);
+        UserId = accessPolicy.User?.Id;
+    }
 }
 
 public class UserServiceAccountAccessPolicyResponseModel : BaseAccessPolicyResponseModel

--- a/src/Api/SecretsManager/Models/Response/ProjectPeopleAccessPoliciesResponseModel.cs
+++ b/src/Api/SecretsManager/Models/Response/ProjectPeopleAccessPoliciesResponseModel.cs
@@ -7,7 +7,7 @@ public class ProjectPeopleAccessPoliciesResponseModel : ResponseModel
 {
     private const string _objectName = "projectPeopleAccessPolicies";
 
-    public ProjectPeopleAccessPoliciesResponseModel(IEnumerable<BaseAccessPolicy> baseAccessPolicies)
+    public ProjectPeopleAccessPoliciesResponseModel(IEnumerable<BaseAccessPolicy> baseAccessPolicies, Guid userId)
         : base(_objectName)
     {
         foreach (var baseAccessPolicy in baseAccessPolicies)
@@ -15,7 +15,7 @@ public class ProjectPeopleAccessPoliciesResponseModel : ResponseModel
             switch (baseAccessPolicy)
             {
                 case UserProjectAccessPolicy accessPolicy:
-                    UserAccessPolicies.Add(new UserProjectAccessPolicyResponseModel(accessPolicy));
+                    UserAccessPolicies.Add(new UserProjectAccessPolicyResponseModel(accessPolicy, userId));
                     break;
                 case GroupProjectAccessPolicy accessPolicy:
                     GroupAccessPolicies.Add(new GroupProjectAccessPolicyResponseModel(accessPolicy));

--- a/src/Core/SecretsManager/Repositories/IAccessPolicyRepository.cs
+++ b/src/Core/SecretsManager/Repositories/IAccessPolicyRepository.cs
@@ -16,7 +16,7 @@ public interface IAccessPolicyRepository
         AccessClientType accessType);
     Task ReplaceAsync(BaseAccessPolicy baseAccessPolicy);
     Task DeleteAsync(Guid id);
-    Task<IEnumerable<BaseAccessPolicy>> GetPeoplePoliciesByGrantedProjectIdAsync(Guid id);
-    Task<IEnumerable<BaseAccessPolicy>> ReplaceProjectPeopleAsync(ProjectPeopleAccessPolicies peopleAccessPolicies);
+    Task<IEnumerable<BaseAccessPolicy>> GetPeoplePoliciesByGrantedProjectIdAsync(Guid id, Guid userId);
+    Task<IEnumerable<BaseAccessPolicy>> ReplaceProjectPeopleAsync(ProjectPeopleAccessPolicies peopleAccessPolicies, Guid userId);
     Task<PeopleGrantees> GetPeopleGranteesAsync(Guid organizationId, Guid currentUserId);
 }

--- a/test/Api.Test/SecretsManager/Controllers/AccessPoliciesControllerTests.cs
+++ b/test/Api.Test/SecretsManager/Controllers/AccessPoliciesControllerTests.cs
@@ -1012,7 +1012,7 @@ public class AccessPoliciesControllerTests
         var result = await sutProvider.Sut.GetProjectPeopleAccessPoliciesAsync(id);
 
         await sutProvider.GetDependency<IAccessPolicyRepository>().Received(1)
-            .GetPeoplePoliciesByGrantedProjectIdAsync(Arg.Is(AssertHelper.AssertPropertyEqual(id)));
+            .GetPeoplePoliciesByGrantedProjectIdAsync(Arg.Is(AssertHelper.AssertPropertyEqual(id)), Arg.Any<Guid>());
 
         Assert.Empty(result.GroupAccessPolicies);
         Assert.Empty(result.UserAccessPolicies);
@@ -1033,7 +1033,7 @@ public class AccessPoliciesControllerTests
         await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.GetProjectPeopleAccessPoliciesAsync(id));
 
         await sutProvider.GetDependency<IAccessPolicyRepository>().DidNotReceiveWithAnyArgs()
-            .GetPeoplePoliciesByGrantedProjectIdAsync(Arg.Any<Guid>());
+            .GetPeoplePoliciesByGrantedProjectIdAsync(Arg.Any<Guid>(), Arg.Any<Guid>());
     }
 
     [Theory]
@@ -1049,13 +1049,13 @@ public class AccessPoliciesControllerTests
         sutProvider.GetDependency<IProjectRepository>().AccessToProjectAsync(default, default, default)
             .Returns((false, false));
 
-        sutProvider.GetDependency<IAccessPolicyRepository>().GetPeoplePoliciesByGrantedProjectIdAsync(default)
+        sutProvider.GetDependency<IAccessPolicyRepository>().GetPeoplePoliciesByGrantedProjectIdAsync(default, default)
             .ReturnsForAnyArgs(new List<BaseAccessPolicy> { resultAccessPolicy });
 
         await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.GetProjectPeopleAccessPoliciesAsync(id));
 
         await sutProvider.GetDependency<IAccessPolicyRepository>().DidNotReceiveWithAnyArgs()
-            .GetPeoplePoliciesByGrantedProjectIdAsync(Arg.Any<Guid>());
+            .GetPeoplePoliciesByGrantedProjectIdAsync(Arg.Any<Guid>(), Arg.Any<Guid>());
     }
 
     [Theory]
@@ -1086,13 +1086,13 @@ public class AccessPoliciesControllerTests
                 break;
         }
 
-        sutProvider.GetDependency<IAccessPolicyRepository>().GetPeoplePoliciesByGrantedProjectIdAsync(default)
+        sutProvider.GetDependency<IAccessPolicyRepository>().GetPeoplePoliciesByGrantedProjectIdAsync(default, default)
             .ReturnsForAnyArgs(new List<BaseAccessPolicy> { resultUserPolicy, resultGroupPolicy });
 
         var result = await sutProvider.Sut.GetProjectPeopleAccessPoliciesAsync(id);
 
         await sutProvider.GetDependency<IAccessPolicyRepository>().Received(1)
-            .GetPeoplePoliciesByGrantedProjectIdAsync(Arg.Is(AssertHelper.AssertPropertyEqual(id)));
+            .GetPeoplePoliciesByGrantedProjectIdAsync(Arg.Is(AssertHelper.AssertPropertyEqual(id)), Arg.Any<Guid>());
 
         Assert.NotEmpty(result.GroupAccessPolicies);
         Assert.NotEmpty(result.UserAccessPolicies);
@@ -1109,7 +1109,7 @@ public class AccessPoliciesControllerTests
             sutProvider.Sut.PutProjectPeopleAccessPoliciesAsync(id, request));
 
         await sutProvider.GetDependency<IAccessPolicyRepository>().DidNotReceiveWithAnyArgs()
-            .ReplaceProjectPeopleAsync(Arg.Any<ProjectPeopleAccessPolicies>());
+            .ReplaceProjectPeopleAsync(Arg.Any<ProjectPeopleAccessPolicies>(), Arg.Any<Guid>());
     }
 
     [Theory]
@@ -1127,7 +1127,7 @@ public class AccessPoliciesControllerTests
             sutProvider.Sut.PutProjectPeopleAccessPoliciesAsync(project.Id, request));
 
         await sutProvider.GetDependency<IAccessPolicyRepository>().DidNotReceiveWithAnyArgs()
-            .ReplaceProjectPeopleAsync(Arg.Any<ProjectPeopleAccessPolicies>());
+            .ReplaceProjectPeopleAsync(Arg.Any<ProjectPeopleAccessPolicies>(), Arg.Any<Guid>());
     }
 
     [Theory]
@@ -1147,28 +1147,30 @@ public class AccessPoliciesControllerTests
             sutProvider.Sut.PutProjectPeopleAccessPoliciesAsync(project.Id, request));
 
         await sutProvider.GetDependency<IAccessPolicyRepository>().DidNotReceiveWithAnyArgs()
-            .ReplaceProjectPeopleAsync(Arg.Any<ProjectPeopleAccessPolicies>());
+            .ReplaceProjectPeopleAsync(Arg.Any<ProjectPeopleAccessPolicies>(), Arg.Any<Guid>());
     }
 
     [Theory]
     [BitAutoData]
     public async void PutProjectPeopleAccessPoliciesAsync_Success(
         SutProvider<AccessPoliciesController> sutProvider,
+        Guid userId,
         Project project,
         PeopleAccessPoliciesRequestModel request)
     {
         sutProvider.GetDependency<IProjectRepository>().GetByIdAsync(default).ReturnsForAnyArgs(project);
+        sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(userId);
         var peoplePolicies = request.ToProjectPeopleAccessPolicies(project.Id, project.OrganizationId);
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), peoplePolicies,
                 Arg.Any<IEnumerable<IAuthorizationRequirement>>()).ReturnsForAnyArgs(AuthorizationResult.Success());
 
-        sutProvider.GetDependency<IAccessPolicyRepository>().ReplaceProjectPeopleAsync(peoplePolicies)
+        sutProvider.GetDependency<IAccessPolicyRepository>().ReplaceProjectPeopleAsync(peoplePolicies, Arg.Any<Guid>())
             .Returns(peoplePolicies.ToBaseAccessPolicies());
 
         await sutProvider.Sut.PutProjectPeopleAccessPoliciesAsync(project.Id, request);
 
         await sutProvider.GetDependency<IAccessPolicyRepository>().Received(1)
-            .ReplaceProjectPeopleAsync(Arg.Any<ProjectPeopleAccessPolicies>());
+            .ReplaceProjectPeopleAsync(Arg.Any<ProjectPeopleAccessPolicies>(), Arg.Any<Guid>());
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The purpose of this PR is to fix an access removal dialog bug that occurs when initially landing on the page without making changes.

In order to fix this, adding the properties `currentUser` and `currentUserInGroup` to `ProjectPeopleAccessPoliciesResponseModel` to provide current user context data.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/AccessPolicyRepository.cs:**
**src/Core/SecretsManager/Repositories/IAccessPolicyRepository.cs:**
Add calculating if the current user is in the group to `GetPeoplePoliciesByGrantedProjectIdAsync`
Add calling `GetPeoplePoliciesByGrantedProjectIdAsync` at the end of `ReplaceProjectPeopleAsync` so current context data is calculated and sent back after a replace.


* **src/Api/SecretsManager/Controllers/AccessPoliciesController.cs:**
Add fetching the current user's userId into project people access policies endpoints.
Add sending the userId to repository and response model construction so `currentUser` and `currentUserInGroup` can be calculated.

* **src/Api/SecretsManager/Models/Response/AccessPolicyResponseModel.cs:**
**src/Api/SecretsManager/Models/Response/ProjectPeopleAccessPoliciesResponseModel.cs:**
Add calculating `currentUser` property in response model


* **test/Api.Test/SecretsManager/Controllers/AccessPoliciesControllerTests.cs:**
Update unit tests with repo method changes.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
