### PR TITLE
Add logic to prevent running on Version Bump PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   testing:
     name: Run tests
-    if: ${{ startsWith(github.head_ref, 'update-test-workflow') == false }}
+    if: ${{ startsWith(github.head_ref, 'version_bump_') == false }}
     runs-on: ubuntu-22.04
     env:
       NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   testing:
     name: Run tests
+    if: ${{ startsWith(github.head_ref, 'update-test-workflow') == false }}
     runs-on: ubuntu-22.04
     env:
       NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR adds an `if` key to the `Testing` job so that it will skip it if the branch starts with `version_bump_`.  The reason we can't use the `branches-ignore` key under the `pull_request` trigger is because the required check would stay pending indefinitely blocking the approval and merge of the PR.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **.github/workflows/test.yml:** Add logic to the `Testing` job to skip running it if the branch starts with `version_bump_` indicating a Version Bump branch.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
