### PR TITLE
Log SignalR pushes

### DIFF
--- a/src/Notifications/AzureQueueHostedService.cs
+++ b/src/Notifications/AzureQueueHostedService.cs
@@ -65,7 +65,7 @@ public class AzureQueueHostedService : IHostedService, IDisposable
                         try
                         {
                             await HubHelpers.SendNotificationToHubAsync(
-                                message.DecodeMessageText(), _hubContext, _anonymousHubContext, cancellationToken);
+                                message.DecodeMessageText(), _hubContext, _anonymousHubContext, _logger, cancellationToken);
                             await _queueClient.DeleteMessageAsync(message.MessageId, message.PopReceipt);
                         }
                         catch (Exception e)

--- a/src/Notifications/Controllers/SendController.cs
+++ b/src/Notifications/Controllers/SendController.cs
@@ -11,11 +11,13 @@ public class SendController : Controller
 {
     private readonly IHubContext<NotificationsHub> _hubContext;
     private readonly IHubContext<AnonymousNotificationsHub> _anonymousHubContext;
+    private readonly ILogger<SendController> _logger;
 
-    public SendController(IHubContext<NotificationsHub> hubContext, IHubContext<AnonymousNotificationsHub> anonymousHubContext)
+    public SendController(IHubContext<NotificationsHub> hubContext, IHubContext<AnonymousNotificationsHub> anonymousHubContext, ILogger<SendController> logger)
     {
         _hubContext = hubContext;
         _anonymousHubContext = anonymousHubContext;
+        _logger = logger;
     }
 
     [HttpPost("~/send")]
@@ -27,7 +29,7 @@ public class SendController : Controller
             var notificationJson = await reader.ReadToEndAsync();
             if (!string.IsNullOrWhiteSpace(notificationJson))
             {
-                await HubHelpers.SendNotificationToHubAsync(notificationJson, _hubContext, _anonymousHubContext);
+                await HubHelpers.SendNotificationToHubAsync(notificationJson, _hubContext, _anonymousHubContext, _logger);
             }
         }
     }

--- a/src/Notifications/HubHelpers.cs
+++ b/src/Notifications/HubHelpers.cs
@@ -14,10 +14,12 @@ public static class HubHelpers
         string notificationJson,
         IHubContext<NotificationsHub> hubContext,
         IHubContext<AnonymousNotificationsHub> anonymousHubContext,
+        ILogger logger,
         CancellationToken cancellationToken = default(CancellationToken)
     )
     {
         var notification = JsonSerializer.Deserialize<PushNotificationData<object>>(notificationJson, _deserializerOptions);
+        logger.LogInformation("Sending notification: {NotificationType}", notification.Type);
         switch (notification.Type)
         {
             case PushType.SyncCipherUpdate:


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-9313

## 📔 Objective

Log SignalR pushes

We are interested in the rate at which signalR notifications are pushed to clients. This enables tracking only of that rate and the type of notification, nothing more identifiable.

Data will be used to determine feasibility of transferring to web push


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
