### PR TITLE
[AC-2744] Add provider portal pricing for consolidated billing

### DIFF
--- a/bitwarden_license/src/Commercial.Core/Billing/ProviderBillingService.cs
+++ b/bitwarden_license/src/Commercial.Core/Billing/ProviderBillingService.cs
@@ -441,7 +441,7 @@ public class ProviderBillingService(
 
         subscriptionItemOptionsList.Add(new SubscriptionItemOptions
         {
-            Price = teamsPlan.PasswordManager.StripeSeatPlanId,
+            Price = teamsPlan.PasswordManager.StripeProviderPortalSeatPlanId,
             Quantity = teamsProviderPlan.SeatMinimum
         });
 
@@ -459,7 +459,7 @@ public class ProviderBillingService(
 
         subscriptionItemOptionsList.Add(new SubscriptionItemOptions
         {
-            Price = enterprisePlan.PasswordManager.StripeSeatPlanId,
+            Price = enterprisePlan.PasswordManager.StripeProviderPortalSeatPlanId,
             Quantity = enterpriseProviderPlan.SeatMinimum
         });
 

--- a/src/Api/Billing/Models/Responses/ConsolidatedBillingSubscriptionResponse.cs
+++ b/src/Api/Billing/Models/Responses/ConsolidatedBillingSubscriptionResponse.cs
@@ -26,7 +26,7 @@ public record ConsolidatedBillingSubscriptionResponse(
             .Select(providerPlan =>
             {
                 var plan = StaticStore.GetPlan(providerPlan.PlanType);
-                var cost = (providerPlan.SeatMinimum + providerPlan.PurchasedSeats) * plan.PasswordManager.SeatPrice;
+                var cost = (providerPlan.SeatMinimum + providerPlan.PurchasedSeats) * plan.PasswordManager.ProviderPortalSeatPrice;
                 var cadence = plan.IsAnnual ? _annualCadence : _monthlyCadence;
                 return new ProviderPlanResponse(
                     plan.Name,
@@ -36,7 +36,9 @@ public record ConsolidatedBillingSubscriptionResponse(
                     cost,
                     cadence);
             });
+
         var gracePeriod = subscription.CollectionMethod == "charge_automatically" ? 14 : 30;
+
         return new ConsolidatedBillingSubscriptionResponse(
             subscription.Status,
             subscription.CurrentPeriodEnd,

--- a/src/Api/Models/Response/PlanResponseModel.cs
+++ b/src/Api/Models/Response/PlanResponseModel.cs
@@ -121,8 +121,10 @@ public class PlanResponseModel : ResponseModel
         {
             StripePlanId = plan.StripePlanId;
             StripeSeatPlanId = plan.StripeSeatPlanId;
+            StripeProviderPortalSeatPlanId = plan.StripeProviderPortalSeatPlanId;
             BasePrice = plan.BasePrice;
             SeatPrice = plan.SeatPrice;
+            ProviderPortalSeatPrice = plan.ProviderPortalSeatPrice;
             AllowSeatAutoscale = plan.AllowSeatAutoscale;
             HasAdditionalSeatsOption = plan.HasAdditionalSeatsOption;
             MaxAdditionalSeats = plan.MaxAdditionalSeats;
@@ -141,8 +143,10 @@ public class PlanResponseModel : ResponseModel
         // Seats
         public string StripePlanId { get; init; }
         public string StripeSeatPlanId { get; init; }
+        public string StripeProviderPortalSeatPlanId { get; init; }
         public decimal BasePrice { get; init; }
         public decimal SeatPrice { get; init; }
+        public decimal ProviderPortalSeatPrice { get; init; }
         public bool AllowSeatAutoscale { get; init; }
         public bool HasAdditionalSeatsOption { get; init; }
         public int? MaxAdditionalSeats { get; init; }

--- a/src/Billing/Services/Implementations/ProviderEventService.cs
+++ b/src/Billing/Services/Implementations/ProviderEventService.cs
@@ -67,9 +67,9 @@ public class ProviderEventService(
 
                     var discountedPercentage = (100 - (invoice.Discount?.Coupon?.PercentOff ?? 0)) / 100;
 
-                    var discountedEnterpriseSeatPrice = enterprisePlan.PasswordManager.SeatPrice * discountedPercentage;
+                    var discountedEnterpriseSeatPrice = enterprisePlan.PasswordManager.ProviderPortalSeatPrice * discountedPercentage;
 
-                    var discountedTeamsSeatPrice = teamsPlan.PasswordManager.SeatPrice * discountedPercentage;
+                    var discountedTeamsSeatPrice = teamsPlan.PasswordManager.ProviderPortalSeatPrice * discountedPercentage;
 
                     var invoiceItems = clients.Select(client => new ProviderInvoiceItem
                     {

--- a/src/Core/Billing/Models/StaticStore/Plan.cs
+++ b/src/Core/Billing/Models/StaticStore/Plan.cs
@@ -63,8 +63,10 @@ public abstract record Plan
         // Seats
         public string StripePlanId { get; init; }
         public string StripeSeatPlanId { get; init; }
+        public string StripeProviderPortalSeatPlanId { get; init; }
         public decimal BasePrice { get; init; }
         public decimal SeatPrice { get; init; }
+        public decimal ProviderPortalSeatPrice { get; init; }
         public bool AllowSeatAutoscale { get; init; }
         public bool HasAdditionalSeatsOption { get; init; }
         public int? MaxAdditionalSeats { get; init; }

--- a/src/Core/Billing/Models/StaticStore/Plans/EnterprisePlan.cs
+++ b/src/Core/Billing/Models/StaticStore/Plans/EnterprisePlan.cs
@@ -92,8 +92,10 @@ public record EnterprisePlan : Plan
             else
             {
                 StripeSeatPlanId = "2023-enterprise-seat-monthly";
+                StripeProviderPortalSeatPlanId = "password-manager-provider-portal-enterprise-monthly-2024";
                 StripeStoragePlanId = "storage-gb-monthly";
                 SeatPrice = 7;
+                ProviderPortalSeatPrice = 6;
                 AdditionalStoragePricePerGb = 0.5M;
             }
         }

--- a/src/Core/Billing/Models/StaticStore/Plans/TeamsPlan.cs
+++ b/src/Core/Billing/Models/StaticStore/Plans/TeamsPlan.cs
@@ -86,8 +86,10 @@ public record TeamsPlan : Plan
             else
             {
                 StripeSeatPlanId = "2023-teams-org-seat-monthly";
+                StripeProviderPortalSeatPlanId = "password-manager-provider-portal-teams-monthly-2024";
                 StripeStoragePlanId = "storage-gb-monthly";
                 SeatPrice = 5;
+                ProviderPortalSeatPrice = 4;
                 AdditionalStoragePricePerGb = 0.5M;
             }
         }

--- a/src/Core/Models/Business/ProviderSubscriptionUpdate.cs
+++ b/src/Core/Models/Business/ProviderSubscriptionUpdate.cs
@@ -24,7 +24,9 @@ public class ProviderSubscriptionUpdate : SubscriptionUpdate
             throw ContactSupport($"Cannot create a {nameof(ProviderSubscriptionUpdate)} for {nameof(PlanType)} that doesn't support consolidated billing");
         }
 
-        _planId = GetPasswordManagerPlanId(Utilities.StaticStore.GetPlan(planType));
+        var plan = Utilities.StaticStore.GetPlan(planType);
+
+        _planId = plan.PasswordManager.StripeProviderPortalSeatPlanId;
         _previouslyPurchasedSeats = previouslyPurchasedSeats;
         _newlyPurchasedSeats = newlyPurchasedSeats;
     }

--- a/test/Api.Test/Billing/Controllers/ProviderBillingControllerTests.cs
+++ b/test/Api.Test/Billing/Controllers/ProviderBillingControllerTests.cs
@@ -348,7 +348,7 @@ public class ProviderBillingControllerTests
         Assert.Equal(50, providerTeamsPlan.SeatMinimum);
         Assert.Equal(10, providerTeamsPlan.PurchasedSeats);
         Assert.Equal(30, providerTeamsPlan.AssignedSeats);
-        Assert.Equal(60 * teamsPlan.PasswordManager.SeatPrice, providerTeamsPlan.Cost);
+        Assert.Equal(60 * teamsPlan.PasswordManager.ProviderPortalSeatPrice, providerTeamsPlan.Cost);
         Assert.Equal("Monthly", providerTeamsPlan.Cadence);
 
         var enterprisePlan = StaticStore.GetPlan(PlanType.EnterpriseMonthly);
@@ -357,7 +357,7 @@ public class ProviderBillingControllerTests
         Assert.Equal(100, providerEnterprisePlan.SeatMinimum);
         Assert.Equal(0, providerEnterprisePlan.PurchasedSeats);
         Assert.Equal(90, providerEnterprisePlan.AssignedSeats);
-        Assert.Equal(100 * enterprisePlan.PasswordManager.SeatPrice, providerEnterprisePlan.Cost);
+        Assert.Equal(100 * enterprisePlan.PasswordManager.ProviderPortalSeatPrice, providerEnterprisePlan.Cost);
         Assert.Equal("Monthly", providerEnterprisePlan.Cadence);
     }
     #endregion

--- a/test/Billing.Test/Services/ProviderEventServiceTests.cs
+++ b/test/Billing.Test/Services/ProviderEventServiceTests.cs
@@ -231,7 +231,7 @@ public class ProviderEventServiceTests
                 options.PlanName == "Teams (Monthly)" &&
                 options.AssignedSeats == 50 &&
                 options.UsedSeats == 30 &&
-                options.Total == options.AssignedSeats * teamsPlan.PasswordManager.SeatPrice * 0.65M));
+                options.Total == options.AssignedSeats * teamsPlan.PasswordManager.ProviderPortalSeatPrice * 0.65M));
 
         await _providerInvoiceItemRepository.Received(1).CreateAsync(Arg.Is<ProviderInvoiceItem>(
             options =>
@@ -242,7 +242,7 @@ public class ProviderEventServiceTests
                 options.PlanName == "Enterprise (Monthly)" &&
                 options.AssignedSeats == 50 &&
                 options.UsedSeats == 30 &&
-                options.Total == options.AssignedSeats * enterprisePlan.PasswordManager.SeatPrice * 0.65M));
+                options.Total == options.AssignedSeats * enterprisePlan.PasswordManager.ProviderPortalSeatPrice * 0.65M));
 
         await _providerInvoiceItemRepository.Received(1).CreateAsync(Arg.Is<ProviderInvoiceItem>(
             options =>
@@ -253,7 +253,7 @@ public class ProviderEventServiceTests
                 options.PlanName == "Teams (Monthly)" &&
                 options.AssignedSeats == 50 &&
                 options.UsedSeats == 0 &&
-                options.Total == options.AssignedSeats * teamsPlan.PasswordManager.SeatPrice * 0.65M));
+                options.Total == options.AssignedSeats * teamsPlan.PasswordManager.ProviderPortalSeatPrice * 0.65M));
 
         await _providerInvoiceItemRepository.Received(1).CreateAsync(Arg.Is<ProviderInvoiceItem>(
             options =>
@@ -264,7 +264,7 @@ public class ProviderEventServiceTests
                 options.PlanName == "Enterprise (Monthly)" &&
                 options.AssignedSeats == 50 &&
                 options.UsedSeats == 0 &&
-                options.Total == options.AssignedSeats * enterprisePlan.PasswordManager.SeatPrice * 0.65M));
+                options.Total == options.AssignedSeats * enterprisePlan.PasswordManager.ProviderPortalSeatPrice * 0.65M));
     }
 
     [Fact]


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/AC-2744

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This PR adds new provider portal pricing for the Teams (Monthly) and Enterprise (Monthly) plan. Because so much of the existing feature's functionality is driven off of matching plan types, I opted for expanding the `PasswordManagerPlanFeatures` object to include `StripeProviderPortalSeatPlanId` and `ProviderPortalSeatPrice` properties. Then, in any Consolidated Billing scenario where were have to create or update subscriptions or show prices, I used these values instead of the original `StripeSeatPlanId` and `SeatPrice` properties. This significantly decreased the blast radius of the changes both on `server` and `client`.  

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
