### PR TITLE
[AC-2626] Re-run collection enhancements migration

### DIFF
--- a/util/Migrator/DbScripts/2024-05-21_00_EnableAllOrgCollectionEnhancements.sql
+++ b/util/Migrator/DbScripts/2024-05-21_00_EnableAllOrgCollectionEnhancements.sql
@@ -1,0 +1,42 @@
+-- This script will enable collection enhancements for organizations that don't have Collection Enhancements enabled.
+-- This is a copy/paste of an earlier migration script: 2024-04-25_00_EnableAllOrgCollectionEnhancements.sql.
+-- The earlier migration was accidentally released for self-host before the feature was enabled for new organizations,
+-- so there was a window in time where existing self-host organizations were migrated, but it was still possible to create
+-- a new organization that needed migration.
+-- This script is being re-run to catch any organizations created during that window.
+
+-- Step 1: Create a temporary table to store the Organizations with FlexibleCollections = 0
+SELECT [Id] AS [OrganizationId]
+INTO #TempOrg
+FROM [dbo].[Organization]
+WHERE [FlexibleCollections] = 0
+
+-- Step 2: Execute the stored procedure for each OrganizationId
+DECLARE @OrganizationId UNIQUEIDENTIFIER;
+
+DECLARE OrgCursor CURSOR FOR
+SELECT [OrganizationId]
+FROM #TempOrg;
+
+OPEN OrgCursor;
+
+FETCH NEXT FROM OrgCursor INTO @OrganizationId;
+
+WHILE (@@FETCH_STATUS = 0)
+BEGIN
+    -- Execute the stored procedure for the current OrganizationId
+    EXEC [dbo].[Organization_EnableCollectionEnhancements] @OrganizationId;
+
+    -- Update the Organization to set FlexibleCollections = 1
+    UPDATE [dbo].[Organization]
+    SET [FlexibleCollections] = 1
+    WHERE [Id] = @OrganizationId;
+
+    FETCH NEXT FROM OrgCursor INTO @OrganizationId;
+END;
+
+CLOSE OrgCursor;
+DEALLOCATE OrgCursor;
+
+-- Step 3: Drop the temporary table
+DROP TABLE #TempOrg;


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Due to a bug in our Github workflows, any self-host servers that upgraded to 2024.4.2 between (approx.) May 8 and May 16 had their existing organizations migrated to Flexible Collections early. However, this didn’t enable FC for new orgs (i.e. set the FlexibleCollectionsSignUp flag to true). The 2024.5.0 release handled this, but any orgs created between these dates still need migration.

This PR duplicates earlier migration scripts to effectively re-run them and catch any orgs needing migration. They do not affect orgs that have already been migrated.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
