### PR TITLE
[AC-2605] Restrict collection access for some custom users

### DIFF
--- a/test/Api.Test/Vault/AuthorizationHandlers/BulkCollectionAuthorizationHandlerTests.cs
+++ b/test/Api.Test/Vault/AuthorizationHandlers/BulkCollectionAuthorizationHandlerTests.cs
@@ -829,250 +829,166 @@ public class BulkCollectionAuthorizationHandlerTests
 
     [Theory, BitAutoData, CollectionCustomization]
     public async Task CanUpdateUsers_WithManageUsersCustomPermission_V1Disabled_Success(
-        SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
-        ICollection<Collection> collections,
-        CurrentContextOrganization organization)
+        SutProvider<BulkCollectionAuthorizationHandler> sutProvider, ICollection<Collection> collections,
+        CurrentContextOrganization organization, Guid actingUserId)
     {
-        var actingUserId = Guid.NewGuid();
-
         organization.Type = OrganizationUserType.Custom;
         organization.Permissions = new Permissions
         {
             ManageUsers = true
         };
 
-        var operationsToTest = new[]
-        {
-            BulkCollectionOperations.ModifyUserAccess,
-        };
+        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
+        sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
+        sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1)
+            .Returns(false);
 
-        foreach (var op in operationsToTest)
-        {
-            sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
-            sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
-            sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1)
-                .Returns(false);
+        var context = new AuthorizationHandlerContext(
+            new[] { BulkCollectionOperations.ModifyUserAccess },
+            new ClaimsPrincipal(),
+            collections);
 
-            var context = new AuthorizationHandlerContext(
-                new[] { op },
-                new ClaimsPrincipal(),
-                collections);
+        await sutProvider.Sut.HandleAsync(context);
 
-            await sutProvider.Sut.HandleAsync(context);
-
-            Assert.True(context.HasSucceeded);
-
-            // Recreate the SUT to reset the mocks/dependencies between tests
-            sutProvider.Recreate();
-        }
+        Assert.True(context.HasSucceeded);
     }
 
     [Theory, BitAutoData, CollectionCustomization]
     public async Task CanUpdateUsers_WithManageUsersCustomPermission_AllowAdminAccessIsTrue_Success(
-        SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
-        ICollection<Collection> collections,
-        CurrentContextOrganization organization)
+        SutProvider<BulkCollectionAuthorizationHandler> sutProvider, ICollection<Collection> collections,
+        CurrentContextOrganization organization, Guid actingUserId)
     {
-        var actingUserId = Guid.NewGuid();
-
         organization.Type = OrganizationUserType.Custom;
         organization.Permissions = new Permissions
         {
             ManageUsers = true
         };
 
-        var operationsToTest = new[]
-        {
-            BulkCollectionOperations.ModifyUserAccess,
-        };
+        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
+        sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
+        sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1)
+            .Returns(true);
+        sutProvider.GetDependency<IApplicationCacheService>().GetOrganizationAbilityAsync(organization.Id)
+            .Returns(new OrganizationAbility { AllowAdminAccessToAllCollectionItems = true });
 
-        foreach (var op in operationsToTest)
-        {
-            sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
-            sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
-            sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1)
-                .Returns(true);
-            sutProvider.GetDependency<IApplicationCacheService>().GetOrganizationAbilityAsync(organization.Id)
-                .Returns(new OrganizationAbility { AllowAdminAccessToAllCollectionItems = true });
+        var context = new AuthorizationHandlerContext(
+            new[] { BulkCollectionOperations.ModifyUserAccess },
+            new ClaimsPrincipal(),
+            collections);
 
-            var context = new AuthorizationHandlerContext(
-                new[] { op },
-                new ClaimsPrincipal(),
-                collections);
+        await sutProvider.Sut.HandleAsync(context);
 
-            await sutProvider.Sut.HandleAsync(context);
-
-            Assert.True(context.HasSucceeded);
-
-            // Recreate the SUT to reset the mocks/dependencies between tests
-            sutProvider.Recreate();
-        }
+        Assert.True(context.HasSucceeded);
     }
 
     [Theory, BitAutoData, CollectionCustomization]
     public async Task CanUpdateUsers_WithManageUsersCustomPermission_AllowAdminAccessIsFalse_Failure(
-        SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
-        ICollection<Collection> collections,
-        CurrentContextOrganization organization)
+        SutProvider<BulkCollectionAuthorizationHandler> sutProvider, ICollection<Collection> collections,
+        CurrentContextOrganization organization, Guid actingUserId)
     {
-        var actingUserId = Guid.NewGuid();
-
         organization.Type = OrganizationUserType.Custom;
         organization.Permissions = new Permissions
         {
             ManageUsers = true
         };
 
-        var operationsToTest = new[]
-        {
-            BulkCollectionOperations.ModifyUserAccess,
-        };
+        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
+        sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
+        sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1)
+            .Returns(true);
+        sutProvider.GetDependency<IApplicationCacheService>().GetOrganizationAbilityAsync(organization.Id)
+            .Returns(new OrganizationAbility { AllowAdminAccessToAllCollectionItems = false });
 
-        foreach (var op in operationsToTest)
-        {
-            sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
-            sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
-            sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1)
-                .Returns(true);
-            sutProvider.GetDependency<IApplicationCacheService>().GetOrganizationAbilityAsync(organization.Id)
-                .Returns(new OrganizationAbility { AllowAdminAccessToAllCollectionItems = false });
+        var context = new AuthorizationHandlerContext(
+            new[] { BulkCollectionOperations.ModifyUserAccess },
+            new ClaimsPrincipal(),
+            collections);
 
-            var context = new AuthorizationHandlerContext(
-                new[] { op },
-                new ClaimsPrincipal(),
-                collections);
+        await sutProvider.Sut.HandleAsync(context);
 
-            await sutProvider.Sut.HandleAsync(context);
-
-            Assert.False(context.HasSucceeded);
-
-            // Recreate the SUT to reset the mocks/dependencies between tests
-            sutProvider.Recreate();
-        }
+        Assert.False(context.HasSucceeded);
     }
 
     [Theory, BitAutoData, CollectionCustomization]
     public async Task CanUpdateGroups_WithManageGroupsCustomPermission_V1Disabled_Success(
-        SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
-        ICollection<Collection> collections,
-        CurrentContextOrganization organization)
+        SutProvider<BulkCollectionAuthorizationHandler> sutProvider, ICollection<Collection> collections,
+        CurrentContextOrganization organization, Guid actingUserId)
     {
-        var actingUserId = Guid.NewGuid();
-
         organization.Type = OrganizationUserType.Custom;
         organization.Permissions = new Permissions
         {
             ManageGroups = true
         };
 
-        var operationsToTest = new[]
-        {
-            BulkCollectionOperations.ModifyGroupAccess,
-        };
+        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
+        sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
+        sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1)
+            .Returns(false);
 
-        foreach (var op in operationsToTest)
-        {
-            sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
-            sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
-            sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1)
-                .Returns(false);
+        var context = new AuthorizationHandlerContext(
+            new[] { BulkCollectionOperations.ModifyGroupAccess },
+            new ClaimsPrincipal(),
+            collections);
 
-            var context = new AuthorizationHandlerContext(
-                new[] { op },
-                new ClaimsPrincipal(),
-                collections);
+        await sutProvider.Sut.HandleAsync(context);
 
-            await sutProvider.Sut.HandleAsync(context);
-
-            Assert.True(context.HasSucceeded);
-
-            // Recreate the SUT to reset the mocks/dependencies between tests
-            sutProvider.Recreate();
-        }
+        Assert.True(context.HasSucceeded);
     }
 
     [Theory, BitAutoData, CollectionCustomization]
     public async Task CanUpdateGroups_WithManageGroupsCustomPermission_AllowAdminAccessIsTrue_Success(
-        SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
-        ICollection<Collection> collections,
-        CurrentContextOrganization organization)
+        SutProvider<BulkCollectionAuthorizationHandler> sutProvider, ICollection<Collection> collections,
+        CurrentContextOrganization organization, Guid actingUserId)
     {
-        var actingUserId = Guid.NewGuid();
-
         organization.Type = OrganizationUserType.Custom;
         organization.Permissions = new Permissions
         {
             ManageGroups = true
         };
 
-        var operationsToTest = new[]
-        {
-            BulkCollectionOperations.ModifyGroupAccess,
-        };
+        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
+        sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
+        sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1)
+            .Returns(true);
+        sutProvider.GetDependency<IApplicationCacheService>().GetOrganizationAbilityAsync(organization.Id)
+            .Returns(new OrganizationAbility { AllowAdminAccessToAllCollectionItems = true });
 
-        foreach (var op in operationsToTest)
-        {
-            sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
-            sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
-            sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1)
-                .Returns(true);
-            sutProvider.GetDependency<IApplicationCacheService>().GetOrganizationAbilityAsync(organization.Id)
-                .Returns(new OrganizationAbility { AllowAdminAccessToAllCollectionItems = true });
+        var context = new AuthorizationHandlerContext(
+            new[] { BulkCollectionOperations.ModifyGroupAccess },
+            new ClaimsPrincipal(),
+            collections);
 
-            var context = new AuthorizationHandlerContext(
-                new[] { op },
-                new ClaimsPrincipal(),
-                collections);
+        await sutProvider.Sut.HandleAsync(context);
 
-            await sutProvider.Sut.HandleAsync(context);
-
-            Assert.True(context.HasSucceeded);
-
-            // Recreate the SUT to reset the mocks/dependencies between tests
-            sutProvider.Recreate();
-        }
+        Assert.True(context.HasSucceeded);
     }
 
     [Theory, BitAutoData, CollectionCustomization]
     public async Task CanUpdateGroups_WithManageGroupsCustomPermission_AllowAdminAccessIsFalse_Failure(
-        SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
-        ICollection<Collection> collections,
-        CurrentContextOrganization organization)
+        SutProvider<BulkCollectionAuthorizationHandler> sutProvider, ICollection<Collection> collections,
+        CurrentContextOrganization organization, Guid actingUserId)
     {
-        var actingUserId = Guid.NewGuid();
-
         organization.Type = OrganizationUserType.Custom;
         organization.Permissions = new Permissions
         {
             ManageGroups = true
         };
 
-        var operationsToTest = new[]
-        {
-            BulkCollectionOperations.ModifyGroupAccess,
-        };
+        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
+        sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
+        sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1)
+            .Returns(true);
+        sutProvider.GetDependency<IApplicationCacheService>().GetOrganizationAbilityAsync(organization.Id)
+            .Returns(new OrganizationAbility { AllowAdminAccessToAllCollectionItems = false });
 
-        foreach (var op in operationsToTest)
-        {
-            sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
-            sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
-            sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1)
-                .Returns(true);
-            sutProvider.GetDependency<IApplicationCacheService>().GetOrganizationAbilityAsync(organization.Id)
-                .Returns(new OrganizationAbility { AllowAdminAccessToAllCollectionItems = false });
+        var context = new AuthorizationHandlerContext(
+            new[] { BulkCollectionOperations.ModifyGroupAccess },
+            new ClaimsPrincipal(),
+            collections);
 
-            var context = new AuthorizationHandlerContext(
-                new[] { op },
-                new ClaimsPrincipal(),
-                collections);
+        await sutProvider.Sut.HandleAsync(context);
 
-            await sutProvider.Sut.HandleAsync(context);
-
-            Assert.False(context.HasSucceeded);
-
-            // Recreate the SUT to reset the mocks/dependencies between tests
-            sutProvider.Recreate();
-        }
+        Assert.False(context.HasSucceeded);
     }
 
     [Theory, BitAutoData, CollectionCustomization]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Currently, the Allow admin access to all collections and items setting does not affect Custom Users with the Manage Groups or Manage Users permissions - they can assign groups and users (respectively) to any collection, including those they don't manage.

Update their permission check to only allow this if Allow admin access is enabled. Otherwise, they must have Can Manage permissions like everyone else. This aligns them with how admins and owners are treated.

Clients PR: https://github.com/bitwarden/clients/pull/9231

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
