### PR TITLE
[PM-517] Added validation to maximum and minimum expiry date

### DIFF
--- a/src/Api/Tools/Models/Request/SendRequestModel.cs
+++ b/src/Api/Tools/Models/Request/SendRequestModel.cs
@@ -110,6 +110,20 @@ public class SendRequestModel
                     "and try again.");
             }
         }
+        if (ExpirationDate.HasValue)
+        {
+            if (ExpirationDate.Value <= nowPlus1Minute)
+            {
+                throw new BadRequestException("You cannot have a Send with a expiration date in the past. " +
+                    "Adjust the expiration date and try again.");
+            }
+            if (ExpirationDate.Value > DeletionDate.Value)
+            {
+                throw new BadRequestException("You cannot have a Send with a expiration date that far " +
+                    "into the future. Adjust the Expiration Date to a value lower than DeletionDate " +
+                    "and try again.");
+            }
+        }
     }
 
     private Send ToSendBase(Send existingSend, ISendService sendService)

--- a/src/Api/Tools/Models/Request/SendRequestModel.cs
+++ b/src/Api/Tools/Models/Request/SendRequestModel.cs
@@ -114,14 +114,13 @@ public class SendRequestModel
         {
             if (ExpirationDate.Value <= nowPlus1Minute)
             {
-                throw new BadRequestException("You cannot have a Send with a expiration date in the past. " +
+                throw new BadRequestException("You cannot have a Send with an expiration date in the past. " +
                     "Adjust the expiration date and try again.");
             }
             if (ExpirationDate.Value > DeletionDate.Value)
             {
-                throw new BadRequestException("You cannot have a Send with a expiration date that far " +
-                    "into the future. Adjust the Expiration Date to a value lower than DeletionDate " +
-                    "and try again.");
+                throw new BadRequestException("You cannot have a Send with an expiration date greater than the deletion date. " +
+                    "Adjust the expiration date and try again.");
             }
         }
     }

--- a/test/Api.Test/Tools/Models/Request/SendRequestModelTests.cs
+++ b/test/Api.Test/Tools/Models/Request/SendRequestModelTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
 using Bit.Api.Tools.Models;
 using Bit.Api.Tools.Models.Request;
+using Bit.Core.Exceptions;
 using Bit.Core.Tools.Enums;
 using Bit.Core.Tools.Services;
 using Bit.Test.Common.Helpers;
@@ -54,5 +55,64 @@ public class SendRequestModelTests
         Assert.False(root.TryGetProperty("Notes", out var _));
         var name = AssertHelper.AssertJsonProperty(root, "Name", JsonValueKind.String).GetString();
         Assert.Equal("encrypted_name", name);
+    }
+
+    [Fact]
+    public void ValidateEdit_DeletionDateInPast_ThrowsBadRequestException()
+    {
+        var send = new SendRequestModel
+        {
+            DeletionDate = DateTime.UtcNow.AddMinutes(-5)
+        };
+
+        Assert.Throws<BadRequestException>(() => send.ValidateEdit());
+    }
+
+    [Fact]
+    public void ValidateEdit_DeletionDateTooFarInFuture_ThrowsBadRequestException()
+    {
+        var send = new SendRequestModel
+        {
+            DeletionDate = DateTime.UtcNow.AddDays(32)
+        };
+
+        Assert.Throws<BadRequestException>(() => send.ValidateEdit());
+    }
+
+    [Fact]
+    public void ValidateEdit_ExpirationDateInPast_ThrowsBadRequestException()
+    {
+        var send = new SendRequestModel
+        {
+            ExpirationDate = DateTime.UtcNow.AddMinutes(-5)
+        };
+
+        Assert.Throws<BadRequestException>(() => send.ValidateEdit());
+    }
+
+    [Fact]
+    public void ValidateEdit_ExpirationDateGreaterThanDeletionDate_ThrowsBadRequestException()
+    {
+        var send = new SendRequestModel
+        {
+            DeletionDate = DateTime.UtcNow.AddDays(1),
+            ExpirationDate = DateTime.UtcNow.AddDays(2)
+        };
+
+        Assert.Throws<BadRequestException>(() => send.ValidateEdit());
+    }
+
+    [Fact]
+    public void ValidateEdit_ValidDates_Success()
+    {
+        var send = new SendRequestModel
+        {
+            DeletionDate = DateTime.UtcNow.AddDays(10),
+            ExpirationDate = DateTime.UtcNow.AddDays(5)
+        };
+
+        Exception ex = Record.Exception(() => send.ValidateEdit());
+
+        Assert.Null(ex);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-517

## 📔 Objective

When an user tries to add a send with an expiry date that is after the deletion date or an expiry date in the past. Should throw na error message

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
