### PR TITLE
[PM 6768] Error autoscaling when organisation is subscription is still trialing

### DIFF
--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -788,7 +788,7 @@ public class StripePaymentService : IPaymentService
             ProrationDate = prorationDate,
         };
         var immediatelyInvoice = false;
-        if (!invoiceNow && isPm5864DollarThresholdEnabled)
+        if (!invoiceNow && isPm5864DollarThresholdEnabled && sub.Status.Trim() != "trialing")
         {
             var upcomingInvoiceWithChanges = await _stripeAdapter.InvoiceUpcomingAsync(new UpcomingInvoiceOptions
             {


### PR DESCRIPTION


## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Steps to Reprdouce 

Create a user and create a paid organization with that user

Logout and create another user

Login to the first user with the paid organization and try to invite the user you created from step 2 as an owner



This  trigger the error
![image](https://github.com/bitwarden/server/assets/108260115/d6357231-861e-44a0-a028-0f914bb13273)



## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team



Uploading ScreenRecording 2024-03-12 at 15.54.43.mov…



