### PR TITLE
[AC-2619] Resolved razor syntax error fix

### DIFF
--- a/src/Admin/Views/Tools/StripeSubscriptions.cshtml
+++ b/src/Admin/Views/Tools/StripeSubscriptions.cshtml
@@ -109,7 +109,7 @@
             <option asp-selected="Model.Filter.Price == null" value="@null">All</option>
             @foreach (var price in Model.Prices)
             {
-                <option asp-selected='@Model.Filter.Price == @price.Id' value="@price.Id">@price.Id</option>
+                <option asp-selected='@(Model.Filter.Price == price.Id)' value="@price.Id">@price.Id</option>
             }
         </select>
     </div>
@@ -119,7 +119,7 @@
             <option asp-selected="Model.Filter.TestClock == null" value="@null">All</option>
             @foreach (var clock in Model.TestClocks)
             {
-                <option asp-selected='@Model.Filter.TestClock == @clock.Id' value="@clock.Id">@clock.Name</option>
+                <option asp-selected='@(Model.Filter.TestClock == clock.Id)' value="@clock.Id">@clock.Name</option>
             }
         </select>
     </div>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The latest dotnet 8 SDK version `8.0.300` introduced a Razor build error by forcing long expressions (expressions with spaces or an operator maybe?) to be [explicit expressions](https://learn.microsoft.com/en-us/aspnet/core/mvc/views/razor?view=aspnetcore-8.0#explicit-razor-expressions). This PR resolves this build error by updating the failing expressions to be explicit `@(...)` instead of implicit `@...`.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
