### PR TITLE
[AC-2795] Add account credit & tax information to provider subscription

### DIFF
--- a/bitwarden_license/src/Commercial.Core/Billing/ProviderBillingService.cs
+++ b/bitwarden_license/src/Commercial.Core/Billing/ProviderBillingService.cs
@@ -1,6 +1,5 @@
 ﻿using System.Globalization;
 using Bit.Commercial.Core.Billing.Models;
-using Bit.Core;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;

--- a/bitwarden_license/test/Commercial.Core.Test/Billing/ProviderBillingServiceTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/Billing/ProviderBillingServiceTests.cs
@@ -27,7 +27,6 @@ using Bit.Test.Common.AutoFixture.Attributes;
 using CsvHelper;
 using NSubstitute;
 using Stripe;
-using Stripe.TestHelpers;
 using Xunit;
 using static Bit.Core.Test.Billing.Utilities;
 

--- a/src/Core/Billing/Models/ConsolidatedBillingSubscriptionDTO.cs
+++ b/src/Core/Billing/Models/ConsolidatedBillingSubscriptionDTO.cs
@@ -5,5 +5,5 @@ namespace Bit.Core.Billing.Models;
 public record ConsolidatedBillingSubscriptionDTO(
     List<ConfiguredProviderPlanDTO> ProviderPlans,
     Subscription Subscription,
-    DateTime? SuspensionDate,
-    DateTime? UnpaidPeriodEndDate);
+    TaxInformationDTO TaxInformation,
+    SubscriptionSuspensionDTO Suspension);

--- a/src/Core/Billing/Models/SubscriptionSuspensionDTO.cs
+++ b/src/Core/Billing/Models/SubscriptionSuspensionDTO.cs
@@ -1,0 +1,6 @@
+﻿namespace Bit.Core.Billing.Models;
+
+public record SubscriptionSuspensionDTO(
+    DateTime SuspensionDate,
+    DateTime UnpaidPeriodEndDate,
+    int GracePeriod);

--- a/src/Core/Billing/Utilities.cs
+++ b/src/Core/Billing/Utilities.cs
@@ -1,4 +1,8 @@
-﻿namespace Bit.Core.Billing;
+﻿using Bit.Core.Billing.Models;
+using Bit.Core.Services;
+using Stripe;
+
+namespace Bit.Core.Billing;
 
 public static class Utilities
 {
@@ -8,4 +12,67 @@ public static class Utilities
         string internalMessage = null,
         Exception innerException = null) => new("Something went wrong with your request. Please contact support.",
         internalMessage, innerException);
+
+    public static async Task<SubscriptionSuspensionDTO> GetSuspensionAsync(
+        IStripeAdapter stripeAdapter,
+        Subscription subscription)
+    {
+        if (subscription.Status is not "past_due" && subscription.Status is not "unpaid")
+        {
+            return null;
+        }
+
+        var openInvoices = await stripeAdapter.InvoiceSearchAsync(new InvoiceSearchOptions
+        {
+            Query = $"subscription:'{subscription.Id}' status:'open'"
+        });
+
+        if (openInvoices.Count == 0)
+        {
+            return null;
+        }
+
+        var currentDate = subscription.TestClock?.FrozenTime ?? DateTime.UtcNow;
+
+        switch (subscription.CollectionMethod)
+        {
+            case "charge_automatically":
+            {
+                var firstOverdueInvoice = openInvoices
+                    .Where(invoice => invoice.PeriodEnd < currentDate && invoice.Attempted)
+                    .MinBy(invoice => invoice.Created);
+
+                if (firstOverdueInvoice == null)
+                {
+                    return null;
+                }
+
+                const int gracePeriod = 14;
+
+                return new SubscriptionSuspensionDTO(
+                    firstOverdueInvoice.Created.AddDays(gracePeriod),
+                    firstOverdueInvoice.PeriodEnd,
+                    gracePeriod);
+            }
+            case "send_invoice":
+            {
+                var firstOverdueInvoice = openInvoices
+                    .Where(invoice => invoice.DueDate < currentDate)
+                    .MinBy(invoice => invoice.Created);
+
+                if (firstOverdueInvoice?.DueDate == null)
+                {
+                    return null;
+                }
+
+                const int gracePeriod = 30;
+
+                return new SubscriptionSuspensionDTO(
+                    firstOverdueInvoice.DueDate.Value.AddDays(gracePeriod),
+                    firstOverdueInvoice.PeriodEnd,
+                    gracePeriod);
+            }
+            default: return null;
+        }
+    }
 }

--- a/src/Core/Billing/Utilities.cs
+++ b/src/Core/Billing/Utilities.cs
@@ -37,41 +37,41 @@ public static class Utilities
         switch (subscription.CollectionMethod)
         {
             case "charge_automatically":
-            {
-                var firstOverdueInvoice = openInvoices
-                    .Where(invoice => invoice.PeriodEnd < currentDate && invoice.Attempted)
-                    .MinBy(invoice => invoice.Created);
-
-                if (firstOverdueInvoice == null)
                 {
-                    return null;
+                    var firstOverdueInvoice = openInvoices
+                        .Where(invoice => invoice.PeriodEnd < currentDate && invoice.Attempted)
+                        .MinBy(invoice => invoice.Created);
+
+                    if (firstOverdueInvoice == null)
+                    {
+                        return null;
+                    }
+
+                    const int gracePeriod = 14;
+
+                    return new SubscriptionSuspensionDTO(
+                        firstOverdueInvoice.Created.AddDays(gracePeriod),
+                        firstOverdueInvoice.PeriodEnd,
+                        gracePeriod);
                 }
-
-                const int gracePeriod = 14;
-
-                return new SubscriptionSuspensionDTO(
-                    firstOverdueInvoice.Created.AddDays(gracePeriod),
-                    firstOverdueInvoice.PeriodEnd,
-                    gracePeriod);
-            }
             case "send_invoice":
-            {
-                var firstOverdueInvoice = openInvoices
-                    .Where(invoice => invoice.DueDate < currentDate)
-                    .MinBy(invoice => invoice.Created);
-
-                if (firstOverdueInvoice?.DueDate == null)
                 {
-                    return null;
+                    var firstOverdueInvoice = openInvoices
+                        .Where(invoice => invoice.DueDate < currentDate)
+                        .MinBy(invoice => invoice.Created);
+
+                    if (firstOverdueInvoice?.DueDate == null)
+                    {
+                        return null;
+                    }
+
+                    const int gracePeriod = 30;
+
+                    return new SubscriptionSuspensionDTO(
+                        firstOverdueInvoice.DueDate.Value.AddDays(gracePeriod),
+                        firstOverdueInvoice.PeriodEnd,
+                        gracePeriod);
                 }
-
-                const int gracePeriod = 30;
-
-                return new SubscriptionSuspensionDTO(
-                    firstOverdueInvoice.DueDate.Value.AddDays(gracePeriod),
-                    firstOverdueInvoice.PeriodEnd,
-                    gracePeriod);
-            }
             default: return null;
         }
     }

--- a/test/Api.Test/Billing/Controllers/ProviderBillingControllerTests.cs
+++ b/test/Api.Test/Billing/Controllers/ProviderBillingControllerTests.cs
@@ -385,19 +385,34 @@ public class ProviderBillingControllerTests
 
         var subscription = new Subscription
         {
-            Status = "active",
-            CurrentPeriodEnd = new DateTime(2025, 1, 1),
-            Customer = new Customer { Discount = new Discount { Coupon = new Coupon { PercentOff = 10 } } }
+            Status = "unpaid",
+            CurrentPeriodEnd = new DateTime(2024, 6, 30),
+            Customer = new Customer
+            {
+                Balance = 100000,
+                Discount = new Discount
+                {
+                    Coupon = new Coupon
+                    {
+                        PercentOff = 10
+                    }
+                }
+            }
         };
 
-        DateTime? SuspensionDate = new DateTime();
-        DateTime? UnpaidPeriodEndDate = new DateTime();
-        var gracePeriod = 30;
+        var taxInformation =
+            new TaxInformationDTO("US", "12345", "123456789", "123 Example St.", null, "Example Town", "NY");
+
+        var suspension = new SubscriptionSuspensionDTO(
+            new DateTime(2024, 7, 30),
+            new DateTime(2024, 5, 30),
+            30);
+
         var consolidatedBillingSubscription = new ConsolidatedBillingSubscriptionDTO(
             configuredProviderPlans,
             subscription,
-            SuspensionDate,
-            UnpaidPeriodEndDate);
+            taxInformation,
+            suspension);
 
         sutProvider.GetDependency<IProviderBillingService>().GetConsolidatedBillingSubscription(provider)
             .Returns(consolidatedBillingSubscription);
@@ -408,13 +423,10 @@ public class ProviderBillingControllerTests
 
         var response = ((Ok<ConsolidatedBillingSubscriptionResponse>)result).Value;
 
-        Assert.Equal(response.Status, subscription.Status);
-        Assert.Equal(response.CurrentPeriodEndDate, subscription.CurrentPeriodEnd);
-        Assert.Equal(response.DiscountPercentage, subscription.Customer!.Discount!.Coupon!.PercentOff);
-        Assert.Equal(response.CollectionMethod, subscription.CollectionMethod);
-        Assert.Equal(response.UnpaidPeriodEndDate, UnpaidPeriodEndDate);
-        Assert.Equal(response.GracePeriod, gracePeriod);
-        Assert.Equal(response.SuspensionDate, SuspensionDate);
+        Assert.Equal(subscription.Status, response.Status);
+        Assert.Equal(subscription.CurrentPeriodEnd, response.CurrentPeriodEndDate);
+        Assert.Equal(subscription.Customer!.Discount!.Coupon!.PercentOff, response.DiscountPercentage);
+        Assert.Equal(subscription.CollectionMethod, response.CollectionMethod);
 
         var teamsPlan = StaticStore.GetPlan(PlanType.TeamsMonthly);
         var providerTeamsPlan = response.Plans.FirstOrDefault(plan => plan.PlanName == teamsPlan.Name);
@@ -433,7 +445,13 @@ public class ProviderBillingControllerTests
         Assert.Equal(90, providerEnterprisePlan.AssignedSeats);
         Assert.Equal(100 * enterprisePlan.PasswordManager.ProviderPortalSeatPrice, providerEnterprisePlan.Cost);
         Assert.Equal("Monthly", providerEnterprisePlan.Cadence);
+
+        Assert.Equal(100000, response.AccountCredit);
+        Assert.Equal(taxInformation, response.TaxInformation);
+        Assert.Null(response.CancelAt);
+        Assert.Equal(suspension, response.Suspension);
     }
+
     #endregion
 
     #region GetTaxInformationAsync


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/AC-2795

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This PR:
1. Updates the `ConsolidatedBillingSubscriptionResponse` to now contain the provider's account credit and tax information.
2. Updates the manner in which we retrieve and attach the provider's subscription suspension information. 

The reason for these is that the Subscription page in the Provider Portal will be consolidated to now include most of the components from the Payment Method except the actual ability to manage a payment method, so it's easier to just have 1 invocation of the API to retrieve everything needed.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
