### PR TITLE
[Flexible collections] Experiment: add CreateNewCollections to JWT claims

### DIFF
--- a/src/Api/Vault/AuthorizationHandlers/Collections/CollectionAuthorizationHandler.cs
+++ b/src/Api/Vault/AuthorizationHandlers/Collections/CollectionAuthorizationHandler.cs
@@ -83,10 +83,7 @@ public class CollectionAuthorizationHandler : BulkAuthorizationHandler<Collectio
     {
         // If the limit collection management setting is disabled, allow any user to create collections
         // Otherwise, Owners, Admins, and users with CreateNewCollections permission can always create collections
-        if (org is
-        { LimitCollectionCreationDeletion: false } or
-        { Type: OrganizationUserType.Owner or OrganizationUserType.Admin } or
-        { Permissions.CreateNewCollections: true })
+        if (org is {CreateNewCollections: true})
         {
             context.Succeed(requirement);
             return;

--- a/src/Core/AdminConsole/Context/CurrentContextOrganization.cs
+++ b/src/Core/AdminConsole/Context/CurrentContextOrganization.cs
@@ -11,18 +11,34 @@ public class CurrentContextOrganization
 
     public CurrentContextOrganization(OrganizationUserOrganizationDetails orgUser)
     {
+        var customPermissions = CoreHelpers.LoadClassFromJsonData<Permissions>(orgUser.Permissions);
+
         Id = orgUser.OrganizationId;
         Type = orgUser.Type;
-        Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(orgUser.Permissions);
+        Permissions = customPermissions;
         AccessSecretsManager = orgUser.AccessSecretsManager && orgUser.UseSecretsManager && orgUser.Enabled;
         LimitCollectionCreationDeletion = orgUser.LimitCollectionCreationDeletion;
         AllowAdminAccessToAllCollectionItems = orgUser.AllowAdminAccessToAllCollectionItems;
+
+        // Permissions that depend on collection management settings
+        // Usually we calculate specific permissions from the orgUser's role, however collection management settings
+        // fundamentally change what different roles can do, so we include them here to avoid db lookups
+        CreateNewCollections = !orgUser.LimitCollectionCreationDeletion ||
+                               customPermissions.CreateNewCollections ||
+                               orgUser.Type is OrganizationUserType.Admin or OrganizationUserType.Owner;
     }
 
     public Guid Id { get; set; }
     public OrganizationUserType Type { get; set; }
     public Permissions Permissions { get; set; } = new();
     public bool AccessSecretsManager { get; set; }
-    public bool LimitCollectionCreationDeletion { get; set; }
-    public bool AllowAdminAccessToAllCollectionItems { get; set; }
+    public bool LimitCollectionCreationDeletion { get; set; }   // this would be deleted
+    public bool AllowAdminAccessToAllCollectionItems { get; set; }   // this would be deleted
+
+    /// <summary>
+    /// Whether the user can create new collections for the organization, taking into account the collection
+    /// management settings introduced with Flexible Collections.
+    /// </summary>
+    public bool CreateNewCollections { get; set; }
+    // TODO: add DeleteManagedCollections (mvp) and AccessAllItems (v1)
 }

--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -175,6 +175,10 @@ public class CurrentContext : ICurrentContext
             ? claimsDict[Claims.SecretsManagerAccess].ToDictionary(s => s.Value, _ => true)
             : new Dictionary<string, bool>();
 
+        var createNewCollections = claimsDict.ContainsKey(Claims.CreateNewCollections)
+            ? claimsDict[Claims.CreateNewCollections].ToDictionary(s => s.Value, _ => true)
+            : new Dictionary<string, bool>();
+
         var organizations = new List<CurrentContextOrganization>();
         if (claimsDict.ContainsKey(Claims.OrganizationOwner))
         {
@@ -184,6 +188,7 @@ public class CurrentContext : ICurrentContext
                     Id = new Guid(c.Value),
                     Type = OrganizationUserType.Owner,
                     AccessSecretsManager = accessSecretsManager.ContainsKey(c.Value),
+                    CreateNewCollections = createNewCollections.ContainsKey(c.Value)
                 }));
         }
         else if (orgApi && OrganizationId.HasValue)
@@ -203,6 +208,7 @@ public class CurrentContext : ICurrentContext
                     Id = new Guid(c.Value),
                     Type = OrganizationUserType.Admin,
                     AccessSecretsManager = accessSecretsManager.ContainsKey(c.Value),
+                    CreateNewCollections = createNewCollections.ContainsKey(c.Value)
                 }));
         }
 
@@ -214,6 +220,7 @@ public class CurrentContext : ICurrentContext
                     Id = new Guid(c.Value),
                     Type = OrganizationUserType.User,
                     AccessSecretsManager = accessSecretsManager.ContainsKey(c.Value),
+                    CreateNewCollections = createNewCollections.ContainsKey(c.Value)
                 }));
         }
 
@@ -225,6 +232,7 @@ public class CurrentContext : ICurrentContext
                     Id = new Guid(c.Value),
                     Type = OrganizationUserType.Manager,
                     AccessSecretsManager = accessSecretsManager.ContainsKey(c.Value),
+                    CreateNewCollections = createNewCollections.ContainsKey(c.Value)
                 }));
         }
 
@@ -237,6 +245,7 @@ public class CurrentContext : ICurrentContext
                     Type = OrganizationUserType.Custom,
                     Permissions = SetOrganizationPermissionsFromClaims(c.Value, claimsDict),
                     AccessSecretsManager = accessSecretsManager.ContainsKey(c.Value),
+                    CreateNewCollections = createNewCollections.ContainsKey(c.Value)
                 }));
         }
 

--- a/src/Core/Identity/Claims.cs
+++ b/src/Core/Identity/Claims.cs
@@ -16,6 +16,9 @@ public static class Claims
     public const string ProviderServiceUser = "providerserviceuser";
 
     public const string SecretsManagerAccess = "accesssecretsmanager";
+    public const string CreateNewCollections = "createcollect";
+    public const string DeleteManagedCollections = "deletecollect";
+    public const string AccessAllItems = "accessitems";
 
     // Service Account
     public const string Organization = "organization";

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -692,12 +692,17 @@ public static class CoreHelpers
                         break;
                 }
 
-                // Secrets Manager
+                // Additional claims for the above orgs
                 foreach (var org in group)
                 {
                     if (org.AccessSecretsManager)
                     {
                         claims.Add(new KeyValuePair<string, string>(Claims.SecretsManagerAccess, org.Id.ToString()));
+                    }
+
+                    if (org.CreateNewCollections)
+                    {
+                        claims.Add(new KeyValuePair<string, string>(Claims.CreateNewCollections, org.Id.ToString()));
                     }
                 }
             }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Collection management settings affect what roles can do:
* LimitCollectionCreationDeletion affects whether everyone can create a new collection, or only users with admin permissions
* LimitCollectionCreationDeletion also affects whether a user with Can Manage permissions for a collection can delete that collection (or only users with admin permissions can)
* AllowAdminAccessToAllCollectionItems affects whether admins and owners can view items in unassigned collections

Therefore, it is no longer enough to just know the role, we also need to know the value of these settings to know what a given role can do.

We have 3 options:
1. Include the setting directly in the claims - rejected in #3433 
2. Calculate the more granular permission and include it in the claims (this PR) - suggested by @withinfocus
3. Leave it out of the claims completely and expand the OrgAbilities cache to include collection management settings (to still avoid a database read)

This PR tries out no. 2, adding granular permissions to the claims. I am not endorsing this approach necessarily.

Advantages:
* more authorization logic can make decisions based on a "dumb" data object (`CurrentContextOrganization`) rather than having to fetch data from multiple sources
* avoids async calls to database or cache service
* centralises this `CanCreateCollections` logic in 1 place, otherwise it's repeated quite a few times across authorization handlers after the changes in #3360. Of course we could always centralise the logic elsewhere, but it's a nice side-effect.
* probably the easiest, based on the changeset in this PR.

Disadvantages:
* Microsoft suggests that claims should be based on identity (e.g. "this user is an owner"), not ability (e.g. "this user can create collections"). This violates that rule. ([docs](https://learn.microsoft.com/en-us/aspnet/core/security/authorization/claims?view=aspnetcore-8.0))
* adding more weight to the JWT which is sent with every request to the server. What's our limit here - is there a risk we keep adding to the JWT instead of investing in other caching solutions?
* inconsistent with how we handle other permissions, which are calculated in the code based on role, not calculated upfront and stored in the JWT
* can be slow to update after db value changes (need to wait until a token refresh)

If we don't go with 2, then we go with 3, adding the collection management settings to the org abilities cache. A collection management setting is not really an org "ability", so it's expanding the purposes of that cache, but that might be OK given that the cache is storing commonly accessed org properties. That would leave it to the authorization code to decide what to do based on the value of `orgAbility.LimitCollectionCreationDeletion`.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
