### PR TITLE
Setup dev environment for redis distributed cache

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -30,6 +30,15 @@ services:
       - storage
       - cloud
 
+  redis:
+    image: redis/redis-stack:latest
+    ports:
+      - "6379:6379"
+      - "8001:8001"
+    profiles:
+      - storage
+      - cloud
+
   mail:
     image: sj26/mailcatcher:latest
     ports:

--- a/dev/secrets.json.example
+++ b/dev/secrets.json.example
@@ -29,6 +29,11 @@
     "dataProtection": {
       "certificateThumbprint": "<your Data Protection certificate thumbprint with no spaces>"
     },
+    "distributedCache": {
+      "redis": {
+        "connectionString": "localhost"
+      }
+    },
     "installation": {
       "id": "<your Installation Id>",
       "key": "<your Installation Key>"

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -716,7 +716,7 @@ public static class ServiceCollectionExtensions
         }
         else
         {
-            services.AddKeyedSingleton<IDistributedCache, MemoryDistributedCache>("persistent");
+            services.AddKeyedSingleton("persistent", (s, _) => s.GetRequiredService<IDistributedCache>());
         }
     }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
There have been several PRs recently (by me) that utilize IDistributedCache more throughout our codebase. In our dev environments we have been using memory-based IDistributedCache fallbacks, which breaks down when cache access is needed across multiple projects. For example, email tokens generated from API cannot be validated by Identity.

Add redis to the dev docker environment and use it in secrets.json generation.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
