### PR TITLE
Suppress AzureSQLMaintenance Warning

### DIFF
--- a/src/Sql/Sql.sqlproj
+++ b/src/Sql/Sql.sqlproj
@@ -12,5 +12,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Build Remove="dbo_future/**/*" />
+
+    <!-- Remove file just so we can add it back with some suppressions -->
+    <Build Remove="dbo/Stored Procedures/AzureSQLMaintenance.sql" />
+    <Build Include="dbo/Stored Procedures/AzureSQLMaintenance.sql">
+      <SuppressTSqlWarnings>71502</SuppressTSqlWarnings>
+    </Build>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
I think it's highly unlikely that we will determine it's worth it to go into this file AND make a migration with the updates to actually get the warnings turned off the right way so instead we can just suppress the warning for this file only. 

Snapshot of the warnings just from this project before the change:
```
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(153,47,153,47): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_stats_properties].[s]::[object_id], [sys].[stats].[object_id] or [sys].[stats].[s]::[object_id]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(154,39,154,39): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_stats_properties].[s]::[object_id], [sys].[stats].[object_id] or [sys].[stats].[s]::[object_id]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(162,34,162,34): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_stats_properties].[s]::[object_id], [sys].[stats].[object_id] or [sys].[stats].[s]::[object_id]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(161,77,161,77): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[stats].[s]::[stats_id] or [sys].[stats].[stats_id]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(157,14,157,14): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_stats_properties].[rows], [sys].[dm_db_stats_properties].[sp]::[rows] or [sys].[stats].[sp]::[rows]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(83,14,83,14): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[i]::[record_count], [sys].[dm_db_index_physical_stats].[record_count] or [sys].[indexes].[i]::[record_count]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(156,14,156,14): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_stats_properties].[last_updated], [sys].[dm_db_stats_properties].[sp]::[last_updated] or [sys].[stats].[sp]::[last_updated]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(163,18,163,18): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_stats_properties].[last_updated], [sys].[dm_db_stats_properties].[sp]::[last_updated] or [sys].[stats].[sp]::[last_updated]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(161,65,161,65): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[stats].[object_id] or [sys].[stats].[s]::[object_id]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(91,55,91,55): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[page_count] or [sys].[indexes].[page_count]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(159,14,159,14): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_stats_properties].[modification_counter], [sys].[dm_db_stats_properties].[sp]::[modification_counter] or [sys].[stats].[sp]::[modification_counter]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(162,61,162,61): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_stats_properties].[modification_counter], [sys].[dm_db_stats_properties].[sp]::[modification_counter] or [sys].[stats].[sp]::[modification_counter]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(89,72,89,72): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[i]::[index_id], [sys].[dm_db_index_physical_stats].[index_id] or [sys].[indexes].[i]::[index_id]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(79,14,79,14): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[i]::[index_id], [sys].[dm_db_index_physical_stats].[index_id] or [sys].[indexes].[i]::[index_id]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(88,14,88,14): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] has an unresolved reference to object [sys].[dm_db_index_physical_stats]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(81,14,81,14): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[i]::[index_type_desc], [sys].[dm_db_index_physical_stats].[index_type_desc] or [sys].[indexes].[i]::[index_type_desc]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(78,14,78,14): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[i]::[page_count], [sys].[dm_db_index_physical_stats].[page_count] or [sys].[indexes].[i]::[page_count]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(89,19,89,19): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] has an unresolved reference to object [sys].[indexes]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(82,14,82,14): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[avg_page_space_used_in_percent], [sys].[dm_db_index_physical_stats].[i]::[avg_page_space_used_in_percent] or [sys].[indexes].[i]::[avg_page_space_used_in_percent]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(84,14,84,14): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[ghost_record_count], [sys].[dm_db_index_physical_stats].[i]::[ghost_record_count] or [sys].[indexes].[i]::[ghost_record_count]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(161,14,161,14): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] has an unresolved reference to object [sys].[stats]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(155,14,155,14): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_stats_properties].[s]::[name], [sys].[stats].[name] or [sys].[stats].[s]::[name]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(90,15,90,15): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[idxs]::[type], [sys].[indexes].[idxs]::[type] or [sys].[indexes].[type]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(85,14,85,14): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[forwarded_record_count], [sys].[dm_db_index_physical_stats].[i]::[forwarded_record_count] or [sys].[indexes].[i]::[forwarded_record_count]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(89,39,89,39): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[i]::[object_id], [sys].[dm_db_index_physical_stats].[object_id] or [sys].[indexes].[i]::[object_id]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(73,13,73,13): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[i]::[object_id], [sys].[dm_db_index_physical_stats].[object_id] or [sys].[indexes].[i]::[object_id]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(74,48,74,48): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[i]::[object_id], [sys].[dm_db_index_physical_stats].[object_id] or [sys].[indexes].[i]::[object_id]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(75,39,75,39): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[i]::[object_id], [sys].[dm_db_index_physical_stats].[object_id] or [sys].[indexes].[i]::[object_id]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(158,14,158,14): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_stats_properties].[rows_sampled], [sys].[dm_db_stats_properties].[sp]::[rows_sampled] or [sys].[stats].[sp]::[rows_sampled]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(89,53,89,53): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[idxs]::[object_id], [sys].[indexes].[idxs]::[object_id] or [sys].[indexes].[object_id]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(80,14,80,14): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[i]::[partition_number], [sys].[dm_db_index_physical_stats].[partition_number] or [sys].[indexes].[i]::[partition_number]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(76,14,76,14): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[idxs]::[name], [sys].[indexes].[idxs]::[name] or [sys].[indexes].[name]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(77,14,77,14): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[avg_fragmentation_in_percent], [sys].[dm_db_index_physical_stats].[i]::[avg_fragmentation_in_percent] or [sys].[indexes].[i]::[avg_fragmentation_in_percent]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(91,18,91,18): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[avg_fragmentation_in_percent], [sys].[dm_db_index_physical_stats].[i]::[avg_fragmentation_in_percent] or [sys].[indexes].[i]::[avg_fragmentation_in_percent]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(89,85,89,85): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[idxs]::[index_id], [sys].[indexes].[idxs]::[index_id] or [sys].[indexes].[index_id]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(161,38,161,38): Build warning SQL71502: SqlProcedure: [dbo].[AzureSQLMaintenance] has an unresolved reference to object [sys].[dm_db_stats_properties]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(82,14,82,14): Build warning SQL71502: SqlComputedColumn: [#idxBefore].[avg_page_space_used_in_percent] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[avg_page_space_used_in_percent], [sys].[dm_db_index_physical_stats].[i]::[avg_page_space_used_in_percent] or [sys].[indexes].[i]::[avg_page_space_used_in_percent]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(85,14,85,14): Build warning SQL71502: SqlComputedColumn: [#idxBefore].[forwarded_record_count] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[forwarded_record_count], [sys].[dm_db_index_physical_stats].[i]::[forwarded_record_count] or [sys].[indexes].[i]::[forwarded_record_count]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(159,14,159,14): Build warning SQL71502: SqlComputedColumn: [#statsBefore].[modification_counter] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_stats_properties].[modification_counter], [sys].[dm_db_stats_properties].[sp]::[modification_counter] or [sys].[stats].[sp]::[modification_counter]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(79,14,79,14): Build warning SQL71502: SqlComputedColumn: [#idxBefore].[index_id] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[i]::[index_id], [sys].[dm_db_index_physical_stats].[index_id] or [sys].[indexes].[i]::[index_id]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(78,14,78,14): Build warning SQL71502: SqlComputedColumn: [#idxBefore].[page_count] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[i]::[page_count], [sys].[dm_db_index_physical_stats].[page_count] or [sys].[indexes].[i]::[page_count]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(157,14,157,14): Build warning SQL71502: SqlComputedColumn: [#statsBefore].[rows] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_stats_properties].[rows], [sys].[dm_db_stats_properties].[sp]::[rows] or [sys].[stats].[sp]::[rows]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(73,13,73,13): Build warning SQL71502: SqlComputedColumn: [#idxBefore].[object_id] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[i]::[object_id], [sys].[dm_db_index_physical_stats].[object_id] or [sys].[indexes].[i]::[object_id]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(80,14,80,14): Build warning SQL71502: SqlComputedColumn: [#idxBefore].[partition_number] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[i]::[partition_number], [sys].[dm_db_index_physical_stats].[partition_number] or [sys].[indexes].[i]::[partition_number]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(81,14,81,14): Build warning SQL71502: SqlComputedColumn: [#idxBefore].[index_type_desc] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[i]::[index_type_desc], [sys].[dm_db_index_physical_stats].[index_type_desc] or [sys].[indexes].[i]::[index_type_desc]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(84,14,84,14): Build warning SQL71502: SqlComputedColumn: [#idxBefore].[ghost_record_count] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[ghost_record_count], [sys].[dm_db_index_physical_stats].[i]::[ghost_record_count] or [sys].[indexes].[i]::[ghost_record_count]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(156,14,156,14): Build warning SQL71502: SqlComputedColumn: [#statsBefore].[last_updated] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_stats_properties].[last_updated], [sys].[dm_db_stats_properties].[sp]::[last_updated] or [sys].[stats].[sp]::[last_updated]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(83,14,83,14): Build warning SQL71502: SqlComputedColumn: [#idxBefore].[record_count] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[i]::[record_count], [sys].[dm_db_index_physical_stats].[record_count] or [sys].[indexes].[i]::[record_count]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(158,14,158,14): Build warning SQL71502: SqlComputedColumn: [#statsBefore].[rows_sampled] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_stats_properties].[rows_sampled], [sys].[dm_db_stats_properties].[sp]::[rows_sampled] or [sys].[stats].[sp]::[rows_sampled]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(76,14,76,14): Build warning SQL71502: SqlComputedColumn: [#idxBefore].[IndexName] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[idxs]::[name], [sys].[indexes].[idxs]::[name] or [sys].[indexes].[name]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(155,14,155,14): Build warning SQL71502: SqlComputedColumn: [#statsBefore].[StatsName] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_stats_properties].[s]::[name], [sys].[stats].[name] or [sys].[stats].[s]::[name]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/AzureSQLMaintenance.sql(77,14,77,14): Build warning SQL71502: SqlComputedColumn: [#idxBefore].[avg_fragmentation_in_percent] contains an unresolved reference to an object. Either the object does not exist or the reference is ambiguous because it could refer to any of the following objects: [sys].[dm_db_index_physical_stats].[avg_fragmentation_in_percent], [sys].[dm_db_index_physical_stats].[i]::[avg_fragmentation_in_percent] or [sys].[indexes].[i]::[avg_fragmentation_in_percent]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/OrganizationSponsorship_ReadBySponsoringOrganiationUserId.sql(1,1,1,1): Build warning SQL71558: The object reference [dbo].[OrganizationSponsorshipView].[SponsoringOrganizationUserId] differs only by case from the object definition [dbo].[OrganizationSponsorshipView].[SponsoringOrganizationUserID]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/OrganizationDomainSsoDetails_ReadByEmail.sql(1,1,1,1): Build warning SQL71558: The object reference [dbo].[Ssoconfig].[OrganizationId] differs only by case from the object definition [dbo].[SsoConfig].[OrganizationId]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/OrganizationDomainSsoDetails_ReadByEmail.sql(1,1,1,1): Build warning SQL71558: The object reference [dbo].[Ssoconfig] differs only by case from the object definition [dbo].[SsoConfig]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/OrganizationDomainSsoDetails_ReadByEmail.sql(1,1,1,1): Build warning SQL71558: The object reference [dbo].[Ssoconfig].[Enabled] differs only by case from the object definition [dbo].[SsoConfig].[Enabled]. [src/Sql/Sql.sqlproj]
```

After:
```
src/Sql/dbo/Stored Procedures/OrganizationSponsorship_ReadBySponsoringOrganiationUserId.sql(1,1,1,1): Build warning SQL71558: The object reference [dbo].[OrganizationSponsorshipView].[SponsoringOrganizationUserId] differs only by case from the object definition [dbo].[OrganizationSponsorshipView].[SponsoringOrganizationUserID]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/OrganizationDomainSsoDetails_ReadByEmail.sql(1,1,1,1): Build warning SQL71558: The object reference [dbo].[Ssoconfig].[OrganizationId] differs only by case from the object definition [dbo].[SsoConfig].[OrganizationId]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/OrganizationDomainSsoDetails_ReadByEmail.sql(1,1,1,1): Build warning SQL71558: The object reference [dbo].[Ssoconfig] differs only by case from the object definition [dbo].[SsoConfig]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/OrganizationDomainSsoDetails_ReadByEmail.sql(1,1,1,1): Build warning SQL71558: The object reference [dbo].[Ssoconfig].[Enabled] differs only by case from the object definition [dbo].[SsoConfig].[Enabled]. [src/Sql/Sql.sqlproj]
```

[The file](https://github.com/bitwarden/server/blob/519b3dea2483ccd06bd9dd9019ef23e96173ee61/src/Sql/dbo/Stored%20Procedures/AzureSQLMaintenance.sql) has not had changes for 5 years so their haven't actually been issues regarding it that have needed to be fixed. 

This now takes us from 87 to 32 warnings which I believe helps us get to a point where warnings are less overwhelming and can be taken care of a little easier. And maybe one step closer to a `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` world.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Sql/Sql.sqlproj:** Remove file from build and add it back with a suppression for a single rule.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
