### PR TITLE
[PM-4767] update grant_save procedure

### DIFF
--- a/src/Core/Auth/Repositories/IGrantRepository.cs
+++ b/src/Core/Auth/Repositories/IGrantRepository.cs
@@ -7,6 +7,7 @@ public interface IGrantRepository
     Task<Grant> GetByKeyAsync(string key);
     Task<ICollection<Grant>> GetManyAsync(string subjectId, string sessionId, string clientId, string type);
     Task SaveAsync(Grant obj);
+    Task SaveAsync(Grant obj, bool grantSaveOptimizationIsEnabled);
     Task DeleteByKeyAsync(string key);
     Task DeleteManyAsync(string subjectId, string sessionId, string clientId, string type);
 }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -66,6 +66,7 @@ public static class FeatureFlagKeys
     public const string BillingPlansUpgrade = "billing-plans-upgrade";
     public const string BillingStarterPlan = "billing-starter-plan";
     public const string KeyRotationImprovements = "key-rotation-improvements";
+    public const string GrantSaveOptimization = "grant-save-optimization";
 
     public static List<string> GetAllKeys()
     {
@@ -81,7 +82,8 @@ public static class FeatureFlagKeys
         return new Dictionary<string, string>()
         {
             { TrustedDeviceEncryption, "true" },
-            { Fido2VaultCredentials, "true" }
+            { Fido2VaultCredentials, "true" },
+            { GrantSaveOptimization, "false"}
         };
     }
 }

--- a/src/Infrastructure.Dapper/Auth/Repositories/GrantRepository.cs
+++ b/src/Infrastructure.Dapper/Auth/Repositories/GrantRepository.cs
@@ -10,6 +10,8 @@ namespace Bit.Infrastructure.Dapper.Auth.Repositories;
 
 public class GrantRepository : BaseRepository, IGrantRepository
 {
+
+
     public GrantRepository(GlobalSettings globalSettings)
         : this(globalSettings.SqlServer.ConnectionString, globalSettings.SqlServer.ReadOnlyConnectionString)
     { }
@@ -44,15 +46,30 @@ public class GrantRepository : BaseRepository, IGrantRepository
             return results.ToList();
         }
     }
-
     public async Task SaveAsync(Grant obj)
     {
+        // This method can be left empty if it's not used in this class
+    }
+    public async Task SaveAsync(Grant obj, bool grantSaveOptimizationIsEnabled)
+    {
+        bool grantSaveOptimization = grantSaveOptimizationIsEnabled;
         using (var connection = new SqlConnection(ConnectionString))
         {
-            var results = await connection.ExecuteAsync(
+            if (!grantSaveOptimization)
+            {
+                var results = await connection.ExecuteAsync(
                 "[dbo].[Grant_Save]",
                 obj,
                 commandType: CommandType.StoredProcedure);
+
+            }
+            else
+            {
+                var results = await connection.ExecuteAsync(
+                "[dbo].[Grant_Save_withInsertUpdate]",
+                obj,
+                commandType: CommandType.StoredProcedure);
+            }
         }
     }
 

--- a/src/Infrastructure.EntityFramework/Auth/Repositories/GrantRepository.cs
+++ b/src/Infrastructure.EntityFramework/Auth/Repositories/GrantRepository.cs
@@ -71,6 +71,7 @@ public class GrantRepository : BaseEntityFrameworkRepository, IGrantRepository
         }
     }
 
+
     public async Task SaveAsync(Core.Auth.Entities.Grant obj)
     {
         using (var scope = ServiceScopeFactory.CreateScope())
@@ -90,6 +91,10 @@ public class GrantRepository : BaseEntityFrameworkRepository, IGrantRepository
                 await dbContext.SaveChangesAsync();
             }
         }
+    }
+    public async Task SaveAsync(Core.Auth.Entities.Grant obj, bool grantSaveOptimizationIsEnabled)
+    {
+        //not used by entity framework
     }
 }
 

--- a/src/Sql/Auth/dbo/Stored Procedures/Grant_Save_withInsertUpdate.sql
+++ b/src/Sql/Auth/dbo/Stored Procedures/Grant_Save_withInsertUpdate.sql
@@ -1,0 +1,61 @@
+CREATE PROCEDURE [dbo].[Grant_Save_withInsertUpdate]
+    @Key  NVARCHAR(200),
+    @Type  NVARCHAR(50),
+    @SubjectId NVARCHAR(200),
+    @SessionId NVARCHAR(100),
+    @ClientId NVARCHAR(200),
+    @Description NVARCHAR(200),
+    @CreationDate DATETIME2,
+    @ExpirationDate DATETIME2,
+    @ConsumedDate DATETIME2,
+    @Data NVARCHAR(MAX)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    -- First, try to update the existing row
+    UPDATE [dbo].[Grant]
+    SET
+        [Type] = @Type,
+        [SubjectId] = @SubjectId,
+        [SessionId] = @SessionId,
+        [ClientId] = @ClientId,
+        [Description] = @Description,
+        [CreationDate] = @CreationDate,
+        [ExpirationDate] = @ExpirationDate,
+        [ConsumedDate] = @ConsumedDate,
+        [Data] = @Data
+    WHERE
+        [Key] = @Key
+
+    -- If no row was updated, insert a new one
+    IF @@ROWCOUNT = 0
+    BEGIN
+        INSERT INTO [dbo].[Grant]
+        (
+            [Key],
+            [Type],
+            [SubjectId],
+            [SessionId],
+            [ClientId],
+            [Description],
+            [CreationDate],
+            [ExpirationDate],
+            [ConsumedDate],
+            [Data]
+        )
+        VALUES
+        (
+            @Key,
+            @Type,
+            @SubjectId,
+            @SessionId,
+            @ClientId,
+            @Description,
+            @CreationDate,
+            @ExpirationDate,
+            @ConsumedDate,
+            @Data
+        )
+    END
+END

--- a/util/Migrator/DbScripts/2023-11-13_00_AuthGrantSaveWithInsertUpdate.sql
+++ b/util/Migrator/DbScripts/2023-11-13_00_AuthGrantSaveWithInsertUpdate.sql
@@ -1,0 +1,61 @@
+CREATE OR ALTER PROCEDURE [dbo].[Grant_Save_withInsertUpdate]
+    @Key  NVARCHAR(200),
+    @Type  NVARCHAR(50),
+    @SubjectId NVARCHAR(200),
+    @SessionId NVARCHAR(100),
+    @ClientId NVARCHAR(200),
+    @Description NVARCHAR(200),
+    @CreationDate DATETIME2,
+    @ExpirationDate DATETIME2,
+    @ConsumedDate DATETIME2,
+    @Data NVARCHAR(MAX)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    -- First, try to update the existing row
+    UPDATE [dbo].[Grant]
+    SET
+        [Type] = @Type,
+        [SubjectId] = @SubjectId,
+        [SessionId] = @SessionId,
+        [ClientId] = @ClientId,
+        [Description] = @Description,
+        [CreationDate] = @CreationDate,
+        [ExpirationDate] = @ExpirationDate,
+        [ConsumedDate] = @ConsumedDate,
+        [Data] = @Data
+    WHERE
+        [Key] = @Key
+
+    -- If no row was updated, insert a new one
+    IF @@ROWCOUNT = 0
+    BEGIN
+        INSERT INTO [dbo].[Grant]
+        (
+            [Key],
+            [Type],
+            [SubjectId],
+            [SessionId],
+            [ClientId],
+            [Description],
+            [CreationDate],
+            [ExpirationDate],
+            [ConsumedDate],
+            [Data]
+        )
+        VALUES
+        (
+            @Key,
+            @Type,
+            @SubjectId,
+            @SessionId,
+            @ClientId,
+            @Description,
+            @CreationDate,
+            @ExpirationDate,
+            @ConsumedDate,
+            @Data
+        )
+    END
+END


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

### **Objective**
Optimize the grant_save sql and uses launchDarkly to use the original or new stored procedure which changes a merge to update insert. Should lock less and increase concurrency leading to not pinning cpu

* add new procedure to be called by AsyncSave depending on LaunchDarkly variable
* add constant and set default for LaunchDarkly variable
* add the ability to pass LaunchDarkly variable to AsyncSave and override depending if dapper or EF
* Add sql script to migration and Auth SQL scripts

### **Code changes**

* **src/Core/Auth/Repositories/IGrantRepository.cs:** Adds new entry to interface that allows SaveAsync to accept grant object and boolean
* **src/Core/Constants.cs:** Adds Boolean Constant GrantSaveOptimization set in LaunchDarkly, set to False in selfHosted
* **src/Identity/IdentityServer/PersistedGrantStore.cs:** Adds two private fields for and constructor for bring in Launchadarkly variable, adds second parameter for variable to await _grantRepository.SaveAsync
* **src/Infrastructure.Dapper/Auth/Repositories/GrantRepository.cs:**  Modifies method  method, SaveAsync, that performs asynchronous database operations related to a Grant object to accept boolean from LaunchDarkly
* **src/Infrastructure.EntityFramework/Auth/Repositories/GrantRepository.cs:** Override method to allow 2 variables even though not used
* **src/Sql/Auth/dbo/Stored Procedures/Grant_Save_withInsertUpdate.sql:** Changes merge command to deafult to update and if nothing updated inesrts
* **util/Migrator/DbScripts/2023-11-13_00_AuthGrantSaveWithInsertUpdate.sql:** Adds the optimized grant_save_WIthInserttUpdate 

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
