### PR TITLE
[AC-1795] Provide extra subscription info when past due

### DIFF
--- a/src/Api/Models/Response/SubscriptionResponseModel.cs
+++ b/src/Api/Models/Response/SubscriptionResponseModel.cs
@@ -75,6 +75,10 @@ public class BillingSubscription
         {
             Items = sub.Items.Select(i => new BillingSubscriptionItem(i));
         }
+        CollectionMethod = sub.CollectionMethod;
+        SuspensionDate = sub.SuspensionDate;
+        UnpaidPeriodEndDate = sub.UnpaidPeriodEndDate;
+        GracePeriod = sub.GracePeriod;
     }
 
     public DateTime? TrialStartDate { get; set; }
@@ -86,6 +90,10 @@ public class BillingSubscription
     public string Status { get; set; }
     public bool Cancelled { get; set; }
     public IEnumerable<BillingSubscriptionItem> Items { get; set; } = new List<BillingSubscriptionItem>();
+    public string CollectionMethod { get; set; }
+    public DateTime? SuspensionDate { get; set; }
+    public DateTime? UnpaidPeriodEndDate { get; set; }
+    public int? GracePeriod { get; set; }
 
     public class BillingSubscriptionItem
     {

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -131,6 +131,7 @@ public static class FeatureFlagKeys
     public const string AC2101UpdateTrialInitiationEmail = "AC-2101-update-trial-initiation-email";
     public const string ShowPaymentMethodWarningBanners = "show-payment-method-warning-banners";
     public const string EnableConsolidatedBilling = "enable-consolidated-billing";
+    public const string AC1795_UpdatedSubscriptionStatusSection = "AC-1795_updated-subscription-status-section";
 
     public static List<string> GetAllKeys()
     {

--- a/src/Core/Models/Business/SubscriptionInfo.cs
+++ b/src/Core/Models/Business/SubscriptionInfo.cs
@@ -43,6 +43,9 @@ public class SubscriptionInfo
                 Items = sub.Items.Data.Select(i => new BillingSubscriptionItem(i));
             }
             CollectionMethod = sub.CollectionMethod;
+            GracePeriod = sub.CollectionMethod == "charge_automatically"
+                ? 14
+                : 30;
         }
 
         public DateTime? TrialStartDate { get; set; }
@@ -56,6 +59,9 @@ public class SubscriptionInfo
         public bool Cancelled { get; set; }
         public IEnumerable<BillingSubscriptionItem> Items { get; set; } = new List<BillingSubscriptionItem>();
         public string CollectionMethod { get; set; }
+        public DateTime? SuspensionDate { get; set; }
+        public DateTime? UnpaidPeriodEndDate { get; set; }
+        public int GracePeriod { get; set; }
 
         public class BillingSubscriptionItem
         {

--- a/src/Core/Services/IStripeAdapter.cs
+++ b/src/Core/Services/IStripeAdapter.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Core.Models.BitStripe;
+using Stripe;
 
 namespace Bit.Core.Services;
 
@@ -16,6 +17,7 @@ public interface IStripeAdapter
     Task<Stripe.Invoice> InvoiceUpcomingAsync(Stripe.UpcomingInvoiceOptions options);
     Task<Stripe.Invoice> InvoiceGetAsync(string id, Stripe.InvoiceGetOptions options);
     Task<List<Stripe.Invoice>> InvoiceListAsync(StripeInvoiceListOptions options);
+    Task<List<Stripe.Invoice>> InvoiceSearchAsync(InvoiceSearchOptions options);
     Task<Stripe.Invoice> InvoiceUpdateAsync(string id, Stripe.InvoiceUpdateOptions options);
     Task<Stripe.Invoice> InvoiceFinalizeInvoiceAsync(string id, Stripe.InvoiceFinalizeOptions options);
     Task<Stripe.Invoice> InvoiceSendInvoiceAsync(string id, Stripe.InvoiceSendOptions options);

--- a/src/Core/Services/Implementations/StripeAdapter.cs
+++ b/src/Core/Services/Implementations/StripeAdapter.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Core.Models.BitStripe;
+using Stripe;
 
 namespace Bit.Core.Services;
 
@@ -102,6 +103,9 @@ public class StripeAdapter : IStripeAdapter
 
         return invoices;
     }
+
+    public async Task<List<Stripe.Invoice>> InvoiceSearchAsync(InvoiceSearchOptions options)
+        => (await _invoiceService.SearchAsync(options)).Data;
 
     public Task<Stripe.Invoice> InvoiceUpdateAsync(string id, Stripe.InvoiceUpdateOptions options)
     {

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -1622,10 +1622,22 @@ public class StripePaymentService : IPaymentService
             return subscriptionInfo;
         }
 
-        var sub = await _stripeAdapter.SubscriptionGetAsync(subscriber.GatewaySubscriptionId);
+        var sub = await _stripeAdapter.SubscriptionGetAsync(subscriber.GatewaySubscriptionId, new SubscriptionGetOptions
+        {
+            Expand = ["test_clock"]
+        });
+
         if (sub != null)
         {
             subscriptionInfo.Subscription = new SubscriptionInfo.BillingSubscription(sub);
+
+            var (suspensionDate, unpaidPeriodEndDate) = await GetSuspensionDateAsync(sub);
+
+            if (suspensionDate.HasValue && unpaidPeriodEndDate.HasValue)
+            {
+                subscriptionInfo.Subscription.SuspensionDate = suspensionDate;
+                subscriptionInfo.Subscription.UnpaidPeriodEndDate = unpaidPeriodEndDate;
+            }
         }
 
         if (sub is { CanceledAt: not null } || string.IsNullOrWhiteSpace(subscriber.GatewayCustomerId))
@@ -1941,5 +1953,46 @@ public class StripePaymentService : IPaymentService
         return subscriberName.Length <= 30
             ? subscriberName
             : subscriberName[..30];
+    }
+
+    private async Task<(DateTime?, DateTime?)> GetSuspensionDateAsync(Subscription subscription)
+    {
+        if (subscription.Status is not "past_due" && subscription.Status is not "unpaid")
+        {
+            return (null, null);
+        }
+
+        var openInvoices = await _stripeAdapter.InvoiceSearchAsync(new InvoiceSearchOptions
+        {
+            Query = $"subscription:'{subscription.Id}' status:'open'"
+        });
+
+        if (openInvoices.Count == 0)
+        {
+            return (null, null);
+        }
+
+        var currentDate = subscription.TestClock?.FrozenTime ?? DateTime.UtcNow;
+
+        switch (subscription.CollectionMethod)
+        {
+            case "charge_automatically":
+                {
+                    var firstOverdueInvoice = openInvoices
+                        .Where(invoice => invoice.PeriodEnd < currentDate && invoice.Attempted)
+                        .MinBy(invoice => invoice.Created);
+
+                    return (firstOverdueInvoice?.Created.AddDays(14), firstOverdueInvoice?.PeriodEnd);
+                }
+            case "send_invoice":
+                {
+                    var firstOverdueInvoice = openInvoices
+                        .Where(invoice => invoice.DueDate < currentDate)
+                        .MinBy(invoice => invoice.Created);
+
+                    return (firstOverdueInvoice?.DueDate?.AddDays(30), firstOverdueInvoice?.PeriodEnd);
+                }
+            default: return (null, null);
+        }
     }
 }

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -1631,12 +1631,15 @@ public class StripePaymentService : IPaymentService
         {
             subscriptionInfo.Subscription = new SubscriptionInfo.BillingSubscription(sub);
 
-            var (suspensionDate, unpaidPeriodEndDate) = await GetSuspensionDateAsync(sub);
-
-            if (suspensionDate.HasValue && unpaidPeriodEndDate.HasValue)
+            if (_featureService.IsEnabled(FeatureFlagKeys.AC1795_UpdatedSubscriptionStatusSection))
             {
-                subscriptionInfo.Subscription.SuspensionDate = suspensionDate;
-                subscriptionInfo.Subscription.UnpaidPeriodEndDate = unpaidPeriodEndDate;
+                var (suspensionDate, unpaidPeriodEndDate) = await GetSuspensionDateAsync(sub);
+
+                if (suspensionDate.HasValue && unpaidPeriodEndDate.HasValue)
+                {
+                    subscriptionInfo.Subscription.SuspensionDate = suspensionDate;
+                    subscriptionInfo.Subscription.UnpaidPeriodEndDate = unpaidPeriodEndDate;
+                }
             }
         }
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This PR adds 4 properties to the subscription response that are used to add further detail to our subscription status section on the subscription page for organizations.

Most of the changes are self-explanatory - the only real logic added is for calculating the grace period/suspension date of a subscription that's past due or unpaid.

To do so, we use the collection method:
- `charge_automatically`: 14 days after the first unpaid invoice was created.
- `send_invoice`: 30 days after the first unpaid invoice was due.

The work is entirely behind a feature flag: `AC-1795_updated-subscription-status-section`
