### PR TITLE
[AC-2384] Send reference event on successful payment by Provider

### DIFF
--- a/src/Core/Tools/Enums/ReferenceEventSource.cs
+++ b/src/Core/Tools/Enums/ReferenceEventSource.cs
@@ -8,4 +8,6 @@ public enum ReferenceEventSource
     Organization,
     [EnumMember(Value = "user")]
     User,
+    [EnumMember(Value = "provider")]
+    Provider,
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Since Providers are all enabled by default and use the `send_invoice` collection method by default, we don't actually to enable the Provider on a successful payment. We do, however, need to send the `Rebilled` reference event like we do with the other 2 billable entities.