### PR TITLE
Fix SM integration test rate limiting

### DIFF
--- a/test/IntegrationTestCommon/FakeRemoteIpAddressMiddleware.cs
+++ b/test/IntegrationTestCommon/FakeRemoteIpAddressMiddleware.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using Bit.IntegrationTestCommon.Factories;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -13,7 +14,7 @@ public class FakeRemoteIpAddressMiddleware
     public FakeRemoteIpAddressMiddleware(RequestDelegate next, IPAddress fakeIpAddress = null)
     {
         _next = next;
-        _fakeIpAddress = fakeIpAddress ?? IPAddress.Parse("127.0.0.1");
+        _fakeIpAddress = fakeIpAddress ?? IPAddress.Parse(FactoryConstants.WhitelistedIp);
     }
 
     public async Task Invoke(HttpContext httpContext)


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The SM integration tests are running into rate limiting errors https://github.com/bitwarden/server/runs/19303223216#r0s4. 

Based on the comments here:
https://github.com/bitwarden/server/blob/f424cc09f72b0b237ef8e892f5146bcff3707a6e/test/IntegrationTestCommon/Factories/WebApplicationFactoryBase.cs#L161-L173

 I believe, we wanted to whitelist an IP from rate limiting and use that IP. Currently, the IP set in `test/IntegrationTestCommon/FakeRemoteIpAddressMiddleware.cs` is different.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **test/IntegrationTestCommon/FakeRemoteIpAddressMiddleware.cs:**
Use the whitelisted IP address for SM integration tests by default.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
