### PR TITLE
[PM-7093] Prevent Stripe call when creating Organization from Reseller in Admin

### DIFF
--- a/bitwarden_license/src/Commercial.Core/AdminConsole/Services/ProviderService.cs
+++ b/bitwarden_license/src/Commercial.Core/AdminConsole/Services/ProviderService.cs
@@ -382,10 +382,14 @@ public class ProviderService : IProviderService
 
         organization.BillingEmail = provider.BillingEmail;
         await _organizationRepository.ReplaceAsync(organization);
-        await _stripeAdapter.CustomerUpdateAsync(organization.GatewayCustomerId, new CustomerUpdateOptions
+
+        if (!string.IsNullOrEmpty(organization.GatewayCustomerId))
         {
-            Email = provider.BillingEmail
-        });
+            await _stripeAdapter.CustomerUpdateAsync(organization.GatewayCustomerId, new CustomerUpdateOptions
+            {
+                Email = provider.BillingEmail
+            });
+        }
 
         await _eventService.LogProviderOrganizationEventAsync(providerOrganization, EventType.ProviderOrganization_Added);
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

When creating a client organization for a reseller from Admin, the client organization will not have a Stripe customer, so we have to prevent the call to Stripe to update that customer in this scenario.