### PR TITLE
[PM-5519] [PM-5526] [PM-5624] [PM-5600] More Grant SQL fixes

### DIFF
--- a/src/Infrastructure.EntityFramework/Auth/Configurations/GrantEntityTypeConfiguration.cs
+++ b/src/Infrastructure.EntityFramework/Auth/Configurations/GrantEntityTypeConfiguration.cs
@@ -10,6 +10,7 @@ public class GrantEntityTypeConfiguration : IEntityTypeConfiguration<Grant>
     {
         builder
             .HasKey(s => s.Id)
+            .HasName("PK_Grant")
             .IsClustered();
 
         builder

--- a/util/MySqlMigrations/Migrations/20231214162533_GrantIdWithIndexes.cs
+++ b/util/MySqlMigrations/Migrations/20231214162533_GrantIdWithIndexes.cs
@@ -72,7 +72,22 @@ public partial class GrantIdWithIndexes : Migration
             .Annotation("MySql:CharSet", "utf8mb4")
             .OldAnnotation("MySql:CharSet", "utf8mb4");
 
-        migrationBuilder.Sql("ALTER TABLE `Grant` ADD COLUMN `Id` INT AUTO_INCREMENT UNIQUE;");
+        migrationBuilder.Sql(@"
+            DROP PROCEDURE IF EXISTS GrantSchemaChange;
+            
+            CREATE PROCEDURE GrantSchemaChange()
+            BEGIN
+                IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'Grant' AND COLUMN_NAME = 'Id') THEN
+                    ALTER TABLE `Grant` DROP COLUMN `Id`;
+                END IF;
+ 
+                ALTER TABLE `Grant` ADD COLUMN `Id` INT AUTO_INCREMENT UNIQUE;
+            END;
+
+            CALL GrantSchemaChange();
+
+            DROP PROCEDURE GrantSchemaChange;"
+        );
 
         migrationBuilder.AddPrimaryKey(
             name: "PK_Grant",

--- a/util/SqliteMigrations/HelperScripts/2023-12-04_00_Down_GrantIndexes.sql
+++ b/util/SqliteMigrations/HelperScripts/2023-12-04_00_Down_GrantIndexes.sql
@@ -1,0 +1,45 @@
+﻿ALTER TABLE
+"Grant" RENAME TO "Old_Grant";
+
+CREATE TABLE "Grant"
+(
+  "Key" TEXT NOT NULL CONSTRAINT "PK_Grant" PRIMARY KEY,
+  "Type" TEXT NULL,
+  "SubjectId" TEXT NULL,
+  "SessionId" TEXT NULL,
+  "ClientId" TEXT NULL,
+  "Description" TEXT NULL,
+  "CreationDate" TEXT NOT NULL,
+  "ExpirationDate" TEXT NULL,
+  "ConsumedDate" TEXT NULL,
+  "Data" TEXT NULL
+);
+
+INSERT INTO
+"Grant"
+  (
+  "Key",
+  "Type",
+  "SubjectId",
+  "SessionId",
+  "ClientId",
+  "Description",
+  "CreationDate",
+  "ExpirationDate",
+  "ConsumedDate",
+  "Data"
+  )
+SELECT
+  "Key",
+  "Type",
+  "SubjectId",
+  "SessionId",
+  "ClientId",
+  "Description",
+  "CreationDate",
+  "ExpirationDate",
+  "ConsumedDate",
+  "Data"
+FROM "Old_Grant";
+
+DROP TABLE "Old_Grant";

--- a/util/SqliteMigrations/HelperScripts/2023-12-04_00_Up_GrantIndexes.sql
+++ b/util/SqliteMigrations/HelperScripts/2023-12-04_00_Up_GrantIndexes.sql
@@ -1,0 +1,46 @@
+﻿ALTER TABLE
+"Grant" RENAME TO "Old_Grant";
+
+CREATE TABLE "Grant"
+(
+  "Id" INTEGER PRIMARY KEY AUTOINCREMENT,
+  "Key" TEXT NOT NULL,
+  "Type" TEXT NOT NULL,
+  "SubjectId" TEXT NULL,
+  "SessionId" TEXT NULL,
+  "ClientId" TEXT NOT NULL,
+  "Description" TEXT NULL,
+  "CreationDate" TEXT NOT NULL,
+  "ExpirationDate" TEXT NULL,
+  "ConsumedDate" TEXT NULL,
+  "Data" TEXT NOT NULL
+);
+
+INSERT INTO
+"Grant"
+  (
+  "Key",
+  "Type",
+  "SubjectId",
+  "SessionId",
+  "ClientId",
+  "Description",
+  "CreationDate",
+  "ExpirationDate",
+  "ConsumedDate",
+  "Data"
+  )
+SELECT
+  "Key",
+  "Type",
+  "SubjectId",
+  "SessionId",
+  "ClientId",
+  "Description",
+  "CreationDate",
+  "ExpirationDate",
+  "ConsumedDate",
+  "Data"
+FROM "Old_Grant";
+
+DROP TABLE "Old_Grant";

--- a/util/SqliteMigrations/Migrations/20231214162537_GrantIdWithIndexes.cs
+++ b/util/SqliteMigrations/Migrations/20231214162537_GrantIdWithIndexes.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Bit.EfShared;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -7,59 +8,12 @@ namespace Bit.SqliteMigrations.Migrations;
 /// <inheritdoc />
 public partial class GrantIdWithIndexes : Migration
 {
+    private const string _scriptLocationTemplate = "2023-12-04_00_{0}_GrantIndexes.sql";
+
     /// <inheritdoc />
     protected override void Up(MigrationBuilder migrationBuilder)
     {
-        migrationBuilder.DropPrimaryKey(
-            name: "PK_Grant",
-            table: "Grant");
-
-        migrationBuilder.AlterColumn<string>(
-            name: "Type",
-            table: "Grant",
-            type: "TEXT",
-            maxLength: 50,
-            nullable: false,
-            defaultValue: "",
-            oldClrType: typeof(string),
-            oldType: "TEXT",
-            oldMaxLength: 50,
-            oldNullable: true);
-
-        migrationBuilder.AlterColumn<string>(
-            name: "Data",
-            table: "Grant",
-            type: "TEXT",
-            nullable: false,
-            defaultValue: "",
-            oldClrType: typeof(string),
-            oldType: "TEXT",
-            oldNullable: true);
-
-        migrationBuilder.AlterColumn<string>(
-            name: "ClientId",
-            table: "Grant",
-            type: "TEXT",
-            maxLength: 200,
-            nullable: false,
-            defaultValue: "",
-            oldClrType: typeof(string),
-            oldType: "TEXT",
-            oldMaxLength: 200,
-            oldNullable: true);
-
-        migrationBuilder.AddColumn<int>(
-            name: "Id",
-            table: "Grant",
-            type: "INTEGER",
-            nullable: false,
-            defaultValue: 0)
-            .Annotation("Sqlite:Autoincrement", true);
-
-        migrationBuilder.AddPrimaryKey(
-            name: "PK_Grant",
-            table: "Grant",
-            column: "Id");
+        migrationBuilder.SqlResource(_scriptLocationTemplate);
 
         migrationBuilder.CreateIndex(
             name: "IX_Grant_Key",
@@ -71,49 +25,10 @@ public partial class GrantIdWithIndexes : Migration
     /// <inheritdoc />
     protected override void Down(MigrationBuilder migrationBuilder)
     {
-        migrationBuilder.DropPrimaryKey(
-            name: "PK_Grant",
-            table: "Grant");
+        migrationBuilder.SqlResource(_scriptLocationTemplate);
 
         migrationBuilder.DropIndex(
             name: "IX_Grant_Key",
             table: "Grant");
-
-        migrationBuilder.DropColumn(
-            name: "Id",
-            table: "Grant");
-
-        migrationBuilder.AlterColumn<string>(
-            name: "Type",
-            table: "Grant",
-            type: "TEXT",
-            maxLength: 50,
-            nullable: true,
-            oldClrType: typeof(string),
-            oldType: "TEXT",
-            oldMaxLength: 50);
-
-        migrationBuilder.AlterColumn<string>(
-            name: "Data",
-            table: "Grant",
-            type: "TEXT",
-            nullable: true,
-            oldClrType: typeof(string),
-            oldType: "TEXT");
-
-        migrationBuilder.AlterColumn<string>(
-            name: "ClientId",
-            table: "Grant",
-            type: "TEXT",
-            maxLength: 200,
-            nullable: true,
-            oldClrType: typeof(string),
-            oldType: "TEXT",
-            oldMaxLength: 200);
-
-        migrationBuilder.AddPrimaryKey(
-            name: "PK_Grant",
-            table: "Grant",
-            column: "Key");
     }
 }

--- a/util/SqliteMigrations/SqliteMigrations.csproj
+++ b/util/SqliteMigrations/SqliteMigrations.csproj
@@ -22,4 +22,9 @@
     <Compile Include="..\EfShared\MigrationBuilderExtensions.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="HelperScripts\2023-12-04_00_Up_GrantIndexes.sql" />
+    <EmbeddedResource Include="HelperScripts\2023-12-04_00_Down_GrantIndexes.sql" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Relates to and continues #3662. Adds additional protections for upgraders that may have been placed in an inconsistent state. Specifically this:

- Declares the name of the primary key constraint name for grants. SQLite does not allow you to name a primary key constraint when combined with auto-incrementing. This is an unfortunate gap but we can't get around it. This likely makes no difference in practice, but I wanted to be explicit. See https://github.com/dotnet/efcore/issues/10195.
- Adds custom up and down scripts as resources for SQLite to establish the new identity column that auto-increments. You have to recreate the entire table to do this in SQLite. This will handle users migrating and in inconsistent states given the table copy.
- Adds custom SQL for MySQL upgrades to delete the potentially-erroneously-created identity column given the Pomelo bug. This is rather complex but MySQL lacks not only the ability to do simple existence checks but conditionals cannot be anywhere but functions or procedures.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
