### PR TITLE
[AC-1331] Remove Manager role - final

### DIFF
--- a/src/Api/AdminConsole/Models/Request/Organizations/OrganizationUserRequestModels.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/OrganizationUserRequestModels.cs
@@ -14,6 +14,7 @@ public class OrganizationUserInviteRequestModel
     [StrictEmailAddressList]
     public IEnumerable<string> Emails { get; set; }
     [Required]
+    [EnumDataType(typeof(OrganizationUserType))]
     public OrganizationUserType? Type { get; set; }
     public bool AccessSecretsManager { get; set; }
     public Permissions Permissions { get; set; }
@@ -83,6 +84,7 @@ public class OrganizationUserBulkConfirmRequestModel
 public class OrganizationUserUpdateRequestModel
 {
     [Required]
+    [EnumDataType(typeof(OrganizationUserType))]
     public OrganizationUserType? Type { get; set; }
     public bool AccessSecretsManager { get; set; }
     public Permissions Permissions { get; set; }

--- a/src/Api/AdminConsole/Public/Models/MemberBaseModel.cs
+++ b/src/Api/AdminConsole/Public/Models/MemberBaseModel.cs
@@ -48,6 +48,7 @@ public abstract class MemberBaseModel
     /// The member's type (or role) within the organization.
     /// </summary>
     [Required]
+    [EnumDataType(typeof(OrganizationUserType))]
     public OrganizationUserType? Type { get; set; }
     /// <summary>
     /// External identifier for reference or linking this member to another system, such as a user directory.

--- a/src/Api/AdminConsole/Public/Models/MemberBaseModel.cs
+++ b/src/Api/AdminConsole/Public/Models/MemberBaseModel.cs
@@ -45,8 +45,7 @@ public abstract class MemberBaseModel
     }
 
     /// <summary>
-    /// The member's type (or role) within the organization. If your organization has is using the latest collection enhancements,
-    /// you will not be allowed to assign the Manager role (OrganizationUserType = 3).
+    /// The member's type (or role) within the organization.
     /// </summary>
     [Required]
     public OrganizationUserType? Type { get; set; }

--- a/src/Core/AdminConsole/Enums/OrganizationUserType.cs
+++ b/src/Core/AdminConsole/Enums/OrganizationUserType.cs
@@ -5,6 +5,5 @@ public enum OrganizationUserType : byte
     Owner = 0,
     Admin = 1,
     User = 2,
-    Manager = 3,
     Custom = 4,
 }

--- a/src/Core/AdminConsole/Enums/OrganizationUserType.cs
+++ b/src/Core/AdminConsole/Enums/OrganizationUserType.cs
@@ -5,5 +5,6 @@ public enum OrganizationUserType : byte
     Owner = 0,
     Admin = 1,
     User = 2,
+    // Manager = 3 has been intentionally permanently deleted
     Custom = 4,
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommand.cs
@@ -61,11 +61,6 @@ public class UpdateOrganizationUserCommand : IUpdateOrganizationUserCommand
 
         // If the organization is using Flexible Collections, prevent use of any deprecated permissions
         var organization = await _organizationRepository.GetByIdAsync(user.OrganizationId);
-        if (organization.FlexibleCollections && user.Type == OrganizationUserType.Manager)
-        {
-            throw new BadRequestException("The Manager role has been deprecated by collection enhancements. Use the collection Can Manage permission instead.");
-        }
-
         if (organization.FlexibleCollections && user.AccessAll)
         {
             throw new BadRequestException("The AccessAll property has been deprecated by collection enhancements. Assign the user to collections instead.");

--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -1039,11 +1039,6 @@ public class OrganizationService : IOrganizationService
         }
 
         // If the organization is using Flexible Collections, prevent use of any deprecated permissions
-        if (organization.FlexibleCollections && invites.Any(i => i.invite.Type is OrganizationUserType.Manager))
-        {
-            throw new BadRequestException("The Manager role has been deprecated by collection enhancements. Use the collection Can Manage permission instead.");
-        }
-
         if (organization.FlexibleCollections && invites.Any(i => i.invite.AccessAll))
         {
             throw new BadRequestException("The AccessAll property has been deprecated by collection enhancements. Assign the user to collections instead.");

--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -217,17 +217,6 @@ public class CurrentContext : ICurrentContext
                 }));
         }
 
-        if (claimsDict.ContainsKey(Claims.OrganizationManager))
-        {
-            organizations.AddRange(claimsDict[Claims.OrganizationManager].Select(c =>
-                new CurrentContextOrganization
-                {
-                    Id = new Guid(c.Value),
-                    Type = OrganizationUserType.Manager,
-                    AccessSecretsManager = accessSecretsManager.ContainsKey(c.Value),
-                }));
-        }
-
         if (claimsDict.ContainsKey(Claims.OrganizationCustom))
         {
             organizations.AddRange(claimsDict[Claims.OrganizationCustom].Select(c =>
@@ -272,12 +261,6 @@ public class CurrentContext : ICurrentContext
     public async Task<bool> OrganizationUser(Guid orgId)
     {
         return (Organizations?.Any(o => o.Id == orgId) ?? false) || await OrganizationOwner(orgId);
-    }
-
-    public async Task<bool> OrganizationManager(Guid orgId)
-    {
-        return await OrganizationAdmin(orgId) ||
-               (Organizations?.Any(o => o.Id == orgId && o.Type == OrganizationUserType.Manager) ?? false);
     }
 
     public async Task<bool> OrganizationAdmin(Guid orgId)

--- a/src/Core/Context/ICurrentContext.cs
+++ b/src/Core/Context/ICurrentContext.cs
@@ -36,8 +36,6 @@ public interface ICurrentContext
 
 
     Task<bool> OrganizationUser(Guid orgId);
-    [Obsolete("Manager role is deprecated after Flexible Collections.")]
-    Task<bool> OrganizationManager(Guid orgId);
     Task<bool> OrganizationAdmin(Guid orgId);
     Task<bool> OrganizationOwner(Guid orgId);
     Task<bool> OrganizationCustom(Guid orgId);

--- a/src/Core/Identity/Claims.cs
+++ b/src/Core/Identity/Claims.cs
@@ -9,7 +9,6 @@ public static class Claims
 
     public const string OrganizationOwner = "orgowner";
     public const string OrganizationAdmin = "orgadmin";
-    public const string OrganizationManager = "orgmanager";
     public const string OrganizationUser = "orguser";
     public const string OrganizationCustom = "orgcustom";
     public const string ProviderAdmin = "providerprovideradmin";

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -700,12 +700,6 @@ public static class CoreHelpers
                             claims.Add(new KeyValuePair<string, string>(Claims.OrganizationAdmin, org.Id.ToString()));
                         }
                         break;
-                    case Enums.OrganizationUserType.Manager:
-                        foreach (var org in group)
-                        {
-                            claims.Add(new KeyValuePair<string, string>(Claims.OrganizationManager, org.Id.ToString()));
-                        }
-                        break;
                     case Enums.OrganizationUserType.User:
                         foreach (var org in group)
                         {

--- a/src/Identity/IdentityServer/ApiResources.cs
+++ b/src/Identity/IdentityServer/ApiResources.cs
@@ -20,7 +20,6 @@ public class ApiResources
                 Claims.Device,
                 Claims.OrganizationOwner,
                 Claims.OrganizationAdmin,
-                Claims.OrganizationManager,
                 Claims.OrganizationUser,
                 Claims.OrganizationCustom,
                 Claims.ProviderAdmin,

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommandTests.cs
@@ -78,44 +78,6 @@ public class UpdateOrganizationUserCommandTests
     }
 
     [Theory, BitAutoData]
-    public async Task UpdateUserAsync_WithFlexibleCollections_WhenUpgradingToManager_Throws(
-        Organization organization,
-        [OrganizationUser(type: OrganizationUserType.User)] OrganizationUser oldUserData,
-        [OrganizationUser(type: OrganizationUserType.Manager)] OrganizationUser newUserData,
-        [OrganizationUser(type: OrganizationUserType.Owner, status: OrganizationUserStatusType.Confirmed)] OrganizationUser savingUser,
-        ICollection<CollectionAccessSelection> collections,
-        IEnumerable<Guid> groups,
-        SutProvider<UpdateOrganizationUserCommand> sutProvider)
-    {
-        organization.FlexibleCollections = true;
-        newUserData.Id = oldUserData.Id;
-        newUserData.UserId = oldUserData.UserId;
-        newUserData.OrganizationId = oldUserData.OrganizationId = savingUser.OrganizationId = organization.Id;
-        newUserData.Permissions = CoreHelpers.ClassToJsonData(new Permissions());
-
-        sutProvider.GetDependency<IOrganizationRepository>()
-            .GetByIdAsync(organization.Id)
-            .Returns(organization);
-
-        sutProvider.GetDependency<IOrganizationService>()
-            .HasConfirmedOwnersExceptAsync(newUserData.OrganizationId, Arg.Is<IEnumerable<Guid>>(i => i.Contains(newUserData.Id)))
-            .Returns(true);
-
-        sutProvider.GetDependency<IOrganizationUserRepository>()
-            .GetByIdAsync(oldUserData.Id)
-            .Returns(oldUserData);
-
-        sutProvider.GetDependency<IOrganizationUserRepository>()
-            .GetManyByOrganizationAsync(organization.Id, OrganizationUserType.Owner)
-            .Returns(new List<OrganizationUser> { savingUser });
-
-        var exception = await Assert.ThrowsAsync<BadRequestException>(
-            () => sutProvider.Sut.UpdateUserAsync(newUserData, oldUserData.UserId, collections, groups));
-
-        Assert.Contains("manager role has been deprecated", exception.Message.ToLowerInvariant());
-    }
-
-    [Theory, BitAutoData]
     public async Task UpdateUserAsync_WithFlexibleCollections_WithAccessAll_Throws(
         Organization organization,
         [OrganizationUser(type: OrganizationUserType.User)] OrganizationUser oldUserData,

--- a/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
@@ -761,6 +761,7 @@ OrganizationUserInvite invite, SutProvider<OrganizationService> sutProvider)
 
     [Theory]
     [OrganizationInviteCustomize(
+        InviteeUserType = OrganizationUserType.User,
         InvitorUserType = OrganizationUserType.Custom
     ), OrganizationCustomize(FlexibleCollections = false), BitAutoData]
     public async Task InviteUsers_CustomUserWithoutManageUsersConfiguringUser_Throws(Organization organization, OrganizationUserInvite invite,

--- a/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
@@ -732,7 +732,6 @@ OrganizationUserInvite invite, SutProvider<OrganizationService> sutProvider)
     [Theory]
     [OrganizationCustomize(FlexibleCollections = false)]
     [BitAutoData(OrganizationUserType.Admin)]
-    [BitAutoData(OrganizationUserType.Manager)]
     [BitAutoData(OrganizationUserType.Owner)]
     [BitAutoData(OrganizationUserType.User)]
     public async Task InviteUsers_WithNonCustomType_WhenUseCustomPermissionsIsFalse_Passes(OrganizationUserType inviteUserType, Organization organization, OrganizationUserInvite invite,
@@ -762,7 +761,6 @@ OrganizationUserInvite invite, SutProvider<OrganizationService> sutProvider)
 
     [Theory]
     [OrganizationInviteCustomize(
-        InviteeUserType = OrganizationUserType.Manager,
         InvitorUserType = OrganizationUserType.Custom
     ), OrganizationCustomize(FlexibleCollections = false), BitAutoData]
     public async Task InviteUsers_CustomUserWithoutManageUsersConfiguringUser_Throws(Organization organization, OrganizationUserInvite invite,
@@ -1181,28 +1179,6 @@ OrganizationUserInvite invite, SutProvider<OrganizationService> sutProvider)
                     !update.MaxAutoscaleSmSeatsChanged &&
                     !update.MaxAutoscaleSmSeatsChanged));
         });
-    }
-
-    [Theory, OrganizationCustomize(FlexibleCollections = true), BitAutoData]
-    public async Task InviteUsers_WithFlexibleCollections_WhenInvitingManager_Throws(Organization organization,
-        OrganizationUserInvite invite, OrganizationUser invitor, SutProvider<OrganizationService> sutProvider)
-    {
-        invite.Type = OrganizationUserType.Manager;
-        organization.FlexibleCollections = true;
-
-        sutProvider.GetDependency<IOrganizationRepository>()
-            .GetByIdAsync(organization.Id)
-            .Returns(organization);
-
-        sutProvider.GetDependency<ICurrentContext>()
-            .ManageUsers(organization.Id)
-            .Returns(true);
-
-        var exception = await Assert.ThrowsAsync<BadRequestException>(
-            () => sutProvider.Sut.InviteUsersAsync(organization.Id, invitor.UserId, systemUser: null,
-                new (OrganizationUserInvite, string)[] { (invite, null) }));
-
-        Assert.Contains("manager role has been deprecated", exception.Message.ToLowerInvariant());
     }
 
     [Theory, OrganizationCustomize(FlexibleCollections = true), BitAutoData]
@@ -2297,7 +2273,6 @@ OrganizationUserInvite invite, SutProvider<OrganizationService> sutProvider)
     [BitAutoData(OrganizationUserType.Owner)]
     [BitAutoData(OrganizationUserType.Admin)]
     [BitAutoData(OrganizationUserType.User)]
-    [BitAutoData(OrganizationUserType.Manager)]
     public async Task ValidateOrganizationCustomPermissionsEnabledAsync_WithNotCustomType_IsValid(
         OrganizationUserType newType,
         Guid organizationId,

--- a/test/Identity.IntegrationTest/Endpoints/IdentityServerTests.cs
+++ b/test/Identity.IntegrationTest/Endpoints/IdentityServerTests.cs
@@ -145,7 +145,6 @@ public class IdentityServerTests : IClassFixture<IdentityApplicationFactory>
     [BitAutoData(OrganizationUserType.Owner)]
     [BitAutoData(OrganizationUserType.Admin)]
     [BitAutoData(OrganizationUserType.User)]
-    [BitAutoData(OrganizationUserType.Manager)]
     [BitAutoData(OrganizationUserType.Custom)]
     public async Task TokenEndpoint_GrantTypePassword_WithAllUserTypes_WithSsoPolicyDisabled_WithEnforceSsoPolicyForAllUsersTrue_Success(OrganizationUserType organizationUserType, Guid organizationId, string deviceId, int generatedUsername)
     {
@@ -173,7 +172,6 @@ public class IdentityServerTests : IClassFixture<IdentityApplicationFactory>
     [BitAutoData(OrganizationUserType.Owner)]
     [BitAutoData(OrganizationUserType.Admin)]
     [BitAutoData(OrganizationUserType.User)]
-    [BitAutoData(OrganizationUserType.Manager)]
     [BitAutoData(OrganizationUserType.Custom)]
     public async Task TokenEndpoint_GrantTypePassword_WithAllUserTypes_WithSsoPolicyDisabled_WithEnforceSsoPolicyForAllUsersFalse_Success(OrganizationUserType organizationUserType, Guid organizationId, string deviceId, int generatedUsername)
     {
@@ -201,7 +199,6 @@ public class IdentityServerTests : IClassFixture<IdentityApplicationFactory>
     [BitAutoData(OrganizationUserType.Owner)]
     [BitAutoData(OrganizationUserType.Admin)]
     [BitAutoData(OrganizationUserType.User)]
-    [BitAutoData(OrganizationUserType.Manager)]
     [BitAutoData(OrganizationUserType.Custom)]
     public async Task TokenEndpoint_GrantTypePassword_WithAllUserTypes_WithSsoPolicyEnabled_WithEnforceSsoPolicyForAllUsersTrue_Throw(OrganizationUserType organizationUserType, Guid organizationId, string deviceId, int generatedUsername)
     {
@@ -253,7 +250,6 @@ public class IdentityServerTests : IClassFixture<IdentityApplicationFactory>
 
     [Theory]
     [BitAutoData(OrganizationUserType.User)]
-    [BitAutoData(OrganizationUserType.Manager)]
     [BitAutoData(OrganizationUserType.Custom)]
     public async Task TokenEndpoint_GrantTypePassword_WithNonOwnerOrAdmin_WithSsoPolicyEnabled_WithEnforceSsoPolicyForAllUsersFalse_Throws(OrganizationUserType organizationUserType, Guid organizationId, string deviceId, int generatedUsername)
     {

--- a/test/Identity.IntegrationTest/openid-configuration.json
+++ b/test/Identity.IntegrationTest/openid-configuration.json
@@ -26,7 +26,6 @@
     "device",
     "orgowner",
     "orgadmin",
-    "orgmanager",
     "orguser",
     "orgcustom",
     "providerprovideradmin",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/AC-1331
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The Manager role was deprecated by collection enhancements (Flexible Collections) and is no longer in the database or used by any authorization or business logic.

This PR finalises the removal of the Manager role by removing the enum value and any remaining references.

It also adds the `[EnumDataType]` validation attribute to api models, which will fail validation if the value is not a valid enum value.

Corresponding clients PR: https://github.com/bitwarden/clients/pull/10060
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
