### PR TITLE
[AC-2488] Return default state for billing metadata when Organization has no Stripe entities

### DIFF
--- a/src/Core/Billing/Models/OrganizationMetadataDTO.cs
+++ b/src/Core/Billing/Models/OrganizationMetadataDTO.cs
@@ -1,4 +1,8 @@
 ﻿namespace Bit.Core.Billing.Models;
 
 public record OrganizationMetadataDTO(
-    bool IsOnSecretsManagerStandalone);
+    bool IsOnSecretsManagerStandalone)
+{
+    public static OrganizationMetadataDTO Default() => new(
+        IsOnSecretsManagerStandalone: default);
+}

--- a/src/Core/Billing/Queries/Implementations/OrganizationBillingQueries.cs
+++ b/src/Core/Billing/Queries/Implementations/OrganizationBillingQueries.cs
@@ -29,7 +29,7 @@ public class OrganizationBillingQueries(
 
         if (customer == null || subscription == null)
         {
-            return null;
+            return OrganizationMetadataDTO.Default();
         }
 
         var isOnSecretsManagerStandalone = IsOnSecretsManagerStandalone(organization, customer, subscription);

--- a/test/Core.Test/Billing/Queries/OrganizationBillingQueriesTests.cs
+++ b/test/Core.Test/Billing/Queries/OrganizationBillingQueriesTests.cs
@@ -35,7 +35,7 @@ public class OrganizationBillingQueriesTests
 
         var metadata = await sutProvider.Sut.GetMetadata(organizationId);
 
-        Assert.Null(metadata);
+        Assert.False(metadata.IsOnSecretsManagerStandalone);
     }
 
     [Theory, BitAutoData]
@@ -50,7 +50,7 @@ public class OrganizationBillingQueriesTests
 
         var metadata = await sutProvider.Sut.GetMetadata(organizationId);
 
-        Assert.Null(metadata);
+        Assert.False(metadata.IsOnSecretsManagerStandalone);
     }
 
     [Theory, BitAutoData]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The people page was still breaking when the organization had no Stripe IDs (CS-Enabled trial or Resellers). This one-liner resolves that.
