### PR TITLE
[AC-2106] Add check for providers and additional check for null response

### DIFF
--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -251,7 +251,7 @@ public class CollectionsController : Controller
 
         await _collectionService.SaveAsync(collection, groups, users);
 
-        if (!_currentContext.UserId.HasValue)
+        if (!_currentContext.UserId.HasValue || await _currentContext.ProviderUserForOrgAsync(orgId))
         {
             return new CollectionResponseModel(collection);
         }
@@ -260,7 +260,9 @@ public class CollectionsController : Controller
         var userCollectionDetails = await _collectionRepository.GetByIdAsync(collection.Id,
             _currentContext.UserId.Value, await FlexibleCollectionsIsEnabledAsync(collection.OrganizationId));
 
-        return new CollectionDetailsResponseModel(userCollectionDetails);
+        return userCollectionDetails == null
+            ? new CollectionResponseModel(collection)
+            : new CollectionDetailsResponseModel(userCollectionDetails);
     }
 
     [HttpPut("{id}")]
@@ -629,7 +631,7 @@ public class CollectionsController : Controller
         var users = model.Users?.Select(g => g.ToSelectionReadOnly());
         await _collectionService.SaveAsync(model.ToCollection(collection), groups, users);
 
-        if (!_currentContext.UserId.HasValue)
+        if (!_currentContext.UserId.HasValue || await _currentContext.ProviderUserForOrgAsync(collection.OrganizationId))
         {
             return new CollectionResponseModel(collection);
         }
@@ -637,7 +639,9 @@ public class CollectionsController : Controller
         // If we have a user, fetch the collection details to get the latest permission details for the user
         var updatedCollectionDetails = await _collectionRepository.GetByIdAsync(id, _currentContext.UserId.Value, await FlexibleCollectionsIsEnabledAsync(collection.OrganizationId));
 
-        return new CollectionDetailsResponseModel(updatedCollectionDetails);
+        return updatedCollectionDetails == null
+            ? new CollectionResponseModel(collection)
+            : new CollectionDetailsResponseModel(updatedCollectionDetails);
     }
 
     private async Task PutUsers_vNext(Guid id, IEnumerable<SelectionReadOnlyRequestModel> model)


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

When permission details were add to the collection `PUT/POST` response in #3658 an additional check for provider users was missed and would cause an exception to be thrown because provider users are not explicitly assigned to the managed organization's collections. 

This PR modifies that logic to exclude trying to fetch the permission details when a provider user is making the request on behalf of the managed organization.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Api/Controllers/CollectionsController.cs:** Don't fetch additional collection permissions for Provider users as the permissions will not be available. Also add a null check when returning the response to avoid any unexpected null reference exceptions.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
