### PR TITLE
[PM-9612] only use Secure cookies if on a https connection

### DIFF
--- a/src/Identity/Startup.cs
+++ b/src/Identity/Startup.cs
@@ -108,6 +108,10 @@ public class Startup
                 options.SaveTokens = false;
                 options.GetClaimsFromUserInfoEndpoint = true;
 
+                // Some browsers (safari) won't allow Secure cookies to be set on a http connection
+                options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+                options.NonceCookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+
                 options.Events = new Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectEvents
                 {
                     OnRedirectToIdentityProvider = context =>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
SSO with Safari 17.5 over http wouldn't work because the cookies needed for the SSO authentication weren't being set. This was due to Safari not allowing Secure cookies to be set over non https contexts (firefox and chrome have [workarounds](https://flaviocopes.com/cookie-not-being-set-in-safari/) for localhost).

This change uses the `SameAsRequest` cookie secure [policy](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.cookiesecurepolicy?view=aspnetcore-8.0&viewFallbackFrom=net-8.0), which will send non-secure cookies when http is detected.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
