### PR TITLE
Prefer compounds for preLaunchTasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,94 +7,251 @@
         {
             "name": "Min Server",
             "configurations": [
-                "Identity",
-                "API"
+                "run-Identity",
+                "run-API"
             ],
             "presentation": {
                 "hidden": false,
                 "group": "AA_compounds",
                 "order": 1
             },
+            "preLaunchTask": "buildIdentityApi",
             "stopAll": true
         },
         {
             "name": "Admin, API, Identity",
             "configurations": [
-                "Admin",
-                "API",
-                "Identity"
+                "run-Admin",
+                "run-API",
+                "run-Identity"
             ],
             "presentation": {
                 "hidden": false,
                 "group": "AA_compounds",
                 "order": 3
             },
+            "preLaunchTask": "buildIdentityApiAdmin",
             "stopAll": true
         },
         {
             "name": "Full Server",
             "configurations": [
-                "Admin",
-                "API",
-                "EventsProcessor",
-                "Identity",
-                "Sso",
-                "Icons",
-                "Billing",
-                "Notifications"
+                "run-Admin",
+                "run-API",
+                "run-EventsProcessor",
+                "run-Identity",
+                "run-Sso",
+                "run-Icons",
+                "run-Billing",
+                "run-Notifications"
             ],
             "presentation": {
                 "hidden": false,
                 "group": "AA_compounds",
                 "order": 4
             },
+            "preLaunchTask": "buildFullServer",
             "stopAll": true
         },
         {
             "name": "Self Host: Bit",
             "configurations": [
-                "Admin-SelfHost",
-                "API-SelfHost",
-                "EventsProcessor-SelfHost",
-                "Identity-SelfHost",
-                "Sso-SelfHost",
-                "Notifications-SelfHost"
+                "run-Admin-SelfHost",
+                "run-API-SelfHost",
+                "run-EventsProcessor-SelfHost",
+                "run-Identity-SelfHost",
+                "run-Sso-SelfHost",
+                "run-Notifications-SelfHost"
             ],
             "presentation": {
                 "hidden": false,
                 "group": "AA_compounds",
                 "order": 2
             },
+            "preLaunchTask": "buildSelfHostBit",
             "stopAll": true
         },
         {
             "name": "Self Host: OSS",
             "configurations": [
-                "Admin-SelfHost",
-                "API-SelfHost",
-                "EventsProcessor-SelfHost",
-                "Identity-SelfHost",
+                "run-Admin-SelfHost",
+                "run-API-SelfHost",
+                "run-EventsProcessor-SelfHost",
+                "run-Identity-SelfHost",
             ],
             "presentation": {
                 "hidden": false,
                 "group": "AA_compounds",
                 "order": 99
             },
+            "preLaunchTask": "buildSelfHostOss",
             "stopAll": true
-        }
-    ],
-    "configurations": [
+        },
         {
-            "name": "Identity",
+            "name": "Admin",
+            "configurations": [
+                "run-Admin"
+            ],
             "presentation": {
                 "hidden": false,
                 "group": "cloud",
-                "order": 10
+            },
+            "preLaunchTask": "buildAdmin",
+        },
+        {
+            "name": "API",
+            "configurations": [
+                "run-API"
+            ],
+            "presentation": {
+                "hidden": false,
+                "group": "cloud",
+            },
+            "preLaunchTask": "buildAPI",
+        },
+        {
+            "name": "Billing",
+            "configurations": [
+                "run-Billing"
+            ],
+            "presentation": {
+                "hidden": false,
+                "group": "cloud",
+            },
+            "preLaunchTask": "buildBilling",
+        },
+        {
+            "name": "Events Processor",
+            "configurations": [
+                "run-EventsProcessor"
+            ],
+            "presentation": {
+                "hidden": false,
+                "group": "cloud",
+            },
+            "preLaunchTask": "buildEventsProcessor",
+        },
+        {
+            "name": "Icons",
+            "configurations": [
+                "run-Icons"
+            ],
+            "presentation": {
+                "hidden": false,
+                "group": "cloud",
+            },
+            "preLaunchTask": "buildIcons",
+        },
+        {
+            "name": "Identity",
+            "configurations": [
+                "run-Identity"
+            ],
+            "presentation": {
+                "hidden": false,
+                "group": "cloud",
+            },
+            "preLaunchTask": "buildIdentity",
+        },
+        {
+            "name": "Notifications",
+            "configurations": [
+                "run-Notifications"
+            ],
+            "presentation": {
+                "hidden": false,
+                "group": "cloud",
+            },
+            "preLaunchTask": "buildNotifications",
+        },
+        {
+            "name": "SSO",
+            "configurations": [
+                "run-Sso"
+            ],
+            "presentation": {
+                "hidden": false,
+                "group": "cloud",
+            },
+            "preLaunchTask": "buildSso",
+        },
+        {
+            "name": "Admin Self Host",
+            "configurations": [
+                "run-Admin-SelfHost"
+            ],
+            "presentation": {
+                "hidden": false,
+                "group": "self-host",
+            },
+            "preLaunchTask": "buildAdmin",
+        },
+        {
+            "name": "API Self Host",
+            "configurations": [
+                "run-API-SelfHost"
+            ],
+            "presentation": {
+                "hidden": false,
+                "group": "self-host",
+            },
+            "preLaunchTask": "buildAPI",
+        },
+        {
+            "name": "Events Processor Self Host",
+            "configurations": [
+                "run-EventsProcessor-SelfHost"
+            ],
+            "presentation": {
+                "hidden": false,
+                "group": "self-host",
+            },
+            "preLaunchTask": "buildEventsProcessor",
+        },
+        {
+            "name": "Identity Self Host",
+            "configurations": [
+                "run-Identity-SelfHost"
+            ],
+            "presentation": {
+                "hidden": false,
+                "group": "self-host",
+            },
+            "preLaunchTask": "buildIdentity",
+        },
+        {
+            "name": "Notifications Self Host",
+            "configurations": [
+                "run-Notifications-SelfHost"
+            ],
+            "presentation": {
+                "hidden": false,
+                "group": "self-host",
+            },
+            "preLaunchTask": "buildNotifications",
+        },
+        {
+            "name": "SSO Self Host",
+            "configurations": [
+                "run-Sso-SelfHost"
+            ],
+            "presentation": {
+                "hidden": false,
+                "group": "self-host",
+            },
+            "preLaunchTask": "buildSso",
+        },
+    ],
+    "configurations": [
+        // Configurations represent run-only scenarios so that they can be used in multiple compounds
+        {
+            "name": "run-Identity",
+            "presentation": {
+                "hidden": true,
             },
             "requireExactSource": true,
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "buildIdentity",
             "program": "${workspaceFolder}/src/Identity/bin/Debug/net6.0/Identity.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Identity",
@@ -107,16 +264,13 @@
             }
         },
         {
-            "name": "API",
+            "name": "run-API",
             "presentation": {
-                "hidden": false,
-                "group": "cloud",
-                "order": 10
+                "hidden": true,
             },
             "requireExactSource": true,
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "buildAPI",
             "program": "${workspaceFolder}/src/Api/bin/Debug/net6.0/Api.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Api",
@@ -129,16 +283,13 @@
             }
         },
         {
-            "name": "Billing",
+            "name": "run-Billing",
             "presentation": {
-                "hidden": false,
-                "group": "cloud",
-                "order": 10
+                "hidden": true,
             },
             "requireExactSource": true,
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "buildBilling",
             "program": "${workspaceFolder}/src/Billing/bin/Debug/net6.0/Billing.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Billing",
@@ -151,16 +302,13 @@
             }
         },
         {
-            "name": "Admin",
+            "name": "run-Admin",
             "presentation": {
-                "hidden": false,
-                "group": "cloud",
-                "order": 20
+                "hidden": true,
             },
             "requireExactSource": true,
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "buildAdmin",
             "OS-COMMENT4": "If you have changed target frameworks, make sure to update the program path.",
             "program": "${workspaceFolder}/src/Admin/bin/Debug/net6.0/Admin.dll",
             "args": [],
@@ -175,16 +323,13 @@
             }
         },
         {
-            "name": "Sso",
+            "name": "run-Sso",
             "presentation": {
-                "hidden": false,
-                "group": "cloud",
-                "order": 50
+                "hidden": true,
             },
             "requireExactSource": true,
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "buildSso",
             "program": "${workspaceFolder}/bitwarden_license/src/Sso/bin/Debug/net6.0/Sso.dll",
             "args": [],
             "cwd": "${workspaceFolder}/bitwarden_license/src/Sso",
@@ -197,16 +342,13 @@
             }
         },
         {
-            "name": "EventsProcessor",
+            "name": "run-EventsProcessor",
             "presentation": {
-                "hidden": false,
-                "group": "cloud",
-                "order": 90
+                "hidden": true,
             },
             "requireExactSource": true,
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "buildEventsProcessor",
             "program": "${workspaceFolder}/src/EventsProcessor/bin/Debug/net6.0/EventsProcessor.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/EventsProcessor",
@@ -219,16 +361,13 @@
             }
         },
         {
-            "name": "Icons",
+            "name": "run-Icons",
             "presentation": {
-                "hidden": false,
-                "group": "cloud",
-                "order": 90
+                "hidden": true,
             },
             "requireExactSource": true,
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "buildIcons",
             "program": "${workspaceFolder}/src/Icons/bin/Debug/net6.0/Icons.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Icons",
@@ -241,16 +380,13 @@
             }
         },
         {
-            "name": "Notifications",
+            "name": "run-Notifications",
             "presentation": {
                 "hidden": true,
-                "group": "cloud",
-                "order": 100
             },
             "requireExactSource": true,
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "buildNotifications",
             "program": "${workspaceFolder}/src/Notifications/bin/Debug/net6.0/Notifications.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Notifications",
@@ -263,16 +399,13 @@
             }
         },
         {
-            "name": "Identity-SelfHost",
+            "name": "run-Identity-SelfHost",
             "presentation": {
                 "hidden": true,
-                "group": "self-host",
-                "order": 999
             },
             "requireExactSource": true,
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "buildIdentity",
             "program": "${workspaceFolder}/src/Identity/bin/Debug/net6.0/Identity.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Identity",
@@ -287,16 +420,13 @@
             }
         },
         {
-            "name": "API-SelfHost",
+            "name": "run-API-SelfHost",
             "presentation": {
                 "hidden": true,
-                "group": "self-host",
-                "order": 999
             },
             "requireExactSource": true,
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "buildAPI",
             "program": "${workspaceFolder}/src/Api/bin/Debug/net6.0/Api.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Api",
@@ -311,16 +441,13 @@
             }
         },
         {
-            "name": "Admin-SelfHost",
+            "name": "run-Admin-SelfHost",
             "presentation": {
                 "hidden": true,
-                "group": "self-host",
-                "order": 999
             },
             "requireExactSource": true,
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "buildAdmin",
             "OS-COMMENT4": "If you have changed target frameworks, make sure to update the program path.",
             "program": "${workspaceFolder}/src/Admin/bin/Debug/net6.0/Admin.dll",
             "args": [],
@@ -337,16 +464,13 @@
             }
         },
         {
-            "name": "Sso-SelfHost",
+            "name": "run-Sso-SelfHost",
             "presentation": {
                 "hidden": true,
-                "group": "self-host",
-                "order": 999
             },
             "requireExactSource": true,
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "buildSso",
             "program": "${workspaceFolder}/bitwarden_license/src/Sso/bin/Debug/net6.0/Sso.dll",
             "args": [],
             "cwd": "${workspaceFolder}/bitwarden_license/src/Sso",
@@ -361,16 +485,13 @@
             }
         },
         {
-            "name": "Notifications-SelfHost",
+            "name": "run-Notifications-SelfHost",
             "presentation": {
                 "hidden": true,
-                "group": "self-host",
-                "order": 999
             },
             "requireExactSource": true,
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "buildNotifications",
             "program": "${workspaceFolder}/src/Notifications/bin/Debug/net6.0/Notifications.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Notifications",
@@ -385,16 +506,13 @@
             }
         },
         {
-            "name": "EventsProcessor-SelfHost",
+            "name": "run-EventsProcessor-SelfHost",
             "presentation": {
                 "hidden": true,
-                "group": "self-host",
-                "order": 999
             },
             "requireExactSource": true,
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "buildEventsProcessor",
             "program": "${workspaceFolder}/src/EventsProcessor/bin/Debug/net6.0/EventsProcessor.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/EventsProcessor",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,65 @@
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "buildIdentityApi",
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "buildIdentity",
+                "buildAPI"
+            ],
+            "problemMatcher": [
+                "$msCompile"
+            ]
+        },
+        {
+            "label": "buildIdentityApiAdmin",
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "buildIdentity",
+                "buildAPI",
+                "buildAdmin"
+            ],
+            "problemMatcher": [
+                "$msCompile"
+            ]
+        },
+        {
+            "label": "buildFullServer",
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "buildAdmin",
+                "buildAPI",
+                "buildEventsProcessor",
+                "buildIdentity",
+                "buildSso",
+                "buildIcons",
+                "buildBilling",
+                "buildNotifications",
+            ],
+        },
+        {
+            "label": "buildSelfHostBit",
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "buildAdmin",
+                "buildAPI",
+                "buildEventsProcessor",
+                "buildIdentity",
+                "buildSso",
+                "buildNotifications",
+            ],
+        },
+        {
+            "label": "buildSelfHostOss",
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "buildAdmin",
+                "buildAPI",
+                "buildEventsProcessor",
+                "buildIdentity",
+            ],
+        },
+        {
             "label": "buildIcons",
             "command": "dotnet",
             "type": "process",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective

Currently, our configurations define `preLaunchTasks`, which are then run concurrently for compound launch configurations. `dotnet` does not do well with parallel builds due to common dependencies that lock files and cause intermittent failures on deploy of `preLauchTasks`. This results in running a `full server` configurations, some fraction of the projects failing to build, and ending up with only `SSO` and `Billing` running. Very annoying.

This rework creates `configurations` that have no build task associated to just run existing code, hides them from the debugging interface, then builds compound tasks that both build and run each project. It also defined `tasks` that sequentially builds each project for a given compound.

I also got rid of the order part of our configurations to prefer alphabetical. This is really just the order the compounds are defined, but I put them in alphabetical order.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
