### PR TITLE
[AC-2521] Remove FlexibleCollectionsSignUp feature flag

### DIFF
--- a/src/Admin/AdminConsole/Controllers/ProvidersController.cs
+++ b/src/Admin/AdminConsole/Controllers/ProvidersController.cs
@@ -305,9 +305,8 @@ public class ProvidersController : Controller
             return RedirectToAction("Index");
         }
 
-        var flexibleCollectionsSignupEnabled = _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsSignup);
         var flexibleCollectionsV1Enabled = _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1);
-        var organization = model.CreateOrganization(provider, flexibleCollectionsSignupEnabled, flexibleCollectionsV1Enabled);
+        var organization = model.CreateOrganization(provider, flexibleCollectionsV1Enabled);
         await _organizationService.CreatePendingOrganization(organization, model.Owners, User, _userService, model.SalesAssistedTrialStarted);
         await _providerService.AddOrganization(providerId, organization.Id, null);
 

--- a/src/Admin/AdminConsole/Models/OrganizationEditModel.cs
+++ b/src/Admin/AdminConsole/Models/OrganizationEditModel.cs
@@ -162,7 +162,7 @@ public class OrganizationEditModel : OrganizationViewModel
                 { "baseServiceAccount", p.SecretsManager.BaseServiceAccount }
             });
 
-    public Organization CreateOrganization(Provider provider, bool flexibleCollectionsSignupEnabled, bool flexibleCollectionsV1Enabled)
+    public Organization CreateOrganization(Provider provider, bool flexibleCollectionsV1Enabled)
     {
         BillingEmail = provider.BillingEmail;
 
@@ -170,11 +170,11 @@ public class OrganizationEditModel : OrganizationViewModel
         {
             // This feature flag indicates that new organizations should be automatically onboarded to
             // Flexible Collections enhancements
-            FlexibleCollections = flexibleCollectionsSignupEnabled,
+            FlexibleCollections = true,
             // These collection management settings smooth the migration for existing organizations by disabling some FC behavior.
             // If the organization is onboarded to Flexible Collections on signup, we turn them OFF to enable all new behaviour.
             // If the organization is NOT onboarded now, they will have to be migrated later, so they default to ON to limit FC changes on migration.
-            LimitCollectionCreationDeletion = !flexibleCollectionsSignupEnabled,
+            LimitCollectionCreationDeletion = false,
             AllowAdminAccessToAllCollectionItems = !flexibleCollectionsV1Enabled
         };
         return ToOrganization(newOrg);

--- a/src/Admin/AdminConsole/Models/OrganizationEditModel.cs
+++ b/src/Admin/AdminConsole/Models/OrganizationEditModel.cs
@@ -174,7 +174,6 @@ public class OrganizationEditModel : OrganizationViewModel
             // These collection management settings smooth the migration for existing organizations by disabling some FC behavior.
             // If the organization is onboarded to Flexible Collections on signup, we turn them OFF to enable all new behaviour.
             // If the organization is NOT onboarded now, they will have to be migrated later, so they default to ON to limit FC changes on migration.
-            LimitCollectionCreationDeletion = false,
             AllowAdminAccessToAllCollectionItems = !flexibleCollectionsV1Enabled
         };
         return ToOrganization(newOrg);

--- a/src/Admin/AdminConsole/Models/OrganizationEditModel.cs
+++ b/src/Admin/AdminConsole/Models/OrganizationEditModel.cs
@@ -168,12 +168,12 @@ public class OrganizationEditModel : OrganizationViewModel
 
         var newOrg = new Organization
         {
-            // This feature flag indicates that new organizations should be automatically onboarded to
-            // Flexible Collections enhancements
+            // Flexible Collections MVP is fully released and all organizations must always have this setting enabled.
+            // AC-1714 will remove this flag after all old code has been removed.
             FlexibleCollections = true,
-            // These collection management settings smooth the migration for existing organizations by disabling some FC behavior.
-            // If the organization is onboarded to Flexible Collections on signup, we turn them OFF to enable all new behaviour.
-            // If the organization is NOT onboarded now, they will have to be migrated later, so they default to ON to limit FC changes on migration.
+
+            // This is a transitional setting that defaults to ON until Flexible Collections v1 is released
+            // (to preserve existing behavior) and defaults to OFF after release (enabling new behavior)
             AllowAdminAccessToAllCollectionItems = !flexibleCollectionsV1Enabled
         };
         return ToOrganization(newOrg);

--- a/src/Core/AdminConsole/Entities/Organization.cs
+++ b/src/Core/AdminConsole/Entities/Organization.cs
@@ -86,20 +86,20 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable,
     public int? MaxAutoscaleSmSeats { get; set; }
     public int? MaxAutoscaleSmServiceAccounts { get; set; }
     /// <summary>
-    /// Refers to the ability for an organization to limit collection creation and deletion to owners and admins only
+    /// If set to true, only owners, admins, and some custom users can create and delete collections.
+    /// If set to false, any organization member can create a collection, and any member can delete a collection that
+    /// they have Can Manage permissions for.
     /// </summary>
     public bool LimitCollectionCreationDeletion { get; set; }
     /// <summary>
-    /// Refers to the ability for an organization to limit owner/admin access to all collection items
-    /// <remarks>
-    /// True: Owner/admins can access all items belonging to any collections
-    /// False: Owner/admins can only access items for collections they are assigned
-    /// </remarks>
+    /// If set to true, admins, owners, and some custom users can read/write all collections and items in the Admin Console.
+    /// If set to false, users generally need collection-level permissions to read/write a collection or its items.
     /// </summary>
     public bool AllowAdminAccessToAllCollectionItems { get; set; }
     /// <summary>
-    /// True if the organization is using the Flexible Collections permission changes, false otherwise.
-    /// For existing organizations, this must only be set to true once data migrations have been run for this organization.
+    /// This is an organization-level feature flag (not controlled via LaunchDarkly) to onboard organizations to the
+    /// Flexible Collections MVP changes. This has been fully released and must always be set to TRUE for all organizations.
+    /// AC-1714 will remove this flag after all old code has been removed.
     /// </summary>
     public bool FlexibleCollections { get; set; }
 

--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -482,7 +482,6 @@ public class OrganizationService : IOrganizationService
             // These collection management settings smooth the migration for existing organizations by disabling some FC behavior.
             // If the organization is onboarded to Flexible Collections on signup, we turn them OFF to enable all new behaviour.
             // If the organization is NOT onboarded now, they will have to be migrated later, so they default to ON to limit FC changes on migration.
-            LimitCollectionCreationDeletion = false,
             AllowAdminAccessToAllCollectionItems = !flexibleCollectionsV1Enabled
         };
 
@@ -574,7 +573,6 @@ public class OrganizationService : IOrganizationService
             // These collection management settings smooth the migration for existing organizations by disabling some FC behavior.
             // If the organization is onboarded to Flexible Collections on signup, we turn them OFF to enable all new behaviour.
             // If the organization is NOT onboarded now, they will have to be migrated later, so they default to ON to limit FC changes on migration.
-            LimitCollectionCreationDeletion = false,
             AllowAdminAccessToAllCollectionItems = !flexibleCollectionsV1IsEnabled
         };
 

--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -434,9 +434,6 @@ public class OrganizationService : IOrganizationService
 
         ValidatePlan(plan, signup.AdditionalSeats, "Password Manager");
 
-        var flexibleCollectionsSignupEnabled =
-            _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsSignup);
-
         var flexibleCollectionsV1Enabled =
             _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1);
 
@@ -480,12 +477,12 @@ public class OrganizationService : IOrganizationService
 
             // This feature flag indicates that new organizations should be automatically onboarded to
             // Flexible Collections enhancements
-            FlexibleCollections = flexibleCollectionsSignupEnabled,
+            FlexibleCollections = true,
 
             // These collection management settings smooth the migration for existing organizations by disabling some FC behavior.
             // If the organization is onboarded to Flexible Collections on signup, we turn them OFF to enable all new behaviour.
             // If the organization is NOT onboarded now, they will have to be migrated later, so they default to ON to limit FC changes on migration.
-            LimitCollectionCreationDeletion = !flexibleCollectionsSignupEnabled,
+            LimitCollectionCreationDeletion = false,
             AllowAdminAccessToAllCollectionItems = !flexibleCollectionsV1Enabled
         };
 
@@ -528,9 +525,6 @@ public class OrganizationService : IOrganizationService
         {
             await ValidateSignUpPoliciesAsync(signup.Owner.Id);
         }
-
-        var flexibleCollectionsSignupEnabled =
-            _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsSignup);
 
         var flexibleCollectionsV1IsEnabled =
             _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1);
@@ -575,12 +569,12 @@ public class OrganizationService : IOrganizationService
 
             // This feature flag indicates that new organizations should be automatically onboarded to
             // Flexible Collections enhancements
-            FlexibleCollections = flexibleCollectionsSignupEnabled,
+            FlexibleCollections = true,
 
             // These collection management settings smooth the migration for existing organizations by disabling some FC behavior.
             // If the organization is onboarded to Flexible Collections on signup, we turn them OFF to enable all new behaviour.
             // If the organization is NOT onboarded now, they will have to be migrated later, so they default to ON to limit FC changes on migration.
-            LimitCollectionCreationDeletion = !flexibleCollectionsSignupEnabled,
+            LimitCollectionCreationDeletion = false,
             AllowAdminAccessToAllCollectionItems = !flexibleCollectionsV1IsEnabled
         };
 
@@ -661,9 +655,6 @@ public class OrganizationService : IOrganizationService
 
         await ValidateSignUpPoliciesAsync(owner.Id);
 
-        var flexibleCollectionsSignupEnabled =
-            _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsSignup);
-
         var organization = new Organization
         {
             Name = license.Name,
@@ -709,7 +700,7 @@ public class OrganizationService : IOrganizationService
 
             // This feature flag indicates that new organizations should be automatically onboarded to
             // Flexible Collections enhancements
-            FlexibleCollections = flexibleCollectionsSignupEnabled,
+            FlexibleCollections = true,
         };
 
         var result = await SignUpAsync(organization, owner.Id, ownerKey, collectionName, false);

--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -475,13 +475,12 @@ public class OrganizationService : IOrganizationService
             // Secrets Manager not available for purchase with Consolidated Billing.
             UseSecretsManager = false,
 
-            // This feature flag indicates that new organizations should be automatically onboarded to
-            // Flexible Collections enhancements
+            // Flexible Collections MVP is fully released and all organizations must always have this setting enabled.
+            // AC-1714 will remove this flag after all old code has been removed.
             FlexibleCollections = true,
 
-            // These collection management settings smooth the migration for existing organizations by disabling some FC behavior.
-            // If the organization is onboarded to Flexible Collections on signup, we turn them OFF to enable all new behaviour.
-            // If the organization is NOT onboarded now, they will have to be migrated later, so they default to ON to limit FC changes on migration.
+            // This is a transitional setting that defaults to ON until Flexible Collections v1 is released
+            // (to preserve existing behavior) and defaults to OFF after release (enabling new behavior)
             AllowAdminAccessToAllCollectionItems = !flexibleCollectionsV1Enabled
         };
 
@@ -566,13 +565,12 @@ public class OrganizationService : IOrganizationService
             UsePasswordManager = true,
             UseSecretsManager = signup.UseSecretsManager,
 
-            // This feature flag indicates that new organizations should be automatically onboarded to
-            // Flexible Collections enhancements
+            // Flexible Collections MVP is fully released and all organizations must always have this setting enabled.
+            // AC-1714 will remove this flag after all old code has been removed.
             FlexibleCollections = true,
 
-            // These collection management settings smooth the migration for existing organizations by disabling some FC behavior.
-            // If the organization is onboarded to Flexible Collections on signup, we turn them OFF to enable all new behaviour.
-            // If the organization is NOT onboarded now, they will have to be migrated later, so they default to ON to limit FC changes on migration.
+            // This is a transitional setting that defaults to ON until Flexible Collections v1 is released
+            // (to preserve existing behavior) and defaults to OFF after release (enabling new behavior)
             AllowAdminAccessToAllCollectionItems = !flexibleCollectionsV1IsEnabled
         };
 

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -115,10 +115,6 @@ public static class FeatureFlagKeys
     public const string KeyRotationImprovements = "key-rotation-improvements";
     public const string DuoRedirect = "duo-redirect";
     /// <summary>
-    /// Enables flexible collections improvements for new organizations on creation
-    /// </summary>
-    public const string FlexibleCollectionsSignup = "flexible-collections-signup";
-    /// <summary>
     /// Exposes a migration button in the web vault which allows users to migrate an existing organization to
     /// flexible collections
     /// </summary>
@@ -151,8 +147,7 @@ public static class FeatureFlagKeys
         return new Dictionary<string, string>()
         {
             { DuoRedirect, "true" },
-            { UnassignedItemsBanner, "true"},
-            { FlexibleCollectionsSignup, "true" }
+            { UnassignedItemsBanner, "true"}
         };
     }
 }

--- a/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
@@ -261,10 +261,6 @@ public class OrganizationServiceTests
         signup.PremiumAccessAddon = false;
         signup.UseSecretsManager = false;
 
-        sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.FlexibleCollectionsSignup)
-            .Returns(true);
-
         // Extract orgUserId when created
         Guid? orgUserId = null;
         await sutProvider.GetDependency<IOrganizationUserRepository>()
@@ -306,10 +302,6 @@ public class OrganizationServiceTests
         signup.PaymentMethodType = PaymentMethodType.Card;
         signup.PremiumAccessAddon = false;
         signup.UseSecretsManager = false;
-
-        sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.FlexibleCollectionsSignup)
-            .Returns(false);
 
         var result = await sutProvider.Sut.SignUpAsync(signup);
 

--- a/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
@@ -252,7 +252,7 @@ public class OrganizationServiceTests
 
     [Theory]
     [BitAutoData(PlanType.FamiliesAnnually)]
-    public async Task SignUp_WithFlexibleCollections_SetsAccessAllToFalse
+    public async Task SignUp_SetsAccessAllToFalse
         (PlanType planType, OrganizationSignup signup, SutProvider<OrganizationService> sutProvider)
     {
         signup.Plan = planType;
@@ -286,29 +286,6 @@ public class OrganizationServiceTests
                     !c.ReadOnly &&
                     !c.HidePasswords &&
                     c.Manage)));
-
-        Assert.NotNull(result.Item1);
-        Assert.NotNull(result.Item2);
-    }
-
-    [Theory]
-    [BitAutoData(PlanType.FamiliesAnnually)]
-    public async Task SignUp_WithoutFlexibleCollections_SetsAccessAllToTrue
-        (PlanType planType, OrganizationSignup signup, SutProvider<OrganizationService> sutProvider)
-    {
-        signup.Plan = planType;
-        var plan = StaticStore.GetPlan(signup.Plan);
-        signup.AdditionalSeats = 0;
-        signup.PaymentMethodType = PaymentMethodType.Card;
-        signup.PremiumAccessAddon = false;
-        signup.UseSecretsManager = false;
-
-        var result = await sutProvider.Sut.SignUpAsync(signup);
-
-        await sutProvider.GetDependency<IOrganizationUserRepository>().Received(1).CreateAsync(
-            Arg.Is<OrganizationUser>(o =>
-                o.UserId == signup.Owner.Id &&
-                o.AccessAll == true));
 
         Assert.NotNull(result.Item1);
         Assert.NotNull(result.Item2);

--- a/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
@@ -216,9 +216,10 @@ public class OrganizationServiceTests
 
         await sutProvider.GetDependency<IOrganizationRepository>().Received(1).CreateAsync(
             Arg.Is<Organization>(o =>
-                o.Seats == plan.PasswordManager.BaseSeats + signup.AdditionalSeats
-                && o.SmSeats == null
-                && o.SmServiceAccounts == null));
+                o.Seats == plan.PasswordManager.BaseSeats + signup.AdditionalSeats &&
+                o.SmSeats == null &&
+                o.SmServiceAccounts == null &&
+                o.FlexibleCollections));
         await sutProvider.GetDependency<IOrganizationUserRepository>().Received(1).CreateAsync(
             Arg.Is<OrganizationUser>(o => o.AccessSecretsManager == signup.UseSecretsManager));
 
@@ -289,6 +290,10 @@ public class OrganizationServiceTests
 
         Assert.NotNull(result.Item1);
         Assert.NotNull(result.Item2);
+
+        await sutProvider.GetDependency<IOrganizationRepository>()
+            .Received(1)
+            .CreateAsync(Arg.Is<Organization>(o => o.FlexibleCollections));
     }
 
     [Theory]
@@ -314,9 +319,10 @@ public class OrganizationServiceTests
 
         await sutProvider.GetDependency<IOrganizationRepository>().Received(1).CreateAsync(
             Arg.Is<Organization>(o =>
-                o.Seats == plan.PasswordManager.BaseSeats + signup.AdditionalSeats
-                && o.SmSeats == plan.SecretsManager.BaseSeats + signup.AdditionalSmSeats
-                && o.SmServiceAccounts == plan.SecretsManager.BaseServiceAccount + signup.AdditionalServiceAccounts));
+                o.Seats == plan.PasswordManager.BaseSeats + signup.AdditionalSeats &&
+                o.SmSeats == plan.SecretsManager.BaseSeats + signup.AdditionalSmSeats &&
+                o.SmServiceAccounts == plan.SecretsManager.BaseServiceAccount + signup.AdditionalServiceAccounts &&
+                o.FlexibleCollections));
         await sutProvider.GetDependency<IOrganizationUserRepository>().Received(1).CreateAsync(
             Arg.Is<OrganizationUser>(o => o.AccessSecretsManager == signup.UseSecretsManager));
 
@@ -437,7 +443,8 @@ public class OrganizationServiceTests
             org.UsePolicies == plan.HasPolicies &&
             org.PublicKey == signup.PublicKey &&
             org.PrivateKey == signup.PrivateKey &&
-            org.UseSecretsManager == false));
+            org.UseSecretsManager == false &&
+            org.FlexibleCollections));
 
         await sutProvider.GetDependency<IOrganizationApiKeyRepository>().Received(1)
             .CreateAsync(Arg.Is<OrganizationApiKey>(orgApiKey =>

--- a/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
@@ -216,10 +216,9 @@ public class OrganizationServiceTests
 
         await sutProvider.GetDependency<IOrganizationRepository>().Received(1).CreateAsync(
             Arg.Is<Organization>(o =>
-                o.Seats == plan.PasswordManager.BaseSeats + signup.AdditionalSeats &&
-                o.SmSeats == null &&
-                o.SmServiceAccounts == null &&
-                o.FlexibleCollections));
+                o.Seats == plan.PasswordManager.BaseSeats + signup.AdditionalSeats
+                && o.SmSeats == null
+                && o.SmServiceAccounts == null));
         await sutProvider.GetDependency<IOrganizationUserRepository>().Received(1).CreateAsync(
             Arg.Is<OrganizationUser>(o => o.AccessSecretsManager == signup.UseSecretsManager));
 
@@ -253,7 +252,7 @@ public class OrganizationServiceTests
 
     [Theory]
     [BitAutoData(PlanType.FamiliesAnnually)]
-    public async Task SignUp_SetsAccessAllToFalse
+    public async Task SignUp_EnablesFlexibleCollectionsFeatures
         (PlanType planType, OrganizationSignup signup, SutProvider<OrganizationService> sutProvider)
     {
         signup.Plan = planType;
@@ -268,6 +267,10 @@ public class OrganizationServiceTests
             .CreateAsync(Arg.Do<OrganizationUser>(ou => orgUserId = ou.Id));
 
         var result = await sutProvider.Sut.SignUpAsync(signup);
+
+        // Assert: Organization.FlexibleCollections is enabled
+        await sutProvider.GetDependency<IOrganizationRepository>().Received(1)
+            .CreateAsync(Arg.Is<Organization>(o => o.FlexibleCollections));
 
         // Assert: AccessAll is not used
         await sutProvider.GetDependency<IOrganizationUserRepository>().Received(1).CreateAsync(
@@ -290,10 +293,6 @@ public class OrganizationServiceTests
 
         Assert.NotNull(result.Item1);
         Assert.NotNull(result.Item2);
-
-        await sutProvider.GetDependency<IOrganizationRepository>()
-            .Received(1)
-            .CreateAsync(Arg.Is<Organization>(o => o.FlexibleCollections));
     }
 
     [Theory]
@@ -319,10 +318,9 @@ public class OrganizationServiceTests
 
         await sutProvider.GetDependency<IOrganizationRepository>().Received(1).CreateAsync(
             Arg.Is<Organization>(o =>
-                o.Seats == plan.PasswordManager.BaseSeats + signup.AdditionalSeats &&
-                o.SmSeats == plan.SecretsManager.BaseSeats + signup.AdditionalSmSeats &&
-                o.SmServiceAccounts == plan.SecretsManager.BaseServiceAccount + signup.AdditionalServiceAccounts &&
-                o.FlexibleCollections));
+                o.Seats == plan.PasswordManager.BaseSeats + signup.AdditionalSeats
+                && o.SmSeats == plan.SecretsManager.BaseSeats + signup.AdditionalSmSeats
+                && o.SmServiceAccounts == plan.SecretsManager.BaseServiceAccount + signup.AdditionalServiceAccounts));
         await sutProvider.GetDependency<IOrganizationUserRepository>().Received(1).CreateAsync(
             Arg.Is<OrganizationUser>(o => o.AccessSecretsManager == signup.UseSecretsManager));
 
@@ -443,8 +441,7 @@ public class OrganizationServiceTests
             org.UsePolicies == plan.HasPolicies &&
             org.PublicKey == signup.PublicKey &&
             org.PrivateKey == signup.PrivateKey &&
-            org.UseSecretsManager == false &&
-            org.FlexibleCollections));
+            org.UseSecretsManager == false));
 
         await sutProvider.GetDependency<IOrganizationApiKeyRepository>().Received(1)
             .CreateAsync(Arg.Is<OrganizationApiKey>(orgApiKey =>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Remove the `FlexibleCollectionsSignUp` feature flag.

This was only ever used server-side to set `Organization` properties on creation, so it doesn't need to be persisted for any clients.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* set `Organization.FlexibleCollections` to `true`
* set `Organization.LimitCollectionCreationDeletion` to `false` (thereby enabling new FC behaviour) - this is done by actually removing the explicit assignment, which defaults to `false`
* remove references from test code, including an old test which will now never run. Update existing test to include this assertion

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
