### PR TITLE
[AC-2804] Provider invoice export's client ID is using provider organization ID

### DIFF
--- a/src/Billing/Services/Implementations/ProviderEventService.cs
+++ b/src/Billing/Services/Implementations/ProviderEventService.cs
@@ -76,7 +76,7 @@ public class ProviderEventService(
                         ProviderId = parsedProviderId,
                         InvoiceId = invoice.Id,
                         InvoiceNumber = invoice.Number,
-                        ClientId = client.Id,
+                        ClientId = client.OrganizationId,
                         ClientName = client.OrganizationName,
                         PlanName = client.Plan,
                         AssignedSeats = client.Seats ?? 0,

--- a/test/Billing.Test/Services/ProviderEventServiceTests.cs
+++ b/test/Billing.Test/Services/ProviderEventServiceTests.cs
@@ -169,10 +169,14 @@ public class ProviderEventServiceTests
 
         _stripeFacade.GetSubscription(subscriptionId).Returns(subscription);
 
+        var client1Id = Guid.NewGuid();
+        var client2Id = Guid.NewGuid();
+
         var clients = new List<ProviderOrganizationOrganizationDetails>
         {
             new ()
             {
+                OrganizationId = client1Id,
                 OrganizationName = "Client 1",
                 Plan = "Teams (Monthly)",
                 Seats = 50,
@@ -181,6 +185,7 @@ public class ProviderEventServiceTests
             },
             new ()
             {
+                OrganizationId = client2Id,
                 OrganizationName = "Client 2",
                 Plan = "Enterprise (Monthly)",
                 Seats = 50,
@@ -228,6 +233,7 @@ public class ProviderEventServiceTests
                 options.InvoiceId == invoice.Id &&
                 options.InvoiceNumber == invoice.Number &&
                 options.ClientName == "Client 1" &&
+                options.ClientId == client1Id &&
                 options.PlanName == "Teams (Monthly)" &&
                 options.AssignedSeats == 50 &&
                 options.UsedSeats == 30 &&
@@ -239,6 +245,7 @@ public class ProviderEventServiceTests
                 options.InvoiceId == invoice.Id &&
                 options.InvoiceNumber == invoice.Number &&
                 options.ClientName == "Client 2" &&
+                options.ClientId == client2Id &&
                 options.PlanName == "Enterprise (Monthly)" &&
                 options.AssignedSeats == 50 &&
                 options.UsedSeats == 30 &&


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/AC-2804

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

I used the wrong ID for the Client ID column in the Provider Invoice Export.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
