### PR TITLE
Properly handle new policy enrollments in the public API

### DIFF
--- a/src/Api/AdminConsole/Public/Controllers/PoliciesController.cs
+++ b/src/Api/AdminConsole/Public/Controllers/PoliciesController.cs
@@ -93,7 +93,7 @@ public class PoliciesController : Controller
             _currentContext.OrganizationId.Value, type);
         if (policy == null)
         {
-            policy = model.ToPolicy(_currentContext.OrganizationId.Value);
+            policy = model.ToPolicy(_currentContext.OrganizationId.Value, type);
         }
         else
         {

--- a/src/Api/AdminConsole/Public/Controllers/PoliciesController.cs
+++ b/src/Api/AdminConsole/Public/Controllers/PoliciesController.cs
@@ -83,7 +83,7 @@ public class PoliciesController : Controller
     /// </remarks>
     /// <param name="type">The type of policy to be updated.</param>
     /// <param name="model">The request model.</param>
-    [HttpPut("{id}")]
+    [HttpPut("{type}")]
     [ProducesResponseType(typeof(PolicyResponseModel), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
     [ProducesResponseType((int)HttpStatusCode.NotFound)]

--- a/src/Api/AdminConsole/Public/Models/Request/PolicyUpdateRequestModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Request/PolicyUpdateRequestModel.cs
@@ -1,15 +1,19 @@
 ﻿using System.Text.Json;
 using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Enums;
 
 namespace Bit.Api.AdminConsole.Public.Models.Request;
 
 public class PolicyUpdateRequestModel : PolicyBaseModel
 {
-    public Policy ToPolicy(Guid orgId)
+    public Policy ToPolicy(Guid orgId, PolicyType type)
     {
         return ToPolicy(new Policy
         {
-            OrganizationId = orgId
+            OrganizationId = orgId,
+            Enabled = Enabled.GetValueOrDefault(),
+            Data = Data != null ? JsonSerializer.Serialize(Data) : null,
+            Type = type
         });
     }
 

--- a/test/Api.Test/AdminConsole/Public/Controllers/PoliciesControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Public/Controllers/PoliciesControllerTests.cs
@@ -1,0 +1,33 @@
+﻿using Bit.Api.AdminConsole.Public.Controllers;
+using Bit.Api.AdminConsole.Public.Models.Request;
+using Bit.Api.AdminConsole.Public.Models.Response;
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Enums;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Context;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Api.Test.AdminConsole.Public.Controllers;
+
+[ControllerCustomize(typeof(PoliciesController))]
+[SutProviderCustomize]
+public class PoliciesControllerTests
+{
+    [Theory]
+    [BitAutoData]
+    [BitAutoData(PolicyType.SendOptions)]
+    public async Task Put_NewPolicy_AppliesCorrectType(PolicyType type, Organization organization, PolicyUpdateRequestModel model, SutProvider<PoliciesController> sutProvider)
+    {
+        sutProvider.GetDependency<ICurrentContext>().OrganizationId.Returns(organization.Id);
+        sutProvider.GetDependency<IPolicyRepository>().GetByOrganizationIdTypeAsync(organization.Id, type).Returns((Policy)null);
+
+        var response = await sutProvider.Sut.Put(type, model) as JsonResult;
+        var responseValue = response.Value as PolicyResponseModel;
+
+        Assert.Equal(type, responseValue.Type);
+    }
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

This commit patches a bug in the public API for policy management. Currently when applying a policy for the first time through the public API the desired configuration is ignored, and a default enablement of the `TwoFactorAuthentication` policy is performed instead. This usually results in no policy being applied and users being booted from the org. Check Jira for a recreation video from QA.

When applying a policy that does not exist some code gets called that looks like this:

```cs
if (existingPolicy == null)
{
    policyToApply = model.ToPolicy(_currentContext.OrganizationId.Value);
}
```

This model construction looks like this:

```cs
return ToPolicy(new Policy
{
    OrganizationId = orgId
});
```

This doesn't set any information other than the `OrganizationId`, so the default policy of `0` (or `TwoFactorAuthentication`) is what ends up being sent to the service to be applied. It needs to look more like this:

```cs
return ToPolicy(new Policy
{
    OrganizationId = orgId,
    Enabled = Enabled.GetValueOrDefault(),
    Data = Data != null ? JsonSerializer.Serialize(Data) : null,
    Type = type
});
```

Changing the model in this way resolved the issue for me during local testing.

## Code changes

- `PoliciesControllerTests`: This is a new file. I just wrote one test for the direct bug.
- `PoliciesController`: pass in the `type` input parameter to the policy constructor for new policies. I also changed the name of the query parameter from `id` to `type` to be more clear and aligned with other methods, but this change is unrelated and functionally doesn't do anything.
- `PolicyUpdateRequestModel`: Properly build out the new policy object being applied.

## Screenshots

Below is an example of me calling the policies endpoint with a `7` (`SendOptions`) policy type. The policy has not been applied to this organization before and applies successfully.

https://github.com/bitwarden/server/assets/15897251/d74c74f1-55f7-42e1-a843-091ba2409268

## References

- [Jira ticket for this work](https://bitwarden.atlassian.net/browse/AC-577)
- [A set of refactors to `PolicyService` developed while debugging this issues](https://github.com/bitwarden/server/pull/4001)