### PR TITLE
[AC-2506 Defect] : Provider admin can't update the enterprise minimum seats and Team minimum seats on the existing MSP's

### DIFF
--- a/src/Admin/AdminConsole/Controllers/ProvidersController.cs
+++ b/src/Admin/AdminConsole/Controllers/ProvidersController.cs
@@ -12,6 +12,7 @@ using Bit.Core.AdminConsole.Services;
 using Bit.Core.Billing.Entities;
 using Bit.Core.Billing.Extensions;
 using Bit.Core.Billing.Repositories;
+using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
@@ -195,9 +196,25 @@ public class ProvidersController : Controller
         }
 
         model.ToProviderPlan(providerPlans);
-        foreach (var providerPlan in providerPlans)
+        if (providerPlans.Count == 0)
         {
-            await _providerPlanRepository.ReplaceAsync(providerPlan);
+            var newProviderPlans = new List<ProviderPlan>
+            {
+                new() {ProviderId = provider.Id, PlanType = PlanType.TeamsMonthly, SeatMinimum= model.TeamsMinimumSeats, PurchasedSeats = 0, AllocatedSeats = 0},
+                new() {ProviderId = provider.Id, PlanType = PlanType.EnterpriseMonthly, SeatMinimum= model.EnterpriseMinimumSeats, PurchasedSeats = 0, AllocatedSeats = 0}
+            };
+
+            foreach (var newProviderPlan in newProviderPlans)
+            {
+                await _providerPlanRepository.CreateAsync(newProviderPlan);
+            }
+        }
+        else
+        {
+            foreach (var providerPlan in providerPlans)
+            {
+                await _providerPlanRepository.ReplaceAsync(providerPlan);
+            }
         }
 
         return RedirectToAction("Edit", new { id });


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
While testing AC-2262, noticed where if i update the existing the enterprise minimum seats and teams minimum seats it is not getting updated


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
