### PR TITLE
db migrations - remove comments before parsing secrets

### DIFF
--- a/dev/migrate.ps1
+++ b/dev/migrate.ps1
@@ -27,7 +27,9 @@ if ($all -or $postgres -or $mysql -or $sqlite) {
 
 if ($all -or $mssql) {
   function Get-UserSecrets {
-    return dotnet user-secrets list --json --project ../src/Api | ConvertFrom-Json
+    # The dotnet cli command sometimes adds //BEGIN and //END comments to the output, Where-Object removes comments
+    # to ensure a valid json
+    return dotnet user-secrets list --json --project ../src/Api | Where-Object { $_ -notmatch "^//" } | ConvertFrom-Json
   }
 
   if ($selfhost) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
N/A
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When running database migrations in `migrate.ps1`, the `dotnet user-secrets list` command output sometimes includes comments that breaks json parsing. This change parses the output first and strips it of any comments (lines beginning with `//`) before it's parsed.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
