### PR TITLE
Fix Container Registry Cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-after-pr.yml
+++ b/.github/workflows/cleanup-after-pr.yml
@@ -10,9 +10,6 @@ jobs:
     name: Remove branch-specific Docker images
     runs-on: ubuntu-22.04
     steps:
-      - name: Check out repo
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-
       ########## ACR ##########
       - name: Log in to Azure - QA Subscription
         uses: Azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # v1.4.7
@@ -33,6 +30,7 @@ jobs:
       ########## Remove Docker images ##########
       - name: Remove the Docker image from ACR
         env:
+          REF: ${{ github.event.pull_request.head.ref }}
           REGISTRIES: |
             registries:
               - bitwardenprod
@@ -59,7 +57,7 @@ jobs:
             for REGISTRY in $( echo "${{ env.REGISTRIES }}" | yq e ".registries[]" - )
             do
               SERVICE_NAME=$(echo $SERVICE | awk '{print tolower($0)}')
-              IMAGE_TAG=$(echo "${GITHUB_REF:11}" | sed "s#/#-#g")  # slash safe branch name
+              IMAGE_TAG=$(echo "${REF}" | sed "s#/#-#g")  # slash safe branch name
 
               echo "[*] Checking if remote exists: $REGISTRY.azurecr.io/$SERVICE_NAME:$IMAGE_TAG"
               TAG_EXISTS=$(


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR updates the `Container Registry Cleanup` workflow so that it generates the proper `IMAGE_TAG` variable to find images to remove from the registries.  Currently it was only ever using `main`.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **.github/workflows/cleanup-after-pr.yml:** Add in the proper ref for the `IMAGE_TAG` calculation.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
