### PR TITLE
[AC-1809] JWT claim for LimitCollectionCreationDeletion

### DIFF
--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -175,6 +175,10 @@ public class CurrentContext : ICurrentContext
             ? claimsDict[Claims.SecretsManagerAccess].ToDictionary(s => s.Value, _ => true)
             : new Dictionary<string, bool>();
 
+        var limitCollectionCreationDeletion = claimsDict.TryGetValue(Claims.LimitCollectionCreationDeletion, out var claims)
+            ? claims.ToDictionary(s => s.Value, _ => true)
+            : new Dictionary<string, bool>();
+
         var organizations = new List<CurrentContextOrganization>();
         if (claimsDict.ContainsKey(Claims.OrganizationOwner))
         {
@@ -184,6 +188,7 @@ public class CurrentContext : ICurrentContext
                     Id = new Guid(c.Value),
                     Type = OrganizationUserType.Owner,
                     AccessSecretsManager = accessSecretsManager.ContainsKey(c.Value),
+                    LimitCollectionCreationDeletion = limitCollectionCreationDeletion.ContainsKey(c.Value)
                 }));
         }
         else if (orgApi && OrganizationId.HasValue)
@@ -203,6 +208,7 @@ public class CurrentContext : ICurrentContext
                     Id = new Guid(c.Value),
                     Type = OrganizationUserType.Admin,
                     AccessSecretsManager = accessSecretsManager.ContainsKey(c.Value),
+                    LimitCollectionCreationDeletion = limitCollectionCreationDeletion.ContainsKey(c.Value)
                 }));
         }
 
@@ -214,6 +220,7 @@ public class CurrentContext : ICurrentContext
                     Id = new Guid(c.Value),
                     Type = OrganizationUserType.User,
                     AccessSecretsManager = accessSecretsManager.ContainsKey(c.Value),
+                    LimitCollectionCreationDeletion = limitCollectionCreationDeletion.ContainsKey(c.Value)
                 }));
         }
 
@@ -225,6 +232,7 @@ public class CurrentContext : ICurrentContext
                     Id = new Guid(c.Value),
                     Type = OrganizationUserType.Manager,
                     AccessSecretsManager = accessSecretsManager.ContainsKey(c.Value),
+                    LimitCollectionCreationDeletion = limitCollectionCreationDeletion.ContainsKey(c.Value)
                 }));
         }
 
@@ -237,6 +245,7 @@ public class CurrentContext : ICurrentContext
                     Type = OrganizationUserType.Custom,
                     Permissions = SetOrganizationPermissionsFromClaims(c.Value, claimsDict),
                     AccessSecretsManager = accessSecretsManager.ContainsKey(c.Value),
+                    LimitCollectionCreationDeletion = limitCollectionCreationDeletion.ContainsKey(c.Value)
                 }));
         }
 

--- a/src/Core/Identity/Claims.cs
+++ b/src/Core/Identity/Claims.cs
@@ -16,6 +16,7 @@ public static class Claims
     public const string ProviderServiceUser = "providerserviceuser";
 
     public const string SecretsManagerAccess = "accesssecretsmanager";
+    public const string LimitCollectionCreationDeletion = "limitcollectioncreationdeletion";
 
     // Service Account
     public const string Organization = "organization";

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -692,12 +692,18 @@ public static class CoreHelpers
                         break;
                 }
 
-                // Secrets Manager
                 foreach (var org in group)
                 {
+                    // Secrets Manager
                     if (org.AccessSecretsManager)
                     {
                         claims.Add(new KeyValuePair<string, string>(Claims.SecretsManagerAccess, org.Id.ToString()));
+                    }
+
+                    // Affects user's ability within the organization to create/delete collections
+                    if (org.LimitCollectionCreationDeletion)
+                    {
+                        claims.Add(new KeyValuePair<string, string>(Claims.LimitCollectionCreationDeletion, org.Id.ToString()));
                     }
                 }
             }

--- a/src/Identity/IdentityServer/ApiResources.cs
+++ b/src/Identity/IdentityServer/ApiResources.cs
@@ -26,6 +26,7 @@ public class ApiResources
                 Claims.ProviderAdmin,
                 Claims.ProviderServiceUser,
                 Claims.SecretsManagerAccess,
+                Claims.LimitCollectionCreationDeletion,
             }),
             new(ApiScopes.Internal, new[] { JwtClaimTypes.Subject }),
             new(ApiScopes.ApiPush, new[] { JwtClaimTypes.Subject }),


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Add JWT claims for the `LimitCollectionCreationDeletion` property when the `CurrentContextOrganization` is constructed/instantiated.

## Code changes
* **src/Core/Context/CurrentContext.cs**: Added mapping from claims and applied them to the `CurrentContextOrganization` being created
* **src/Core/Identity/Claims.cs**: Added `LimitCollectionCreationDeletion` claim key
* **src/Core/Utilities/CoreHelpers.cs**: Added logic to create the claim with the `orgId` as the value
* **src/Identity/IdentityServer/ApiResources.cs**: Added new claim property to list of claims resources available to the `api`

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
