### PR TITLE
Remove ComposeVersion from template

### DIFF
--- a/util/Setup/Configuration.cs
+++ b/util/Setup/Configuration.cs
@@ -31,10 +31,6 @@ public class Configuration
         "Learn more: https://docs.docker.com/compose/compose-file/#ports")]
     public string HttpsPort { get; set; } = "443";
 
-    [Description("Docker compose file version. Leave empty for default.\n" +
-        "Learn more: https://docs.docker.com/compose/compose-file/compose-versioning/")]
-    public string ComposeVersion { get; set; }
-
     [Description("Configure Nginx for Captcha.")]
     public bool Captcha { get; set; } = false;
 

--- a/util/Setup/DockerComposeBuilder.cs
+++ b/util/Setup/DockerComposeBuilder.cs
@@ -42,10 +42,6 @@ public class DockerComposeBuilder
     {
         public TemplateModel(Context context)
         {
-            if (!string.IsNullOrWhiteSpace(context.Config.ComposeVersion))
-            {
-                ComposeVersion = context.Config.ComposeVersion;
-            }
             MssqlDataDockerVolume = context.Config.DatabaseDockerVolume;
             EnableKeyConnector = context.Config.EnableKeyConnector;
             EnableScim = context.Config.EnableScim;
@@ -65,7 +61,6 @@ public class DockerComposeBuilder
             }
         }
 
-        public string ComposeVersion { get; set; } = "3";
         public bool MssqlDataDockerVolume { get; set; }
         public bool EnableKeyConnector { get; set; }
         public bool EnableScim { get; set; }

--- a/util/Setup/Templates/DockerCompose.hbs
+++ b/util/Setup/Templates/DockerCompose.hbs
@@ -13,8 +13,6 @@
 # ./bwdata/config.yml file for your installation.                       #
 #########################################################################
 
-version: '{{{ComposeVersion}}}'
-
 services:
   mssql:
     image: bitwarden/mssql:{{{CoreVersion}}}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fixes https://github.com/bitwarden/self-host/issues/232
Version is completely optional for docker compose and in the newest version is being labeled as obsolete. 

[04-version-and-name.md](https://github.com/compose-spec/compose-spec/blob/master/04-version-and-name.md)

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Simply removes the `ComposeVersion` string and the templating for it that creates the Docker Compose file.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
