### PR TITLE
[AC-2104] Add flexible collections properties to provider organizations sync response

### DIFF
--- a/src/Api/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModel.cs
@@ -43,5 +43,8 @@ public class ProfileProviderOrganizationResponseModel : ProfileOrganizationRespo
         ProviderId = organization.ProviderId;
         ProviderName = organization.ProviderName;
         PlanProductType = StaticStore.GetPlan(organization.PlanType).Product;
+        LimitCollectionCreationDeletion = organization.LimitCollectionCreationDeletion;
+        AllowAdminAccessToAllCollectionItems = organization.AllowAdminAccessToAllCollectionItems;
+        FlexibleCollections = organization.FlexibleCollections;
     }
 }

--- a/src/Core/AdminConsole/Models/Data/Provider/ProviderUserOrganizationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Provider/ProviderUserOrganizationDetails.cs
@@ -35,4 +35,7 @@ public class ProviderUserOrganizationDetails
     public Guid? ProviderUserId { get; set; }
     public string ProviderName { get; set; }
     public Core.Enums.PlanType PlanType { get; set; }
+    public bool LimitCollectionCreationDeletion { get; set; }
+    public bool AllowAdminAccessToAllCollectionItems { get; set; }
+    public bool FlexibleCollections { get; set; }
 }

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/ProviderUserOrganizationDetailsViewQuery.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/ProviderUserOrganizationDetailsViewQuery.cs
@@ -43,7 +43,10 @@ public class ProviderUserOrganizationDetailsViewQuery : IQuery<ProviderUserOrgan
             PrivateKey = x.o.PrivateKey,
             ProviderId = x.p.Id,
             ProviderName = x.p.Name,
-            PlanType = x.o.PlanType
+            PlanType = x.o.PlanType,
+            LimitCollectionCreationDeletion = x.o.LimitCollectionCreationDeletion,
+            AllowAdminAccessToAllCollectionItems = x.o.AllowAdminAccessToAllCollectionItems,
+            FlexibleCollections = x.o.FlexibleCollections
         });
     }
 }

--- a/util/Migrator/DbScripts/2024-01-29_00_ProviderOrganizationsFlexibleCollectionColumns.sql
+++ b/util/Migrator/DbScripts/2024-01-29_00_ProviderOrganizationsFlexibleCollectionColumns.sql
@@ -1,4 +1,5 @@
-﻿CREATE VIEW [dbo].[ProviderUserProviderOrganizationDetailsView]
+-- Add columns LimitCollectionCreationDeletion, AllowAdminAccessToAllCollectionItems, FlexibleCollections to view
+CREATE OR ALTER VIEW [dbo].[ProviderUserProviderOrganizationDetailsView]
 AS
 SELECT
     PU.[UserId],
@@ -43,3 +44,11 @@ INNER JOIN
     [dbo].[Organization] O ON O.[Id] = PO.[OrganizationId]
 INNER JOIN
     [dbo].[Provider] P ON P.[Id] = PU.[ProviderId]
+GO
+
+--Manually refresh ProviderOrganizationOrganizationDetailsView
+IF OBJECT_ID('[dbo].[ProviderUserProviderOrganizationDetails_ReadByUserIdStatus]') IS NOT NULL
+BEGIN
+    EXECUTE sp_refreshsqlmodule N'[dbo].[ProviderUserProviderOrganizationDetails_ReadByUserIdStatus]';
+END
+GO


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
The organizations returned in the Sync response lacked the Flexible Collections properties leading to some issues on the client side.

## Code changes

- **src/Api/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModel.cs:** Set response property values from the Organization
- **src/Core/AdminConsole/Models/Data/Provider/ProviderUserOrganizationDetails.cs:** Added missing Flexible Collections properties
- **src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/ProviderUserOrganizationDetailsViewQuery.cs:** Updated EF query to retrieve the missing values
- **src/Sql/dbo/Views/ProviderUserProviderOrganizationDetailsView.sql:** Updated the view script to retrieve the missing values
- **util/Migrator/DbScripts/2024-01-29_00_ProviderOrganizationsFlexibleCollectionColumns.sql:** Migration script to update the view script to retrieve the missing values

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
