### PR TITLE
[AC-2436] Show unassigned items banner

### DIFF
--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -1118,8 +1118,11 @@ public class CiphersController : Controller
     [HttpGet("has-unassigned-ciphers")]
     public async Task<bool> HasUnassignedCiphers()
     {
+        var orgAbilities = await _applicationCacheService.GetOrganizationAbilitiesAsync();
+
         var adminOrganizations = _currentContext.Organizations
-            .Where(o => o.Type is OrganizationUserType.Admin or OrganizationUserType.Owner);
+            .Where(o => o.Type is OrganizationUserType.Admin or OrganizationUserType.Owner &&
+                        orgAbilities.ContainsKey(o.Id) && orgAbilities[o.Id].FlexibleCollections);
 
         foreach (var org in adminOrganizations)
         {

--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -1110,6 +1110,30 @@ public class CiphersController : Controller
         });
     }
 
+    /// <summary>
+    /// Returns true if the user is an admin or owner of an organization with unassigned ciphers (i.e. ciphers that
+    /// are not assigned to a collection).
+    /// </summary>
+    /// <returns></returns>
+    [HttpGet("has-unassigned-ciphers")]
+    public async Task<bool> HasUnassignedCiphers()
+    {
+        var adminOrganizations = _currentContext.Organizations
+            .Where(o => o.Type is OrganizationUserType.Admin or OrganizationUserType.Owner);
+
+        foreach (var org in adminOrganizations)
+        {
+            var unassignedCiphers = await _cipherRepository.GetManyUnassignedOrganizationDetailsByOrganizationIdAsync(org.Id);
+            // We only care about non-deleted ciphers
+            if (unassignedCiphers.Any(c => c.DeletedDate == null))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private void ValidateAttachment()
     {
         if (!Request?.ContentType.Contains("multipart/") ?? true)

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -132,6 +132,7 @@ public static class FeatureFlagKeys
     public const string ShowPaymentMethodWarningBanners = "show-payment-method-warning-banners";
     public const string EnableConsolidatedBilling = "enable-consolidated-billing";
     public const string AC1795_UpdatedSubscriptionStatusSection = "AC-1795_updated-subscription-status-section";
+    public const string UnassignedItemsBanner = "unassigned-items-banner";
 
     public static List<string> GetAllKeys()
     {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Add a server endpoint that returns `true` if the current user is an owner or admin of any organization that has unassigned ciphers. Otherwise return `false`.

The clients will use this to show a banner: client PR is https://github.com/bitwarden/clients/pull/8655

This is limited to orgs using flexible collections because self-host has not yet been migrated and it would be premature to show them the banner.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Add endpoint in CiphersController. Notes:
* this uses `_cipherRepository.GetManyUnassignedOrganizationDetailsByOrganizationIdAsync` to determine whether an org has any unassigned ciphers. This is behind a feature flag elsewhere, can @shane-melton please confirm this is OK to use here? I see nothing that strictly ties it to flexible collections v1.
* looped database calls are obviously not great but (a) this is going out as a hotfix, (b) the response will be cached client-side and (c) most people have 0-1 organizations. I opted to use what we already have rather than adding database changes to the hotfix lift.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
