### PR TITLE
Added missing `Provider_Edit` permission for admins in Bitwarden portal

### DIFF
--- a/src/Admin/Utilities/RolePermissionMapping.cs
+++ b/src/Admin/Utilities/RolePermissionMapping.cs
@@ -88,6 +88,7 @@ public static class RolePermissionMapping
                 Permission.Provider_List_View,
                 Permission.Provider_Create,
                 Permission.Provider_View,
+                Permission.Provider_Edit,
                 Permission.Provider_ResendEmailInvite,
                 Permission.Tools_ChargeBrainTreeCustomer,
                 Permission.Tools_PromoteAdmin,


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Priya discovered that admin users in the Bitwarden Portal were not able to edit providers in the Bitwarden Portal. This PR adds permission for that role. Additionally, I was able to verify that, of all the permissions we have in the Bitwarden Portal, this was the one permission missing for admins.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **RolePermissionMapping.cs:** Added the one permission that admins were lacking in the Bitwarden Portal

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
