### PR TITLE
[AC-2570] Existing providers see new CB experience on Admin Console org Billing Subscription page

### DIFF
--- a/src/Api/AdminConsole/Models/Response/Providers/ProviderResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/Providers/ProviderResponseModel.cs
@@ -26,6 +26,7 @@ public class ProviderResponseModel : ResponseModel
         BillingEmail = provider.BillingEmail;
         CreationDate = provider.CreationDate;
         Type = provider.Type;
+        Status = provider.Status;
     }
 
     public Guid Id { get; set; }
@@ -40,4 +41,5 @@ public class ProviderResponseModel : ResponseModel
     public string BillingEmail { get; set; }
     public DateTime CreationDate { get; set; }
     public ProviderType Type { get; set; }
+    public ProviderStatusType Status { get; set; }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Existing (pre consolidated billing/created flag off) Provider admins and service users see the new CB page when navigating to the Admin Console client org billing page implemented in [AC-2265](https://bitwarden.atlassian.net/jira/software/c/projects/BW/boards/101?selectedIssue=AC-2265) 

Previously, provider admins and service users saw the Manage Billing Subscription page for client organizations. Now, they will be unable to manage the subscription.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
