### PR TITLE
Auth/PM-5340 - Fix Enterprise Org User Invites not working when SSO config is null

### DIFF
--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -1118,7 +1118,7 @@ public class OrganizationService : IOrganizationService
 
         // Determine if org has SSO enabled and if user is required to login with SSO
         // Note: we only want to call the DB after checking if the org can use SSO per plan and if they have any policies enabled.
-        var orgSsoEnabled = organization.UseSso && (await _ssoConfigRepository.GetByOrganizationIdAsync(organization.Id)).Enabled;
+        var orgSsoEnabled = organization.UseSso && (await _ssoConfigRepository.GetByOrganizationIdAsync(organization.Id))?.Enabled == true;
         // Even though the require SSO policy can be turned on regardless of SSO being enabled, for this logic, we only
         // need to check the policy if the org has SSO enabled.
         var orgSsoLoginRequiredPolicyEnabled = orgSsoEnabled &&


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Resolve bug: [PM-5340](https://bitwarden.atlassian.net/browse/PM-5340)

Fix bug where new enterprise orgs without an SSO config couldn't invite new users as I was missing null SSO config handling. The error was introduced as part of the #3378 work. 

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/AdminConsole/Services/Implementations/OrganizationService.cs:** Actually check if the SSO configuration is null before trying to access it. 
* **test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs:** Add test to prevent this scenario from happening again

Video of fix in action:

https://github.com/bitwarden/server/assets/116684653/3de42566-314d-499c-9b3d-1b96cfdb5e50



## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team


[PM-5340]: https://bitwarden.atlassian.net/browse/PM-5340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ