### PR TITLE
[AC-1792] Remove UseKeyConnector field from Enterprise Plan Upgrade

### DIFF
--- a/util/Migrator/DbScripts/2023-10-13_01_2019EnterprisePlanFeatureUpgrade.sql
+++ b/util/Migrator/DbScripts/2023-10-13_01_2019EnterprisePlanFeatureUpgrade.sql
@@ -5,7 +5,6 @@ BEGIN TRY
         [dbo].[Organization]
     SET
         [UseSso] = 1,
-        [UseKeyConnector] = 1,
         [UseScim] = 1,
         [UseResetPassword] = 1
     WHERE


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
As a part of https://github.com/bitwarden/server/pull/3320, I mistaken enabled `UseKeyConnector` for old 2019 enterprise orgs, where it should have been left disabled. Since this script has not been deployed yet, I modified the existing script to catch the error.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **DbScripts\2023-10-13_01_2019EnterprisePlanFeatureUpgrade.sql:** Removed the update to `UseKeyConnector`

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
