### PR TITLE
[PM-8844] Families sponsorship line items bug

### DIFF
--- a/src/Core/Billing/Models/Business/SponsorOrganizationSubscriptionUpdate.cs
+++ b/src/Core/Billing/Models/Business/SponsorOrganizationSubscriptionUpdate.cs
@@ -1,6 +1,7 @@
-﻿using Stripe;
+﻿using Bit.Core.Models.Business;
+using Stripe;
 
-namespace Bit.Core.Models.Business;
+namespace Bit.Core.Billing.Models.Business;
 
 public class SponsorOrganizationSubscriptionUpdate : SubscriptionUpdate
 {
@@ -9,11 +10,11 @@ public class SponsorOrganizationSubscriptionUpdate : SubscriptionUpdate
     private readonly bool _applySponsorship;
     protected override List<string> PlanIds => new() { _existingPlanStripeId, _sponsoredPlanStripeId };
 
-    public SponsorOrganizationSubscriptionUpdate(StaticStore.Plan existingPlan, StaticStore.SponsoredPlan sponsoredPlan, bool applySponsorship)
+    public SponsorOrganizationSubscriptionUpdate(Core.Models.StaticStore.Plan existingPlan, Core.Models.StaticStore.SponsoredPlan sponsoredPlan, bool applySponsorship)
     {
         _existingPlanStripeId = existingPlan.PasswordManager.StripePlanId;
         _sponsoredPlanStripeId = sponsoredPlan?.StripePlanId
-                                 ?? Utilities.StaticStore.SponsoredPlans.FirstOrDefault()?.StripePlanId;
+                                 ?? Core.Utilities.StaticStore.SponsoredPlans.FirstOrDefault()?.StripePlanId;
         _applySponsorship = applySponsorship;
     }
 

--- a/src/Core/Models/Business/SponsorOrganizationSubscriptionUpdate.cs
+++ b/src/Core/Models/Business/SponsorOrganizationSubscriptionUpdate.cs
@@ -12,7 +12,8 @@ public class SponsorOrganizationSubscriptionUpdate : SubscriptionUpdate
     public SponsorOrganizationSubscriptionUpdate(StaticStore.Plan existingPlan, StaticStore.SponsoredPlan sponsoredPlan, bool applySponsorship)
     {
         _existingPlanStripeId = existingPlan.PasswordManager.StripePlanId;
-        _sponsoredPlanStripeId = sponsoredPlan?.StripePlanId;
+        _sponsoredPlanStripeId = sponsoredPlan?.StripePlanId
+                                 ?? Utilities.StaticStore.SponsoredPlans.FirstOrDefault()?.StripePlanId;
         _applySponsorship = applySponsorship;
     }
 

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -2,6 +2,7 @@
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Models;
+using Bit.Core.Billing.Models.Business;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-8844

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR addresses an edge case where an organization sponsorship's free Stripe price ID wasn't being removed from the corresponding Stripe subscription when cancelling the organization's sponsorship. This was resulting in Stripe subscriptions with both a free Families price, and the standard $40 Families price.

This PR addresses this by null coalescing the Stripe Plan ID to the expected value found in the `StaticStore`.

Also, moved the sponsorship update object to the billing namespace.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
