### PR TITLE
[PM-8792] BUG - Remove required annotation from AccessAll

### DIFF
--- a/src/Api/AdminConsole/Models/Request/GroupRequestModel.cs
+++ b/src/Api/AdminConsole/Models/Request/GroupRequestModel.cs
@@ -9,7 +9,6 @@ public class GroupRequestModel
     [Required]
     [StringLength(100)]
     public string Name { get; set; }
-    [Required]
     public bool? AccessAll { get; set; }
     public IEnumerable<SelectionReadOnlyRequestModel> Collections { get; set; }
     public IEnumerable<Guid> Users { get; set; }
@@ -25,7 +24,7 @@ public class GroupRequestModel
     public Group ToGroup(Group existingGroup)
     {
         existingGroup.Name = Name;
-        existingGroup.AccessAll = AccessAll.Value;
+        existingGroup.AccessAll = AccessAll ?? false;
         return existingGroup;
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8792


## 📔 Objective

> Removes the `Required` annotation from the `GroupRequestModel.AccessAll` property. This is a quick fix to address an issue where the same model on the `clients` repository was already updated by removing the properly entirely. The removal of the server-side property will be handled in AC-2699.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
