### PR TITLE
[AC-2206] Fix assigning Manage access to default collection

### DIFF
--- a/bitwarden_license/src/Commercial.Core/AdminConsole/Services/ProviderService.cs
+++ b/bitwarden_license/src/Commercial.Core/AdminConsole/Services/ProviderService.cs
@@ -523,7 +523,7 @@ public class ProviderService : IProviderService
             ]
             : Array.Empty<CollectionAccessSelection>();
 
-        var orgUsers = await _organizationService.InviteUsersAsync(organization.Id, user.Id,
+        await _organizationService.InviteUsersAsync(organization.Id, user.Id,
             new (OrganizationUserInvite, string)[]
             {
                 (

--- a/bitwarden_license/test/Commercial.Core.Test/AdminConsole/Services/ProviderServiceTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/AdminConsole/Services/ProviderServiceTests.cs
@@ -523,7 +523,7 @@ public class ProviderServiceTests
         sutProvider.GetDependency<IProviderRepository>().GetByIdAsync(provider.Id).Returns(provider);
         var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
         sutProvider.GetDependency<IOrganizationService>().SignUpAsync(organizationSignup, true)
-            .Returns(Tuple.Create(organization, null as OrganizationUser));
+            .Returns((organization, null as OrganizationUser, new Collection()));
 
         var providerOrganization =
             await sutProvider.Sut.CreateOrganizationAsync(provider.Id, organizationSignup, clientOwnerEmail, user);
@@ -539,20 +539,21 @@ public class ProviderServiceTests
                 t.First().Item1.Emails.First() == clientOwnerEmail &&
                 t.First().Item1.Type == OrganizationUserType.Owner &&
                 t.First().Item1.AccessAll &&
+                !t.First().Item1.Collections.Any() &&
                 t.First().Item2 == null));
     }
 
     [Theory, OrganizationCustomize(FlexibleCollections = true), BitAutoData]
     public async Task CreateOrganizationAsync_WithFlexibleCollections_SetsAccessAllToFalse
         (Provider provider, OrganizationSignup organizationSignup, Organization organization, string clientOwnerEmail,
-            User user, SutProvider<ProviderService> sutProvider)
+            User user, SutProvider<ProviderService> sutProvider, Collection defaultCollection)
     {
         organizationSignup.Plan = PlanType.EnterpriseAnnually;
 
         sutProvider.GetDependency<IProviderRepository>().GetByIdAsync(provider.Id).Returns(provider);
         var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
         sutProvider.GetDependency<IOrganizationService>().SignUpAsync(organizationSignup, true)
-            .Returns(Tuple.Create(organization, null as OrganizationUser));
+            .Returns((organization, null as OrganizationUser, defaultCollection));
 
         var providerOrganization =
             await sutProvider.Sut.CreateOrganizationAsync(provider.Id, organizationSignup, clientOwnerEmail, user);
@@ -568,6 +569,8 @@ public class ProviderServiceTests
                 t.First().Item1.Emails.First() == clientOwnerEmail &&
                 t.First().Item1.Type == OrganizationUserType.Owner &&
                 t.First().Item1.AccessAll == false &&
+                t.First().Item1.Collections.Single().Id == defaultCollection.Id &&
+                t.First().Item1.Collections.Single().Manage &&
                 t.First().Item2 == null));
     }
 

--- a/bitwarden_license/test/Commercial.Core.Test/AdminConsole/Services/ProviderServiceTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/AdminConsole/Services/ProviderServiceTests.cs
@@ -570,6 +570,8 @@ public class ProviderServiceTests
                 t.First().Item1.Type == OrganizationUserType.Owner &&
                 t.First().Item1.AccessAll == false &&
                 t.First().Item1.Collections.Single().Id == defaultCollection.Id &&
+                !t.First().Item1.Collections.Single().HidePasswords &&
+                !t.First().Item1.Collections.Single().ReadOnly &&
                 t.First().Item1.Collections.Single().Manage &&
                 t.First().Item2 == null));
     }

--- a/src/Core/AdminConsole/Services/IOrganizationService.cs
+++ b/src/Core/AdminConsole/Services/IOrganizationService.cs
@@ -20,8 +20,17 @@ public interface IOrganizationService
     Task AutoAddSeatsAsync(Organization organization, int seatsToAdd, DateTime? prorationDate = null);
     Task<string> AdjustSeatsAsync(Guid organizationId, int seatAdjustment, DateTime? prorationDate = null);
     Task VerifyBankAsync(Guid organizationId, int amount1, int amount2);
-    Task<Tuple<Organization, OrganizationUser>> SignUpAsync(OrganizationSignup organizationSignup, bool provider = false);
-    Task<Tuple<Organization, OrganizationUser>> SignUpAsync(OrganizationLicense license, User owner,
+#nullable enable
+    /// <summary>
+    /// Create a new organization in a cloud environment
+    /// </summary>
+    /// <returns>A tuple containing the new organization, the initial organizationUser (if any) and the default collection (if any)</returns>
+    Task<(Organization organization, OrganizationUser? organizationUser, Collection? defaultCollection)> SignUpAsync(OrganizationSignup organizationSignup, bool provider = false);
+#nullable disable
+    /// <summary>
+    /// Create a new organization on a self-hosted instance
+    /// </summary>
+    Task<(Organization organization, OrganizationUser organizationUser)> SignUpAsync(OrganizationLicense license, User owner,
         string ownerKey, string collectionName, string publicKey, string privateKey);
     Task DeleteAsync(Organization organization);
     Task EnableAsync(Guid organizationId, DateTime? expirationDate);

--- a/src/Core/AdminConsole/Services/IOrganizationService.cs
+++ b/src/Core/AdminConsole/Services/IOrganizationService.cs
@@ -20,11 +20,11 @@ public interface IOrganizationService
     Task AutoAddSeatsAsync(Organization organization, int seatsToAdd, DateTime? prorationDate = null);
     Task<string> AdjustSeatsAsync(Guid organizationId, int seatAdjustment, DateTime? prorationDate = null);
     Task VerifyBankAsync(Guid organizationId, int amount1, int amount2);
-#nullable enable
     /// <summary>
     /// Create a new organization in a cloud environment
     /// </summary>
     /// <returns>A tuple containing the new organization, the initial organizationUser (if any) and the default collection (if any)</returns>
+#nullable enable
     Task<(Organization organization, OrganizationUser? organizationUser, Collection? defaultCollection)> SignUpAsync(OrganizationSignup organizationSignup, bool provider = false);
 #nullable disable
     /// <summary>

--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -698,7 +698,7 @@ public class OrganizationService : IOrganizationService
 
                 // If using Flexible Collections, give the owner Can Manage access over the default collection
                 List<CollectionAccessSelection> defaultOwnerAccess = null;
-                if (ownerId != default && organization.FlexibleCollections)
+                if (orgUser != null && organization.FlexibleCollections)
                 {
                     defaultOwnerAccess =
                         [new CollectionAccessSelection { Id = orgUser.Id, HidePasswords = false, ReadOnly = false, Manage = true }];

--- a/test/Api.IntegrationTest/Helpers/OrganizationTestHelpers.cs
+++ b/test/Api.IntegrationTest/Helpers/OrganizationTestHelpers.cs
@@ -22,7 +22,7 @@ public static class OrganizationTestHelpers
 
         var owner = await userRepository.GetByEmailAsync(ownerEmail);
 
-        return await organizationService.SignUpAsync(new OrganizationSignup
+        var signUpResult = await organizationService.SignUpAsync(new OrganizationSignup
         {
             Name = name,
             BillingEmail = billingEmail,
@@ -30,6 +30,8 @@ public static class OrganizationTestHelpers
             OwnerKey = ownerKey,
             Owner = owner,
         });
+
+        return new Tuple<Organization, OrganizationUser>(signUpResult.organization, signUpResult.organizationUser);
     }
 
     public static async Task<OrganizationUser> CreateUserAsync<T>(

--- a/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
@@ -232,10 +232,8 @@ public class OrganizationServiceTests
                 referenceEvent.Storage == result.Item1.MaxStorageGb));
         // TODO: add reference events for SmSeats and Service Accounts - see AC-1481
 
-        Assert.NotNull(result);
         Assert.NotNull(result.Item1);
         Assert.NotNull(result.Item2);
-        Assert.IsType<Tuple<Organization, OrganizationUser>>(result);
 
         await sutProvider.GetDependency<IPaymentService>().Received(1).PurchaseOrganizationAsync(
             Arg.Any<Organization>(),
@@ -294,10 +292,8 @@ public class OrganizationServiceTests
                     !c.HidePasswords &&
                     c.Manage)));
 
-        Assert.NotNull(result);
         Assert.NotNull(result.Item1);
         Assert.NotNull(result.Item2);
-        Assert.IsType<Tuple<Organization, OrganizationUser>>(result);
     }
 
     [Theory]
@@ -323,10 +319,8 @@ public class OrganizationServiceTests
                 o.UserId == signup.Owner.Id &&
                 o.AccessAll == true));
 
-        Assert.NotNull(result);
         Assert.NotNull(result.Item1);
         Assert.NotNull(result.Item2);
-        Assert.IsType<Tuple<Organization, OrganizationUser>>(result);
     }
 
     [Theory]
@@ -367,10 +361,8 @@ public class OrganizationServiceTests
                 referenceEvent.Storage == result.Item1.MaxStorageGb));
         // TODO: add reference events for SmSeats and Service Accounts - see AC-1481
 
-        Assert.NotNull(result);
         Assert.NotNull(result.Item1);
         Assert.NotNull(result.Item2);
-        Assert.IsType<Tuple<Organization, OrganizationUser>>(result);
 
         await sutProvider.GetDependency<IPaymentService>().Received(1).PurchaseOrganizationAsync(
             Arg.Any<Organization>(),


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix #3776 which did not account for `orgUser` being `null` in the private `OrganizationService.SignUp` method. This occurs when a provider is creating an organization, the org is created without an owner and then an invite is sent out separately (see `ProviderService.CreateOrganizationAsync`).

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* return the `defaultCollection` from the private `OrganizationService.SignUp` method
* to make this less ugly, change to using named value tuples in these return signatures
* if `orgUser` is null, skip assigning access to the default collection
* in `ProviderService.CreateOrganizationAsync`, take the returned collection and give the owner Manage access when inviting them

I don't like how this is handled in multiple places, but I am avoiding any larger refactors until we split up OrganizationService into separate classes (which we have tech debt tickets for).

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
