### PR TITLE
[AC-2560] Defect - Unlink organization from provider throws error in Admin Portal

### DIFF
--- a/src/Api/AdminConsole/Models/Response/Providers/ProviderResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/Providers/ProviderResponseModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 using Bit.Core.AdminConsole.Entities.Provider;
+using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.Models.Api;
 using Bit.Core.Utilities;
 
@@ -24,6 +25,7 @@ public class ProviderResponseModel : ResponseModel
         BusinessTaxNumber = provider.BusinessTaxNumber;
         BillingEmail = provider.BillingEmail;
         CreationDate = provider.CreationDate;
+        Type = provider.Type;
     }
 
     public Guid Id { get; set; }
@@ -37,4 +39,5 @@ public class ProviderResponseModel : ResponseModel
     public string BusinessTaxNumber { get; set; }
     public string BillingEmail { get; set; }
     public DateTime CreationDate { get; set; }
+    public ProviderType Type { get; set; }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
When a provider admin accesses the Org Billing Subscription page through the Admin Console, rather than the Provider Portal, the user is still able to see Manage Billing Subscription 

They should instead see the [design outlined here](https://www.figma.com/proto/m8eMk6yeKfOq4AUuyp70ih/Consolidated-Billing?page-id=698%3A10060&type=design&node-id=873-6419&viewport=-339%2C-3810%2C0.71&t=yF61N9Za3qW0lHMW-1&scaling=min-zoom&starting-point-node-id=913%3A20780)


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
