### PR TITLE
Protected scanner runs

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -7,25 +7,33 @@ on:
       - "main"
       - "rc"
       - "hotfix-rc"
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize]
 
 permissions: read-all
 
 jobs:
+  check-run:
+    name: Check PR run
+    uses: bitwarden/gh-actions/.github/workflows/check-run.yml@main
+
   sast:
     name: SAST scan
     runs-on: ubuntu-22.04
+    needs: check-run
     permissions:
       security-events: write
 
     steps:
       - name: Check out repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{  github.event.pull_request.head.sha }}
 
       - name: Scan with Checkmarx
         uses: checkmarx/ast-github-action@749fec53e0db0f6404a97e2e0807c3e80e3583a7 #2.0.23
         env:
-          INCREMENTAL: "${{ github.event_name == 'pull_request' && '--sast-incremental' || '' }}"
+          INCREMENTAL: "${{ contains(github.event_name, 'pull_request') && '--sast-incremental' || '' }}"
         with:
           project_name: ${{ github.repository }}
           cx_tenant: ${{ secrets.CHECKMARX_TENANT }}
@@ -35,19 +43,21 @@ jobs:
           additional_params: --report-format sarif --output-path . ${{ env.INCREMENTAL }}
 
       - name: Upload Checkmarx results to GitHub
-        uses: github/codeql-action/upload-sarif@b7bf0a3ed3ecfa44160715d7c442788f65f0f923 # v3.23.2
+        uses: github/codeql-action/upload-sarif@8a470fddafa5cbb6266ee11b37ef4d8aae19c571 # v3.24.6
         with:
           sarif_file: cx_result.sarif
 
   quality:
     name: Quality scan
     runs-on: ubuntu-22.04
+    needs: check-run
 
     steps:
       - name: Check out repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
+          ref: ${{  github.event.pull_request.head.sha }}
 
       - name: Scan with SonarCloud
         uses: sonarsource/sonarcloud-github-action@49e6cd3b187936a73b8280d59ffd9da69df63ec9 # v2.1.1


### PR DESCRIPTION
## Objective

Changes to the `.github/workflows/scan.yml` file to enhance the security scans performed on pull requests. The most important changes include switching from `pull_request` to `pull_request_target`, adding a new `check-run` job, and updating the version of `github/codeql-action/upload-sarif` used.

Changes to the pull request event trigger:

* [`.github/workflows/scan.yml`](diffhunk://#diff-246cd0c2f7db532638dd80a92ac011f49b3d26038983a4c0169ea8f8a5c39280L10-R36): Switched from `pull_request` to `pull_request_target` and added types `opened` and `synchronize` to specify when the workflow should be triggered.

Addition of a new job:

* [`.github/workflows/scan.yml`](diffhunk://#diff-246cd0c2f7db532638dd80a92ac011f49b3d26038983a4c0169ea8f8a5c39280L10-R36): Added a new job `check-run` that uses `bitwarden/gh-actions/.github/workflows/check-run.yml@main`. This job is now a dependency for the `sast` and `quality` jobs. [[1]](diffhunk://#diff-246cd0c2f7db532638dd80a92ac011f49b3d26038983a4c0169ea8f8a5c39280L10-R36) [[2]](diffhunk://#diff-246cd0c2f7db532638dd80a92ac011f49b3d26038983a4c0169ea8f8a5c39280L38-R60)

Changes to the `sast` and `quality` jobs:

* [`.github/workflows/scan.yml`](diffhunk://#diff-246cd0c2f7db532638dd80a92ac011f49b3d26038983a4c0169ea8f8a5c39280L10-R36): In the `sast` and `quality` jobs, the repository is now checked out at the SHA of the head commit of the pull request. Also, the `INCREMENTAL` environment variable in the `sast` job is now set based on whether `github.event_name` contains 'pull_request'. [[1]](diffhunk://#diff-246cd0c2f7db532638dd80a92ac011f49b3d26038983a4c0169ea8f8a5c39280L10-R36) [[2]](diffhunk://#diff-246cd0c2f7db532638dd80a92ac011f49b3d26038983a4c0169ea8f8a5c39280L38-R60)

Update of a GitHub action:

* [`.github/workflows/scan.yml`](diffhunk://#diff-246cd0c2f7db532638dd80a92ac011f49b3d26038983a4c0169ea8f8a5c39280L38-R60): Updated the `github/codeql-action/upload-sarif` action to version `v3.24.6`.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team