### PR TITLE
[AC-2678] Enterprise to Families Sponsorship Bugs

### DIFF
--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -497,7 +497,6 @@ public class AccountController : Controller
             var occupiedSeats = await _organizationUserRepository.GetOccupiedSeatCountByOrganizationIdAsync(organization.Id);
             var initialSeatCount = organization.Seats.Value;
             var availableSeats = initialSeatCount - occupiedSeats;
-            var prorationDate = DateTime.UtcNow;
             if (availableSeats < 1)
             {
                 try
@@ -507,13 +506,13 @@ public class AccountController : Controller
                         throw new Exception("Cannot autoscale on self-hosted instance.");
                     }
 
-                    await _organizationService.AutoAddSeatsAsync(organization, 1, prorationDate);
+                    await _organizationService.AutoAddSeatsAsync(organization, 1);
                 }
                 catch (Exception e)
                 {
                     if (organization.Seats.Value != initialSeatCount)
                     {
-                        await _organizationService.AdjustSeatsAsync(orgId, initialSeatCount - organization.Seats.Value, prorationDate);
+                        await _organizationService.AdjustSeatsAsync(orgId, initialSeatCount - organization.Seats.Value);
                     }
                     _logger.LogInformation(e, "SSO auto provisioning failed");
                     throw new Exception(_i18nService.T("NoSeatsAvailable", organization.DisplayName()));

--- a/src/Api/Billing/Controllers/OrganizationSponsorshipsController.cs
+++ b/src/Api/Billing/Controllers/OrganizationSponsorshipsController.cs
@@ -13,7 +13,7 @@ using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Bit.Api.Controllers;
+namespace Bit.Api.Billing.Controllers;
 
 [Route("organization/sponsorship")]
 public class OrganizationSponsorshipsController : Controller

--- a/src/Billing/Controllers/StripeController.cs
+++ b/src/Billing/Controllers/StripeController.cs
@@ -1196,7 +1196,9 @@ public class StripeController : Controller
     }
 
     private static bool IsSponsoredSubscription(Subscription subscription) =>
-        StaticStore.SponsoredPlans.Any(p => p.StripePlanId == subscription.Id);
+        StaticStore.SponsoredPlans
+            .Any(p => subscription.Items
+                .Any(i => i.Plan.Id == p.StripePlanId));
 
     /// <summary>
     /// Handles the <see cref="HandledStripeWebhook.PaymentFailed"/> event type from Stripe.

--- a/src/Core/AdminConsole/Services/IOrganizationService.cs
+++ b/src/Core/AdminConsole/Services/IOrganizationService.cs
@@ -17,8 +17,8 @@ public interface IOrganizationService
     Task ReinstateSubscriptionAsync(Guid organizationId);
     Task<string> AdjustStorageAsync(Guid organizationId, short storageAdjustmentGb);
     Task UpdateSubscription(Guid organizationId, int seatAdjustment, int? maxAutoscaleSeats);
-    Task AutoAddSeatsAsync(Organization organization, int seatsToAdd, DateTime? prorationDate = null);
-    Task<string> AdjustSeatsAsync(Guid organizationId, int seatAdjustment, DateTime? prorationDate = null);
+    Task AutoAddSeatsAsync(Organization organization, int seatsToAdd);
+    Task<string> AdjustSeatsAsync(Guid organizationId, int seatAdjustment);
     Task VerifyBankAsync(Guid organizationId, int amount1, int amount2);
     /// <summary>
     /// Create a new organization in a cloud environment

--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -282,7 +282,7 @@ public class OrganizationService : IOrganizationService
         await ReplaceAndUpdateCacheAsync(organization);
     }
 
-    public async Task<string> AdjustSeatsAsync(Guid organizationId, int seatAdjustment, DateTime? prorationDate = null)
+    public async Task<string> AdjustSeatsAsync(Guid organizationId, int seatAdjustment)
     {
         var organization = await GetOrgById(organizationId);
         if (organization == null)
@@ -290,10 +290,10 @@ public class OrganizationService : IOrganizationService
             throw new NotFoundException();
         }
 
-        return await AdjustSeatsAsync(organization, seatAdjustment, prorationDate);
+        return await AdjustSeatsAsync(organization, seatAdjustment);
     }
 
-    private async Task<string> AdjustSeatsAsync(Organization organization, int seatAdjustment, DateTime? prorationDate = null, IEnumerable<string> ownerEmails = null)
+    private async Task<string> AdjustSeatsAsync(Organization organization, int seatAdjustment, IEnumerable<string> ownerEmails = null)
     {
         if (organization.Seats == null)
         {
@@ -349,7 +349,7 @@ public class OrganizationService : IOrganizationService
             }
         }
 
-        var paymentIntentClientSecret = await _paymentService.AdjustSeatsAsync(organization, plan, additionalSeats, prorationDate);
+        var paymentIntentClientSecret = await _paymentService.AdjustSeatsAsync(organization, plan, additionalSeats);
         await _referenceEventService.RaiseEventAsync(
             new ReferenceEvent(ReferenceEventType.AdjustSeats, organization, _currentContext)
             {
@@ -1121,7 +1121,6 @@ public class OrganizationService : IOrganizationService
             throw new AggregateException("One or more errors occurred while inviting users.", exceptions);
         }
 
-        var prorationDate = DateTime.UtcNow;
         try
         {
             await _organizationUserRepository.CreateManyAsync(orgUsers);
@@ -1140,11 +1139,10 @@ public class OrganizationService : IOrganizationService
                 throw new BadRequestException("Cannot add seats. Cannot manage organization users.");
             }
 
-            await AutoAddSeatsAsync(organization, newSeatsRequired, prorationDate);
+            await AutoAddSeatsAsync(organization, newSeatsRequired);
 
             if (additionalSmSeatsRequired > 0)
             {
-                smSubscriptionUpdate.ProrationDate = prorationDate;
                 await _updateSecretsManagerSubscriptionCommand.UpdateSubscriptionAsync(smSubscriptionUpdate);
             }
 
@@ -1166,7 +1164,7 @@ public class OrganizationService : IOrganizationService
             // Revert autoscaling
             if (initialSeatCount.HasValue && currentOrganization.Seats.HasValue && currentOrganization.Seats.Value != initialSeatCount.Value)
             {
-                await AdjustSeatsAsync(organization, initialSeatCount.Value - currentOrganization.Seats.Value, prorationDate);
+                await AdjustSeatsAsync(organization, initialSeatCount.Value - currentOrganization.Seats.Value);
             }
 
             // Revert SmSeat autoscaling
@@ -1175,8 +1173,7 @@ public class OrganizationService : IOrganizationService
             {
                 var smSubscriptionUpdateRevert = new SecretsManagerSubscriptionUpdate(currentOrganization, false)
                 {
-                    SmSeats = initialSmSeatCount.Value,
-                    ProrationDate = prorationDate
+                    SmSeats = initialSmSeatCount.Value
                 };
                 await _updateSecretsManagerSubscriptionCommand.UpdateSubscriptionAsync(smSubscriptionUpdateRevert);
             }
@@ -1417,7 +1414,7 @@ public class OrganizationService : IOrganizationService
         return (true, failureReason);
     }
 
-    public async Task AutoAddSeatsAsync(Organization organization, int seatsToAdd, DateTime? prorationDate = null)
+    public async Task AutoAddSeatsAsync(Organization organization, int seatsToAdd)
     {
         if (seatsToAdd < 1 || !organization.Seats.HasValue)
         {
@@ -1445,7 +1442,7 @@ public class OrganizationService : IOrganizationService
         }
         var initialSeatCount = organization.Seats.Value;
 
-        await AdjustSeatsAsync(organization, seatsToAdd, prorationDate, ownerEmails);
+        await AdjustSeatsAsync(organization, seatsToAdd, ownerEmails);
 
         if (!organization.OwnersNotifiedOfAutoscaling.HasValue)
         {
@@ -2373,7 +2370,7 @@ public class OrganizationService : IOrganizationService
         var availableSeats = organization.Seats.GetValueOrDefault(0) - occupiedSeats;
         if (availableSeats < 1)
         {
-            await AutoAddSeatsAsync(organization, 1, DateTime.UtcNow);
+            await AutoAddSeatsAsync(organization, 1);
         }
 
         await CheckPoliciesBeforeRestoreAsync(organizationUser, userService);
@@ -2400,7 +2397,7 @@ public class OrganizationService : IOrganizationService
         var occupiedSeats = await _organizationUserRepository.GetOccupiedSeatCountByOrganizationIdAsync(organization.Id);
         var availableSeats = organization.Seats.GetValueOrDefault(0) - occupiedSeats;
         var newSeatsRequired = organizationUserIds.Count() - availableSeats;
-        await AutoAddSeatsAsync(organization, newSeatsRequired, DateTime.UtcNow);
+        await AutoAddSeatsAsync(organization, newSeatsRequired);
 
         var deletingUserIsOwner = false;
         if (restoringUserId.HasValue)

--- a/src/Core/Models/Business/SecretsManagerSubscriptionUpdate.cs
+++ b/src/Core/Models/Business/SecretsManagerSubscriptionUpdate.cs
@@ -30,11 +30,6 @@ public class SecretsManagerSubscriptionUpdate
     public int? MaxAutoscaleSmServiceAccounts { get; set; }
 
     /// <summary>
-    /// The proration date for the subscription update (optional)
-    /// </summary>
-    public DateTime? ProrationDate { get; set; }
-
-    /// <summary>
     /// Whether the subscription update is a result of autoscaling
     /// </summary>
     public bool Autoscaling { get; }

--- a/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpdateSecretsManagerSubscriptionCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpdateSecretsManagerSubscriptionCommand.cs
@@ -66,7 +66,7 @@ public class UpdateSecretsManagerSubscriptionCommand : IUpdateSecretsManagerSubs
     {
         if (update.SmSeatsChanged)
         {
-            await _paymentService.AdjustSmSeatsAsync(update.Organization, update.Plan, update.SmSeatsExcludingBase, update.ProrationDate);
+            await _paymentService.AdjustSmSeatsAsync(update.Organization, update.Plan, update.SmSeatsExcludingBase);
 
             // TODO: call ReferenceEventService - see AC-1481
         }
@@ -74,7 +74,7 @@ public class UpdateSecretsManagerSubscriptionCommand : IUpdateSecretsManagerSubs
         if (update.SmServiceAccountsChanged)
         {
             await _paymentService.AdjustServiceAccountsAsync(update.Organization, update.Plan,
-                update.SmServiceAccountsExcludingBase, update.ProrationDate);
+                update.SmServiceAccountsExcludingBase);
 
             // TODO: call ReferenceEventService - see AC-1481
         }

--- a/src/Core/Services/IPaymentService.cs
+++ b/src/Core/Services/IPaymentService.cs
@@ -26,20 +26,17 @@ public interface IPaymentService
         bool subscribedToSecretsManager,
         int? newlyPurchasedSecretsManagerSeats,
         int? newlyPurchasedAdditionalSecretsManagerServiceAccounts,
-        int newlyPurchasedAdditionalStorage,
-        DateTime? prorationDate = null);
-    Task<string> AdjustSeatsAsync(Organization organization, Plan plan, int additionalSeats, DateTime? prorationDate = null);
+        int newlyPurchasedAdditionalStorage);
+    Task<string> AdjustSeatsAsync(Organization organization, Plan plan, int additionalSeats);
     Task<string> AdjustSeats(
         Provider provider,
         Plan plan,
         int currentlySubscribedSeats,
-        int newlySubscribedSeats,
-        DateTime? prorationDate = null);
-    Task<string> AdjustSmSeatsAsync(Organization organization, Plan plan, int additionalSeats, DateTime? prorationDate = null);
-    Task<string> AdjustStorageAsync(IStorableSubscriber storableSubscriber, int additionalStorage, string storagePlanId, DateTime? prorationDate = null);
+        int newlySubscribedSeats);
+    Task<string> AdjustSmSeatsAsync(Organization organization, Plan plan, int additionalSeats);
+    Task<string> AdjustStorageAsync(IStorableSubscriber storableSubscriber, int additionalStorage, string storagePlanId);
 
-    Task<string> AdjustServiceAccountsAsync(Organization organization, Plan plan, int additionalServiceAccounts,
-        DateTime? prorationDate = null);
+    Task<string> AdjustServiceAccountsAsync(Organization organization, Plan plan, int additionalServiceAccounts);
     Task CancelSubscriptionAsync(ISubscriber subscriber, bool endOfPeriod = false);
     Task ReinstateSubscriptionAsync(ISubscriber subscriber);
     Task<bool> UpdatePaymentMethodAsync(ISubscriber subscriber, PaymentMethodType paymentMethodType,
@@ -54,7 +51,7 @@ public interface IPaymentService
     Task UpdateTaxRateAsync(TaxRate taxRate);
     Task ArchiveTaxRateAsync(TaxRate taxRate);
     Task<string> AddSecretsManagerToSubscription(Organization org, Plan plan, int additionalSmSeats,
-        int additionalServiceAccount, DateTime? prorationDate = null);
+        int additionalServiceAccount);
     Task<bool> RisksSubscriptionFailure(Organization organization);
     Task<bool> HasSecretsManagerStandalone(Organization organization);
 }

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -226,7 +226,10 @@ public class StripePaymentService : IPaymentService
         }
     }
 
-    private async Task ChangeOrganizationSponsorship(Organization org, OrganizationSponsorship sponsorship, bool applySponsorship)
+    private async Task ChangeOrganizationSponsorship(
+        Organization org,
+        OrganizationSponsorship sponsorship,
+        bool applySponsorship)
     {
         var existingPlan = Utilities.StaticStore.GetPlan(org.PlanType);
         var sponsoredPlan = sponsorship != null ?
@@ -234,7 +237,7 @@ public class StripePaymentService : IPaymentService
             null;
         var subscriptionUpdate = new SponsorOrganizationSubscriptionUpdate(existingPlan, sponsoredPlan, applySponsorship);
 
-        await FinalizeSubscriptionChangeAsync(org, subscriptionUpdate, DateTime.UtcNow, true);
+        await FinalizeSubscriptionChangeAsync(org, subscriptionUpdate, true);
 
         var sub = await _stripeAdapter.SubscriptionGetAsync(org.GatewaySubscriptionId);
         org.ExpirationDate = sub.CurrentPeriodEnd;
@@ -759,7 +762,7 @@ public class StripePaymentService : IPaymentService
     }
 
     private async Task<string> FinalizeSubscriptionChangeAsync(ISubscriber subscriber,
-        SubscriptionUpdate subscriptionUpdate, DateTime? prorationDate, bool invoiceNow = false)
+        SubscriptionUpdate subscriptionUpdate, bool invoiceNow = false)
     {
         // remember, when in doubt, throw
         var subGetOptions = new SubscriptionGetOptions();
@@ -771,7 +774,6 @@ public class StripePaymentService : IPaymentService
             throw new GatewayException("Subscription not found.");
         }
 
-        prorationDate ??= DateTime.UtcNow;
         var collectionMethod = sub.CollectionMethod;
         var daysUntilDue = sub.DaysUntilDue;
         var chargeNow = collectionMethod == "charge_automatically";
@@ -786,8 +788,7 @@ public class StripePaymentService : IPaymentService
             ? Constants.AlwaysInvoice
             : Constants.CreateProrations,
             DaysUntilDue = daysUntilDue ?? 1,
-            CollectionMethod = "send_invoice",
-            ProrationDate = prorationDate,
+            CollectionMethod = "send_invoice"
         };
         if (!invoiceNow && isAnnualPlan && isPm5864DollarThresholdEnabled && sub.Status.Trim() != "trialing")
         {
@@ -907,9 +908,8 @@ public class StripePaymentService : IPaymentService
         bool subscribedToSecretsManager,
         int? newlyPurchasedSecretsManagerSeats,
         int? newlyPurchasedAdditionalSecretsManagerServiceAccounts,
-        int newlyPurchasedAdditionalStorage,
-        DateTime? prorationDate = null)
-        => FinalizeSubscriptionChangeAsync(
+        int newlyPurchasedAdditionalStorage) =>
+        FinalizeSubscriptionChangeAsync(
             organization,
             new CompleteSubscriptionUpdate(
                 organization,
@@ -919,41 +919,47 @@ public class StripePaymentService : IPaymentService
                     PurchasedPasswordManagerSeats = newlyPurchasedPasswordManagerSeats,
                     SubscribedToSecretsManager = subscribedToSecretsManager,
                     PurchasedSecretsManagerSeats = newlyPurchasedSecretsManagerSeats,
-                    PurchasedAdditionalSecretsManagerServiceAccounts = newlyPurchasedAdditionalSecretsManagerServiceAccounts,
+                    PurchasedAdditionalSecretsManagerServiceAccounts =
+                        newlyPurchasedAdditionalSecretsManagerServiceAccounts,
                     PurchasedAdditionalStorage = newlyPurchasedAdditionalStorage
-                }),
-            prorationDate, true);
+                }), true);
 
-    public Task<string> AdjustSeatsAsync(Organization organization, StaticStore.Plan plan, int additionalSeats, DateTime? prorationDate = null)
-    {
-        return FinalizeSubscriptionChangeAsync(organization, new SeatSubscriptionUpdate(organization, plan, additionalSeats), prorationDate);
-    }
+    public Task<string> AdjustSeatsAsync(Organization organization, StaticStore.Plan plan, int additionalSeats) =>
+        FinalizeSubscriptionChangeAsync(organization, new SeatSubscriptionUpdate(organization, plan, additionalSeats));
 
     public Task<string> AdjustSeats(
         Provider provider,
         StaticStore.Plan plan,
         int currentlySubscribedSeats,
-        int newlySubscribedSeats,
-        DateTime? prorationDate = null)
+        int newlySubscribedSeats)
         => FinalizeSubscriptionChangeAsync(
             provider,
-            new ProviderSubscriptionUpdate(plan.Type, currentlySubscribedSeats, newlySubscribedSeats),
-            prorationDate);
+            new ProviderSubscriptionUpdate(
+                plan.Type,
+                currentlySubscribedSeats,
+                newlySubscribedSeats));
 
-    public Task<string> AdjustSmSeatsAsync(Organization organization, StaticStore.Plan plan, int additionalSeats, DateTime? prorationDate = null)
-    {
-        return FinalizeSubscriptionChangeAsync(organization, new SmSeatSubscriptionUpdate(organization, plan, additionalSeats), prorationDate);
-    }
+    public Task<string> AdjustSmSeatsAsync(Organization organization, StaticStore.Plan plan, int additionalSeats) =>
+        FinalizeSubscriptionChangeAsync(
+            organization,
+            new SmSeatSubscriptionUpdate(organization, plan, additionalSeats));
 
-    public Task<string> AdjustServiceAccountsAsync(Organization organization, StaticStore.Plan plan, int additionalServiceAccounts, DateTime? prorationDate = null)
-    {
-        return FinalizeSubscriptionChangeAsync(organization, new ServiceAccountSubscriptionUpdate(organization, plan, additionalServiceAccounts), prorationDate);
-    }
+    public Task<string> AdjustServiceAccountsAsync(
+        Organization organization,
+        StaticStore.Plan plan,
+        int additionalServiceAccounts) =>
+        FinalizeSubscriptionChangeAsync(
+            organization,
+            new ServiceAccountSubscriptionUpdate(organization, plan, additionalServiceAccounts));
 
-    public Task<string> AdjustStorageAsync(IStorableSubscriber storableSubscriber, int additionalStorage,
-        string storagePlanId, DateTime? prorationDate = null)
+    public Task<string> AdjustStorageAsync(
+        IStorableSubscriber storableSubscriber,
+        int additionalStorage,
+        string storagePlanId)
     {
-        return FinalizeSubscriptionChangeAsync(storableSubscriber, new StorageSubscriptionUpdate(storagePlanId, additionalStorage), prorationDate);
+        return FinalizeSubscriptionChangeAsync(
+            storableSubscriber,
+            new StorageSubscriptionUpdate(storagePlanId, additionalStorage));
     }
 
     public async Task CancelAndRecoverChargesAsync(ISubscriber subscriber)
@@ -1734,13 +1740,15 @@ public class StripePaymentService : IPaymentService
         }
     }
 
-    public async Task<string> AddSecretsManagerToSubscription(Organization org, StaticStore.Plan plan, int additionalSmSeats,
-        int additionalServiceAccount, DateTime? prorationDate = null)
-    {
-        return await FinalizeSubscriptionChangeAsync(org,
-            new SecretsManagerSubscribeUpdate(org, plan, additionalSmSeats, additionalServiceAccount), prorationDate,
+    public async Task<string> AddSecretsManagerToSubscription(
+        Organization org,
+        StaticStore.Plan plan,
+        int additionalSmSeats,
+        int additionalServiceAccount) =>
+        await FinalizeSubscriptionChangeAsync(
+            org,
+            new SecretsManagerSubscribeUpdate(org, plan, additionalSmSeats, additionalServiceAccount),
             true);
-    }
 
     public async Task<bool> RisksSubscriptionFailure(Organization organization)
     {

--- a/test/Api.Test/Billing/Controllers/OrganizationSponsorshipsControllerTests.cs
+++ b/test/Api.Test/Billing/Controllers/OrganizationSponsorshipsControllerTests.cs
@@ -1,4 +1,4 @@
-﻿using Bit.Api.Controllers;
+﻿using Bit.Api.Billing.Controllers;
 using Bit.Api.Models.Request.Organizations;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.Context;
@@ -14,7 +14,7 @@ using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Api.Test.AdminConsole.Controllers;
+namespace Bit.Api.Test.Billing.Controllers;
 
 [ControllerCustomize(typeof(OrganizationSponsorshipsController))]
 [SutProviderCustomize]


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR resolves two bugs:

1. Depending on how fast the server could process the request, redeeming a sponsorship would sometimes fail. This was due to our manually setting `prorationDate` on the Stripe `SubscriptionUpdateOptions` object to the value of `DateTime.UtcNow`. Occasionally, the `DateTime.UtcNow` value would be _before_ the lower bound of the Stripe subscriptions billing cycle, causing Stripe to throw an exception since you cannot have a proration set to before the subscription began.

    After some investigation and testing, we found that `prorationDate` was always being set to `DateTime.UtcNow` throughout the app. By removing all references to `prorationDate` we're effectively setting it to `null` on the `SubscriptionUpdateOptions`. When Stripe receives an update to a subscription with a proration behavior, but no proration date set, then they set it to "now" on their end, ensuring that it will never be before the billing cycle begins.
    
    A potential reason you might want to set `prorationDate` would be to apply exactly the same proration that was previewed with the [upcoming invoice](https://docs.stripe.com/api/subscriptions/update#upcoming_invoice) endpoint. It can also be used to implement custom proration logic, such as prorating by day instead of by second, by providing the time that you wish to use for proration calculations. We have no need for this logic, so it's being culled.
    
2. After an organization was successfully sponsored if the sponsoring enterprise organization is then deleted, or the sponsorship relationship otherwise removed, the free families price would never be updated to be full price again.

    When we receive the `invoice.upcoming` webhook event from Stripe, we check if the invoice is for a sponsored organization. If it is for a sponsored organization, and the sponsoring enterprise organization is deleted or the sponsorship relationship otherwise removed, then we update the subscription to be a full priced family plan. This was broken since the webhook was looking to see if the subscription's ID matched our hard-coded IDs for a sponsored price, instead of checking the price IDs on the subscription itself.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

**Changes around removing `prorationDate`**

* **bitwarden_license\src\Sso\Controllers\AccountController.cs**
* **src\Core\AdminConsole\Services\IOrganizationService.cs**
* **src\Core\AdminConsole\Services\Implementations\OrganizationService.cs**
* **src\Core\Models\Business\SecretsManagerSubscriptionUpdate.cs**
* **src\Core\OrganizationFeatures\OrganizationSubscriptions\UpdateSecretsManagerSubscriptionCommand.cs**
* **src\Core\Services\IPaymentService.cs**
* **src\Core\Services\Implementations\StripePaymentService.cs**

**Change to update organization to full-priced Family plan**
* **src\Billing\Controllers\StripeController.cs**

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
