### PR TITLE
[PM-6177] Persistent distributed cache using Cosmos

### DIFF
--- a/src/Api/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Api/Utilities/ServiceCollectionExtensions.cs
@@ -90,9 +90,9 @@ public static class ServiceCollectionExtensions
                 builder.AddSqlServer(globalSettings.SqlServer.ConnectionString);
             }
 
-            if (CoreHelpers.SettingHasValue(globalSettings.Redis.ConnectionString))
+            if (CoreHelpers.SettingHasValue(globalSettings.DistributedCache?.Redis?.ConnectionString))
             {
-                builder.AddRedis(globalSettings.Redis.ConnectionString);
+                builder.AddRedis(globalSettings.DistributedCache.Redis.ConnectionString);
             }
 
             if (CoreHelpers.SettingHasValue(globalSettings.Storage.ConnectionString))

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
     <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="4.1.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Cosmos" Version="1.6.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.25" />

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -55,7 +55,7 @@ public class GlobalSettings : IGlobalSettings
     public virtual MailSettings Mail { get; set; } = new MailSettings();
     public virtual IConnectionStringSettings Storage { get; set; } = new ConnectionStringSettings();
     public virtual ConnectionStringSettings Events { get; set; } = new ConnectionStringSettings();
-    public virtual IConnectionStringSettings Redis { get; set; } = new ConnectionStringSettings();
+    public virtual DistributedCacheSettings DistributedCache { get; set; } = new DistributedCacheSettings();
     public virtual NotificationsSettings Notifications { get; set; } = new NotificationsSettings();
     public virtual IFileStorageSettings Attachment { get; set; }
     public virtual FileStorageSettings Send { get; set; }
@@ -549,5 +549,11 @@ public class GlobalSettings : IGlobalSettings
         public string SdkKey { get; set; }
         public string FlagDataFilePath { get; set; } = "flags.json";
         public Dictionary<string, string> FlagValues { get; set; } = new Dictionary<string, string>();
+    }
+
+    public class DistributedCacheSettings
+    {
+        public virtual IConnectionStringSettings Redis { get; set; } = new ConnectionStringSettings();
+        public virtual IConnectionStringSettings Cosmos { get; set; } = new ConnectionStringSettings();
     }
 }

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -48,6 +48,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.Localization;
+using Microsoft.Azure.Cosmos.Fluent;
+using Microsoft.Extensions.Caching.Cosmos;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -693,16 +695,33 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services,
         GlobalSettings globalSettings)
     {
-        if (globalSettings.SelfHosted || string.IsNullOrEmpty(globalSettings.Redis.ConnectionString))
+        if (!string.IsNullOrEmpty(globalSettings.DistributedCache?.Redis?.ConnectionString))
+        {
+            services.AddStackExchangeRedisCache(options =>
+            {
+                options.Configuration = globalSettings.DistributedCache.Redis.ConnectionString;
+            });
+        }
+        else
         {
             services.AddDistributedMemoryCache();
-            return;
         }
 
-        services.AddStackExchangeRedisCache(options =>
+        if (!string.IsNullOrEmpty(globalSettings.DistributedCache?.Cosmos?.ConnectionString))
         {
-            options.Configuration = globalSettings.Redis.ConnectionString;
-        });
+            services.AddKeyedSingleton<IDistributedCache>("persistent", (s, _) =>
+                new CosmosCache(new CosmosCacheOptions
+                {
+                    DatabaseName = "cache",
+                    ContainerName = "persistent",
+                    CreateIfNotExists = false,
+                    ClientBuilder = new CosmosClientBuilder(globalSettings.DistributedCache?.Cosmos?.ConnectionString)
+                }));
+        }
+        else
+        {
+            services.AddKeyedSingleton<IDistributedCache, MemoryDistributedCache>("persistent");
+        }
     }
 
     public static IServiceCollection AddOptionality(this IServiceCollection services)

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -713,7 +713,7 @@ public static class ServiceCollectionExtensions
                 new CosmosCache(new CosmosCacheOptions
                 {
                     DatabaseName = "cache",
-                    ContainerName = "persistent",
+                    ContainerName = "default",
                     CreateIfNotExists = false,
                     ClientBuilder = new CosmosClientBuilder(globalSettings.DistributedCache?.Cosmos?.ConnectionString)
                 }));


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
We have various short-lived items that need persistence, such as TOTP code, identity tickets, etc. Today they use Redis, which by default does not provide the persistence that we need and is arguably not the right technology for this use case.

Add a new type of IDistributedCache that can be used for the persistent things using Cosmos with TTL as the backing store.

A follow-up PR will implement this new IDistributedCache in the appropriate places.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
