### PR TITLE
[PM-5331] Fix ciphers missing collectionId in sync data

### DIFF
--- a/src/Api/Vault/Controllers/SyncController.cs
+++ b/src/Api/Vault/Controllers/SyncController.cs
@@ -96,6 +96,7 @@ public class SyncController : Controller
         {
             collections = await _collectionRepository.GetManyByUserIdAsync(user.Id, UseFlexibleCollections);
             var collectionCiphers = await _collectionCipherRepository.GetManyByUserIdAsync(user.Id, UseFlexibleCollections);
+            collectionCiphersGroupDict = collectionCiphers.GroupBy(c => c.CipherId).ToDictionary(s => s.Key);
         }
 
         var userTwoFactorEnabled = await _userService.TwoFactorIsEnabledAsync(user);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

In #3505 I accidentally deleted the line which matches ciphers with collectionIds in sync data: https://github.com/bitwarden/server/pull/3505/files#diff-8148a746eb217c98f001101d76213e8cf852ad5ea287ccdfcd090a736fef5556L99

This results in vault filters not working correctly, viz. collection filters never show any items.

There was no reason for this deletion, just a mistake that wasn't caught during review.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* restore missing line

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
