### PR TITLE
[AC-2648] Remove Organization.FlexibleCollections from Models

### DIFF
--- a/src/Api/AdminConsole/Models/Response/Organizations/OrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/Organizations/OrganizationResponseModel.cs
@@ -57,7 +57,6 @@ public class OrganizationResponseModel : ResponseModel
         MaxAutoscaleSmServiceAccounts = organization.MaxAutoscaleSmServiceAccounts;
         LimitCollectionCreationDeletion = organization.LimitCollectionCreationDeletion;
         AllowAdminAccessToAllCollectionItems = organization.AllowAdminAccessToAllCollectionItems;
-        FlexibleCollections = organization.FlexibleCollections;
     }
 
     public Guid Id { get; set; }
@@ -101,7 +100,6 @@ public class OrganizationResponseModel : ResponseModel
     public int? MaxAutoscaleSmServiceAccounts { get; set; }
     public bool LimitCollectionCreationDeletion { get; set; }
     public bool AllowAdminAccessToAllCollectionItems { get; set; }
-    public bool FlexibleCollections { get; set; }
 }
 
 public class OrganizationSubscriptionResponseModel : OrganizationResponseModel

--- a/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
@@ -64,7 +64,6 @@ public class ProfileOrganizationResponseModel : ResponseModel
         AccessSecretsManager = organization.AccessSecretsManager;
         LimitCollectionCreationDeletion = organization.LimitCollectionCreationDeletion;
         AllowAdminAccessToAllCollectionItems = organization.AllowAdminAccessToAllCollectionItems;
-        FlexibleCollections = organization.FlexibleCollections;
 
         if (organization.SsoConfig != null)
         {
@@ -73,38 +72,35 @@ public class ProfileOrganizationResponseModel : ResponseModel
             KeyConnectorUrl = ssoConfigData.KeyConnectorUrl;
         }
 
-        if (FlexibleCollections)
+        // Downgrade Custom users with no other permissions than 'Edit/Delete Assigned Collections' to User
+        if (Type == OrganizationUserType.Custom && Permissions is not null)
         {
-            // Downgrade Custom users with no other permissions than 'Edit/Delete Assigned Collections' to User
-            if (Type == OrganizationUserType.Custom && Permissions is not null)
-            {
-                if ((Permissions.EditAssignedCollections || Permissions.DeleteAssignedCollections) &&
-                    Permissions is
-                    {
-                        AccessEventLogs: false,
-                        AccessImportExport: false,
-                        AccessReports: false,
-                        CreateNewCollections: false,
-                        EditAnyCollection: false,
-                        DeleteAnyCollection: false,
-                        ManageGroups: false,
-                        ManagePolicies: false,
-                        ManageSso: false,
-                        ManageUsers: false,
-                        ManageResetPassword: false,
-                        ManageScim: false
-                    })
+            if ((Permissions.EditAssignedCollections || Permissions.DeleteAssignedCollections) &&
+                Permissions is
                 {
-                    organization.Type = OrganizationUserType.User;
-                }
-            }
-
-            // Set 'Edit/Delete Assigned Collections' custom permissions to false
-            if (Permissions is not null)
+                    AccessEventLogs: false,
+                    AccessImportExport: false,
+                    AccessReports: false,
+                    CreateNewCollections: false,
+                    EditAnyCollection: false,
+                    DeleteAnyCollection: false,
+                    ManageGroups: false,
+                    ManagePolicies: false,
+                    ManageSso: false,
+                    ManageUsers: false,
+                    ManageResetPassword: false,
+                    ManageScim: false
+                })
             {
-                Permissions.EditAssignedCollections = false;
-                Permissions.DeleteAssignedCollections = false;
+                organization.Type = OrganizationUserType.User;
             }
+        }
+
+        // Set 'Edit/Delete Assigned Collections' custom permissions to false
+        if (Permissions is not null)
+        {
+            Permissions.EditAssignedCollections = false;
+            Permissions.DeleteAssignedCollections = false;
         }
     }
 
@@ -157,5 +153,4 @@ public class ProfileOrganizationResponseModel : ResponseModel
     public bool AccessSecretsManager { get; set; }
     public bool LimitCollectionCreationDeletion { get; set; }
     public bool AllowAdminAccessToAllCollectionItems { get; set; }
-    public bool FlexibleCollections { get; set; }
 }

--- a/src/Api/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModel.cs
@@ -46,6 +46,5 @@ public class ProfileProviderOrganizationResponseModel : ProfileOrganizationRespo
         ProductTierType = StaticStore.GetPlan(organization.PlanType).ProductTier;
         LimitCollectionCreationDeletion = organization.LimitCollectionCreationDeletion;
         AllowAdminAccessToAllCollectionItems = organization.AllowAdminAccessToAllCollectionItems;
-        FlexibleCollections = organization.FlexibleCollections;
     }
 }

--- a/src/Core/AdminConsole/Models/Data/Organizations/OrganizationAbility.cs
+++ b/src/Core/AdminConsole/Models/Data/Organizations/OrganizationAbility.cs
@@ -23,7 +23,6 @@ public class OrganizationAbility
         UsePolicies = organization.UsePolicies;
         LimitCollectionCreationDeletion = organization.LimitCollectionCreationDeletion;
         AllowAdminAccessToAllCollectionItems = organization.AllowAdminAccessToAllCollectionItems;
-        FlexibleCollections = organization.FlexibleCollections;
     }
 
     public Guid Id { get; set; }
@@ -40,5 +39,4 @@ public class OrganizationAbility
     public bool UsePolicies { get; set; }
     public bool LimitCollectionCreationDeletion { get; set; }
     public bool AllowAdminAccessToAllCollectionItems { get; set; }
-    public bool FlexibleCollections { get; set; }
 }

--- a/src/Core/AdminConsole/Models/Data/Organizations/SelfHostedOrganizationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Organizations/SelfHostedOrganizationDetails.cs
@@ -146,7 +146,6 @@ public class SelfHostedOrganizationDetails : Organization
             OwnersNotifiedOfAutoscaling = OwnersNotifiedOfAutoscaling,
             LimitCollectionCreationDeletion = LimitCollectionCreationDeletion,
             AllowAdminAccessToAllCollectionItems = AllowAdminAccessToAllCollectionItems,
-            FlexibleCollections = FlexibleCollections,
             Status = Status
         };
     }

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationRepository.cs
@@ -100,8 +100,7 @@ public class OrganizationRepository : Repository<Core.AdminConsole.Entities.Orga
                 UseCustomPermissions = e.UseCustomPermissions,
                 UsePolicies = e.UsePolicies,
                 LimitCollectionCreationDeletion = e.LimitCollectionCreationDeletion,
-                AllowAdminAccessToAllCollectionItems = e.AllowAdminAccessToAllCollectionItems,
-                FlexibleCollections = e.FlexibleCollections
+                AllowAdminAccessToAllCollectionItems = e.AllowAdminAccessToAllCollectionItems
             }).ToListAsync();
         }
     }

--- a/test/Api.Test/Vault/AuthorizationHandlers/BulkCollectionAuthorizationHandlerTests.cs
+++ b/test/Api.Test/Vault/AuthorizationHandlers/BulkCollectionAuthorizationHandlerTests.cs
@@ -1477,7 +1477,6 @@ public class BulkCollectionAuthorizationHandlerTests
     {
         var organizationAbility = new OrganizationAbility();
         organizationAbility.Id = organization.Id;
-        organizationAbility.FlexibleCollections = true;
         organizationAbility.LimitCollectionCreationDeletion = limitCollectionCreationDeletion;
         organizationAbility.AllowAdminAccessToAllCollectionItems = allowAdminAccessToAllCollectionItems;
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/AC-2648


## 📔 Objective

> Remove all references to `Organization.FlexibleCollections` from all `Request/Reponse/Data` models. This does **not** remove it from the Entity layer as it still exists in the database at this time.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team


## 🦮 Reviewer guidelines

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
