### PR TITLE
[PM-8285] add endpoint for alerting when device lost trust

### DIFF
--- a/src/Api/Controllers/DevicesController.cs
+++ b/src/Api/Controllers/DevicesController.cs
@@ -3,6 +3,7 @@ using Bit.Api.Auth.Models.Request;
 using Bit.Api.Auth.Models.Request.Accounts;
 using Bit.Api.Models.Request;
 using Bit.Api.Models.Response;
+using Bit.Core;
 using Bit.Core.Auth.Models.Api.Request;
 using Bit.Core.Auth.Models.Api.Response;
 using Bit.Core.Context;
@@ -25,19 +26,22 @@ public class DevicesController : Controller
     private readonly IUserService _userService;
     private readonly IUserRepository _userRepository;
     private readonly ICurrentContext _currentContext;
+    private readonly ILogger<DevicesController> _logger;
 
     public DevicesController(
         IDeviceRepository deviceRepository,
         IDeviceService deviceService,
         IUserService userService,
         IUserRepository userRepository,
-        ICurrentContext currentContext)
+        ICurrentContext currentContext,
+        ILogger<DevicesController> logger)
     {
         _deviceRepository = deviceRepository;
         _deviceService = deviceService;
         _userService = userService;
         _userRepository = userRepository;
         _currentContext = currentContext;
+        _logger = logger;
     }
 
     [HttpGet("{id}")]
@@ -231,4 +235,22 @@ public class DevicesController : Controller
         var device = await _deviceRepository.GetByIdentifierAsync(identifier, user.Id);
         return device != null;
     }
+
+    [RequireFeature(FeatureFlagKeys.DeviceTrustLogging)]
+    [HttpPost("lost-trust")]
+    public async Task PostLostTrust()
+    {
+        var user = await _userService.GetUserByPrincipalAsync(User);
+
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
+        var device = _currentContext.DeviceIdentifier;
+
+        _logger.LogError("User {id} has a device key, but didn't receive decryption keys for device {device}", user.Id,
+            device);
+    }
+
 }

--- a/src/Api/Controllers/DevicesController.cs
+++ b/src/Api/Controllers/DevicesController.cs
@@ -238,19 +238,22 @@ public class DevicesController : Controller
 
     [RequireFeature(FeatureFlagKeys.DeviceTrustLogging)]
     [HttpPost("lost-trust")]
-    public async Task PostLostTrust()
+    public void PostLostTrust()
     {
-        var user = await _userService.GetUserByPrincipalAsync(User);
-
-        if (user == null)
+        var userId = _currentContext.UserId.GetValueOrDefault();
+        if (userId == default)
         {
             throw new UnauthorizedAccessException();
         }
 
-        var device = _currentContext.DeviceIdentifier;
+        var deviceId = _currentContext.DeviceIdentifier;
+        if (deviceId == null)
+        {
+            throw new BadRequestException("Please provide a device identifier");
+        }
 
-        _logger.LogError("User {id} has a device key, but didn't receive decryption keys for device {device}", user.Id,
-            device);
+        _logger.LogError("User {id} has a device key, but didn't receive decryption keys for device {device}", userId,
+            deviceId);
     }
 
 }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -135,6 +135,7 @@ public static class FeatureFlagKeys
     public const string GroupsComponentRefactor = "groups-component-refactor";
     public const string AC2828_ProviderPortalMembersPage = "AC-2828_provider-portal-members-page";
     public const string ProviderClientVaultPrivacyBanner = "ac-2833-provider-client-vault-privacy-banner";
+    public const string DeviceTrustLogging = "pm-8285-device-trust-logging";
 
     public static List<string> GetAllKeys()
     {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-8285
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Adds a new endpoint that the client can use when devices have a device key, but don't receive decryption keys as a part of user decryption options. This is helpful to track lost app ids.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
