### PR TITLE
[PM-2260] Remove TDE feature flag

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationAuthRequestsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationAuthRequestsController.cs
@@ -1,14 +1,12 @@
 ﻿using Bit.Api.AdminConsole.Models.Request;
 using Bit.Api.AdminConsole.Models.Response;
 using Bit.Api.Models.Response;
-using Bit.Core;
 using Bit.Core.AdminConsole.OrganizationAuth.Interfaces;
 using Bit.Core.Auth.Models.Api.Request.AuthRequest;
 using Bit.Core.Auth.Services;
 using Bit.Core.Context;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
-using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -16,7 +14,6 @@ namespace Bit.Api.AdminConsole.Controllers;
 
 [Route("organizations/{orgId}/auth-requests")]
 [Authorize("Application")]
-[RequireFeature(FeatureFlagKeys.TrustedDeviceEncryption)]
 public class OrganizationAuthRequestsController : Controller
 {
     private readonly IAuthRequestRepository _authRequestRepository;

--- a/src/Api/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationsController.cs
@@ -764,11 +764,6 @@ public class OrganizationsController : Controller
             throw new NotFoundException();
         }
 
-        if (model.Data.MemberDecryptionType == MemberDecryptionType.TrustedDeviceEncryption)
-        {
-            throw new BadRequestException(nameof(model.Data.MemberDecryptionType), "Invalid member decryption type.");
-        }
-
         var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(id);
         ssoConfig = ssoConfig == null ? model.ToSsoConfig(id) : model.ToSsoConfig(ssoConfig);
         organization.Identifier = model.Identifier;

--- a/src/Api/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationsController.cs
@@ -764,8 +764,7 @@ public class OrganizationsController : Controller
             throw new NotFoundException();
         }
 
-        if (model.Data.MemberDecryptionType == MemberDecryptionType.TrustedDeviceEncryption &&
-            !_featureService.IsEnabled(FeatureFlagKeys.TrustedDeviceEncryption, _currentContext))
+        if (model.Data.MemberDecryptionType == MemberDecryptionType.TrustedDeviceEncryption)
         {
             throw new BadRequestException(nameof(model.Data.MemberDecryptionType), "Invalid member decryption type.");
         }

--- a/src/Identity/IdentityServer/UserDecryptionOptionsBuilder.cs
+++ b/src/Identity/IdentityServer/UserDecryptionOptionsBuilder.cs
@@ -95,7 +95,7 @@ public class UserDecryptionOptionsBuilder : IUserDecryptionOptionsBuilder
     private async Task BuildTrustedDeviceOptions()
     {
         // TrustedDeviceEncryption only exists for SSO, if that changes then these guards should change
-        if (_ssoConfig == null || !_featureService.IsEnabled(FeatureFlagKeys.TrustedDeviceEncryption, _currentContext))
+        if (_ssoConfig == null)
         {
             return;
         }

--- a/src/Identity/IdentityServer/UserDecryptionOptionsBuilder.cs
+++ b/src/Identity/IdentityServer/UserDecryptionOptionsBuilder.cs
@@ -1,12 +1,10 @@
-﻿using Bit.Core;
-using Bit.Core.Auth.Entities;
+﻿using Bit.Core.Auth.Entities;
 using Bit.Core.Auth.Enums;
 using Bit.Core.Auth.Models.Api.Response;
 using Bit.Core.Auth.Utilities;
 using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Repositories;
-using Bit.Core.Services;
 using Bit.Identity.Utilities;
 
 namespace Bit.Identity.IdentityServer;
@@ -20,7 +18,6 @@ namespace Bit.Identity.IdentityServer;
 public class UserDecryptionOptionsBuilder : IUserDecryptionOptionsBuilder
 {
     private readonly ICurrentContext _currentContext;
-    private readonly IFeatureService _featureService;
     private readonly IDeviceRepository _deviceRepository;
     private readonly IOrganizationUserRepository _organizationUserRepository;
 
@@ -31,13 +28,11 @@ public class UserDecryptionOptionsBuilder : IUserDecryptionOptionsBuilder
 
     public UserDecryptionOptionsBuilder(
         ICurrentContext currentContext,
-        IFeatureService featureService,
         IDeviceRepository deviceRepository,
         IOrganizationUserRepository organizationUserRepository
     )
     {
         _currentContext = currentContext;
-        _featureService = featureService;
         _deviceRepository = deviceRepository;
         _organizationUserRepository = organizationUserRepository;
     }

--- a/test/Identity.IntegrationTest/Endpoints/IdentityServerSsoTests.cs
+++ b/test/Identity.IntegrationTest/Endpoints/IdentityServerSsoTests.cs
@@ -380,36 +380,6 @@ public class IdentityServerSsoTests
 
     }
 
-
-    [Fact]
-    public async Task SsoLogin_TrustedDeviceEncryption_FlagTurnedOff_DoesNotReturnOption()
-    {
-        // This creates SsoConfig that HAS enabled trusted device encryption which should have only been
-        // done with the feature flag turned on but we are testing that even if they have done that, this will turn off
-        // if returning as an option if the flag has later been turned off.  We should be very careful turning the flag
-        // back off.
-        using var responseBody = await RunSuccessTestAsync(async factory =>
-        {
-            await UpdateUserAsync(factory, user => user.MasterPassword = null);
-        }, MemberDecryptionType.TrustedDeviceEncryption, trustedDeviceEnabled: false);
-
-        // Assert
-        // If the organization has selected TrustedDeviceEncryption but the user still has their master password
-        // they can decrypt with either option
-        var root = responseBody.RootElement;
-        AssertHelper.AssertJsonProperty(root, "access_token", JsonValueKind.String);
-        var userDecryptionOptions = AssertHelper.AssertJsonProperty(root, "UserDecryptionOptions", JsonValueKind.Object);
-
-        // Expected to look like:
-        // "UserDecryptionOptions": {
-        //   "Object": "userDecryptionOptions"
-        //   "HasMasterPassword": false
-        // }
-
-        // Should only have 2 properties
-        Assert.Equal(2, userDecryptionOptions.EnumerateObject().Count());
-    }
-
     [Fact]
     public async Task SsoLogin_KeyConnector_ReturnsOptions()
     {

--- a/test/Identity.IntegrationTest/Endpoints/IdentityServerSsoTests.cs
+++ b/test/Identity.IntegrationTest/Endpoints/IdentityServerSsoTests.cs
@@ -1,18 +1,15 @@
 ﻿using System.Security.Claims;
 using System.Text.Json;
-using Bit.Core;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.Auth.Entities;
 using Bit.Core.Auth.Enums;
 using Bit.Core.Auth.Models.Api.Request.Accounts;
 using Bit.Core.Auth.Models.Data;
 using Bit.Core.Auth.Repositories;
-using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Models.Data;
 using Bit.Core.Repositories;
-using Bit.Core.Services;
 using Bit.Core.Utilities;
 using Bit.IntegrationTestCommon.Factories;
 using Bit.Test.Common.Helpers;
@@ -509,12 +506,6 @@ public class IdentityServerSsoTests
         {
             service.GetAuthorizationCodeAsync("test_code")
                 .Returns(authorizationCode);
-        });
-
-        factory.SubstitueService<IFeatureService>(service =>
-        {
-            service.IsEnabled(FeatureFlagKeys.TrustedDeviceEncryption, Arg.Any<ICurrentContext>())
-                .Returns(trustedDeviceEnabled);
         });
 
         // This starts the server and finalizes services

--- a/test/Identity.Test/IdentityServer/UserDecryptionOptionsBuilderTests.cs
+++ b/test/Identity.Test/IdentityServer/UserDecryptionOptionsBuilderTests.cs
@@ -17,7 +17,6 @@ namespace Bit.Identity.Test.IdentityServer;
 public class UserDecryptionOptionsBuilderTests
 {
     private readonly ICurrentContext _currentContext;
-    private readonly IFeatureService _featureService;
     private readonly IDeviceRepository _deviceRepository;
     private readonly IOrganizationUserRepository _organizationUserRepository;
     private readonly UserDecryptionOptionsBuilder _builder;
@@ -25,7 +24,6 @@ public class UserDecryptionOptionsBuilderTests
     public UserDecryptionOptionsBuilderTests()
     {
         _currentContext = Substitute.For<ICurrentContext>();
-        _featureService = Substitute.For<IFeatureService>();
         _deviceRepository = Substitute.For<IDeviceRepository>();
         _organizationUserRepository = Substitute.For<IOrganizationUserRepository>();
         _builder = new UserDecryptionOptionsBuilder(_currentContext, _featureService, _deviceRepository, _organizationUserRepository);
@@ -79,7 +77,6 @@ public class UserDecryptionOptionsBuilderTests
     [Theory, BitAutoData]
     public async Task Build_WhenTrustedDeviceIsEnabled_ShouldReturnTrustedDeviceOptions(SsoConfig ssoConfig, SsoConfigurationData configurationData, Device device)
     {
-        _featureService.IsEnabled(FeatureFlagKeys.TrustedDeviceEncryption, _currentContext).Returns(true);
         configurationData.MemberDecryptionType = MemberDecryptionType.TrustedDeviceEncryption;
         ssoConfig.Data = configurationData.Serialize();
 
@@ -91,23 +88,9 @@ public class UserDecryptionOptionsBuilderTests
         Assert.False(result.TrustedDeviceOption!.HasManageResetPasswordPermission);
     }
 
-    // TODO: Remove when FeatureFlagKeys.TrustedDeviceEncryption is removed
-    [Theory, BitAutoData]
-    public async Task Build_WhenTrustedDeviceIsEnabledButFeatureFlagIsDisabled_ShouldNotReturnTrustedDeviceOptions(SsoConfig ssoConfig, SsoConfigurationData configurationData, Device device)
-    {
-        _featureService.IsEnabled(FeatureFlagKeys.TrustedDeviceEncryption, _currentContext).Returns(false);
-        configurationData.MemberDecryptionType = MemberDecryptionType.TrustedDeviceEncryption;
-        ssoConfig.Data = configurationData.Serialize();
-
-        var result = await _builder.WithSso(ssoConfig).WithDevice(device).BuildAsync();
-
-        Assert.Null(result.TrustedDeviceOption);
-    }
-
     [Theory, BitAutoData]
     public async Task Build_WhenDeviceIsTrusted_ShouldReturnKeys(SsoConfig ssoConfig, SsoConfigurationData configurationData, Device device)
     {
-        _featureService.IsEnabled(FeatureFlagKeys.TrustedDeviceEncryption, _currentContext).Returns(true);
         configurationData.MemberDecryptionType = MemberDecryptionType.TrustedDeviceEncryption;
         ssoConfig.Data = configurationData.Serialize();
         device.EncryptedPrivateKey = "encryptedPrivateKey";
@@ -123,7 +106,6 @@ public class UserDecryptionOptionsBuilderTests
     [Theory, BitAutoData]
     public async Task Build_WhenHasLoginApprovingDevice_ShouldApprovingDeviceTrue(SsoConfig ssoConfig, SsoConfigurationData configurationData, User user, Device device, Device approvingDevice)
     {
-        _featureService.IsEnabled(FeatureFlagKeys.TrustedDeviceEncryption, _currentContext).Returns(true);
         configurationData.MemberDecryptionType = MemberDecryptionType.TrustedDeviceEncryption;
         ssoConfig.Data = configurationData.Serialize();
         approvingDevice.Type = LoginApprovingDeviceTypes.Types.First();
@@ -140,7 +122,6 @@ public class UserDecryptionOptionsBuilderTests
         SsoConfigurationData configurationData,
         CurrentContextOrganization organization)
     {
-        _featureService.IsEnabled(FeatureFlagKeys.TrustedDeviceEncryption, _currentContext).Returns(true);
         configurationData.MemberDecryptionType = MemberDecryptionType.TrustedDeviceEncryption;
         ssoConfig.Data = configurationData.Serialize();
         ssoConfig.OrganizationId = organization.Id;
@@ -159,7 +140,6 @@ public class UserDecryptionOptionsBuilderTests
         OrganizationUser organizationUser,
         User user)
     {
-        _featureService.IsEnabled(FeatureFlagKeys.TrustedDeviceEncryption, _currentContext).Returns(true);
         configurationData.MemberDecryptionType = MemberDecryptionType.TrustedDeviceEncryption;
         ssoConfig.Data = configurationData.Serialize();
         organizationUser.ResetPasswordKey = "resetPasswordKey";

--- a/test/Identity.Test/IdentityServer/UserDecryptionOptionsBuilderTests.cs
+++ b/test/Identity.Test/IdentityServer/UserDecryptionOptionsBuilderTests.cs
@@ -26,7 +26,7 @@ public class UserDecryptionOptionsBuilderTests
         _currentContext = Substitute.For<ICurrentContext>();
         _deviceRepository = Substitute.For<IDeviceRepository>();
         _organizationUserRepository = Substitute.For<IOrganizationUserRepository>();
-        _builder = new UserDecryptionOptionsBuilder(_currentContext, _featureService, _deviceRepository, _organizationUserRepository);
+        _builder = new UserDecryptionOptionsBuilder(_currentContext, _deviceRepository, _organizationUserRepository);
     }
 
     [Theory]

--- a/test/Identity.Test/IdentityServer/UserDecryptionOptionsBuilderTests.cs
+++ b/test/Identity.Test/IdentityServer/UserDecryptionOptionsBuilderTests.cs
@@ -1,11 +1,9 @@
-﻿using Bit.Core;
-using Bit.Core.Auth.Entities;
+﻿using Bit.Core.Auth.Entities;
 using Bit.Core.Auth.Enums;
 using Bit.Core.Auth.Models.Data;
 using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Repositories;
-using Bit.Core.Services;
 using Bit.Identity.IdentityServer;
 using Bit.Identity.Utilities;
 using Bit.Test.Common.AutoFixture.Attributes;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Remove the TDE feature flag and all restrictions based on it.

See https://github.com/bitwarden/clients/pull/7352 for the corresponding clients PR.

## Code Changes

- **OrganizationAuthRequestController.cs:** Remove the feature flag attribute restricting access.
- **OrganizationsController.cs:** Remove check for flag for TDE feature flag on POSTing of SSO config.
- **UserDecryptionOptionsBuilder.cs:** Remove `FeatureService` references and check for feature flag.
- **IdentityServerSsoTests.cs:** Remove test that tests flag behavior, as it is no longer valid.
- **UserDecryptionOptionsBuilderTests.cs:** Remove test that tests flag behavior as well as test scaffolding to set the flag value.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
