### PR TITLE
[AC-2154] Log backup data in OrganizationEnableCollectionEnhancementsCommand as Json

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationCollectionEnhancements/OrganizationEnableCollectionEnhancementsCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationCollectionEnhancements/OrganizationEnableCollectionEnhancementsCommand.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.AdminConsole.Entities;
+﻿using System.Text.Json;
+using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationCollectionEnhancements.Interfaces;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Enums;
@@ -107,6 +108,6 @@ public class OrganizationEnableCollectionEnhancementsCommand : IOrganizationEnab
             CollectionUsers = collectionUsersData
         };
 
-        _logger.LogWarning("Flexible Collections data migration started. Backup data: {@LogObject}", logObject);
+        _logger.LogWarning("Flexible Collections data migration started. Backup data: {LogObject}", JsonSerializer.Serialize(logObject));
     }
 }


### PR DESCRIPTION
## Type of change

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Previously, when logging data during the "Flexible Collections" data migration process, the logged information was not presented in a human-readable format. Instead, on Datadog it appeared as complex data structures such as `System.Collections.Generic.List1[System.Guid]`, making it challenging to interpret.

Solution:
To address this issue, the logging mechanism has been updated to serialize the log data into JSON format using `System.Text.Json.JsonSerializer.Serialize`.


## Code changes

* **src/Core/AdminConsole/OrganizationFeatures/OrganizationCollectionEnhancements/OrganizationEnableCollectionEnhancementsCommand.cs:** Log Json serialized data

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
