### PR TITLE
[PM-9826] Remove validation from 2fa GET and mask sensitive data

### DIFF
--- a/src/Api/Auth/Controllers/TwoFactorController.cs
+++ b/src/Api/Auth/Controllers/TwoFactorController.cs
@@ -433,7 +433,7 @@ public class TwoFactorController : Controller
         return Task.FromResult(new DeviceVerificationResponseModel(false, false));
     }
 
-    private async Task<User> CheckAsync(SecretVerificationRequestModel model, bool premium, bool verify = true)
+    private async Task<User> CheckAsync(SecretVerificationRequestModel model, bool premium, bool isSetMethod = true)
     {
         var user = await _userService.GetUserByPrincipalAsync(User);
         if (user == null)
@@ -441,14 +441,10 @@ public class TwoFactorController : Controller
             throw new UnauthorizedAccessException();
         }
 
-        if (verify)
+        if (!await _userService.VerifySecretAsync(user, model.Secret, isSetMethod))
         {
-            if (!await _userService.VerifySecretAsync(user, model.Secret))
-            {
-                await Task.Delay(2000);
-                throw new BadRequestException(string.Empty, "User verification failed.");
-            }
-
+            await Task.Delay(2000);
+            throw new BadRequestException(string.Empty, "User verification failed.");
         }
 
         if (premium && !await _userService.CanAccessPremium(user))

--- a/src/Api/Auth/Controllers/TwoFactorController.cs
+++ b/src/Api/Auth/Controllers/TwoFactorController.cs
@@ -93,7 +93,7 @@ public class TwoFactorController : Controller
     public async Task<TwoFactorAuthenticatorResponseModel> GetAuthenticator(
         [FromBody] SecretVerificationRequestModel model)
     {
-        var user = await CheckAsync(model, false);
+        var user = await CheckAsync(model, false, false);
         var response = new TwoFactorAuthenticatorResponseModel(user);
         return response;
     }
@@ -103,7 +103,7 @@ public class TwoFactorController : Controller
     public async Task<TwoFactorAuthenticatorResponseModel> PutAuthenticator(
         [FromBody] UpdateTwoFactorAuthenticatorRequestModel model)
     {
-        var user = await CheckAsync(model, false, false);
+        var user = await CheckAsync(model, false);
         model.ToUser(user);
 
         if (!await _userManager.VerifyTwoFactorTokenAsync(user,

--- a/src/Api/Auth/Controllers/TwoFactorController.cs
+++ b/src/Api/Auth/Controllers/TwoFactorController.cs
@@ -296,7 +296,7 @@ public class TwoFactorController : Controller
     [HttpPost("send-email")]
     public async Task SendEmail([FromBody] TwoFactorEmailRequestModel model)
     {
-        var user = await CheckAsync(model, false);
+        var user = await CheckAsync(model, false, false);
         model.ToUser(user);
         await _userService.SendTwoFactorEmailAsync(user);
     }
@@ -349,7 +349,7 @@ public class TwoFactorController : Controller
     [HttpPost("email")]
     public async Task<TwoFactorEmailResponseModel> PutEmail([FromBody] UpdateTwoFactorEmailRequestModel model)
     {
-        var user = await CheckAsync(model, false, false);
+        var user = await CheckAsync(model, false);
         model.ToUser(user);
 
         if (!await _userManager.VerifyTwoFactorTokenAsync(user,

--- a/src/Api/Auth/Controllers/TwoFactorController.cs
+++ b/src/Api/Auth/Controllers/TwoFactorController.cs
@@ -349,7 +349,7 @@ public class TwoFactorController : Controller
     [HttpPost("email")]
     public async Task<TwoFactorEmailResponseModel> PutEmail([FromBody] UpdateTwoFactorEmailRequestModel model)
     {
-        var user = await CheckAsync(model, false);
+        var user = await CheckAsync(model, false, false);
         model.ToUser(user);
 
         if (!await _userManager.VerifyTwoFactorTokenAsync(user,

--- a/src/Api/Auth/Controllers/TwoFactorController.cs
+++ b/src/Api/Auth/Controllers/TwoFactorController.cs
@@ -93,7 +93,7 @@ public class TwoFactorController : Controller
     public async Task<TwoFactorAuthenticatorResponseModel> GetAuthenticator(
         [FromBody] SecretVerificationRequestModel model)
     {
-        var user = await CheckAsync(model, false, false);
+        var user = await CheckAsync(model, false);
         var response = new TwoFactorAuthenticatorResponseModel(user);
         return response;
     }
@@ -103,7 +103,7 @@ public class TwoFactorController : Controller
     public async Task<TwoFactorAuthenticatorResponseModel> PutAuthenticator(
         [FromBody] UpdateTwoFactorAuthenticatorRequestModel model)
     {
-        var user = await CheckAsync(model, false);
+        var user = await CheckAsync(model, false, false);
         model.ToUser(user);
 
         if (!await _userManager.VerifyTwoFactorTokenAsync(user,

--- a/src/Api/Auth/Models/Response/TwoFactor/TwoFactorDuoResponseModel.cs
+++ b/src/Api/Auth/Models/Response/TwoFactor/TwoFactorDuoResponseModel.cs
@@ -117,7 +117,7 @@ public class TwoFactorDuoResponseModel : ResponseModel
 
     private static string MaskKey(string key)
     {
-        if (string.IsNullOrWhiteSpace(key))
+        if (string.IsNullOrWhiteSpace(key) || key.Length <= 6)
         {
             return key;
         }

--- a/src/Api/Auth/Models/Response/TwoFactor/TwoFactorDuoResponseModel.cs
+++ b/src/Api/Auth/Models/Response/TwoFactor/TwoFactorDuoResponseModel.cs
@@ -59,8 +59,8 @@ public class TwoFactorDuoResponseModel : ResponseModel
             // check Skey and IKey first if they exist
             if (provider.MetaData.TryGetValue("SKey", out var sKey))
             {
-                ClientSecret = (string)sKey;
-                SecretKey = (string)sKey;
+                ClientSecret = MaskKey((string)sKey);
+                SecretKey = MaskKey((string)sKey);
             }
             if (provider.MetaData.TryGetValue("IKey", out var iKey))
             {
@@ -73,8 +73,8 @@ public class TwoFactorDuoResponseModel : ResponseModel
             {
                 if (!string.IsNullOrWhiteSpace((string)clientSecret))
                 {
-                    ClientSecret = (string)clientSecret;
-                    SecretKey = (string)clientSecret;
+                    ClientSecret = MaskKey((string)clientSecret);
+                    SecretKey = MaskKey((string)clientSecret);
                 }
             }
             if (provider.MetaData.TryGetValue("ClientId", out var clientId))
@@ -113,5 +113,16 @@ public class TwoFactorDuoResponseModel : ResponseModel
         {
             throw new InvalidDataException("Invalid Duo parameters.");
         }
+    }
+
+    private static string MaskKey(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return key;
+        }
+
+        // Mask all but the first 6 characters.
+        return string.Concat(key.AsSpan(0, 6), new string('*', key.Length - 6));
     }
 }

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -75,7 +75,7 @@ public interface IUserService
     string GetUserName(ClaimsPrincipal principal);
     Task SendOTPAsync(User user);
     Task<bool> VerifyOTPAsync(User user, string token);
-    Task<bool> VerifySecretAsync(User user, string secret, bool isSettingMFA = true);
+    Task<bool> VerifySecretAsync(User user, string secret, bool isSettingMFA = false);
 
 
     void SetTwoFactorProvider(User user, TwoFactorProviderType type, bool setEnabled = true);

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -75,7 +75,7 @@ public interface IUserService
     string GetUserName(ClaimsPrincipal principal);
     Task SendOTPAsync(User user);
     Task<bool> VerifyOTPAsync(User user, string token);
-    Task<bool> VerifySecretAsync(User user, string secret);
+    Task<bool> VerifySecretAsync(User user, string secret, bool isSettingMFA = true);
 
 
     void SetTwoFactorProvider(User user, TwoFactorProviderType type, bool setEnabled = true);

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -1342,7 +1342,7 @@ public class UserService : UserManager<User>, IUserService, IDisposable
             "otp:" + user.Email, token);
     }
 
-    public async Task<bool> VerifySecretAsync(User user, string secret, bool isSettingMFA = true)
+    public async Task<bool> VerifySecretAsync(User user, string secret, bool isSettingMFA = false)
     {
         bool isVerified;
         if (user.HasMasterPassword())
@@ -1357,6 +1357,7 @@ public class UserService : UserManager<User>, IUserService, IDisposable
         else if (isSettingMFA)
         {
             // this is temporary to allow users to view their MFA settings without invalidating email TOTP
+            // Will be removed with PM-9925
             isVerified = true;
         }
         else

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -1342,7 +1342,7 @@ public class UserService : UserManager<User>, IUserService, IDisposable
             "otp:" + user.Email, token);
     }
 
-    public async Task<bool> VerifySecretAsync(User user, string secret)
+    public async Task<bool> VerifySecretAsync(User user, string secret, bool isSettingMFA = true)
     {
         bool isVerified;
         if (user.HasMasterPassword())
@@ -1353,6 +1353,11 @@ public class UserService : UserManager<User>, IUserService, IDisposable
             // does still have a password we will allow the use of OTP.
             isVerified = await CheckPasswordAsync(user, secret) ||
                 await VerifyOTPAsync(user, secret);
+        }
+        else if (isSettingMFA)
+        {
+            // this is temporary to allow users to view their MFA settings without invalidating email TOTP
+            isVerified = true;
         }
         else
         {

--- a/test/Api.Test/Auth/Models/Response/OrganizationTwoFactorDuoResponseModelTests.cs
+++ b/test/Api.Test/Auth/Models/Response/OrganizationTwoFactorDuoResponseModelTests.cs
@@ -21,9 +21,9 @@ public class OrganizationTwoFactorDuoResponseModelTests
         // Assert if v4 data Ikey and Skey are set to clientId and clientSecret
         Assert.NotNull(model);
         Assert.Equal("clientId", model.ClientId);
-        Assert.Equal("clientSecret", model.ClientSecret);
+        Assert.Equal("secret************", model.ClientSecret);
         Assert.Equal("clientId", model.IntegrationKey);
-        Assert.Equal("clientSecret", model.SecretKey);
+        Assert.Equal("secret************", model.SecretKey);
     }
 
     [Theory]
@@ -57,9 +57,9 @@ public class OrganizationTwoFactorDuoResponseModelTests
         /// Assert Even if both versions are present priority is given to v4 data
         Assert.NotNull(model);
         Assert.Equal("clientId", model.ClientId);
-        Assert.Equal("clientSecret", model.ClientSecret);
+        Assert.Equal("secret************", model.ClientSecret);
         Assert.Equal("clientId", model.IntegrationKey);
-        Assert.Equal("clientSecret", model.SecretKey);
+        Assert.Equal("secret************", model.SecretKey);
     }
 
     [Theory]
@@ -92,12 +92,14 @@ public class OrganizationTwoFactorDuoResponseModelTests
 
     private string GetTwoFactorOrganizationDuoProvidersJson()
     {
-        return "{\"6\":{\"Enabled\":true,\"MetaData\":{\"SKey\":\"SKey\",\"IKey\":\"IKey\",\"ClientSecret\":\"clientSecret\",\"ClientId\":\"clientId\",\"Host\":\"example.com\"}}}";
+        return
+            "{\"6\":{\"Enabled\":true,\"MetaData\":{\"SKey\":\"SKey\",\"IKey\":\"IKey\",\"ClientSecret\":\"secretClientSecret\",\"ClientId\":\"clientId\",\"Host\":\"example.com\"}}}";
     }
 
     private string GetTwoFactorOrganizationDuoV4ProvidersJson()
     {
-        return "{\"6\":{\"Enabled\":true,\"MetaData\":{\"ClientSecret\":\"clientSecret\",\"ClientId\":\"clientId\",\"Host\":\"example.com\"}}}";
+        return
+            "{\"6\":{\"Enabled\":true,\"MetaData\":{\"ClientSecret\":\"secretClientSecret\",\"ClientId\":\"clientId\",\"Host\":\"example.com\"}}}";
     }
 
     private string GetTwoFactorOrganizationDuoV2ProvidersJson()

--- a/test/Api.Test/Auth/Models/Response/UserTwoFactorDuoResponseModelTests.cs
+++ b/test/Api.Test/Auth/Models/Response/UserTwoFactorDuoResponseModelTests.cs
@@ -21,9 +21,9 @@ public class UserTwoFactorDuoResponseModelTests
         // Assert if v4 data Ikey and Skey are set to clientId and clientSecret
         Assert.NotNull(model);
         Assert.Equal("clientId", model.ClientId);
-        Assert.Equal("clientSecret", model.ClientSecret);
+        Assert.Equal("secret************", model.ClientSecret);
         Assert.Equal("clientId", model.IntegrationKey);
-        Assert.Equal("clientSecret", model.SecretKey);
+        Assert.Equal("secret************", model.SecretKey);
     }
 
     [Theory]
@@ -57,9 +57,9 @@ public class UserTwoFactorDuoResponseModelTests
         // Assert Even if both versions are present priority is given to v4 data
         Assert.NotNull(model);
         Assert.Equal("clientId", model.ClientId);
-        Assert.Equal("clientSecret", model.ClientSecret);
+        Assert.Equal("secret************", model.ClientSecret);
         Assert.Equal("clientId", model.IntegrationKey);
-        Assert.Equal("clientSecret", model.SecretKey);
+        Assert.Equal("secret************", model.SecretKey);
     }
 
     [Theory]
@@ -92,12 +92,14 @@ public class UserTwoFactorDuoResponseModelTests
 
     private string GetTwoFactorDuoProvidersJson()
     {
-        return "{\"2\":{\"Enabled\":true,\"MetaData\":{\"SKey\":\"SKey\",\"IKey\":\"IKey\",\"ClientSecret\":\"clientSecret\",\"ClientId\":\"clientId\",\"Host\":\"example.com\"}}}";
+        return
+            "{\"2\":{\"Enabled\":true,\"MetaData\":{\"SKey\":\"SKey\",\"IKey\":\"IKey\",\"ClientSecret\":\"secretClientSecret\",\"ClientId\":\"clientId\",\"Host\":\"example.com\"}}}";
     }
 
     private string GetTwoFactorDuoV4ProvidersJson()
     {
-        return "{\"2\":{\"Enabled\":true,\"MetaData\":{\"ClientSecret\":\"clientSecret\",\"ClientId\":\"clientId\",\"Host\":\"example.com\"}}}";
+        return
+            "{\"2\":{\"Enabled\":true,\"MetaData\":{\"ClientSecret\":\"secretClientSecret\",\"ClientId\":\"clientId\",\"Host\":\"example.com\"}}}";
     }
 
     private string GetTwoFactorDuoV2ProvidersJson()


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-9826

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Since we can't re-use TOTPs anymore, updating 2fa on accounts without a MP is currently broken. This is because we're validating the TOTP multiple times in the process (once on the GET, and once on the POST).

This removes the validation from 2fa getters, since this information mostly isn't sensitive. For the information that IS sensitive (Duo Client Secret), it masks the value before returning to user.

The TOTP is then only validated when updating the 2fa information.

Note: I also removed the validation from `/get-webauthn-challenge` and `/send-email` endpoints since they would invalidate the TOTP too early.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
See Jira for video

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
