### PR TITLE
[PM-7919] return exception if trying to overwrite keypair

### DIFF
--- a/src/Api/Auth/Controllers/AccountsController.cs
+++ b/src/Api/Auth/Controllers/AccountsController.cs
@@ -618,9 +618,12 @@ public class AccountsController : Controller
             throw new UnauthorizedAccessException();
         }
 
-        if (!string.IsNullOrWhiteSpace(user.PrivateKey) || !string.IsNullOrWhiteSpace(user.PublicKey))
+        if (_featureService.IsEnabled(FeatureFlagKeys.ReturnErrorOnExistingKeypair))
         {
-            throw new BadRequestException("User has existing keypair");
+            if (!string.IsNullOrWhiteSpace(user.PrivateKey) || !string.IsNullOrWhiteSpace(user.PublicKey))
+            {
+                throw new BadRequestException("User has existing keypair");
+            }
         }
 
         await _userService.SaveUserAsync(model.ToUser(user));

--- a/src/Api/Auth/Controllers/AccountsController.cs
+++ b/src/Api/Auth/Controllers/AccountsController.cs
@@ -618,6 +618,11 @@ public class AccountsController : Controller
             throw new UnauthorizedAccessException();
         }
 
+        if (!string.IsNullOrWhiteSpace(user.PrivateKey) || !string.IsNullOrWhiteSpace(user.PublicKey))
+        {
+            throw new BadRequestException("User has existing keypair");
+        }
+
         await _userService.SaveUserAsync(model.ToUser(user));
         return new KeysResponseModel(user);
     }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -109,6 +109,8 @@ public static class FeatureFlagKeys
     public const string Fido2VaultCredentials = "fido2-vault-credentials";
     public const string VaultOnboarding = "vault-onboarding";
     public const string BrowserFilelessImport = "browser-fileless-import";
+    public const string ReturnErrorOnExistingKeypair = "return-error-on-existing-keypair";
+
     /// <summary>
     /// Deprecated - never used, do not use. Will always default to false. Will be deleted as part of Flexible Collections cleanup
     /// </summary>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This endpoint was already preventing overwriting a users keypair through the `model.toUser(user)` call, but that just silently returns a 200. This change will return a 400 so the client knows to stop the rest of the current process, which currently sets keys in memory.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
