### PR TITLE
Fix key rotation being broken due to org ciphers being included

### DIFF
--- a/src/Api/Vault/Validators/CipherRotationValidator.cs
+++ b/src/Api/Vault/Validators/CipherRotationValidator.cs
@@ -28,12 +28,18 @@ public class CipherRotationValidator : IRotationValidator<IEnumerable<CipherWith
         var result = new List<Cipher>();
 
         var existingCiphers = await _cipherRepository.GetManyByUserIdAsync(user.Id, UseFlexibleCollections);
-        if (existingCiphers == null || existingCiphers.Count == 0)
+        if (existingCiphers == null)
         {
             return result;
         }
 
-        foreach (var existing in existingCiphers)
+        var existingUserCiphers = existingCiphers.Where(c => c.OrganizationId == null);
+        if (existingUserCiphers.Count() == 0)
+        {
+            return result;
+        }
+
+        foreach (var existing in existingUserCiphers)
         {
             var cipher = ciphers.FirstOrDefault(c => c.Id == existing.Id);
             if (cipher == null)


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-9868
https://github.com/bitwarden/clients/pull/10140

## 📔 Objective

Fixes key rotation for org members. It was broken since the user account key rotation tried to rotate org ciphers using the user-key.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
