### PR TITLE
[DEVOPS-1646] MsSqlMigratorUtility docker image is not recognizing input

### DIFF
--- a/util/MsSqlMigratorUtility/Dockerfile
+++ b/util/MsSqlMigratorUtility/Dockerfile
@@ -5,6 +5,4 @@ LABEL com.bitwarden.product="bitwarden"
 WORKDIR /app
 COPY obj/build-output/publish .
 
-ENTRYPOINT ["sh", "-c", "dotnet /app/MsSqlMigratorUtility.dll \"${MSSQL_CONN_STRING}\""]
-
-CMD [ "-v" ]
+ENTRYPOINT ["sh", "-c", "dotnet /app/MsSqlMigratorUtility.dll \"${MSSQL_CONN_STRING}\" -v ${@}", "--" ]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix the MsSqlMigratorUtility docker image is not recognizing additional inputs when run by `docker run`.

Add `${@}` to the`ENTRYPOINT` to pass any additional arguments. Using `sh -c` in the `ENTRYPOINT`, the `ENTRYPOINT` and `CMD` are treated as separate commands, not concatenated. The sh -c is needed to parse the $MSSQL_CONN_STRING passed as an env variable in `docker run`.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **util/MsSqlMigratorUtility/Dockerfile:** Add `${@}` to the entrypoint to pass any additional arguments. Remove `CMD` as using `sh -c` in  the `ENTRYPOINT`, the `ENTRYPOINT` and `CMD` are treated as separate commands, not concatenated. The `sh -c` is needed to parse the $MSSQL_CONN_STRING passed as env variable in `docker run`.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
