### PR TITLE
[PM-5938] Prevent permanent vault coruption on key-rotation with desycned vault

### DIFF
--- a/src/Api/AdminConsole/Validators/OrganizationUserRotationValidator.cs
+++ b/src/Api/AdminConsole/Validators/OrganizationUserRotationValidator.cs
@@ -27,13 +27,9 @@ public class OrganizationUserRotationValidator : IRotationValidator<IEnumerable<
         }
 
         var result = new List<OrganizationUser>();
-        if (resetPasswordKeys == null || !resetPasswordKeys.Any())
-        {
-            return result;
-        }
 
         var existing = await _organizationUserRepository.GetManyByUserAsync(user.Id);
-        if (existing == null || !existing.Any())
+        if (existing == null || existing.Count == 0)
         {
             return result;
         }

--- a/src/Api/Auth/Validators/EmergencyAccessRotationValidator.cs
+++ b/src/Api/Auth/Validators/EmergencyAccessRotationValidator.cs
@@ -24,13 +24,9 @@ public class EmergencyAccessRotationValidator : IRotationValidator<IEnumerable<E
         IEnumerable<EmergencyAccessWithIdRequestModel> emergencyAccessKeys)
     {
         var result = new List<EmergencyAccess>();
-        if (emergencyAccessKeys == null || !emergencyAccessKeys.Any())
-        {
-            return result;
-        }
 
         var existing = await _emergencyAccessRepository.GetManyDetailsByGrantorIdAsync(user.Id);
-        if (existing == null || !existing.Any())
+        if (existing == null || existing.Count == 0)
         {
             return result;
         }

--- a/src/Api/Tools/Validators/SendRotationValidator.cs
+++ b/src/Api/Tools/Validators/SendRotationValidator.cs
@@ -30,13 +30,9 @@ public class SendRotationValidator : IRotationValidator<IEnumerable<SendWithIdRe
     public async Task<IReadOnlyList<Send>> ValidateAsync(User user, IEnumerable<SendWithIdRequestModel> sends)
     {
         var result = new List<Send>();
-        if (sends == null || !sends.Any())
-        {
-            return result;
-        }
 
         var existingSends = await _sendRepository.GetManyByUserIdAsync(user.Id);
-        if (existingSends == null || !existingSends.Any())
+        if (existingSends == null || existingSends.Count == 0)
         {
             return result;
         }

--- a/src/Api/Vault/Validators/CipherRotationValidator.cs
+++ b/src/Api/Vault/Validators/CipherRotationValidator.cs
@@ -26,13 +26,9 @@ public class CipherRotationValidator : IRotationValidator<IEnumerable<CipherWith
     public async Task<IEnumerable<Cipher>> ValidateAsync(User user, IEnumerable<CipherWithIdRequestModel> ciphers)
     {
         var result = new List<Cipher>();
-        if (ciphers == null || !ciphers.Any())
-        {
-            return result;
-        }
 
         var existingCiphers = await _cipherRepository.GetManyByUserIdAsync(user.Id, UseFlexibleCollections);
-        if (existingCiphers == null || !existingCiphers.Any())
+        if (existingCiphers == null || existingCiphers.Count == 0)
         {
             return result;
         }

--- a/src/Api/Vault/Validators/FolderRotationValidator.cs
+++ b/src/Api/Vault/Validators/FolderRotationValidator.cs
@@ -19,13 +19,9 @@ public class FolderRotationValidator : IRotationValidator<IEnumerable<FolderWith
     public async Task<IEnumerable<Folder>> ValidateAsync(User user, IEnumerable<FolderWithIdRequestModel> folders)
     {
         var result = new List<Folder>();
-        if (folders == null || !folders.Any())
-        {
-            return result;
-        }
 
         var existingFolders = await _folderRepository.GetManyByUserIdAsync(user.Id);
-        if (existingFolders == null || !existingFolders.Any())
+        if (existingFolders == null || existingFolders.Count == 0)
         {
             return result;
         }

--- a/src/Core/Auth/UserFeatures/UserKey/Implementations/RotateUserKeyCommand.cs
+++ b/src/Core/Auth/UserFeatures/UserKey/Implementations/RotateUserKeyCommand.cs
@@ -1,6 +1,5 @@
 ﻿using Bit.Core.Auth.Models.Data;
 using Bit.Core.Entities;
-using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Tools.Repositories;
@@ -60,14 +59,6 @@ public class RotateUserKeyCommand : IRotateUserKeyCommand
         if (!await _userService.CheckPasswordAsync(user, model.MasterPasswordHash))
         {
             return IdentityResult.Failed(_identityErrorDescriber.PasswordMismatch());
-        }
-
-        if ((!model.Ciphers.Any()) && (await _cipherRepository.GetManyByUserIdAsync(user.Id, false, false)).Count != 0)
-        {
-            // if there are no ciphers in the req but some in the db, the local client state is likely de-synced and rotating would lead to permanent vault corruption
-            // we cannot filter by exact counts/ids since a users vault might already contain corrupt ciphers, which would permanently block them from key-rotation, unless
-            // we filter and drop these on the client
-            throw new BadRequestException("No ciphers in request, but ciphers in database. Local vault is not synced.");
         }
 
         var now = DateTime.UtcNow;

--- a/src/Core/Auth/UserFeatures/UserKey/Implementations/RotateUserKeyCommand.cs
+++ b/src/Core/Auth/UserFeatures/UserKey/Implementations/RotateUserKeyCommand.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Core.Auth.Models.Data;
 using Bit.Core.Entities;
+using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Tools.Repositories;
@@ -59,6 +60,14 @@ public class RotateUserKeyCommand : IRotateUserKeyCommand
         if (!await _userService.CheckPasswordAsync(user, model.MasterPasswordHash))
         {
             return IdentityResult.Failed(_identityErrorDescriber.PasswordMismatch());
+        }
+
+        if ((!model.Ciphers.Any()) && (await _cipherRepository.GetManyByUserIdAsync(user.Id, false, false)).Count != 0)
+        {
+            // if there are no ciphers in the req but some in the db, the local client state is likely de-synced and rotating would lead to permanent vault corruption
+            // we cannot filter by exact counts/ids since a users vault might already contain corrupt ciphers, which would permanently block them from key-rotation, unless
+            // we filter and drop these on the client
+            throw new BadRequestException("No ciphers in request, but ciphers in database. Local vault is not synced.");
         }
 
         var now = DateTime.UtcNow;

--- a/test/Api.Test/Vault/Validators/FolderRotationValidatorTests.cs
+++ b/test/Api.Test/Vault/Validators/FolderRotationValidatorTests.cs
@@ -39,4 +39,14 @@ public class FolderRotationValidatorTests
 
         Assert.DoesNotContain(result, c => c.Id == folders.First().Id);
     }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_SentFoldersAreEmptyButDatabaseFoldersAreNot_Throws(
+        SutProvider<FolderRotationValidator> sutProvider, User user, IEnumerable<FolderWithIdRequestModel> folders)
+    {
+        var userFolders = folders.Select(f => f.ToFolder(new Folder())).ToList();
+        sutProvider.GetDependency<IFolderRepository>().GetManyByUserIdAsync(user.Id).Returns(userFolders);
+
+        await Assert.ThrowsAsync<BadRequestException>(async () => await sutProvider.Sut.ValidateAsync(user, Enumerable.Empty<FolderWithIdRequestModel>()));
+    }
 }

--- a/test/Core.Test/Auth/UserFeatures/UserKey/RotateUserKeyCommandTests.cs
+++ b/test/Core.Test/Auth/UserFeatures/UserKey/RotateUserKeyCommandTests.cs
@@ -1,11 +1,7 @@
 ﻿using Bit.Core.Auth.Models.Data;
 using Bit.Core.Auth.UserFeatures.UserKey.Implementations;
 using Bit.Core.Entities;
-using Bit.Core.Exceptions;
 using Bit.Core.Services;
-using Bit.Core.Vault.Entities;
-using Bit.Core.Vault.Models.Data;
-using Bit.Core.Vault.Repositories;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using Microsoft.AspNetCore.Identity;
@@ -54,22 +50,4 @@ public class RotateUserKeyCommandTests
             .PushLogOutAsync(default, default);
     }
 
-    [Theory, BitAutoData]
-    public async Task RotateUserKeyAsync_PreventDesyncedVaultRotation(
-        SutProvider<RotateUserKeyCommand> sutProvider,
-        User user,
-        RotateUserKeyData model,
-        List<CipherDetails> ciphers
-    )
-    {
-        model.Ciphers = new List<Cipher>();
-        sutProvider.GetDependency<IUserService>().CheckPasswordAsync(user, model.MasterPasswordHash)
-            .Returns(true);
-
-        sutProvider.GetDependency<ICipherRepository>().GetManyByUserIdAsync(user.Id, false, false)
-            .Returns(ciphers);
-
-        var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.RotateUserKeyAsync(user, model));
-        Assert.Contains("No ciphers", exception.Message);
-    }
 }

--- a/test/Core.Test/Auth/UserFeatures/UserKey/RotateUserKeyCommandTests.cs
+++ b/test/Core.Test/Auth/UserFeatures/UserKey/RotateUserKeyCommandTests.cs
@@ -1,7 +1,11 @@
 ﻿using Bit.Core.Auth.Models.Data;
 using Bit.Core.Auth.UserFeatures.UserKey.Implementations;
 using Bit.Core.Entities;
+using Bit.Core.Exceptions;
 using Bit.Core.Services;
+using Bit.Core.Vault.Entities;
+using Bit.Core.Vault.Models.Data;
+using Bit.Core.Vault.Repositories;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using Microsoft.AspNetCore.Identity;
@@ -48,5 +52,24 @@ public class RotateUserKeyCommandTests
 
         await sutProvider.GetDependency<IPushNotificationService>().ReceivedWithAnyArgs()
             .PushLogOutAsync(default, default);
+    }
+
+    [Theory, BitAutoData]
+    public async Task RotateUserKeyAsync_PreventDesyncedVaultRotation(
+        SutProvider<RotateUserKeyCommand> sutProvider,
+        User user,
+        RotateUserKeyData model,
+        List<CipherDetails> ciphers
+    )
+    {
+        model.Ciphers = new List<Cipher>();
+        sutProvider.GetDependency<IUserService>().CheckPasswordAsync(user, model.MasterPasswordHash)
+            .Returns(true);
+
+        sutProvider.GetDependency<ICipherRepository>().GetManyByUserIdAsync(user.Id, false, false)
+            .Returns(ciphers);
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.RotateUserKeyAsync(user, model));
+        Assert.Contains("No ciphers", exception.Message);
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Under specific circumstances, the local vault of the web client can be desynced (no full sync, or cipher decryption errors). Rotating keys in this state permanently corrupts the vault (Reproduction steps https://github.com/bitwarden/clients/issues/7709). This PR adds a basic check to vault rotation that ensures if the update request has an obviously bad state (no ciphers at all in the request, but there are ciphers in the DB), the key rotation request is rejected.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
