### PR TITLE
Remove tech-leads as default codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,7 +44,3 @@ bitwarden_license/src/test/Scim.ScimTest @bitwarden/team-admin-console-dev
 **/*stripe* @bitwarden/team-billing-dev
 **/*subscription* @bitwarden/team-billing-dev
 **/Billing @bitwarden/team-billing-dev
-
-# Multiple owners
-**/packages.lock.json
-Directory.Build.props

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,8 @@
-﻿# Please sort lines alphabetically, this will ensure we don't accidentally add duplicates.
+# Please sort into logical groups with comment headers. Sort groups in order of specificity.
+# For example, default owners should always be the first group.
+# Sort lines alphabetically within these groups to avoid accidentally adding duplicates.
 #
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-
-# The following owners will be the default owners for everything in the repo
-# unless a later match takes precedence
-* @bitwarden/tech-leads
 
 # DevOps for Actions and other workflow changes
 .github/workflows @bitwarden/dept-devops


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Removes the tech-leads as the default code owner to speed up work. Most files should have gotten an owner by now.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
