### PR TITLE
[AC-2350] - FIX - Add DNS TXT record generation

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationDomainController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationDomainController.cs
@@ -80,7 +80,6 @@ public class OrganizationDomainController : Controller
         var organizationDomain = new OrganizationDomain
         {
             OrganizationId = orgId,
-            Txt = model.Txt,
             DomainName = model.DomainName.ToLower()
         };
 

--- a/src/Api/AdminConsole/Models/Request/OrganizationDomainRequestModel.cs
+++ b/src/Api/AdminConsole/Models/Request/OrganizationDomainRequestModel.cs
@@ -5,8 +5,5 @@ namespace Bit.Api.AdminConsole.Models.Request;
 public class OrganizationDomainRequestModel
 {
     [Required]
-    public string Txt { get; set; }
-
-    [Required]
     public string DomainName { get; set; }
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationDomains/CreateOrganizationDomainCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationDomains/CreateOrganizationDomainCommand.cs
@@ -5,6 +5,7 @@ using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Settings;
+using Bit.Core.Utilities;
 using Microsoft.Extensions.Logging;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationDomains;
@@ -50,26 +51,16 @@ public class CreateOrganizationDomainCommand : ICreateOrganizationDomainCommand
             throw new ConflictException("A domain already exists for this organization.");
         }
 
-        try
-        {
-            if (await _dnsResolverService.ResolveAsync(organizationDomain.DomainName, organizationDomain.Txt))
-            {
-                organizationDomain.SetVerifiedDate();
-            }
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(e, "Error verifying Organization domain.");
-        }
-
+        // Generate and set DNS TXT Record
+        // DNS-Based Service Discovery RFC: https://www.ietf.org/rfc/rfc6763.txt; see section 6.1
+        // Google uses 43 chars for their TXT record value: https://support.google.com/a/answer/2716802
+        // A random 44 character string was used here to keep parity with prior client-side generation of 47 characters
+        organizationDomain.Txt = string.Join("=", "bw", CoreHelpers.RandomString(44));
         organizationDomain.SetNextRunDate(_globalSettings.DomainVerification.VerificationInterval);
-        organizationDomain.SetLastCheckedDate();
 
         var orgDomain = await _organizationDomainRepository.CreateAsync(organizationDomain);
 
         await _eventService.LogOrganizationDomainEventAsync(orgDomain, EventType.OrganizationDomain_Added);
-        await _eventService.LogOrganizationDomainEventAsync(orgDomain,
-            orgDomain.VerifiedDate != null ? EventType.OrganizationDomain_Verified : EventType.OrganizationDomain_NotVerified);
 
         return orgDomain;
     }


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other


## Objective

> Move the DNS TXT record generation server-side in order to increase security reliability with regards to Domain Verification.


## Code changes

* **src/Api/AdminConsole/Controllers/OrganizationDomainController.cs**: Removed setting the `Txt` property via passed in model for the `OrganizationDomain` object creation.
* **src/Api/AdminConsole/Models/Request/OrganizationDomainRequestModel.cs**: Removed the `Txt` property from the request model
* **.../CreateOrganizationDomainCommand.cs**: Added DNS TXT Record generation and aligned it with the client-side implementation. **Removed** instant verification step as the user will not have their generated Txt string yet. This includes the removal of setting the `LastCheckedDate` and sending an additional event about whether or not the domain was verified in this step.
* **.../CreateOrganizationDomainCommandTests.cs**: Added a couple of small assertions to better illustrate the `Txt` expectations. Removed all unnecessary tests regarding instant verification vis DNS resolving.


## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
