### PR TITLE
Handle a previously unhandled null case

### DIFF
--- a/src/Infrastructure.Dapper/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.Dapper/Repositories/CollectionRepository.cs
@@ -197,7 +197,7 @@ public class CollectionRepository : Repository<Collection, Guid>, ICollectionRep
 
             var collectionDetails = await results.ReadFirstOrDefaultAsync<CollectionAdminDetails>();
 
-            if (!includeAccessRelationships) return collectionDetails;
+            if (!includeAccessRelationships || collectionDetails == null) return collectionDetails;
 
             collectionDetails.Groups = (await results.ReadAsync<CollectionAccessSelection>()).ToList();
             collectionDetails.Users = (await results.ReadAsync<CollectionAccessSelection>()).ToList();


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/AC-2835

## 📔 Objective

The CLI is experiencing an issue running `bw get org-collection` for a collection that does not exist. Instead of returning a not found error, the API is returning an unhandled server exception, resulting in a confusing error being output from the CLI call. This is because there is a missing null check in the repository layer that throws an unhandled null reference exception.

This commit allows the `GetByIdWithPermissionsAsync()` repository method to return null if that is what is returned from the database. This trickles down to fix the issues in the CLI.

## 📸 Screenshots

<img width="895" alt="Screenshot 2024-07-18 at 3 27 22 PM" src="https://github.com/user-attachments/assets/193b85b7-9566-4cbc-b601-8e86d83e649c">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
