### PR TITLE
[AC-1868] Fix UserCipherDetails_V2 Function

### DIFF
--- a/src/Sql/Vault/dbo/Functions/UserCipherDetails_V2.sql
+++ b/src/Sql/Vault/dbo/Functions/UserCipherDetails_V2.sql
@@ -14,9 +14,9 @@ WITH [CTE] AS (
 SELECT
     C.*,
     CASE
-	    WHEN COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) = 0
-	    THEN 1
-	    ELSE 0
+        WHEN COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) = 0
+        THEN 1
+        ELSE 0
     END [Edit],
     CASE
     	WHEN COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0

--- a/src/Sql/Vault/dbo/Functions/UserCipherDetails_V2.sql
+++ b/src/Sql/Vault/dbo/Functions/UserCipherDetails_V2.sql
@@ -22,7 +22,7 @@ SELECT
     	WHEN COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
     	THEN 1
     	ELSE 0
-	END [ViewPassword],
+    END [ViewPassword],
     CASE
         WHEN O.[UseTotp] = 1
         THEN 1

--- a/util/Migrator/DbScripts/2023-11-29_00_FixUserCipherDetails_V2.sql
+++ b/util/Migrator/DbScripts/2023-11-29_00_FixUserCipherDetails_V2.sql
@@ -1,4 +1,4 @@
-﻿CREATE FUNCTION [dbo].[UserCipherDetails_V2](@UserId UNIQUEIDENTIFIER)
+CREATE OR ALTER FUNCTION [dbo].[UserCipherDetails_V2](@UserId UNIQUEIDENTIFIER)
 RETURNS TABLE
 AS RETURN
 WITH [CTE] AS (
@@ -27,7 +27,7 @@ SELECT
         WHEN O.[UseTotp] = 1
         THEN 1
         ELSE 0
-    END [OrganizationUseTotp]
+END [OrganizationUseTotp]
 FROM
     [dbo].[CipherDetails](@UserId) C
 INNER JOIN
@@ -59,3 +59,4 @@ FROM
     [dbo].[CipherDetails](@UserId)
 WHERE
     [UserId] = @UserId
+    GO

--- a/util/Migrator/DbScripts/2023-11-29_00_FixUserCipherDetails_V2.sql
+++ b/util/Migrator/DbScripts/2023-11-29_00_FixUserCipherDetails_V2.sql
@@ -27,7 +27,7 @@ SELECT
         WHEN O.[UseTotp] = 1
         THEN 1
         ELSE 0
-END [OrganizationUseTotp]
+    END [OrganizationUseTotp]
 FROM
     [dbo].[CipherDetails](@UserId) C
 INNER JOIN
@@ -59,4 +59,4 @@ FROM
     [dbo].[CipherDetails](@UserId)
 WHERE
     [UserId] = @UserId
-    GO
+GO

--- a/util/Migrator/DbScripts/2023-11-29_00_FixUserCipherDetails_V2.sql
+++ b/util/Migrator/DbScripts/2023-11-29_00_FixUserCipherDetails_V2.sql
@@ -14,9 +14,9 @@ WITH [CTE] AS (
 SELECT
     C.*,
     CASE
-	    WHEN COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) = 0
-	    THEN 1
-	    ELSE 0
+        WHEN COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) = 0
+        THEN 1
+        ELSE 0
     END [Edit],
     CASE
     	WHEN COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0

--- a/util/Migrator/DbScripts/2023-11-29_00_FixUserCipherDetails_V2.sql
+++ b/util/Migrator/DbScripts/2023-11-29_00_FixUserCipherDetails_V2.sql
@@ -22,7 +22,7 @@ SELECT
     	WHEN COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
     	THEN 1
     	ELSE 0
-	END [ViewPassword],
+    END [ViewPassword],
     CASE
         WHEN O.[UseTotp] = 1
         THEN 1


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

We introduced `UserCipherDetails_V2` in https://github.com/bitwarden/server/pull/3372 and we mistakenly inverted the logic surrounding the `[Edit]` and `[ViewPassword]` fields. This PR fixes that by re-introducing the `CASE WHEN .. THEN .. ELSE` statement for both of those fields.


## Code changes

Update the Db funciton and add a migration script.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
