### PR TITLE
[SM-1211] Adding API endpoint to send out Access Request for SM to Admins, addi…

### DIFF
--- a/src/Api/Auth/Controllers/AccountsController.cs
+++ b/src/Api/Auth/Controllers/AccountsController.cs
@@ -255,6 +255,18 @@ public class AccountsController : Controller
         await _userService.SendEmailVerificationAsync(user);
     }
 
+    [HttpPost("request-sm-access")]
+    public async Task RequestSMAccessFromAdmins([FromBody] RequestSMAccessRequestModel model)
+    {
+        var user = await _userService.GetUserByPrincipalAsync(User);
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
+        await _userService.SendRequestAccessToSM(Guid.Parse(model.OrganizationId), user, model.EmailContent);
+    }
+
     [HttpPost("verify-email-token")]
     [AllowAnonymous]
     public async Task PostVerifyEmailToken([FromBody] VerifyEmailRequestModel model)

--- a/src/Api/Auth/Models/Request/Accounts/RequestSMAccessRequestModel.cs
+++ b/src/Api/Auth/Models/Request/Accounts/RequestSMAccessRequestModel.cs
@@ -1,0 +1,9 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Bit.Api.Auth.Models.Request.Accounts;
+
+public class RequestSMAccessRequestModel
+{
+    public string OrganizationId { get; set; }
+    public string EmailContent { get; set; }
+}

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -20,6 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="MailTemplates\Handlebars\SecretsManagerAccessRequest.html.hbs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AspNetCoreRateLimit.Redis" Version="2.0.0" />
     <PackageReference Include="AWSSDK.SimpleEmail" Version="3.7.300.95" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.301.8" />

--- a/src/Core/MailTemplates/Handlebars/SecretsManagerAccessRequest.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/SecretsManagerAccessRequest.html.hbs
@@ -1,0 +1,27 @@
+{{#>FullHtmlLayout}}
+
+<table width="100%" cellpadding="0" cellspacing="0" style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0; -webkit-text-size-adjust: none;" valign="top">
+            {{{UserNameRequestingAccess}}} has requested access to secrets manager: <br /><br />
+            <pre style="background-color: #ECECEC; max-width: 700px; overflow-wrap: break-word; border-radius: 10px; padding: 1em; margin-bottom: 2em; ">{{{EmailContent}}} - {{{UserNameRequestingAccess}}}</pre>
+        </td>
+        <br/>
+    </tr>
+    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        <td class="content-block" style="margin-bottom:1em; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0; -webkit-text-size-adjust: none;" valign="top" align="left">
+            <a href="{{{TrySecretsManagerUrl}}}/?utm_source=welcome_email&utm_medium=email" clicktracking=off target="_blank" rel="noopener" style="color: #ffffff; text-decoration: none; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; background-color: #175DDC; border-color: #175DDC; border-style: solid; border-width: 10px 20px; margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+                Contact Bitwarden
+            </a>
+            <br/>
+        </td>
+    </tr>
+    <tr style="margin-top:1em; margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        <td class="content-block last" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0; -webkit-text-size-adjust: none; font-weight: bold;" valign="top">
+            <br/> Stay safe and secure,<br style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;" />
+            The Bitwarden Team
+        </td>
+    </tr>
+</table>
+
+{{/FullHtmlLayout}}

--- a/src/Core/Models/Mail/RequestSecretsManagerAccessViewModel.cs
+++ b/src/Core/Models/Mail/RequestSecretsManagerAccessViewModel.cs
@@ -1,0 +1,9 @@
+﻿namespace Bit.Core.Models.Mail;
+
+public class RequestSecretsManagerAccessViewModel : BaseMailModel
+{
+    public string UserNameRequestingAccess { get; set; }
+    public string OrgName { get; set; }
+    public string EmailContent { get; set; }
+    public string TrySecretsManagerUrl { get; set; }
+}

--- a/src/Core/Services/IMailService.cs
+++ b/src/Core/Services/IMailService.cs
@@ -80,5 +80,6 @@ public interface IMailService
     Task SendTrialInitiationEmailAsync(string email);
     Task SendInitiateDeletProviderEmailAsync(string email, Provider provider, string token);
     Task SendInitiateDeleteOrganzationEmailAsync(string email, Organization organization, string token);
+    Task SendRequestSMAccessToAdminEmailAsync(IEnumerable<string> adminEmails, string organizationName, string userRequestingAccess, string emailContent);
 }
 

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -76,4 +76,5 @@ public interface IUserService
     Task SendOTPAsync(User user);
     Task<bool> VerifyOTPAsync(User user, string token);
     Task<bool> VerifySecretAsync(User user, string secret);
+    Task<bool> SendRequestAccessToSM(Guid organizationId, User user, string EmailContent);
 }

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -378,6 +378,21 @@ public class HandlebarsMailService : IMailService
         await _mailDeliveryService.SendEmailAsync(message);
     }
 
+    public async Task SendRequestSMAccessToAdminEmailAsync(IEnumerable<string> emails, string organizationName, string requestingUserName, string emailContent)
+    {
+        var message = CreateDefaultMessage("Access Requested for Secrets Manager", emails);
+        var model = new RequestSecretsManagerAccessViewModel
+        {
+            OrgName = CoreHelpers.SanitizeForEmail(organizationName, false),
+            UserNameRequestingAccess = CoreHelpers.SanitizeForEmail(requestingUserName, false),
+            EmailContent = CoreHelpers.SanitizeForEmail(emailContent),
+            TrySecretsManagerUrl = "https://bitwarden.com/contact-sales/"
+        };
+        await AddMessageContentAsync(message, "SecretsManagerAccessRequest", model);
+        message.Category = "SecretsManagerAccessRequest";
+        await _mailDeliveryService.SendEmailAsync(message);
+    }
+
     public async Task SendNewDeviceLoggedInEmail(string email, string deviceType, DateTime timestamp, string ip)
     {
         var message = CreateDefaultMessage($"New Device Logged In From {deviceType}", email);

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -392,6 +392,20 @@ public class UserService : UserManager<User>, IUserService, IDisposable
         await _mailService.SendMasterPasswordHintEmailAsync(email, user.MasterPasswordHint);
     }
 
+
+    public async Task<bool> SendRequestAccessToSM(Guid organizationId, User user, string emailContent)
+    {
+        var orgUsers = await _organizationUserRepository.GetManyDetailsByOrganizationAsync(organizationId);
+        var emailList = orgUsers.Where(o => o.Type <= OrganizationUserType.Admin || o.GetPermissions()?.ManageSso == true)
+            .Select(a => a.Email).Distinct().ToList();
+
+        var organization = await _organizationRepository.GetByIdAsync(organizationId);
+
+        await _mailService.SendRequestSMAccessToAdminEmailAsync(emailList, organization.Name, user.Name, emailContent);
+        return true;
+    }
+
+
     public async Task SendTwoFactorEmailAsync(User user)
     {
         var provider = user.GetTwoFactorProvider(TwoFactorProviderType.Email);

--- a/src/Core/Services/NoopImplementations/NoopMailService.cs
+++ b/src/Core/Services/NoopImplementations/NoopMailService.cs
@@ -275,5 +275,6 @@ public class NoopMailService : IMailService
     {
         return Task.FromResult(0);
     }
+    public Task SendRequestSMAccessToAdminEmailAsync(IEnumerable<string> adminEmails, string organizationName, string userRequestingAccess, string emailContent) => throw new NotImplementedException();
 }
 


### PR DESCRIPTION
…ng email template

## 🎟️ Tracking

[<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
](https://bitwarden.atlassian.net/browse/SM-1211)

## 📔 Objective

Creating API Endpoints for sending access request email to admins for Secrets Manger

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
