### PR TITLE
[AC-2334] Fix unable to load members when permissions is "null"

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -94,8 +94,11 @@ public class OrganizationUsersController : Controller
             response.Type = GetFlexibleCollectionsUserType(response.Type, response.Permissions);
 
             // Set 'Edit/Delete Assigned Collections' custom permissions to false
-            response.Permissions.EditAssignedCollections = false;
-            response.Permissions.DeleteAssignedCollections = false;
+            if (response.Permissions is not null)
+            {
+                response.Permissions.EditAssignedCollections = false;
+                response.Permissions.DeleteAssignedCollections = false;
+            }
         }
 
         if (includeGroups)
@@ -552,8 +555,11 @@ public class OrganizationUsersController : Controller
                 orgUser.Type = GetFlexibleCollectionsUserType(orgUser.Type, orgUser.Permissions);
 
                 // Set 'Edit/Delete Assigned Collections' custom permissions to false
-                orgUser.Permissions.EditAssignedCollections = false;
-                orgUser.Permissions.DeleteAssignedCollections = false;
+                if (orgUser.Permissions is not null)
+                {
+                    orgUser.Permissions.EditAssignedCollections = false;
+                    orgUser.Permissions.DeleteAssignedCollections = false;
+                }
 
                 return orgUser;
             });
@@ -565,7 +571,7 @@ public class OrganizationUsersController : Controller
     private OrganizationUserType GetFlexibleCollectionsUserType(OrganizationUserType type, Permissions permissions)
     {
         // Downgrade Custom users with no other permissions than 'Edit/Delete Assigned Collections' to User
-        if (type == OrganizationUserType.Custom)
+        if (type == OrganizationUserType.Custom && permissions is not null)
         {
             if ((permissions.EditAssignedCollections || permissions.DeleteAssignedCollections) &&
                 permissions is

--- a/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
@@ -74,7 +74,7 @@ public class ProfileOrganizationResponseModel : ResponseModel
         if (FlexibleCollections)
         {
             // Downgrade Custom users with no other permissions than 'Edit/Delete Assigned Collections' to User
-            if (Type == OrganizationUserType.Custom)
+            if (Type == OrganizationUserType.Custom && Permissions is not null)
             {
                 if ((Permissions.EditAssignedCollections || Permissions.DeleteAssignedCollections) &&
                     Permissions is

--- a/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
@@ -98,8 +98,11 @@ public class ProfileOrganizationResponseModel : ResponseModel
             }
 
             // Set 'Edit/Delete Assigned Collections' custom permissions to false
-            Permissions.EditAssignedCollections = false;
-            Permissions.DeleteAssignedCollections = false;
+            if (Permissions is not null)
+            {
+                Permissions.EditAssignedCollections = false;
+                Permissions.DeleteAssignedCollections = false;
+            }
         }
     }
 

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -32,6 +32,11 @@ public static class CoreHelpers
     private static readonly Random _random = new Random();
     private static readonly string RealConnectingIp = "X-Connecting-IP";
     private static readonly Regex _whiteSpaceRegex = new Regex(@"\s+");
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
 
     /// <summary>
     /// Generate sequential Guid for Sql Server.
@@ -763,6 +768,14 @@ public static class CoreHelpers
         return claims;
     }
 
+    /// <summary>
+    /// Deserializes JSON data into the specified type.
+    /// If the JSON data is a null reference, it will still return an instantiated class.
+    /// However, if the JSON data is a string "null", it will return null.
+    /// </summary>
+    /// <param name="jsonData">The JSON data</param>
+    /// <typeparam name="T">The type to deserialize into</typeparam>
+    /// <returns></returns>
     public static T LoadClassFromJsonData<T>(string jsonData) where T : new()
     {
         if (string.IsNullOrWhiteSpace(jsonData))
@@ -770,22 +783,12 @@ public static class CoreHelpers
             return new T();
         }
 
-        var options = new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        };
-
-        return System.Text.Json.JsonSerializer.Deserialize<T>(jsonData, options);
+        return System.Text.Json.JsonSerializer.Deserialize<T>(jsonData, _jsonSerializerOptions);
     }
 
     public static string ClassToJsonData<T>(T data)
     {
-        var options = new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        };
-
-        return System.Text.Json.JsonSerializer.Serialize(data, options);
+        return System.Text.Json.JsonSerializer.Serialize(data, _jsonSerializerOptions);
     }
 
     public static ICollection<T> AddIfNotExists<T>(this ICollection<T> list, T item)

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
@@ -1,21 +1,27 @@
 ﻿using System.Security.Claims;
 using Bit.Api.AdminConsole.Controllers;
 using Bit.Api.AdminConsole.Models.Request.Organizations;
+using Bit.Api.Vault.AuthorizationHandlers.OrganizationUsers;
 using Bit.Core;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
 using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Auth.Models;
 using Bit.Core.Context;
 using Bit.Core.Entities;
+using Bit.Core.Enums;
 using Bit.Core.Models.Data;
 using Bit.Core.Models.Data.Organizations;
+using Bit.Core.Models.Data.Organizations.OrganizationUsers;
 using Bit.Core.OrganizationFeatures.OrganizationUsers.Interfaces;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Utilities;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
+using Bit.Test.Common.Helpers;
+using Microsoft.AspNetCore.Authorization;
 using NSubstitute;
 using Xunit;
 
@@ -200,5 +206,105 @@ public class OrganizationUsersControllerTests
             Arg.Is<List<CollectionAccessSelection>>(cas =>
                 cas.All(c => model.Collections.Any(m => m.Id == c.Id))),
             model.Groups);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Get_WithFlexibleCollections_ReturnsUsers(
+        ICollection<OrganizationUserUserDetails> organizationUsers, OrganizationAbility organizationAbility,
+        SutProvider<OrganizationUsersController> sutProvider)
+    {
+        Get_Setup(organizationAbility, organizationUsers, sutProvider);
+        var response = await sutProvider.Sut.Get(organizationAbility.Id);
+
+        Assert.True(response.Data.All(r => organizationUsers.Any(ou => ou.Id == r.Id)));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Get_WithFlexibleCollections_HandlesNullPermissionsObject(
+        ICollection<OrganizationUserUserDetails> organizationUsers, OrganizationAbility organizationAbility,
+        SutProvider<OrganizationUsersController> sutProvider)
+    {
+        Get_Setup(organizationAbility, organizationUsers, sutProvider);
+        organizationUsers.First().Permissions = "null";
+        var response = await sutProvider.Sut.Get(organizationAbility.Id);
+
+        Assert.True(response.Data.All(r => organizationUsers.Any(ou => ou.Id == r.Id)));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Get_WithFlexibleCollections_SetsDeprecatedCustomPermissionstoFalse(
+        ICollection<OrganizationUserUserDetails> organizationUsers, OrganizationAbility organizationAbility,
+        SutProvider<OrganizationUsersController> sutProvider)
+    {
+        Get_Setup(organizationAbility, organizationUsers, sutProvider);
+
+        var customUser = organizationUsers.First();
+        customUser.Type = OrganizationUserType.Custom;
+        customUser.Permissions = CoreHelpers.ClassToJsonData(new Permissions
+        {
+            AccessReports = true,
+            EditAssignedCollections = true,
+            DeleteAssignedCollections = true,
+            AccessEventLogs = true
+        });
+
+        var response = await sutProvider.Sut.Get(organizationAbility.Id);
+
+        var customUserResponse = response.Data.First(r => r.Id == organizationUsers.First().Id);
+        Assert.Equal(OrganizationUserType.Custom, customUserResponse.Type);
+        Assert.True(customUserResponse.Permissions.AccessReports);
+        Assert.True(customUserResponse.Permissions.AccessEventLogs);
+        Assert.False(customUserResponse.Permissions.EditAssignedCollections);
+        Assert.False(customUserResponse.Permissions.DeleteAssignedCollections);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Get_WithFlexibleCollections_DowngradesCustomUsersWithDeprecatedPermissions(
+        ICollection<OrganizationUserUserDetails> organizationUsers, OrganizationAbility organizationAbility,
+        SutProvider<OrganizationUsersController> sutProvider)
+    {
+        Get_Setup(organizationAbility, organizationUsers, sutProvider);
+
+        var customUser = organizationUsers.First();
+        customUser.Type = OrganizationUserType.Custom;
+        customUser.Permissions = CoreHelpers.ClassToJsonData(new Permissions
+        {
+            EditAssignedCollections = true,
+            DeleteAssignedCollections = true,
+        });
+
+        var response = await sutProvider.Sut.Get(organizationAbility.Id);
+
+        var customUserResponse = response.Data.First(r => r.Id == organizationUsers.First().Id);
+        Assert.Equal(OrganizationUserType.User, customUserResponse.Type);
+        Assert.False(customUserResponse.Permissions.EditAssignedCollections);
+        Assert.False(customUserResponse.Permissions.DeleteAssignedCollections);
+    }
+
+    private void Get_Setup(OrganizationAbility organizationAbility,
+        ICollection<OrganizationUserUserDetails> organizationUsers,
+        SutProvider<OrganizationUsersController> sutProvider)
+    {
+        organizationAbility.FlexibleCollections = true;
+        foreach (var orgUser in organizationUsers)
+        {
+            orgUser.Permissions = null;
+        }
+        sutProvider.GetDependency<IApplicationCacheService>().GetOrganizationAbilityAsync(organizationAbility.Id)
+            .Returns(organizationAbility);
+
+        sutProvider.GetDependency<IAuthorizationService>().AuthorizeAsync(
+            user: Arg.Any<ClaimsPrincipal>(),
+            resource: Arg.Any<Object>(),
+            requirements: Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+            .Returns(AuthorizationResult.Success());
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetManyDetailsByOrganizationAsync(organizationAbility.Id, Arg.Any<bool>(), Arg.Any<bool>())
+            .Returns(organizationUsers);
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix a crash when trying to load the members page in the Admin Console.

This happens when `OrganizationUser.Permissions` is equal to the **string** `null`. Our CoreHelpers deserializer will deserialize that into a null reference, and we weren't checking for that before accessing the property.

This is different to the database value being a literal `NULL`, which CoreHelpers handles by instantiating the object anyway.

This is a gotcha so I've added an xmldoc comment on the CoreHelpers method. I'm not making any further changes per @justindbaur's preference to address it via `nullable enable` across our codebase.

There is also a small change to the json options requested by @justindbaur that I thought was OK to do while I'm here.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
