### PR TITLE
Vault/ac 2084/include permissions for admin endpoints

### DIFF
--- a/src/Api/Models/Response/CollectionResponseModel.cs
+++ b/src/Api/Models/Response/CollectionResponseModel.cs
@@ -50,6 +50,17 @@ public class CollectionAccessDetailsResponseModel : CollectionResponseModel
         Users = users.Select(g => new SelectionReadOnlyResponseModel(g));
     }
 
+    public CollectionAccessDetailsResponseModel(CollectionAdminDetails collection)
+        : base(collection, "collectionAccessDetails")
+    {
+        Assigned = collection.Assigned;
+        ReadOnly = collection.ReadOnly;
+        HidePasswords = collection.HidePasswords;
+        Manage = collection.Manage;
+        Groups = collection.Groups?.Select(g => new SelectionReadOnlyResponseModel(g)) ?? Enumerable.Empty<SelectionReadOnlyResponseModel>();
+        Users = collection.Users?.Select(g => new SelectionReadOnlyResponseModel(g)) ?? Enumerable.Empty<SelectionReadOnlyResponseModel>();
+    }
+
     public IEnumerable<SelectionReadOnlyResponseModel> Groups { get; set; }
     public IEnumerable<SelectionReadOnlyResponseModel> Users { get; set; }
 
@@ -57,4 +68,8 @@ public class CollectionAccessDetailsResponseModel : CollectionResponseModel
     /// True if the acting user is explicitly assigned to the collection
     /// </summary>
     public bool Assigned { get; set; }
+
+    public bool ReadOnly { get; set; }
+    public bool HidePasswords { get; set; }
+    public bool Manage { get; set; }
 }

--- a/src/Core/Models/Data/CollectionAdminDetails.cs
+++ b/src/Core/Models/Data/CollectionAdminDetails.cs
@@ -1,0 +1,17 @@
+﻿#nullable enable
+namespace Bit.Core.Models.Data;
+
+/// <summary>
+/// Collection information that includes permission details for a particular user along with optional
+/// access relationships for Groups/Users. Used for collection management.
+/// </summary>
+public class CollectionAdminDetails : CollectionDetails
+{
+    public IEnumerable<CollectionAccessSelection>? Groups { get; set; } = new List<CollectionAccessSelection>();
+    public IEnumerable<CollectionAccessSelection>? Users { get; set; } = new List<CollectionAccessSelection>();
+
+    /// <summary>
+    /// Flag for whether the user has been explicitly assigned to the collection either directly or through a group.
+    /// </summary>
+    public bool Assigned { get; set; }
+}

--- a/src/Core/Models/Data/CollectionDetails.cs
+++ b/src/Core/Models/Data/CollectionDetails.cs
@@ -2,6 +2,9 @@
 
 namespace Bit.Core.Models.Data;
 
+/// <summary>
+/// Collection information that includes permission details for a particular user
+/// </summary>
 public class CollectionDetails : Collection
 {
     public bool ReadOnly { get; set; }

--- a/src/Core/Repositories/ICollectionRepository.cs
+++ b/src/Core/Repositories/ICollectionRepository.cs
@@ -6,13 +6,48 @@ namespace Bit.Core.Repositories;
 public interface ICollectionRepository : IRepository<Collection, Guid>
 {
     Task<int> GetCountByOrganizationIdAsync(Guid organizationId);
+
+    /// <summary>
+    /// Returns a collection and fetches group/user associations for the collection.
+    /// </summary>
     Task<Tuple<Collection, CollectionAccessDetails>> GetByIdWithAccessAsync(Guid id);
+
+    /// <summary>
+    /// Returns a collection with permission details for the provided userId and fetches group/user associations for
+    /// the collection.
+    /// If the user does not have a relationship with the collection, nothing is returned.
+    /// </summary>
     Task<Tuple<CollectionDetails, CollectionAccessDetails>> GetByIdWithAccessAsync(Guid id, Guid userId, bool useFlexibleCollections);
+
+    /// <summary>
+    /// Return all collections that belong to the organization. Does not include any permission details or group/user
+    /// access relationships.
+    /// </summary>
     Task<ICollection<Collection>> GetManyByOrganizationIdAsync(Guid organizationId);
+
+    /// <summary>
+    /// Return all collections that belong to the organization. Includes group/user access relationships for each collection.
+    /// </summary>
     Task<ICollection<Tuple<Collection, CollectionAccessDetails>>> GetManyByOrganizationIdWithAccessAsync(Guid organizationId);
+
+    /// <summary>
+    /// Returns collections that both, belong to the organization AND have an access relationship with the provided user.
+    /// Includes permission details for the provided user and group/user access relationships for each collection.
+    /// </summary>
     Task<ICollection<Tuple<CollectionDetails, CollectionAccessDetails>>> GetManyByUserIdWithAccessAsync(Guid userId, Guid organizationId, bool useFlexibleCollections);
+
+    /// <summary>
+    /// Returns a collection with permission details for the provided userId. Does not include group/user access
+    /// relationships.
+    /// If the user does not have a relationship with the collection, nothing is returned.
+    /// </summary>
     Task<CollectionDetails> GetByIdAsync(Guid id, Guid userId, bool useFlexibleCollections);
     Task<ICollection<Collection>> GetManyByManyIdsAsync(IEnumerable<Guid> collectionIds);
+
+    /// <summary>
+    /// Return all collections a user has access to across all of the organization they're a member of. Includes permission
+    /// details for each collection.
+    /// </summary>
     Task<ICollection<CollectionDetails>> GetManyByUserIdAsync(Guid userId, bool useFlexibleCollections);
     Task CreateAsync(Collection obj, IEnumerable<CollectionAccessSelection> groups, IEnumerable<CollectionAccessSelection> users);
     Task ReplaceAsync(Collection obj, IEnumerable<CollectionAccessSelection> groups, IEnumerable<CollectionAccessSelection> users);

--- a/src/Core/Repositories/ICollectionRepository.cs
+++ b/src/Core/Repositories/ICollectionRepository.cs
@@ -49,6 +49,21 @@ public interface ICollectionRepository : IRepository<Collection, Guid>
     /// details for each collection.
     /// </summary>
     Task<ICollection<CollectionDetails>> GetManyByUserIdAsync(Guid userId, bool useFlexibleCollections);
+
+    /// <summary>
+    /// Returns all collections for an organization, including permission info for the specified user.
+    /// This does not perform any authorization checks internally!
+    /// Optionally, you can include access relationships for other Groups/Users and the collections.
+    /// </summary>
+    Task<ICollection<CollectionAdminDetails>> GetManyByOrganizationIdWithPermissionsAsync(Guid organizationId, Guid userId, bool includeAccessRelationships);
+
+    /// <summary>
+    /// Returns the collection by Id, including permission info for the specified user.
+    /// This does not perform any authorization checks internally!
+    /// Optionally, you can include access relationships for other Groups/Users and the collection.
+    /// </summary>
+    Task<CollectionAdminDetails> GetByIdWithPermissionsAsync(Guid collectionId, Guid? userId, bool includeAccessRelationships);
+
     Task CreateAsync(Collection obj, IEnumerable<CollectionAccessSelection> groups, IEnumerable<CollectionAccessSelection> users);
     Task ReplaceAsync(Collection obj, IEnumerable<CollectionAccessSelection> groups, IEnumerable<CollectionAccessSelection> users);
     Task DeleteUserAsync(Guid collectionId, Guid organizationUserId);

--- a/src/Infrastructure.Dapper/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.Dapper/Repositories/CollectionRepository.cs
@@ -225,6 +225,75 @@ public class CollectionRepository : Repository<Collection, Guid>, ICollectionRep
         }
     }
 
+    public async Task<ICollection<CollectionAdminDetails>> GetManyByOrganizationIdWithPermissionsAsync(Guid organizationId, Guid userId, bool includeAccessRelationships)
+    {
+        using (var connection = new SqlConnection(ConnectionString))
+        {
+            var results = await connection.QueryMultipleAsync(
+                $"[{Schema}].[Collection_ReadByOrganizationIdWithPermissions]",
+                new { OrganizationId = organizationId, UserId = userId, IncludeAccessRelationships = includeAccessRelationships },
+                commandType: CommandType.StoredProcedure);
+
+            var collections = (await results.ReadAsync<CollectionAdminDetails>()).ToList();
+
+            if (!includeAccessRelationships)
+            {
+                return collections;
+            }
+
+            var groups = (await results.ReadAsync<CollectionGroup>())
+                .GroupBy(g => g.CollectionId)
+                .ToList();
+            var users = (await results.ReadAsync<CollectionUser>())
+                .GroupBy(u => u.CollectionId)
+                .ToList();
+
+            foreach (var collection in collections)
+            {
+                collection.Groups = groups
+                    .FirstOrDefault(g => g.Key == collection.Id)?
+                    .Select(g => new CollectionAccessSelection
+                    {
+                        Id = g.GroupId,
+                        HidePasswords = g.HidePasswords,
+                        ReadOnly = g.ReadOnly,
+                        Manage = g.Manage
+                    }).ToList() ?? new List<CollectionAccessSelection>();
+                collection.Users = users
+                    .FirstOrDefault(u => u.Key == collection.Id)?
+                    .Select(c => new CollectionAccessSelection
+                    {
+                        Id = c.OrganizationUserId,
+                        HidePasswords = c.HidePasswords,
+                        ReadOnly = c.ReadOnly,
+                        Manage = c.Manage
+                    }).ToList() ?? new List<CollectionAccessSelection>();
+            }
+
+            return collections;
+        }
+    }
+
+    public async Task<CollectionAdminDetails> GetByIdWithPermissionsAsync(Guid collectionId, Guid? userId, bool includeAccessRelationships)
+    {
+        using (var connection = new SqlConnection(ConnectionString))
+        {
+            var results = await connection.QueryMultipleAsync(
+                $"[{Schema}].[Collection_ReadByIdWithPermissions]",
+                new { CollectionId = collectionId, UserId = userId, IncludeAccessRelationships = includeAccessRelationships },
+                commandType: CommandType.StoredProcedure);
+
+            var collectionDetails = await results.ReadFirstOrDefaultAsync<CollectionAdminDetails>();
+
+            if (!includeAccessRelationships) return collectionDetails;
+
+            collectionDetails.Groups = (await results.ReadAsync<CollectionAccessSelection>()).ToList();
+            collectionDetails.Users = (await results.ReadAsync<CollectionAccessSelection>()).ToList();
+
+            return collectionDetails;
+        }
+    }
+
     public async Task CreateAsync(Collection obj, IEnumerable<CollectionAccessSelection> groups, IEnumerable<CollectionAccessSelection> users)
     {
         obj.SetNewId();

--- a/src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs
@@ -48,6 +48,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
         }
     }
 
+    public async Task<CollectionAdminDetails> GetByIdWithPermissionsAsync(Guid collectionId, Guid? userId, bool includeAccessRelationships) => throw new NotImplementedException();
+
     public async Task CreateAsync(Core.Entities.Collection obj, IEnumerable<CollectionAccessSelection> groups, IEnumerable<CollectionAccessSelection> users)
     {
         await CreateAsync(obj);
@@ -369,6 +371,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                           }).ToListAsync();
         }
     }
+
+    public async Task<ICollection<CollectionAdminDetails>> GetManyByOrganizationIdWithPermissionsAsync(Guid organizationId, Guid userId, bool includeAccessRelationships) => throw new NotImplementedException();
 
     public async Task<ICollection<CollectionAccessSelection>> GetManyUsersByIdAsync(Guid id)
     {

--- a/src/Infrastructure.EntityFramework/Repositories/Queries/CollectionAdminDetailsQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/CollectionAdminDetailsQuery.cs
@@ -1,0 +1,87 @@
+﻿using Bit.Core.Models.Data;
+
+namespace Bit.Infrastructure.EntityFramework.Repositories.Queries;
+
+/// <summary>
+/// Query to get collection details, including permissions for the specified user if provided.
+/// </summary>
+public class CollectionAdminDetailsQuery : IQuery<CollectionAdminDetails>
+{
+    private readonly Guid? _userId;
+    private readonly Guid? _organizationId;
+    private readonly Guid? _collectionId;
+
+    private CollectionAdminDetailsQuery(Guid? userId, Guid? organizationId, Guid? collectionId)
+    {
+        _userId = userId;
+        _organizationId = organizationId;
+        _collectionId = collectionId;
+    }
+
+    public virtual IQueryable<CollectionAdminDetails> Run(DatabaseContext dbContext)
+    {
+        var baseCollectionQuery = from c in dbContext.Collections
+                                  join ou in dbContext.OrganizationUsers
+                                      on new { c.OrganizationId, UserId = _userId } equals
+                                      new { ou.OrganizationId, ou.UserId } into ou_g
+                                  from ou in ou_g.DefaultIfEmpty()
+
+                                  join cu in dbContext.CollectionUsers
+                                      on new { CollectionId = c.Id, OrganizationUserId = ou.Id } equals
+                                      new { cu.CollectionId, cu.OrganizationUserId } into cu_g
+                                  from cu in cu_g.DefaultIfEmpty()
+
+                                  join gu in dbContext.GroupUsers
+                                      on new { CollectionId = (Guid?)cu.CollectionId, OrganizationUserId = ou.Id } equals
+                                      new { CollectionId = (Guid?)null, gu.OrganizationUserId } into gu_g
+                                  from gu in gu_g.DefaultIfEmpty()
+
+                                  join g in dbContext.Groups
+                                      on gu.GroupId equals g.Id into g_g
+                                  from g in g_g.DefaultIfEmpty()
+
+                                  join cg in dbContext.CollectionGroups
+                                      on new { CollectionId = c.Id, gu.GroupId } equals
+                                      new { cg.CollectionId, cg.GroupId } into cg_g
+                                  from cg in cg_g.DefaultIfEmpty()
+                                  select new { c, cu, cg };
+
+        if (_organizationId.HasValue)
+        {
+            baseCollectionQuery = baseCollectionQuery.Where(x => x.c.OrganizationId == _organizationId);
+        }
+        else if (_collectionId.HasValue)
+        {
+            baseCollectionQuery = baseCollectionQuery.Where(x => x.c.Id == _collectionId);
+        }
+        else
+        {
+            throw new InvalidOperationException("OrganizationId or CollectionId must be specified.");
+        }
+
+        return baseCollectionQuery.Select(x => new CollectionAdminDetails
+        {
+            Id = x.c.Id,
+            OrganizationId = x.c.OrganizationId,
+            Name = x.c.Name,
+            ExternalId = x.c.ExternalId,
+            CreationDate = x.c.CreationDate,
+            RevisionDate = x.c.RevisionDate,
+            ReadOnly = (bool?)x.cu.ReadOnly ?? (bool?)x.cg.ReadOnly ?? false,
+            HidePasswords = (bool?)x.cu.HidePasswords ?? (bool?)x.cg.HidePasswords ?? false,
+            Manage = (bool?)x.cu.Manage ?? (bool?)x.cg.Manage ?? false,
+            Assigned = x.cu != null || x.cg != null,
+        });
+    }
+
+    public static CollectionAdminDetailsQuery ByCollectionId(Guid collectionId, Guid? userId)
+    {
+        return new CollectionAdminDetailsQuery(userId, null, collectionId);
+    }
+
+    public static CollectionAdminDetailsQuery ByOrganizationId(Guid organizationId, Guid? userId)
+    {
+        return new CollectionAdminDetailsQuery(userId, organizationId, null);
+    }
+
+}

--- a/src/Sql/Vault/dbo/Stored Procedures/Collections/Collection_ReadByIdWithPermissions.sql
+++ b/src/Sql/Vault/dbo/Stored Procedures/Collections/Collection_ReadByIdWithPermissions.sql
@@ -1,0 +1,54 @@
+CREATE PROCEDURE [dbo].[Collection_ReadByIdWithPermissions]
+    @CollectionId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @IncludeAccessRelationships BIT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+	SELECT
+	    C.*,
+	    CASE
+	        WHEN
+	            COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) = 0
+	        THEN 0
+	        ELSE 1
+	    END [ReadOnly],
+	    CASE
+	        WHEN
+	            COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
+	        THEN 0
+	        ELSE 1
+	    END [HidePasswords],
+	    CASE
+	        WHEN
+	            COALESCE(CU.[Manage], CG.[Manage], 0) = 0
+	        THEN 0
+	        ELSE 1
+	    END [Manage],
+	    CASE
+	    	WHEN CU.[CollectionId] IS NULL AND CG.[CollectionId] IS NULL
+	    	THEN 0
+	    	ELSE 1
+	    END [Assigned]
+	FROM
+	    [dbo].[CollectionView] C
+	LEFT JOIN
+	    [dbo].[OrganizationUser] OU ON C.[OrganizationId] = OU.[OrganizationId] AND OU.[UserId] = @UserId
+	LEFT JOIN
+	    [dbo].[CollectionUser] CU ON CU.[CollectionId] = C.[Id] AND CU.[OrganizationUserId] = [OU].[Id]
+	LEFT JOIN
+	    [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND GU.[OrganizationUserId] = OU.[Id]
+	LEFT JOIN
+	    [dbo].[Group] G ON G.[Id] = GU.[GroupId]
+	LEFT JOIN
+	    [dbo].[CollectionGroup] CG ON CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
+	WHERE
+	    C.[Id] = @CollectionId
+
+   IF (@IncludeAccessRelationships = 1)
+    BEGIN
+        EXEC [dbo].[CollectionGroup_ReadByCollectionId] @CollectionId
+        EXEC [dbo].[CollectionUser_ReadByCollectionId] @CollectionId
+	END
+END

--- a/src/Sql/Vault/dbo/Stored Procedures/Collections/Collection_ReadByOrganizationIdWithPermissions.sql
+++ b/src/Sql/Vault/dbo/Stored Procedures/Collections/Collection_ReadByOrganizationIdWithPermissions.sql
@@ -1,0 +1,54 @@
+CREATE PROCEDURE [dbo].[Collection_ReadByOrganizationIdWithPermissions]
+    @OrganizationId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @IncludeAccessRelationships BIT
+AS
+BEGIN
+	SET NOCOUNT ON
+
+	SELECT
+	    C.*,
+	    CASE
+	        WHEN
+	            COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) = 0
+	        THEN 0
+	        ELSE 1
+	    END [ReadOnly],
+	    CASE
+	        WHEN
+	            COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
+	        THEN 0
+	        ELSE 1
+	    END [HidePasswords],
+	    CASE
+	        WHEN
+	            COALESCE(CU.[Manage], CG.[Manage], 0) = 0
+	        THEN 0
+	        ELSE 1
+	    END [Manage],
+	    CASE
+	    	WHEN CU.[CollectionId] IS NULL AND CG.[CollectionId] IS NULL
+	    	THEN 0
+	    	ELSE 1
+	    END [Assigned]
+	FROM
+	    [dbo].[CollectionView] C
+	LEFT JOIN
+	    [dbo].[OrganizationUser] OU ON C.[OrganizationId] = OU.[OrganizationId] AND OU.[UserId] = @UserId
+	LEFT JOIN
+	    [dbo].[CollectionUser] CU ON CU.[CollectionId] = C.[Id] AND CU.[OrganizationUserId] = [OU].[Id]
+	LEFT JOIN
+	    [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND GU.[OrganizationUserId] = OU.[Id]
+	LEFT JOIN
+	    [dbo].[Group] G ON G.[Id] = GU.[GroupId]
+	LEFT JOIN
+	    [dbo].[CollectionGroup] CG ON CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
+	WHERE
+	    C.[OrganizationId] = @OrganizationId
+
+   IF (@IncludeAccessRelationships = 1)
+    BEGIN
+        EXEC [dbo].[CollectionGroup_ReadByOrganizationId] @OrganizationId
+        EXEC [dbo].[CollectionUser_ReadByOrganizationId] @OrganizationId
+    END
+END

--- a/test/Infrastructure.IntegrationTest/Vault/Repositories/CollectionRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/Vault/Repositories/CollectionRepositoryTests.cs
@@ -1,0 +1,180 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data;
+using Bit.Core.Repositories;
+using Xunit;
+
+namespace Bit.Infrastructure.IntegrationTest.Repositories;
+
+public class CollectionRepositoryTests
+{
+    [DatabaseTheory, DatabaseData]
+    public async Task GetByIdWithPermissionsAsync_Works(IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        ICollectionRepository collectionRepository,
+        IOrganizationUserRepository organizationUserRepository, IGroupRepository groupRepository)
+    {
+        var user = await userRepository.CreateAsync(new User
+        {
+            Name = "Test User",
+            Email = $"test+{Guid.NewGuid()}@email.com",
+            ApiKey = "TEST",
+            SecurityStamp = "stamp",
+        });
+
+        var organization = await organizationRepository.CreateAsync(new Organization
+        {
+            Name = "Test Org",
+            PlanType = PlanType.EnterpriseAnnually
+        });
+
+        var orgUser = await organizationUserRepository.CreateAsync(new OrganizationUser
+        {
+            OrganizationId = organization.Id,
+            UserId = user.Id,
+            Status = OrganizationUserStatusType.Confirmed,
+        });
+
+        var group = await groupRepository.CreateAsync(new Group
+        {
+            Name = "Test Group",
+            OrganizationId = organization.Id,
+        });
+
+        var collection = new Collection { Name = "Test Collection", OrganizationId = organization.Id, };
+
+        await collectionRepository.CreateAsync(collection, groups: new[]
+        {
+            new CollectionAccessSelection
+            {
+                Id = group.Id, HidePasswords = false, ReadOnly = true, Manage = false
+            }
+        }, users: new[]
+        {
+            new CollectionAccessSelection()
+            {
+                Id = orgUser.Id, HidePasswords = false, ReadOnly = false, Manage = true
+            }
+        });
+
+        var collectionWithPermissions = await collectionRepository.GetByIdWithPermissionsAsync(collection.Id, user.Id, true);
+
+        Assert.NotNull(collectionWithPermissions);
+        Assert.Equal(1, collectionWithPermissions.Users?.Count());
+        Assert.Equal(1, collectionWithPermissions.Groups?.Count());
+        Assert.True(collectionWithPermissions.Assigned);
+        Assert.True(collectionWithPermissions.Manage);
+        Assert.False(collectionWithPermissions.ReadOnly);
+        Assert.False(collectionWithPermissions.HidePasswords);
+    }
+
+    [DatabaseTheory, DatabaseData]
+    public async Task GetManyByOrganizationIdWithPermissionsAsync(IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        ICollectionRepository collectionRepository,
+        IOrganizationUserRepository organizationUserRepository, IGroupRepository groupRepository)
+    {
+        var user = await userRepository.CreateAsync(new User
+        {
+            Name = "Test User",
+            Email = $"test+{Guid.NewGuid()}@email.com",
+            ApiKey = "TEST",
+            SecurityStamp = "stamp",
+        });
+
+        var organization = await organizationRepository.CreateAsync(new Organization
+        {
+            Name = "Test Org",
+            PlanType = PlanType.EnterpriseAnnually
+        });
+
+        var orgUser = await organizationUserRepository.CreateAsync(new OrganizationUser
+        {
+            OrganizationId = organization.Id,
+            UserId = user.Id,
+            Status = OrganizationUserStatusType.Confirmed,
+        });
+
+        var group = await groupRepository.CreateAsync(new Group
+        {
+            Name = "Test Group",
+            OrganizationId = organization.Id,
+        });
+
+        var collection1 = new Collection { Name = "Collection 1", OrganizationId = organization.Id, };
+
+        await collectionRepository.CreateAsync(collection1, groups: new[]
+        {
+            new CollectionAccessSelection
+            {
+                Id = group.Id, HidePasswords = false, ReadOnly = true, Manage = false
+            }
+        }, users: new[]
+        {
+            new CollectionAccessSelection()
+            {
+                Id = orgUser.Id, HidePasswords = false, ReadOnly = false, Manage = true
+            }
+        });
+
+        var collection2 = new Collection { Name = "Collection 2", OrganizationId = organization.Id, };
+
+        await collectionRepository.CreateAsync(collection2, null, users: new[]
+        {
+            new CollectionAccessSelection()
+            {
+                Id = orgUser.Id, HidePasswords = false, ReadOnly = true, Manage = false
+            }
+        });
+
+        var collection3 = new Collection { Name = "Collection 3", OrganizationId = organization.Id, };
+
+        await collectionRepository.CreateAsync(collection3, groups: new[]
+        {
+            new CollectionAccessSelection()
+            {
+                Id = group.Id, HidePasswords = false, ReadOnly = false, Manage = true
+            }
+        }, null);
+
+        var collections = await collectionRepository.GetManyByOrganizationIdWithPermissionsAsync(organization.Id, user.Id, true);
+
+        Assert.NotNull(collections);
+
+        collections = collections.OrderBy(c => c.Name).ToList();
+
+        Assert.Collection(collections, c1 =>
+        {
+            Assert.NotNull(c1);
+            Assert.Equal(1, c1.Users?.Count());
+            Assert.Equal(1, c1.Groups?.Count());
+            Assert.True(c1.Assigned);
+            Assert.True(c1.Manage);
+            Assert.False(c1.ReadOnly);
+            Assert.False(c1.HidePasswords);
+        }, c2 =>
+        {
+            Assert.NotNull(c2);
+            Assert.Equal(1, c2.Users?.Count());
+            Assert.Equal(0, c2.Groups?.Count());
+            Assert.True(c2.Assigned);
+            Assert.False(c2.Manage);
+            Assert.True(c2.ReadOnly);
+            Assert.False(c2.HidePasswords);
+        }, c3 =>
+        {
+            Assert.NotNull(c3);
+            Assert.Equal(0, c3.Users?.Count());
+            Assert.Equal(1, c3.Groups?.Count());
+            Assert.False(c3.Assigned);
+            Assert.False(c3.Manage);
+            Assert.False(c3.ReadOnly);
+            Assert.False(c3.HidePasswords);
+        });
+    }
+
+
+
+}

--- a/util/Migrator/DbScripts/2024-02-12_00_CollectionsWithPermissionsQueries.sql
+++ b/util/Migrator/DbScripts/2024-02-12_00_CollectionsWithPermissionsQueries.sql
@@ -1,0 +1,111 @@
+CREATE OR ALTER PROCEDURE [dbo].[Collection_ReadByIdWithPermissions]
+    @CollectionId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @IncludeAccessRelationships BIT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+	SELECT
+	    C.*,
+	    CASE
+	        WHEN
+	            COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) = 0
+	        THEN 0
+	        ELSE 1
+	    END [ReadOnly],
+	    CASE
+	        WHEN
+	            COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
+	        THEN 0
+	        ELSE 1
+	    END [HidePasswords],
+	    CASE
+	        WHEN
+	            COALESCE(CU.[Manage], CG.[Manage], 0) = 0
+	        THEN 0
+	        ELSE 1
+	    END [Manage],
+	    CASE
+	    	WHEN CU.[CollectionId] IS NULL AND CG.[CollectionId] IS NULL
+	    	THEN 0
+	    	ELSE 1
+	    END [Assigned]
+	FROM
+	    [dbo].[CollectionView] C
+	LEFT JOIN
+	    [dbo].[OrganizationUser] OU ON C.[OrganizationId] = OU.[OrganizationId] AND OU.[UserId] = @UserId
+	LEFT JOIN
+	    [dbo].[CollectionUser] CU ON CU.[CollectionId] = C.[Id] AND CU.[OrganizationUserId] = [OU].[Id]
+	LEFT JOIN
+	    [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND GU.[OrganizationUserId] = OU.[Id]
+	LEFT JOIN
+	    [dbo].[Group] G ON G.[Id] = GU.[GroupId]
+	LEFT JOIN
+	    [dbo].[CollectionGroup] CG ON CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
+	WHERE
+	    C.[Id] = @CollectionId
+
+   IF (@IncludeAccessRelationships = 1)
+    BEGIN
+        EXEC [dbo].[CollectionGroup_ReadByCollectionId] @CollectionId
+        EXEC [dbo].[CollectionUser_ReadByCollectionId] @CollectionId
+	END
+END
+GO
+
+CREATE OR ALTER PROCEDURE [dbo].[Collection_ReadByOrganizationIdWithPermissions]
+    @OrganizationId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @IncludeAccessRelationships BIT
+AS
+BEGIN
+	SET NOCOUNT ON
+
+	SELECT
+	    C.*,
+	    CASE
+	        WHEN
+	            COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) = 0
+	        THEN 0
+	        ELSE 1
+	    END [ReadOnly],
+	    CASE
+	        WHEN
+	            COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
+	        THEN 0
+	        ELSE 1
+	    END [HidePasswords],
+	    CASE
+	        WHEN
+	            COALESCE(CU.[Manage], CG.[Manage], 0) = 0
+	        THEN 0
+	        ELSE 1
+	    END [Manage],
+	    CASE
+	    	WHEN CU.[CollectionId] IS NULL AND CG.[CollectionId] IS NULL
+	    	THEN 0
+	    	ELSE 1
+	    END [Assigned]
+	FROM
+	    [dbo].[CollectionView] C
+	LEFT JOIN
+	    [dbo].[OrganizationUser] OU ON C.[OrganizationId] = OU.[OrganizationId] AND OU.[UserId] = @UserId
+	LEFT JOIN
+	    [dbo].[CollectionUser] CU ON CU.[CollectionId] = C.[Id] AND CU.[OrganizationUserId] = [OU].[Id]
+	LEFT JOIN
+	    [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND GU.[OrganizationUserId] = OU.[Id]
+	LEFT JOIN
+	    [dbo].[Group] G ON G.[Id] = GU.[GroupId]
+	LEFT JOIN
+	    [dbo].[CollectionGroup] CG ON CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
+	WHERE
+	    C.[OrganizationId] = @OrganizationId
+
+   IF (@IncludeAccessRelationships = 1)
+    BEGIN
+        EXEC [dbo].[CollectionGroup_ReadByOrganizationId] @OrganizationId
+        EXEC [dbo].[CollectionUser_ReadByOrganizationId] @OrganizationId
+    END
+END
+GO


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
We’ve run into multiple places where we need the current user’s collection permissions after fetching them from the admin endpoints. Those responses do not include the manage, readonly, hidePasswords flags so we’ve been forced to merge the permissions from the collection sync data with the admin endpoint response multiple times. 

This PR adds those permission details to those admin endpoint responses. Doing so required creating new SQL queries to fetch collections and permission information even if there is no relationship (all existing queries that included permission info automatically filter out collections that have no existing User/Group relationship).


## Code changes

#### New `CollectionAdminDetails` Model
Add a new Domain model that represents collection details that are intended to be used for collection management/administrative purposes. The model includes permission details for a given user, a flag for if that user is explicitly assigned to the collection, and optional lists for User/Group access relationships.


#### `ICollectionRepository.cs`
Add additional documentation to existing methods and add the two new `*WithPermissions` queries. By their inherent nature, these queries do not perform our normal database level authorization checks, so care should be taken to ensure the requesting user has access to the organization. (Our existing queries quietly remove any collection resources the user does not have access to.)
- `GetManyByOrganizationIdWithPermissionsAsync()`
  - Fetches all of collections that belong to an organization, with permission details for a provided userId. Can also optionally include User/Group access relationships.
- `GetByIdWithPermissionsAsync()`
  - Fetches a single collection by Id with permission details for the provided userId. Can also optionally include User/Group access relationships.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
