### PR TITLE
SM-1119: Rename service accounts to machine accounts

### DIFF
--- a/src/Admin/AdminConsole/Views/Organizations/_ViewInformation.cshtml
+++ b/src/Admin/AdminConsole/Views/Organizations/_ViewInformation.cshtml
@@ -68,7 +68,7 @@
     <dt class="col-sm-4 col-lg-3">Projects</dt>
     <dd class="col-sm-8 col-lg-9">@(Model.UseSecretsManager ? Model.ProjectsCount: "N/A")</dd>
 
-    <dt class="col-sm-4 col-lg-3">Service Accounts</dt>
+    <dt class="col-sm-4 col-lg-3">Machine Accounts</dt>
     <dd class="col-sm-8 col-lg-9">@(Model.UseSecretsManager ? Model.ServiceAccountsCount: "N/A")</dd>
 
     <dt class="col-sm-4 col-lg-3">Secrets Manager Seats</dt>

--- a/src/Admin/AdminConsole/Views/Organizations/_ViewInformation.cshtml
+++ b/src/Admin/AdminConsole/Views/Organizations/_ViewInformation.cshtml
@@ -68,7 +68,7 @@
     <dt class="col-sm-4 col-lg-3">Projects</dt>
     <dd class="col-sm-8 col-lg-9">@(Model.UseSecretsManager ? Model.ProjectsCount: "N/A")</dd>
 
-    <dt class="col-sm-4 col-lg-3">Machine Accounts</dt>
+    <dt class="col-sm-4 col-lg-3">Service Accounts</dt>
     <dd class="col-sm-8 col-lg-9">@(Model.UseSecretsManager ? Model.ServiceAccountsCount: "N/A")</dd>
 
     <dt class="col-sm-4 col-lg-3">Secrets Manager Seats</dt>

--- a/src/Api/SecretsManager/Models/Request/PeopleAccessPoliciesRequestModel.cs
+++ b/src/Api/SecretsManager/Models/Request/PeopleAccessPoliciesRequestModel.cs
@@ -85,7 +85,7 @@ public class PeopleAccessPoliciesRequestModel
 
         if (!policies.All(ap => ap.Read && ap.Write))
         {
-            throw new BadRequestException("Service account access must be Can read, write");
+            throw new BadRequestException("Machine account access must be Can read, write");
         }
 
         return new ServiceAccountPeopleAccessPolicies

--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -2037,7 +2037,7 @@ public class OrganizationService : IOrganizationService
 
         if (!plan.SecretsManager.HasAdditionalServiceAccountOption && upgrade.AdditionalServiceAccounts > 0)
         {
-            throw new BadRequestException("Plan does not allow additional Service Accounts.");
+            throw new BadRequestException("Plan does not allow additional Machine Accounts.");
         }
 
         if ((plan.Product == ProductType.TeamsStarter &&
@@ -2050,7 +2050,7 @@ public class OrganizationService : IOrganizationService
 
         if (upgrade.AdditionalServiceAccounts.GetValueOrDefault() < 0)
         {
-            throw new BadRequestException("You can't subtract Service Accounts!");
+            throw new BadRequestException("You can't subtract Machine Accounts!");
         }
 
         switch (plan.SecretsManager.HasAdditionalSeatsOption)

--- a/src/Core/MailTemplates/Handlebars/OrganizationSmServiceAccountsMaxReached.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/OrganizationSmServiceAccountsMaxReached.html.hbs
@@ -6,7 +6,7 @@
         <td class="content-block"
             style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;"
             valign="top">
-            Your organization has reached the Secrets Manager service accounts limit of {{MaxServiceAccountsCount}}. New service accounts cannot be created
+            Your organization has reached the Secrets Manager machine accounts limit of {{MaxServiceAccountsCount}}. New machine accounts cannot be created
         </td>
     </tr>
     <tr

--- a/src/Core/MailTemplates/Handlebars/OrganizationSmServiceAccountsMaxReached.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/OrganizationSmServiceAccountsMaxReached.text.hbs
@@ -1,5 +1,5 @@
 {{#>BasicTextLayout}}
-Your organization has reached the Secrets Manager service accounts limit of {{MaxServiceAccountsCount}}. New service accounts cannot be created
+Your organization has reached the Secrets Manager machine accounts limit of {{MaxServiceAccountsCount}}. New machine accounts cannot be created
 
 For more information, please refer to the following help article: https://bitwarden.com/help/managing-users
 {{/BasicTextLayout}}

--- a/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpdateSecretsManagerSubscriptionCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpdateSecretsManagerSubscriptionCommand.cs
@@ -118,7 +118,7 @@ public class UpdateSecretsManagerSubscriptionCommand : IUpdateSecretsManagerSubs
         }
         catch (Exception e)
         {
-            _logger.LogError(e, $"Error encountered notifying organization owners of service accounts limit reached.");
+            _logger.LogError(e, $"Error encountered notifying organization owners of machine accounts limit reached.");
         }
 
     }
@@ -253,12 +253,12 @@ public class UpdateSecretsManagerSubscriptionCommand : IUpdateSecretsManagerSubs
         // Check if the organization has unlimited service accounts
         if (organization.SmServiceAccounts == null)
         {
-            throw new BadRequestException("Organization has no service accounts limit, no need to adjust service accounts");
+            throw new BadRequestException("Organization has no machine accounts limit, no need to adjust machine accounts");
         }
 
         if (update.Autoscaling && update.SmServiceAccounts.Value < organization.SmServiceAccounts.Value)
         {
-            throw new BadRequestException("Cannot use autoscaling to subtract service accounts.");
+            throw new BadRequestException("Cannot use autoscaling to subtract machine accounts.");
         }
 
         // Check plan maximum service accounts
@@ -267,7 +267,7 @@ public class UpdateSecretsManagerSubscriptionCommand : IUpdateSecretsManagerSubs
         {
             var planMaxServiceAccounts = plan.SecretsManager.BaseServiceAccount +
                                          plan.SecretsManager.MaxAdditionalServiceAccount.GetValueOrDefault();
-            throw new BadRequestException($"You have reached the maximum number of service accounts ({planMaxServiceAccounts}) for this plan.");
+            throw new BadRequestException($"You have reached the maximum number of machine accounts ({planMaxServiceAccounts}) for this plan.");
         }
 
         // Check autoscale maximum service accounts
@@ -275,21 +275,21 @@ public class UpdateSecretsManagerSubscriptionCommand : IUpdateSecretsManagerSubs
             update.SmServiceAccounts.Value > update.MaxAutoscaleSmServiceAccounts.Value)
         {
             var message = update.Autoscaling
-                ? "Secrets Manager service account limit has been reached."
-                : "Cannot set max service accounts autoscaling below service account amount.";
+                ? "Secrets Manager machine account limit has been reached."
+                : "Cannot set max machine accounts autoscaling below machine account amount.";
             throw new BadRequestException(message);
         }
 
         // Check minimum service accounts included with plan
         if (plan.SecretsManager.BaseServiceAccount > update.SmServiceAccounts.Value)
         {
-            throw new BadRequestException($"Plan has a minimum of {plan.SecretsManager.BaseServiceAccount} service accounts.");
+            throw new BadRequestException($"Plan has a minimum of {plan.SecretsManager.BaseServiceAccount} machine accounts.");
         }
 
         // Check minimum service accounts required by business logic
         if (update.SmServiceAccounts.Value <= 0)
         {
-            throw new BadRequestException("You must have at least 1 service account.");
+            throw new BadRequestException("You must have at least 1 machine account.");
         }
 
         // Check minimum service accounts currently in use by the organization
@@ -298,8 +298,8 @@ public class UpdateSecretsManagerSubscriptionCommand : IUpdateSecretsManagerSubs
             var currentServiceAccounts = await _serviceAccountRepository.GetServiceAccountCountByOrganizationIdAsync(organization.Id);
             if (currentServiceAccounts > update.SmServiceAccounts)
             {
-                throw new BadRequestException($"Your organization currently has {currentServiceAccounts} service accounts. " +
-                                              $"You cannot decrease your subscription below your current service account usage.");
+                throw new BadRequestException($"Your organization currently has {currentServiceAccounts} machine accounts. " +
+                                              $"You cannot decrease your subscription below your current machine account usage.");
             }
         }
     }
@@ -346,18 +346,18 @@ public class UpdateSecretsManagerSubscriptionCommand : IUpdateSecretsManagerSubs
         if (update.SmServiceAccounts.HasValue && update.MaxAutoscaleSmServiceAccounts.Value < update.SmServiceAccounts.Value)
         {
             throw new BadRequestException(
-                $"Cannot set max service accounts autoscaling below current service accounts count.");
+                $"Cannot set max machine accounts autoscaling below current machine accounts count.");
         }
 
         if (!plan.SecretsManager.AllowServiceAccountsAutoscale)
         {
-            throw new BadRequestException("Your plan does not allow service accounts autoscaling.");
+            throw new BadRequestException("Your plan does not allow machine accounts autoscaling.");
         }
 
         if (plan.SecretsManager.MaxServiceAccounts.HasValue && update.MaxAutoscaleSmServiceAccounts.Value > plan.SecretsManager.MaxServiceAccounts)
         {
             throw new BadRequestException(string.Concat(
-                $"Your plan has a service account limit of {plan.SecretsManager.MaxServiceAccounts}, ",
+                $"Your plan has a machine account limit of {plan.SecretsManager.MaxServiceAccounts}, ",
                 $"but you have specified a max autoscale count of {update.MaxAutoscaleSmServiceAccounts}.",
                 "Reduce your max autoscale count."));
         }

--- a/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs
@@ -330,9 +330,9 @@ public class UpgradeOrganizationPlanCommand : IUpgradeOrganizationPlanCommand
             if (currentServiceAccounts > newPlanServiceAccounts)
             {
                 throw new BadRequestException(
-                    $"Your organization currently has {currentServiceAccounts} service accounts. " +
-                    $"Your new plan only allows {newSecretsManagerPlan.SecretsManager.MaxServiceAccounts} service accounts. " +
-                    "Remove some service accounts or increase your subscription.");
+                    $"Your organization currently has {currentServiceAccounts} machine accounts. " +
+                    $"Your new plan only allows {newSecretsManagerPlan.SecretsManager.MaxServiceAccounts} machine accounts. " +
+                    "Remove some machine accounts or increase your subscription.");
             }
         }
     }

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -951,7 +951,7 @@ public class HandlebarsMailService : IMailService
     public async Task SendSecretsManagerMaxServiceAccountLimitReachedEmailAsync(Organization organization, int maxSeatCount,
         IEnumerable<string> ownerEmails)
     {
-        var message = CreateDefaultMessage($"{organization.DisplayName()} Secrets Manager Service Accounts Limit Reached", ownerEmails);
+        var message = CreateDefaultMessage($"{organization.DisplayName()} Secrets Manager Machine Accounts Limit Reached", ownerEmails);
         var model = new OrganizationServiceAccountsMaxReachedViewModel
         {
             OrganizationId = organization.Id,

--- a/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
@@ -410,7 +410,7 @@ public class OrganizationServiceTests
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.SignUpAsync(signup));
-        Assert.Contains("Plan does not allow additional Service Accounts.", exception.Message);
+        Assert.Contains("Plan does not allow additional Machine Accounts.", exception.Message);
     }
 
     [Theory]
@@ -444,7 +444,7 @@ public class OrganizationServiceTests
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.SignUpAsync(signup));
-        Assert.Contains("You can't subtract Service Accounts!", exception.Message);
+        Assert.Contains("You can't subtract Machine Accounts!", exception.Message);
     }
 
     [Theory]
@@ -2208,7 +2208,7 @@ OrganizationUserInvite invite, SutProvider<OrganizationService> sutProvider)
             AdditionalSeats = 3
         };
         var exception = Assert.Throws<BadRequestException>(() => sutProvider.Sut.ValidateSecretsManagerPlan(plan, signup));
-        Assert.Contains("Plan does not allow additional Service Accounts.", exception.Message);
+        Assert.Contains("Plan does not allow additional Machine Accounts.", exception.Message);
     }
 
     [Theory]
@@ -2249,7 +2249,7 @@ OrganizationUserInvite invite, SutProvider<OrganizationService> sutProvider)
             AdditionalSeats = 5
         };
         var exception = Assert.Throws<BadRequestException>(() => sutProvider.Sut.ValidateSecretsManagerPlan(plan, signup));
-        Assert.Contains("You can't subtract Service Accounts!", exception.Message);
+        Assert.Contains("You can't subtract Machine Accounts!", exception.Message);
     }
 
     [Theory]

--- a/test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/UpdateSecretsManagerSubscriptionCommandTests.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/UpdateSecretsManagerSubscriptionCommandTests.cs
@@ -447,7 +447,7 @@ public class UpdateSecretsManagerSubscriptionCommandTests
         var update = new SecretsManagerSubscriptionUpdate(organization, false).AdjustServiceAccounts(1);
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.UpdateSubscriptionAsync(update));
-        Assert.Contains("Organization has no service accounts limit, no need to adjust service accounts", exception.Message);
+        Assert.Contains("Organization has no machine accounts limit, no need to adjust machine accounts", exception.Message);
         await VerifyDependencyNotCalledAsync(sutProvider);
     }
 
@@ -460,7 +460,7 @@ public class UpdateSecretsManagerSubscriptionCommandTests
         var update = new SecretsManagerSubscriptionUpdate(organization, true).AdjustServiceAccounts(-2);
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.UpdateSubscriptionAsync(update));
-        Assert.Contains("Cannot use autoscaling to subtract service accounts.", exception.Message);
+        Assert.Contains("Cannot use autoscaling to subtract machine accounts.", exception.Message);
         await VerifyDependencyNotCalledAsync(sutProvider);
     }
 
@@ -475,7 +475,7 @@ public class UpdateSecretsManagerSubscriptionCommandTests
         var update = new SecretsManagerSubscriptionUpdate(organization, false).AdjustServiceAccounts(1);
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.UpdateSubscriptionAsync(update));
-        Assert.Contains("You have reached the maximum number of service accounts (3) for this plan",
+        Assert.Contains("You have reached the maximum number of machine accounts (3) for this plan",
             exception.Message, StringComparison.InvariantCultureIgnoreCase);
         await VerifyDependencyNotCalledAsync(sutProvider);
     }
@@ -492,7 +492,7 @@ public class UpdateSecretsManagerSubscriptionCommandTests
         var update = new SecretsManagerSubscriptionUpdate(organization, true).AdjustServiceAccounts(2);
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.UpdateSubscriptionAsync(update));
-        Assert.Contains("Secrets Manager service account limit has been reached.", exception.Message);
+        Assert.Contains("Secrets Manager machine account limit has been reached.", exception.Message);
         await VerifyDependencyNotCalledAsync(sutProvider);
     }
 
@@ -516,7 +516,7 @@ public class UpdateSecretsManagerSubscriptionCommandTests
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.UpdateSubscriptionAsync(update));
-        Assert.Contains("Cannot set max service accounts autoscaling below service account amount", exception.Message);
+        Assert.Contains("Cannot set max machine accounts autoscaling below machine account amount", exception.Message);
         await VerifyDependencyNotCalledAsync(sutProvider);
     }
 
@@ -537,7 +537,7 @@ public class UpdateSecretsManagerSubscriptionCommandTests
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.UpdateSubscriptionAsync(update));
-        Assert.Contains("Plan has a minimum of 200 service accounts", exception.Message);
+        Assert.Contains("Plan has a minimum of 200 machine accounts", exception.Message);
         await VerifyDependencyNotCalledAsync(sutProvider);
     }
 
@@ -570,7 +570,7 @@ public class UpdateSecretsManagerSubscriptionCommandTests
             .Returns(currentServiceAccounts);
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.UpdateSubscriptionAsync(update));
-        Assert.Contains("Your organization currently has 301 service accounts. You cannot decrease your subscription below your current service account usage", exception.Message);
+        Assert.Contains("Your organization currently has 301 machine accounts. You cannot decrease your subscription below your current machine account usage", exception.Message);
         await VerifyDependencyNotCalledAsync(sutProvider);
     }
 
@@ -648,7 +648,7 @@ public class UpdateSecretsManagerSubscriptionCommandTests
         var update = new SecretsManagerSubscriptionUpdate(organization, false) { MaxAutoscaleSmServiceAccounts = 3 };
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.UpdateSubscriptionAsync(update));
-        Assert.Contains("Your plan does not allow service accounts autoscaling.", exception.Message);
+        Assert.Contains("Your plan does not allow machine accounts autoscaling.", exception.Message);
         await VerifyDependencyNotCalledAsync(sutProvider);
     }
 

--- a/test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/UpgradeOrganizationPlanCommandTests.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/UpgradeOrganizationPlanCommandTests.cs
@@ -192,7 +192,7 @@ public class UpgradeOrganizationPlanCommandTests
             .GetServiceAccountCountByOrganizationIdAsync(organization.Id).Returns(currentServiceAccounts);
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.UpgradePlanAsync(organization.Id, upgrade));
-        Assert.Contains($"Your organization currently has {currentServiceAccounts} service accounts. Your new plan only allows", exception.Message);
+        Assert.Contains($"Your organization currently has {currentServiceAccounts} machine accounts. Your new plan only allows", exception.Message);
 
         sutProvider.GetDependency<IOrganizationService>().DidNotReceiveWithAnyArgs().ReplaceAndUpdateCacheAsync(default);
     }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Renaming service accounts to machine accounts.

Web PR: https://github.com/bitwarden/clients/pull/8444

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
