### PR TITLE
[PM-5183] Install specific dotnet-ef version and restore before first usage

### DIFF
--- a/dev/migrate.ps1
+++ b/dev/migrate.ps1
@@ -24,7 +24,8 @@ if ($all -or $postgres -or $mysql -or $sqlite) {
   dotnet ef *> $null
   if ($LASTEXITCODE -ne 0) {
     Write-Host "Entity Framework Core tools were not found in the dotnet global tools. Attempting to install"
-    dotnet tool install dotnet-ef -g
+    dotnet tool install dotnet-ef -g --version 6.0.25
+    dotnet tool restore
   }
 }
 


### PR DESCRIPTION
## Type of change

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

I was trying to follow your development guide (https://contributing.bitwarden.com/getting-started/server/guide/#configure-user-secrets) step by step on Ubuntu 23.10 with VSCode and .NET 6 + .NET 7 and .NET 8 installed.

It went problematic when I tried to apply the migrations because `dotnet tool install dotnet-ef -g` tries to install the newest version (8.x.x) which is incompatible with .NET 6:

```
error NU1202: Das Paket dotnet-ef 8.0.0 ist nicht mit net6.0 (.NETCoreApp,Version=v6.0)/any kompatibel. Paket dotnet-ef 8.0.0 unterstützt Folgendes: net8.0 (.NETCoreApp,Version=v8.0)/any
```

That is why I modified the `dotnet tool install dotnet-ef -g` line to become `dotnet tool install dotnet-ef -g --version 6.0.25` (I don't know how to tell dotnet tool to install the latest minor version).

This change alone was not enough, since the tool is not yet restored but is about to be used a few lines later (`dotnet ef database update`). Which is why is also added `dotnet tool restore` to the script.

Again, this was not sufficient to make migrations work because then the error became `No Postgres connection string found.`. I found that it is required to configure the user secrets before doing the migrations so that the connection string is available. So I jumped to [Configure User Secrets](https://contributing.bitwarden.com/getting-started/server/guide/#configure-user-secrets) and after following that guide I was able to apply the migrations. This means the documentation should be changed so that [Configure User Secrets](https://contributing.bitwarden.com/getting-started/server/guide/#configure-user-secrets) comes before [Create database](https://contributing.bitwarden.com/getting-started/server/guide/#create-database). How do I `notify the documentation team` as mentioned below?


## Code changes

see description above, only 2 lines have changed

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
