### PR TITLE
[AC-2721][Defect] Apply Subscription Status Updates in Provider Subscription details

### DIFF
--- a/src/Api/Billing/Models/Responses/ConsolidatedBillingSubscriptionResponse.cs
+++ b/src/Api/Billing/Models/Responses/ConsolidatedBillingSubscriptionResponse.cs
@@ -7,6 +7,10 @@ public record ConsolidatedBillingSubscriptionResponse(
     string Status,
     DateTime CurrentPeriodEndDate,
     decimal? DiscountPercentage,
+    string CollectionMethod,
+    DateTime? UnpaidPeriodEndDate,
+    int? GracePeriod,
+    DateTime? SuspensionDate,
     IEnumerable<ProviderPlanResponse> Plans)
 {
     private const string _annualCadence = "Annual";
@@ -15,7 +19,7 @@ public record ConsolidatedBillingSubscriptionResponse(
     public static ConsolidatedBillingSubscriptionResponse From(
         ConsolidatedBillingSubscriptionDTO consolidatedBillingSubscription)
     {
-        var (providerPlans, subscription) = consolidatedBillingSubscription;
+        var (providerPlans, subscription, suspensionDate, unpaidPeriodEndDate) = consolidatedBillingSubscription;
 
         var providerPlansDTO = providerPlans
             .Select(providerPlan =>
@@ -31,11 +35,15 @@ public record ConsolidatedBillingSubscriptionResponse(
                     cost,
                     cadence);
             });
-
+        var gracePeriod = subscription.CollectionMethod == "charge_automatically" ? 14 : 30;
         return new ConsolidatedBillingSubscriptionResponse(
             subscription.Status,
             subscription.CurrentPeriodEnd,
             subscription.Customer?.Discount?.Coupon?.PercentOff,
+            subscription.CollectionMethod,
+            unpaidPeriodEndDate,
+            gracePeriod,
+            suspensionDate,
             providerPlansDTO);
     }
 }

--- a/src/Core/Billing/Models/ConsolidatedBillingSubscriptionDTO.cs
+++ b/src/Core/Billing/Models/ConsolidatedBillingSubscriptionDTO.cs
@@ -4,4 +4,6 @@ namespace Bit.Core.Billing.Models;
 
 public record ConsolidatedBillingSubscriptionDTO(
     List<ConfiguredProviderPlanDTO> ProviderPlans,
-    Subscription Subscription);
+    Subscription Subscription,
+    DateTime? SuspensionDate,
+    DateTime? UnpaidPeriodEndDate);

--- a/src/Core/Services/IPaymentService.cs
+++ b/src/Core/Services/IPaymentService.cs
@@ -55,4 +55,5 @@ public interface IPaymentService
         int additionalServiceAccount);
     Task<bool> RisksSubscriptionFailure(Organization organization);
     Task<bool> HasSecretsManagerStandalone(Organization organization);
+    Task<(DateTime?, DateTime?)> GetSuspensionDateAsync(Stripe.Subscription subscription);
 }

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -1820,6 +1820,47 @@ public class StripePaymentService : IPaymentService
         return customer?.Discount?.Coupon?.Id == SecretsManagerStandaloneDiscountId;
     }
 
+    public async Task<(DateTime?, DateTime?)> GetSuspensionDateAsync(Subscription subscription)
+    {
+        if (subscription.Status is not "past_due" && subscription.Status is not "unpaid")
+        {
+            return (null, null);
+        }
+
+        var openInvoices = await _stripeAdapter.InvoiceSearchAsync(new InvoiceSearchOptions
+        {
+            Query = $"subscription:'{subscription.Id}' status:'open'"
+        });
+
+        if (openInvoices.Count == 0)
+        {
+            return (null, null);
+        }
+
+        var currentDate = subscription.TestClock?.FrozenTime ?? DateTime.UtcNow;
+
+        switch (subscription.CollectionMethod)
+        {
+            case "charge_automatically":
+                {
+                    var firstOverdueInvoice = openInvoices
+                        .Where(invoice => invoice.PeriodEnd < currentDate && invoice.Attempted)
+                        .MinBy(invoice => invoice.Created);
+
+                    return (firstOverdueInvoice?.Created.AddDays(14), firstOverdueInvoice?.PeriodEnd);
+                }
+            case "send_invoice":
+                {
+                    var firstOverdueInvoice = openInvoices
+                        .Where(invoice => invoice.DueDate < currentDate)
+                        .MinBy(invoice => invoice.Created);
+
+                    return (firstOverdueInvoice?.DueDate?.AddDays(30), firstOverdueInvoice?.PeriodEnd);
+                }
+            default: return (null, null);
+        }
+    }
+
     private PaymentMethod GetLatestCardPaymentMethod(string customerId)
     {
         var cardPaymentMethods = _stripeAdapter.PaymentMethodListAutoPaging(
@@ -1961,46 +2002,5 @@ public class StripePaymentService : IPaymentService
         return subscriberName.Length <= 30
             ? subscriberName
             : subscriberName[..30];
-    }
-
-    private async Task<(DateTime?, DateTime?)> GetSuspensionDateAsync(Subscription subscription)
-    {
-        if (subscription.Status is not "past_due" && subscription.Status is not "unpaid")
-        {
-            return (null, null);
-        }
-
-        var openInvoices = await _stripeAdapter.InvoiceSearchAsync(new InvoiceSearchOptions
-        {
-            Query = $"subscription:'{subscription.Id}' status:'open'"
-        });
-
-        if (openInvoices.Count == 0)
-        {
-            return (null, null);
-        }
-
-        var currentDate = subscription.TestClock?.FrozenTime ?? DateTime.UtcNow;
-
-        switch (subscription.CollectionMethod)
-        {
-            case "charge_automatically":
-                {
-                    var firstOverdueInvoice = openInvoices
-                        .Where(invoice => invoice.PeriodEnd < currentDate && invoice.Attempted)
-                        .MinBy(invoice => invoice.Created);
-
-                    return (firstOverdueInvoice?.Created.AddDays(14), firstOverdueInvoice?.PeriodEnd);
-                }
-            case "send_invoice":
-                {
-                    var firstOverdueInvoice = openInvoices
-                        .Where(invoice => invoice.DueDate < currentDate)
-                        .MinBy(invoice => invoice.Created);
-
-                    return (firstOverdueInvoice?.DueDate?.AddDays(30), firstOverdueInvoice?.PeriodEnd);
-                }
-            default: return (null, null);
-        }
     }
 }

--- a/test/Api.Test/Billing/Controllers/ProviderBillingControllerTests.cs
+++ b/test/Api.Test/Billing/Controllers/ProviderBillingControllerTests.cs
@@ -282,9 +282,14 @@ public class ProviderBillingControllerTests
             Customer = new Customer { Discount = new Discount { Coupon = new Coupon { PercentOff = 10 } } }
         };
 
+        DateTime? SuspensionDate = new DateTime();
+        DateTime? UnpaidPeriodEndDate = new DateTime();
+        var gracePeriod = 30;
         var consolidatedBillingSubscription = new ConsolidatedBillingSubscriptionDTO(
             configuredProviderPlans,
-            subscription);
+            subscription,
+            SuspensionDate,
+            UnpaidPeriodEndDate);
 
         sutProvider.GetDependency<IProviderBillingService>().GetConsolidatedBillingSubscription(provider)
             .Returns(consolidatedBillingSubscription);
@@ -298,6 +303,10 @@ public class ProviderBillingControllerTests
         Assert.Equal(response.Status, subscription.Status);
         Assert.Equal(response.CurrentPeriodEndDate, subscription.CurrentPeriodEnd);
         Assert.Equal(response.DiscountPercentage, subscription.Customer!.Discount!.Coupon!.PercentOff);
+        Assert.Equal(response.CollectionMethod, subscription.CollectionMethod);
+        Assert.Equal(response.UnpaidPeriodEndDate, UnpaidPeriodEndDate);
+        Assert.Equal(response.GracePeriod, gracePeriod);
+        Assert.Equal(response.SuspensionDate, SuspensionDate);
 
         var teamsPlan = StaticStore.GetPlan(PlanType.TeamsMonthly);
         var providerTeamsPlan = response.Plans.FirstOrDefault(plan => plan.PlanName == teamsPlan.Name);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/AC-2721
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Apply the status banners we have today on admin console for organisation subscription page to provider subscription page

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
