### PR TITLE
Adjust scan permissions

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,8 +10,6 @@ on:
   pull_request_target:
     types: [opened, synchronize]
 
-permissions: read-all
-
 jobs:
   check-run:
     name: Check PR run
@@ -22,6 +20,8 @@ jobs:
     runs-on: ubuntu-22.04
     needs: check-run
     permissions:
+      contents: read
+      pull-requests: write
       security-events: write
 
     steps:
@@ -43,7 +43,7 @@ jobs:
           additional_params: --report-format sarif --output-path . ${{ env.INCREMENTAL }}
 
       - name: Upload Checkmarx results to GitHub
-        uses: github/codeql-action/upload-sarif@8a470fddafa5cbb6266ee11b37ef4d8aae19c571 # v3.24.6
+        uses: github/codeql-action/upload-sarif@1b1aada464948af03b950897e5eb522f92603cc2 # v3.24.9
         with:
           sarif_file: cx_result.sarif
 
@@ -51,6 +51,9 @@ jobs:
     name: Quality scan
     runs-on: ubuntu-22.04
     needs: check-run
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Check out repo


### PR DESCRIPTION

## Objective

Adjusts the permissions for the scanning workflow per our standard template.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
