### PR TITLE
[AC-2651] Remove obsolete permissions code from ImportCiphersController

### DIFF
--- a/src/Api/Tools/Controllers/ImportCiphersController.cs
+++ b/src/Api/Tools/Controllers/ImportCiphersController.cs
@@ -24,7 +24,6 @@ public class ImportCiphersController : Controller
     private readonly GlobalSettings _globalSettings;
     private readonly ICollectionRepository _collectionRepository;
     private readonly IAuthorizationService _authorizationService;
-    private readonly IOrganizationRepository _organizationRepository;
 
     public ImportCiphersController(
         ICipherService cipherService,
@@ -43,7 +42,6 @@ public class ImportCiphersController : Controller
         _globalSettings = globalSettings;
         _collectionRepository = collectionRepository;
         _authorizationService = authorizationService;
-        _organizationRepository = organizationRepository;
     }
 
     [HttpPost("import")]
@@ -96,13 +94,6 @@ public class ImportCiphersController : Controller
         if (await _currentContext.AccessImportExport(orgId))
         {
             return true;
-        }
-
-        //If flexible collections is disabled the user cannot continue with the import
-        var orgFlexibleCollections = await _organizationRepository.GetByIdAsync(orgId);
-        if (!orgFlexibleCollections?.FlexibleCollections ?? false)
-        {
-            return false;
         }
 
         //Users allowed to import if they CanCreate Collections


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

All organizations have been migrated to collection enhancements (Flexible Collections initiative), so we are removing references to the organization-level flag `organization.FlexibleCollections`.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/Api/Tools/Controllers/ImportCiphersController.cs** - remove the flexible collections guard

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
