### PR TITLE
[PM-9522[PM-9758] Add null check for default value to new fields on Bitwarden Portal

### DIFF
--- a/src/Admin/Views/Users/_ViewInformation.cshtml
+++ b/src/Admin/Views/Users/_ViewInformation.cshtml
@@ -29,15 +29,15 @@
     <dd class="col-sm-8 col-lg-9">@Model.User.RevisionDate.ToString()</dd>
 
     <dt class="col-sm-4 col-lg-3">Last Email Address Change</dt>
-    <dd class="col-sm-8 col-lg-9">@(Model.User.LastEmailChangeDate.ToString() ?? "-")</dd>
+    <dd class="col-sm-8 col-lg-9">@(Model.User.LastEmailChangeDate?.ToString() ?? "-")</dd>
 
     <dt class="col-sm-4 col-lg-3">Last KDF Change</dt>
-    <dd class="col-sm-8 col-lg-9">@(Model.User.LastKdfChangeDate.ToString() ?? "-")</dd>
+    <dd class="col-sm-8 col-lg-9">@(Model.User.LastKdfChangeDate?.ToString() ?? "-")</dd>
 
     <dt class="col-sm-4 col-lg-3">Last Key Rotation</dt>
-    <dd class="col-sm-8 col-lg-9">@(Model.User.LastKeyRotationDate.ToString() ?? "-")</dd>
+    <dd class="col-sm-8 col-lg-9">@(Model.User.LastKeyRotationDate?.ToString() ?? "-")</dd>
 
     <dt class="col-sm-4 col-lg-3">Last Password Change</dt>
-    <dd class="col-sm-8 col-lg-9">@(Model.User.LastPasswordChangeDate.ToString() ?? "-")</dd>
+    <dd class="col-sm-8 col-lg-9">@(Model.User.LastPasswordChangeDate?.ToString() ?? "-")</dd>
 
 </dl>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-9522

## 📔 Objective

In https://github.com/bitwarden/server/pull/4465, I added new fields to the Bitwarden Portal.  However, due to the lack of a `null` check, the default `-` value was not being displayed.  This PR fixes that.

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/bda3af80-6f76-44e6-af19-39c27374d5bb)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
