### PR TITLE
[AC-1971] Add SwaggerUI to CORS policy

### DIFF
--- a/src/Identity/Startup.cs
+++ b/src/Identity/Startup.cs
@@ -10,7 +10,6 @@ using Bit.Core.Settings;
 using Bit.Core.Utilities;
 using Bit.Identity.Utilities;
 using Bit.SharedWeb.Utilities;
-using BitPayLight;
 using Duende.IdentityServer.Extensions;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.IdentityModel.Logging;

--- a/src/Identity/Startup.cs
+++ b/src/Identity/Startup.cs
@@ -10,6 +10,7 @@ using Bit.Core.Settings;
 using Bit.Core.Utilities;
 using Bit.Identity.Utilities;
 using Bit.SharedWeb.Utilities;
+using BitPayLight;
 using Duende.IdentityServer.Extensions;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.IdentityModel.Logging;
@@ -213,7 +214,11 @@ public class Startup
         app.UseRouting();
 
         // Add Cors
-        app.UseCors(policy => policy.SetIsOriginAllowed(o => CoreHelpers.IsCorsOriginAllowed(o, globalSettings))
+        app.UseCors(policy => policy.SetIsOriginAllowed(o =>
+                CoreHelpers.IsCorsOriginAllowed(o, globalSettings) ||
+
+                // If development - allow requests from the Swagger UI so it can authorize
+                (Environment.IsDevelopment() && o == globalSettings.BaseServiceUri.Api))
             .AllowAnyMethod().AllowAnyHeader().AllowCredentials());
 
         // Add current context


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

When developing locally, SwaggerUI is available at `localhost:4000/docs`, which is the api project.

To authorize, it needs to communicate with identity, which is at a different origin (`localhost:33656`). This is not permitted by the current CORS policy.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* Identity/Startup.cs - if in development, allow cross-origin requests from the api project.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
