### PR TITLE
[AC-2284] Set organization billing email to MSP billing email when linked

### DIFF
--- a/bitwarden_license/src/Commercial.Core/AdminConsole/Services/ProviderService.cs
+++ b/bitwarden_license/src/Commercial.Core/AdminConsole/Services/ProviderService.cs
@@ -17,6 +17,7 @@ using Bit.Core.Services;
 using Bit.Core.Settings;
 using Bit.Core.Utilities;
 using Microsoft.AspNetCore.DataProtection;
+using Stripe;
 
 namespace Bit.Commercial.Core.AdminConsole.Services;
 
@@ -374,8 +375,18 @@ public class ProviderService : IProviderService
             Key = key,
         };
 
-        await ApplyProviderPriceRateAsync(organizationId, providerId);
+        var provider = await _providerRepository.GetByIdAsync(providerId);
+
+        await ApplyProviderPriceRateAsync(organization, provider);
         await _providerOrganizationRepository.CreateAsync(providerOrganization);
+
+        organization.BillingEmail = provider.BillingEmail;
+        await _organizationRepository.ReplaceAsync(organization);
+        await _stripeAdapter.CustomerUpdateAsync(organization.GatewayCustomerId, new CustomerUpdateOptions
+        {
+            Email = provider.BillingEmail
+        });
+
         await _eventService.LogProviderOrganizationEventAsync(providerOrganization, EventType.ProviderOrganization_Added);
     }
 
@@ -400,16 +411,14 @@ public class ProviderService : IProviderService
         await _eventService.LogProviderOrganizationEventsAsync(insertedProviderOrganizations.Select(ipo => (ipo, EventType.ProviderOrganization_Added, (DateTime?)null)));
     }
 
-    private async Task ApplyProviderPriceRateAsync(Guid organizationId, Guid providerId)
+    private async Task ApplyProviderPriceRateAsync(Organization organization, Provider provider)
     {
-        var provider = await _providerRepository.GetByIdAsync(providerId);
         // if a provider was created before Nov 6, 2023.If true, the organization plan assigned to that provider is updated to a 2020 plan.
         if (provider.CreationDate >= Constants.ProviderCreatedPriorNov62023)
         {
             return;
         }
 
-        var organization = await _organizationRepository.GetByIdAsync(organizationId);
         var subscriptionItem = await GetSubscriptionItemAsync(organization.GatewaySubscriptionId, GetStripeSeatPlanId(organization.PlanType));
         var extractedPlanType = PlanTypeMappings(organization);
         if (subscriptionItem != null)

--- a/bitwarden_license/test/Commercial.Core.Test/AdminConsole/Services/ProviderServiceTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/AdminConsole/Services/ProviderServiceTests.cs
@@ -458,9 +458,42 @@ public class ProviderServiceTests
     {
         organization.PlanType = PlanType.EnterpriseAnnually;
 
-        sutProvider.GetDependency<IProviderRepository>().GetByIdAsync(provider.Id).Returns(provider);
+        var providerRepository = sutProvider.GetDependency<IProviderRepository>();
+        providerRepository.GetByIdAsync(provider.Id).Returns(provider);
+
         var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
         providerOrganizationRepository.GetByOrganizationId(organization.Id).ReturnsNull();
+
+        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
+        organizationRepository.GetByIdAsync(organization.Id).Returns(organization);
+
+        await sutProvider.Sut.AddOrganization(provider.Id, organization.Id, key);
+
+        await providerOrganizationRepository.ReceivedWithAnyArgs().CreateAsync(default);
+
+        await organizationRepository.Received(1)
+            .ReplaceAsync(Arg.Is<Organization>(org => org.BillingEmail == provider.BillingEmail));
+
+        await sutProvider.GetDependency<IStripeAdapter>().Received(1).CustomerUpdateAsync(
+            organization.GatewayCustomerId,
+            Arg.Is<CustomerUpdateOptions>(options => options.Email == provider.BillingEmail));
+
+        await sutProvider.GetDependency<IEventService>()
+            .Received().LogProviderOrganizationEventAsync(Arg.Any<ProviderOrganization>(),
+                EventType.ProviderOrganization_Added);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AddOrganization_CreateAfterNov62023_PlanTypeDoesNotUpdated(Provider provider, Organization organization, string key,
+        SutProvider<ProviderService> sutProvider)
+    {
+        provider.Type = ProviderType.Msp;
+
+        sutProvider.GetDependency<IProviderRepository>().GetByIdAsync(provider.Id).Returns(provider);
+
+        var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
+        var expectedPlanType = PlanType.EnterpriseAnnually;
+        organization.PlanType = PlanType.EnterpriseAnnually;
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
 
         await sutProvider.Sut.AddOrganization(provider.Id, organization.Id, key);
@@ -469,6 +502,44 @@ public class ProviderServiceTests
         await sutProvider.GetDependency<IEventService>()
             .Received().LogProviderOrganizationEventAsync(Arg.Any<ProviderOrganization>(),
                 EventType.ProviderOrganization_Added);
+        Assert.Equal(organization.PlanType, expectedPlanType);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AddOrganization_CreateBeforeNov62023_PlanTypeUpdated(Provider provider, Organization organization, string key,
+        SutProvider<ProviderService> sutProvider)
+    {
+        var newCreationDate = new DateTime(2023, 11, 5);
+        BackdateProviderCreationDate(provider, newCreationDate);
+        provider.Type = ProviderType.Msp;
+
+        organization.PlanType = PlanType.EnterpriseAnnually;
+        organization.Plan = "Enterprise (Annually)";
+
+        var expectedPlanType = PlanType.EnterpriseAnnually2020;
+
+        var expectedPlanId = "2020-enterprise-org-seat-annually";
+
+        sutProvider.GetDependency<IProviderRepository>().GetByIdAsync(provider.Id).Returns(provider);
+        var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
+        providerOrganizationRepository.GetByOrganizationId(organization.Id).ReturnsNull();
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
+
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
+        var subscriptionItem = GetSubscription(organization.GatewaySubscriptionId);
+        sutProvider.GetDependency<IStripeAdapter>().SubscriptionGetAsync(organization.GatewaySubscriptionId)
+            .Returns(GetSubscription(organization.GatewaySubscriptionId));
+        await sutProvider.GetDependency<IStripeAdapter>().SubscriptionUpdateAsync(
+            organization.GatewaySubscriptionId, SubscriptionUpdateRequest(expectedPlanId, subscriptionItem));
+
+        await sutProvider.Sut.AddOrganization(provider.Id, organization.Id, key);
+
+        await providerOrganizationRepository.ReceivedWithAnyArgs().CreateAsync(default);
+        await sutProvider.GetDependency<IEventService>()
+            .Received().LogProviderOrganizationEventAsync(Arg.Any<ProviderOrganization>(),
+                EventType.ProviderOrganization_Added);
+
+        Assert.Equal(organization.PlanType, expectedPlanType);
     }
 
     [Theory, BitAutoData]
@@ -574,65 +645,6 @@ public class ProviderServiceTests
                 !t.First().Item1.Collections.Single().ReadOnly &&
                 t.First().Item1.Collections.Single().Manage &&
                 t.First().Item2 == null));
-    }
-
-    [Theory, BitAutoData]
-    public async Task AddOrganization_CreateAfterNov62023_PlanTypeDoesNotUpdated(Provider provider, Organization organization, string key,
-        SutProvider<ProviderService> sutProvider)
-    {
-        provider.Type = ProviderType.Msp;
-
-        sutProvider.GetDependency<IProviderRepository>().GetByIdAsync(provider.Id).Returns(provider);
-
-        var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
-        var expectedPlanType = PlanType.EnterpriseAnnually;
-        organization.PlanType = PlanType.EnterpriseAnnually;
-        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
-
-        await sutProvider.Sut.AddOrganization(provider.Id, organization.Id, key);
-
-        await providerOrganizationRepository.ReceivedWithAnyArgs().CreateAsync(default);
-        await sutProvider.GetDependency<IEventService>()
-            .Received().LogProviderOrganizationEventAsync(Arg.Any<ProviderOrganization>(),
-                EventType.ProviderOrganization_Added);
-        Assert.Equal(organization.PlanType, expectedPlanType);
-    }
-
-    [Theory, BitAutoData]
-    public async Task AddOrganization_CreateBeforeNov62023_PlanTypeUpdated(Provider provider, Organization organization, string key,
-        SutProvider<ProviderService> sutProvider)
-    {
-        var newCreationDate = new DateTime(2023, 11, 5);
-        BackdateProviderCreationDate(provider, newCreationDate);
-        provider.Type = ProviderType.Msp;
-
-        organization.PlanType = PlanType.EnterpriseAnnually;
-        organization.Plan = "Enterprise (Annually)";
-
-        var expectedPlanType = PlanType.EnterpriseAnnually2020;
-
-        var expectedPlanId = "2020-enterprise-org-seat-annually";
-
-        sutProvider.GetDependency<IProviderRepository>().GetByIdAsync(provider.Id).Returns(provider);
-        var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
-        providerOrganizationRepository.GetByOrganizationId(organization.Id).ReturnsNull();
-        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
-
-        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
-        var subscriptionItem = GetSubscription(organization.GatewaySubscriptionId);
-        sutProvider.GetDependency<IStripeAdapter>().SubscriptionGetAsync(organization.GatewaySubscriptionId)
-            .Returns(GetSubscription(organization.GatewaySubscriptionId));
-        await sutProvider.GetDependency<IStripeAdapter>().SubscriptionUpdateAsync(
-            organization.GatewaySubscriptionId, SubscriptionUpdateRequest(expectedPlanId, subscriptionItem));
-
-        await sutProvider.Sut.AddOrganization(provider.Id, organization.Id, key);
-
-        await providerOrganizationRepository.ReceivedWithAnyArgs().CreateAsync(default);
-        await sutProvider.GetDependency<IEventService>()
-            .Received().LogProviderOrganizationEventAsync(Arg.Any<ProviderOrganization>(),
-                EventType.ProviderOrganization_Added);
-
-        Assert.Equal(organization.PlanType, expectedPlanType);
     }
 
     private static SubscriptionUpdateOptions SubscriptionUpdateRequest(string expectedPlanId, Subscription subscriptionItem) =>

--- a/bitwarden_license/test/Commercial.Core.Test/AdminConsole/Services/ProviderServiceTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/AdminConsole/Services/ProviderServiceTests.cs
@@ -469,7 +469,11 @@ public class ProviderServiceTests
 
         await sutProvider.Sut.AddOrganization(provider.Id, organization.Id, key);
 
-        await providerOrganizationRepository.ReceivedWithAnyArgs().CreateAsync(default);
+        await providerOrganizationRepository.Received(1)
+            .CreateAsync(Arg.Is<ProviderOrganization>(providerOrganization =>
+                providerOrganization.ProviderId == provider.Id &&
+                providerOrganization.OrganizationId == organization.Id &&
+                providerOrganization.Key == key));
 
         await organizationRepository.Received(1)
             .ReplaceAsync(Arg.Is<Organization>(org => org.BillingEmail == provider.BillingEmail));
@@ -479,7 +483,10 @@ public class ProviderServiceTests
             Arg.Is<CustomerUpdateOptions>(options => options.Email == provider.BillingEmail));
 
         await sutProvider.GetDependency<IEventService>()
-            .Received().LogProviderOrganizationEventAsync(Arg.Any<ProviderOrganization>(),
+            .Received().LogProviderOrganizationEventAsync(Arg.Is<ProviderOrganization>(providerOrganization =>
+                    providerOrganization.ProviderId == provider.Id &&
+                    providerOrganization.OrganizationId == organization.Id &&
+                    providerOrganization.Key == key),
                 EventType.ProviderOrganization_Added);
     }
 
@@ -498,10 +505,19 @@ public class ProviderServiceTests
 
         await sutProvider.Sut.AddOrganization(provider.Id, organization.Id, key);
 
-        await providerOrganizationRepository.ReceivedWithAnyArgs().CreateAsync(default);
+        await providerOrganizationRepository.Received(1)
+            .CreateAsync(Arg.Is<ProviderOrganization>(providerOrganization =>
+                providerOrganization.ProviderId == provider.Id &&
+                providerOrganization.OrganizationId == organization.Id &&
+                providerOrganization.Key == key));
+
         await sutProvider.GetDependency<IEventService>()
-            .Received().LogProviderOrganizationEventAsync(Arg.Any<ProviderOrganization>(),
+            .Received().LogProviderOrganizationEventAsync(Arg.Is<ProviderOrganization>(providerOrganization =>
+                    providerOrganization.ProviderId == provider.Id &&
+                    providerOrganization.OrganizationId == organization.Id &&
+                    providerOrganization.Key == key),
                 EventType.ProviderOrganization_Added);
+
         Assert.Equal(organization.PlanType, expectedPlanType);
     }
 
@@ -534,9 +550,17 @@ public class ProviderServiceTests
 
         await sutProvider.Sut.AddOrganization(provider.Id, organization.Id, key);
 
-        await providerOrganizationRepository.ReceivedWithAnyArgs().CreateAsync(default);
+        await providerOrganizationRepository.Received(1)
+            .CreateAsync(Arg.Is<ProviderOrganization>(providerOrganization =>
+                providerOrganization.ProviderId == provider.Id &&
+                providerOrganization.OrganizationId == organization.Id &&
+                providerOrganization.Key == key));
+
         await sutProvider.GetDependency<IEventService>()
-            .Received().LogProviderOrganizationEventAsync(Arg.Any<ProviderOrganization>(),
+            .Received().LogProviderOrganizationEventAsync(Arg.Is<ProviderOrganization>(providerOrganization =>
+                    providerOrganization.ProviderId == provider.Id &&
+                    providerOrganization.OrganizationId == organization.Id &&
+                    providerOrganization.Key == key),
                 EventType.ProviderOrganization_Added);
 
         Assert.Equal(organization.PlanType, expectedPlanType);


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This PR adds business logic that has been missing from the "Add client organization" process. Whenever an organization is linked to an MSP, that organization's billing email and Stripe account email needs to be set to the MSP's billing email.

https://github.com/bitwarden/server/assets/144709477/7141f202-4d09-41fd-8b39-b9673606f71a




## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **ProviderService.cs:** Set the organization's billing email and Stripe account email to the MSP's billing email when the organization is added to the MSP.
* **ProviderServiceTests.cs:** Update the success case to account for the new invocations.
