### PR TITLE
[AC-2214] Defect - provider reseller org creation when fc signup flag enabled

### DIFF
--- a/src/Admin/Controllers/ProvidersController.cs
+++ b/src/Admin/Controllers/ProvidersController.cs
@@ -1,6 +1,7 @@
 ﻿using Bit.Admin.Enums;
 using Bit.Admin.Models;
 using Bit.Admin.Utilities;
+using Bit.Core;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.AdminConsole.Providers.Interfaces;
@@ -31,6 +32,7 @@ public class ProvidersController : Controller
     private readonly IReferenceEventService _referenceEventService;
     private readonly IUserService _userService;
     private readonly ICreateProviderCommand _createProviderCommand;
+    private readonly IFeatureService _featureService;
 
     public ProvidersController(
         IOrganizationRepository organizationRepository,
@@ -43,7 +45,8 @@ public class ProvidersController : Controller
         IApplicationCacheService applicationCacheService,
         IReferenceEventService referenceEventService,
         IUserService userService,
-        ICreateProviderCommand createProviderCommand)
+        ICreateProviderCommand createProviderCommand,
+        IFeatureService featureService)
     {
         _organizationRepository = organizationRepository;
         _organizationService = organizationService;
@@ -56,6 +59,7 @@ public class ProvidersController : Controller
         _referenceEventService = referenceEventService;
         _userService = userService;
         _createProviderCommand = createProviderCommand;
+        _featureService = featureService;
     }
 
     [RequirePermission(Permission.Provider_List_View)]
@@ -236,7 +240,7 @@ public class ProvidersController : Controller
             return RedirectToAction("Index");
         }
 
-        var organization = model.CreateOrganization(provider);
+        var organization = model.CreateOrganization(provider, _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsSignup));
         await _organizationService.CreatePendingOrganization(organization, model.Owners, User, _userService, model.SalesAssistedTrialStarted);
         await _providerService.AddOrganization(providerId, organization.Id, null);
 

--- a/src/Admin/Controllers/ProvidersController.cs
+++ b/src/Admin/Controllers/ProvidersController.cs
@@ -240,7 +240,9 @@ public class ProvidersController : Controller
             return RedirectToAction("Index");
         }
 
-        var organization = model.CreateOrganization(provider, _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsSignup));
+        var flexibleCollectionsSignupEnabled = _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsSignup);
+        var flexibleCollectionsV1Enabled = _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1);
+        var organization = model.CreateOrganization(provider, flexibleCollectionsSignupEnabled, flexibleCollectionsV1Enabled);
         await _organizationService.CreatePendingOrganization(organization, model.Owners, User, _userService, model.SalesAssistedTrialStarted);
         await _providerService.AddOrganization(providerId, organization.Id, null);
 

--- a/src/Admin/Models/OrganizationEditModel.cs
+++ b/src/Admin/Models/OrganizationEditModel.cs
@@ -164,11 +164,11 @@ public class OrganizationEditModel : OrganizationViewModel
                 { "baseServiceAccount", p.SecretsManager.BaseServiceAccount }
             });
 
-    public Organization CreateOrganization(Provider provider)
+    public Organization CreateOrganization(Provider provider, bool flexibleCollectionsSignupEnabled)
     {
         BillingEmail = provider.BillingEmail;
 
-        return ToOrganization(new Organization());
+        return ToOrganization(new Organization { FlexibleCollections = flexibleCollectionsSignupEnabled });
     }
 
     public Organization ToOrganization(Organization existingOrganization)

--- a/src/Admin/Models/OrganizationEditModel.cs
+++ b/src/Admin/Models/OrganizationEditModel.cs
@@ -164,11 +164,22 @@ public class OrganizationEditModel : OrganizationViewModel
                 { "baseServiceAccount", p.SecretsManager.BaseServiceAccount }
             });
 
-    public Organization CreateOrganization(Provider provider, bool flexibleCollectionsSignupEnabled)
+    public Organization CreateOrganization(Provider provider, bool flexibleCollectionsSignupEnabled, bool flexibleCollectionsV1Enabled)
     {
         BillingEmail = provider.BillingEmail;
 
-        return ToOrganization(new Organization { FlexibleCollections = flexibleCollectionsSignupEnabled });
+        var newOrg = new Organization
+        {
+            // This feature flag indicates that new organizations should be automatically onboarded to
+            // Flexible Collections enhancements
+            FlexibleCollections = flexibleCollectionsSignupEnabled,
+            // These collection management settings smooth the migration for existing organizations by disabling some FC behavior.
+            // If the organization is onboarded to Flexible Collections on signup, we turn them OFF to enable all new behaviour.
+            // If the organization is NOT onboarded now, they will have to be migrated later, so they default to ON to limit FC changes on migration.
+            LimitCollectionCreationDeletion = !flexibleCollectionsSignupEnabled,
+            AllowAdminAccessToAllCollectionItems = !flexibleCollectionsV1Enabled
+        };
+        return ToOrganization(newOrg);
     }
 
     public Organization ToOrganization(Organization existingOrganization)


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> New Organization created by Reseller Provider does not have Flexible Collection features when `flexible-collections-signup` flag is enabled

## Code changes

* **src/Admin/Controllers/ProvidersController.cs**: Injected `featureService` and passed along the value of the `flexible-collection-signup` flag to the organization model creation
* **src/Admin/Models/OrganizationEditModel.cs**: Assigned the fc signup enabled state to the `Organization.FlexibleCollections` property that will be used to create the db entity for the pending org.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
