### PR TITLE
[PM-6165] Add x-enum-varnames to improve swagger generation

### DIFF
--- a/src/Api/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Api/Utilities/ServiceCollectionExtensions.cs
@@ -1,11 +1,11 @@
-﻿using Bit.Api.Utilities.Swagger;
-using Bit.Api.Vault.AuthorizationHandlers.Collections;
+﻿using Bit.Api.Vault.AuthorizationHandlers.Collections;
 using Bit.Api.Vault.AuthorizationHandlers.Groups;
 using Bit.Api.Vault.AuthorizationHandlers.OrganizationUsers;
 using Bit.Core.IdentityServer;
 using Bit.Core.Settings;
 using Bit.Core.Utilities;
 using Bit.SharedWeb.Health;
+using Bit.SharedWeb.Swagger;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.OpenApi.Models;
 

--- a/src/Api/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Api/Utilities/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Api.Vault.AuthorizationHandlers.Collections;
+﻿using Bit.Api.Utilities.Swagger;
+using Bit.Api.Vault.AuthorizationHandlers.Collections;
 using Bit.Api.Vault.AuthorizationHandlers.Groups;
 using Bit.Api.Vault.AuthorizationHandlers.OrganizationUsers;
 using Bit.Core.IdentityServer;
@@ -68,6 +69,8 @@ public static class ServiceCollectionExtensions
 
             config.DescribeAllParametersInCamelCase();
             // config.UseReferencedDefinitionsForEnums();
+
+            config.SchemaFilter<EnumSchemaFilter>();
 
             var apiFilePath = Path.Combine(AppContext.BaseDirectory, "Api.xml");
             config.IncludeXmlComments(apiFilePath, true);

--- a/src/Api/Utilities/Swagger/EnumSchemaFilter.cs
+++ b/src/Api/Utilities/Swagger/EnumSchemaFilter.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Bit.Api.Utilities.Swagger;
+
+/// <summary>
+/// Adds x-enum-varnames containing the name of enums. Useful for code generation.
+///</summary>
+/// <remarks>
+/// Ideally we would use `oneOf` instead but it's not currently handled well by our swagger generator.
+///
+/// Credits: https://github.com/domaindrivendev/Swashbuckle.WebApi/issues/1287#issuecomment-655164215
+/// </remarks>
+public class EnumSchemaFilter : ISchemaFilter
+{
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (context.Type.IsEnum)
+        {
+            var array = new OpenApiArray();
+            array.AddRange(Enum.GetNames(context.Type).Select(n => new OpenApiString(n)));
+            schema.Extensions.Add("x-enum-varnames", array);
+        }
+    }
+}

--- a/src/Identity/Identity.csproj
+++ b/src/Identity/Identity.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="MessagePack" Version="2.5.140" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Identity/Startup.cs
+++ b/src/Identity/Startup.cs
@@ -9,6 +9,7 @@ using Bit.Core.SecretsManager.Repositories.Noop;
 using Bit.Core.Settings;
 using Bit.Core.Utilities;
 using Bit.Identity.Utilities;
+using Bit.SharedWeb.Swagger;
 using Bit.SharedWeb.Utilities;
 using Duende.IdentityServer.Extensions;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -64,6 +65,7 @@ public class Startup
 
         services.AddSwaggerGen(c =>
         {
+            c.SchemaFilter<EnumSchemaFilter>();
             c.SwaggerDoc("v1", new OpenApiInfo { Title = "Bitwarden Identity", Version = "v1" });
         });
 

--- a/src/SharedWeb/SharedWeb.csproj
+++ b/src/SharedWeb/SharedWeb.csproj
@@ -1,9 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <ItemGroup>
-      <ProjectReference Include="..\Infrastructure.Dapper\Infrastructure.Dapper.csproj" />
-      <ProjectReference Include="..\Core\Core.csproj" />
-      <ProjectReference Include="..\Infrastructure.EntityFramework\Infrastructure.EntityFramework.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Infrastructure.Dapper\Infrastructure.Dapper.csproj" />
+    <ProjectReference Include="..\Core\Core.csproj" />
+    <ProjectReference Include="..\Infrastructure.EntityFramework\Infrastructure.EntityFramework.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
+  </ItemGroup>
 
 </Project>

--- a/src/SharedWeb/Swagger/EnumSchemaFilter.cs
+++ b/src/SharedWeb/Swagger/EnumSchemaFilter.cs
@@ -2,7 +2,7 @@
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
-namespace Bit.Api.Utilities.Swagger;
+namespace Bit.SharedWeb.Swagger;
 
 /// <summary>
 /// Adds x-enum-varnames containing the name of enums. Useful for code generation.


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Improves code generation of enums for the server bindings in the sdk. Bindings will now use the appropiate variable name from the server.

Works by adding a filter which appends `x-enum-varnames` to enums with the name from c#.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
