### PR TITLE
[AC-2679] Adding a revoked member with Can Manage access does not resolve unmanaged collections

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/Queries/CollectionAdminDetailsQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/CollectionAdminDetailsQuery.cs
@@ -47,11 +47,12 @@ public class CollectionAdminDetailsQuery : IQuery<CollectionAdminDetails>
                                   from cg in cg_g.DefaultIfEmpty()
                                   select new { c, cu, cg };
 
-        // Subqueries to determine if a colection is managed by an active user or group.
+        // Subqueries to determine if a collection is managed by an active user or group.
         var activeUserManageRights = from cu in dbContext.CollectionUsers
                                      join ou in dbContext.OrganizationUsers
                                          on cu.OrganizationUserId equals ou.Id
-                                     where ou.Status == OrganizationUserStatusType.Confirmed && cu.Manage
+                                     where (ou.Status == OrganizationUserStatusType.Confirmed
+                                            || ou.Status == OrganizationUserStatusType.Revoked) && cu.Manage
                                      select cu.CollectionId;
 
         var activeGroupManageRights = from cg in dbContext.CollectionGroups

--- a/src/Sql/Vault/dbo/Stored Procedures/Collections/Collection_ReadByIdWithPermissions.sql
+++ b/src/Sql/Vault/dbo/Stored Procedures/Collections/Collection_ReadByIdWithPermissions.sql
@@ -41,7 +41,7 @@ BEGIN
                              JOIN [dbo].[OrganizationUser] OU2 ON CU2.[OrganizationUserId] = OU2.[Id]
                     WHERE
                         CU2.[CollectionId] = C.[Id] AND
-                        OU2.[Status] = 2 AND
+                        OU2.[Status] IN (-1, 2) AND
                         CU2.[Manage] = 1
                 )
                     AND NOT EXISTS (

--- a/src/Sql/Vault/dbo/Stored Procedures/Collections/Collection_ReadByOrganizationIdWithPermissions.sql
+++ b/src/Sql/Vault/dbo/Stored Procedures/Collections/Collection_ReadByOrganizationIdWithPermissions.sql
@@ -41,7 +41,7 @@ BEGIN
 	                JOIN [dbo].[OrganizationUser] OU2 ON CU2.[OrganizationUserId] = OU2.[Id]
                     WHERE
                         CU2.[CollectionId] = C.[Id] AND
-                        OU2.[Status] = 2 AND
+                        OU2.[Status] IN (-1, 2) AND
                         CU2.[Manage] = 1
 	            )
 	            AND NOT EXISTS (

--- a/util/Migrator/DbScripts/2024-06-26_00_FixUnmangedForRevokedUsersCollectionWithPermissions.sql
+++ b/util/Migrator/DbScripts/2024-06-26_00_FixUnmangedForRevokedUsersCollectionWithPermissions.sql
@@ -1,0 +1,171 @@
+CREATE OR ALTER PROCEDURE [dbo].[Collection_ReadByOrganizationIdWithPermissions]
+    @OrganizationId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @IncludeAccessRelationships BIT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        C.*,
+        MIN(CASE
+                WHEN
+                    COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) = 0
+                    THEN 0
+                ELSE 1
+            END) AS [ReadOnly],
+        MIN(CASE
+                WHEN
+                    COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
+                    THEN 0
+                ELSE 1
+            END) AS [HidePasswords],
+        MAX(CASE
+                WHEN
+                    COALESCE(CU.[Manage], CG.[Manage], 0) = 0
+                    THEN 0
+                ELSE 1
+            END) AS [Manage],
+        MAX(CASE
+                WHEN
+                    CU.[CollectionId] IS NULL AND CG.[CollectionId] IS NULL
+                    THEN 0
+                ELSE 1
+            END) AS [Assigned],
+        CASE
+            WHEN
+                -- No active user or group has manage rights
+                NOT EXISTS(
+                    SELECT 1
+                    FROM [dbo].[CollectionUser] CU2
+                             JOIN [dbo].[OrganizationUser] OU2 ON CU2.[OrganizationUserId] = OU2.[Id]
+                    WHERE
+                        CU2.[CollectionId] = C.[Id] AND
+                        OU2.[Status] IN (-1, 2) AND
+                        CU2.[Manage] = 1
+                )
+                    AND NOT EXISTS (
+                    SELECT 1
+                    FROM [dbo].[CollectionGroup] CG2
+                    WHERE
+                        CG2.[CollectionId] = C.[Id] AND
+                        CG2.[Manage] = 1
+                )
+                THEN 1
+            ELSE 0
+            END AS [Unmanaged]
+    FROM
+        [dbo].[CollectionView] C
+            LEFT JOIN
+        [dbo].[OrganizationUser] OU ON C.[OrganizationId] = OU.[OrganizationId] AND OU.[UserId] = @UserId
+            LEFT JOIN
+        [dbo].[CollectionUser] CU ON CU.[CollectionId] = C.[Id] AND CU.[OrganizationUserId] = [OU].[Id]
+            LEFT JOIN
+        [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND GU.[OrganizationUserId] = OU.[Id]
+            LEFT JOIN
+        [dbo].[Group] G ON G.[Id] = GU.[GroupId]
+            LEFT JOIN
+        [dbo].[CollectionGroup] CG ON CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
+    WHERE
+        C.[OrganizationId] = @OrganizationId
+    GROUP BY
+        C.[Id],
+        C.[OrganizationId],
+        C.[Name],
+        C.[CreationDate],
+        C.[RevisionDate],
+        C.[ExternalId]
+
+    IF (@IncludeAccessRelationships = 1)
+        BEGIN
+            EXEC [dbo].[CollectionGroup_ReadByOrganizationId] @OrganizationId
+            EXEC [dbo].[CollectionUser_ReadByOrganizationId] @OrganizationId
+        END
+END
+GO
+
+CREATE OR ALTER PROCEDURE [dbo].[Collection_ReadByIdWithPermissions]
+    @CollectionId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @IncludeAccessRelationships BIT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        C.*,
+        MIN(CASE
+                WHEN
+                    COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) = 0
+                    THEN 0
+                ELSE 1
+            END) AS [ReadOnly],
+        MIN (CASE
+                 WHEN
+                     COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
+                     THEN 0
+                 ELSE 1
+            END) AS [HidePasswords],
+        MAX(CASE
+                WHEN
+                    COALESCE(CU.[Manage], CG.[Manage], 0) = 0
+                    THEN 0
+                ELSE 1
+            END) AS [Manage],
+        MAX(CASE
+                WHEN
+                    CU.[CollectionId] IS NULL AND CG.[CollectionId] IS NULL
+                    THEN 0
+                ELSE 1
+            END) AS [Assigned],
+        CASE
+            WHEN
+                -- No active user or group has manage rights
+                NOT EXISTS(
+                    SELECT 1
+                    FROM [dbo].[CollectionUser] CU2
+                             JOIN [dbo].[OrganizationUser] OU2 ON CU2.[OrganizationUserId] = OU2.[Id]
+                    WHERE
+                        CU2.[CollectionId] = C.[Id] AND
+                        OU2.[Status] IN (-1, 2) AND
+                        CU2.[Manage] = 1
+                )
+                    AND NOT EXISTS (
+                    SELECT 1
+                    FROM [dbo].[CollectionGroup] CG2
+                    WHERE
+                        CG2.[CollectionId] = C.[Id] AND
+                        CG2.[Manage] = 1
+                )
+                THEN 1
+            ELSE 0
+            END AS [Unmanaged]
+    FROM
+        [dbo].[CollectionView] C
+            LEFT JOIN
+        [dbo].[OrganizationUser] OU ON C.[OrganizationId] = OU.[OrganizationId] AND OU.[UserId] = @UserId
+            LEFT JOIN
+        [dbo].[CollectionUser] CU ON CU.[CollectionId] = C.[Id] AND CU.[OrganizationUserId] = [OU].[Id]
+            LEFT JOIN
+        [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND GU.[OrganizationUserId] = OU.[Id]
+            LEFT JOIN
+        [dbo].[Group] G ON G.[Id] = GU.[GroupId]
+            LEFT JOIN
+        [dbo].[CollectionGroup] CG ON CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
+    WHERE
+        C.[Id] = @CollectionId
+    GROUP BY
+        C.[Id],
+        C.[OrganizationId],
+        C.[Name],
+        C.[CreationDate],
+        C.[RevisionDate],
+        C.[ExternalId]
+
+    IF (@IncludeAccessRelationships = 1)
+        BEGIN
+            EXEC [dbo].[CollectionGroup_ReadByCollectionId] @CollectionId
+            EXEC [dbo].[CollectionUser_ReadByCollectionId] @CollectionId
+        END
+END
+GO


### PR DESCRIPTION
## 🎟️ Tracking
[AC-2679](https://bitwarden.atlassian.net/browse/AC-2679)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Adding a revoked or confirmed user with `can manage` rights should hide the `add access` badge.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/bitwarden/server/assets/13024008/b67c25c5-dfd9-4ff4-bbee-eacf78c4c63f


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
