### PR TITLE
Disabled major updates for bootstrap, del, gulp

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,6 +41,12 @@
       "reviewers": ["team:team-auth-dev"]
     },
     {
+      "matchPackageNames": ["bootstrap", "del", "gulp"],
+      "matchUpdateTypes": ["major"],
+      "description": "Lock bootstrap, del, and gulp major versions due to ASP.NET conflicts",
+      "enabled": false
+    },
+    {
       "matchPackageNames": [
         "AspNetCoreRateLimit",
         "AspNetCoreRateLimit.Redis",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

We have agreed to lock `del`, `gulp`, and `bootstrap` at their current major versions due to issues we encountered when updating them, with the ASP.NET MVC site for the Bitwarden Portal.  These client dependencies are used for the MVC sites for SSO and Admin.

## Code changes
**renovate.json:** Added major version restriction on `del`, `gulp`, and `bootstrap`.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
