### PR TITLE
[PM-5788] Ensure Collection Service respects Flexible Collections falg

### DIFF
--- a/src/Core/Services/Implementations/CollectionService.cs
+++ b/src/Core/Services/Implementations/CollectionService.cs
@@ -56,7 +56,7 @@ public class CollectionService : ICollectionService
         var usersList = users?.ToList();
 
         // If using Flexible Collections - a collection should always have someone with Can Manage permissions
-        if (_featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1))
+        if (org.FlexibleCollections && _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1))
         {
             var groupHasManageAccess = groupsList?.Any(g => g.Manage) ?? false;
             var userHasManageAccess = usersList?.Any(u => u.Manage) ?? false;

--- a/test/Core.Test/Services/CollectionServiceTests.cs
+++ b/test/Core.Test/Services/CollectionServiceTests.cs
@@ -112,6 +112,7 @@ public class CollectionServiceTest
         [CollectionAccessSelectionCustomize] IEnumerable<CollectionAccessSelection> users, SutProvider<CollectionService> sutProvider)
     {
         collection.Id = default;
+        organization.FlexibleCollections = true;
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
         sutProvider.GetDependency<IFeatureService>()
             .IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1, Arg.Any<bool>())


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

The `CollectionService.SaveAsync()` method assumed that if the V1 FC flag was enabled for a user it implied that FC MVP was also enabled. However, now that we moved FC MVP to opt-in and moved the feature flag to the organization table – that may not always be the case. So this adds an additional check that the organization also has FC enabled before enforcing FC rules when saving a Collection.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Core/Services/Implementations/CollectionService.cs:** Add check for `org.FlexibleCollections`

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
