### PR TITLE
[PM-6577] Handle any exceptions in Duo HealthCheck

### DIFF
--- a/src/Core/Auth/Identity/TemporaryDuoWebV4SDKService.cs
+++ b/src/Core/Auth/Identity/TemporaryDuoWebV4SDKService.cs
@@ -4,6 +4,7 @@ using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Settings;
 using Bit.Core.Tokens;
+using Microsoft.Extensions.Logging;
 using Duo = DuoUniversal;
 
 namespace Bit.Core.Auth.Identity;
@@ -25,6 +26,7 @@ public class TemporaryDuoWebV4SDKService : ITemporaryDuoWebV4SDKService
     private readonly ICurrentContext _currentContext;
     private readonly GlobalSettings _globalSettings;
     private readonly IDataProtectorTokenFactory<DuoUserStateTokenable> _tokenDataFactory;
+    private readonly ILogger<TemporaryDuoWebV4SDKService> _logger;
 
     /// <summary>
     /// Constructor for the DuoUniversalPromptService. Used to supplement v2 implementation of Duo with v4 SDK
@@ -34,11 +36,13 @@ public class TemporaryDuoWebV4SDKService : ITemporaryDuoWebV4SDKService
     public TemporaryDuoWebV4SDKService(
         ICurrentContext currentContext,
         GlobalSettings globalSettings,
-        IDataProtectorTokenFactory<DuoUserStateTokenable> tokenDataFactory)
+        IDataProtectorTokenFactory<DuoUserStateTokenable> tokenDataFactory,
+        ILogger<TemporaryDuoWebV4SDKService> logger)
     {
         _currentContext = currentContext;
         _globalSettings = globalSettings;
         _tokenDataFactory = tokenDataFactory;
+        _logger = logger;
     }
 
     /// <summary>
@@ -131,6 +135,7 @@ public class TemporaryDuoWebV4SDKService : ITemporaryDuoWebV4SDKService
 
         if (!await client.DoHealthCheck(true))
         {
+            _logger.LogError("Unable to connect to Duo. Health check failed.");
             return null;
         }
         return client;

--- a/src/Core/Auth/Identity/TemporaryDuoWebV4SDKService.cs
+++ b/src/Core/Auth/Identity/TemporaryDuoWebV4SDKService.cs
@@ -129,7 +129,7 @@ public class TemporaryDuoWebV4SDKService : ITemporaryDuoWebV4SDKService
             (string)provider.MetaData["Host"],
             redirectUri).Build();
 
-        if (!await client.DoHealthCheck())
+        if (!await client.DoHealthCheck(true))
         {
             return null;
         }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

https://bitwarden.atlassian.net/browse/PM-6577

The new Duo SDK provides a health check method, which we call to confirm connectivity to the API prior to issuing the Auth URL or verifying it after 2FA has been performed.

In order to avoid returning a 500 error to the client if connectivity cannot be made, we tell the health check method to swallow the exception and return `false` instead, so that we can properly handle the response.

This could happen due to intermittent connectivity problems, or for self-hosted users with improper network configurations, so the log should help those users diagnose the problem.

## Code changes

* **[TemporaryDuoWebV4SDKService.cs](https://github.com/bitwarden/server/pull/3861/files#diff-fcb28637f0b140490b27fe766fd9919befd39f14b88fe402fde4202646c6c1e8):** Added logger and passed `true` to the `healthCheck` method to suppress and handle exceptions.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
