### PR TITLE
[PM-8004] Move Unmanaged collection logic out of component for better reuse

### DIFF
--- a/src/Api/Models/Response/CollectionResponseModel.cs
+++ b/src/Api/Models/Response/CollectionResponseModel.cs
@@ -89,6 +89,7 @@ public class CollectionAccessDetailsResponseModel : CollectionResponseModel
         ReadOnly = collection.ReadOnly;
         HidePasswords = collection.HidePasswords;
         Manage = collection.Manage;
+        Unmanaged = collection.Unmanaged;
         Groups = collection.Groups?.Select(g => new SelectionReadOnlyResponseModel(g)) ?? Enumerable.Empty<SelectionReadOnlyResponseModel>();
         Users = collection.Users?.Select(g => new SelectionReadOnlyResponseModel(g)) ?? Enumerable.Empty<SelectionReadOnlyResponseModel>();
     }
@@ -104,4 +105,5 @@ public class CollectionAccessDetailsResponseModel : CollectionResponseModel
     public bool ReadOnly { get; set; }
     public bool HidePasswords { get; set; }
     public bool Manage { get; set; }
+    public bool Unmanaged { get; set; }
 }

--- a/src/Core/Models/Data/CollectionAdminDetails.cs
+++ b/src/Core/Models/Data/CollectionAdminDetails.cs
@@ -14,4 +14,9 @@ public class CollectionAdminDetails : CollectionDetails
     /// Flag for whether the user has been explicitly assigned to the collection either directly or through a group.
     /// </summary>
     public bool Assigned { get; set; }
+
+    /// <summary>
+    /// Flag for whether a collection is managed by an active user or group.
+    /// </summary>
+    public bool Unmanaged { get; set; }
 }

--- a/src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CollectionRepository.cs
@@ -391,7 +391,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                         c.Name,
                         c.CreationDate,
                         c.RevisionDate,
-                        c.ExternalId
+                        c.ExternalId,
+                        c.Unmanaged
                     }).Select(collectionGroup => new CollectionAdminDetails
                     {
                         Id = collectionGroup.Key.Id,
@@ -404,7 +405,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                         HidePasswords =
                             Convert.ToBoolean(collectionGroup.Min(c => Convert.ToInt32(c.HidePasswords))),
                         Manage = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Manage))),
-                        Assigned = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Assigned)))
+                        Assigned = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Assigned))),
+                        Unmanaged = collectionGroup.Key.Unmanaged
                     }).ToList();
             }
             else
@@ -417,7 +419,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                                          c.Name,
                                          c.CreationDate,
                                          c.RevisionDate,
-                                         c.ExternalId
+                                         c.ExternalId,
+                                         c.Unmanaged
                                      }
                     into collectionGroup
                                      select new CollectionAdminDetails
@@ -432,7 +435,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                                          HidePasswords =
                                              Convert.ToBoolean(collectionGroup.Min(c => Convert.ToInt32(c.HidePasswords))),
                                          Manage = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Manage))),
-                                         Assigned = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Assigned)))
+                                         Assigned = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Assigned))),
+                                         Unmanaged = collectionGroup.Key.Unmanaged
                                      }).ToListAsync();
             }
 
@@ -511,7 +515,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                         HidePasswords =
                             Convert.ToBoolean(collectionGroup.Min(c => Convert.ToInt32(c.HidePasswords))),
                         Manage = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Manage))),
-                        Assigned = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Assigned)))
+                        Assigned = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Assigned))),
+                        Unmanaged = collectionGroup.Select(c => c.Unmanaged).FirstOrDefault()
                     }).FirstOrDefault();
             }
             else
@@ -539,7 +544,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                                                HidePasswords =
                                                    Convert.ToBoolean(collectionGroup.Min(c => Convert.ToInt32(c.HidePasswords))),
                                                Manage = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Manage))),
-                                               Assigned = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Assigned)))
+                                               Assigned = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Assigned))),
+                                               Unmanaged = collectionGroup.Select(c => c.Unmanaged).FirstOrDefault()
                                            }).FirstOrDefaultAsync();
             }
 

--- a/src/Sql/Vault/dbo/Stored Procedures/Collections/Collection_ReadByIdWithPermissions.sql
+++ b/src/Sql/Vault/dbo/Stored Procedures/Collections/Collection_ReadByIdWithPermissions.sql
@@ -35,7 +35,7 @@ BEGIN
 	    CASE
             WHEN
                 -- No active user or group has manage rights
-                NOT EXISTS(
+                 NOT EXISTS(
                     SELECT 1
                     FROM [dbo].[CollectionUser] CU2
                              JOIN [dbo].[OrganizationUser] OU2 ON CU2.[OrganizationUserId] = OU2.[Id]
@@ -51,7 +51,7 @@ BEGIN
                         CG2.[CollectionId] = C.[Id] AND
                         CG2.[Manage] = 1
                 )
-                THEN 1
+            THEN 1
             ELSE 0
         END AS [Unmanaged]
 	FROM

--- a/src/Sql/Vault/dbo/Stored Procedures/Collections/Collection_ReadByIdWithPermissions.sql
+++ b/src/Sql/Vault/dbo/Stored Procedures/Collections/Collection_ReadByIdWithPermissions.sql
@@ -31,7 +31,29 @@ BEGIN
 	    	    CU.[CollectionId] IS NULL AND CG.[CollectionId] IS NULL
 	    	THEN 0
 	    	ELSE 1
-	    END) AS [Assigned]
+	    END) AS [Assigned],
+	    CASE
+            WHEN
+                -- No active user or group has manage rights
+                NOT EXISTS(
+                    SELECT 1
+                    FROM [dbo].[CollectionUser] CU2
+                             JOIN [dbo].[OrganizationUser] OU2 ON CU2.[OrganizationUserId] = OU2.[Id]
+                    WHERE
+                        CU2.[CollectionId] = C.[Id] AND
+                        OU2.[Status] = 2 AND
+                        CU2.[Manage] = 1
+                )
+                    AND NOT EXISTS (
+                    SELECT 1
+                    FROM [dbo].[CollectionGroup] CG2
+                    WHERE
+                        CG2.[CollectionId] = C.[Id] AND
+                        CG2.[Manage] = 1
+                )
+                THEN 1
+            ELSE 0
+        END AS [Unmanaged]
 	FROM
 	    [dbo].[CollectionView] C
 	LEFT JOIN

--- a/src/Sql/Vault/dbo/Stored Procedures/Collections/Collection_ReadByOrganizationIdWithPermissions.sql
+++ b/src/Sql/Vault/dbo/Stored Procedures/Collections/Collection_ReadByOrganizationIdWithPermissions.sql
@@ -31,7 +31,29 @@ BEGIN
 	    	    CU.[CollectionId] IS NULL AND CG.[CollectionId] IS NULL
 	    	THEN 0
 	    	ELSE 1
-	    END) AS [Assigned]
+	    END) AS [Assigned],
+	    CASE
+	        WHEN
+	            -- No active user or group has manage rights
+	            NOT EXISTS(
+	                SELECT 1
+	                FROM [dbo].[CollectionUser] CU2
+	                JOIN [dbo].[OrganizationUser] OU2 ON CU2.[OrganizationUserId] = OU2.[Id]
+                    WHERE
+                        CU2.[CollectionId] = C.[Id] AND
+                        OU2.[Status] = 2 AND
+                        CU2.[Manage] = 1
+	            )
+	            AND NOT EXISTS (
+                    SELECT 1
+                    FROM [dbo].[CollectionGroup] CG2
+                    WHERE
+                        CG2.[CollectionId] = C.[Id] AND
+                        CG2.[Manage] = 1
+	            )
+            THEN 1
+            ELSE 0
+	    END AS [Unmanaged]
 	FROM
 	    [dbo].[CollectionView] C
 	LEFT JOIN

--- a/test/Infrastructure.IntegrationTest/Vault/Repositories/CollectionRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/Vault/Repositories/CollectionRepositoryTests.cs
@@ -310,6 +310,7 @@ public class CollectionRepositoryTests
             Assert.True(c1.Manage);
             Assert.False(c1.ReadOnly);
             Assert.False(c1.HidePasswords);
+            Assert.False(c1.Unmanaged);
         }, c2 =>
         {
             Assert.NotNull(c2);
@@ -319,6 +320,7 @@ public class CollectionRepositoryTests
             Assert.False(c2.Manage);
             Assert.True(c2.ReadOnly);
             Assert.False(c2.HidePasswords);
+            Assert.True(c2.Unmanaged);
         }, c3 =>
         {
             Assert.NotNull(c3);
@@ -328,6 +330,7 @@ public class CollectionRepositoryTests
             Assert.False(c3.Manage);
             Assert.False(c3.ReadOnly);
             Assert.False(c3.HidePasswords);
+            Assert.False(c3.Unmanaged);
         });
     }
 
@@ -436,6 +439,7 @@ public class CollectionRepositoryTests
             Assert.True(c1.Manage);
             Assert.False(c1.ReadOnly);
             Assert.False(c1.HidePasswords);
+            Assert.False(c1.Unmanaged);
         }, c2 =>
         {
             Assert.NotNull(c2);
@@ -445,6 +449,7 @@ public class CollectionRepositoryTests
             Assert.False(c2.Manage);
             Assert.True(c2.ReadOnly);
             Assert.False(c2.HidePasswords);
+            Assert.True(c2.Unmanaged);
         }, c3 =>
         {
             Assert.NotNull(c3);
@@ -454,6 +459,7 @@ public class CollectionRepositoryTests
             Assert.True(c3.Manage); // Group 2 is Manage
             Assert.False(c3.ReadOnly);
             Assert.False(c3.HidePasswords);
+            Assert.False(c3.Unmanaged);
         });
     }
 }

--- a/util/Migrator/DbScripts/2024-05-17_00_CollectionWithPermissionsAndUnmanagedQueries.sql
+++ b/util/Migrator/DbScripts/2024-05-17_00_CollectionWithPermissionsAndUnmanagedQueries.sql
@@ -1,0 +1,171 @@
+CREATE OR ALTER PROCEDURE [dbo].[Collection_ReadByOrganizationIdWithPermissions]
+    @OrganizationId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @IncludeAccessRelationships BIT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        C.*,
+        MIN(CASE
+                WHEN
+                    COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) = 0
+                    THEN 0
+                ELSE 1
+            END) AS [ReadOnly],
+        MIN(CASE
+                WHEN
+                    COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
+                    THEN 0
+                ELSE 1
+            END) AS [HidePasswords],
+        MAX(CASE
+                WHEN
+                    COALESCE(CU.[Manage], CG.[Manage], 0) = 0
+                    THEN 0
+                ELSE 1
+            END) AS [Manage],
+        MAX(CASE
+                WHEN
+                    CU.[CollectionId] IS NULL AND CG.[CollectionId] IS NULL
+                    THEN 0
+                ELSE 1
+            END) AS [Assigned],
+        CASE
+            WHEN
+                -- No active user or group has manage rights
+                NOT EXISTS(
+                    SELECT 1
+                    FROM [dbo].[CollectionUser] CU2
+                             JOIN [dbo].[OrganizationUser] OU2 ON CU2.[OrganizationUserId] = OU2.[Id]
+                    WHERE
+                        CU2.[CollectionId] = C.[Id] AND
+                        OU2.[Status] = 2 AND
+                        CU2.[Manage] = 1
+                )
+                    AND NOT EXISTS (
+                    SELECT 1
+                    FROM [dbo].[CollectionGroup] CG2
+                    WHERE
+                        CG2.[CollectionId] = C.[Id] AND
+                        CG2.[Manage] = 1
+                )
+                THEN 1
+            ELSE 0
+        END AS [Unmanaged]
+    FROM
+        [dbo].[CollectionView] C
+            LEFT JOIN
+        [dbo].[OrganizationUser] OU ON C.[OrganizationId] = OU.[OrganizationId] AND OU.[UserId] = @UserId
+            LEFT JOIN
+        [dbo].[CollectionUser] CU ON CU.[CollectionId] = C.[Id] AND CU.[OrganizationUserId] = [OU].[Id]
+            LEFT JOIN
+        [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND GU.[OrganizationUserId] = OU.[Id]
+            LEFT JOIN
+        [dbo].[Group] G ON G.[Id] = GU.[GroupId]
+            LEFT JOIN
+        [dbo].[CollectionGroup] CG ON CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
+    WHERE
+        C.[OrganizationId] = @OrganizationId
+    GROUP BY
+        C.[Id],
+        C.[OrganizationId],
+        C.[Name],
+        C.[CreationDate],
+        C.[RevisionDate],
+        C.[ExternalId]
+
+    IF (@IncludeAccessRelationships = 1)
+        BEGIN
+            EXEC [dbo].[CollectionGroup_ReadByOrganizationId] @OrganizationId
+            EXEC [dbo].[CollectionUser_ReadByOrganizationId] @OrganizationId
+        END
+END
+GO
+
+CREATE OR ALTER PROCEDURE [dbo].[Collection_ReadByIdWithPermissions]
+    @CollectionId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @IncludeAccessRelationships BIT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        C.*,
+        MIN(CASE
+                WHEN
+                    COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) = 0
+                    THEN 0
+                ELSE 1
+            END) AS [ReadOnly],
+        MIN (CASE
+                 WHEN
+                     COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
+                     THEN 0
+                 ELSE 1
+            END) AS [HidePasswords],
+        MAX(CASE
+                WHEN
+                    COALESCE(CU.[Manage], CG.[Manage], 0) = 0
+                    THEN 0
+                ELSE 1
+            END) AS [Manage],
+        MAX(CASE
+                WHEN
+                    CU.[CollectionId] IS NULL AND CG.[CollectionId] IS NULL
+                    THEN 0
+                ELSE 1
+            END) AS [Assigned],
+        CASE
+            WHEN
+                -- No active user or group has manage rights
+                NOT EXISTS(
+                    SELECT 1
+                    FROM [dbo].[CollectionUser] CU2
+                             JOIN [dbo].[OrganizationUser] OU2 ON CU2.[OrganizationUserId] = OU2.[Id]
+                    WHERE
+                        CU2.[CollectionId] = C.[Id] AND
+                        OU2.[Status] = 2 AND
+                        CU2.[Manage] = 1
+                )
+                    AND NOT EXISTS (
+                    SELECT 1
+                    FROM [dbo].[CollectionGroup] CG2
+                    WHERE
+                        CG2.[CollectionId] = C.[Id] AND
+                        CG2.[Manage] = 1
+                )
+                THEN 1
+            ELSE 0
+        END AS [Unmanaged]
+    FROM
+        [dbo].[CollectionView] C
+            LEFT JOIN
+        [dbo].[OrganizationUser] OU ON C.[OrganizationId] = OU.[OrganizationId] AND OU.[UserId] = @UserId
+            LEFT JOIN
+        [dbo].[CollectionUser] CU ON CU.[CollectionId] = C.[Id] AND CU.[OrganizationUserId] = [OU].[Id]
+            LEFT JOIN
+        [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND GU.[OrganizationUserId] = OU.[Id]
+            LEFT JOIN
+        [dbo].[Group] G ON G.[Id] = GU.[GroupId]
+            LEFT JOIN
+        [dbo].[CollectionGroup] CG ON CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
+    WHERE
+        C.[Id] = @CollectionId
+    GROUP BY
+        C.[Id],
+        C.[OrganizationId],
+        C.[Name],
+        C.[CreationDate],
+        C.[RevisionDate],
+        C.[ExternalId]
+
+    IF (@IncludeAccessRelationships = 1)
+        BEGIN
+            EXEC [dbo].[CollectionGroup_ReadByCollectionId] @CollectionId
+            EXEC [dbo].[CollectionUser_ReadByCollectionId] @CollectionId
+        END
+END
+GO


### PR DESCRIPTION
… to return to return unmanaged

## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Moved check to determine if a collection is unmanaged from client to server. The check is moved to the server side by adding a new Unmanaged flag to the CollectionAccessDetailsResponseModel. This flag value is calculated in the Collection_ReadByOrganizationIdWithPermissions and Collection_ReadByIdWithPermissions sprocs with a subquery.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **util/Migrator/DbScripts/2024-05-17_00_CollectionWithPermissionsAndUnmanagedQueries.sql:** Altered the sprocs `Collection_ReadByOrganizationIdWithPermissions` and `Collection_ReadByIdWithPermissions` to return `Unmanaged` flag when a collection doesn't have any active user or group managing it.
* **src/Core/Models/Data/CollectionAdminDetails.cs:** I updated the CollectionAdminDetails response to have the `Unmanaged` flag.
* **src/Infrastructure.EntityFramework/Repositories/Queries/CollectionAdminDetailsQuery.cs:** Added 
## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
