### PR TITLE
[AC-2538] Member modal - limit admin access - fix ManageUsers custom permission

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -199,7 +199,7 @@ public class OrganizationUsersController : Controller
         {
             var collections = await _collectionRepository.GetManyByManyIdsAsync(model.Collections.Select(a => a.Id));
             var authorized =
-                (await _authorizationService.AuthorizeAsync(User, collections, BulkCollectionOperations.ModifyAccess))
+                (await _authorizationService.AuthorizeAsync(User, collections, BulkCollectionOperations.ModifyUserAccess))
                 .Succeeded;
             if (!authorized)
             {
@@ -390,7 +390,7 @@ public class OrganizationUsersController : Controller
         var readonlyCollectionIds = new HashSet<Guid>();
         foreach (var collection in currentCollections)
         {
-            if (!(await _authorizationService.AuthorizeAsync(User, collection, BulkCollectionOperations.ModifyAccess))
+            if (!(await _authorizationService.AuthorizeAsync(User, collection, BulkCollectionOperations.ModifyUserAccess))
                 .Succeeded)
             {
                 readonlyCollectionIds.Add(collection.Id);

--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -335,7 +335,8 @@ public class CollectionsController : Controller
             throw new NotFoundException("One or more collections not found.");
         }
 
-        var result = await _authorizationService.AuthorizeAsync(User, collections, BulkCollectionOperations.ModifyAccess);
+        var result = await _authorizationService.AuthorizeAsync(User, collections,
+            new[] { BulkCollectionOperations.ModifyUserAccess, BulkCollectionOperations.ModifyGroupAccess });
 
         if (!result.Succeeded)
         {
@@ -686,7 +687,7 @@ public class CollectionsController : Controller
     private async Task PutUsers_vNext(Guid id, IEnumerable<SelectionReadOnlyRequestModel> model)
     {
         var collection = await _collectionRepository.GetByIdAsync(id);
-        var authorized = (await _authorizationService.AuthorizeAsync(User, collection, BulkCollectionOperations.ModifyAccess)).Succeeded;
+        var authorized = (await _authorizationService.AuthorizeAsync(User, collection, BulkCollectionOperations.ModifyUserAccess)).Succeeded;
         if (!authorized)
         {
             throw new NotFoundException();
@@ -710,7 +711,7 @@ public class CollectionsController : Controller
     private async Task DeleteUser_vNext(Guid id, Guid orgUserId)
     {
         var collection = await _collectionRepository.GetByIdAsync(id);
-        var authorized = (await _authorizationService.AuthorizeAsync(User, collection, BulkCollectionOperations.ModifyAccess)).Succeeded;
+        var authorized = (await _authorizationService.AuthorizeAsync(User, collection, BulkCollectionOperations.ModifyUserAccess)).Succeeded;
         if (!authorized)
         {
             throw new NotFoundException();

--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -661,11 +661,8 @@ public class CollectionsController : Controller
     private async Task<CollectionResponseModel> Put_vNext(Guid id, CollectionRequestModel model)
     {
         var collection = await _collectionRepository.GetByIdAsync(id);
-        var authorizationResult = await _authorizationService.AuthorizeAsync(User, collection,
-            new[]{ BulkCollectionOperations.Update,
-                BulkCollectionOperations.ModifyUserAccess,
-                BulkCollectionOperations.ModifyGroupAccess});
-        if (!authorizationResult.Succeeded)
+        var authorized = (await _authorizationService.AuthorizeAsync(User, collection, BulkCollectionOperations.Update)).Succeeded;
+        if (!authorized)
         {
             throw new NotFoundException();
         }

--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -661,8 +661,11 @@ public class CollectionsController : Controller
     private async Task<CollectionResponseModel> Put_vNext(Guid id, CollectionRequestModel model)
     {
         var collection = await _collectionRepository.GetByIdAsync(id);
-        var authorized = (await _authorizationService.AuthorizeAsync(User, collection, BulkCollectionOperations.Update)).Succeeded;
-        if (!authorized)
+        var authorizationResult = await _authorizationService.AuthorizeAsync(User, collection,
+            new[]{ BulkCollectionOperations.Update,
+                BulkCollectionOperations.ModifyUserAccess,
+                BulkCollectionOperations.ModifyGroupAccess});
+        if (!authorizationResult.Succeeded)
         {
             throw new NotFoundException();
         }

--- a/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionOperations.cs
+++ b/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionOperations.cs
@@ -14,7 +14,7 @@ public static class BulkCollectionOperations
     public static readonly BulkCollectionOperationRequirement ReadAccess = new() { Name = nameof(ReadAccess) };
     public static readonly BulkCollectionOperationRequirement ReadWithAccess = new() { Name = nameof(ReadWithAccess) };
     /// <summary>
-    /// Update a collection, including its user and group associations
+    /// Update a collection, including user and group access
     /// </summary>
     public static readonly BulkCollectionOperationRequirement Update = new() { Name = nameof(Update) };
     /// <summary>
@@ -26,11 +26,11 @@ public static class BulkCollectionOperations
     /// </summary>
     public static readonly BulkCollectionOperationRequirement ImportCiphers = new() { Name = nameof(ImportCiphers) };
     /// <summary>
-    /// Create, update or delete Collection-User associations
+    /// Create, update or delete user access (CollectionUser)
     /// </summary>
     public static readonly BulkCollectionOperationRequirement ModifyUserAccess = new() { Name = nameof(ModifyUserAccess) };
     /// <summary>
-    /// Create, update or delete Collection-Group associations
+    /// Create, update or delete group access (CollectionGroup)
     /// </summary>
     public static readonly BulkCollectionOperationRequirement ModifyGroupAccess = new() { Name = nameof(ModifyGroupAccess) };
 }

--- a/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionOperations.cs
+++ b/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionOperations.cs
@@ -14,7 +14,7 @@ public static class BulkCollectionOperations
     public static readonly BulkCollectionOperationRequirement ReadAccess = new() { Name = nameof(ReadAccess) };
     public static readonly BulkCollectionOperationRequirement ReadWithAccess = new() { Name = nameof(ReadWithAccess) };
     /// <summary>
-    /// Update a Collection. This does not include modifying user or group access - see ModifyUserAccess and ModifyGroupAccess
+    /// Update a collection, including its user and group associations
     /// </summary>
     public static readonly BulkCollectionOperationRequirement Update = new() { Name = nameof(Update) };
     /// <summary>
@@ -26,11 +26,11 @@ public static class BulkCollectionOperations
     /// </summary>
     public static readonly BulkCollectionOperationRequirement ImportCiphers = new() { Name = nameof(ImportCiphers) };
     /// <summary>
-    /// Create, update or delete a user's access to this collection
+    /// Create, update or delete Collection-User associations
     /// </summary>
     public static readonly BulkCollectionOperationRequirement ModifyUserAccess = new() { Name = nameof(ModifyUserAccess) };
     /// <summary>
-    /// Create, update or delete a group's access to this collection
+    /// Create, update or delete Collection-Group associations
     /// </summary>
     public static readonly BulkCollectionOperationRequirement ModifyGroupAccess = new() { Name = nameof(ModifyGroupAccess) };
 }

--- a/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionOperations.cs
+++ b/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionOperations.cs
@@ -14,7 +14,7 @@ public static class BulkCollectionOperations
     public static readonly BulkCollectionOperationRequirement ReadAccess = new() { Name = nameof(ReadAccess) };
     public static readonly BulkCollectionOperationRequirement ReadWithAccess = new() { Name = nameof(ReadWithAccess) };
     /// <summary>
-    /// Update a collection, including its user and group associations
+    /// Update a Collection. This does not include modifying user or group access - see ModifyUserAccess and ModifyGroupAccess
     /// </summary>
     public static readonly BulkCollectionOperationRequirement Update = new() { Name = nameof(Update) };
     /// <summary>
@@ -26,11 +26,11 @@ public static class BulkCollectionOperations
     /// </summary>
     public static readonly BulkCollectionOperationRequirement ImportCiphers = new() { Name = nameof(ImportCiphers) };
     /// <summary>
-    /// Create, update or delete Collection-User associations
+    /// Create, update or delete a user's access to this collection
     /// </summary>
     public static readonly BulkCollectionOperationRequirement ModifyUserAccess = new() { Name = nameof(ModifyUserAccess) };
     /// <summary>
-    /// Create, update or delete Collection-Group associations
+    /// Create, update or delete a group's access to this collection
     /// </summary>
     public static readonly BulkCollectionOperationRequirement ModifyGroupAccess = new() { Name = nameof(ModifyGroupAccess) };
 }

--- a/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionOperations.cs
+++ b/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionOperations.cs
@@ -6,17 +6,31 @@ public class BulkCollectionOperationRequirement : OperationAuthorizationRequirem
 
 public static class BulkCollectionOperations
 {
+    /// <summary>
+    /// Create a new collection
+    /// </summary>
     public static readonly BulkCollectionOperationRequirement Create = new() { Name = nameof(Create) };
     public static readonly BulkCollectionOperationRequirement Read = new() { Name = nameof(Read) };
     public static readonly BulkCollectionOperationRequirement ReadAccess = new() { Name = nameof(ReadAccess) };
     public static readonly BulkCollectionOperationRequirement ReadWithAccess = new() { Name = nameof(ReadWithAccess) };
+    /// <summary>
+    /// Update a collection, including its user and group associations
+    /// </summary>
     public static readonly BulkCollectionOperationRequirement Update = new() { Name = nameof(Update) };
     /// <summary>
-    /// The operation that represents creating, updating, or removing collection access.
-    /// Combined together to allow for a single requirement to be used for each operation
-    /// as they all currently share the same underlying authorization logic.
+    /// Delete a collection
     /// </summary>
-    public static readonly BulkCollectionOperationRequirement ModifyAccess = new() { Name = nameof(ModifyAccess) };
     public static readonly BulkCollectionOperationRequirement Delete = new() { Name = nameof(Delete) };
+    /// <summary>
+    /// Import ciphers into a collection
+    /// </summary>
     public static readonly BulkCollectionOperationRequirement ImportCiphers = new() { Name = nameof(ImportCiphers) };
+    /// <summary>
+    /// Create, update or delete Collection-User associations
+    /// </summary>
+    public static readonly BulkCollectionOperationRequirement ModifyUserAccess = new() { Name = nameof(ModifyUserAccess) };
+    /// <summary>
+    /// Create, update or delete Collection-Group associations
+    /// </summary>
+    public static readonly BulkCollectionOperationRequirement ModifyGroupAccess = new() { Name = nameof(ModifyGroupAccess) };
 }

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
@@ -120,7 +120,7 @@ public class OrganizationUsersControllerTests
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(),
                 Arg.Any<IEnumerable<Collection>>(),
-                Arg.Is<IEnumerable<IAuthorizationRequirement>>(reqs => reqs.Contains(BulkCollectionOperations.ModifyAccess)))
+                Arg.Is<IEnumerable<IAuthorizationRequirement>>(reqs => reqs.Contains(BulkCollectionOperations.ModifyUserAccess)))
             .Returns(AuthorizationResult.Success());
         sutProvider.GetDependency<IUserService>().GetProperUserId(Arg.Any<ClaimsPrincipal>()).Returns(userId);
 
@@ -147,7 +147,7 @@ public class OrganizationUsersControllerTests
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(),
                 Arg.Any<IEnumerable<Collection>>(),
-                Arg.Is<IEnumerable<IAuthorizationRequirement>>(reqs => reqs.Contains(BulkCollectionOperations.ModifyAccess)))
+                Arg.Is<IEnumerable<IAuthorizationRequirement>>(reqs => reqs.Contains(BulkCollectionOperations.ModifyUserAccess)))
             .Returns(AuthorizationResult.Failed());
         sutProvider.GetDependency<IUserService>().GetProperUserId(Arg.Any<ClaimsPrincipal>()).Returns(userId);
 
@@ -309,13 +309,13 @@ public class OrganizationUsersControllerTests
         // Authorize the editedCollection
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Is<Collection>(c => c.Id == editedCollectionId),
-                Arg.Is<IEnumerable<IAuthorizationRequirement>>(reqs => reqs.Contains(BulkCollectionOperations.ModifyAccess)))
+                Arg.Is<IEnumerable<IAuthorizationRequirement>>(reqs => reqs.Contains(BulkCollectionOperations.ModifyUserAccess)))
             .Returns(AuthorizationResult.Success());
 
         // Do not authorize the readonly collections
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Is<Collection>(c => c.Id == readonlyCollectionId1 || c.Id == readonlyCollectionId2),
-                Arg.Is<IEnumerable<IAuthorizationRequirement>>(reqs => reqs.Contains(BulkCollectionOperations.ModifyAccess)))
+                Arg.Is<IEnumerable<IAuthorizationRequirement>>(reqs => reqs.Contains(BulkCollectionOperations.ModifyUserAccess)))
             .Returns(AuthorizationResult.Failed());
 
         await sutProvider.Sut.Put(organizationAbility.Id, organizationUser.Id, model);
@@ -357,7 +357,7 @@ public class OrganizationUsersControllerTests
 
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Is<Collection>(c => collections.Contains(c)),
-                Arg.Is<IEnumerable<IAuthorizationRequirement>>(reqs => reqs.Contains(BulkCollectionOperations.ModifyAccess)))
+                Arg.Is<IEnumerable<IAuthorizationRequirement>>(reqs => reqs.Contains(BulkCollectionOperations.ModifyUserAccess)))
             .Returns(AuthorizationResult.Failed());
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.Put(organizationAbility.Id, organizationUser.Id, model));
@@ -466,7 +466,7 @@ public class OrganizationUsersControllerTests
 
             sutProvider.GetDependency<IAuthorizationService>()
                 .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Is<Collection>(c => collections.Contains(c)),
-                Arg.Is<IEnumerable<IAuthorizationRequirement>>(r => r.Contains(BulkCollectionOperations.ModifyAccess)))
+                Arg.Is<IEnumerable<IAuthorizationRequirement>>(r => r.Contains(BulkCollectionOperations.ModifyUserAccess)))
                 .Returns(AuthorizationResult.Success());
         }
     }

--- a/test/Api.Test/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.Test/Controllers/CollectionsControllerTests.cs
@@ -64,7 +64,11 @@ public class CollectionsControllerTests
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(),
                 collection,
-                Arg.Is<IEnumerable<IAuthorizationRequirement>>(r => r.Contains(BulkCollectionOperations.Update)))
+                Arg.Is<IEnumerable<IAuthorizationRequirement>>(
+                    reqs => reqs.All(r =>
+                        r == BulkCollectionOperations.Update ||
+                        r == BulkCollectionOperations.ModifyUserAccess ||
+                        r == BulkCollectionOperations.ModifyGroupAccess)))
             .Returns(AuthorizationResult.Success());
 
         _ = await sutProvider.Sut.Put(collection.OrganizationId, collection.Id, collectionRequest);
@@ -85,7 +89,10 @@ public class CollectionsControllerTests
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(),
                 collection,
-                Arg.Is<IEnumerable<IAuthorizationRequirement>>(r => r.Contains(BulkCollectionOperations.Update)))
+                Arg.Is<IEnumerable<IAuthorizationRequirement>>(
+                    reqs => reqs.All(r =>
+                        r == BulkCollectionOperations.ModifyUserAccess ||
+                        r == BulkCollectionOperations.ModifyGroupAccess)))
             .Returns(AuthorizationResult.Failed());
 
         sutProvider.GetDependency<ICollectionRepository>()

--- a/test/Api.Test/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.Test/Controllers/CollectionsControllerTests.cs
@@ -345,7 +345,9 @@ public class CollectionsControllerTests
         sutProvider.GetDependency<IAuthorizationService>().AuthorizeAsync(
                 Arg.Any<ClaimsPrincipal>(), ExpectedCollectionAccess(),
                 Arg.Is<IEnumerable<IAuthorizationRequirement>>(
-                    r => r.Contains(BulkCollectionOperations.ModifyAccess)
+                    reqs => reqs.All(r =>
+                        r == BulkCollectionOperations.ModifyUserAccess ||
+                        r == BulkCollectionOperations.ModifyGroupAccess)
                 ))
             .Returns(AuthorizationResult.Success());
 
@@ -359,8 +361,9 @@ public class CollectionsControllerTests
             Arg.Any<ClaimsPrincipal>(),
             ExpectedCollectionAccess(),
             Arg.Is<IEnumerable<IAuthorizationRequirement>>(
-                r => r.Contains(BulkCollectionOperations.ModifyAccess))
-            );
+                reqs => reqs.All(r =>
+                    r == BulkCollectionOperations.ModifyUserAccess ||
+                    r == BulkCollectionOperations.ModifyGroupAccess)));
         await sutProvider.GetDependency<IBulkAddCollectionAccessCommand>().Received()
             .AddAccessAsync(
                 Arg.Is<ICollection<Collection>>(g => g.SequenceEqual(collections)),
@@ -500,7 +503,9 @@ public class CollectionsControllerTests
         sutProvider.GetDependency<IAuthorizationService>().AuthorizeAsync(
                 Arg.Any<ClaimsPrincipal>(), ExpectedCollectionAccess(),
                 Arg.Is<IEnumerable<IAuthorizationRequirement>>(
-                    r => r.Contains(BulkCollectionOperations.ModifyAccess)
+                    reqs => reqs.All(r =>
+                        r == BulkCollectionOperations.ModifyUserAccess ||
+                        r == BulkCollectionOperations.ModifyGroupAccess)
                 ))
             .Returns(AuthorizationResult.Failed());
 
@@ -511,7 +516,9 @@ public class CollectionsControllerTests
             Arg.Any<ClaimsPrincipal>(),
             ExpectedCollectionAccess(),
             Arg.Is<IEnumerable<IAuthorizationRequirement>>(
-                r => r.Contains(BulkCollectionOperations.ModifyAccess))
+                    reqs => reqs.All(r =>
+                        r == BulkCollectionOperations.ModifyUserAccess ||
+                        r == BulkCollectionOperations.ModifyGroupAccess))
             );
         await sutProvider.GetDependency<IBulkAddCollectionAccessCommand>().DidNotReceiveWithAnyArgs()
             .AddAccessAsync(default, default, default);

--- a/test/Api.Test/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.Test/Controllers/CollectionsControllerTests.cs
@@ -64,11 +64,7 @@ public class CollectionsControllerTests
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(),
                 collection,
-                Arg.Is<IEnumerable<IAuthorizationRequirement>>(
-                    reqs => reqs.All(r =>
-                        r == BulkCollectionOperations.Update ||
-                        r == BulkCollectionOperations.ModifyUserAccess ||
-                        r == BulkCollectionOperations.ModifyGroupAccess)))
+                Arg.Is<IEnumerable<IAuthorizationRequirement>>(r => r.Contains(BulkCollectionOperations.Update)))
             .Returns(AuthorizationResult.Success());
 
         _ = await sutProvider.Sut.Put(collection.OrganizationId, collection.Id, collectionRequest);
@@ -89,10 +85,7 @@ public class CollectionsControllerTests
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(),
                 collection,
-                Arg.Is<IEnumerable<IAuthorizationRequirement>>(
-                    reqs => reqs.All(r =>
-                        r == BulkCollectionOperations.ModifyUserAccess ||
-                        r == BulkCollectionOperations.ModifyGroupAccess)))
+                Arg.Is<IEnumerable<IAuthorizationRequirement>>(r => r.Contains(BulkCollectionOperations.Update)))
             .Returns(AuthorizationResult.Failed());
 
         sutProvider.GetDependency<ICollectionRepository>()

--- a/test/Api.Test/Vault/AuthorizationHandlers/BulkCollectionAuthorizationHandlerTests.cs
+++ b/test/Api.Test/Vault/AuthorizationHandlers/BulkCollectionAuthorizationHandlerTests.cs
@@ -548,7 +548,9 @@ public class BulkCollectionAuthorizationHandlerTests
 
         var operationsToTest = new[]
         {
-            BulkCollectionOperations.Update, BulkCollectionOperations.ModifyAccess
+            BulkCollectionOperations.Update,
+            BulkCollectionOperations.ModifyUserAccess,
+            BulkCollectionOperations.ModifyGroupAccess,
         };
 
         foreach (var op in operationsToTest)
@@ -586,7 +588,9 @@ public class BulkCollectionAuthorizationHandlerTests
 
         var operationsToTest = new[]
         {
-            BulkCollectionOperations.Update, BulkCollectionOperations.ModifyAccess
+            BulkCollectionOperations.Update,
+            BulkCollectionOperations.ModifyUserAccess,
+            BulkCollectionOperations.ModifyGroupAccess,
         };
 
         foreach (var op in operationsToTest)
@@ -627,7 +631,9 @@ public class BulkCollectionAuthorizationHandlerTests
 
         var operationsToTest = new[]
         {
-            BulkCollectionOperations.Update, BulkCollectionOperations.ModifyAccess
+            BulkCollectionOperations.Update,
+            BulkCollectionOperations.ModifyUserAccess,
+            BulkCollectionOperations.ModifyGroupAccess,
         };
 
         foreach (var op in operationsToTest)
@@ -668,7 +674,9 @@ public class BulkCollectionAuthorizationHandlerTests
 
         var operationsToTest = new[]
         {
-            BulkCollectionOperations.Update, BulkCollectionOperations.ModifyAccess
+            BulkCollectionOperations.Update,
+            BulkCollectionOperations.ModifyUserAccess,
+            BulkCollectionOperations.ModifyGroupAccess,
         };
 
         foreach (var op in operationsToTest)
@@ -708,7 +716,9 @@ public class BulkCollectionAuthorizationHandlerTests
 
         var operationsToTest = new[]
         {
-            BulkCollectionOperations.Update, BulkCollectionOperations.ModifyAccess
+            BulkCollectionOperations.Update,
+            BulkCollectionOperations.ModifyUserAccess,
+            BulkCollectionOperations.ModifyGroupAccess,
         };
 
         foreach (var op in operationsToTest)
@@ -760,7 +770,9 @@ public class BulkCollectionAuthorizationHandlerTests
 
         var operationsToTest = new[]
         {
-            BulkCollectionOperations.Update, BulkCollectionOperations.ModifyAccess
+            BulkCollectionOperations.Update,
+            BulkCollectionOperations.ModifyUserAccess,
+            BulkCollectionOperations.ModifyGroupAccess,
         };
 
         foreach (var op in operationsToTest)
@@ -790,7 +802,9 @@ public class BulkCollectionAuthorizationHandlerTests
     {
         var operationsToTest = new[]
         {
-            BulkCollectionOperations.Update, BulkCollectionOperations.ModifyAccess
+            BulkCollectionOperations.Update,
+            BulkCollectionOperations.ModifyUserAccess,
+            BulkCollectionOperations.ModifyGroupAccess,
         };
 
         foreach (var op in operationsToTest)
@@ -1023,7 +1037,8 @@ public class BulkCollectionAuthorizationHandlerTests
             BulkCollectionOperations.Read,
             BulkCollectionOperations.ReadAccess,
             BulkCollectionOperations.Update,
-            BulkCollectionOperations.ModifyAccess,
+            BulkCollectionOperations.ModifyUserAccess,
+            BulkCollectionOperations.ModifyGroupAccess,
             BulkCollectionOperations.Delete,
         };
 

--- a/test/Api.Test/Vault/AuthorizationHandlers/BulkCollectionAuthorizationHandlerTests.cs
+++ b/test/Api.Test/Vault/AuthorizationHandlers/BulkCollectionAuthorizationHandlerTests.cs
@@ -827,6 +827,82 @@ public class BulkCollectionAuthorizationHandlerTests
         }
     }
 
+    [Theory, BitAutoData, CollectionCustomization]
+    public async Task CanUpdateUsers_WithManageUsersCustomPermission_Success(
+        SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
+        ICollection<Collection> collections,
+        CurrentContextOrganization organization)
+    {
+        var actingUserId = Guid.NewGuid();
+
+        organization.Type = OrganizationUserType.Custom;
+        organization.Permissions = new Permissions
+        {
+            ManageUsers = true
+        };
+
+        var operationsToTest = new[]
+        {
+            BulkCollectionOperations.ModifyUserAccess,
+        };
+
+        foreach (var op in operationsToTest)
+        {
+            sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
+            sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
+
+            var context = new AuthorizationHandlerContext(
+                new[] { op },
+                new ClaimsPrincipal(),
+                collections);
+
+            await sutProvider.Sut.HandleAsync(context);
+
+            Assert.True(context.HasSucceeded);
+
+            // Recreate the SUT to reset the mocks/dependencies between tests
+            sutProvider.Recreate();
+        }
+    }
+
+    [Theory, BitAutoData, CollectionCustomization]
+    public async Task CanUpdateGroups_WithManageGroupsCustomPermission_Success(
+        SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
+        ICollection<Collection> collections,
+        CurrentContextOrganization organization)
+    {
+        var actingUserId = Guid.NewGuid();
+
+        organization.Type = OrganizationUserType.Custom;
+        organization.Permissions = new Permissions
+        {
+            ManageGroups = true
+        };
+
+        var operationsToTest = new[]
+        {
+            BulkCollectionOperations.ModifyGroupAccess,
+        };
+
+        foreach (var op in operationsToTest)
+        {
+            sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
+            sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
+
+            var context = new AuthorizationHandlerContext(
+                new[] { op },
+                new ClaimsPrincipal(),
+                collections);
+
+            await sutProvider.Sut.HandleAsync(context);
+
+            Assert.True(context.HasSucceeded);
+
+            // Recreate the SUT to reset the mocks/dependencies between tests
+            sutProvider.Recreate();
+        }
+    }
+
     [Theory, CollectionCustomization]
     [BitAutoData(OrganizationUserType.Admin)]
     [BitAutoData(OrganizationUserType.Owner)]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix bug for Flexible Collections v1: the `BulkCollectionAuthorizationHandler` did not authorize the "Manage Users" or "Manage Groups" custom permissions, which broke the flow for #3934 (and would've for #3998).

This requires that we split the `ModifyAccess` operation into `ModifyUserAccess` and `ModifyGroupAccess`, to match the granularity of the custom permissions, and use these new operations where required.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionOperations.cs** - delete `ModifyAccess` and replace it with `ModifyUserAccess` and `ModifyGroupAccess`
- **src/Api/AdminConsole/Controllers/OrganizationUsersController.cs** - update to use `ModifyUserAccess`, which is always what you're doing via the `OrganizationUsersController`
- **src/Api/Controllers/CollectionsController.cs** - update to use the new operations as appropriate (depending on what the endpoint is updating)
- **src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionAuthorizationHandler.cs** - the biggest changes:
  - make all private methods return a bool and call `context.Succeed` from the top-level method only. I really like how this simplified the handler
  - add private methods for the 2x new operations/requirements. They are subsets of the more general `Update` operation, e.g. if you can `Update` then you can `ModifyUserAccess`. There's an argument for splitting these out completely (so that `Update` only refers to the collection and not its access) but I decided to pull up for now.
- update tests.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
