### PR TITLE
Update vault out of sync error message in CipherService.cs

### DIFF
--- a/src/Core/Vault/Services/Implementations/CipherService.cs
+++ b/src/Core/Vault/Services/Implementations/CipherService.cs
@@ -1013,7 +1013,7 @@ public class CipherService : ICipherService
         if ((cipher.RevisionDate - lastKnownRevisionDate.Value).Duration() > TimeSpan.FromSeconds(1))
         {
             throw new BadRequestException(
-                "The cipher you are updating is out of date. Please save your work, sync your vault, and try again."
+                "Your vault is out of sync & changes could not be saved. Please logout & back in to your vault and try again."
             );
         }
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective
Suggested change to error message to reduce confusion for non-technical users.  Also if vault out of sync the changes cannot be saved so the error is misleading for the user.

See forum discussion at https://community.bitwarden.com/t/clearer-error-message-when-vault-is-out-of-sync/16154/8

## Code changes
Change of error message in file below
* **server/src/Core/Vault/Services/Implementations/CipherService.cs** Change of error message

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
