### PR TITLE
[AC-1962] Propagate organization status during billing sync

### DIFF
--- a/src/Core/AdminConsole/Models/Data/Organizations/SelfHostedOrganizationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Organizations/SelfHostedOrganizationDetails.cs
@@ -146,7 +146,8 @@ public class SelfHostedOrganizationDetails : Organization
             OwnersNotifiedOfAutoscaling = OwnersNotifiedOfAutoscaling,
             LimitCollectionCreationDeletion = LimitCollectionCreationDeletion,
             AllowAdminAccessToAllCollectionItems = AllowAdminAccessToAllCollectionItems,
-            FlexibleCollections = FlexibleCollections
+            FlexibleCollections = FlexibleCollections,
+            Status = Status
         };
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

There's currently a bug where org owners no longer show in Admin after a billing sync. It's because the status of the organization changes during the billing sync due to the `Status` property not being set in the `SelfHostedOrganizationDetails.ToOrganization` [method](https://github.com/bitwarden/server/blob/96f9fbb9511abbec0b68107404ddf256d23add96/src/Core/OrganizationFeatures/OrganizationLicenses/UpdateOrganizationLicenseCommand.cs#L61). This PR resolves that.


https://github.com/bitwarden/server/assets/144709477/2725bd4c-c35f-4cde-9750-67a3d71b71da


