### PR TITLE
[PM-4165] Collect all Stripe invoices for Billing history page

### DIFF
--- a/src/Core/Models/Stripe/StripeInvoiceListOptions.cs
+++ b/src/Core/Models/Stripe/StripeInvoiceListOptions.cs
@@ -1,0 +1,27 @@
+﻿using Stripe;
+
+namespace Bit.Core.Models.BitStripe;
+
+/// <summary>
+/// A model derived from the Stripe <see cref="InvoiceListOptions"/> class that includes a flag used to
+/// retrieve all invoices from the Stripe API rather than a limited set.
+/// </summary>
+public class StripeInvoiceListOptions : InvoiceListOptions
+{
+    public bool SelectAll { get; set; }
+
+    public InvoiceListOptions ToInvoiceListOptions()
+    {
+        var options = (InvoiceListOptions)this;
+
+        if (!SelectAll)
+        {
+            return options;
+        }
+
+        options.EndingBefore = null;
+        options.StartingAfter = null;
+
+        return options;
+    }
+}

--- a/src/Core/Services/IStripeAdapter.cs
+++ b/src/Core/Services/IStripeAdapter.cs
@@ -18,7 +18,7 @@ public interface IStripeAdapter
     Task<Stripe.Invoice> InvoiceCreateAsync(Stripe.InvoiceCreateOptions options);
     Task<Stripe.InvoiceItem> InvoiceItemCreateAsync(Stripe.InvoiceItemCreateOptions options);
     Task<Stripe.Invoice> InvoiceGetAsync(string id, Stripe.InvoiceGetOptions options);
-    Task<Stripe.StripeList<Stripe.Invoice>> InvoiceListAsync(Stripe.InvoiceListOptions options);
+    Task<List<Stripe.Invoice>> InvoiceListAsync(StripeInvoiceListOptions options);
     IEnumerable<InvoiceItem> InvoiceItemListAsync(InvoiceItemListOptions options);
     Task<Stripe.Invoice> InvoiceUpdateAsync(string id, Stripe.InvoiceUpdateOptions options);
     Task<Stripe.Invoice> InvoiceFinalizeInvoiceAsync(string id, Stripe.InvoiceFinalizeOptions options);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

[PM-4165](https://bitwarden.atlassian.net/browse/PM-4165)

Currently, for the Billing history page, we only collect the first 50 invoices a customer has. This PR updates that logic to collect all the invoices using the optional [`starting_after`](https://stripe.com/docs/api/invoices/list#list_invoices-starting_after) property in the Stripe List Invoices endpoint.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **StripePaymentService.cs:** Retrieve invoices from Stripe's List Invoices endpoint until there are none left to retrieve. Use a 100 limit to limit this to as few network requests as possible.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team


[PM-4165]: https://bitwarden.atlassian.net/browse/PM-4165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ