### PR TITLE
[AC-2706] [Defect] ProviderId does not populate when payment for provider subscription is created/updated

### DIFF
--- a/src/Billing/Controllers/StripeController.cs
+++ b/src/Billing/Controllers/StripeController.cs
@@ -582,6 +582,7 @@ public class StripeController : Controller
                 CreationDate = refund.Created,
                 OrganizationId = parentTransaction.OrganizationId,
                 UserId = parentTransaction.UserId,
+                ProviderId = parentTransaction.ProviderId,
                 Type = TransactionType.Refund,
                 Gateway = GatewayType.Stripe,
                 GatewayId = refund.Id,
@@ -606,7 +607,7 @@ public class StripeController : Controller
         }
 
         var (organizationId, userId, providerId) = await GetEntityIdsFromChargeAsync(charge);
-        if (!organizationId.HasValue && !userId.HasValue)
+        if (!organizationId.HasValue && !userId.HasValue && !providerId.HasValue)
         {
             _logger.LogWarning("Charge success has no subscriber ids. {ChargeId}", charge.Id);
             return;

--- a/test/Billing.Test/Controllers/PayPalControllerTests.cs
+++ b/test/Billing.Test/Controllers/PayPalControllerTests.cs
@@ -2,6 +2,7 @@
 using Bit.Billing.Controllers;
 using Bit.Billing.Test.Utilities;
 using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Repositories;
@@ -32,6 +33,7 @@ public class PayPalControllerTests
     private readonly IPaymentService _paymentService = Substitute.For<IPaymentService>();
     private readonly ITransactionRepository _transactionRepository = Substitute.For<ITransactionRepository>();
     private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly IProviderRepository _providerRepository = Substitute.For<IProviderRepository>();
 
     private const string _defaultWebhookKey = "webhook-key";
 
@@ -110,7 +112,7 @@ public class PayPalControllerTests
 
         HasStatusCode(result, 400);
 
-        LoggedError(logger, "PayPal IPN (2PK15573S8089712Y): 'custom' did not contain a User ID or Organization ID");
+        LoggedError(logger, "PayPal IPN (2PK15573S8089712Y): 'custom' did not contain a User ID or Organization ID or provider ID");
     }
 
     [Fact]
@@ -542,7 +544,8 @@ public class PayPalControllerTests
             _organizationRepository,
             _paymentService,
             _transactionRepository,
-            _userRepository);
+            _userRepository,
+            _providerRepository);
 
         var httpContext = new DefaultHttpContext();
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/AC-2706

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Resolve the issue of ProviderId does not populate when payment for provider subscription is created/updated

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
