### PR TITLE
[AC-2602] Fix error when provider edits existing group

### DIFF
--- a/src/Api/AdminConsole/Controllers/GroupsController.cs
+++ b/src/Api/AdminConsole/Controllers/GroupsController.cs
@@ -200,7 +200,8 @@ public class GroupsController : Controller
             var userId = _userService.GetProperUserId(User).Value;
             var organizationUser = await _organizationUserRepository.GetByOrganizationAsync(orgId, userId);
             var currentGroupUsers = await _groupRepository.GetManyUserIdsByIdAsync(id);
-            if (!currentGroupUsers.Contains(organizationUser.Id) && model.Users.Contains(organizationUser.Id))
+            // OrganizationUser may be null if the current user is a provider
+            if (organizationUser != null && !currentGroupUsers.Contains(organizationUser.Id) && model.Users.Contains(organizationUser.Id))
             {
                 throw new BadRequestException("You cannot add yourself to groups.");
             }

--- a/test/Api.Test/AdminConsole/Controllers/GroupsControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/GroupsControllerTests.cs
@@ -284,7 +284,7 @@ public class GroupsControllerTests
         sutProvider.GetDependency<ICurrentContext>().ManageGroups(organization.Id).Returns(true);
         sutProvider.GetDependency<IOrganizationUserRepository>()
             .GetByOrganizationAsync(organization.Id, Arg.Any<Guid>())
-                .Returns((OrganizationUser) null); // Provider is not an OrganizationUser, so it will always return null
+                .Returns((OrganizationUser)null); // Provider is not an OrganizationUser, so it will always return null
         sutProvider.GetDependency<IUserService>().GetProperUserId(Arg.Any<ClaimsPrincipal>())
             .Returns(savingUserId);
         sutProvider.GetDependency<IGroupRepository>().GetManyUserIdsByIdAsync(group.Id)


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Fix error when provider tries to edit an existing group and "admins can access all collections" is off.

Same fix as bitwarden/clients#9182 - we just need a null check on the OrganizationUser.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
