### PR TITLE
Shard notification hub clients across multiple accounts

### DIFF
--- a/src/Api/Controllers/PushController.cs
+++ b/src/Api/Controllers/PushController.cs
@@ -42,11 +42,11 @@ public class PushController : Controller
             Prefix(model.UserId), Prefix(model.Identifier), model.Type);
     }
 
-    [HttpDelete("{id}")]
-    public async Task Delete(string id)
+    [HttpPost("delete")]
+    public async Task PostDelete([FromBody] PushDeviceRequestModel model)
     {
         CheckUsage();
-        await _pushRegistrationService.DeleteRegistrationAsync(Prefix(id));
+        await _pushRegistrationService.DeleteRegistrationAsync(Prefix(model.Id), model.Type);
     }
 
     [HttpPut("add-organization")]
@@ -54,7 +54,8 @@ public class PushController : Controller
     {
         CheckUsage();
         await _pushRegistrationService.AddUserRegistrationOrganizationAsync(
-            model.DeviceIds.Select(d => Prefix(d)), Prefix(model.OrganizationId));
+            model.Devices.Select(d => new KeyValuePair<string, Core.Enums.DeviceType>(Prefix(d.Id), d.Type)),
+            Prefix(model.OrganizationId));
     }
 
     [HttpPut("delete-organization")]
@@ -62,7 +63,8 @@ public class PushController : Controller
     {
         CheckUsage();
         await _pushRegistrationService.DeleteUserRegistrationOrganizationAsync(
-            model.DeviceIds.Select(d => Prefix(d)), Prefix(model.OrganizationId));
+            model.Devices.Select(d => new KeyValuePair<string, Core.Enums.DeviceType>(Prefix(d.Id), d.Type)),
+            Prefix(model.OrganizationId));
     }
 
     [HttpPost("send")]

--- a/src/Core/Enums/NotificationHubType.cs
+++ b/src/Core/Enums/NotificationHubType.cs
@@ -1,0 +1,11 @@
+﻿namespace Bit.Core.Enums;
+
+public enum NotificationHubType
+{
+    General = 0,
+    Android = 1,
+    iOS = 2,
+    GeneralWeb = 3,
+    GeneralBrowserExtension = 4,
+    GeneralDesktop = 5,
+}

--- a/src/Core/Models/Api/Request/PushDeviceRequestModel.cs
+++ b/src/Core/Models/Api/Request/PushDeviceRequestModel.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.Enums;
+
+namespace Bit.Core.Models.Api;
+
+public class PushDeviceRequestModel
+{
+    [Required]
+    public string Id { get; set; }
+    [Required]
+    public DeviceType Type { get; set; }
+}

--- a/src/Core/Models/Api/Request/PushUpdateRequestModel.cs
+++ b/src/Core/Models/Api/Request/PushUpdateRequestModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.Enums;
 
 namespace Bit.Core.Models.Api;
 
@@ -7,14 +8,14 @@ public class PushUpdateRequestModel
     public PushUpdateRequestModel()
     { }
 
-    public PushUpdateRequestModel(IEnumerable<string> deviceIds, string organizationId)
+    public PushUpdateRequestModel(IEnumerable<KeyValuePair<string, DeviceType>> devices, string organizationId)
     {
-        DeviceIds = deviceIds;
+        Devices = devices.Select(d => new PushDeviceRequestModel { Id = d.Key, Type = d.Value });
         OrganizationId = organizationId;
     }
 
     [Required]
-    public IEnumerable<string> DeviceIds { get; set; }
+    public IEnumerable<PushDeviceRequestModel> Devices { get; set; }
     [Required]
     public string OrganizationId { get; set; }
 }

--- a/src/Core/Services/IPushRegistrationService.cs
+++ b/src/Core/Services/IPushRegistrationService.cs
@@ -6,7 +6,7 @@ public interface IPushRegistrationService
 {
     Task CreateOrUpdateRegistrationAsync(string pushToken, string deviceId, string userId,
         string identifier, DeviceType type);
-    Task DeleteRegistrationAsync(string deviceId);
-    Task AddUserRegistrationOrganizationAsync(IEnumerable<string> deviceIds, string organizationId);
-    Task DeleteUserRegistrationOrganizationAsync(IEnumerable<string> deviceIds, string organizationId);
+    Task DeleteRegistrationAsync(string deviceId, DeviceType type);
+    Task AddUserRegistrationOrganizationAsync(IEnumerable<KeyValuePair<string, DeviceType>> devices, string organizationId);
+    Task DeleteUserRegistrationOrganizationAsync(IEnumerable<KeyValuePair<string, DeviceType>> devices, string organizationId);
 }

--- a/src/Core/Services/Implementations/DeviceService.cs
+++ b/src/Core/Services/Implementations/DeviceService.cs
@@ -38,13 +38,13 @@ public class DeviceService : IDeviceService
     public async Task ClearTokenAsync(Device device)
     {
         await _deviceRepository.ClearPushTokenAsync(device.Id);
-        await _pushRegistrationService.DeleteRegistrationAsync(device.Id.ToString());
+        await _pushRegistrationService.DeleteRegistrationAsync(device.Id.ToString(), device.Type);
     }
 
     public async Task DeleteAsync(Device device)
     {
         await _deviceRepository.DeleteAsync(device);
-        await _pushRegistrationService.DeleteRegistrationAsync(device.Id.ToString());
+        await _pushRegistrationService.DeleteRegistrationAsync(device.Id.ToString(), device.Type);
     }
 
     public async Task UpdateDevicesTrustAsync(string currentDeviceIdentifier,

--- a/src/Core/Services/Implementations/MultiServicePushNotificationService.cs
+++ b/src/Core/Services/Implementations/MultiServicePushNotificationService.cs
@@ -43,6 +43,7 @@ public class MultiServicePushNotificationService : IPushNotificationService
         }
         else
         {
+            /*
             if (CoreHelpers.SettingHasValue(globalSettings.NotificationHub.ConnectionString))
             {
                 _services.Add(new NotificationHubPushNotificationService(installationDeviceRepository,
@@ -52,6 +53,8 @@ public class MultiServicePushNotificationService : IPushNotificationService
             {
                 _services.Add(new AzureQueuePushNotificationService(globalSettings, httpContextAccessor));
             }
+            */
+            // TODO
         }
 
         _logger = logger;

--- a/src/Core/Services/Implementations/MultiServicePushNotificationService.cs
+++ b/src/Core/Services/Implementations/MultiServicePushNotificationService.cs
@@ -43,8 +43,8 @@ public class MultiServicePushNotificationService : IPushNotificationService
         }
         else
         {
-            /*
-            if (CoreHelpers.SettingHasValue(globalSettings.NotificationHub.ConnectionString))
+            if (globalSettings.NotificationHubs != null && globalSettings.NotificationHubs.Count > 0 &&
+                CoreHelpers.SettingHasValue(globalSettings.NotificationHubs.First().ConnectionString))
             {
                 _services.Add(new NotificationHubPushNotificationService(installationDeviceRepository,
                     globalSettings, httpContextAccessor, hubLogger));
@@ -53,8 +53,6 @@ public class MultiServicePushNotificationService : IPushNotificationService
             {
                 _services.Add(new AzureQueuePushNotificationService(globalSettings, httpContextAccessor));
             }
-            */
-            // TODO
         }
 
         _logger = logger;

--- a/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
+++ b/src/Core/Services/Implementations/NotificationHubPushNotificationService.cs
@@ -32,10 +32,9 @@ public class NotificationHubPushNotificationService : IPushNotificationService
         _installationDeviceRepository = installationDeviceRepository;
         _globalSettings = globalSettings;
         _httpContextAccessor = httpContextAccessor;
+        // TODO
         _client = NotificationHubClient.CreateClientFromConnectionString(
-            _globalSettings.NotificationHub.ConnectionString,
-            _globalSettings.NotificationHub.HubName,
-            _globalSettings.NotificationHub.EnableSendTracing);
+            "", "", true);
         _logger = logger;
     }
 
@@ -261,7 +260,8 @@ public class NotificationHubPushNotificationService : IPushNotificationService
                 { "type",  ((byte)type).ToString() },
                 { "payload", JsonSerializer.Serialize(payload) }
             }, tag);
-        if (_globalSettings.NotificationHub.EnableSendTracing)
+        // TODO
+        if (false)
         {
             _logger.LogInformation("Azure Notification Hub Tracking ID: {id} | {type} push notification with {success} successes and {failure} failures with a payload of {@payload} and result of {@results}",
                 outcome.TrackingId, type, outcome.Success, outcome.Failure, payload, outcome.Results);

--- a/src/Core/Services/Implementations/NotificationHubPushRegistrationService.cs
+++ b/src/Core/Services/Implementations/NotificationHubPushRegistrationService.cs
@@ -21,21 +21,22 @@ public class NotificationHubPushRegistrationService : IPushRegistrationService
         _installationDeviceRepository = installationDeviceRepository;
         _globalSettings = globalSettings;
 
-        AddHub(globalSettings.NotificationHub.Ios, DeviceType.iOS);
-        AddHub(globalSettings.NotificationHub.Android, DeviceType.Android);
-    }
-
-    private void AddHub(List<GlobalSettings.NotificationHubSettings.HubRegistration> deviceHubs, DeviceType deviceType)
-    {
-        var hubRegistration = deviceHubs.FirstOrDefault(h => h.OpenForRegistration);
-        if (hubRegistration != null)
+        // Is this dirty to do in the ctor?
+        void addHub(List<GlobalSettings.NotificationHubSettings.HubRegistration> deviceHubs, DeviceType deviceType)
         {
-            var client = NotificationHubClient.CreateClientFromConnectionString(
-                hubRegistration.ConnectionString,
-                hubRegistration.HubName,
-                hubRegistration.EnableSendTracing);
-            _clients.Add(deviceType, client);
+            var hubRegistration = deviceHubs.FirstOrDefault(h => h.OpenForRegistration);
+            if (hubRegistration != null)
+            {
+                var client = NotificationHubClient.CreateClientFromConnectionString(
+                    hubRegistration.ConnectionString,
+                    hubRegistration.HubName,
+                    hubRegistration.EnableSendTracing);
+                _clients.Add(deviceType, client);
+            }
         }
+
+        addHub(globalSettings.NotificationHub.Ios, DeviceType.iOS);
+        addHub(globalSettings.NotificationHub.Android, DeviceType.Android);
     }
 
     public async Task CreateOrUpdateRegistrationAsync(string pushToken, string deviceId, string userId,

--- a/src/Core/Services/Implementations/NotificationHubPushRegistrationService.cs
+++ b/src/Core/Services/Implementations/NotificationHubPushRegistrationService.cs
@@ -27,7 +27,7 @@ public class NotificationHubPushRegistrationService : IPushRegistrationService
 
     private void AddHub(List<GlobalSettings.NotificationHubSettings.HubRegistration> deviceHubs, DeviceType deviceType)
     {
-        var hubRegistration = _globalSettings.NotificationHub.Ios.FirstOrDefault(h => h.OpenForRegistration);
+        var hubRegistration = deviceHubs.FirstOrDefault(h => h.OpenForRegistration);
         if (hubRegistration != null)
         {
             var client = NotificationHubClient.CreateClientFromConnectionString(

--- a/src/Core/Services/Implementations/RelayPushRegistrationService.cs
+++ b/src/Core/Services/Implementations/RelayPushRegistrationService.cs
@@ -38,30 +38,37 @@ public class RelayPushRegistrationService : BaseIdentityClientService, IPushRegi
         await SendAsync(HttpMethod.Post, "push/register", requestModel);
     }
 
-    public async Task DeleteRegistrationAsync(string deviceId)
+    public async Task DeleteRegistrationAsync(string deviceId, DeviceType type)
     {
-        await SendAsync(HttpMethod.Delete, string.Concat("push/", deviceId));
+        var requestModel = new PushDeviceRequestModel
+        {
+            Id = deviceId,
+            Type = type,
+        };
+        await SendAsync(HttpMethod.Post, "push/delete", requestModel);
     }
 
-    public async Task AddUserRegistrationOrganizationAsync(IEnumerable<string> deviceIds, string organizationId)
+    public async Task AddUserRegistrationOrganizationAsync(
+        IEnumerable<KeyValuePair<string, DeviceType>> devices, string organizationId)
     {
-        if (!deviceIds.Any())
+        if (!devices.Any())
         {
             return;
         }
 
-        var requestModel = new PushUpdateRequestModel(deviceIds, organizationId);
+        var requestModel = new PushUpdateRequestModel(devices, organizationId);
         await SendAsync(HttpMethod.Put, "push/add-organization", requestModel);
     }
 
-    public async Task DeleteUserRegistrationOrganizationAsync(IEnumerable<string> deviceIds, string organizationId)
+    public async Task DeleteUserRegistrationOrganizationAsync(
+        IEnumerable<KeyValuePair<string, DeviceType>> devices, string organizationId)
     {
-        if (!deviceIds.Any())
+        if (!devices.Any())
         {
             return;
         }
 
-        var requestModel = new PushUpdateRequestModel(deviceIds, organizationId);
+        var requestModel = new PushUpdateRequestModel(devices, organizationId);
         await SendAsync(HttpMethod.Put, "push/delete-organization", requestModel);
     }
 }

--- a/src/Core/Services/NoopImplementations/NoopPushRegistrationService.cs
+++ b/src/Core/Services/NoopImplementations/NoopPushRegistrationService.cs
@@ -4,7 +4,7 @@ namespace Bit.Core.Services;
 
 public class NoopPushRegistrationService : IPushRegistrationService
 {
-    public Task AddUserRegistrationOrganizationAsync(IEnumerable<string> deviceIds, string organizationId)
+    public Task AddUserRegistrationOrganizationAsync(IEnumerable<KeyValuePair<string, DeviceType>> devices, string organizationId)
     {
         return Task.FromResult(0);
     }
@@ -15,12 +15,12 @@ public class NoopPushRegistrationService : IPushRegistrationService
         return Task.FromResult(0);
     }
 
-    public Task DeleteRegistrationAsync(string deviceId)
+    public Task DeleteRegistrationAsync(string deviceId, DeviceType deviceType)
     {
         return Task.FromResult(0);
     }
 
-    public Task DeleteUserRegistrationOrganizationAsync(IEnumerable<string> deviceIds, string organizationId)
+    public Task DeleteUserRegistrationOrganizationAsync(IEnumerable<KeyValuePair<string, DeviceType>> devices, string organizationId)
     {
         return Task.FromResult(0);
     }

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -405,20 +405,32 @@ public class GlobalSettings : IGlobalSettings
 
     public class NotificationHubSettings
     {
-        private string _connectionString;
+        public HubRegistration Legacy { get; set; }
+        public List<HubRegistration> Ios { get; set; }
+        public List<HubRegistration> Android { get; set; }
+        // Example more:
+        //public List<HubRegistration> BrowserExtenstion { get; set; }
+        //public List<HubRegistration> Desktop { get; set; }
+        //public List<HubRegistration> Web { get; set; }
 
-        public string ConnectionString
+        public class HubRegistration
         {
-            get => _connectionString;
-            set => _connectionString = value.Trim('"');
-        }
-        public string HubName { get; set; }
+            private string _connectionString;
 
-        /// <summary>
-        /// Enables TestSend on the Azure Notification Hub, which allows tracing of the request through the hub and to the platform-specific push notification service (PNS).
-        /// Enabling this will result in delayed responses because the Hub must wait on delivery to the PNS.  This should ONLY be enabled in a non-production environment, as results are throttled.
-        /// </summary>
-        public bool EnableSendTracing { get; set; } = false;
+            public string ConnectionString
+            {
+                get => _connectionString;
+                set => _connectionString = value.Trim('"');
+            }
+            public string HubName { get; set; }
+
+            /// <summary>
+            /// Enables TestSend on the Azure Notification Hub, which allows tracing of the request through the hub and to the platform-specific push notification service (PNS).
+            /// Enabling this will result in delayed responses because the Hub must wait on delivery to the PNS.  This should ONLY be enabled in a non-production environment, as results are throttled.
+            /// </summary>
+            public bool EnableSendTracing { get; set; } = false;
+            public bool OpenForRegistration { get; set; }
+        }
     }
 
     public class YubicoSettings

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Core.Auth.Settings;
+using Bit.Core.Enums;
 using Bit.Core.Settings.LoggingSettings;
 
 namespace Bit.Core.Settings;
@@ -64,7 +65,7 @@ public class GlobalSettings : IGlobalSettings
     public virtual SentrySettings Sentry { get; set; } = new SentrySettings();
     public virtual SyslogSettings Syslog { get; set; } = new SyslogSettings();
     public virtual ILogLevelSettings MinLogLevel { get; set; } = new LogLevelSettings();
-    public virtual NotificationHubSettings NotificationHub { get; set; } = new NotificationHubSettings();
+    public virtual List<NotificationHubSettings> NotificationHubs { get; set; } = new();
     public virtual YubicoSettings Yubico { get; set; } = new YubicoSettings();
     public virtual DuoSettings Duo { get; set; } = new DuoSettings();
     public virtual BraintreeSettings Braintree { get; set; } = new BraintreeSettings();
@@ -405,32 +406,22 @@ public class GlobalSettings : IGlobalSettings
 
     public class NotificationHubSettings
     {
-        public HubRegistration Legacy { get; set; }
-        public List<HubRegistration> Ios { get; set; }
-        public List<HubRegistration> Android { get; set; }
-        // Example more:
-        //public List<HubRegistration> BrowserExtenstion { get; set; }
-        //public List<HubRegistration> Desktop { get; set; }
-        //public List<HubRegistration> Web { get; set; }
+        private string _connectionString;
 
-        public class HubRegistration
+        public string ConnectionString
         {
-            private string _connectionString;
-
-            public string ConnectionString
-            {
-                get => _connectionString;
-                set => _connectionString = value.Trim('"');
-            }
-            public string HubName { get; set; }
-
-            /// <summary>
-            /// Enables TestSend on the Azure Notification Hub, which allows tracing of the request through the hub and to the platform-specific push notification service (PNS).
-            /// Enabling this will result in delayed responses because the Hub must wait on delivery to the PNS.  This should ONLY be enabled in a non-production environment, as results are throttled.
-            /// </summary>
-            public bool EnableSendTracing { get; set; } = false;
-            public bool OpenForRegistration { get; set; }
+            get => _connectionString;
+            set => _connectionString = value.Trim('"');
         }
+        public string HubName { get; set; }
+
+        /// <summary>
+        /// Enables TestSend on the Azure Notification Hub, which allows tracing of the request through the hub and to the platform-specific push notification service (PNS).
+        /// Enabling this will result in delayed responses because the Hub must wait on delivery to the PNS.  This should ONLY be enabled in a non-production environment, as results are throttled.
+        /// </summary>
+        public bool EnableSendTracing { get; set; } = false;
+        public bool OpenForRegistration { get; set; }
+        public DeviceType? DeviceType { get; set; }
     }
 
     public class YubicoSettings

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -414,14 +414,16 @@ public class GlobalSettings : IGlobalSettings
             set => _connectionString = value.Trim('"');
         }
         public string HubName { get; set; }
-
         /// <summary>
         /// Enables TestSend on the Azure Notification Hub, which allows tracing of the request through the hub and to the platform-specific push notification service (PNS).
         /// Enabling this will result in delayed responses because the Hub must wait on delivery to the PNS.  This should ONLY be enabled in a non-production environment, as results are throttled.
         /// </summary>
         public bool EnableSendTracing { get; set; } = false;
-        public bool OpenForRegistration { get; set; }
-        public DeviceType? DeviceType { get; set; }
+        /// <summary>
+        /// At least one hub configiration should have registration enabled.
+        /// </summary>
+        public bool EnableRegistration { get; set; }
+        public NotificationHubType HubType { get; set; }
     }
 
     public class YubicoSettings

--- a/test/Core.Test/Services/NotificationHubPushRegistrationServiceTests.cs
+++ b/test/Core.Test/Services/NotificationHubPushRegistrationServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Settings;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
 
@@ -11,16 +12,19 @@ public class NotificationHubPushRegistrationServiceTests
     private readonly NotificationHubPushRegistrationService _sut;
 
     private readonly IInstallationDeviceRepository _installationDeviceRepository;
+    private readonly ILogger<NotificationHubPushRegistrationService> _logger;
     private readonly GlobalSettings _globalSettings;
 
     public NotificationHubPushRegistrationServiceTests()
     {
         _installationDeviceRepository = Substitute.For<IInstallationDeviceRepository>();
+        _logger = Substitute.For<ILogger<NotificationHubPushRegistrationService>>();
         _globalSettings = new GlobalSettings();
 
         _sut = new NotificationHubPushRegistrationService(
             _installationDeviceRepository,
-            _globalSettings
+            _globalSettings,
+            _logger
         );
     }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
As we grow beyond the limits of what notification hub supports out of the box, implement a strategy to shard clients across multiple Notification Hub accounts.


## Code changes

See inline comments.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
