### PR TITLE
Fix validation of IDN emails

### DIFF
--- a/src/Core/Utilities/StrictEmailAddressAttribute.cs
+++ b/src/Core/Utilities/StrictEmailAddressAttribute.cs
@@ -21,7 +21,7 @@ public class StrictEmailAddressAttribute : ValidationAttribute
         try
         {
             var parsedEmailAddress = MailboxAddress.Parse(emailAddress).Address;
-            if (parsedEmailAddress != emailAddress)
+            if (string.IsNullOrEmpty(parsedEmailAddress))
             {
                 return false;
             }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

Tracking the flow of emails when signing up / changing emails (`[StrictEmailAddressAttribute]`):

1. (frontend) emails are checked using this regex: https://github.com/angular/angular/blob/17.3.6/packages/forms/src/validators.ts#L127
2. (backend) check for `ParseException` and `MimeKit.MailboxAddress.Parse(X).Address == X`
3. (backend) check "edge cases" regex
4. (backend) check `EmailAddressAttribute().IsValid` (https://github.com/Microsoft/referencesource/blob/master/System.ComponentModel.DataAnnotations/DataAnnotations/EmailAddressAttribute.cs#L54)

The problem:

1. doesn't allow IDN
2. requires IDN
3. allows IDN
4. allows IDN

This PR relaxes (2) to only check for ParseExceptions, allowing IDN to be specified in punycode form.

Would have been nice if MimeKit had a ParserOptions to not turn punycode into IDN-form, but that is not the case: https://github.com/jstedfast/MimeKit/blob/master/MimeKit/InternetAddress.cs#L418-L419

Bitwarden already have a ton of (unit-)test-cases for handling IDN, so that should already be covered.
