### PR TITLE
[AC-2447] Owner/Admin Can Remove Last Accessible Collection From Item

### DIFF
--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -574,6 +574,10 @@ public class CiphersController : Controller
             model.CollectionIds.Select(c => new Guid(c)), userId, false);
 
         var updatedCipherCollections = await GetByIdAsync(id, userId);
+        // If user cannot access cipher after update return an error to client
+        if (updatedCipherCollections == null){
+            throw new NotFoundException();
+        }
         var response = new CipherResponseModel(updatedCipherCollections, _globalSettings);
         return response;
     }

--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -575,7 +575,8 @@ public class CiphersController : Controller
 
         var updatedCipherCollections = await GetByIdAsync(id, userId);
         // If user cannot access cipher after update return an error to client
-        if (updatedCipherCollections == null){
+        if (updatedCipherCollections == null)
+        {
             throw new NotFoundException();
         }
         var response = new CipherResponseModel(updatedCipherCollections, _globalSettings);


### PR DESCRIPTION
```
- [ X ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

When an owner/admin removes the last collections they have any access to from an item they were receiving an error. Updated the `putCollections` call to address this

## Code changes

* `CiphersController` - add throw error to putCollections call before return response

## Screen Recording

https://github.com/bitwarden/server/assets/8302660/138a242a-f717-48ad-bc1e-3e7a6dbecc84

