### PR TITLE
[AC-2730] Remove AccessAll - CollectionCipher

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/CollectionCipherRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CollectionCipherRepository.cs
@@ -1,5 +1,4 @@
 ﻿using AutoMapper;
-using Bit.Core.Enums;
 using Bit.Core.Repositories;
 using Bit.Infrastructure.EntityFramework.Repositories.Queries;
 using Microsoft.EntityFrameworkCore;

--- a/src/Infrastructure.EntityFramework/Repositories/CollectionCipherRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/CollectionCipherRepository.cs
@@ -81,36 +81,10 @@ public class CollectionCipherRepository : BaseEntityFrameworkRepository, ICollec
                 .Select(c => c.OrganizationId)
                 .FirstAsync();
 
-            List<Guid> availableCollections;
-
-            // TODO AC-1375: use the query below to remove AccessAll from this method
-            // var availableCollectionsQuery = new CollectionsReadByOrganizationIdUserIdQuery(organizationId, userId);
-            // availableCollections = await availableCollectionsQuery
-            //     .Run(dbContext)
-            //     .Select(c => c.Id).ToListAsync();
-
-            availableCollections = await (from c in dbContext.Collections
-                                          join o in dbContext.Organizations on c.OrganizationId equals o.Id
-                                          join ou in dbContext.OrganizationUsers
-                                             on new { OrganizationId = o.Id, UserId = (Guid?)userId } equals
-                                             new { ou.OrganizationId, ou.UserId }
-                                          join cu in dbContext.CollectionUsers
-                                             on new { ou.AccessAll, CollectionId = c.Id, OrganizationUserId = ou.Id } equals
-                                             new { AccessAll = false, cu.CollectionId, cu.OrganizationUserId } into cu_g
-                                          from cu in cu_g.DefaultIfEmpty()
-                                          join gu in dbContext.GroupUsers
-                                             on new { CollectionId = (Guid?)cu.CollectionId, ou.AccessAll, OrganizationUserId = ou.Id } equals
-                                             new { CollectionId = (Guid?)null, AccessAll = false, gu.OrganizationUserId } into gu_g
-                                          from gu in gu_g.DefaultIfEmpty()
-                                          join g in dbContext.Groups on gu.GroupId equals g.Id into g_g
-                                          from g in g_g.DefaultIfEmpty()
-                                          join cg in dbContext.CollectionGroups
-                                             on new { g.AccessAll, CollectionId = c.Id, gu.GroupId } equals
-                                             new { AccessAll = false, cg.CollectionId, cg.GroupId } into cg_g
-                                          from cg in cg_g.DefaultIfEmpty()
-                                          where o.Id == organizationId && o.Enabled && ou.Status == OrganizationUserStatusType.Confirmed
-                                             && (ou.AccessAll || !cu.ReadOnly || g.AccessAll || !cg.ReadOnly)
-                                          select c.Id).ToListAsync();
+            var availableCollectionsQuery = new CollectionsReadByOrganizationIdUserIdQuery(organizationId, userId);
+            var availableCollections = await availableCollectionsQuery
+                .Run(dbContext)
+                .Select(c => c.Id).ToListAsync();
 
             var collectionCiphers = await (from cc in dbContext.CollectionCiphers
                                            where cc.CipherId == cipherId
@@ -190,37 +164,9 @@ public class CollectionCipherRepository : BaseEntityFrameworkRepository, ICollec
         {
             var dbContext = GetDatabaseContext(scope);
 
-            IQueryable<Models.Collection> availableCollections;
-
-            // TODO AC-1375: use the query below to remove AccessAll from this method
-            // var availableCollectionsQuery = new CollectionsReadByOrganizationIdUserIdQuery(organizationId, userId);
-            // availableCollections = availableCollectionsQuery
-            //     .Run(dbContext);
-
-            availableCollections = from c in dbContext.Collections
-                                   join o in dbContext.Organizations
-                                       on c.OrganizationId equals o.Id
-                                   join ou in dbContext.OrganizationUsers
-                                       on o.Id equals ou.OrganizationId
-                                   where ou.UserId == userId
-                                   join cu in dbContext.CollectionUsers
-                                       on ou.Id equals cu.OrganizationUserId into cu_g
-                                   from cu in cu_g.DefaultIfEmpty()
-                                   where !ou.AccessAll && cu.CollectionId == c.Id
-                                   join gu in dbContext.GroupUsers
-                                       on ou.Id equals gu.OrganizationUserId into gu_g
-                                   from gu in gu_g.DefaultIfEmpty()
-                                   where cu.CollectionId == null && !ou.AccessAll
-                                   join g in dbContext.Groups
-                                       on gu.GroupId equals g.Id into g_g
-                                   from g in g_g.DefaultIfEmpty()
-                                   join cg in dbContext.CollectionGroups
-                                       on gu.GroupId equals cg.GroupId into cg_g
-                                   from cg in cg_g.DefaultIfEmpty()
-                                   where !g.AccessAll && cg.CollectionId == c.Id &&
-                                   (o.Id == organizationId && o.Enabled && ou.Status == OrganizationUserStatusType.Confirmed &&
-                                   (ou.AccessAll || !cu.ReadOnly || g.AccessAll || !cg.ReadOnly))
-                                   select c;
+            var availableCollectionsQuery = new CollectionsReadByOrganizationIdUserIdQuery(organizationId, userId);
+            var availableCollections = availableCollectionsQuery
+                .Run(dbContext);
 
             if (await availableCollections.CountAsync() < 1)
             {

--- a/src/Infrastructure.EntityFramework/Repositories/Queries/CollectionCipherReadByUserIdQuery.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/Queries/CollectionCipherReadByUserIdQuery.cs
@@ -14,11 +14,6 @@ public class CollectionCipherReadByUserIdQuery : IQuery<CollectionCipher>
 
     public virtual IQueryable<CollectionCipher> Run(DatabaseContext dbContext)
     {
-        return Run_VCurrent(dbContext);
-    }
-
-    private IQueryable<CollectionCipher> Run_VNext(DatabaseContext dbContext)
-    {
         var query = from cc in dbContext.CollectionCiphers
 
                     join c in dbContext.Collections
@@ -49,42 +44,6 @@ public class CollectionCipherReadByUserIdQuery : IQuery<CollectionCipher>
 
                     where ou.Status == OrganizationUserStatusType.Confirmed &&
                         (cu.CollectionId != null || cg.CollectionId != null)
-                    select cc;
-        return query;
-    }
-
-    private IQueryable<CollectionCipher> Run_VCurrent(DatabaseContext dbContext)
-    {
-        var query = from cc in dbContext.CollectionCiphers
-
-                    join c in dbContext.Collections
-                        on cc.CollectionId equals c.Id
-
-                    join ou in dbContext.OrganizationUsers
-                        on new { c.OrganizationId, UserId = (Guid?)_userId } equals
-                           new { ou.OrganizationId, ou.UserId }
-
-                    join cu in dbContext.CollectionUsers
-                        on new { ou.AccessAll, CollectionId = c.Id, OrganizationUserId = ou.Id } equals
-                           new { AccessAll = false, cu.CollectionId, cu.OrganizationUserId } into cu_g
-                    from cu in cu_g.DefaultIfEmpty()
-
-                    join gu in dbContext.GroupUsers
-                        on new { CollectionId = (Guid?)cu.CollectionId, ou.AccessAll, OrganizationUserId = ou.Id } equals
-                           new { CollectionId = (Guid?)null, AccessAll = false, gu.OrganizationUserId } into gu_g
-                    from gu in gu_g.DefaultIfEmpty()
-
-                    join g in dbContext.Groups
-                        on gu.GroupId equals g.Id into g_g
-                    from g in g_g.DefaultIfEmpty()
-
-                    join cg in dbContext.CollectionGroups
-                        on new { g.AccessAll, CollectionId = c.Id, gu.GroupId } equals
-                           new { AccessAll = false, cg.CollectionId, cg.GroupId } into cg_g
-                    from cg in cg_g.DefaultIfEmpty()
-
-                    where ou.Status == OrganizationUserStatusType.Confirmed &&
-                        (ou.AccessAll || cu.CollectionId != null || g.AccessAll || cg.CollectionId != null)
                     select cc;
         return query;
     }

--- a/src/Sql/dbo/Stored Procedures/CollectionCipher_ReadByUserId.sql
+++ b/src/Sql/dbo/Stored Procedures/CollectionCipher_ReadByUserId.sql
@@ -13,19 +13,17 @@ BEGIN
     INNER JOIN
         [dbo].[OrganizationUser] OU ON OU.[OrganizationId] = S.[OrganizationId] AND OU.[UserId] = @UserId
     LEFT JOIN
-        [dbo].[CollectionUser] CU ON OU.[AccessAll] = 0 AND CU.[CollectionId] = S.[Id] AND CU.[OrganizationUserId] = OU.[Id]
+        [dbo].[CollectionUser] CU ON CU.[CollectionId] = S.[Id] AND CU.[OrganizationUserId] = OU.[Id]
     LEFT JOIN
-        [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND OU.[AccessAll] = 0 AND GU.[OrganizationUserId] = OU.[Id]
+        [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND GU.[OrganizationUserId] = OU.[Id]
     LEFT JOIN
         [dbo].[Group] G ON G.[Id] = GU.[GroupId]
     LEFT JOIN
-        [dbo].[CollectionGroup] CG ON G.[AccessAll] = 0 AND CG.[CollectionId] = CC.[CollectionId] AND CG.[GroupId] = GU.[GroupId]
+        [dbo].[CollectionGroup] CG ON CG.[CollectionId] = CC.[CollectionId] AND CG.[GroupId] = GU.[GroupId]
     WHERE
         OU.[Status] = 2 -- Confirmed
         AND (
-            OU.[AccessAll] = 1
-            OR CU.[CollectionId] IS NOT NULL
-            OR G.[AccessAll] = 1
+            CU.[CollectionId] IS NOT NULL
             OR CG.[CollectionId] IS NOT NULL
         )
 END

--- a/src/Sql/dbo/Stored Procedures/CollectionCipher_ReadByUserIdCipherId.sql
+++ b/src/Sql/dbo/Stored Procedures/CollectionCipher_ReadByUserIdCipherId.sql
@@ -14,20 +14,18 @@ BEGIN
     INNER JOIN
         [dbo].[OrganizationUser] OU ON OU.[OrganizationId] = S.[OrganizationId] AND OU.[UserId] = @UserId
     LEFT JOIN
-        [dbo].[CollectionUser] CU ON OU.[AccessAll] = 0 AND CU.[CollectionId] = S.[Id] AND CU.[OrganizationUserId] = OU.[Id]
+        [dbo].[CollectionUser] CU ON CU.[CollectionId] = S.[Id] AND CU.[OrganizationUserId] = OU.[Id]
     LEFT JOIN
-        [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND OU.[AccessAll] = 0 AND GU.[OrganizationUserId] = OU.[Id]
+        [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND GU.[OrganizationUserId] = OU.[Id]
     LEFT JOIN
         [dbo].[Group] G ON G.[Id] = GU.[GroupId]
     LEFT JOIN
-        [dbo].[CollectionGroup] CG ON G.[AccessAll] = 0 AND CG.[CollectionId] = CC.[CollectionId] AND CG.[GroupId] = GU.[GroupId]
+        [dbo].[CollectionGroup] CG ON CG.[CollectionId] = CC.[CollectionId] AND CG.[GroupId] = GU.[GroupId]
     WHERE
         CC.[CipherId] = @CipherId
         AND OU.[Status] = 2 -- Confirmed
         AND (
-            OU.[AccessAll] = 1
-            OR CU.[CollectionId] IS NOT NULL
-            OR G.[AccessAll] = 1
+            CU.[CollectionId] IS NOT NULL
             OR CG.[CollectionId] IS NOT NULL
         )
 END

--- a/src/Sql/dbo/Stored Procedures/CollectionCipher_UpdateCollections.sql
+++ b/src/Sql/dbo/Stored Procedures/CollectionCipher_UpdateCollections.sql
@@ -25,21 +25,19 @@ BEGIN
         INNER JOIN
             [dbo].[OrganizationUser] OU ON OU.[OrganizationId] = O.[Id] AND OU.[UserId] = @UserId
         LEFT JOIN
-            [dbo].[CollectionUser] CU ON OU.[AccessAll] = 0 AND CU.[CollectionId] = C.[Id] AND CU.[OrganizationUserId] = OU.[Id]
+            [dbo].[CollectionUser] CU ON CU.[CollectionId] = C.[Id] AND CU.[OrganizationUserId] = OU.[Id]
         LEFT JOIN
-            [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND OU.[AccessAll] = 0 AND GU.[OrganizationUserId] = OU.[Id]
+            [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND GU.[OrganizationUserId] = OU.[Id]
         LEFT JOIN
             [dbo].[Group] G ON G.[Id] = GU.[GroupId]
         LEFT JOIN
-            [dbo].[CollectionGroup] CG ON G.[AccessAll] = 0 AND CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
+            [dbo].[CollectionGroup] CG ON CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
         WHERE
             O.[Id] = @OrgId
             AND O.[Enabled] = 1
             AND OU.[Status] = 2 -- Confirmed
             AND (
-                OU.[AccessAll] = 1
-                OR CU.[ReadOnly] = 0
-                OR G.[AccessAll] = 1
+                CU.[ReadOnly] = 0
                 OR CG.[ReadOnly] = 0
             )
     ),
@@ -54,7 +52,7 @@ BEGIN
     )
     MERGE
         [CollectionCiphersCTE] AS [Target]
-    USING 
+    USING
         @CollectionIds AS [Source]
     ON
         [Target].[CollectionId] = [Source].[Id]

--- a/src/Sql/dbo/Stored Procedures/CollectionCipher_UpdateCollectionsForCiphers.sql
+++ b/src/Sql/dbo/Stored Procedures/CollectionCipher_UpdateCollectionsForCiphers.sql
@@ -21,21 +21,19 @@ BEGIN
         INNER JOIN
             [dbo].[OrganizationUser] OU ON OU.[OrganizationId] = O.[Id] AND OU.[UserId] = @UserId
         LEFT JOIN
-            [dbo].[CollectionUser] CU ON OU.[AccessAll] = 0 AND CU.[CollectionId] = C.[Id] AND CU.[OrganizationUserId] = OU.[Id]
+            [dbo].[CollectionUser] CU ON CU.[CollectionId] = C.[Id] AND CU.[OrganizationUserId] = OU.[Id]
         LEFT JOIN
-            [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND OU.[AccessAll] = 0 AND GU.[OrganizationUserId] = OU.[Id]
+            [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND GU.[OrganizationUserId] = OU.[Id]
         LEFT JOIN
             [dbo].[Group] G ON G.[Id] = GU.[GroupId]
         LEFT JOIN
-            [dbo].[CollectionGroup] CG ON G.[AccessAll] = 0 AND CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
+            [dbo].[CollectionGroup] CG ON CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
         WHERE
             O.[Id] = @OrganizationId
             AND O.[Enabled] = 1
             AND OU.[Status] = 2 -- Confirmed
             AND (
-                OU.[AccessAll] = 1
-                OR CU.[ReadOnly] = 0
-                OR G.[AccessAll] = 1
+                CU.[ReadOnly] = 0
                 OR CG.[ReadOnly] = 0
             )
 
@@ -50,7 +48,7 @@ BEGIN
         [CollectionId],
         [CipherId]
     )
-    SELECT 
+    SELECT
         [Collection].[Id],
         [Cipher].[Id]
     FROM

--- a/util/Migrator/DbScripts/2024-07-09_00_CollectionCipherRemoveAccessAll.sql
+++ b/util/Migrator/DbScripts/2024-07-09_00_CollectionCipherRemoveAccessAll.sql
@@ -1,0 +1,213 @@
+-- Remove AccessAll from CollectionCipher sprocs
+-- We created v2 versions of these, but the feature is now fully released, so this copies v2 changes back to non-versioned sproc
+
+-- CollectionCipher_ReadByUserId
+CREATE OR ALTER PROCEDURE [dbo].[CollectionCipher_ReadByUserId]
+    @UserId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        CC.*
+    FROM
+        [dbo].[CollectionCipher] CC
+    INNER JOIN
+        [dbo].[Collection] S ON S.[Id] = CC.[CollectionId]
+    INNER JOIN
+        [dbo].[OrganizationUser] OU ON OU.[OrganizationId] = S.[OrganizationId] AND OU.[UserId] = @UserId
+    LEFT JOIN
+        [dbo].[CollectionUser] CU ON CU.[CollectionId] = S.[Id] AND CU.[OrganizationUserId] = OU.[Id]
+    LEFT JOIN
+        [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND GU.[OrganizationUserId] = OU.[Id]
+    LEFT JOIN
+        [dbo].[Group] G ON G.[Id] = GU.[GroupId]
+    LEFT JOIN
+        [dbo].[CollectionGroup] CG ON CG.[CollectionId] = CC.[CollectionId] AND CG.[GroupId] = GU.[GroupId]
+    WHERE
+        OU.[Status] = 2 -- Confirmed
+        AND (
+            CU.[CollectionId] IS NOT NULL
+            OR CG.[CollectionId] IS NOT NULL
+        )
+END
+GO
+
+-- CollectionCipher_ReadByUserIdCipherId
+CREATE OR ALTER PROCEDURE [dbo].[CollectionCipher_ReadByUserIdCipherId]
+    @UserId UNIQUEIDENTIFIER,
+    @CipherId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        CC.*
+    FROM
+        [dbo].[CollectionCipher] CC
+    INNER JOIN
+        [dbo].[Collection] S ON S.[Id] = CC.[CollectionId]
+    INNER JOIN
+        [dbo].[OrganizationUser] OU ON OU.[OrganizationId] = S.[OrganizationId] AND OU.[UserId] = @UserId
+    LEFT JOIN
+        [dbo].[CollectionUser] CU ON CU.[CollectionId] = S.[Id] AND CU.[OrganizationUserId] = OU.[Id]
+    LEFT JOIN
+        [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND GU.[OrganizationUserId] = OU.[Id]
+    LEFT JOIN
+        [dbo].[Group] G ON G.[Id] = GU.[GroupId]
+    LEFT JOIN
+        [dbo].[CollectionGroup] CG ON CG.[CollectionId] = CC.[CollectionId] AND CG.[GroupId] = GU.[GroupId]
+    WHERE
+        CC.[CipherId] = @CipherId
+        AND OU.[Status] = 2 -- Confirmed
+        AND (
+            CU.[CollectionId] IS NOT NULL
+            OR CG.[CollectionId] IS NOT NULL
+        )
+END
+GO
+
+-- CollectionCipher_UpdateCollections
+CREATE OR ALTER PROCEDURE [dbo].[CollectionCipher_UpdateCollections]
+    @CipherId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @CollectionIds AS [dbo].[GuidIdArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    DECLARE @OrgId UNIQUEIDENTIFIER = (
+        SELECT TOP 1
+            [OrganizationId]
+        FROM
+            [dbo].[Cipher]
+        WHERE
+            [Id] = @CipherId
+    )
+
+    ;WITH [AvailableCollectionsCTE] AS(
+        SELECT
+            C.[Id]
+        FROM
+            [dbo].[Collection] C
+        INNER JOIN
+            [Organization] O ON O.[Id] = C.[OrganizationId]
+        INNER JOIN
+            [dbo].[OrganizationUser] OU ON OU.[OrganizationId] = O.[Id] AND OU.[UserId] = @UserId
+        LEFT JOIN
+            [dbo].[CollectionUser] CU ON CU.[CollectionId] = C.[Id] AND CU.[OrganizationUserId] = OU.[Id]
+        LEFT JOIN
+            [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND GU.[OrganizationUserId] = OU.[Id]
+        LEFT JOIN
+            [dbo].[Group] G ON G.[Id] = GU.[GroupId]
+        LEFT JOIN
+            [dbo].[CollectionGroup] CG ON CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
+        WHERE
+            O.[Id] = @OrgId
+            AND O.[Enabled] = 1
+            AND OU.[Status] = 2 -- Confirmed
+            AND (
+                CU.[ReadOnly] = 0
+                OR CG.[ReadOnly] = 0
+            )
+    ),
+    [CollectionCiphersCTE] AS(
+        SELECT
+            [CollectionId],
+            [CipherId]
+        FROM
+            [dbo].[CollectionCipher]
+        WHERE
+            [CipherId] = @CipherId
+    )
+    MERGE
+        [CollectionCiphersCTE] AS [Target]
+    USING
+        @CollectionIds AS [Source]
+    ON
+        [Target].[CollectionId] = [Source].[Id]
+        AND [Target].[CipherId] = @CipherId
+    WHEN NOT MATCHED BY TARGET
+    AND [Source].[Id] IN (SELECT [Id] FROM [AvailableCollectionsCTE]) THEN
+        INSERT VALUES
+        (
+            [Source].[Id],
+            @CipherId
+        )
+    WHEN NOT MATCHED BY SOURCE
+    AND [Target].[CipherId] = @CipherId
+    AND [Target].[CollectionId] IN (SELECT [Id] FROM [AvailableCollectionsCTE]) THEN
+        DELETE
+    ;
+
+    IF @OrgId IS NOT NULL
+    BEGIN
+        EXEC [dbo].[User_BumpAccountRevisionDateByOrganizationId] @OrgId
+    END
+END
+GO
+
+-- CollectionCipher_UpdateCollectionsForCiphers
+CREATE OR ALTER PROCEDURE [dbo].[CollectionCipher_UpdateCollectionsForCiphers]
+    @CipherIds AS [dbo].[GuidIdArray] READONLY,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @CollectionIds AS [dbo].[GuidIdArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    CREATE TABLE #AvailableCollections (
+        [Id] UNIQUEIDENTIFIER
+    )
+
+    INSERT INTO #AvailableCollections
+        SELECT
+            C.[Id]
+        FROM
+            [dbo].[Collection] C
+        INNER JOIN
+            [Organization] O ON O.[Id] = C.[OrganizationId]
+        INNER JOIN
+            [dbo].[OrganizationUser] OU ON OU.[OrganizationId] = O.[Id] AND OU.[UserId] = @UserId
+        LEFT JOIN
+            [dbo].[CollectionUser] CU ON CU.[CollectionId] = C.[Id] AND CU.[OrganizationUserId] = OU.[Id]
+        LEFT JOIN
+            [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND GU.[OrganizationUserId] = OU.[Id]
+        LEFT JOIN
+            [dbo].[Group] G ON G.[Id] = GU.[GroupId]
+        LEFT JOIN
+            [dbo].[CollectionGroup] CG ON CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
+        WHERE
+            O.[Id] = @OrganizationId
+            AND O.[Enabled] = 1
+            AND OU.[Status] = 2 -- Confirmed
+            AND (
+                CU.[ReadOnly] = 0
+                OR CG.[ReadOnly] = 0
+            )
+
+    IF (SELECT COUNT(1) FROM #AvailableCollections) < 1
+    BEGIN
+        -- No writable collections available to share with in this organization.
+        RETURN
+    END
+
+    INSERT INTO [dbo].[CollectionCipher]
+    (
+        [CollectionId],
+        [CipherId]
+    )
+    SELECT
+        [Collection].[Id],
+        [Cipher].[Id]
+    FROM
+        @CollectionIds [Collection]
+    INNER JOIN
+        @CipherIds [Cipher] ON 1 = 1
+    WHERE
+        [Collection].[Id] IN (SELECT [Id] FROM #AvailableCollections)
+
+    EXEC [dbo].[User_BumpAccountRevisionDateByOrganizationId] @OrganizationId
+END
+GO


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/AC-2730
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Remove `AccessAll` logic from CollectionCipher sprocs:

* ./dbo/Stored Procedures/CollectionCipher_ReadByUserId.sql
* ./dbo/Stored Procedures/CollectionCipher_ReadByUserIdCipherId.sql
* ./dbo/Stored Procedures/CollectionCipher_UpdateCollections.sql
* ./dbo/Stored Procedures/CollectionCipher_UpdateCollectionsForCiphers.sql

We'd already made v2 versions of these sprocs with these changes, but they were never used. Now that the feature is released there's no need to use the v2 versions, we can just update the existing sprocs in place.

This PR copies the v2 logic (without AccessAll) back to the current sprocs. We'll drop the v2 sprocs in a later PR.

Note that this does not change the sproc parameters so there should be no other EDD concerns.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
