### PR TITLE
[SM-1048] Fix linq2db Regression

### DIFF
--- a/src/Infrastructure.EntityFramework/Infrastructure.EntityFramework.csproj
+++ b/src/Infrastructure.EntityFramework/Infrastructure.EntityFramework.csproj
@@ -2,6 +2,7 @@
 
     <ItemGroup>
       <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+      <PackageReference Include="linq2db" Version="5.3.2" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.14" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.14" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.14" />


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The purpose of this PR is to fix a known regression with linq2db 5.3.1 which is implicitly installed by linq2db.EntityFrameworkCore 7.6.0.  

The recommend fix is explicitly adding linq2db 5.3.2 as a dependency.

https://github.com/linq2db/linq2db.EntityFrameworkCore/issues/368

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Infrastructure.EntityFramework/Infrastructure.EntityFramework.csproj:** 
Explicitly add linq2db 5.3.2 as a dependency.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
