### PR TITLE
[AC-2654] Remove old permissions code from OrganizationUsersController

### DIFF
--- a/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
@@ -113,7 +113,6 @@ public class OrganizationUsersControllerTests
     public async Task Invite_Success(OrganizationAbility organizationAbility, OrganizationUserInviteRequestModel model,
         Guid userId, SutProvider<OrganizationUsersController> sutProvider)
     {
-        organizationAbility.FlexibleCollections = true;
         sutProvider.GetDependency<ICurrentContext>().ManageUsers(organizationAbility.Id).Returns(true);
         sutProvider.GetDependency<IApplicationCacheService>().GetOrganizationAbilityAsync(organizationAbility.Id)
             .Returns(organizationAbility);
@@ -139,7 +138,6 @@ public class OrganizationUsersControllerTests
     public async Task Invite_NotAuthorizedToGiveAccessToCollections_Throws(OrganizationAbility organizationAbility, OrganizationUserInviteRequestModel model,
         Guid userId, SutProvider<OrganizationUsersController> sutProvider)
     {
-        organizationAbility.FlexibleCollections = true;
         sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1).Returns(true);
         sutProvider.GetDependency<ICurrentContext>().ManageUsers(organizationAbility.Id).Returns(true);
         sutProvider.GetDependency<IApplicationCacheService>().GetOrganizationAbilityAsync(organizationAbility.Id)
@@ -161,10 +159,9 @@ public class OrganizationUsersControllerTests
         OrganizationUser organizationUser, OrganizationAbility organizationAbility,
         SutProvider<OrganizationUsersController> sutProvider, Guid savingUserId)
     {
-        organizationAbility.FlexibleCollections = false;
         sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1).Returns(false);
 
-        Put_Setup(sutProvider, organizationAbility, organizationUser, savingUserId, model, false);
+        Put_Setup(sutProvider, organizationAbility, organizationUser, savingUserId, model, true);
 
         // Save these for later - organizationUser object will be mutated
         var orgUserId = organizationUser.Id;
@@ -193,7 +190,6 @@ public class OrganizationUsersControllerTests
         // Updating self
         organizationUser.UserId = savingUserId;
         organizationAbility.AllowAdminAccessToAllCollectionItems = false;
-        organizationAbility.FlexibleCollections = true;
         sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1).Returns(true);
 
         Put_Setup(sutProvider, organizationAbility, organizationUser, savingUserId, model, false);
@@ -223,7 +219,6 @@ public class OrganizationUsersControllerTests
         // Updating self
         organizationUser.UserId = savingUserId;
         organizationAbility.AllowAdminAccessToAllCollectionItems = false;
-        organizationAbility.FlexibleCollections = true;
         sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1).Returns(true);
 
         Put_Setup(sutProvider, organizationAbility, organizationUser, savingUserId, model, true);
@@ -253,7 +248,6 @@ public class OrganizationUsersControllerTests
     {
         // Updating self
         organizationUser.UserId = savingUserId;
-        organizationAbility.FlexibleCollections = true;
         organizationAbility.AllowAdminAccessToAllCollectionItems = true;
         sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1).Returns(true);
 
@@ -282,7 +276,6 @@ public class OrganizationUsersControllerTests
         OrganizationUser organizationUser, OrganizationAbility organizationAbility,
         SutProvider<OrganizationUsersController> sutProvider, Guid savingUserId)
     {
-        organizationAbility.FlexibleCollections = true;
         sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1).Returns(true);
         Put_Setup(sutProvider, organizationAbility, organizationUser, savingUserId, model, false);
 
@@ -372,7 +365,6 @@ public class OrganizationUsersControllerTests
         OrganizationUser organizationUser, OrganizationAbility organizationAbility,
         SutProvider<OrganizationUsersController> sutProvider, Guid savingUserId)
     {
-        organizationAbility.FlexibleCollections = true;
         sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1).Returns(true);
         Put_Setup(sutProvider, organizationAbility, organizationUser, savingUserId, model, false);
 
@@ -396,7 +388,7 @@ public class OrganizationUsersControllerTests
 
     [Theory]
     [BitAutoData]
-    public async Task Get_WithFlexibleCollections_ReturnsUsers(
+    public async Task Get_ReturnsUsers(
         ICollection<OrganizationUserUserDetails> organizationUsers, OrganizationAbility organizationAbility,
         SutProvider<OrganizationUsersController> sutProvider)
     {
@@ -408,7 +400,7 @@ public class OrganizationUsersControllerTests
 
     [Theory]
     [BitAutoData]
-    public async Task Get_WithFlexibleCollections_HandlesNullPermissionsObject(
+    public async Task Get_HandlesNullPermissionsObject(
         ICollection<OrganizationUserUserDetails> organizationUsers, OrganizationAbility organizationAbility,
         SutProvider<OrganizationUsersController> sutProvider)
     {
@@ -421,7 +413,7 @@ public class OrganizationUsersControllerTests
 
     [Theory]
     [BitAutoData]
-    public async Task Get_WithFlexibleCollections_SetsDeprecatedCustomPermissionstoFalse(
+    public async Task Get_SetsDeprecatedCustomPermissionstoFalse(
         ICollection<OrganizationUserUserDetails> organizationUsers, OrganizationAbility organizationAbility,
         SutProvider<OrganizationUsersController> sutProvider)
     {
@@ -449,7 +441,7 @@ public class OrganizationUsersControllerTests
 
     [Theory]
     [BitAutoData]
-    public async Task Get_WithFlexibleCollections_DowngradesCustomUsersWithDeprecatedPermissions(
+    public async Task Get_DowngradesCustomUsersWithDeprecatedPermissions(
         ICollection<OrganizationUserUserDetails> organizationUsers, OrganizationAbility organizationAbility,
         SutProvider<OrganizationUsersController> sutProvider)
     {
@@ -544,7 +536,6 @@ public class OrganizationUsersControllerTests
         ICollection<OrganizationUserUserDetails> organizationUsers,
         SutProvider<OrganizationUsersController> sutProvider)
     {
-        organizationAbility.FlexibleCollections = true;
         foreach (var orgUser in organizationUsers)
         {
             orgUser.Permissions = null;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/AC-2654
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Remove pre-Flexible Collections code from OrganizationUsersController.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
