### PR TITLE
[AC-1873] Fix: restore logic assigning Managers to new collections server-side

### DIFF
--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -4,7 +4,9 @@ using Bit.Api.Vault.AuthorizationHandlers.Collections;
 using Bit.Core;
 using Bit.Core.Context;
 using Bit.Core.Entities;
+using Bit.Core.Enums;
 using Bit.Core.Exceptions;
+using Bit.Core.Models.Data;
 using Bit.Core.OrganizationFeatures.OrganizationCollections.Interfaces;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
@@ -26,6 +28,7 @@ public class CollectionsController : Controller
     private readonly ICurrentContext _currentContext;
     private readonly IBulkAddCollectionAccessCommand _bulkAddCollectionAccessCommand;
     private readonly IFeatureService _featureService;
+    private readonly IOrganizationUserRepository _organizationUserRepository;
 
     public CollectionsController(
         ICollectionRepository collectionRepository,
@@ -35,7 +38,8 @@ public class CollectionsController : Controller
         IAuthorizationService authorizationService,
         ICurrentContext currentContext,
         IBulkAddCollectionAccessCommand bulkAddCollectionAccessCommand,
-        IFeatureService featureService)
+        IFeatureService featureService,
+        IOrganizationUserRepository organizationUserRepository)
     {
         _collectionRepository = collectionRepository;
         _collectionService = collectionService;
@@ -45,6 +49,7 @@ public class CollectionsController : Controller
         _currentContext = currentContext;
         _bulkAddCollectionAccessCommand = bulkAddCollectionAccessCommand;
         _featureService = featureService;
+        _organizationUserRepository = organizationUserRepository;
     }
 
     private bool FlexibleCollectionsIsEnabled => _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollections, _currentContext);
@@ -168,7 +173,28 @@ public class CollectionsController : Controller
         }
 
         var groups = model.Groups?.Select(g => g.ToSelectionReadOnly());
-        var users = model.Users?.Select(g => g.ToSelectionReadOnly());
+        var users = model.Users?.Select(g => g.ToSelectionReadOnly()).ToList();
+
+        // Pre-flexible collections logic assigned Managers to collections they create
+        var assignUserToCollection =
+            !FlexibleCollectionsIsEnabled &&
+            !await _currentContext.EditAnyCollection(orgId) &&
+            await _currentContext.EditAssignedCollections(orgId);
+        var isNewCollection = collection.Id == default;
+
+        if (assignUserToCollection && isNewCollection && _currentContext.UserId.HasValue)
+        {
+            var orgUser = await _organizationUserRepository.GetByOrganizationAsync(orgId, _currentContext.UserId.Value);
+            if (orgUser is { Status: OrganizationUserStatusType.Confirmed })
+            {
+                users ??= new List<CollectionAccessSelection>();
+                users.Add(new CollectionAccessSelection
+                {
+                    Id = orgUser.Id,
+                    ReadOnly = false
+                });
+            }
+        }
 
         await _collectionService.SaveAsync(collection, groups, users);
         return new CollectionResponseModel(collection);


### PR DESCRIPTION
…ections

## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Restore previous behaviour when creating a new collection:

* front-end - no users are added by default
* server - if you're a Manager or have EditAssignedCollections permission, you're assigned to the collection on creation

The clients PR is https://github.com/bitwarden/clients/pull/7051.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Previously, we calculated an [assignUserToCollection](https://github.com/bitwarden/server/blob/e16d5f058528f97045bfd5f38ec972144c36450a/src/Api/Controllers/CollectionsController.cs#L153-L154) variable in the controller, and passed it into CollectionService.SaveAsync which would [give that user access](https://github.com/bitwarden/server/blob/e16d5f058528f97045bfd5f38ec972144c36450a/src/Core/Services/Implementations/CollectionService.cs#L66-L76).

Our interfaces have changed since then, we've removed the `assignUserId` parameter from `SaveAsync`, which I think is for the best. We already pass in a list of users with access, let's just add the current user to that list in the controller if required. It wasn't used by any other calling location.

Therefore, this PR just updates the controller to add the currentUser to the user collection access, if the flag is off and they have manager permissions.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
