### PR TITLE
[AC-2545] Member modal - limit admin access - prevent user from adding themselves to collection

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -364,26 +364,35 @@ public class OrganizationUsersController : Controller
             throw new NotFoundException();
         }
 
-        var organizationUser = await _organizationUserRepository.GetByIdAsync(id);
+        var (organizationUser, currentAccess) = await _organizationUserRepository.GetByIdWithCollectionsAsync(id);
         if (organizationUser == null || organizationUser.OrganizationId != orgId)
         {
             throw new NotFoundException();
         }
 
-        // If admins are not allowed access to all collections, you cannot add yourself to a group
-        // In this case we just don't update groups
         var userId = _userService.GetProperUserId(User).Value;
-        var organizationAbility = await _applicationCacheService.GetOrganizationAbilityAsync(orgId);
         var editingSelf = userId == organizationUser.UserId;
 
-        var groups = editingSelf && !organizationAbility.AllowAdminAccessToAllCollectionItems
+        // If admins are not allowed access to all collections, you cannot add yourself to a group.
+        // In this case we just don't update groups.
+        var organizationAbility = await _applicationCacheService.GetOrganizationAbilityAsync(orgId);
+        var groupsToSave = editingSelf && !organizationAbility.AllowAdminAccessToAllCollectionItems
             ? null
             : model.Groups;
 
+        // If admins are not allowed access to all collections, you cannot add yourself to collections.
+        // This is not caught by the requirement below that you can ModifyUserAccess and must be checked separately
+        var currentAccessIds = currentAccess.Select(c => c.Id).ToHashSet();
+        if (editingSelf &&
+            !organizationAbility.AllowAdminAccessToAllCollectionItems &&
+            model.Collections.Any(c => !currentAccessIds.Contains(c.Id)))
+        {
+            throw new BadRequestException("You cannot add yourself to a collection.");
+        }
+
         // The client only sends collections that the saving user has permissions to edit.
-        // On the server side, we need to (1) confirm this and (2) concat these with the collections that the user
-        // can't edit before saving to the database.
-        var (_, currentAccess) = await _organizationUserRepository.GetByIdWithCollectionsAsync(id);
+        // On the server side, we need to (1) make sure the user has permissions for these collections, and
+        // (2) concat these with the collections that the user can't edit before saving to the database.
         var currentCollections = await _collectionRepository
             .GetManyByManyIdsAsync(currentAccess.Select(cas => cas.Id));
 
@@ -411,7 +420,7 @@ public class OrganizationUsersController : Controller
             .ToList();
 
         await _updateOrganizationUserCommand.UpdateUserAsync(model.ToOrganizationUser(organizationUser), userId,
-            collectionsToSave, groups);
+            collectionsToSave, groupsToSave);
     }
 
     [HttpPut("{userId}/reset-password-enrollment")]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Follow up from #4032.

We need to explicitly check that a user is not trying to add themselves to a collection, given that the Manage Users custom permission can add users to collections they don't manage.

While I was here I also did some slight rearrangement of code/comments to keep the endpoint method readable. This is exacerbating the amount of code in this endpoint, but I _think_ this should be the last tweak required here, and it doesn't fit the `AuthorizationService` interface (which can't compare old & new values). So I still think it lives here until we review authorization more generally.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
