### PR TITLE
[AC-2330] Adding Response to PutCollections for Client Side Use

### DIFF
--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -560,7 +560,7 @@ public class CiphersController : Controller
 
     [HttpPut("{id}/collections")]
     [HttpPost("{id}/collections")]
-    public async Task PutCollections(Guid id, [FromBody] CipherCollectionsRequestModel model)
+    public async Task<CipherResponseModel> PutCollections(Guid id, [FromBody] CipherCollectionsRequestModel model)
     {
         var userId = _userService.GetProperUserId(User).Value;
         var cipher = await GetByIdAsync(id, userId);
@@ -572,6 +572,10 @@ public class CiphersController : Controller
 
         await _cipherService.SaveCollectionsAsync(cipher,
             model.CollectionIds.Select(c => new Guid(c)), userId, false);
+
+        var updatedCipherCollections = await GetByIdAsync(id, userId);
+        var response = new CipherResponseModel(updatedCipherCollections, _globalSettings);
+        return response;
     }
 
     [HttpPut("{id}/collections-admin")]


### PR DESCRIPTION
```
- [ X ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

* When an items collections list is updated the client requires an updated `edit` value for their ciphers to properly show if that item should be readOnly or editable by the user. 
* Client side logic is here: https://github.com/bitwarden/clients/pull/8549

## Code changes

* Passing the updated cipher as a response back to the client in `PutCollections` of `CiphersController`
