### PR TITLE
Set mysql version to 8.0 in docker compose, prevent upgrading to 8.4

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - postgres
 
   mysql:
-    image: mysql:8
+    image: mysql:8.0
     container_name: bw-mysql
     ports:
       - "3306:3306"

--- a/util/MySqlMigrations/MySqlDbMigrator.cs
+++ b/util/MySqlMigrations/MySqlDbMigrator.cs
@@ -35,7 +35,8 @@ public class MySqlDbMigrator : IDbMigrator
             _logger.LogInformation(Constants.BypassFiltersEventId, "Migration successful.");
         }
 
-        cancellationToken.ThrowIfCancellationRequested();
+        
+		cancellationToken.ThrowIfCancellationRequested();
         return true;
     }
 }

--- a/util/MySqlMigrations/MySqlDbMigrator.cs
+++ b/util/MySqlMigrations/MySqlDbMigrator.cs
@@ -35,8 +35,7 @@ public class MySqlDbMigrator : IDbMigrator
             _logger.LogInformation(Constants.BypassFiltersEventId, "Migration successful.");
         }
 
-        
-		cancellationToken.ThrowIfCancellationRequested();
+        cancellationToken.ThrowIfCancellationRequested();
         return true;
     }
 }


### PR DESCRIPTION
…4 for now

## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The Docker compose set Mysql version to 8 and next Major version of Mysql is 8.4 which breaks some things, setting version to be 8.0 last LTS version before 8.4


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **dev/docker-compose.yml:** 
The version is changed from 8 to 8.0 which will pick up 8.0.x instead of 8.4.*+
## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
