### PR TITLE
[AC-2799] Finalize sprocs that added the Manage permission (2 of 3)

### DIFF
--- a/src/Infrastructure.Dapper/AdminConsole/Repositories/GroupRepository.cs
+++ b/src/Infrastructure.Dapper/AdminConsole/Repositories/GroupRepository.cs
@@ -142,7 +142,7 @@ public class GroupRepository : Repository<Group, Guid>, IGroupRepository
         using (var connection = new SqlConnection(ConnectionString))
         {
             var results = await connection.ExecuteAsync(
-                $"[{Schema}].[Group_CreateWithCollections_V2]",
+                $"[{Schema}].[Group_CreateWithCollections]",
                 objWithCollections,
                 commandType: CommandType.StoredProcedure);
         }
@@ -156,7 +156,7 @@ public class GroupRepository : Repository<Group, Guid>, IGroupRepository
         using (var connection = new SqlConnection(ConnectionString))
         {
             var results = await connection.ExecuteAsync(
-                $"[{Schema}].[Group_UpdateWithCollections_V2]",
+                $"[{Schema}].[Group_UpdateWithCollections]",
                 objWithCollections,
                 commandType: CommandType.StoredProcedure);
         }

--- a/src/Infrastructure.Dapper/AdminConsole/Repositories/OrganizationUserRepository.cs
+++ b/src/Infrastructure.Dapper/AdminConsole/Repositories/OrganizationUserRepository.cs
@@ -329,7 +329,7 @@ public class OrganizationUserRepository : Repository<OrganizationUser, Guid>, IO
         using (var connection = new SqlConnection(ConnectionString))
         {
             var results = await connection.ExecuteAsync(
-                $"[{Schema}].[OrganizationUser_CreateWithCollections_V2]",
+                $"[{Schema}].[OrganizationUser_CreateWithCollections]",
                 objWithCollections,
                 commandType: CommandType.StoredProcedure);
         }
@@ -346,7 +346,7 @@ public class OrganizationUserRepository : Repository<OrganizationUser, Guid>, IO
         using (var connection = new SqlConnection(ConnectionString))
         {
             var results = await connection.ExecuteAsync(
-                $"[{Schema}].[OrganizationUser_UpdateWithCollections_V2]",
+                $"[{Schema}].[OrganizationUser_UpdateWithCollections]",
                 objWithCollections,
                 commandType: CommandType.StoredProcedure);
         }

--- a/src/Infrastructure.Dapper/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.Dapper/Repositories/CollectionRepository.cs
@@ -305,7 +305,7 @@ public class CollectionRepository : Repository<Collection, Guid>, ICollectionRep
         using (var connection = new SqlConnection(ConnectionString))
         {
             var results = await connection.ExecuteAsync(
-                $"[{Schema}].[Collection_CreateWithGroupsAndUsers_V2]",
+                $"[{Schema}].[Collection_CreateWithGroupsAndUsers]",
                 objWithGroupsAndUsers,
                 commandType: CommandType.StoredProcedure);
         }
@@ -321,7 +321,7 @@ public class CollectionRepository : Repository<Collection, Guid>, ICollectionRep
         using (var connection = new SqlConnection(ConnectionString))
         {
             var results = await connection.ExecuteAsync(
-                $"[{Schema}].[Collection_UpdateWithGroupsAndUsers_V2]",
+                $"[{Schema}].[Collection_UpdateWithGroupsAndUsers]",
                 objWithGroupsAndUsers,
                 commandType: CommandType.StoredProcedure);
         }
@@ -378,7 +378,7 @@ public class CollectionRepository : Repository<Collection, Guid>, ICollectionRep
         using (var connection = new SqlConnection(ConnectionString))
         {
             var results = await connection.ExecuteAsync(
-                $"[{Schema}].[CollectionUser_UpdateUsers_V2]",
+                $"[{Schema}].[CollectionUser_UpdateUsers]",
                 new { CollectionId = id, Users = users.ToArrayTVP() },
                 commandType: CommandType.StoredProcedure);
         }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/AC-2799
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
From https://github.com/bitwarden/server/pull/4204:

> When we added the CollectionUser.Manage and CollectionGroup.Manage columns, we updated a number of sprocs by duplicating them and adding a _V2 suffix. We later dropped the old, non-suffixed sprocs, but the V2 naming remained.

This series of PRs just renames the V2 sprocs to drop the suffix. e.g. `CollectionUser_UpdateUsers_V2` becomes `CollectionUser_UpdateUsers`.

https://github.com/bitwarden/server/pull/4204 copied V2 sprocs back to V0 (no suffix), and is in the current `rc` branch. This PR updates the code to use the non-suffixed sprocs, and will go out in the following deployment.

The final PR (in the deployment following that one) will drop the V2 sprocs, completing the EDD cycle.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
