### PR TITLE
Auth/PM-4680 - Set Password Request model tweak to allow MP Hint to be optional on mobile

### DIFF
--- a/src/Api/Auth/Models/Request/Accounts/SetPasswordRequestModel.cs
+++ b/src/Api/Auth/Models/Request/Accounts/SetPasswordRequestModel.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.Auth.Models.Api.Request.Accounts;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
@@ -17,7 +15,7 @@ public class SetPasswordRequestModel : IValidatableObject
     public string Key { get; set; }
     [StringLength(50)]
     public string MasterPasswordHint { get; set; }
-    public KeysRequestModel? Keys { get; set; }
+    public KeysRequestModel Keys { get; set; }
     [Required]
     public KdfType Kdf { get; set; }
     [Required]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Resolve [PM-4680](https://bitwarden.atlassian.net/browse/PM-4680) by removing `#nullable enable` as it introduced incorrect behavior (requiring the optional mp hint - clients sent it in as "" but mobile was getting rejected b/c it sent in null).  Bug was introduced in https://github.com/bitwarden/server/pull/3242


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Api/Auth/Models/Request/Accounts/SetPasswordRequestModel.cs:** Remove `#nullable enable` 

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team


[PM-4680]: https://bitwarden.atlassian.net/browse/PM-4680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ