### PR TITLE
[SM-1197] - Duplicate GUIDS Show a more detailed error message if duplicate GUIDS are passed ot g…

### DIFF
--- a/src/Api/SecretsManager/Models/Request/GetSecretsRequestModel.cs
+++ b/src/Api/SecretsManager/Models/Request/GetSecretsRequestModel.cs
@@ -1,9 +1,24 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 
 namespace Bit.Api.SecretsManager.Models.Request;
 
-public class GetSecretsRequestModel
+public class GetSecretsRequestModel : IValidatableObject
 {
     [Required]
     public IEnumerable<Guid> Ids { get; set; }
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        bool isDistinct = Ids.Distinct().Count() == Ids.Count();
+        if (!isDistinct)
+        {
+            IEnumerable<Guid> duplicateGuids = Ids.GroupBy(x => x)
+                                  .Where(g => g.Count() > 1)
+                                  .SelectMany(g => g);
+
+            yield return new ValidationResult(
+                $"The following GUIDs were duplicated {string.Join(", ", duplicateGuids.Distinct())} ",
+                new[] { nameof(GetSecretsRequestModel) });
+        }
+    }
 }


### PR DESCRIPTION
…et by Ids

## 🎟️ Tracking

[<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
](https://bitwarden.atlassian.net/browse/SM-1197)

## 📔 Objective

Show a more detailed error message when getting secrets by ids includes a duplicate guid.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
