### PR TITLE
Add DbOps for database changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,19 +2,23 @@
 #
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# The following owners will be the default owners for everything in the repo.
-# Unless a later match takes precedence
+# The following owners will be the default owners for everything in the repo
+# unless a later match takes precedence
 * @bitwarden/tech-leads
 
-# DevOps for Actions and other workflow changes.
+# DevOps for Actions and other workflow changes
 .github/workflows @bitwarden/dept-devops
 
-# DevOps for Docker changes.
+# DevOps for Docker changes
 **/Dockerfile @bitwarden/dept-devops
 **/*.Dockerfile @bitwarden/dept-devops
 **/.dockerignore @bitwarden/dept-devops
 
-## Auth team files ##
+# Database Operations for database changes
+src/Sql/** @bitwarden/dept-dbops
+util/Migrator/** @bitwarden/dept-dbops
+
+# Auth team
 **/Auth @bitwarden/team-auth-dev
 bitwarden_license/src/Sso @bitwarden/team-auth-dev
 src/Identity @bitwarden/team-auth-dev
@@ -22,17 +26,17 @@ src/Identity @bitwarden/team-auth-dev
 **/SecretsManager @bitwarden/team-secrets-manager-dev
 **/Tools @bitwarden/team-tools-dev
 
-## Vault Team files
+# Vault team
 **/Vault @bitwarden/team-vault-dev
 **/Vault/AuthorizationHandlers @bitwarden/team-vault-dev @bitwarden/team-admin-console-dev  # joint ownership over authorization handlers that affect organization users
 
-# Admin-Console Team
+# Admin Console team
 **/AdminConsole @bitwarden/team-admin-console-dev
 bitwarden_license/src/Scim @bitwarden/team-admin-console-dev
 bitwarden_license/src/test/Scim.IntegrationTest @bitwarden/team-admin-console-dev
 bitwarden_license/src/test/Scim.ScimTest @bitwarden/team-admin-console-dev
 
-# Billing Team
+# Billing team
 **/*billing* @bitwarden/team-billing-dev
 **/*bitpay* @bitwarden/team-billing-dev
 **/*braintree* @bitwarden/team-billing-dev
@@ -43,6 +47,6 @@ bitwarden_license/src/test/Scim.ScimTest @bitwarden/team-admin-console-dev
 **/*subscription* @bitwarden/team-billing-dev
 **/Billing @bitwarden/team-billing-dev
 
-# Multiple Owners
+# Multiple owners
 **/packages.lock.json
 Directory.Build.props


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

Adds "Database Operations" as a code owner for review on database-related pull requests. While teams are still expected to also review their own changes, DbOps will want to be involved for official acceptance. This will change over time as teams become more autonomous, but as we enhance our "reliability at scale" practices we should have DBA review.

Also performed some file cleanup while here for consistency's sake.

## Code changes

* **.github/CODEOWNERS:** Ownership additions.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
