### PR TITLE
[AC-2214] Bug - Accept invite for provider created org

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -226,7 +226,7 @@ public class OrganizationUsersController : Controller
             throw new UnauthorizedAccessException();
         }
 
-        await _organizationService.InitPendingOrganization(user.Id, orgId, model.Keys.PublicKey, model.Keys.EncryptedPrivateKey, model.CollectionName);
+        await _organizationService.InitPendingOrganization(user.Id, orgId, organizationUserId, model.Keys.PublicKey, model.Keys.EncryptedPrivateKey, model.CollectionName);
         await _acceptOrgUserCommand.AcceptOrgUserByEmailTokenAsync(organizationUserId, user, model.Token, _userService);
         await _organizationService.ConfirmUserAsync(orgId, organizationUserId, model.Key, user.Id, _userService);
     }

--- a/src/Core/AdminConsole/Services/IOrganizationService.cs
+++ b/src/Core/AdminConsole/Services/IOrganizationService.cs
@@ -84,7 +84,7 @@ public interface IOrganizationService
     /// <remarks>
     /// This method must target a disabled Organization that has null keys and status as 'Pending'.
     /// </remarks>
-    Task InitPendingOrganization(Guid userId, Guid organizationId, string publicKey, string privateKey, string collectionName);
+    Task InitPendingOrganization(Guid userId, Guid organizationId, Guid organizationUserId, string publicKey, string privateKey, string collectionName);
     Task ReplaceAndUpdateCacheAsync(Organization org, EventType? orgEvent = null);
 
     void ValidatePasswordManagerPlan(Models.StaticStore.Plan plan, OrganizationUpgrade upgrade);

--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -2526,7 +2526,7 @@ public class OrganizationService : IOrganizationService
         });
     }
 
-    public async Task InitPendingOrganization(Guid userId, Guid organizationId, string publicKey, string privateKey, string collectionName)
+    public async Task InitPendingOrganization(Guid userId, Guid organizationId, Guid organizationUserId, string publicKey, string privateKey, string collectionName)
     {
         await ValidateSignUpPoliciesAsync(userId);
 
@@ -2565,9 +2565,8 @@ public class OrganizationService : IOrganizationService
             List<CollectionAccessSelection> defaultOwnerAccess = null;
             if (org.FlexibleCollections)
             {
-                var orgUser = await _organizationUserRepository.GetByOrganizationAsync(org.Id, userId);
                 defaultOwnerAccess =
-                    [new CollectionAccessSelection { Id = orgUser.Id, HidePasswords = false, ReadOnly = false, Manage = true }];
+                    [new CollectionAccessSelection { Id = organizationUserId, HidePasswords = false, ReadOnly = false, Manage = true }];
             }
 
             var defaultCollection = new Collection


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Initializing a pending organization would fail due to the `orgUser` being null while trying to assign the default collection. This was fixed by accepting the `orgUserId` we already have from request params itself. Removing an extra database call as well.

> Introduced in #3776 : This was throwing because `orgUser` would come back as `null`. We don't associate the `user.Id` with the `Organization User` until the invite is `accepted`. The initialization of a pending organization was happening before that. Luckily, the id we need was indeed on hand and just needed to be passed through the controller into the service. 

## Code changes
* **src/Api/AdminConsole/Controllers/OrganizationUsersController.cs**: Added `organizationUserId` to the parameters of `InitPendingOrganization`
* **src/Core/AdminConsole/Services/Implementations/OrganizationService.cs**: Removed repository call. Used passed in `organizationUserId` when creating `CollectionAccessSelection` object.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
