### PR TITLE
[AC-1288] Move AssociationWithPermissions public api model to AC Team

### DIFF
--- a/src/Api/AdminConsole/Public/Models/AssociationWithPermissionsBaseModel.cs
+++ b/src/Api/AdminConsole/Public/Models/AssociationWithPermissionsBaseModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace Bit.Api.Auth.Models.Public;
+namespace Bit.Api.AdminConsole.Public.Models;
 
 public abstract class AssociationWithPermissionsBaseModel
 {

--- a/src/Api/AdminConsole/Public/Models/Request/AssociationWithPermissionsRequestModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Request/AssociationWithPermissionsRequestModel.cs
@@ -1,6 +1,6 @@
 ﻿using Bit.Core.Models.Data;
 
-namespace Bit.Api.Auth.Models.Public.Request;
+namespace Bit.Api.AdminConsole.Public.Models.Request;
 
 public class AssociationWithPermissionsRequestModel : AssociationWithPermissionsBaseModel
 {

--- a/src/Api/AdminConsole/Public/Models/Request/GroupCreateUpdateRequestModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Request/GroupCreateUpdateRequestModel.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Api.Auth.Models.Public.Request;
-using Bit.Core.AdminConsole.Entities;
+﻿using Bit.Core.AdminConsole.Entities;
 
 namespace Bit.Api.AdminConsole.Public.Models.Request;
 

--- a/src/Api/AdminConsole/Public/Models/Request/MemberUpdateRequestModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Request/MemberUpdateRequestModel.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Api.Auth.Models.Public.Request;
-using Bit.Core.Entities;
+﻿using Bit.Core.Entities;
 
 namespace Bit.Api.AdminConsole.Public.Models.Request;
 

--- a/src/Api/AdminConsole/Public/Models/Response/AssociationWithPermissionsResponseModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Response/AssociationWithPermissionsResponseModel.cs
@@ -1,6 +1,6 @@
 ﻿using Bit.Core.Models.Data;
 
-namespace Bit.Api.Auth.Models.Public.Response;
+namespace Bit.Api.AdminConsole.Public.Models.Response;
 
 public class AssociationWithPermissionsResponseModel : AssociationWithPermissionsBaseModel
 {

--- a/src/Api/AdminConsole/Public/Models/Response/GroupResponseModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Response/GroupResponseModel.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using Bit.Api.Auth.Models.Public.Response;
 using Bit.Api.Models.Public.Response;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.Models.Data;

--- a/src/Api/AdminConsole/Public/Models/Response/MemberResponseModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Response/MemberResponseModel.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using Bit.Api.Auth.Models.Public.Response;
 using Bit.Api.Models.Public.Response;
 using Bit.Core.Entities;
 using Bit.Core.Enums;

--- a/src/Api/Models/Public/Request/CollectionUpdateRequestModel.cs
+++ b/src/Api/Models/Public/Request/CollectionUpdateRequestModel.cs
@@ -1,4 +1,4 @@
-﻿using Bit.Api.Auth.Models.Public.Request;
+﻿using Bit.Api.AdminConsole.Public.Models.Request;
 using Bit.Core.Entities;
 
 namespace Bit.Api.Models.Public.Request;

--- a/src/Api/Models/Public/Response/CollectionResponseModel.cs
+++ b/src/Api/Models/Public/Response/CollectionResponseModel.cs
@@ -1,5 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using Bit.Api.Auth.Models.Public.Response;
+using Bit.Api.AdminConsole.Public.Models.Response;
 using Bit.Core.Entities;
 using Bit.Core.Models.Data;
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The AssociationWithPermissions model is used to upsert CollectionUser or CollectionGroup associations via the Public API. It goes to OrganizationUser/Group permissions, so should be owned by AC Team. (Or arguably Vault, but I already discussed with @shane-melton and we agreed it could live with AC at least for now.)

I'm not sure why it's currently owned by Auth, maybe it was just scooped up with other file moves? Happy to discuss if there are any queries/issues here.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
