### PR TITLE
[AC-2488] Add billing endpoint to determine SM standalone for organization

### DIFF
--- a/src/Api/Billing/Controllers/OrganizationBillingController.cs
+++ b/src/Api/Billing/Controllers/OrganizationBillingController.cs
@@ -1,10 +1,12 @@
 ﻿using Bit.Api.Billing.Models.Responses;
 using Bit.Core.Billing.Queries;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Bit.Api.Billing.Controllers;
 
 [Route("organizations/{organizationId:guid}/billing")]
+[Authorize("Application")]
 public class OrganizationBillingController(
     IOrganizationBillingQueries organizationBillingQueries) : Controller
 {

--- a/src/Api/Billing/Controllers/OrganizationBillingController.cs
+++ b/src/Api/Billing/Controllers/OrganizationBillingController.cs
@@ -1,0 +1,25 @@
+﻿using Bit.Api.Billing.Models.Responses;
+using Bit.Core.Billing.Queries;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bit.Api.Billing.Controllers;
+
+[Route("organizations/{organizationId:guid}/billing")]
+public class OrganizationBillingController(
+    IOrganizationBillingQueries organizationBillingQueries) : Controller
+{
+    [HttpGet("metadata")]
+    public async Task<IResult> GetMetadataAsync([FromRoute] Guid organizationId)
+    {
+        var metadata = await organizationBillingQueries.GetMetadata(organizationId);
+
+        if (metadata == null)
+        {
+            return TypedResults.NotFound();
+        }
+
+        var response = OrganizationMetadataResponse.From(metadata);
+
+        return TypedResults.Ok(response);
+    }
+}

--- a/src/Api/Billing/Models/Responses/OrganizationMetadataResponse.cs
+++ b/src/Api/Billing/Models/Responses/OrganizationMetadataResponse.cs
@@ -1,0 +1,10 @@
+﻿using Bit.Core.Billing.Models;
+
+namespace Bit.Api.Billing.Models.Responses;
+
+public record OrganizationMetadataResponse(
+    bool IsOnSecretsManagerStandalone)
+{
+    public static OrganizationMetadataResponse From(OrganizationMetadataDTO metadataDTO)
+        => new(metadataDTO.IsOnSecretsManagerStandalone);
+}

--- a/src/Core/Billing/Constants/StripeConstants.cs
+++ b/src/Core/Billing/Constants/StripeConstants.cs
@@ -16,6 +16,11 @@ public static class StripeConstants
         public const string SendInvoice = "send_invoice";
     }
 
+    public static class CouponIDs
+    {
+        public const string SecretsManagerStandalone = "sm-standalone";
+    }
+
     public static class ProrationBehavior
     {
         public const string AlwaysInvoice = "always_invoice";

--- a/src/Core/Billing/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Core/Billing/Extensions/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ public static class ServiceCollectionExtensions
     public static void AddBillingOperations(this IServiceCollection services)
     {
         // Queries
+        services.AddTransient<IOrganizationBillingQueries, OrganizationBillingQueries>();
         services.AddTransient<IProviderBillingQueries, ProviderBillingQueries>();
         services.AddTransient<ISubscriberQueries, SubscriberQueries>();
 

--- a/src/Core/Billing/Models/OrganizationMetadataDTO.cs
+++ b/src/Core/Billing/Models/OrganizationMetadataDTO.cs
@@ -1,0 +1,4 @@
+﻿namespace Bit.Core.Billing.Models;
+
+public record OrganizationMetadataDTO(
+    bool IsOnSecretsManagerStandalone);

--- a/src/Core/Billing/Queries/IOrganizationBillingQueries.cs
+++ b/src/Core/Billing/Queries/IOrganizationBillingQueries.cs
@@ -1,0 +1,8 @@
+﻿using Bit.Core.Billing.Models;
+
+namespace Bit.Core.Billing.Queries;
+
+public interface IOrganizationBillingQueries
+{
+    Task<OrganizationMetadataDTO> GetMetadata(Guid organizationId);
+}

--- a/src/Core/Billing/Queries/Implementations/OrganizationBillingQueries.cs
+++ b/src/Core/Billing/Queries/Implementations/OrganizationBillingQueries.cs
@@ -1,0 +1,65 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.Billing.Constants;
+using Bit.Core.Billing.Models;
+using Bit.Core.Repositories;
+using Bit.Core.Utilities;
+using Stripe;
+
+namespace Bit.Core.Billing.Queries.Implementations;
+
+public class OrganizationBillingQueries(
+    IOrganizationRepository organizationRepository,
+    ISubscriberQueries subscriberQueries) : IOrganizationBillingQueries
+{
+    public async Task<OrganizationMetadataDTO> GetMetadata(Guid organizationId)
+    {
+        var organization = await organizationRepository.GetByIdAsync(organizationId);
+
+        if (organization == null)
+        {
+            return null;
+        }
+
+        var customer = await subscriberQueries.GetCustomer(organization, new CustomerGetOptions
+        {
+            Expand = ["discount.coupon.applies_to"]
+        });
+
+        var subscription = await subscriberQueries.GetSubscription(organization);
+
+        if (customer == null || subscription == null)
+        {
+            return null;
+        }
+
+        var isOnSecretsManagerStandalone = IsOnSecretsManagerStandalone(organization, customer, subscription);
+
+        return new OrganizationMetadataDTO(isOnSecretsManagerStandalone);
+    }
+
+    private static bool IsOnSecretsManagerStandalone(
+        Organization organization,
+        Customer customer,
+        Subscription subscription)
+    {
+        var plan = StaticStore.GetPlan(organization.PlanType);
+
+        if (!plan.SupportsSecretsManager)
+        {
+            return false;
+        }
+
+        var hasCoupon = customer.Discount?.Coupon?.Id == StripeConstants.CouponIDs.SecretsManagerStandalone;
+
+        if (!hasCoupon)
+        {
+            return false;
+        }
+
+        var subscriptionProductIds = subscription.Items.Data.Select(item => item.Plan.ProductId);
+
+        var couponAppliesTo = customer.Discount?.Coupon?.AppliesTo?.Products;
+
+        return subscriptionProductIds.Intersect(couponAppliesTo ?? []).Any();
+    }
+}

--- a/test/Api.Test/Billing/Controllers/OrganizationBillingControllerTests.cs
+++ b/test/Api.Test/Billing/Controllers/OrganizationBillingControllerTests.cs
@@ -1,0 +1,43 @@
+﻿using Bit.Api.Billing.Controllers;
+using Bit.Api.Billing.Models.Responses;
+using Bit.Core.Billing.Models;
+using Bit.Core.Billing.Queries;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Microsoft.AspNetCore.Http.HttpResults;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Api.Test.Billing.Controllers;
+
+[ControllerCustomize(typeof(OrganizationBillingController))]
+[SutProviderCustomize]
+public class OrganizationBillingControllerTests
+{
+    [Theory, BitAutoData]
+    public async Task GetMetadataAsync_MetadataNull_NotFound(
+        Guid organizationId,
+        SutProvider<OrganizationBillingController> sutProvider)
+    {
+        var result = await sutProvider.Sut.GetMetadataAsync(organizationId);
+
+        Assert.IsType<NotFound>(result);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMetadataAsync_OK(
+        Guid organizationId,
+        SutProvider<OrganizationBillingController> sutProvider)
+    {
+        sutProvider.GetDependency<IOrganizationBillingQueries>().GetMetadata(organizationId)
+            .Returns(new OrganizationMetadataDTO(true));
+
+        var result = await sutProvider.Sut.GetMetadataAsync(organizationId);
+
+        Assert.IsType<Ok<OrganizationMetadataResponse>>(result);
+
+        var organizationMetadataResponse = ((Ok<OrganizationMetadataResponse>)result).Value;
+
+        Assert.True(organizationMetadataResponse.IsOnSecretsManagerStandalone);
+    }
+}

--- a/test/Core.Test/Billing/Queries/OrganizationBillingQueriesTests.cs
+++ b/test/Core.Test/Billing/Queries/OrganizationBillingQueriesTests.cs
@@ -1,0 +1,105 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.Billing.Constants;
+using Bit.Core.Billing.Queries;
+using Bit.Core.Billing.Queries.Implementations;
+using Bit.Core.Repositories;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
+using Stripe;
+using Xunit;
+
+namespace Bit.Core.Test.Billing.Queries;
+
+[SutProviderCustomize]
+public class OrganizationBillingQueriesTests
+{
+    #region GetMetadata
+    [Theory, BitAutoData]
+    public async Task GetMetadata_OrganizationNull_ReturnsNull(
+        Guid organizationId,
+        SutProvider<OrganizationBillingQueries> sutProvider)
+    {
+        var metadata = await sutProvider.Sut.GetMetadata(organizationId);
+
+        Assert.Null(metadata);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMetadata_CustomerNull_ReturnsNull(
+        Guid organizationId,
+        Organization organization,
+        SutProvider<OrganizationBillingQueries> sutProvider)
+    {
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organizationId).Returns(organization);
+
+        var metadata = await sutProvider.Sut.GetMetadata(organizationId);
+
+        Assert.Null(metadata);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMetadata_SubscriptionNull_ReturnsNull(
+        Guid organizationId,
+        Organization organization,
+        SutProvider<OrganizationBillingQueries> sutProvider)
+    {
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organizationId).Returns(organization);
+
+        sutProvider.GetDependency<ISubscriberQueries>().GetCustomer(organization).Returns(new Customer());
+
+        var metadata = await sutProvider.Sut.GetMetadata(organizationId);
+
+        Assert.Null(metadata);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMetadata_Succeeds(
+        Guid organizationId,
+        Organization organization,
+        SutProvider<OrganizationBillingQueries> sutProvider)
+    {
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organizationId).Returns(organization);
+
+        var subscriberQueries = sutProvider.GetDependency<ISubscriberQueries>();
+
+        subscriberQueries
+            .GetCustomer(organization, Arg.Is<CustomerGetOptions>(options => options.Expand.FirstOrDefault() == "discount.coupon.applies_to"))
+            .Returns(new Customer
+            {
+                Discount = new Discount
+                {
+                    Coupon = new Coupon
+                    {
+                        Id = StripeConstants.CouponIDs.SecretsManagerStandalone,
+                        AppliesTo = new CouponAppliesTo
+                        {
+                            Products = ["product_id"]
+                        }
+                    }
+                }
+            });
+
+        subscriberQueries.GetSubscription(organization).Returns(new Subscription
+        {
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Plan = new Plan
+                        {
+                            ProductId = "product_id"
+                        }
+                    }
+                ]
+            }
+        });
+
+        var metadata = await sutProvider.Sut.GetMetadata(organizationId);
+
+        Assert.True(metadata.IsOnSecretsManagerStandalone);
+    }
+    #endregion
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

In one of my previous changes, I added an API invocation to the `people.component` on the Web Vault that gets the organization's subscription. However, this endpoint is permission protected, which broke the `people.component` for anyone that wasn't an owner. 

That invocation was just being used to determine whether the organization was using SM Standalone. Instead, I created a new endpoint that doesn't do any unnecessary permissions check and just returns the data required by the component.

`clients`: https://github.com/bitwarden/clients/pull/8904


https://github.com/bitwarden/server/assets/144709477/9dccf62f-f234-4f53-82c0-8a285f8649cf

