### PR TITLE
Change error message

### DIFF
--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -483,7 +483,8 @@ public class AccountController : Controller
             if (orgUser.Status == OrganizationUserStatusType.Invited)
             {
                 // Org User is invited - they must manually accept the invite via email and authenticate with MP
-                throw new Exception(_i18nService.T("UserAlreadyInvited", email, organization.DisplayName()));
+                // This allows us to enroll them in MP reset if required
+                throw new Exception(_i18nService.T("AcceptInviteBeforeUsingSSO", organization.DisplayName()));
             }
 
             // Accepted or Confirmed - create SSO link and return;

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -529,8 +529,8 @@
   <data name="NoSeatsAvailable" xml:space="preserve">
     <value>No seats available for organization, '{0}'</value>
   </data>
-  <data name="UserAlreadyInvited" xml:space="preserve">
-    <value>User, '{0}', has already been invited to this organization, '{1}'. Accept the invite in order to log in with SSO.</value>
+  <data name="AcceptInviteBeforeUsingSSO" xml:space="preserve">
+    <value>To accept your invite to {0}, you must first log in using your master password. Once your invite has been accepted, you will be able to log in using SSO.</value>
   </data>
   <data name="UserAlreadyExistsInviteProcess" xml:space="preserve">
     <value>You were removed from the organization managing single sign-on for your account. Contact the organization administrator for help regaining access to your account.</value>
@@ -540,7 +540,7 @@
   </data>
   <data name="RedirectGet" xml:space="preserve">
     <value>Redirect GET</value>
-    <comment>An OIDC Connect Redirect Behavior, Redirect; Emits a 302 response 
+    <comment>An OIDC Connect Redirect Behavior, Redirect; Emits a 302 response
     to redirect the user agent to the OpenID Connect provider using a GET request.</comment>
   </data>
   <data name="FormPost" xml:space="preserve">


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-1636
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
If a user already has an account and gets invited to an organization that uses SSO, they will get the error message: "User, 'XXXXXXX', has already been invited to this organization, 'XXXXXXX'. Accept the invite in order to log in with SSO."

This changes this to be: "To accept your invite to 'XXXXX', you must first log in using your master password. Once your invite has been accepted, you will be able to log in using SSO." in order to better direct the user.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
