### PR TITLE
[AC-2317] Public API - remove old permissions code

### DIFF
--- a/src/Api/AdminConsole/Public/Controllers/GroupsController.cs
+++ b/src/Api/AdminConsole/Public/Controllers/GroupsController.cs
@@ -111,7 +111,7 @@ public class GroupsController : Controller
     {
         var group = model.ToGroup(_currentContext.OrganizationId.Value);
         var organization = await _organizationRepository.GetByIdAsync(_currentContext.OrganizationId.Value);
-        var associations = model.Collections?.Select(c => c.ToCollectionAccessSelection(organization.FlexibleCollections)).ToList();
+        var associations = model.Collections?.Select(c => c.ToCollectionAccessSelection()).ToList();
         await _createGroupCommand.CreateGroupAsync(group, organization, associations);
         var response = new GroupResponseModel(group, associations);
         return new JsonResult(response);
@@ -140,7 +140,7 @@ public class GroupsController : Controller
 
         var updatedGroup = model.ToGroup(existingGroup);
         var organization = await _organizationRepository.GetByIdAsync(_currentContext.OrganizationId.Value);
-        var associations = model.Collections?.Select(c => c.ToCollectionAccessSelection(organization.FlexibleCollections)).ToList();
+        var associations = model.Collections?.Select(c => c.ToCollectionAccessSelection()).ToList();
         await _updateGroupCommand.UpdateGroupAsync(updatedGroup, organization, associations);
         var response = new GroupResponseModel(updatedGroup, associations);
         return new JsonResult(response);

--- a/src/Api/AdminConsole/Public/Models/GroupBaseModel.cs
+++ b/src/Api/AdminConsole/Public/Models/GroupBaseModel.cs
@@ -12,12 +12,6 @@ public abstract class GroupBaseModel
     [StringLength(100)]
     public string Name { get; set; }
     /// <summary>
-    /// Determines if this group can access all collections within the organization, or only the associated
-    /// collections. If set to <c>true</c>, this option overrides any collection assignments. If your organization is using
-    /// the latest collection enhancements, you will not be allowed to set this property to <c>true</c>.
-    /// </summary>
-    public bool? AccessAll { get; set; }
-    /// <summary>
     /// External identifier for reference or linking this group to another system, such as a user directory.
     /// </summary>
     /// <example>external_id_123456</example>

--- a/src/Api/AdminConsole/Public/Models/MemberBaseModel.cs
+++ b/src/Api/AdminConsole/Public/Models/MemberBaseModel.cs
@@ -20,7 +20,6 @@ public abstract class MemberBaseModel
         }
 
         Type = GetFlexibleCollectionsUserType(user.Type, user.GetPermissions());
-        AccessAll = user.AccessAll;
         ExternalId = user.ExternalId;
         ResetPasswordEnrolled = user.ResetPasswordKey != null;
 
@@ -38,7 +37,6 @@ public abstract class MemberBaseModel
         }
 
         Type = GetFlexibleCollectionsUserType(user.Type, user.GetPermissions());
-        AccessAll = user.AccessAll;
         ExternalId = user.ExternalId;
         ResetPasswordEnrolled = user.ResetPasswordKey != null;
 
@@ -54,12 +52,6 @@ public abstract class MemberBaseModel
     /// </summary>
     [Required]
     public OrganizationUserType? Type { get; set; }
-    /// <summary>
-    /// Determines if this member can access all collections within the organization, or only the associated
-    /// collections. If set to <c>true</c>, this option overrides any collection assignments. If your organization is using
-    /// the latest collection enhancements, you will not be allowed to set this property to <c>true</c>.
-    /// </summary>
-    public bool? AccessAll { get; set; }
     /// <summary>
     /// External identifier for reference or linking this member to another system, such as a user directory.
     /// </summary>

--- a/src/Api/AdminConsole/Public/Models/MemberBaseModel.cs
+++ b/src/Api/AdminConsole/Public/Models/MemberBaseModel.cs
@@ -12,14 +12,14 @@ public abstract class MemberBaseModel
 {
     public MemberBaseModel() { }
 
-    public MemberBaseModel(OrganizationUser user, bool flexibleCollectionsEnabled)
+    public MemberBaseModel(OrganizationUser user)
     {
         if (user == null)
         {
             throw new ArgumentNullException(nameof(user));
         }
 
-        Type = flexibleCollectionsEnabled ? GetFlexibleCollectionsUserType(user.Type, user.GetPermissions()) : user.Type;
+        Type = GetFlexibleCollectionsUserType(user.Type, user.GetPermissions());
         AccessAll = user.AccessAll;
         ExternalId = user.ExternalId;
         ResetPasswordEnrolled = user.ResetPasswordKey != null;
@@ -30,14 +30,14 @@ public abstract class MemberBaseModel
         }
     }
 
-    public MemberBaseModel(OrganizationUserUserDetails user, bool flexibleCollectionsEnabled)
+    public MemberBaseModel(OrganizationUserUserDetails user)
     {
         if (user == null)
         {
             throw new ArgumentNullException(nameof(user));
         }
 
-        Type = flexibleCollectionsEnabled ? GetFlexibleCollectionsUserType(user.Type, user.GetPermissions()) : user.Type;
+        Type = GetFlexibleCollectionsUserType(user.Type, user.GetPermissions());
         AccessAll = user.AccessAll;
         ExternalId = user.ExternalId;
         ResetPasswordEnrolled = user.ResetPasswordKey != null;

--- a/src/Api/AdminConsole/Public/Models/Request/AssociationWithPermissionsRequestModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Request/AssociationWithPermissionsRequestModel.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Core.Exceptions;
-using Bit.Core.Models.Data;
+﻿using Bit.Core.Models.Data;
 
 namespace Bit.Api.AdminConsole.Public.Models.Request;
 

--- a/src/Api/AdminConsole/Public/Models/Request/AssociationWithPermissionsRequestModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Request/AssociationWithPermissionsRequestModel.cs
@@ -5,7 +5,7 @@ namespace Bit.Api.AdminConsole.Public.Models.Request;
 
 public class AssociationWithPermissionsRequestModel : AssociationWithPermissionsBaseModel
 {
-    public CollectionAccessSelection ToCollectionAccessSelection(bool migratedToFlexibleCollections)
+    public CollectionAccessSelection ToCollectionAccessSelection()
     {
         var collectionAccessSelection = new CollectionAccessSelection
         {
@@ -14,13 +14,6 @@ public class AssociationWithPermissionsRequestModel : AssociationWithPermissions
             HidePasswords = HidePasswords.GetValueOrDefault(),
             Manage = Manage.GetValueOrDefault()
         };
-
-        // Throws if the org has not migrated to use FC but has passed in a Manage value in the request
-        if (!migratedToFlexibleCollections && Manage.GetValueOrDefault())
-        {
-            throw new BadRequestException(
-                "Your organization must be using the latest collection enhancements to use the Manage property.");
-        }
 
         return collectionAccessSelection;
     }

--- a/src/Api/AdminConsole/Public/Models/Request/GroupCreateUpdateRequestModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Request/GroupCreateUpdateRequestModel.cs
@@ -20,7 +20,6 @@ public class GroupCreateUpdateRequestModel : GroupBaseModel
     public Group ToGroup(Group existingGroup)
     {
         existingGroup.Name = Name;
-        existingGroup.AccessAll = AccessAll.Value;
         existingGroup.ExternalId = ExternalId;
         return existingGroup;
     }

--- a/src/Api/AdminConsole/Public/Models/Request/MemberCreateRequestModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Request/MemberCreateRequestModel.cs
@@ -22,14 +22,13 @@ public class MemberCreateRequestModel : MemberUpdateRequestModel
         throw new NotImplementedException();
     }
 
-    public OrganizationUserInvite ToOrganizationUserInvite(bool flexibleCollectionsIsEnabled)
+    public OrganizationUserInvite ToOrganizationUserInvite()
     {
         var invite = new OrganizationUserInvite
         {
             Emails = new[] { Email },
             Type = Type.Value,
-            AccessAll = AccessAll.Value,
-            Collections = Collections?.Select(c => c.ToCollectionAccessSelection(flexibleCollectionsIsEnabled)).ToList(),
+            Collections = Collections?.Select(c => c.ToCollectionAccessSelection()).ToList(),
             Groups = Groups
         };
 

--- a/src/Api/AdminConsole/Public/Models/Request/MemberUpdateRequestModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Request/MemberUpdateRequestModel.cs
@@ -19,7 +19,6 @@ public class MemberUpdateRequestModel : MemberBaseModel, IValidatableObject
     public virtual OrganizationUser ToOrganizationUser(OrganizationUser existingUser)
     {
         existingUser.Type = Type.Value;
-        existingUser.AccessAll = AccessAll.Value;
         existingUser.ExternalId = ExternalId;
 
         // Permissions property is optional for backwards compatibility with existing usage

--- a/src/Api/AdminConsole/Public/Models/Response/GroupResponseModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Response/GroupResponseModel.cs
@@ -19,7 +19,6 @@ public class GroupResponseModel : GroupBaseModel, IResponseModel
 
         Id = group.Id;
         Name = group.Name;
-        AccessAll = group.AccessAll;
         ExternalId = group.ExternalId;
         Collections = collections?.Select(c => new AssociationWithPermissionsResponseModel(c));
     }

--- a/src/Api/AdminConsole/Public/Models/Response/MemberResponseModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Response/MemberResponseModel.cs
@@ -16,9 +16,7 @@ public class MemberResponseModel : MemberBaseModel, IResponseModel
     [JsonConstructor]
     public MemberResponseModel() { }
 
-    public MemberResponseModel(OrganizationUser user, IEnumerable<CollectionAccessSelection> collections,
-        bool flexibleCollectionsEnabled)
-        : base(user, flexibleCollectionsEnabled)
+    public MemberResponseModel(OrganizationUser user, IEnumerable<CollectionAccessSelection> collections) : base(user)
     {
         if (user == null)
         {
@@ -33,8 +31,7 @@ public class MemberResponseModel : MemberBaseModel, IResponseModel
     }
 
     public MemberResponseModel(OrganizationUserUserDetails user, bool twoFactorEnabled,
-        IEnumerable<CollectionAccessSelection> collections, bool flexibleCollectionsEnabled)
-        : base(user, flexibleCollectionsEnabled)
+        IEnumerable<CollectionAccessSelection> collections) : base(user)
     {
         if (user == null)
         {

--- a/src/Api/Public/Controllers/CollectionsController.cs
+++ b/src/Api/Public/Controllers/CollectionsController.cs
@@ -92,8 +92,7 @@ public class CollectionsController : Controller
             return new NotFoundResult();
         }
         var updatedCollection = model.ToCollection(existingCollection);
-        var organizationAbility = await _applicationCacheService.GetOrganizationAbilityAsync(_currentContext.OrganizationId.Value);
-        var associations = model.Groups?.Select(c => c.ToCollectionAccessSelection(organizationAbility?.FlexibleCollections ?? false)).ToList();
+        var associations = model.Groups?.Select(c => c.ToCollectionAccessSelection()).ToList();
         await _collectionService.SaveAsync(updatedCollection, associations);
         var response = new CollectionResponseModel(updatedCollection, associations);
         return new JsonResult(response);

--- a/test/Api.IntegrationTest/AdminConsole/Public/Controllers/MembersControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Public/Controllers/MembersControllerTests.cs
@@ -135,7 +135,6 @@ public class MembersControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
             Email = email,
             Type = OrganizationUserType.Custom,
             ExternalId = "myCustomUser",
-            AccessAll = false,
             Collections = [],
             Groups = []
         };
@@ -150,7 +149,6 @@ public class MembersControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
         Assert.Equal(email, result.Email);
         Assert.Equal(OrganizationUserType.Custom, result.Type);
         Assert.Equal("myCustomUser", result.ExternalId);
-        Assert.False(result.AccessAll);
         Assert.Empty(result.Collections);
 
         // Assert against the database values
@@ -160,7 +158,6 @@ public class MembersControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
         Assert.Equal(email, orgUser.Email);
         Assert.Equal(OrganizationUserType.Custom, orgUser.Type);
         Assert.Equal("myCustomUser", orgUser.ExternalId);
-        Assert.False(orgUser.AccessAll);
         Assert.Equal(OrganizationUserStatusType.Invited, orgUser.Status);
         Assert.Equal(_organization.Id, orgUser.OrganizationId);
     }
@@ -180,7 +177,6 @@ public class MembersControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
                 EditAnyCollection = true,
                 AccessEventLogs = true
             },
-            AccessAll = false,
             ExternalId = "example",
             Collections = []
         };
@@ -198,7 +194,6 @@ public class MembersControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
         AssertHelper.AssertPropertyEqual(
             new PermissionsModel { DeleteAnyCollection = true, EditAnyCollection = true, AccessEventLogs = true },
             result.Permissions);
-        Assert.False(result.AccessAll);
         Assert.Empty(result.Collections);
 
         // Assert against the database values
@@ -207,7 +202,6 @@ public class MembersControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
 
         Assert.Equal(OrganizationUserType.Custom, updatedOrgUser.Type);
         Assert.Equal("example", updatedOrgUser.ExternalId);
-        Assert.False(updatedOrgUser.AccessAll);
         Assert.Equal(OrganizationUserStatusType.Confirmed, updatedOrgUser.Status);
         Assert.Equal(_organization.Id, updatedOrgUser.OrganizationId);
     }
@@ -225,7 +219,6 @@ public class MembersControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
         var request = new MemberUpdateRequestModel
         {
             Type = OrganizationUserType.Custom,
-            AccessAll = false,
             ExternalId = "example",
             Collections = []
         };

--- a/test/Api.Test/AdminConsole/Public/Controllers/GroupsControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Public/Controllers/GroupsControllerTests.cs
@@ -5,7 +5,6 @@ using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.OrganizationFeatures.Groups.Interfaces;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Context;
-using Bit.Core.Exceptions;
 using Bit.Core.Models.Data;
 using Bit.Core.Repositories;
 using Bit.Test.Common.AutoFixture;
@@ -22,105 +21,7 @@ public class GroupsControllerTests
 {
     [Theory]
     [BitAutoData]
-    public async Task Post_Success_BeforeFlexibleCollectionMigration(Organization organization, GroupCreateUpdateRequestModel groupRequestModel, SutProvider<GroupsController> sutProvider)
-    {
-        // Organization has not migrated
-        organization.FlexibleCollections = false;
-
-        // Permissions do not contain Manage property
-        var expectedPermissions = (groupRequestModel.Collections ?? []).Select(model => new AssociationWithPermissionsRequestModel { Id = model.Id, ReadOnly = model.ReadOnly, HidePasswords = model.HidePasswords.GetValueOrDefault() });
-        groupRequestModel.Collections = expectedPermissions;
-
-        sutProvider.GetDependency<ICurrentContext>().OrganizationId.Returns(organization.Id);
-        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
-
-        var response = await sutProvider.Sut.Post(groupRequestModel) as JsonResult;
-        var responseValue = response.Value as GroupResponseModel;
-
-        await sutProvider.GetDependency<ICreateGroupCommand>().Received(1).CreateGroupAsync(
-            Arg.Is<Group>(g =>
-                g.OrganizationId == organization.Id && g.Name == groupRequestModel.Name &&
-                g.AccessAll == groupRequestModel.AccessAll && g.ExternalId == groupRequestModel.ExternalId),
-            organization,
-            Arg.Any<ICollection<CollectionAccessSelection>>());
-
-        Assert.Equal(groupRequestModel.Name, responseValue.Name);
-        Assert.Equal(groupRequestModel.AccessAll, responseValue.AccessAll);
-        Assert.Equal(groupRequestModel.ExternalId, responseValue.ExternalId);
-    }
-
-    [Theory]
-    [BitAutoData]
-    public async Task Post_Throws_BadRequestException_BeforeFlexibleCollectionMigration_Manage(Organization organization, GroupCreateUpdateRequestModel groupRequestModel, SutProvider<GroupsController> sutProvider)
-    {
-        // Organization has not migrated
-        organization.FlexibleCollections = false;
-
-        // Contains at least one can manage
-        groupRequestModel.Collections.First().Manage = true;
-
-        sutProvider.GetDependency<ICurrentContext>().OrganizationId.Returns(organization.Id);
-        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
-
-        await sutProvider.GetDependency<ICreateGroupCommand>().DidNotReceiveWithAnyArgs().CreateGroupAsync(default, default, default, default);
-        await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.Post(groupRequestModel));
-    }
-
-    [Theory]
-    [BitAutoData]
-    public async Task Put_Success_BeforeFlexibleCollectionMigration(Organization organization, Group group, GroupCreateUpdateRequestModel groupRequestModel, SutProvider<GroupsController> sutProvider)
-    {
-        // Organization has not migrated
-        organization.FlexibleCollections = false;
-
-        // Permissions do not contain Manage property
-        var expectedPermissions = (groupRequestModel.Collections ?? []).Select(model => new AssociationWithPermissionsRequestModel { Id = model.Id, ReadOnly = model.ReadOnly, HidePasswords = model.HidePasswords.GetValueOrDefault() });
-        groupRequestModel.Collections = expectedPermissions;
-
-        group.OrganizationId = organization.Id;
-
-        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
-        sutProvider.GetDependency<IGroupRepository>().GetByIdAsync(group.Id).Returns(group);
-        sutProvider.GetDependency<ICurrentContext>().OrganizationId.Returns(organization.Id);
-
-        var response = await sutProvider.Sut.Put(group.Id, groupRequestModel) as JsonResult;
-        var responseValue = response.Value as GroupResponseModel;
-
-        await sutProvider.GetDependency<IUpdateGroupCommand>().Received(1).UpdateGroupAsync(
-            Arg.Is<Group>(g =>
-                g.OrganizationId == organization.Id && g.Name == groupRequestModel.Name &&
-                g.AccessAll == groupRequestModel.AccessAll && g.ExternalId == groupRequestModel.ExternalId),
-            Arg.Is<Organization>(o => o.Id == organization.Id),
-            Arg.Any<ICollection<CollectionAccessSelection>>());
-
-        Assert.Equal(groupRequestModel.Name, responseValue.Name);
-        Assert.Equal(groupRequestModel.AccessAll, responseValue.AccessAll);
-        Assert.Equal(groupRequestModel.ExternalId, responseValue.ExternalId);
-    }
-
-    [Theory]
-    [BitAutoData]
-    public async Task Put_Throws_BadRequestException_BeforeFlexibleCollectionMigration_Manage(Organization organization, Group group, GroupCreateUpdateRequestModel groupRequestModel, SutProvider<GroupsController> sutProvider)
-    {
-        // Organization has not migrated
-        organization.FlexibleCollections = false;
-
-        // Contains at least one can manage
-        groupRequestModel.Collections.First().Manage = true;
-
-        group.OrganizationId = organization.Id;
-
-        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
-        sutProvider.GetDependency<IGroupRepository>().GetByIdAsync(group.Id).Returns(group);
-        sutProvider.GetDependency<ICurrentContext>().OrganizationId.Returns(organization.Id);
-
-        await sutProvider.GetDependency<IUpdateGroupCommand>().DidNotReceiveWithAnyArgs().UpdateGroupAsync(default, default, default, default);
-        await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.Put(group.Id, groupRequestModel));
-    }
-
-    [Theory]
-    [BitAutoData]
-    public async Task Post_Success_AfterFlexibleCollectionMigration(Organization organization, GroupCreateUpdateRequestModel groupRequestModel, SutProvider<GroupsController> sutProvider)
+    public async Task Post_Success(Organization organization, GroupCreateUpdateRequestModel groupRequestModel, SutProvider<GroupsController> sutProvider)
     {
         // Organization has migrated
         organization.FlexibleCollections = true;
@@ -137,18 +38,17 @@ public class GroupsControllerTests
         await sutProvider.GetDependency<ICreateGroupCommand>().Received(1).CreateGroupAsync(
             Arg.Is<Group>(g =>
                 g.OrganizationId == organization.Id && g.Name == groupRequestModel.Name &&
-                g.AccessAll == groupRequestModel.AccessAll && g.ExternalId == groupRequestModel.ExternalId),
+                g.ExternalId == groupRequestModel.ExternalId),
             organization,
             Arg.Any<ICollection<CollectionAccessSelection>>());
 
         Assert.Equal(groupRequestModel.Name, responseValue.Name);
-        Assert.Equal(groupRequestModel.AccessAll, responseValue.AccessAll);
         Assert.Equal(groupRequestModel.ExternalId, responseValue.ExternalId);
     }
 
     [Theory]
     [BitAutoData]
-    public async Task Put_Success_AfterFlexibleCollectionMigration(Organization organization, Group group, GroupCreateUpdateRequestModel groupRequestModel, SutProvider<GroupsController> sutProvider)
+    public async Task Put_Success(Organization organization, Group group, GroupCreateUpdateRequestModel groupRequestModel, SutProvider<GroupsController> sutProvider)
     {
         // Organization has migrated
         organization.FlexibleCollections = true;
@@ -168,12 +68,11 @@ public class GroupsControllerTests
         await sutProvider.GetDependency<IUpdateGroupCommand>().Received(1).UpdateGroupAsync(
             Arg.Is<Group>(g =>
                 g.OrganizationId == organization.Id && g.Name == groupRequestModel.Name &&
-                g.AccessAll == groupRequestModel.AccessAll && g.ExternalId == groupRequestModel.ExternalId),
+                g.ExternalId == groupRequestModel.ExternalId),
             Arg.Is<Organization>(o => o.Id == organization.Id),
             Arg.Any<ICollection<CollectionAccessSelection>>());
 
         Assert.Equal(groupRequestModel.Name, responseValue.Name);
-        Assert.Equal(groupRequestModel.AccessAll, responseValue.AccessAll);
         Assert.Equal(groupRequestModel.ExternalId, responseValue.ExternalId);
     }
 }


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Remove deprecated permissions code from the Public API now that collection enhancements have fully rolled out.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* remove `organization.FlexibleCollections` checks - all organizations are now using these features.
* remove `AccessAll` property from the Public API (groups and members)
* the Manager enum is unchanged because that's still being referenced by core code - it'll be removed later
* `GetFlexibleCollectionsUserType` also stays until we properly migrate custom users.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
