### PR TITLE
SwaggerUI - persist authorization in dev mode

### DIFF
--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -288,6 +288,12 @@ public class Startup
                     "Bitwarden Public API");
                 config.OAuthClientId("accountType.id");
                 config.OAuthClientSecret("secretKey");
+
+                // Persist authorization on page refresh - for development use only
+                if (Environment.IsDevelopment())
+                {
+                    config.EnablePersistAuthorization();
+                }
             });
         }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

I found an option that will persist your SwaggerUI authorization between page refreshes. This is useful for development because you can change your code, restart your api project, and refresh the page without having to reauthorize every time.

I have enabled it for development only, keeping the stricter behaviour for production environments.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
