### PR TITLE
[AC-2286] Include the OrganizationUserId for each Organization in the user sync data

### DIFF
--- a/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
@@ -139,7 +139,7 @@ public class ProfileOrganizationResponseModel : ResponseModel
     public Permissions Permissions { get; set; }
     public bool ResetPasswordEnrolled { get; set; }
     public Guid? UserId { get; set; }
-    public Guid? OrganizationUserId { get; set; }
+    public Guid OrganizationUserId { get; set; }
     public bool HasPublicAndPrivateKeys { get; set; }
     public Guid? ProviderId { get; set; }
     [JsonConverter(typeof(HtmlEncodingStringConverter))]

--- a/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
@@ -48,6 +48,7 @@ public class ProfileOrganizationResponseModel : ResponseModel
         Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(organization.Permissions);
         ResetPasswordEnrolled = organization.ResetPasswordKey != null;
         UserId = organization.UserId;
+        OrganizationUserId = organization.OrganizationUserId;
         ProviderId = organization.ProviderId;
         ProviderName = organization.ProviderName;
         ProviderType = organization.ProviderType;
@@ -138,6 +139,7 @@ public class ProfileOrganizationResponseModel : ResponseModel
     public Permissions Permissions { get; set; }
     public bool ResetPasswordEnrolled { get; set; }
     public Guid? UserId { get; set; }
+    public Guid? OrganizationUserId { get; set; }
     public bool HasPublicAndPrivateKeys { get; set; }
     public Guid? ProviderId { get; set; }
     [JsonConverter(typeof(HtmlEncodingStringConverter))]

--- a/src/Core/AdminConsole/Models/Data/Organizations/OrganizationUsers/OrganizationUserOrganizationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Organizations/OrganizationUsers/OrganizationUserOrganizationDetails.cs
@@ -8,7 +8,7 @@ public class OrganizationUserOrganizationDetails
 {
     public Guid OrganizationId { get; set; }
     public Guid? UserId { get; set; }
-    public Guid? OrganizationUserId { get; set; }
+    public Guid OrganizationUserId { get; set; }
     [JsonConverter(typeof(HtmlEncodingStringConverter))]
     public string Name { get; set; }
     public bool UsePolicies { get; set; }

--- a/src/Core/AdminConsole/Models/Data/Organizations/OrganizationUsers/OrganizationUserOrganizationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Organizations/OrganizationUsers/OrganizationUserOrganizationDetails.cs
@@ -8,6 +8,7 @@ public class OrganizationUserOrganizationDetails
 {
     public Guid OrganizationId { get; set; }
     public Guid? UserId { get; set; }
+    public Guid? OrganizationUserId { get; set; }
     [JsonConverter(typeof(HtmlEncodingStringConverter))]
     public string Name { get; set; }
     public bool UsePolicies { get; set; }

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/OrganizationUserOrganizationDetailsViewQuery.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/OrganizationUserOrganizationDetailsViewQuery.cs
@@ -23,6 +23,7 @@ public class OrganizationUserOrganizationDetailsViewQuery : IQuery<OrganizationU
                     {
                         UserId = ou.UserId,
                         OrganizationId = ou.OrganizationId,
+                        OrganizationUserId = ou.Id,
                         Name = o.Name,
                         Enabled = o.Enabled,
                         PlanType = o.PlanType,

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepositoryTests.cs
@@ -176,4 +176,82 @@ public class OrganizationUserRepositoryTests
             r.ResetPasswordKey == "resetpasswordkey2" &&
             r.EncryptedPrivateKey == "privatekey");
     }
+
+    [DatabaseTheory, DatabaseData]
+    public async Task GetManyDetailsByUserAsync_Works(IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository)
+    {
+        var user1 = await userRepository.CreateAsync(new User
+        {
+            Name = "Test User 1",
+            Email = $"test+{Guid.NewGuid()}@example.com",
+            ApiKey = "TEST",
+            SecurityStamp = "stamp",
+            Kdf = KdfType.PBKDF2_SHA256,
+            KdfIterations = 1,
+            KdfMemory = 2,
+            KdfParallelism = 3
+        });
+
+        var organization = await organizationRepository.CreateAsync(new Organization
+        {
+            Name = "Test Org",
+            BillingEmail = user1.Email, // TODO: EF does not enforce this being NOT NULl
+            Plan = "Test", // TODO: EF does not enforce this being NOT NULl
+            PrivateKey = "privatekey",
+        });
+
+        var orgUser1 = await organizationUserRepository.CreateAsync(new OrganizationUser
+        {
+            OrganizationId = organization.Id,
+            UserId = user1.Id,
+            Status = OrganizationUserStatusType.Confirmed,
+            ResetPasswordKey = "resetpasswordkey1",
+        });
+
+        var responseModel = await organizationUserRepository.GetManyDetailsByUserAsync(user1.Id);
+
+        Assert.NotNull(responseModel);
+        Assert.Single(responseModel);
+        var result = responseModel.Single();
+        Assert.Equal(organization.Id, result.OrganizationId);
+        Assert.Equal(user1.Id, result.UserId);
+        Assert.Equal(orgUser1.Id, result.OrganizationUserId);
+        Assert.Equal(organization.Name, result.Name);
+        Assert.Equal(organization.UsePolicies, result.UsePolicies);
+        Assert.Equal(organization.UseSso, result.UseSso);
+        Assert.Equal(organization.UseKeyConnector, result.UseKeyConnector);
+        Assert.Equal(organization.UseScim, result.UseScim);
+        Assert.Equal(organization.UseGroups, result.UseGroups);
+        Assert.Equal(organization.UseDirectory, result.UseDirectory);
+        Assert.Equal(organization.UseEvents, result.UseEvents);
+        Assert.Equal(organization.UseTotp, result.UseTotp);
+        Assert.Equal(organization.Use2fa, result.Use2fa);
+        Assert.Equal(organization.UseApi, result.UseApi);
+        Assert.Equal(organization.UseResetPassword, result.UseResetPassword);
+        Assert.Equal(organization.UseSecretsManager, result.UseSecretsManager);
+        Assert.Equal(organization.UsePasswordManager, result.UsePasswordManager);
+        Assert.Equal(organization.UsersGetPremium, result.UsersGetPremium);
+        Assert.Equal(organization.UseCustomPermissions, result.UseCustomPermissions);
+        Assert.Equal(organization.SelfHost, result.SelfHost);
+        Assert.Equal(organization.Seats, result.Seats);
+        Assert.Equal(organization.MaxCollections, result.MaxCollections);
+        Assert.Equal(organization.MaxStorageGb, result.MaxStorageGb);
+        Assert.Equal(organization.Identifier, result.Identifier);
+        Assert.Equal(orgUser1.Key, result.Key);
+        Assert.Equal(orgUser1.ResetPasswordKey, result.ResetPasswordKey);
+        Assert.Equal(organization.PublicKey, result.PublicKey);
+        Assert.Equal(organization.PrivateKey, result.PrivateKey);
+        Assert.Equal(orgUser1.Status, result.Status);
+        Assert.Equal(orgUser1.Type, result.Type);
+        Assert.Equal(organization.Enabled, result.Enabled);
+        Assert.Equal(organization.PlanType, result.PlanType);
+        Assert.Equal(orgUser1.Permissions, result.Permissions);
+        Assert.Equal(organization.SmSeats, result.SmSeats);
+        Assert.Equal(organization.SmServiceAccounts, result.SmServiceAccounts);
+        Assert.Equal(organization.LimitCollectionCreationDeletion, result.LimitCollectionCreationDeletion);
+        Assert.Equal(organization.AllowAdminAccessToAllCollectionItems, result.AllowAdminAccessToAllCollectionItems);
+        Assert.Equal(organization.FlexibleCollections, result.FlexibleCollections);
+    }
 }

--- a/util/Migrator/DbScripts/2024-05-30_00_OrganizationUserOrganizationDetailsView_AddOrgUserIdCol.sql
+++ b/util/Migrator/DbScripts/2024-05-30_00_OrganizationUserOrganizationDetailsView_AddOrgUserIdCol.sql
@@ -1,4 +1,5 @@
-﻿CREATE VIEW [dbo].[OrganizationUserOrganizationDetailsView]
+﻿-- Add OrganizationUserId column to OrganizationUserOrganizationDetailsView
+CREATE OR ALTER VIEW [dbo].[OrganizationUserOrganizationDetailsView]
 AS
 SELECT
     OU.[UserId],
@@ -63,3 +64,18 @@ LEFT JOIN
     [dbo].[SsoConfig] SS ON SS.[OrganizationId] = OU.[OrganizationId]
 LEFT JOIN
     [dbo].[OrganizationSponsorship] OS ON OS.[SponsoringOrganizationUserID] = OU.[Id]
+GO
+
+-- Refresh modules for SPROCs reliant on 'OrganizationUserOrganizationDetailsView'.
+IF OBJECT_ID('[dbo].[OrganizationUserOrganizationDetails_ReadByUserIdStatus]') IS NOT NULL
+BEGIN
+    EXECUTE sp_refreshsqlmodule N'[dbo].[OrganizationUserOrganizationDetails_ReadByUserIdStatus]';
+END
+GO
+
+IF OBJECT_ID('[dbo].[OrganizationUserOrganizationDetails_ReadByUserIdStatusOrganizationId]') IS NOT NULL
+BEGIN
+    EXECUTE sp_refreshsqlmodule N'[dbo].[OrganizationUserOrganizationDetails_ReadByUserIdStatusOrganizationId]';
+END
+GO
+


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/AC-2286

## 📔 Objective

These server changes are necessary for the CLI work on https://github.com/bitwarden/clients/pull/9409. It required a a way of getting the `OrganizationUserId` for the user creating the collection and its more efficient to include it in the sync data.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
