### PR TITLE
Add events collection to full server launch configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,6 +38,7 @@
             "configurations": [
                 "run-Admin",
                 "run-API",
+                "run-Events",
                 "run-EventsProcessor",
                 "run-Identity",
                 "run-Sso",
@@ -58,6 +59,7 @@
             "configurations": [
                 "run-Admin-SelfHost",
                 "run-API-SelfHost",
+                "run-Events-SelfHost",
                 "run-EventsProcessor-SelfHost",
                 "run-Identity-SelfHost",
                 "run-Sso-SelfHost",
@@ -76,6 +78,7 @@
             "configurations": [
                 "run-Admin-SelfHost",
                 "run-API-SelfHost",
+                "run-Events-SelfHost",
                 "run-EventsProcessor-SelfHost",
                 "run-Identity-SelfHost",
             ],
@@ -119,6 +122,17 @@
                 "group": "cloud",
             },
             "preLaunchTask": "buildBilling",
+        },
+        {
+            "name": "Events",
+            "configurations": [
+                "run-Events"
+            ],
+            "presentation": {
+                "hidden": false,
+                "group": "cloud",
+            },
+            "preLaunchTask": "buildEvents",
         },
         {
             "name": "Events Processor",
@@ -342,6 +356,25 @@
             }
         },
         {
+            "name": "run-Events",
+            "presentation": {
+                "hidden": true,
+            },
+            "requireExactSource": true,
+            "type": "coreclr",
+            "request": "launch",
+            "program": "${workspaceFolder}/src/Events/bin/Debug/net8.0/Events.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/Events",
+            "stopAtEntry": false,
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development",
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
             "name": "run-EventsProcessor",
             "presentation": {
                 "hidden": true,
@@ -506,6 +539,27 @@
             }
         },
         {
+            "name": "run-Events-SelfHost",
+            "presentation": {
+                "hidden": true,
+            },
+            "requireExactSource": true,
+            "type": "coreclr",
+            "request": "launch",
+            "program": "${workspaceFolder}/src/Events/bin/Debug/net8.0/Events.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/Events",
+            "stopAtEntry": false,
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development",
+                "ASPNETCORE_URLS": "http://localhost:46274",
+                "developSelfHosted": "true",
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
             "name": "run-EventsProcessor-SelfHost",
             "presentation": {
                 "hidden": true,
@@ -519,7 +573,7 @@
             "stopAtEntry": false,
             "env": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
-                "ASPNETCORE_URLS": "http://localhost:46274",
+                "ASPNETCORE_URLS": "http://localhost:54103",
                 "developSelfHosted": "true",
             },
             "sourceFileMap": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -97,6 +97,18 @@
             "problemMatcher": "$msCompile"
         },
         {
+            "label": "buildEvents",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/Events/Events.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
             "label": "buildEventsProcessor",
             "command": "dotnet",
             "type": "process",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective

#3446 missed the Events collection project as part of a full server execution. It also mistakenly used the event project's port for self host events processor. This corrects both of those errors.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
