### PR TITLE
[AC-2443] Enable unassigned items banner for self-host

### DIFF
--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -1118,11 +1118,10 @@ public class CiphersController : Controller
     [HttpGet("has-unassigned-ciphers")]
     public async Task<bool> HasUnassignedCiphers()
     {
-        var orgAbilities = await _applicationCacheService.GetOrganizationAbilitiesAsync();
-
+        // We don't filter for organization.FlexibleCollections here, it's shown for all orgs, and the client determines
+        // whether the message is shown in future tense (not yet migrated) or present tense (already migrated)
         var adminOrganizations = _currentContext.Organizations
-            .Where(o => o.Type is OrganizationUserType.Admin or OrganizationUserType.Owner &&
-                        orgAbilities.ContainsKey(o.Id) && orgAbilities[o.Id].FlexibleCollections);
+            .Where(o => o.Type is OrganizationUserType.Admin or OrganizationUserType.Owner);
 
         foreach (var org in adminOrganizations)
         {

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -149,7 +149,8 @@ public static class FeatureFlagKeys
         {
             { TrustedDeviceEncryption, "true" },
             { Fido2VaultCredentials, "true" },
-            { DuoRedirect, "true" }
+            { DuoRedirect, "true" },
+            { UnassignedItemsBanner, "true"}
         };
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Pairs with https://github.com/bitwarden/clients/pull/8719 to enable the unassigned items banner for self-host.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* turn on the unassigned items feature flag for self-hosted
* do not filter by flexible collections organizations. In cloud, everyone is on flexible collections, so it adds nothing. On self-host, orgs haven't been migrated yet, and we want to show the banner before they do. The client PR ensures that the correct text is shown depending on that situation.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
