### PR TITLE
[AC-1578] Fixed issue where legacy plans couldn't sign up for SM

### DIFF
--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1950,6 +1950,11 @@ public class OrganizationService : IOrganizationService
 
     private static void ValidatePlan(Models.StaticStore.Plan plan, int additionalSeats, string productType)
     {
+        if (plan is null)
+        {
+            throw new BadRequestException($"{productType} Plan was null.");
+        }
+
         if (plan.Disabled)
         {
             throw new BadRequestException($"{productType} Plan not found.");
@@ -1963,6 +1968,11 @@ public class OrganizationService : IOrganizationService
 
     public void ValidatePasswordManagerPlan(Models.StaticStore.Plan plan, OrganizationUpgrade upgrade)
     {
+        if (plan is not { LegacyYear: null })
+        {
+            throw new BadRequestException("Invalid Password Manager plan selected.");
+        }
+
         ValidatePlan(plan, upgrade.AdditionalSeats, "Password Manager");
 
         if (plan.PasswordManager.BaseSeats + upgrade.AdditionalSeats <= 0)

--- a/src/Core/Services/Implementations/OrganizationService.cs
+++ b/src/Core/Services/Implementations/OrganizationService.cs
@@ -1950,11 +1950,6 @@ public class OrganizationService : IOrganizationService
 
     private static void ValidatePlan(Models.StaticStore.Plan plan, int additionalSeats, string productType)
     {
-        if (plan is not { LegacyYear: null })
-        {
-            throw new BadRequestException($"Invalid {productType} plan selected.");
-        }
-
         if (plan.Disabled)
         {
             throw new BadRequestException($"{productType} Plan not found.");

--- a/test/Core.Test/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/Services/OrganizationServiceTests.cs
@@ -1715,25 +1715,6 @@ public class OrganizationServiceTests
     }
 
     [Theory]
-    [BitAutoData(PlanType.EnterpriseAnnually2019)]
-    public void ValidateSecretsManagerPlan_ThrowsException_WhenInvalidPlanSelected(
-        PlanType planType, SutProvider<OrganizationService> sutProvider)
-    {
-        var plan = StaticStore.GetPlan(planType);
-
-        var signup = new OrganizationUpgrade
-        {
-            UseSecretsManager = true,
-            AdditionalSmSeats = 1,
-            AdditionalServiceAccounts = 10,
-            AdditionalSeats = 1
-        };
-
-        var exception = Assert.Throws<BadRequestException>(() => sutProvider.Sut.ValidateSecretsManagerPlan(plan, signup));
-        Assert.Contains("Invalid Secrets Manager plan selected.", exception.Message);
-    }
-
-    [Theory]
     [BitAutoData(PlanType.TeamsAnnually)]
     [BitAutoData(PlanType.TeamsMonthly)]
     [BitAutoData(PlanType.EnterpriseAnnually)]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
An issue was encountered in production where old 2019 plans couldn't sign up for secrets manager, even after my latest work on this was merged which should have accomplished this. This PR addresses this by removing the validation which ensures legacy plans aren't included when upgrading a plan to SM


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **OrganizationService.cs:** Removed validation that ensured legacy plans couldn't be upgraded to SM
* **OrganizationServiceTests.cs:** Removed unit test that ensured enterprise 2019 couldn't be upgraded to SM

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
