### PR TITLE
Revert "Remove .NET SDK constraint for Renovate"

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -199,5 +199,10 @@
       "reviewers": ["team:team-vault-dev"]
     }
   ],
+  "force": {
+    "constraints": {
+      "dotnet": "6.0.100"
+    }
+  },
   "ignoreDeps": ["dotnet-sdk"]
 }


### PR DESCRIPTION
Reverts bitwarden/server#3488 as this did not work as tested. If we were running .NET 8 as is expected in the Renovate container it would be fine I guess.