### PR TITLE
[AC-1809] Make LimitCollectionCreationDeletion in Current Context

### DIFF
--- a/src/Core/Context/ICurrentContext.cs
+++ b/src/Core/Context/ICurrentContext.cs
@@ -6,6 +6,7 @@ using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Identity;
+using Bit.Core.Models.Data.Organizations;
 using Bit.Core.Repositories;
 using Bit.Core.Settings;
 using Microsoft.AspNetCore.Http;
@@ -32,7 +33,7 @@ public interface ICurrentContext
     Task BuildAsync(HttpContext httpContext, GlobalSettings globalSettings);
     Task BuildAsync(ClaimsPrincipal user, GlobalSettings globalSettings);
 
-    Task SetContextAsync(ClaimsPrincipal user);
+    Task SetContextAsync(ClaimsPrincipal user, IDictionary<Guid, OrganizationAbility> cachedOrgs);
 
 
     Task<bool> OrganizationUser(Guid orgId);

--- a/src/Core/Models/Data/Organizations/OrganizationAbility.cs
+++ b/src/Core/Models/Data/Organizations/OrganizationAbility.cs
@@ -21,6 +21,7 @@ public class OrganizationAbility
         UseResetPassword = organization.UseResetPassword;
         UseCustomPermissions = organization.UseCustomPermissions;
         UsePolicies = organization.UsePolicies;
+        LimitCollectionCreationDeletion = organization.LimitCollectionCreationDeletion;
     }
 
     public Guid Id { get; set; }
@@ -35,4 +36,5 @@ public class OrganizationAbility
     public bool UseResetPassword { get; set; }
     public bool UseCustomPermissions { get; set; }
     public bool UsePolicies { get; set; }
+    public bool LimitCollectionCreationDeletion { get; set; }
 }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Apply the value of the `LimitCollectionCreationDeletion` property to the `CurrentContextOrganization` during claims generation. This allows the property to be accessed downstream for permission logic conditionals.

## Code changes
* **src/Core/Context/CurrentContext.cs**: Injected `ApplicationCacheService` and retrieved/applied `LimitCollectionCreationDeletion` from the cached orgs.
* **src/Core/Context/ICurrentContext.cs**: Updated signature method in interface
* **src/Core/Models/Data/Organizations/OrganizationAbility.cs**: Added `LimitCollectionCreationDeletion` property

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
