### PR TITLE
[AC-2662] Remove FC MVP from CurrentContext

### DIFF
--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -2178,11 +2178,6 @@ public class OrganizationService : IOrganizationService
             return false;
         }
 
-        if (permissions.DeleteAssignedCollections && !await _currentContext.DeleteAssignedCollections(organizationId))
-        {
-            return false;
-        }
-
         if (permissions.EditAnyCollection && !await _currentContext.EditAnyCollection(organizationId))
         {
             return false;

--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -2188,11 +2188,6 @@ public class OrganizationService : IOrganizationService
             return false;
         }
 
-        if (permissions.EditAssignedCollections && !await _currentContext.EditAssignedCollections(organizationId))
-        {
-            return false;
-        }
-
         if (permissions.ManageResetPassword && !await _currentContext.ManageResetPassword(organizationId))
         {
             return false;

--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -336,12 +336,6 @@ public class CurrentContext : ICurrentContext
         return await EditAnyCollection(orgId) || (org != null && org.Permissions.DeleteAnyCollection);
     }
 
-    public async Task<bool> EditAssignedCollections(Guid orgId)
-    {
-        return await OrganizationManager(orgId) || (Organizations?.Any(o => o.Id == orgId
-                    && (o.Permissions?.EditAssignedCollections ?? false)) ?? false);
-    }
-
     public async Task<bool> DeleteAssignedCollections(Guid orgId)
     {
         return await OrganizationManager(orgId) || (Organizations?.Any(o => o.Id == orgId
@@ -357,8 +351,7 @@ public class CurrentContext : ICurrentContext
          */
 
         var org = GetOrganization(orgId);
-        return await EditAssignedCollections(orgId)
-               || await DeleteAssignedCollections(orgId)
+        return await DeleteAssignedCollections(orgId)
                || (org != null && org.Permissions.CreateNewCollections);
     }
 

--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -336,12 +336,6 @@ public class CurrentContext : ICurrentContext
         return await EditAnyCollection(orgId) || (org != null && org.Permissions.DeleteAnyCollection);
     }
 
-    public async Task<bool> DeleteAssignedCollections(Guid orgId)
-    {
-        return await OrganizationManager(orgId) || (Organizations?.Any(o => o.Id == orgId
-                    && (o.Permissions?.DeleteAssignedCollections ?? false)) ?? false);
-    }
-
     public async Task<bool> ViewAssignedCollections(Guid orgId)
     {
         /*
@@ -351,8 +345,7 @@ public class CurrentContext : ICurrentContext
          */
 
         var org = GetOrganization(orgId);
-        return await DeleteAssignedCollections(orgId)
-               || (org != null && org.Permissions.CreateNewCollections);
+        return org != null && org.Permissions.CreateNewCollections;
     }
 
     public async Task<bool> ManageGroups(Guid orgId)

--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -336,18 +336,6 @@ public class CurrentContext : ICurrentContext
         return await EditAnyCollection(orgId) || (org != null && org.Permissions.DeleteAnyCollection);
     }
 
-    public async Task<bool> ViewAssignedCollections(Guid orgId)
-    {
-        /*
-         * Required to display the existing collections under which the new collection can be nested.
-         * Owner, Admin, Manager, and Provider checks are handled via the EditAssigned/DeleteAssigned context calls.
-         * This entire method will be moved to the CollectionAuthorizationHandler in the future
-         */
-
-        var org = GetOrganization(orgId);
-        return org != null && org.Permissions.CreateNewCollections;
-    }
-
     public async Task<bool> ManageGroups(Guid orgId)
     {
         return await OrganizationAdmin(orgId) || (Organizations?.Any(o => o.Id == orgId

--- a/src/Core/Context/ICurrentContext.cs
+++ b/src/Core/Context/ICurrentContext.cs
@@ -47,8 +47,6 @@ public interface ICurrentContext
     Task<bool> EditAnyCollection(Guid orgId);
     Task<bool> ViewAllCollections(Guid orgId);
     [Obsolete("Pre-Flexible Collections logic.")]
-    Task<bool> EditAssignedCollections(Guid orgId);
-    [Obsolete("Pre-Flexible Collections logic.")]
     Task<bool> DeleteAssignedCollections(Guid orgId);
     [Obsolete("Pre-Flexible Collections logic.")]
     Task<bool> ViewAssignedCollections(Guid orgId);

--- a/src/Core/Context/ICurrentContext.cs
+++ b/src/Core/Context/ICurrentContext.cs
@@ -47,8 +47,6 @@ public interface ICurrentContext
     Task<bool> EditAnyCollection(Guid orgId);
     Task<bool> ViewAllCollections(Guid orgId);
     [Obsolete("Pre-Flexible Collections logic.")]
-    Task<bool> DeleteAssignedCollections(Guid orgId);
-    [Obsolete("Pre-Flexible Collections logic.")]
     Task<bool> ViewAssignedCollections(Guid orgId);
     Task<bool> ManageGroups(Guid orgId);
     Task<bool> ManagePolicies(Guid orgId);

--- a/src/Core/Context/ICurrentContext.cs
+++ b/src/Core/Context/ICurrentContext.cs
@@ -46,8 +46,6 @@ public interface ICurrentContext
     Task<bool> AccessReports(Guid orgId);
     Task<bool> EditAnyCollection(Guid orgId);
     Task<bool> ViewAllCollections(Guid orgId);
-    [Obsolete("Pre-Flexible Collections logic.")]
-    Task<bool> ViewAssignedCollections(Guid orgId);
     Task<bool> ManageGroups(Guid orgId);
     Task<bool> ManagePolicies(Guid orgId);
     Task<bool> ManageSso(Guid orgId);

--- a/src/Core/Services/Implementations/CollectionService.cs
+++ b/src/Core/Services/Implementations/CollectionService.cs
@@ -114,7 +114,6 @@ public class CollectionService : ICollectionService
     public async Task<IEnumerable<Collection>> GetOrganizationCollectionsAsync(Guid organizationId)
     {
         if (
-            !await _currentContext.ViewAssignedCollections(organizationId) &&
             !await _currentContext.ViewAllCollections(organizationId) &&
             !await _currentContext.ManageUsers(organizationId) &&
             !await _currentContext.ManageGroups(organizationId) &&

--- a/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
@@ -979,7 +979,6 @@ OrganizationUserInvite invite, SutProvider<OrganizationService> sutProvider)
         currentContext.ManageSso(organization.Id).Returns(true);
         currentContext.AccessEventLogs(organization.Id).Returns(true);
         currentContext.AccessImportExport(organization.Id).Returns(true);
-        currentContext.DeleteAssignedCollections(organization.Id).Returns(true);
         currentContext.EditAnyCollection(organization.Id).Returns(true);
         currentContext.ManageResetPassword(organization.Id).Returns(true);
         currentContext.GetOrganization(organization.Id)

--- a/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
@@ -981,7 +981,6 @@ OrganizationUserInvite invite, SutProvider<OrganizationService> sutProvider)
         currentContext.AccessImportExport(organization.Id).Returns(true);
         currentContext.DeleteAssignedCollections(organization.Id).Returns(true);
         currentContext.EditAnyCollection(organization.Id).Returns(true);
-        currentContext.EditAssignedCollections(organization.Id).Returns(true);
         currentContext.ManageResetPassword(organization.Id).Returns(true);
         currentContext.GetOrganization(organization.Id)
             .Returns(new CurrentContextOrganization()

--- a/test/Core.Test/Services/CollectionServiceTests.cs
+++ b/test/Core.Test/Services/CollectionServiceTests.cs
@@ -182,27 +182,6 @@ public class CollectionServiceTest
     }
 
     [Theory, BitAutoData]
-    public async Task GetOrganizationCollectionsAsync_WithViewAssignedCollectionsTrue_ReturnsAssignedCollections(
-        CollectionDetails collectionDetails, Guid organizationId, Guid userId, SutProvider<CollectionService> sutProvider)
-    {
-        collectionDetails.OrganizationId = organizationId;
-
-        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(userId);
-        sutProvider.GetDependency<ICollectionRepository>()
-            .GetManyByUserIdAsync(userId, Arg.Any<bool>())
-            .Returns(new List<CollectionDetails> { collectionDetails });
-        sutProvider.GetDependency<ICurrentContext>().ViewAssignedCollections(organizationId).Returns(true);
-
-        var result = await sutProvider.Sut.GetOrganizationCollectionsAsync(organizationId);
-
-        Assert.Single(result);
-        Assert.Equal(collectionDetails, result.First());
-
-        await sutProvider.GetDependency<ICollectionRepository>().DidNotReceiveWithAnyArgs().GetManyByOrganizationIdAsync(default);
-        await sutProvider.GetDependency<ICollectionRepository>().Received(1).GetManyByUserIdAsync(userId, Arg.Any<bool>());
-    }
-
-    [Theory, BitAutoData]
     public async Task GetOrganizationCollectionsAsync_WithViewAllCollectionsTrue_ReturnsAllOrganizationCollections(
         Collection collection, Guid organizationId, Guid userId, SutProvider<CollectionService> sutProvider)
     {
@@ -210,7 +189,6 @@ public class CollectionServiceTest
         sutProvider.GetDependency<ICollectionRepository>()
             .GetManyByOrganizationIdAsync(organizationId)
             .Returns(new List<Collection> { collection });
-        sutProvider.GetDependency<ICurrentContext>().ViewAssignedCollections(organizationId).Returns(true);
         sutProvider.GetDependency<ICurrentContext>().ViewAllCollections(organizationId).Returns(true);
 
         var result = await sutProvider.Sut.GetOrganizationCollectionsAsync(organizationId);
@@ -226,8 +204,6 @@ public class CollectionServiceTest
     public async Task GetOrganizationCollectionsAsync_WithViewAssignedCollectionsFalse_ThrowsBadRequestException(
         Guid organizationId, SutProvider<CollectionService> sutProvider)
     {
-        sutProvider.GetDependency<ICurrentContext>().ViewAssignedCollections(organizationId).Returns(false);
-
         await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.GetOrganizationCollectionsAsync(organizationId));
 
         await sutProvider.GetDependency<ICollectionRepository>().DidNotReceiveWithAnyArgs().GetManyByOrganizationIdAsync(default);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/AC-2662


## 📔 Objective

> Remove `EditAssignedCollections`, `DeleteAssignedCollections`, and `ViewAssignedCollections` from `CurrentContext` and update all callers/test to reflect the changes.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
