### PR TITLE
[AC-2569] Fix 404 error when creating users/groups

### DIFF
--- a/src/Api/AdminConsole/Controllers/GroupsController.cs
+++ b/src/Api/AdminConsole/Controllers/GroupsController.cs
@@ -137,7 +137,9 @@ public class GroupsController : Controller
         }
 
         // Flexible Collections - check the user has permission to grant access to the collections for the new group
-        if (await FlexibleCollectionsIsEnabledAsync(orgId) && _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1))
+        if (await FlexibleCollectionsIsEnabledAsync(orgId) &&
+            _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1) &&
+            model.Collections?.Any() == true)
         {
             var collections = await _collectionRepository.GetManyByManyIdsAsync(model.Collections.Select(a => a.Id));
             var authorized =

--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -195,7 +195,9 @@ public class OrganizationUsersController : Controller
         }
 
         // Flexible Collections - check the user has permission to grant access to the collections for the new user
-        if (await FlexibleCollectionsIsEnabledAsync(orgId) && _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1))
+        if (await FlexibleCollectionsIsEnabledAsync(orgId) &&
+            _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1) &&
+            model.Collections?.Any() == true)
         {
             var collections = await _collectionRepository.GetManyByManyIdsAsync(model.Collections.Select(a => a.Id));
             var authorized =


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix a `Resource not found` error when creating users and groups with FCv1 flag on.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

The `BulkCollectionAuthorizationHandler` does not authorize an empty list, so it was failing to authorize when creating a user or group with no collections assigned. Skip this authorization call if there are no collections.

PUT operations are structured around foreach loops which naturally skip empty lists, so they do not have the same problem.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
