### PR TITLE
[AC-2461] Scale provider seats on client organization deletion

### DIFF
--- a/src/Admin/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Admin/AdminConsole/Controllers/OrganizationsController.cs
@@ -3,10 +3,12 @@ using Bit.Admin.AdminConsole.Models;
 using Bit.Admin.Enums;
 using Bit.Admin.Services;
 using Bit.Admin.Utilities;
+using Bit.Core;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Providers.Interfaces;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Billing.Commands;
+using Bit.Core.Billing.Extensions;
 using Bit.Core.Context;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
@@ -53,6 +55,8 @@ public class OrganizationsController : Controller
     private readonly IProviderOrganizationRepository _providerOrganizationRepository;
     private readonly IRemoveOrganizationFromProviderCommand _removeOrganizationFromProviderCommand;
     private readonly IRemovePaymentMethodCommand _removePaymentMethodCommand;
+    private readonly IFeatureService _featureService;
+    private readonly IScaleSeatsCommand _scaleSeatsCommand;
 
     public OrganizationsController(
         IOrganizationService organizationService,
@@ -78,7 +82,9 @@ public class OrganizationsController : Controller
         IServiceAccountRepository serviceAccountRepository,
         IProviderOrganizationRepository providerOrganizationRepository,
         IRemoveOrganizationFromProviderCommand removeOrganizationFromProviderCommand,
-        IRemovePaymentMethodCommand removePaymentMethodCommand)
+        IRemovePaymentMethodCommand removePaymentMethodCommand,
+        IFeatureService featureService,
+        IScaleSeatsCommand scaleSeatsCommand)
     {
         _organizationService = organizationService;
         _organizationRepository = organizationRepository;
@@ -104,6 +110,8 @@ public class OrganizationsController : Controller
         _providerOrganizationRepository = providerOrganizationRepository;
         _removeOrganizationFromProviderCommand = removeOrganizationFromProviderCommand;
         _removePaymentMethodCommand = removePaymentMethodCommand;
+        _featureService = featureService;
+        _scaleSeatsCommand = scaleSeatsCommand;
     }
 
     [RequirePermission(Permission.Org_List_View)]
@@ -234,8 +242,24 @@ public class OrganizationsController : Controller
     public async Task<IActionResult> Delete(Guid id)
     {
         var organization = await _organizationRepository.GetByIdAsync(id);
+
         if (organization != null)
         {
+            var consolidatedBillingEnabled = _featureService.IsEnabled(FeatureFlagKeys.EnableConsolidatedBilling);
+
+            if (consolidatedBillingEnabled && organization.IsValidClient())
+            {
+                var provider = await _providerRepository.GetByOrganizationIdAsync(organization.Id);
+
+                if (provider.IsBillable())
+                {
+                    await _scaleSeatsCommand.ScalePasswordManagerSeats(
+                        provider,
+                        organization.PlanType,
+                        -organization.Seats ?? 0);
+                }
+            }
+
             await _organizationRepository.DeleteAsync(organization);
             await _applicationCacheService.DeleteOrganizationAbilityAsync(organization.Id);
         }

--- a/src/Core/Billing/Extensions/BillingExtensions.cs
+++ b/src/Core/Billing/Extensions/BillingExtensions.cs
@@ -1,9 +1,27 @@
-﻿using Bit.Core.Enums;
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Entities.Provider;
+using Bit.Core.AdminConsole.Enums.Provider;
+using Bit.Core.Enums;
 
 namespace Bit.Core.Billing.Extensions;
 
 public static class BillingExtensions
 {
+    public static bool IsBillable(this Provider provider) =>
+        provider is
+        {
+            Type: ProviderType.Msp,
+            Status: ProviderStatusType.Billable
+        };
+
+    public static bool IsValidClient(this Organization organization)
+        => organization is
+        {
+            Seats: not null,
+            Status: OrganizationStatusType.Managed,
+            PlanType: PlanType.TeamsMonthly or PlanType.EnterpriseMonthly
+        };
+
     public static bool SupportsConsolidatedBilling(this PlanType planType)
         => planType is PlanType.TeamsMonthly or PlanType.EnterpriseMonthly;
 }

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationsControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationsControllerTests.cs
@@ -2,8 +2,11 @@
 using AutoFixture.Xunit2;
 using Bit.Api.AdminConsole.Controllers;
 using Bit.Api.AdminConsole.Models.Request.Organizations;
+using Bit.Api.Auth.Models.Request.Accounts;
 using Bit.Api.Models.Request.Organizations;
+using Bit.Core;
 using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationApiKeys.Interfaces;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationCollectionEnhancements.Interfaces;
 using Bit.Core.AdminConsole.Repositories;
@@ -25,6 +28,7 @@ using Bit.Core.OrganizationFeatures.OrganizationSubscriptions.Interface;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Tools.Services;
+using Bit.Infrastructure.EntityFramework.AdminConsole.Models.Provider;
 using NSubstitute;
 using NSubstitute.ReturnsExtensions;
 using Xunit;
@@ -59,6 +63,8 @@ public class OrganizationsControllerTests : IDisposable
     private readonly ISubscriberQueries _subscriberQueries;
     private readonly IReferenceEventService _referenceEventService;
     private readonly IOrganizationEnableCollectionEnhancementsCommand _organizationEnableCollectionEnhancementsCommand;
+    private readonly IProviderRepository _providerRepository;
+    private readonly IScaleSeatsCommand _scaleSeatsCommand;
 
     private readonly OrganizationsController _sut;
 
@@ -89,6 +95,8 @@ public class OrganizationsControllerTests : IDisposable
         _subscriberQueries = Substitute.For<ISubscriberQueries>();
         _referenceEventService = Substitute.For<IReferenceEventService>();
         _organizationEnableCollectionEnhancementsCommand = Substitute.For<IOrganizationEnableCollectionEnhancementsCommand>();
+        _providerRepository = Substitute.For<IProviderRepository>();
+        _scaleSeatsCommand = Substitute.For<IScaleSeatsCommand>();
 
         _sut = new OrganizationsController(
             _organizationRepository,
@@ -115,7 +123,9 @@ public class OrganizationsControllerTests : IDisposable
             _cancelSubscriptionCommand,
             _subscriberQueries,
             _referenceEventService,
-            _organizationEnableCollectionEnhancementsCommand);
+            _organizationEnableCollectionEnhancementsCommand,
+            _providerRepository,
+            _scaleSeatsCommand);
     }
 
     public void Dispose()
@@ -413,5 +423,40 @@ public class OrganizationsControllerTests : IDisposable
 
         await _organizationEnableCollectionEnhancementsCommand.DidNotReceiveWithAnyArgs().EnableCollectionEnhancements(Arg.Any<Organization>());
         await _pushNotificationService.DidNotReceiveWithAnyArgs().PushSyncOrganizationsAsync(Arg.Any<Guid>());
+    }
+
+    [Theory, AutoData]
+    public async Task Delete_OrganizationIsConsolidatedBillingClient_ScalesProvidersSeats(
+        Provider provider,
+        Organization organization,
+        User user,
+        Guid organizationId,
+        SecretVerificationRequestModel requestModel)
+    {
+        organization.Status = OrganizationStatusType.Managed;
+        organization.PlanType = PlanType.TeamsMonthly;
+        organization.Seats = 10;
+
+        provider.Type = ProviderType.Msp;
+        provider.Status = ProviderStatusType.Billable;
+
+        _currentContext.OrganizationOwner(organizationId).Returns(true);
+
+        _organizationRepository.GetByIdAsync(organizationId).Returns(organization);
+
+        _userService.GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
+
+        _userService.VerifySecretAsync(user, requestModel.Secret).Returns(true);
+
+        _featureService.IsEnabled(FeatureFlagKeys.EnableConsolidatedBilling).Returns(true);
+
+        _providerRepository.GetByOrganizationIdAsync(organization.Id).Returns(provider);
+
+        await _sut.Delete(organizationId.ToString(), requestModel);
+
+        await _scaleSeatsCommand.Received(1)
+            .ScalePasswordManagerSeats(provider, organization.PlanType, -organization.Seats.Value);
+
+        await _organizationService.Received(1).DeleteAsync(organization);
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This PR invokes the `ScaleSeatsCommand` for a `Provider` anytime an `Organization` that belongs to that `Provider` is deleted. This includes from the Bitwarden Admin Portal as well as from the Organization settings page of the Web Vault.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
