### PR TITLE
Add key change fields to view in Bitwarden Portal

### DIFF
--- a/src/Admin/Views/Users/_ViewInformation.cshtml
+++ b/src/Admin/Views/Users/_ViewInformation.cshtml
@@ -27,4 +27,17 @@
 
     <dt class="col-sm-4 col-lg-3">Modified</dt>
     <dd class="col-sm-8 col-lg-9">@Model.User.RevisionDate.ToString()</dd>
+
+    <dt class="col-sm-4 col-lg-3">Last Email Address Change</dt>
+    <dd class="col-sm-8 col-lg-9">@(Model.User.LastEmailChangeDate.ToString() ?? "-")</dd>
+
+    <dt class="col-sm-4 col-lg-3">Last KDF Change</dt>
+    <dd class="col-sm-8 col-lg-9">@(Model.User.LastKdfChangeDate.ToString() ?? "-")</dd>
+
+    <dt class="col-sm-4 col-lg-3">Last Key Rotation</dt>
+    <dd class="col-sm-8 col-lg-9">@(Model.User.LastKeyRotationDate.ToString() ?? "-")</dd>
+
+    <dt class="col-sm-4 col-lg-3">Last Password Change</dt>
+    <dd class="col-sm-8 col-lg-9">@(Model.User.LastPasswordChangeDate.ToString() ?? "-")</dd>
+
 </dl>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-9522

## 📔 Objective
For cases of corrupt vault data, it is useful to see when a user has last changed their email, password, KDF iterations, and encryption key.

Currently this requires asking someone with production database access to get the data. This PR will put these fields on the Bitwarden Portal.

📓 Note that the access to this screen is restricted with the `User_UserInformation_View` permission.

## 📸 Screenshots

`localhost` CSS is not applying on the `Admin` project, but this occurs regardless of this change.

![image](https://github.com/bitwarden/server/assets/106564991/76e4bcff-f111-49c8-a9df-e37ee5e17815)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
