### PR TITLE
[PM-7742] Set hasManageResetPasswordPermission for owner and admin invitees

### DIFF
--- a/src/Identity/IdentityServer/UserDecryptionOptionsBuilder.cs
+++ b/src/Identity/IdentityServer/UserDecryptionOptionsBuilder.cs
@@ -4,6 +4,7 @@ using Bit.Core.Auth.Models.Api.Response;
 using Bit.Core.Auth.Utilities;
 using Bit.Core.Context;
 using Bit.Core.Entities;
+using Bit.Core.Enums;
 using Bit.Core.Repositories;
 using Bit.Identity.Utilities;
 
@@ -136,6 +137,7 @@ public class UserDecryptionOptionsBuilder : IUserDecryptionOptionsBuilder
             // If sso configuration data is not null then I know for sure that ssoConfiguration isn't null
             var organizationUser = await _organizationUserRepository.GetByOrganizationAsync(_ssoConfig.OrganizationId, _user.Id);
 
+            hasManageResetPasswordPermission |= organizationUser.Type == OrganizationUserType.Owner || organizationUser.Type == OrganizationUserType.Admin;
             // They are only able to be approved by an admin if they have enrolled is reset password
             hasAdminApproval = organizationUser != null && !string.IsNullOrEmpty(organizationUser.ResetPasswordKey);
         }

--- a/src/Identity/IdentityServer/UserDecryptionOptionsBuilder.cs
+++ b/src/Identity/IdentityServer/UserDecryptionOptionsBuilder.cs
@@ -137,7 +137,7 @@ public class UserDecryptionOptionsBuilder : IUserDecryptionOptionsBuilder
             // If sso configuration data is not null then I know for sure that ssoConfiguration isn't null
             var organizationUser = await _organizationUserRepository.GetByOrganizationAsync(_ssoConfig.OrganizationId, _user.Id);
 
-            hasManageResetPasswordPermission |= organizationUser.Type == OrganizationUserType.Owner || organizationUser.Type == OrganizationUserType.Admin;
+            hasManageResetPasswordPermission |= organizationUser != null && (organizationUser.Type == OrganizationUserType.Owner || organizationUser.Type == OrganizationUserType.Admin);
             // They are only able to be approved by an admin if they have enrolled is reset password
             hasAdminApproval = organizationUser != null && !string.IsNullOrEmpty(organizationUser.ResetPasswordKey);
         }

--- a/test/Identity.Test/IdentityServer/UserDecryptionOptionsBuilderTests.cs
+++ b/test/Identity.Test/IdentityServer/UserDecryptionOptionsBuilderTests.cs
@@ -3,6 +3,7 @@ using Bit.Core.Auth.Enums;
 using Bit.Core.Auth.Models.Data;
 using Bit.Core.Context;
 using Bit.Core.Entities;
+using Bit.Core.Enums;
 using Bit.Core.Repositories;
 using Bit.Identity.IdentityServer;
 using Bit.Identity.Utilities;
@@ -127,6 +128,40 @@ public class UserDecryptionOptionsBuilderTests
         _currentContext.ManageResetPassword(organization.Id).Returns(true);
 
         var result = await _builder.WithSso(ssoConfig).BuildAsync();
+
+        Assert.True(result.TrustedDeviceOption?.HasManageResetPasswordPermission);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Build_WhenIsOwnerInvite_ShouldReturnHasManageResetPasswordPermissionTrue(
+        SsoConfig ssoConfig,
+        SsoConfigurationData configurationData,
+        OrganizationUser organizationUser,
+        User user)
+    {
+        configurationData.MemberDecryptionType = MemberDecryptionType.TrustedDeviceEncryption;
+        ssoConfig.Data = configurationData.Serialize();
+        organizationUser.Type = OrganizationUserType.Owner;
+        _organizationUserRepository.GetByOrganizationAsync(ssoConfig.OrganizationId, user.Id).Returns(organizationUser);
+
+        var result = await _builder.ForUser(user).WithSso(ssoConfig).BuildAsync();
+
+        Assert.True(result.TrustedDeviceOption?.HasManageResetPasswordPermission);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Build_WhenIsAdminInvite_ShouldReturnHasManageResetPasswordPermissionTrue(
+        SsoConfig ssoConfig,
+        SsoConfigurationData configurationData,
+        OrganizationUser organizationUser,
+        User user)
+    {
+        configurationData.MemberDecryptionType = MemberDecryptionType.TrustedDeviceEncryption;
+        ssoConfig.Data = configurationData.Serialize();
+        organizationUser.Type = OrganizationUserType.Admin;
+        _organizationUserRepository.GetByOrganizationAsync(ssoConfig.OrganizationId, user.Id).Returns(organizationUser);
+
+        var result = await _builder.ForUser(user).WithSso(ssoConfig).BuildAsync();
 
         Assert.True(result.TrustedDeviceOption?.HasManageResetPasswordPermission);
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-7742

## 📔 Objective

When a user is invited as an owner or admin, the hasManageResetPasswordPermission needs to be set, so that they are forced to set a master-password, after trusting their initial device upon accepting the invite. Tests are included.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
