### PR TITLE
[AC-1839] Fixed missing reference on OrganizationLicenseFileFixtures

### DIFF
--- a/test/Core.Test/Models/Business/OrganizationLicenseFileFixtures.cs
+++ b/test/Core.Test/Models/Business/OrganizationLicenseFileFixtures.cs
@@ -1,5 +1,5 @@
 ﻿using System.Text.Json;
-using Bit.Core.Entities;
+using Bit.Core.AdminConsole.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Models.Business;
 

--- a/test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/UpdateSecretsManagerSubscriptionCommandTests.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/UpdateSecretsManagerSubscriptionCommandTests.cs
@@ -94,6 +94,7 @@ public class UpdateSecretsManagerSubscriptionCommandTests
         SutProvider<UpdateSecretsManagerSubscriptionCommand> sutProvider)
     {
         organization.PlanType = planType;
+        organization.Seats = 20;
 
         const int updateSmSeats = 15;
         const int updateSmServiceAccounts = 450;


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective
The changes in https://github.com/bitwarden/server/pull/3474 were missing a reference on `OrganizationLicenseFileFixtures` which broke the build. Also fixed an unrelated flaky unit test on `UpdateSecretsManagerSubscriptionCommandTests`.


## Code changes
The original changes were in https://github.com/bitwarden/server/pull/3474.

* **test/Core.Test/Models/Business/OrganizationLicenseFileFixtures.cs:** Added missing reference
* **test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/UpdateSecretsManagerSubscriptionCommandTests.cs:** Fixed flaky unit test

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
