### PR TITLE
SM-904: Phase 1 - Removing the SecretsManagerBeta Flag

### DIFF
--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Queries/ServiceAccounts/CountNewServiceAccountSlotsRequiredQuery.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Queries/ServiceAccounts/CountNewServiceAccountSlotsRequiredQuery.cs
@@ -26,7 +26,7 @@ public class CountNewServiceAccountSlotsRequiredQuery : ICountNewServiceAccountS
             throw new NotFoundException();
         }
 
-        if (!organization.SmServiceAccounts.HasValue || serviceAccountsToAdd == 0 || organization.SecretsManagerBeta)
+        if (!organization.SmServiceAccounts.HasValue || serviceAccountsToAdd == 0)
         {
             return 0;
         }

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Queries/ServiceAccounts/CountNewServiceAccountSlotsRequiredQueryTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Queries/ServiceAccounts/CountNewServiceAccountSlotsRequiredQueryTests.cs
@@ -28,7 +28,6 @@ public class CountNewServiceAccountSlotsRequiredQueryTests
     {
         organization.UseSecretsManager = true;
         organization.SmServiceAccounts = organizationSmServiceAccounts;
-        organization.SecretsManagerBeta = false;
 
         sutProvider.GetDependency<IOrganizationRepository>()
             .GetByIdAsync(organization.Id)
@@ -62,7 +61,6 @@ public class CountNewServiceAccountSlotsRequiredQueryTests
 
         organization.UseSecretsManager = true;
         organization.SmServiceAccounts = null;
-        organization.SecretsManagerBeta = false;
 
         sutProvider.GetDependency<IOrganizationRepository>()
             .GetByIdAsync(organization.Id)
@@ -75,27 +73,6 @@ public class CountNewServiceAccountSlotsRequiredQueryTests
         var result = await sutProvider.Sut.CountNewServiceAccountSlotsRequiredAsync(organization.Id, serviceAccountsToAdd);
 
         Assert.Equal(expectedRequiredServiceAccountsToScale, result);
-
-        await sutProvider.GetDependency<IServiceAccountRepository>().DidNotReceiveWithAnyArgs()
-            .GetServiceAccountCountByOrganizationIdAsync(default);
-    }
-
-    [Theory, BitAutoData]
-    public async Task CountNewServiceAccountSlotsRequiredAsync_WithSecretsManagerBeta_ReturnsZero(
-        int serviceAccountsToAdd,
-        Organization organization,
-        SutProvider<CountNewServiceAccountSlotsRequiredQuery> sutProvider)
-    {
-        organization.UseSecretsManager = true;
-        organization.SecretsManagerBeta = true;
-
-        sutProvider.GetDependency<IOrganizationRepository>()
-            .GetByIdAsync(organization.Id)
-            .Returns(organization);
-
-        var result = await sutProvider.Sut.CountNewServiceAccountSlotsRequiredAsync(organization.Id, serviceAccountsToAdd);
-
-        Assert.Equal(0, result);
 
         await sutProvider.GetDependency<IServiceAccountRepository>().DidNotReceiveWithAnyArgs()
             .GetServiceAccountCountByOrganizationIdAsync(default);

--- a/src/Admin/Controllers/OrganizationsController.cs
+++ b/src/Admin/Controllers/OrganizationsController.cs
@@ -207,7 +207,6 @@ public class OrganizationsController : Controller
         var organization = await GetOrganization(id, model);
 
         if (organization.UseSecretsManager &&
-            !organization.SecretsManagerBeta &&
             !StaticStore.GetPlan(organization.PlanType).SupportsSecretsManager)
         {
             throw new BadRequestException("Plan does not support Secrets Manager");
@@ -338,7 +337,6 @@ public class OrganizationsController : Controller
             organization.UseTotp = model.UseTotp;
             organization.UsersGetPremium = model.UsersGetPremium;
             organization.UseSecretsManager = model.UseSecretsManager;
-            organization.SecretsManagerBeta = model.SecretsManagerBeta;
 
             //secrets
             organization.SmSeats = model.SmSeats;

--- a/src/Admin/Models/OrganizationEditModel.cs
+++ b/src/Admin/Models/OrganizationEditModel.cs
@@ -70,7 +70,6 @@ public class OrganizationEditModel : OrganizationViewModel
         MaxAutoscaleSmSeats = org.MaxAutoscaleSmSeats;
         SmServiceAccounts = org.SmServiceAccounts;
         MaxAutoscaleSmServiceAccounts = org.MaxAutoscaleSmServiceAccounts;
-        SecretsManagerBeta = org.SecretsManagerBeta;
     }
 
     public BillingInfo BillingInfo { get; set; }
@@ -150,8 +149,6 @@ public class OrganizationEditModel : OrganizationViewModel
     public int? SmServiceAccounts { get; set; }
     [Display(Name = "Max Autoscale Service Accounts")]
     public int? MaxAutoscaleSmServiceAccounts { get; set; }
-    [Display(Name = "Secrets Manager Beta")]
-    public bool SecretsManagerBeta { get; set; }
 
     /**
      * Creates a Plan[] object for use in Javascript
@@ -210,7 +207,6 @@ public class OrganizationEditModel : OrganizationViewModel
         existingOrganization.MaxAutoscaleSmSeats = MaxAutoscaleSmSeats;
         existingOrganization.SmServiceAccounts = SmServiceAccounts;
         existingOrganization.MaxAutoscaleSmServiceAccounts = MaxAutoscaleSmServiceAccounts;
-        existingOrganization.SecretsManagerBeta = SecretsManagerBeta;
         return existingOrganization;
     }
 }

--- a/src/Admin/Views/Shared/_OrganizationForm.cshtml
+++ b/src/Admin/Views/Shared/_OrganizationForm.cshtml
@@ -170,10 +170,6 @@
                     <input type="checkbox" class="form-check-input" asp-for="UseSecretsManager" disabled='@(canEditPlan ? null : "disabled")'>
                     <label class="form-check-label" asp-for="UseSecretsManager"></label>
                 </div>
-                <div class="form-check">
-                    <input type="checkbox" class="form-check-input" asp-for="SecretsManagerBeta" disabled='@(canEditPlan ? null : "disabled")'>
-                    <label class="form-check-label" asp-for="SecretsManagerBeta"></label>
-                </div>
             </div>
         </div>
     }
@@ -213,7 +209,7 @@
 
     @if (canViewPlan)
     {
-        <div id="organization-secrets-configuration" hidden="@(!Model.UseSecretsManager || Model.SecretsManagerBeta)">
+        <div id="organization-secrets-configuration" hidden="@(!Model.UseSecretsManager)">
             <h2>Secrets Manager Configuration</h2>
             <div class="row">
                 <div class="col-sm">

--- a/src/Admin/Views/Shared/_OrganizationFormScripts.cshtml
+++ b/src/Admin/Views/Shared/_OrganizationFormScripts.cshtml
@@ -46,23 +46,7 @@
                 return;
             }
 
-            // SM beta requires SM access
-            document.getElementById('@(nameof(Model.SecretsManagerBeta))').checked = false;
             clearSecretsManagerConfiguration();
-        });
-
-        document.getElementById('@(nameof(Model.SecretsManagerBeta))').addEventListener('change', (event) => {
-            document.getElementById('organization-secrets-configuration').hidden = event.target.checked;
-
-            if (event.target.checked) {
-                // SM beta requires SM access
-                document.getElementById('@(nameof(Model.UseSecretsManager))').checked = true;
-                // SM Beta orgs do not have subscription limits
-                clearSecretsManagerConfiguration();
-                return;
-            }
-
-            setInitialSecretsManagerConfiguration();
         });
     })();
 

--- a/src/Api/AdminConsole/Models/Response/Organizations/OrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/Organizations/OrganizationResponseModel.cs
@@ -44,7 +44,7 @@ public class OrganizationResponseModel : ResponseModel
         Use2fa = organization.Use2fa;
         UseApi = organization.UseApi;
         UseResetPassword = organization.UseResetPassword;
-        UseSecretsManager = organization.UseSecretsManager;
+        UseSecretsManager = organization.UseSecretsManager && !organization.SecretsManagerBeta;
         UsersGetPremium = organization.UsersGetPremium;
         UseCustomPermissions = organization.UseCustomPermissions;
         SelfHost = organization.SelfHost;
@@ -106,7 +106,7 @@ public class OrganizationSubscriptionResponseModel : OrganizationResponseModel
             CoreHelpers.ReadableBytesSize(organization.Storage.Value) : null;
         StorageGb = organization.Storage.HasValue ?
             Math.Round(organization.Storage.Value / 1073741824D, 2) : 0; // 1 GB
-        SecretsManagerBeta = organization.SecretsManagerBeta;
+        UseSecretsManager = organization.UseSecretsManager && !organization.SecretsManagerBeta;
     }
 
     public OrganizationSubscriptionResponseModel(Organization organization, SubscriptionInfo subscription, bool hideSensitiveData)
@@ -124,7 +124,7 @@ public class OrganizationSubscriptionResponseModel : OrganizationResponseModel
             UpcomingInvoice.Amount = null;
         }
 
-        SecretsManagerBeta = organization.SecretsManagerBeta;
+        UseSecretsManager = organization.UseSecretsManager && !organization.SecretsManagerBeta;
     }
 
     public OrganizationSubscriptionResponseModel(Organization organization, OrganizationLicense license) :
@@ -140,7 +140,7 @@ public class OrganizationSubscriptionResponseModel : OrganizationResponseModel
                                                  .OrganizationSelfHostSubscriptionGracePeriodDays);
         }
 
-        SecretsManagerBeta = organization.SecretsManagerBeta;
+        UseSecretsManager = organization.UseSecretsManager && !organization.SecretsManagerBeta;
     }
 
     public string StorageName { get; set; }
@@ -158,6 +158,4 @@ public class OrganizationSubscriptionResponseModel : OrganizationResponseModel
     /// Date when a self-hosted organization expires (includes grace period).
     /// </summary>
     public DateTime? Expiration { get; set; }
-
-    public bool SecretsManagerBeta { get; set; }
 }

--- a/src/Api/AdminConsole/Models/Response/Organizations/OrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/Organizations/OrganizationResponseModel.cs
@@ -44,7 +44,7 @@ public class OrganizationResponseModel : ResponseModel
         Use2fa = organization.Use2fa;
         UseApi = organization.UseApi;
         UseResetPassword = organization.UseResetPassword;
-        UseSecretsManager = organization.UseSecretsManager && !organization.SecretsManagerBeta;
+        UseSecretsManager = organization.UseSecretsManager;
         UsersGetPremium = organization.UsersGetPremium;
         UseCustomPermissions = organization.UseCustomPermissions;
         SelfHost = organization.SelfHost;
@@ -106,7 +106,6 @@ public class OrganizationSubscriptionResponseModel : OrganizationResponseModel
             CoreHelpers.ReadableBytesSize(organization.Storage.Value) : null;
         StorageGb = organization.Storage.HasValue ?
             Math.Round(organization.Storage.Value / 1073741824D, 2) : 0; // 1 GB
-        UseSecretsManager = organization.UseSecretsManager && !organization.SecretsManagerBeta;
     }
 
     public OrganizationSubscriptionResponseModel(Organization organization, SubscriptionInfo subscription, bool hideSensitiveData)
@@ -123,8 +122,6 @@ public class OrganizationSubscriptionResponseModel : OrganizationResponseModel
             Subscription.Items = null;
             UpcomingInvoice.Amount = null;
         }
-
-        UseSecretsManager = organization.UseSecretsManager && !organization.SecretsManagerBeta;
     }
 
     public OrganizationSubscriptionResponseModel(Organization organization, OrganizationLicense license) :
@@ -139,8 +136,6 @@ public class OrganizationSubscriptionResponseModel : OrganizationResponseModel
                                              license.Expires?.AddDays(-Constants
                                                  .OrganizationSelfHostSubscriptionGracePeriodDays);
         }
-
-        UseSecretsManager = organization.UseSecretsManager && !organization.SecretsManagerBeta;
     }
 
     public string StorageName { get; set; }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/CountNewSmSeatsRequiredQuery.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/CountNewSmSeatsRequiredQuery.cs
@@ -34,7 +34,7 @@ public class CountNewSmSeatsRequiredQuery : ICountNewSmSeatsRequiredQuery
             throw new BadRequestException("Organization does not use Secrets Manager");
         }
 
-        if (!organization.SmSeats.HasValue || organization.SecretsManagerBeta)
+        if (!organization.SmSeats.HasValue)
         {
             return 0;
         }

--- a/src/Core/OrganizationFeatures/OrganizationSubscriptions/AddSecretsManagerSubscriptionCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSubscriptions/AddSecretsManagerSubscriptionCommand.cs
@@ -68,12 +68,6 @@ public class AddSecretsManagerSubscriptionCommand : IAddSecretsManagerSubscripti
             throw new NotFoundException();
         }
 
-        if (organization.SecretsManagerBeta)
-        {
-            throw new BadRequestException("Organization is enrolled in Secrets Manager Beta. " +
-                                          "Please contact Customer Success to add Secrets Manager to your subscription.");
-        }
-
         if (organization.UseSecretsManager)
         {
             throw new BadRequestException("Organization already uses Secrets Manager.");

--- a/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpdateSecretsManagerSubscriptionCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpdateSecretsManagerSubscriptionCommand.cs
@@ -165,12 +165,6 @@ public class UpdateSecretsManagerSubscriptionCommand : IUpdateSecretsManagerSubs
             throw new BadRequestException("Organization has no access to Secrets Manager.");
         }
 
-        if (organization.SecretsManagerBeta)
-        {
-            throw new BadRequestException("Organization is enrolled in Secrets Manager Beta. " +
-                                          "Please contact Customer Success to add Secrets Manager to your subscription.");
-        }
-
         if (update.Plan.Product == ProductType.Free)
         {
             // No need to check the organization is set up with Stripe

--- a/src/Infrastructure.Dapper/Repositories/OrganizationRepository.cs
+++ b/src/Infrastructure.Dapper/Repositories/OrganizationRepository.cs
@@ -28,7 +28,11 @@ public class OrganizationRepository : Repository<Organization, Guid>, IOrganizat
                 new { Identifier = identifier },
                 commandType: CommandType.StoredProcedure);
 
-            return results.SingleOrDefault();
+            var result = results.SingleOrDefault();
+
+            result.UseSecretsManager = result.UseSecretsManager && !result.SecretsManagerBeta;
+
+            return result;
         }
     }
 
@@ -40,7 +44,14 @@ public class OrganizationRepository : Repository<Organization, Guid>, IOrganizat
                 "[dbo].[Organization_ReadByEnabled]",
                 commandType: CommandType.StoredProcedure);
 
-            return results.ToList();
+            var orgs = results.ToList();
+
+            foreach (Organization org in orgs)
+            {
+                org.UseSecretsManager = org.UseSecretsManager && !org.SecretsManagerBeta;
+            }
+
+            return orgs;
         }
     }
 
@@ -53,7 +64,14 @@ public class OrganizationRepository : Repository<Organization, Guid>, IOrganizat
                 new { UserId = userId },
                 commandType: CommandType.StoredProcedure);
 
-            return results.ToList();
+            var orgs = results.ToList();
+
+            foreach (Organization org in orgs)
+            {
+                org.UseSecretsManager = org.UseSecretsManager && !org.SecretsManagerBeta;
+            }
+
+            return orgs;
         }
     }
 
@@ -68,7 +86,14 @@ public class OrganizationRepository : Repository<Organization, Guid>, IOrganizat
                 commandType: CommandType.StoredProcedure,
                 commandTimeout: 120);
 
-            return results.ToList();
+            var orgs = results.ToList();
+
+            foreach (Organization org in orgs)
+            {
+                org.UseSecretsManager = org.UseSecretsManager && !org.SecretsManagerBeta;
+            }
+
+            return orgs;
         }
     }
 
@@ -105,7 +130,11 @@ public class OrganizationRepository : Repository<Organization, Guid>, IOrganizat
                 new { LicenseKey = licenseKey },
                 commandType: CommandType.StoredProcedure);
 
-            return result.SingleOrDefault();
+            var org = result.SingleOrDefault();
+
+            org.UseSecretsManager = org.UseSecretsManager && !org.SecretsManagerBeta;
+
+            return org;
         }
     }
 
@@ -131,6 +160,7 @@ public class OrganizationRepository : Repository<Organization, Guid>, IOrganizat
             selfHostOrganization.Policies = await result.ReadAsync<Policy>();
             selfHostOrganization.SsoConfig = await result.ReadFirstOrDefaultAsync<SsoConfig>();
             selfHostOrganization.ScimConnections = await result.ReadAsync<OrganizationConnection>();
+            selfHostOrganization.UseSecretsManager = selfHostOrganization.UseSecretsManager && !selfHostOrganization.SecretsManagerBeta;
 
             return selfHostOrganization;
         }
@@ -146,7 +176,14 @@ public class OrganizationRepository : Repository<Organization, Guid>, IOrganizat
                 commandType: CommandType.StoredProcedure,
                 commandTimeout: 120);
 
-            return results.ToList();
+            var orgs = results.ToList();
+
+            foreach (Organization org in orgs)
+            {
+                org.UseSecretsManager = org.UseSecretsManager && !org.SecretsManagerBeta;
+            }
+
+            return orgs;
         }
     }
 

--- a/src/Infrastructure.EntityFramework/Repositories/OrganizationRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/OrganizationRepository.cs
@@ -36,9 +36,9 @@ public class OrganizationRepository : Repository<Core.Entities.Organization, Org
             var organizations = await GetDbSet(dbContext).Where(e => e.Enabled).ToListAsync();
             var list = Mapper.Map<List<Core.Entities.Organization>>(organizations);
 
-            foreach (Core.Entities.Organization entity in list)
+            foreach (Core.Entities.Organization org in list)
             {
-                entity.UseSecretsManager = organization.UseSecretsManager && !organization.SecretsManagerBeta;
+                org.UseSecretsManager = org.UseSecretsManager && !org.SecretsManagerBeta;
             }
 
             return list;
@@ -57,9 +57,9 @@ public class OrganizationRepository : Repository<Core.Entities.Organization, Org
                 .ToListAsync();
             var list = Mapper.Map<List<Core.Entities.Organization>>(organizations);
 
-            foreach (Core.Entities.Organization entity in list)
+            foreach (Core.Entities.Organization org in list)
             {
-                entity.UseSecretsManager = organization.UseSecretsManager && !organization.SecretsManagerBeta;
+                org.UseSecretsManager = org.UseSecretsManager && !org.SecretsManagerBeta;
             }
 
             return list;
@@ -83,9 +83,9 @@ public class OrganizationRepository : Repository<Core.Entities.Organization, Org
                 .ToListAsync();
             var list = Mapper.Map<List<Core.Entities.Organization>>(organizations);
 
-            foreach (Core.Entities.Organization entity in list)
+            foreach (Core.Entities.Organization org in list)
             {
-                entity.UseSecretsManager = organization.UseSecretsManager && !organization.SecretsManagerBeta;
+                org.UseSecretsManager = org.UseSecretsManager && !org.SecretsManagerBeta;
             }
 
             return list;
@@ -128,17 +128,17 @@ public class OrganizationRepository : Repository<Core.Entities.Organization, Org
 
         if (string.IsNullOrWhiteSpace(ownerEmail))
         {
-            var list = await query.OrderByDescending(o => o.CreationDate)
+            var orgs = await query.OrderByDescending(o => o.CreationDate)
                 .Skip(skip)
                 .Take(take)
                 .ToArrayAsync();
 
-            foreach (Core.Entities.Organization entity in list)
+            foreach (Core.Entities.Organization org in orgs)
             {
-                entity.UseSecretsManager = organization.UseSecretsManager && !organization.SecretsManagerBeta;
+                org.UseSecretsManager = org.UseSecretsManager && !org.SecretsManagerBeta;
             }
 
-            return list;
+            return orgs;
         }
 
         if (dbContext.Database.IsNpgsql())
@@ -164,9 +164,9 @@ public class OrganizationRepository : Repository<Core.Entities.Organization, Org
 
         var list = await query.OrderByDescending(o => o.CreationDate).Skip(skip).Take(take).ToArrayAsync();
 
-        foreach (Core.Entities.Organization entity in list)
+        foreach (Core.Entities.Organization org in list)
         {
-            entity.UseSecretsManager = organization.UseSecretsManager && !organization.SecretsManagerBeta;
+            org.UseSecretsManager = org.UseSecretsManager && !org.SecretsManagerBeta;
         }
 
         return list;
@@ -245,6 +245,8 @@ public class OrganizationRepository : Repository<Core.Entities.Organization, Org
             var organization = await GetDbSet(dbContext)
                 .FirstOrDefaultAsync(o => o.LicenseKey == licenseKey);
 
+            organization.UseSecretsManager = organization.UseSecretsManager && !organization.SecretsManagerBeta;
+
             return organization;
         }
     }
@@ -260,6 +262,8 @@ public class OrganizationRepository : Repository<Core.Entities.Organization, Org
                 .AsSplitQuery()
                 .ProjectTo<SelfHostedOrganizationDetails>(Mapper.ConfigurationProvider)
                 .SingleOrDefaultAsync();
+
+            selfHostedOrganization.UseSecretsManager = selfHostedOrganization.UseSecretsManager && !selfHostedOrganization.SecretsManagerBeta;
 
             return selfHostedOrganization;
         }
@@ -292,6 +296,7 @@ public class OrganizationRepository : Repository<Core.Entities.Organization, Org
             var dbContext = GetDatabaseContext(scope);
             var entity = await GetDbSet(dbContext).FindAsync(id);
             var result = Mapper.Map<Core.Entities.Organization>(entity);
+
             result.UseSecretsManager = result.UseSecretsManager && !result.SecretsManagerBeta;
 
             return result;

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/CountNewSmSeatsRequiredQueryTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/CountNewSmSeatsRequiredQueryTests.cs
@@ -86,25 +86,4 @@ public class CountNewSmSeatsRequiredQueryTests
             await sutProvider.Sut.CountNewSmSeatsRequiredAsync(organization.Id, usersToAdd));
         Assert.Contains("Organization does not use Secrets Manager", exception.Message);
     }
-
-    [Theory, BitAutoData]
-    public async Task CountNewSmSeatsRequiredAsync_WithSecretsManagerBeta_ReturnsZero(
-        int usersToAdd,
-        Organization organization,
-        SutProvider<CountNewSmSeatsRequiredQuery> sutProvider)
-    {
-        organization.UseSecretsManager = true;
-        organization.SecretsManagerBeta = true;
-
-        sutProvider.GetDependency<IOrganizationRepository>()
-            .GetByIdAsync(organization.Id)
-            .Returns(organization);
-
-        var result = await sutProvider.Sut.CountNewSmSeatsRequiredAsync(organization.Id, usersToAdd);
-
-        Assert.Equal(0, result);
-
-        await sutProvider.GetDependency<IOrganizationUserRepository>().DidNotReceiveWithAnyArgs()
-            .GetOccupiedSmSeatCountByOrganizationIdAsync(default);
-    }
 }

--- a/test/Core.Test/AutoFixture/OrganizationFixtures.cs
+++ b/test/Core.Test/AutoFixture/OrganizationFixtures.cs
@@ -139,7 +139,6 @@ public class SecretsManagerOrganizationCustomization : ICustomization
         fixture.Customize<Organization>(composer => composer
             .With(o => o.Id, organizationId)
             .With(o => o.UseSecretsManager, true)
-            .With(o => o.SecretsManagerBeta, false)
             .With(o => o.PlanType, planType)
             .With(o => o.Plan, StaticStore.GetPlan(planType).Name)
             .With(o => o.MaxAutoscaleSmSeats, (int?)null)

--- a/test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/AddSecretsManagerSubscriptionCommandTests.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/AddSecretsManagerSubscriptionCommandTests.cs
@@ -109,28 +109,11 @@ public class AddSecretsManagerSubscriptionCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task SignUpAsync_ThrowsException_WhenOrganizationEnrolledInSmBeta(
-        SutProvider<AddSecretsManagerSubscriptionCommand> sutProvider,
-        Organization organization)
-    {
-        organization.UseSecretsManager = true;
-        organization.SecretsManagerBeta = true;
-
-        var exception = await Assert.ThrowsAsync<BadRequestException>(
-            () => sutProvider.Sut.SignUpAsync(organization, 10, 10));
-
-        Assert.Contains("Organization is enrolled in Secrets Manager Beta", exception.Message);
-        await VerifyDependencyNotCalledAsync(sutProvider);
-    }
-
-    [Theory]
-    [BitAutoData]
     public async Task SignUpAsync_ThrowsException_WhenOrganizationAlreadyHasSecretsManager(
         SutProvider<AddSecretsManagerSubscriptionCommand> sutProvider,
         Organization organization)
     {
         organization.UseSecretsManager = true;
-        organization.SecretsManagerBeta = false;
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.SignUpAsync(organization, 10, 10));
@@ -147,7 +130,6 @@ public class AddSecretsManagerSubscriptionCommandTests
         Provider provider)
     {
         organization.UseSecretsManager = false;
-        organization.SecretsManagerBeta = false;
         provider.Type = ProviderType.Msp;
         sutProvider.GetDependency<IProviderRepository>().GetByOrganizationIdAsync(organization.Id).Returns(provider);
 

--- a/test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/UpdateSecretsManagerSubscriptionCommandTests.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/UpdateSecretsManagerSubscriptionCommandTests.cs
@@ -162,23 +162,6 @@ public class UpdateSecretsManagerSubscriptionCommandTests
     }
 
     [Theory]
-    [BitAutoData]
-    public async Task UpdateSubscriptionAsync_OrganizationEnrolledInSmBeta_ThrowsException(
-        SutProvider<UpdateSecretsManagerSubscriptionCommand> sutProvider,
-        Organization organization)
-    {
-        organization.UseSecretsManager = true;
-        organization.SecretsManagerBeta = true;
-        var update = new SecretsManagerSubscriptionUpdate(organization, false);
-
-        var exception = await Assert.ThrowsAsync<BadRequestException>(
-             () => sutProvider.Sut.UpdateSubscriptionAsync(update));
-
-        Assert.Contains("Organization is enrolled in Secrets Manager Beta", exception.Message);
-        await VerifyDependencyNotCalledAsync(sutProvider);
-    }
-
-    [Theory]
     [BitAutoData(PlanType.EnterpriseAnnually2019)]
     [BitAutoData(PlanType.EnterpriseAnnually2020)]
     [BitAutoData(PlanType.EnterpriseAnnually)]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This PR is phase 1 of deprecating and removing the SecretsManagerBeta flag now that the Secrets Manager Beta sunset grace period is over.

Phase 1 is the following:

- Remove SecretsManagerBeta from the `clients` repository
- Remove any SecretsManagerBeta flags from the server code, excluding the database and core entities
- At the repository level, set UseSecretsManager like the following: `UseSecretsManager = UseSecretsManager && !SecretsManagerBeta`. Further changes to SecretsManagerBeta will not be possible, and if an org has access to SecretsManagerBeta, it means they are not paying for it, so UseSecretsManager should be false in this case (as the sunset period has ended).

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
