### PR TITLE
[AC-1981] Fix CollectionsController.Get auth check by just checking collections for the requested orgId

### DIFF
--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -611,11 +611,6 @@ public class CollectionsController : Controller
         {
             var assignedCollections = await _collectionRepository.GetManyByUserIdAsync(_currentContext.UserId.Value, FlexibleCollectionsIsEnabled);
             orgCollections = assignedCollections.Where(c => c.OrganizationId == orgId && c.Manage).ToList();
-            var readAuthorized = (await _authorizationService.AuthorizeAsync(User, orgCollections, BulkCollectionOperations.Read)).Succeeded;
-            if (!readAuthorized)
-            {
-                throw new NotFoundException();
-            }
         }
 
         var responses = orgCollections.Select(c => new CollectionResponseModel(c));

--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -610,7 +610,7 @@ public class CollectionsController : Controller
         else
         {
             var assignedCollections = await _collectionRepository.GetManyByUserIdAsync(_currentContext.UserId.Value, FlexibleCollectionsIsEnabled);
-            orgCollections = assignedCollections.Where(c => c.OrganizationId == orgId).ToList();
+            orgCollections = assignedCollections.Where(c => c.OrganizationId == orgId && c.Manage).ToList();
             var readAuthorized = (await _authorizationService.AuthorizeAsync(User, orgCollections, BulkCollectionOperations.Read)).Succeeded;
             if (!readAuthorized)
             {

--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -609,13 +609,10 @@ public class CollectionsController : Controller
         }
         else
         {
-            var collections = await _collectionRepository.GetManyByUserIdAsync(_currentContext.UserId.Value, FlexibleCollectionsIsEnabled);
-            var readAuthorized = (await _authorizationService.AuthorizeAsync(User, collections, BulkCollectionOperations.Read)).Succeeded;
-            if (readAuthorized)
-            {
-                orgCollections = collections.Where(c => c.OrganizationId == orgId);
-            }
-            else
+            var assignedCollections = await _collectionRepository.GetManyByUserIdAsync(_currentContext.UserId.Value, FlexibleCollectionsIsEnabled);
+            orgCollections = assignedCollections.Where(c => c.OrganizationId == orgId).ToList();
+            var readAuthorized = (await _authorizationService.AuthorizeAsync(User, orgCollections, BulkCollectionOperations.Read)).Succeeded;
+            if (!readAuthorized)
             {
                 throw new NotFoundException();
             }

--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -584,11 +584,6 @@ public class CollectionsController : Controller
 
         // Filter the assigned collections to only return those where the user has Manage permission
         var manageableOrgCollections = assignedOrgCollections.Where(c => c.Item1.Manage).ToList();
-        var readAssignedAuthorized = await _authorizationService.AuthorizeAsync(User, manageableOrgCollections.Select(c => c.Item1), BulkCollectionOperations.ReadWithAccess);
-        if (!readAssignedAuthorized.Succeeded)
-        {
-            throw new NotFoundException();
-        }
 
         return new ListResponseModel<CollectionAccessDetailsResponseModel>(manageableOrgCollections.Select(c =>
             new CollectionAccessDetailsResponseModel(c.Item1, c.Item2.Groups, c.Item2.Users)

--- a/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionAuthorizationHandler.cs
+++ b/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionAuthorizationHandler.cs
@@ -131,8 +131,8 @@ public class BulkCollectionAuthorizationHandler : BulkAuthorizationHandler<BulkC
         // ensure they have access for the collection being read
         if (org is not null)
         {
-            var isAssignedToCollections = await IsAssignedToCollectionsAsync(resources, org, false);
-            if (isAssignedToCollections)
+            var canManageCollections = await CanManageCollectionsAsync(resources, org);
+            if (canManageCollections)
             {
                 context.Succeed(requirement);
                 return;
@@ -164,8 +164,8 @@ public class BulkCollectionAuthorizationHandler : BulkAuthorizationHandler<BulkC
         // ensure they have access with manage permission for the collection being read
         if (org is not null)
         {
-            var isAssignedToCollections = await IsAssignedToCollectionsAsync(resources, org, true);
-            if (isAssignedToCollections)
+            var canManageCollections = await CanManageCollectionsAsync(resources, org);
+            if (canManageCollections)
             {
                 context.Succeed(requirement);
                 return;
@@ -199,7 +199,7 @@ public class BulkCollectionAuthorizationHandler : BulkAuthorizationHandler<BulkC
         // ensure they have manage permission for the collection being managed
         if (org is not null)
         {
-            var canManageCollections = await IsAssignedToCollectionsAsync(resources, org, true);
+            var canManageCollections = await CanManageCollectionsAsync(resources, org);
             if (canManageCollections)
             {
                 context.Succeed(requirement);
@@ -230,7 +230,7 @@ public class BulkCollectionAuthorizationHandler : BulkAuthorizationHandler<BulkC
         // ensure acting user has manage permissions for all collections being deleted
         if (org is { LimitCollectionCreationDeletion: false })
         {
-            var canManageCollections = await IsAssignedToCollectionsAsync(resources, org, true);
+            var canManageCollections = await CanManageCollectionsAsync(resources, org);
             if (canManageCollections)
             {
                 context.Succeed(requirement);
@@ -245,17 +245,16 @@ public class BulkCollectionAuthorizationHandler : BulkAuthorizationHandler<BulkC
         }
     }
 
-    private async Task<bool> IsAssignedToCollectionsAsync(
+    private async Task<bool> CanManageCollectionsAsync(
         ICollection<Collection> targetCollections,
-        CurrentContextOrganization org,
-        bool requireManagePermission)
+        CurrentContextOrganization org)
     {
         // List of collection Ids the acting user has access to
         var assignedCollectionIds =
             (await _collectionRepository.GetManyByUserIdAsync(_currentContext.UserId!.Value, useFlexibleCollections: true))
             .Where(c =>
                 // Check Collections with Manage permission
-                (!requireManagePermission || c.Manage) && c.OrganizationId == org.Id)
+                c.Manage && c.OrganizationId == org.Id)
             .Select(c => c.Id)
             .ToHashSet();
 

--- a/test/Api.Test/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.Test/Controllers/CollectionsControllerTests.cs
@@ -195,9 +195,11 @@ public class CollectionsControllerTests
     }
 
     [Theory, BitAutoData]
-    public async Task GetOrganizationCollections_MissingReadAllPermissions_GetsAssignedCollections(Organization organization, ICollection<CollectionDetails> collections, Guid userId, SutProvider<CollectionsController> sutProvider)
+    public async Task GetOrganizationCollections_MissingReadAllPermissions_GetsManageableCollections(Organization organization, ICollection<CollectionDetails> collections, Guid userId, SutProvider<CollectionsController> sutProvider)
     {
         collections.First().OrganizationId = organization.Id;
+        collections.First().Manage = true;
+        collections.Skip(1).First().OrganizationId = organization.Id;
 
         sutProvider.GetDependency<ICurrentContext>().UserId.Returns(userId);
 

--- a/test/Api.Test/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.Test/Controllers/CollectionsControllerTests.cs
@@ -236,33 +236,6 @@ public class CollectionsControllerTests
     }
 
     [Theory, BitAutoData]
-    public async Task GetOrganizationCollections_MissingReadPermissions_ThrowsNotFound(Organization organization, Guid userId, SutProvider<CollectionsController> sutProvider)
-    {
-        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(userId);
-
-        sutProvider.GetDependency<IAuthorizationService>()
-            .AuthorizeAsync(
-                Arg.Any<ClaimsPrincipal>(),
-                Arg.Any<object>(),
-                Arg.Is<IEnumerable<IAuthorizationRequirement>>(requirements =>
-                    requirements.Cast<CollectionOperationRequirement>().All(operation =>
-                        operation.Name == nameof(CollectionOperations.ReadAll)
-                        && operation.OrganizationId == organization.Id)))
-            .Returns(AuthorizationResult.Failed());
-
-        sutProvider.GetDependency<IAuthorizationService>()
-            .AuthorizeAsync(
-                Arg.Any<ClaimsPrincipal>(),
-                Arg.Any<object>(),
-                Arg.Is<IEnumerable<IAuthorizationRequirement>>(requirements =>
-                    requirements.Cast<BulkCollectionOperationRequirement>().All(operation =>
-                        operation.Name == nameof(BulkCollectionOperations.Read))))
-            .Returns(AuthorizationResult.Failed());
-
-        _ = await Assert.ThrowsAsync<NotFoundException>(async () => await sutProvider.Sut.Get(organization.Id));
-    }
-
-    [Theory, BitAutoData]
     public async Task DeleteMany_Success(Guid orgId, Collection collection1, Collection collection2, SutProvider<CollectionsController> sutProvider)
     {
         // Arrange

--- a/test/Api.Test/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.Test/Controllers/CollectionsControllerTests.cs
@@ -142,33 +142,6 @@ public class CollectionsControllerTests
     }
 
     [Theory, BitAutoData]
-    public async Task GetOrganizationCollectionsWithGroups_MissingReadPermissions_ThrowsNotFound(Organization organization, Guid userId, SutProvider<CollectionsController> sutProvider)
-    {
-        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(userId);
-
-        sutProvider.GetDependency<IAuthorizationService>()
-            .AuthorizeAsync(
-                Arg.Any<ClaimsPrincipal>(),
-                Arg.Any<object>(),
-                Arg.Is<IEnumerable<IAuthorizationRequirement>>(requirements =>
-                    requirements.Cast<CollectionOperationRequirement>().All(operation =>
-                        operation.Name == nameof(CollectionOperations.ReadAllWithAccess)
-                        && operation.OrganizationId == organization.Id)))
-            .Returns(AuthorizationResult.Failed());
-
-        sutProvider.GetDependency<IAuthorizationService>()
-            .AuthorizeAsync(
-                Arg.Any<ClaimsPrincipal>(),
-                Arg.Any<object>(),
-                Arg.Is<IEnumerable<IAuthorizationRequirement>>(requirements =>
-                    requirements.Cast<BulkCollectionOperationRequirement>().All(operation =>
-                        operation.Name == nameof(BulkCollectionOperations.ReadWithAccess))))
-            .Returns(AuthorizationResult.Failed());
-
-        _ = await Assert.ThrowsAsync<NotFoundException>(async () => await sutProvider.Sut.GetManyWithDetails(organization.Id));
-    }
-
-    [Theory, BitAutoData]
     public async Task GetOrganizationCollections_WithReadAllPermissions_GetsAllCollections(Organization organization, ICollection<Collection> collections, Guid userId, SutProvider<CollectionsController> sutProvider)
     {
         sutProvider.GetDependency<ICurrentContext>().UserId.Returns(userId);

--- a/test/Api.Test/Vault/AuthorizationHandlers/BulkCollectionAuthorizationHandlerTests.cs
+++ b/test/Api.Test/Vault/AuthorizationHandlers/BulkCollectionAuthorizationHandlerTests.cs
@@ -204,12 +204,17 @@ public class BulkCollectionAuthorizationHandlerTests
     }
 
     [Theory, BitAutoData, CollectionCustomization]
-    public async Task CanReadAsync_WhenUserIsAssignedToCollections_Success(
+    public async Task CanReadAsync_WhenUserCanManageCollections_Success(
         SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
         ICollection<CollectionDetails> collections,
         CurrentContextOrganization organization)
     {
         var actingUserId = Guid.NewGuid();
+
+        foreach (var c in collections)
+        {
+            c.Manage = true;
+        }
 
         organization.Type = OrganizationUserType.User;
         organization.LimitCollectionCreationDeletion = false;


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
`CollectionsController.Get` would throw a `NotFoundException` if the user was assigned to collections in multiple organizations.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
