### PR TITLE
[AC-2212] Fix Flexible Collections block in Public API

### DIFF
--- a/src/Api/AdminConsole/Public/Models/Request/AssociationWithPermissionsRequestModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Request/AssociationWithPermissionsRequestModel.cs
@@ -16,7 +16,7 @@ public class AssociationWithPermissionsRequestModel : AssociationWithPermissions
         };
 
         // Throws if the org has not migrated to use FC but has passed in a Manage value in the request
-        if (!migratedToFlexibleCollections && Manage.HasValue)
+        if (!migratedToFlexibleCollections && Manage.GetValueOrDefault())
         {
             throw new BadRequestException(
                 "Your organization must be using the latest collection enhancements to use the Manage property.");


### PR DESCRIPTION
Only throw if collection.Manage is true

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The Public API Members controller was throwing if any value was provided for `manage` without Flexible Collections being enabled. However, this is a problem for scripts that GET a member (which includes `manage: false` for any collections) and then use that result in their PUT request. Really we should only block the action if `manage` is set to `true`.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
