### PR TITLE
[AC-2644] Remove Flexible Collections property from Bitwarden Portal

### DIFF
--- a/src/Admin/AdminConsole/Models/OrganizationViewModel.cs
+++ b/src/Admin/AdminConsole/Models/OrganizationViewModel.cs
@@ -69,14 +69,4 @@ public class OrganizationViewModel
     public int ServiceAccountsCount { get; set; }
     public int OccupiedSmSeatsCount { get; set; }
     public bool UseSecretsManager => Organization.UseSecretsManager;
-
-    public string GetCollectionManagementSetting(bool collectionManagementSetting)
-    {
-        if (!Organization.FlexibleCollections)
-        {
-            return "N/A";
-        }
-
-        return collectionManagementSetting ? "On" : "Off";
-    }
 }

--- a/src/Admin/AdminConsole/Views/Organizations/_ViewInformation.cshtml
+++ b/src/Admin/AdminConsole/Views/Organizations/_ViewInformation.cshtml
@@ -50,14 +50,11 @@
     <dt class="col-sm-4 col-lg-3">Collections</dt>
     <dd class="col-sm-8 col-lg-9">@Model.CollectionCount</dd>
 
-    <dt class="col-sm-4 col-lg-3">Collection management enhancements</dt>
-    <dd class="col-sm-8 col-lg-9">@(Model.Organization.FlexibleCollections ? "On" : "Off")</dd>
-
     <dt class="col-sm-4 col-lg-3">Administrators manage all collections</dt>
-    <dd class="col-sm-8 col-lg-9">@(Model.GetCollectionManagementSetting(Model.Organization.AllowAdminAccessToAllCollectionItems))</dd>
+    <dd class="col-sm-8 col-lg-9">@(Model.Organization.AllowAdminAccessToAllCollectionItems ? "On" : "Off")</dd>
 
     <dt class="col-sm-4 col-lg-3">Limit collection creation to administrators</dt>
-    <dd class="col-sm-8 col-lg-9">@(Model.GetCollectionManagementSetting(Model.Organization.LimitCollectionCreationDeletion))</dd>
+    <dd class="col-sm-8 col-lg-9">@(Model.Organization.LimitCollectionCreationDeletion ? "On" : "Off")</dd>
 </dl>
 
 <h2>Secrets Manager</h2>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/AC-2644
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Remove transitional Flexible Collections MVP code from the Bitwarden Portal.

This is a minor change, just removing the `Organization.FlexibleCollections` value from display on the organization information page.

Note that there are a few references to the unused `FlexibleCollections` feature flag still, they will be removed separately.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
