### PR TITLE
[PM-5638] Bump minimum client version for vault item encryption

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -23,7 +23,7 @@ public static class Constants
 
     public const string Fido2KeyCipherMinimumVersion = "2023.10.0";
 
-    public const string CipherKeyEncryptionMinimumVersion = "2023.12.0";
+    public const string CipherKeyEncryptionMinimumVersion = "2024.1.3";
 
     /// <summary>
     /// Used by IdentityServer to identify our own provider.


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Set the minimum client version that will support vault item encryption to `2024.1.3`, as the final pieces of this will be released with the release on 2/6, which will be:

- web: `2024.1.3`
- browser: `2024.1.2`
- desktop: `2024.1.1`
- CLI: `2024.1.1`

Clients PR: https://github.com/bitwarden/clients/pull/7705
Mobile PR: https://github.com/bitwarden/mobile/pull/2959

## Code changes

* **Constants.cs:** Updated minimum version.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
