### PR TITLE
Auth/PM-10130 - Registration with Email Verification - Respect Self-hosted Disable Open Registration flag

### DIFF
--- a/src/Core/Auth/UserFeatures/Registration/Implementations/SendVerificationEmailForRegistrationCommand.cs
+++ b/src/Core/Auth/UserFeatures/Registration/Implementations/SendVerificationEmailForRegistrationCommand.cs
@@ -39,6 +39,11 @@ public class SendVerificationEmailForRegistrationCommand : ISendVerificationEmai
 
     public async Task<string?> Run(string email, string? name, bool receiveMarketingEmails)
     {
+        if (_globalSettings.DisableUserRegistration)
+        {
+            throw new BadRequestException("Open registration has been disabled by the system administrator.");
+        }
+
         if (string.IsNullOrWhiteSpace(email))
         {
             throw new ArgumentNullException(nameof(email));

--- a/test/Core.Test/Auth/UserFeatures/Registration/RegisterUserCommandTests.cs
+++ b/test/Core.Test/Auth/UserFeatures/Registration/RegisterUserCommandTests.cs
@@ -367,4 +367,18 @@ public class RegisterUserCommandTests
 
     }
 
+    [Theory]
+    [BitAutoData]
+    public async Task RegisterUserViaEmailVerificationToken_DisabledOpenRegistration_ThrowsBadRequestException(SutProvider<RegisterUserCommand> sutProvider, User user, string masterPasswordHash, string emailVerificationToken)
+    {
+        // Arrange
+        sutProvider.GetDependency<IGlobalSettings>()
+            .DisableUserRegistration = true;
+
+        // Act & Assert
+        var result = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.RegisterUserViaEmailVerificationToken(user, masterPasswordHash, emailVerificationToken));
+        Assert.Equal("Open registration has been disabled by the system administrator.", result.Message);
+
+    }
+
 }

--- a/test/Core.Test/Auth/UserFeatures/Registration/SendVerificationEmailForRegistrationCommandTests.cs
+++ b/test/Core.Test/Auth/UserFeatures/Registration/SendVerificationEmailForRegistrationCommandTests.cs
@@ -31,6 +31,9 @@ public class SendVerificationEmailForRegistrationCommandTests
         sutProvider.GetDependency<GlobalSettings>()
             .EnableEmailVerification = true;
 
+        sutProvider.GetDependency<GlobalSettings>()
+            .DisableUserRegistration = false;
+
         sutProvider.GetDependency<IMailService>()
             .SendRegistrationVerificationEmailAsync(email, Arg.Any<string>())
             .Returns(Task.CompletedTask);
@@ -63,6 +66,9 @@ public class SendVerificationEmailForRegistrationCommandTests
         sutProvider.GetDependency<GlobalSettings>()
             .EnableEmailVerification = true;
 
+        sutProvider.GetDependency<GlobalSettings>()
+            .DisableUserRegistration = false;
+
         var mockedToken = "token";
         sutProvider.GetDependency<IDataProtectorTokenFactory<RegistrationEmailVerificationTokenable>>()
             .Protect(Arg.Any<RegistrationEmailVerificationTokenable>())
@@ -90,6 +96,9 @@ public class SendVerificationEmailForRegistrationCommandTests
 
         sutProvider.GetDependency<GlobalSettings>()
             .EnableEmailVerification = false;
+
+        sutProvider.GetDependency<GlobalSettings>()
+            .DisableUserRegistration = false;
 
         var mockedToken = "token";
         sutProvider.GetDependency<IDataProtectorTokenFactory<RegistrationEmailVerificationTokenable>>()
@@ -138,6 +147,9 @@ public class SendVerificationEmailForRegistrationCommandTests
     public async Task SendVerificationEmailForRegistrationCommand_WhenNullEmail_ThrowsArgumentNullException(SutProvider<SendVerificationEmailForRegistrationCommand> sutProvider,
    string name, bool receiveMarketingEmails)
     {
+        sutProvider.GetDependency<GlobalSettings>()
+            .DisableUserRegistration = false;
+
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await sutProvider.Sut.Run(null, name, receiveMarketingEmails));
     }
 
@@ -146,6 +158,8 @@ public class SendVerificationEmailForRegistrationCommandTests
     public async Task SendVerificationEmailForRegistrationCommand_WhenEmptyEmail_ThrowsArgumentNullException(SutProvider<SendVerificationEmailForRegistrationCommand> sutProvider,
    string name, bool receiveMarketingEmails)
     {
+        sutProvider.GetDependency<GlobalSettings>()
+            .DisableUserRegistration = false;
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await sutProvider.Sut.Run("", name, receiveMarketingEmails));
     }
 }

--- a/test/Core.Test/Auth/UserFeatures/Registration/SendVerificationEmailForRegistrationCommandTests.cs
+++ b/test/Core.Test/Auth/UserFeatures/Registration/SendVerificationEmailForRegistrationCommandTests.cs
@@ -105,6 +105,19 @@ public class SendVerificationEmailForRegistrationCommandTests
 
     [Theory]
     [BitAutoData]
+    public async Task SendVerificationEmailForRegistrationCommand_WhenOpenRegistrationDisabled_ThrowsBadRequestException(SutProvider<SendVerificationEmailForRegistrationCommand> sutProvider,
+        string email, string name, bool receiveMarketingEmails)
+    {
+        // Arrange
+        sutProvider.GetDependency<GlobalSettings>()
+            .DisableUserRegistration = true;
+
+        // Act & Assert
+        await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.Run(email, name, receiveMarketingEmails));
+    }
+
+    [Theory]
+    [BitAutoData]
     public async Task SendVerificationEmailForRegistrationCommand_WhenIsExistingUserAndEnableEmailVerificationFalse_ThrowsBadRequestException(SutProvider<SendVerificationEmailForRegistrationCommand> sutProvider,
         string email, string name, bool receiveMarketingEmails)
     {

--- a/test/Identity.IntegrationTest/Controllers/AccountsControllerTests.cs
+++ b/test/Identity.IntegrationTest/Controllers/AccountsControllerTests.cs
@@ -62,6 +62,28 @@ public class AccountsControllerTests : IClassFixture<IdentityApplicationFactory>
         Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
     }
 
+    [Theory, BitAutoData]
+    public async Task PostRegisterSendEmailVerification_DisabledOpenRegistration_ThrowsBadRequestException(string name, bool receiveMarketingEmails)
+    {
+
+        // Localize substitutions to this test.
+        var localFactory = new IdentityApplicationFactory();
+        localFactory.UpdateConfiguration("globalSettings:disableUserRegistration", "true");
+
+        var email = $"test+register+{name}@email.com";
+        var model = new RegisterSendVerificationEmailRequestModel
+        {
+            Email = email,
+            Name = name,
+            ReceiveMarketingEmails = receiveMarketingEmails
+        };
+
+        var context = await localFactory.PostRegisterSendEmailVerificationAsync(model);
+
+        Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
+    }
+
+
     [Theory]
     [BitAutoData(true)]
     [BitAutoData(false)]
@@ -196,6 +218,38 @@ public class AccountsControllerTests : IClassFixture<IdentityApplicationFactory>
         Assert.Equal(AuthConstants.PBKDF2_ITERATIONS.Default, user.KdfIterations);
         Assert.Equal(kdfMemory, user.KdfMemory);
         Assert.Equal(kdfParallelism, user.KdfParallelism);
+    }
+
+
+    [Theory, BitAutoData]
+    public async Task RegistrationWithEmailVerification_OpenRegistrationDisabled_ThrowsBadRequestException([Required] string name, string emailVerificationToken,
+       [StringLength(1000), Required] string masterPasswordHash, [StringLength(50)] string masterPasswordHint, [Required] string userSymmetricKey,
+       [Required] KeysRequestModel userAsymmetricKeys, int kdfMemory, int kdfParallelism)
+    {
+        // Localize substitutions to this test.
+        var localFactory = new IdentityApplicationFactory();
+        localFactory.UpdateConfiguration("globalSettings:disableUserRegistration", "true");
+
+        var email = $"test+register+{name}@email.com";
+
+        // Now we call the finish registration endpoint with the email verification token
+        var registerFinishReqModel = new RegisterFinishRequestModel
+        {
+            Email = email,
+            MasterPasswordHash = masterPasswordHash,
+            MasterPasswordHint = masterPasswordHint,
+            EmailVerificationToken = emailVerificationToken,
+            Kdf = KdfType.PBKDF2_SHA256,
+            KdfIterations = AuthConstants.PBKDF2_ITERATIONS.Default,
+            UserSymmetricKey = userSymmetricKey,
+            UserAsymmetricKeys = userAsymmetricKeys,
+            KdfMemory = kdfMemory,
+            KdfParallelism = kdfParallelism
+        };
+
+        var postRegisterFinishHttpContext = await localFactory.PostRegisterFinishAsync(registerFinishReqModel);
+
+        Assert.Equal(StatusCodes.Status400BadRequest, postRegisterFinishHttpContext.Response.StatusCode);
     }
 
     [Theory, BitAutoData]

--- a/test/IntegrationTestCommon/Factories/WebApplicationFactoryBase.cs
+++ b/test/IntegrationTestCommon/Factories/WebApplicationFactoryBase.cs
@@ -144,6 +144,7 @@ public abstract class WebApplicationFactoryBase<T> : WebApplicationFactory<T>
 
                 // Email Verification
                 { "globalSettings:enableEmailVerification", "true" },
+                { "globalSettings:disableUserRegistration", "false" },
                 { "globalSettings:launchDarkly:flagValues:email-verification", "true" }
             });
         });


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-10130

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To fix the following two scenarios which weren't properly rejecting account registration when the `disableUserRegistration` flag was turned on on the server:

1. User goes to create an account - should be rejected on initial step of sending email verification. 
2. If user has received email verification email and self hosted admin disables open registration, the user should be prevented from finishing their account creation. 

See videos below for examples.

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/59dad56d-fd13-493d-98a7-533f1c0ab489

https://github.com/user-attachments/assets/eafadb64-e4bc-4ae9-9a09-54f9b7db67ba


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
