### PR TITLE
[AC-2167] Upgrade logging packages for .NET 8

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -44,13 +44,13 @@
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.25" />
     <PackageReference Include="Quartz" Version="3.4.0" />
     <PackageReference Include="SendGrid" Version="9.29.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
     <PackageReference Include="Sentry.Serilog" Version="3.41.3" />
     <PackageReference Include="Duende.IdentityServer" Version="6.3.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Serilog.Sinks.SyslogMessages" Version="2.0.9" />
+    <PackageReference Include="Serilog.Sinks.SyslogMessages" Version="3.0.1" />
     <PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
     <PackageReference Include="Braintree" Version="5.23.0" />
     <PackageReference Include="Stripe.net" Version="43.7.0" />

--- a/src/Core/Utilities/LoggerFactoryExtensions.cs
+++ b/src/Core/Utilities/LoggerFactoryExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System.Security.Authentication;
-using System.Security.Cryptography.X509Certificates;
+﻿using System.Security.Cryptography.X509Certificates;
 using Bit.Core.Settings;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -91,20 +90,17 @@ public static class LoggerFactoryExtensions
                 }
                 else if (syslogAddress.Scheme.Equals("tls"))
                 {
-                    // TLS v1.1, v1.2 and v1.3 are explicitly selected (leaving out TLS v1.0)
-                    const SslProtocols protocols = SslProtocols.Tls11 | SslProtocols.Tls12 | SslProtocols.Tls13;
-
                     if (CoreHelpers.SettingHasValue(globalSettings.Syslog.CertificateThumbprint))
                     {
                         config.WriteTo.TcpSyslog(syslogAddress.Host, port, appName,
-                            secureProtocols: protocols,
+                            useTls: true,
                             certProvider: new CertificateStoreProvider(StoreName.My, StoreLocation.CurrentUser,
                                                                        globalSettings.Syslog.CertificateThumbprint));
                     }
                     else
                     {
                         config.WriteTo.TcpSyslog(syslogAddress.Host, port, appName,
-                            secureProtocols: protocols,
+                            useTls: true,
                             certProvider: new CertificateFileProvider(globalSettings.Syslog.CertificatePath,
                                                                       globalSettings.Syslog?.CertificatePassword ?? string.Empty));
                     }

--- a/util/Migrator/Migrator.csproj
+++ b/util/Migrator/Migrator.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="dbup-sqlserver" Version="5.0.40" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/util/MsSqlMigratorUtility/MsSqlMigratorUtility.csproj
+++ b/util/MsSqlMigratorUtility/MsSqlMigratorUtility.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandDotNet" Version="7.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/util/Setup/Setup.csproj
+++ b/util/Setup/Setup.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Handlebars.Net" Version="2.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This PR updates the following packages to their .NET 8 supported versions:

* `Microsoft.Extensions.Logging`
* `Serilog.AspNetCore`
* `Serilog.Extensions.Logging`
* `Serilog.Sinks.SyslogMessages`
