### PR TITLE
[AC-2539] Defect - Request Delete/Delete modal does not match formatting

### DIFF
--- a/src/Admin/AdminConsole/Views/Providers/Edit.cshtml
+++ b/src/Admin/AdminConsole/Views/Providers/Edit.cshtml
@@ -69,7 +69,7 @@
          <div class="modal-dialog">
              <div class="modal-content rounded">
                  <div class="p-3">
-                     <h3 class="font-weight-bolder" id="exampleModalLabel">Request provider deletion</h3>
+                     <h4 class="font-weight-bolder" id="exampleModalLabel">Request provider deletion</h4>
                  </div>
                  <div class="modal-body">
                      <span class="font-weight-light">
@@ -93,7 +93,7 @@
          <div class="modal-dialog">
              <div class="modal-content rounded">
                  <div class="p-3">
-                     <h3 class="font-weight-bolder" id="exampleModalLabel">Delete provider</h3>
+                     <h4 class="font-weight-bolder" id="exampleModalLabel">Delete provider</h4>
                  </div>
                  <div class="modal-body">
                      <span class="font-weight-light">
@@ -118,7 +118,7 @@
              <div class="modal-content rounded">
                  <div class="modal-body">
                      <h4 class="font-weight-bolder">Cannot Delete @Model.Name</h4>
-                     <p class="font-weight-lighter">you must unlink all clients before deleting @Model.Name</p>
+                     <p class="font-weight-lighter">You must unlink all clients before you can delete @Model.Name.</p>
                  </div>
                  <div class="modal-footer">
                      <button type="button" class="btn btn-outline-primary btn-pill" data-dismiss="modal">Cancel</button>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The modal that is displayed in the Admin Portal for a provider with or without clients linked does not match the format in the Figma or for other modals used in the Admin Portal

per Figma, the text for a provider with clients linked should be adjusted from, “you must unlink all clients before deleting [provider name].” to, “You must unlink all clients before you can delete [provider name].” 

Per Figma, the header text for a provider without clients linked should not be in all capital letters

Currently “REQUEST PROVIDER DELETION”

Should read, “Request provider deletion”


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
[
<img width="1728" alt="Screenshot 2024-05-01 at 10 42 35" src="https://github.com/bitwarden/server/assets/108260115/282e8242-a2a0-4f13-a009-9ea6d007895b">
<img width="1728" alt="Screenshot 2024-05-01 at 10 42 50" src="https://github.com/bitwarden/server/assets/108260115/b4677b24-9491-4cc5-8d20-ed5fb7b79138">
](url)