### PR TITLE
Remove unnecessary identity column indication

### DIFF
--- a/src/Infrastructure.EntityFramework/Auth/Configurations/GrantEntityTypeConfiguration.cs
+++ b/src/Infrastructure.EntityFramework/Auth/Configurations/GrantEntityTypeConfiguration.cs
@@ -14,10 +14,6 @@ public class GrantEntityTypeConfiguration : IEntityTypeConfiguration<Grant>
             .IsClustered();
 
         builder
-            .Property(s => s.Id)
-            .UseIdentityColumn();
-
-        builder
             .HasIndex(s => s.Key)
             .IsUnique(true);
 


### PR DESCRIPTION
## Type of change

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Gets rid of the indicator that the ID column is an identity as this is auto-discovered by EF.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
