### PR TITLE
Remove AcceptOrgUserByOrgId from AcceptOrgUserCommand to simplify interface

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -347,7 +347,7 @@ public class OrganizationUsersController : Controller
         var orgUser = await _organizationUserRepository.GetByOrganizationAsync(orgId, user.Id);
         if (orgUser.Status == OrganizationUserStatusType.Invited)
         {
-            await _acceptOrgUserCommand.AcceptOrgUserByOrgIdAsync(orgId, user, _userService);
+            await _acceptOrgUserCommand.AcceptOrgUserAsync(orgUser, user, _userService);
         }
     }
 

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptOrgUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptOrgUserCommand.cs
@@ -103,33 +103,9 @@ public class AcceptOrgUserCommand : IAcceptOrgUserCommand
         return organizationUser;
     }
 
-    private bool ValidateOrgUserInviteToken(string orgUserInviteToken, OrganizationUser orgUser)
-    {
-        return _orgUserInviteTokenDataFactory.TryUnprotect(orgUserInviteToken, out var decryptedToken)
-               && decryptedToken.Valid
-               && decryptedToken.TokenIsValid(orgUser);
-    }
-
     public async Task<OrganizationUser> AcceptOrgUserByOrgSsoIdAsync(string orgSsoIdentifier, User user, IUserService userService)
     {
         var org = await _organizationRepository.GetByIdentifierAsync(orgSsoIdentifier);
-        if (org == null)
-        {
-            throw new BadRequestException("Organization invalid.");
-        }
-
-        var orgUser = await _organizationUserRepository.GetByOrganizationAsync(org.Id, user.Id);
-        if (orgUser == null)
-        {
-            throw new BadRequestException("User not found within organization.");
-        }
-
-        return await AcceptOrgUserAsync(orgUser, user, userService);
-    }
-
-    public async Task<OrganizationUser> AcceptOrgUserByOrgIdAsync(Guid organizationId, User user, IUserService userService)
-    {
-        var org = await _organizationRepository.GetByIdAsync(organizationId);
         if (org == null)
         {
             throw new BadRequestException("Organization invalid.");

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/Interfaces/IAcceptOrgUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/Interfaces/IAcceptOrgUserCommand.cs
@@ -13,6 +13,5 @@ public interface IAcceptOrgUserCommand
     /// <returns>The accepted OrganizationUser.</returns>
     Task<OrganizationUser> AcceptOrgUserByEmailTokenAsync(Guid organizationUserId, User user, string emailToken, IUserService userService);
     Task<OrganizationUser> AcceptOrgUserByOrgSsoIdAsync(string orgIdentifier, User user, IUserService userService);
-    Task<OrganizationUser> AcceptOrgUserByOrgIdAsync(Guid organizationId, User user, IUserService userService);
     Task<OrganizationUser> AcceptOrgUserAsync(OrganizationUser orgUser, User user, IUserService userService);
 }

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
@@ -31,7 +31,7 @@ public class OrganizationUsersControllerTests
 
         await sutProvider.Sut.PutResetPasswordEnrollment(orgId, userId, model);
 
-        await sutProvider.GetDependency<IAcceptOrgUserCommand>().Received(1).AcceptOrgUserByOrgIdAsync(orgId, user, sutProvider.GetDependency<IUserService>());
+        await sutProvider.GetDependency<IAcceptOrgUserCommand>().Received(1).AcceptOrgUserAsync(orgUser, user, sutProvider.GetDependency<IUserService>());
     }
 
     [Theory]
@@ -45,7 +45,7 @@ public class OrganizationUsersControllerTests
 
         await sutProvider.Sut.PutResetPasswordEnrollment(orgId, userId, model);
 
-        await sutProvider.GetDependency<IAcceptOrgUserCommand>().Received(0).AcceptOrgUserByOrgIdAsync(orgId, user, sutProvider.GetDependency<IUserService>());
+        await sutProvider.GetDependency<IAcceptOrgUserCommand>().Received(0).AcceptOrgUserAsync(orgUser, user, sutProvider.GetDependency<IUserService>());
     }
 
     [Theory]

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptOrgUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptOrgUserCommandTests.cs
@@ -183,7 +183,7 @@ public class AcceptOrgUserCommandTests
     }
 
 
-    // AcceptOrgUserByOrgIdAsync tests --------------------------------------------------------------------------------
+    // AcceptOrgUserByEmailTokenAsync tests --------------------------------------------------------------------------------
 
     [Theory]
     [EphemeralDataProtectionAutoData]
@@ -478,71 +478,6 @@ public class AcceptOrgUserCommandTests
         // Act & Assert
         var exception = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.AcceptOrgUserByOrgSsoIdAsync(org.Identifier, user, _userService));
-
-        Assert.Equal("User not found within organization.", exception.Message);
-    }
-
-    // AcceptOrgUserByOrgIdAsync ---------------------------------------------------------------------------------------
-
-    [Theory]
-    [BitAutoData]
-    public async Task AcceptOrgUserByOrgId_ValidData_AcceptsOrgUser(
-        SutProvider<AcceptOrgUserCommand> sutProvider,
-        User user, Organization org, OrganizationUser orgUser, OrganizationUserUserDetails adminUserDetails)
-    {
-        // Arrange
-        SetupCommonAcceptOrgUserMocks(sutProvider, user, org, orgUser, adminUserDetails);
-
-        sutProvider.GetDependency<IOrganizationRepository>()
-            .GetByIdAsync(org.Id)
-            .Returns(org);
-
-        sutProvider.GetDependency<IOrganizationUserRepository>()
-            .GetByOrganizationAsync(org.Id, user.Id)
-            .Returns(orgUser);
-
-        // Act
-        var resultOrgUser = await sutProvider.Sut.AcceptOrgUserByOrgIdAsync(org.Id, user, _userService);
-
-        // Assert
-        AssertValidAcceptedOrgUser(resultOrgUser, orgUser, user);
-    }
-
-    [Theory]
-    [BitAutoData]
-    public async Task AcceptOrgUserByOrgId_InvalidOrg_ThrowsBadRequest(SutProvider<AcceptOrgUserCommand> sutProvider,
-        Guid orgId, User user)
-    {
-        // Arrange
-
-        sutProvider.GetDependency<IOrganizationRepository>()
-            .GetByIdAsync(orgId)
-            .Returns((Organization)null);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<BadRequestException>(
-            () => sutProvider.Sut.AcceptOrgUserByOrgIdAsync(orgId, user, _userService));
-
-        Assert.Equal("Organization invalid.", exception.Message);
-    }
-
-    [Theory]
-    [BitAutoData]
-    public async Task AcceptOrgUserByOrgId_UserNotInOrg_ThrowsBadRequest(SutProvider<AcceptOrgUserCommand> sutProvider,
-        Organization org, User user)
-    {
-        // Arrange
-        sutProvider.GetDependency<IOrganizationRepository>()
-            .GetByIdAsync(org.Id)
-            .Returns(org);
-
-        sutProvider.GetDependency<IOrganizationUserRepository>()
-            .GetByOrganizationAsync(org.Id, user.Id)
-            .Returns((OrganizationUser)null);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<BadRequestException>(
-            () => sutProvider.Sut.AcceptOrgUserByOrgIdAsync(org.Id, user, _userService));
 
         Assert.Equal("User not found within organization.", exception.Message);
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

In researching a bug, I identified that there was the potential to remove one of the methods by which we accept a user into an org.  We could simplify the interface and also avoid re-retrieving the `OrganizationUser` when we already have it in the calling method.

## Code changes

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
