### PR TITLE
DEVOPS-1965 - Add IgnoreUnmatchedProperties when deserializing YAML

### DIFF
--- a/util/Setup/Context.cs
+++ b/util/Setup/Context.cs
@@ -150,6 +150,7 @@ public class Context
         var configText = File.ReadAllText(ConfigPath);
         var deserializer = new DeserializerBuilder()
             .WithNamingConvention(UnderscoredNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
             .Build();
         Config = deserializer.Deserialize<Configuration>(configText);
 


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
- [Card](https://bitwarden.atlassian.net/browse/DEVOPS-1965?atlOrigin=eyJpIjoiMTVhYjc5YmI4MGExNDNiOGE5ZDc2NjhjNDMxOGViMDAiLCJwIjoiaiJ9)

This PR changes how we deserialize the `config.yml` file for self-hosted installations.  It now allows any extra properties to be defined in the file without causing an exception to be raised.  This will allow us to deprecate and remove options from the config file in the future.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **util/Setup/Context.cs:** Added `IgnoreUnmatchedProperties` in order to skip deprecated or incorrect keys in the `config.yml` file when parsing.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
