### PR TITLE
[PM-2740] Add null check on base64-encoded values on knowndevice query

### DIFF
--- a/src/Api/Controllers/DevicesController.cs
+++ b/src/Api/Controllers/DevicesController.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Api.Auth.Models.Request;
+﻿using Api.Models.Request;
+using Bit.Api.Auth.Models.Request;
 using Bit.Api.Auth.Models.Request.Accounts;
 using Bit.Api.Models.Request;
 using Bit.Api.Models.Response;
@@ -206,16 +207,8 @@ public class DevicesController : Controller
 
     [AllowAnonymous]
     [HttpGet("knowndevice")]
-    public async Task<bool> GetByIdentifierQuery(
-        [FromHeader(Name = "X-Request-Email")] string email,
-        [FromHeader(Name = "X-Device-Identifier")] string deviceIdentifier)
-        {
-            if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(deviceIdentifier))
-            {
-                throw new BadRequestException("Please provide an email and device identifier");
-            }
-            return await GetByIdentifier(CoreHelpers.Base64UrlDecodeString(email), deviceIdentifier);
-        }
+    public async Task<bool> GetByIdentifierQuery([FromHeader] KnownDeviceRequestModel request) 
+        => await GetByIdentifier(CoreHelpers.Base64UrlDecodeString(request.Email), request.DeviceIdentifier);
 
     [Obsolete("Path is deprecated due to encoding issues, use /knowndevice instead.")]
     [AllowAnonymous]

--- a/src/Api/Controllers/DevicesController.cs
+++ b/src/Api/Controllers/DevicesController.cs
@@ -207,7 +207,7 @@ public class DevicesController : Controller
 
     [AllowAnonymous]
     [HttpGet("knowndevice")]
-    public async Task<bool> GetByIdentifierQuery([FromHeader] KnownDeviceRequestModel request) 
+    public async Task<bool> GetByIdentifierQuery([FromHeader] KnownDeviceRequestModel request)
         => await GetByIdentifier(CoreHelpers.Base64UrlDecodeString(request.Email), request.DeviceIdentifier);
 
     [Obsolete("Path is deprecated due to encoding issues, use /knowndevice instead.")]

--- a/src/Api/Controllers/DevicesController.cs
+++ b/src/Api/Controllers/DevicesController.cs
@@ -209,7 +209,13 @@ public class DevicesController : Controller
     public async Task<bool> GetByIdentifierQuery(
         [FromHeader(Name = "X-Request-Email")] string email,
         [FromHeader(Name = "X-Device-Identifier")] string deviceIdentifier)
-        => await GetByIdentifier(CoreHelpers.Base64UrlDecodeString(email), deviceIdentifier);
+        {
+            if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(deviceIdentifier))
+            {
+                throw new BadRequestException("Please provide an email and device identifier");
+            }
+            return await GetByIdentifier(CoreHelpers.Base64UrlDecodeString(email), deviceIdentifier);
+        }
 
     [Obsolete("Path is deprecated due to encoding issues, use /knowndevice instead.")]
     [AllowAnonymous]

--- a/src/Api/Models/Request/KnownDeviceRequestModel.cs
+++ b/src/Api/Models/Request/KnownDeviceRequestModel.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Models.Request;
+
+public class KnownDeviceRequestModel
+{
+    [Required]
+    [FromHeader(Name = "X-Request-Email")]
+    public string Email { get; set; }
+
+    [Required]
+    [FromHeader(Name = "X-Device-Identifier")]
+    public string DeviceIdentifier { get; set; }
+    
+}

--- a/src/Api/Models/Request/KnownDeviceRequestModel.cs
+++ b/src/Api/Models/Request/KnownDeviceRequestModel.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Models.Request;
@@ -12,5 +12,5 @@ public class KnownDeviceRequestModel
     [Required]
     [FromHeader(Name = "X-Device-Identifier")]
     public string DeviceIdentifier { get; set; }
-    
+
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
In diagnosing some server exceptions, I noticed that 99% of the 500 error responses from our API service were due to null reference exceptions on the `knowndevice` endpoint.

The query-string implementation had a `null` check on both email and identifier, so I replicated that on this implementation as well.

This should result in a more informative `400` error with a message in it, but primarily the benefit is to allow us to have better visibility of true, unexpected `500` status error messages in our logs.

```
System.NullReferenceException: Object reference not set to an instance of an object.
at Bit.Core.Utilities.CoreHelpers.Base64UrlDecode(String input) in /home/runner/work/server/server/src/Core/Utilities/CoreHelpers.cs:line 370
at Bit.Core.Utilities.CoreHelpers.Base64UrlDecodeString(String input) in /home/runner/work/server/server/src/Core/Utilities/CoreHelpers.cs:line 338
at Bit.Api.Controllers.DevicesController.GetByIdentifierQuery(String email, String deviceIdentifier) in /home/runner/work/server/server/src/Api/Controllers/DevicesController.cs:line 212
```

📓 **Note**
This will still cause 500 error responses if an invalid base64-encoded value is passed in, instead of nothing at all.  The change to address that is larger in scope and will be in a subsequent PR.

## Code changes
- **KnownDeviceRequestModel.cs:** Added new model to represent inputs for known device call.
- **DevicesController.cs:** Modified known device query to use the model for input.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
