### PR TITLE
Set SDK to 6.0.100 and ignore with Renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -175,7 +175,8 @@
   ],
   "force": {
     "constraints": {
-      "dotnet": "6.0.413"
+      "dotnet": "6.0.100"
     }
-  }
+  },
+  "ignoreDeps": ["dotnet-sdk"]
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.415",
+    "version": "6.0.100",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Sets our use of the .NET 6 SDK to 6.0.100 per prior conversations and since the roll-forward strategy will grab what we need for builds. This in practice will be easier to maintain, especially for developer setups.

Also excludes the SDK from being updated by Renovate. While this updates configuration to the latest available, it often is met with runners and other systems not having that available and since the latest runtime is coming along per the above we should be fine.

Relevant discussion at https://bitwarden.slack.com/archives/C04LE162PHA/p1699296762613869.

## Code changes

* **global.json:** Sets SDK to 6.0.100.
* **.github/renovate.json:** Ignores the .NET SDK dependency for updates.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
