### PR TITLE
[PM-5072] Update minimum version for cipher key encryption

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -23,7 +23,7 @@ public static class Constants
 
     public const string Fido2KeyCipherMinimumVersion = "2023.10.0";
 
-    public const string CipherKeyEncryptionMinimumVersion = "2023.9.2";
+    public const string CipherKeyEncryptionMinimumVersion = "2024.1.0";
 
     /// <summary>
     /// Used by IdentityServer to identify our own provider.


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Updated the minimum supported version for cipher key encryption to be the `2024.1.0` release.

See https://github.com/bitwarden/clients/pull/7351 for corresponding client PR.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
