### PR TITLE
[AC-2000] Get 400 response code when a secrets manager is not enabled for Organisation while password Manager is Updated

### DIFF
--- a/src/Api/Billing/Public/Controllers/OrganizationController.cs
+++ b/src/Api/Billing/Public/Controllers/OrganizationController.cs
@@ -74,8 +74,11 @@ public class OrganizationController : Controller
             var organization =
                 await _organizationRepository.GetByIdAsync(organizationId);
 
-            var organizationUpdate = model.SecretsManager.ToSecretsManagerSubscriptionUpdate(organization);
-            await _updateSecretsManagerSubscriptionCommand.UpdateSubscriptionAsync(organizationUpdate);
+            if (organization.UseSecretsManager)
+            {
+                var organizationUpdate = model.SecretsManager.ToSecretsManagerSubscriptionUpdate(organization);
+                await _updateSecretsManagerSubscriptionCommand.UpdateSubscriptionAsync(organizationUpdate);
+            }
         }
     }
 }

--- a/src/Api/Billing/Public/Controllers/OrganizationController.cs
+++ b/src/Api/Billing/Public/Controllers/OrganizationController.cs
@@ -43,12 +43,23 @@ public class OrganizationController : Controller
     [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public async Task<IActionResult> PostSubscriptionAsync([FromBody] OrganizationSubscriptionUpdateRequestModel model)
     {
+        try
+        {
+            await UpdatePasswordManagerAsync(model, _currentContext.OrganizationId.Value);
 
-        await UpdatePasswordManagerAsync(model, _currentContext.OrganizationId.Value);
+            var secretsManagerResult = await UpdateSecretsManagerAsync(model, _currentContext.OrganizationId.Value);
 
-        await UpdateSecretsManagerAsync(model, _currentContext.OrganizationId.Value);
+            if (!string.IsNullOrEmpty(secretsManagerResult))
+            {
+                return Ok(new { Message = secretsManagerResult });
+            }
 
-        return new OkResult();
+            return Ok(new { Message = "Subscription updated successfully." });
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new { Message = "An error occurred while updating the subscription." });
+        }
     }
 
     private async Task UpdatePasswordManagerAsync(OrganizationSubscriptionUpdateRequestModel model, Guid organizationId)
@@ -67,18 +78,23 @@ public class OrganizationController : Controller
         }
     }
 
-    private async Task UpdateSecretsManagerAsync(OrganizationSubscriptionUpdateRequestModel model, Guid organizationId)
+    private async Task<string> UpdateSecretsManagerAsync(OrganizationSubscriptionUpdateRequestModel model, Guid organizationId)
     {
-        if (model.SecretsManager != null)
+        if (model.SecretsManager == null)
         {
-            var organization =
-                await _organizationRepository.GetByIdAsync(organizationId);
-
-            if (organization.UseSecretsManager)
-            {
-                var organizationUpdate = model.SecretsManager.ToSecretsManagerSubscriptionUpdate(organization);
-                await _updateSecretsManagerSubscriptionCommand.UpdateSubscriptionAsync(organizationUpdate);
-            }
+            return string.Empty;
         }
+
+        var organization = await _organizationRepository.GetByIdAsync(organizationId);
+
+        if (!organization.UseSecretsManager)
+        {
+            return "Organization has no access to Secrets Manager.";
+        }
+
+        var secretsManagerUpdate = model.SecretsManager.ToSecretsManagerSubscriptionUpdate(organization);
+        await _updateSecretsManagerSubscriptionCommand.UpdateSubscriptionAsync(secretsManagerUpdate);
+
+        return string.Empty;
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When a user is try to update both password manager and secret manager details, it returns 400 mean while password manager details has been updated but the 400 is coming as a result of secrets manager not setup for that organization.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
