### PR TITLE
Add Entity Framework paths as owned by DbOps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,12 @@
 
 # Database Operations for database changes
 src/Sql/** @bitwarden/dept-dbops
+util/EfShared/** @bitwarden/dept-dbops
 util/Migrator/** @bitwarden/dept-dbops
+util/MySqlMigrations/** @bitwarden/dept-dbops
+util/PostgresMigrations/** @bitwarden/dept-dbops
+util/SqlServerEFScaffold/** @bitwarden/dept-dbops
+util/SqliteMigrations/** @bitwarden/dept-dbops
 
 # Auth team
 **/Auth @bitwarden/team-auth-dev


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

Adds a few paths for EF files to be owned by DbOps.

## Code changes

* **.github/CODEOWNERS:** Path additions.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
