### PR TITLE
[PM-10291] Remove Flexible Collections v1 flag from API

### DIFF
--- a/src/Api/AdminConsole/Controllers/GroupsController.cs
+++ b/src/Api/AdminConsole/Controllers/GroupsController.cs
@@ -126,8 +126,8 @@ public class GroupsController : Controller
             throw new NotFoundException();
         }
 
-        // Flexible Collections - check the user has permission to grant access to the collections for the new group
-        if (_featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1) && model.Collections?.Any() == true)
+        // Check the user has permission to grant access to the collections for the new group
+        if (model.Collections?.Any() == true)
         {
             var collections = await _collectionRepository.GetManyByManyIdsAsync(model.Collections.Select(a => a.Id));
             var authorized =
@@ -149,31 +149,6 @@ public class GroupsController : Controller
     [HttpPut("{id}")]
     [HttpPost("{id}")]
     public async Task<GroupResponseModel> Put(Guid orgId, Guid id, [FromBody] GroupRequestModel model)
-    {
-        if (_featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1))
-        {
-            // Use new Flexible Collections v1 logic
-            return await Put_vNext(orgId, id, model);
-        }
-
-        // Pre-Flexible Collections v1 logic follows
-        var group = await _groupRepository.GetByIdAsync(id);
-        if (group == null || !await _currentContext.ManageGroups(group.OrganizationId))
-        {
-            throw new NotFoundException();
-        }
-
-        var organization = await _organizationRepository.GetByIdAsync(orgId);
-
-        await _updateGroupCommand.UpdateGroupAsync(model.ToGroup(group), organization,
-            model.Collections.Select(c => c.ToSelectionReadOnly()).ToList(), model.Users);
-        return new GroupResponseModel(group);
-    }
-
-    /// <summary>
-    /// Put logic for Flexible Collections v1
-    /// </summary>
-    private async Task<GroupResponseModel> Put_vNext(Guid orgId, Guid id, [FromBody] GroupRequestModel model)
     {
         if (!await _currentContext.ManageGroups(orgId))
         {

--- a/src/Api/AdminConsole/Controllers/GroupsController.cs
+++ b/src/Api/AdminConsole/Controllers/GroupsController.cs
@@ -4,7 +4,6 @@ using Bit.Api.Models.Response;
 using Bit.Api.Utilities;
 using Bit.Api.Vault.AuthorizationHandlers.Collections;
 using Bit.Api.Vault.AuthorizationHandlers.Groups;
-using Bit.Core;
 using Bit.Core.AdminConsole.OrganizationFeatures.Groups.Interfaces;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.AdminConsole.Services;

--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -221,8 +221,8 @@ public class OrganizationUsersController : Controller
             throw new NotFoundException();
         }
 
-        // Flexible Collections - check the user has permission to grant access to the collections for the new user
-        if (_featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1) && model.Collections?.Any() == true)
+        // Check the user has permission to grant access to the collections for the new user
+        if (model.Collections?.Any() == true)
         {
             var collections = await _collectionRepository.GetManyByManyIdsAsync(model.Collections.Select(a => a.Id));
             var authorized =
@@ -356,35 +356,6 @@ public class OrganizationUsersController : Controller
     [HttpPut("{id}")]
     [HttpPost("{id}")]
     public async Task Put(Guid orgId, Guid id, [FromBody] OrganizationUserUpdateRequestModel model)
-    {
-        if (_featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1))
-        {
-            // Use new Flexible Collections v1 logic
-            await Put_vNext(orgId, id, model);
-            return;
-        }
-
-        // Pre-Flexible Collections v1 code follows
-        if (!await _currentContext.ManageUsers(orgId))
-        {
-            throw new NotFoundException();
-        }
-
-        var organizationUser = await _organizationUserRepository.GetByIdAsync(id);
-        if (organizationUser == null || organizationUser.OrganizationId != orgId)
-        {
-            throw new NotFoundException();
-        }
-
-        var userId = _userService.GetProperUserId(User);
-        await _updateOrganizationUserCommand.UpdateUserAsync(model.ToOrganizationUser(organizationUser), userId.Value,
-            model.Collections.Select(c => c.ToSelectionReadOnly()).ToList(), model.Groups);
-    }
-
-    /// <summary>
-    /// Put logic for Flexible Collections v1
-    /// </summary>
-    private async Task Put_vNext(Guid orgId, Guid id, [FromBody] OrganizationUserUpdateRequestModel model)
     {
         if (!await _currentContext.ManageUsers(orgId))
         {

--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -5,7 +5,6 @@ using Bit.Api.Models.Response;
 using Bit.Api.Utilities;
 using Bit.Api.Vault.AuthorizationHandlers.Collections;
 using Bit.Api.Vault.AuthorizationHandlers.OrganizationUsers;
-using Bit.Core;
 using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interfaces;

--- a/src/Api/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationsController.cs
@@ -539,14 +539,6 @@ public class OrganizationsController : Controller
             throw new NotFoundException();
         }
 
-        var v1Enabled = _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1);
-
-        if (!v1Enabled)
-        {
-            // V1 is disabled, ensure V1 setting doesn't change
-            model.AllowAdminAccessToAllCollectionItems = organization.AllowAdminAccessToAllCollectionItems;
-        }
-
         await _organizationService.UpdateAsync(model.ToOrganization(organization), eventType: EventType.Organization_CollectionManagement_Updated);
         return new OrganizationResponseModel(organization);
     }

--- a/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionAuthorizationHandler.cs
+++ b/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionAuthorizationHandler.cs
@@ -191,8 +191,7 @@ public class BulkCollectionAuthorizationHandler : BulkAuthorizationHandler<BulkC
         }
 
         // Owners and Admins can update any collection only if permitted by collection management settings
-        var organizationAbility = await GetOrganizationAbilityAsync(org);
-        if (await AllowAdminAccessToAllCollectionItems(orgAbility: organizationAbility) && org is { Type: OrganizationUserType.Owner or OrganizationUserType.Admin })
+        if (await AllowAdminAccessToAllCollectionItems(org) && org is { Type: OrganizationUserType.Owner or OrganizationUserType.Admin })
         {
             return true;
         }
@@ -241,8 +240,7 @@ public class BulkCollectionAuthorizationHandler : BulkAuthorizationHandler<BulkC
         }
 
         // If AllowAdminAccessToAllCollectionItems is true, Owners and Admins can delete any collection, regardless of LimitCollectionCreationDeletion setting
-        var organizationAbility = await GetOrganizationAbilityAsync(org);
-        if (await AllowAdminAccessToAllCollectionItems(orgAbility: organizationAbility) && org is { Type: OrganizationUserType.Owner or OrganizationUserType.Admin })
+        if (await AllowAdminAccessToAllCollectionItems(org) && org is { Type: OrganizationUserType.Owner or OrganizationUserType.Admin })
         {
             return true;
         }
@@ -250,6 +248,7 @@ public class BulkCollectionAuthorizationHandler : BulkAuthorizationHandler<BulkC
         // If LimitCollectionCreationDeletion is false, AllowAdminAccessToAllCollectionItems setting is irrelevant.
         // Ensure acting user has manage permissions for all collections being deleted
         // If LimitCollectionCreationDeletion is true, only Owners and Admins can delete collections they manage
+        var organizationAbility = await GetOrganizationAbilityAsync(org);
         var canDeleteManagedCollections = organizationAbility is { LimitCollectionCreationDeletion: false } ||
                                           org is { Type: OrganizationUserType.Owner or OrganizationUserType.Admin };
         if (canDeleteManagedCollections && await CanManageCollectionsAsync(resources, org))
@@ -319,8 +318,8 @@ public class BulkCollectionAuthorizationHandler : BulkAuthorizationHandler<BulkC
         return await _applicationCacheService.GetOrganizationAbilityAsync(organization.Id);
     }
 
-    private async Task<bool> AllowAdminAccessToAllCollectionItems(CurrentContextOrganization? org = null, OrganizationAbility? orgAbility = null)
+    private async Task<bool> AllowAdminAccessToAllCollectionItems(CurrentContextOrganization? org)
     {
-        return (orgAbility ?? await GetOrganizationAbilityAsync(org)) is { AllowAdminAccessToAllCollectionItems: true };
+        return await GetOrganizationAbilityAsync(org) is { AllowAdminAccessToAllCollectionItems: true };
     }
 }

--- a/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionAuthorizationHandler.cs
+++ b/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionAuthorizationHandler.cs
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-using Bit.Core;
 using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Enums;

--- a/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionAuthorizationHandler.cs
+++ b/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionAuthorizationHandler.cs
@@ -191,10 +191,9 @@ public class BulkCollectionAuthorizationHandler : BulkAuthorizationHandler<BulkC
             return true;
         }
 
-        // If V1 is enabled, Owners and Admins can update any collection only if permitted by collection management settings
+        // Owners and Admins can update any collection only if permitted by collection management settings
         var organizationAbility = await GetOrganizationAbilityAsync(org);
-        var allowAdminAccessToAllCollectionItems = !_featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1) ||
-                                                   organizationAbility is { AllowAdminAccessToAllCollectionItems: true };
+        var allowAdminAccessToAllCollectionItems = organizationAbility is { AllowAdminAccessToAllCollectionItems: true };
         if (allowAdminAccessToAllCollectionItems && org is { Type: OrganizationUserType.Owner or OrganizationUserType.Admin })
         {
             return true;
@@ -245,8 +244,7 @@ public class BulkCollectionAuthorizationHandler : BulkAuthorizationHandler<BulkC
 
         // If AllowAdminAccessToAllCollectionItems is true, Owners and Admins can delete any collection, regardless of LimitCollectionCreationDeletion setting
         var organizationAbility = await GetOrganizationAbilityAsync(org);
-        var allowAdminAccessToAllCollectionItems = !_featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1) ||
-                                                   organizationAbility is { AllowAdminAccessToAllCollectionItems: true };
+        var allowAdminAccessToAllCollectionItems = organizationAbility is { AllowAdminAccessToAllCollectionItems: true };
         if (allowAdminAccessToAllCollectionItems && org is { Type: OrganizationUserType.Owner or OrganizationUserType.Admin })
         {
             return true;
@@ -326,8 +324,6 @@ public class BulkCollectionAuthorizationHandler : BulkAuthorizationHandler<BulkC
 
     private async Task<bool> AllowAdminAccessToAllCollectionItems(CurrentContextOrganization? org)
     {
-        var organizationAbility = await GetOrganizationAbilityAsync(org);
-        return !_featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1) ||
-            organizationAbility is { AllowAdminAccessToAllCollectionItems: true };
+        return await GetOrganizationAbilityAsync(org) is { AllowAdminAccessToAllCollectionItems: true };
     }
 }

--- a/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionAuthorizationHandler.cs
+++ b/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionAuthorizationHandler.cs
@@ -193,8 +193,7 @@ public class BulkCollectionAuthorizationHandler : BulkAuthorizationHandler<BulkC
 
         // Owners and Admins can update any collection only if permitted by collection management settings
         var organizationAbility = await GetOrganizationAbilityAsync(org);
-        var allowAdminAccessToAllCollectionItems = organizationAbility is { AllowAdminAccessToAllCollectionItems: true };
-        if (allowAdminAccessToAllCollectionItems && org is { Type: OrganizationUserType.Owner or OrganizationUserType.Admin })
+        if (await AllowAdminAccessToAllCollectionItems(orgAbility: organizationAbility) && org is { Type: OrganizationUserType.Owner or OrganizationUserType.Admin })
         {
             return true;
         }
@@ -244,8 +243,7 @@ public class BulkCollectionAuthorizationHandler : BulkAuthorizationHandler<BulkC
 
         // If AllowAdminAccessToAllCollectionItems is true, Owners and Admins can delete any collection, regardless of LimitCollectionCreationDeletion setting
         var organizationAbility = await GetOrganizationAbilityAsync(org);
-        var allowAdminAccessToAllCollectionItems = organizationAbility is { AllowAdminAccessToAllCollectionItems: true };
-        if (allowAdminAccessToAllCollectionItems && org is { Type: OrganizationUserType.Owner or OrganizationUserType.Admin })
+        if (await AllowAdminAccessToAllCollectionItems(orgAbility: organizationAbility) && org is { Type: OrganizationUserType.Owner or OrganizationUserType.Admin })
         {
             return true;
         }
@@ -322,8 +320,8 @@ public class BulkCollectionAuthorizationHandler : BulkAuthorizationHandler<BulkC
         return await _applicationCacheService.GetOrganizationAbilityAsync(organization.Id);
     }
 
-    private async Task<bool> AllowAdminAccessToAllCollectionItems(CurrentContextOrganization? org)
+    private async Task<bool> AllowAdminAccessToAllCollectionItems(CurrentContextOrganization? org = null, OrganizationAbility? orgAbility = null)
     {
-        return await GetOrganizationAbilityAsync(org) is { AllowAdminAccessToAllCollectionItems: true };
+        return (orgAbility ?? await GetOrganizationAbilityAsync(org)) is { AllowAdminAccessToAllCollectionItems: true };
     }
 }

--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -239,37 +239,24 @@ public class CiphersController : Controller
     [HttpGet("organization-details")]
     public async Task<ListResponseModel<CipherMiniDetailsResponseModel>> GetOrganizationCiphers(Guid organizationId)
     {
-        // Flexible Collections V1 Logic
-        if (UseFlexibleCollectionsV1())
+        if (!await CanAccessAllCiphersAsync(organizationId))
         {
-            return await GetAllOrganizationCiphersAsync(organizationId);
+            throw new NotFoundException();
         }
 
-        // Pre-Flexible Collections V1 Logic
-        var userId = _userService.GetProperUserId(User).Value;
+        var allOrganizationCiphers = await _organizationCiphersQuery.GetAllOrganizationCiphers(organizationId);
 
-        (IEnumerable<CipherOrganizationDetails> orgCiphers, Dictionary<Guid, IGrouping<Guid, CollectionCipher>> collectionCiphersGroupDict) = await _cipherService.GetOrganizationCiphers(userId, organizationId);
+        var allOrganizationCipherResponses =
+            allOrganizationCiphers.Select(c =>
+                new CipherMiniDetailsResponseModel(c, _globalSettings, c.OrganizationUseTotp)
+            );
 
-        var responses = orgCiphers.Select(c => new CipherMiniDetailsResponseModel(c, _globalSettings,
-            collectionCiphersGroupDict, c.OrganizationUseTotp));
-
-        var providerId = await _currentContext.ProviderIdForOrg(organizationId);
-        if (providerId.HasValue)
-        {
-            await _providerService.LogProviderAccessToOrganizationAsync(organizationId);
-        }
-
-        return new ListResponseModel<CipherMiniDetailsResponseModel>(responses);
+        return new ListResponseModel<CipherMiniDetailsResponseModel>(allOrganizationCipherResponses);
     }
 
     [HttpGet("organization-details/assigned")]
     public async Task<ListResponseModel<CipherDetailsResponseModel>> GetAssignedOrganizationCiphers(Guid organizationId)
     {
-        if (!UseFlexibleCollectionsV1())
-        {
-            throw new FeatureUnavailableException();
-        }
-
         if (!await CanAccessOrganizationCiphersAsync(organizationId) || !_currentContext.UserId.HasValue)
         {
             throw new NotFoundException();
@@ -294,27 +281,6 @@ public class CiphersController : Controller
     }
 
     /// <summary>
-    /// Returns all ciphers belonging to the organization if the user has access to All ciphers.
-    /// </summary>
-    /// <exception cref="NotFoundException"></exception>
-    private async Task<ListResponseModel<CipherMiniDetailsResponseModel>> GetAllOrganizationCiphersAsync(Guid organizationId)
-    {
-        if (!await CanAccessAllCiphersAsync(organizationId))
-        {
-            throw new NotFoundException();
-        }
-
-        var allOrganizationCiphers = await _organizationCiphersQuery.GetAllOrganizationCiphers(organizationId);
-
-        var allOrganizationCipherResponses =
-            allOrganizationCiphers.Select(c =>
-                new CipherMiniDetailsResponseModel(c, _globalSettings, c.OrganizationUseTotp)
-            );
-
-        return new ListResponseModel<CipherMiniDetailsResponseModel>(allOrganizationCipherResponses);
-    }
-
-    /// <summary>
     /// Permission helper to determine if the current user can use the "/admin" variants of the cipher endpoints.
     /// Allowed for custom users with EditAnyCollection, providers, unrestricted owners and admins (allowAdminAccess setting is ON).
     /// Falls back to original EditAnyCollection permission check for when V1 flag is disabled.
@@ -322,12 +288,6 @@ public class CiphersController : Controller
     /// </summary>
     private async Task<bool> CanEditCipherAsAdminAsync(Guid organizationId, IEnumerable<Guid> cipherIds)
     {
-        // Pre-Flexible collections V1 only needs to check EditAnyCollection
-        if (!UseFlexibleCollectionsV1())
-        {
-            return await _currentContext.EditAnyCollection(organizationId);
-        }
-
         var org = _currentContext.GetOrganization(organizationId);
 
         // If we're not an "admin", we don't need to check the ciphers
@@ -389,14 +349,6 @@ public class CiphersController : Controller
     private async Task<bool> CanEditAllCiphersAsync(Guid organizationId)
     {
         var org = _currentContext.GetOrganization(organizationId);
-
-        // If not using V1, owners, admins, and users with EditAnyCollection permissions, and providers can always edit all ciphers
-        if (!UseFlexibleCollectionsV1())
-        {
-            return org is { Type: OrganizationUserType.Owner or OrganizationUserType.Admin } or
-            { Permissions.EditAnyCollection: true } ||
-                await _currentContext.ProviderUserForOrgAsync(organizationId);
-        }
 
         // Custom users with EditAnyCollection permissions can always edit all ciphers
         if (org is { Type: OrganizationUserType.Custom, Permissions.EditAnyCollection: true })
@@ -662,7 +614,7 @@ public class CiphersController : Controller
 
         // In V1, we still need to check if the user can edit the collections they're submitting
         // This should only happen for unassigned ciphers (otherwise restricted admins would use the normal collections endpoint)
-        if (UseFlexibleCollectionsV1() && !await CanEditItemsInCollections(cipher.OrganizationId.Value, collectionIds))
+        if (!await CanEditItemsInCollections(cipher.OrganizationId.Value, collectionIds))
         {
             throw new NotFoundException();
         }
@@ -1218,10 +1170,5 @@ public class CiphersController : Controller
     private async Task<CipherDetails> GetByIdAsync(Guid cipherId, Guid userId)
     {
         return await _cipherRepository.GetByIdAsync(cipherId, userId);
-    }
-
-    private bool UseFlexibleCollectionsV1()
-    {
-        return _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1);
     }
 }

--- a/test/Api.Test/AdminConsole/Controllers/GroupsControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/GroupsControllerTests.cs
@@ -26,33 +26,12 @@ public class GroupsControllerTests
 {
     [Theory]
     [BitAutoData]
-    public async Task Post_PreFCv1_Success(Organization organization, GroupRequestModel groupRequestModel, SutProvider<GroupsController> sutProvider)
-    {
-        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
-        sutProvider.GetDependency<ICurrentContext>().ManageGroups(organization.Id).Returns(true);
-
-        var response = await sutProvider.Sut.Post(organization.Id, groupRequestModel);
-
-        await sutProvider.GetDependency<ICurrentContext>().Received(1).ManageGroups(organization.Id);
-        await sutProvider.GetDependency<ICreateGroupCommand>().Received(1).CreateGroupAsync(
-            Arg.Is<Group>(g =>
-                g.OrganizationId == organization.Id && g.Name == groupRequestModel.Name),
-            organization,
-            Arg.Any<ICollection<CollectionAccessSelection>>(),
-            Arg.Any<IEnumerable<Guid>>());
-        Assert.Equal(groupRequestModel.Name, response.Name);
-        Assert.Equal(organization.Id, response.OrganizationId);
-    }
-
-    [Theory]
-    [BitAutoData]
     public async Task Post_AuthorizedToGiveAccessToCollections_Success(Organization organization,
         GroupRequestModel groupRequestModel, SutProvider<GroupsController> sutProvider)
     {
-        // Enable FC and v1
+        // Enable FC
         sutProvider.GetDependency<IApplicationCacheService>().GetOrganizationAbilityAsync(organization.Id).Returns(
             new OrganizationAbility { Id = organization.Id, AllowAdminAccessToAllCollectionItems = false });
-        sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1).Returns(true);
 
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(),
@@ -93,10 +72,9 @@ public class GroupsControllerTests
     [BitAutoData]
     public async Task Post_NotAuthorizedToGiveAccessToCollections_Throws(Organization organization, GroupRequestModel groupRequestModel, SutProvider<GroupsController> sutProvider)
     {
-        // Enable FC and v1
+        // Enable FC
         sutProvider.GetDependency<IApplicationCacheService>().GetOrganizationAbilityAsync(organization.Id).Returns(
             new OrganizationAbility { Id = organization.Id, AllowAdminAccessToAllCollectionItems = false });
-        sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1).Returns(true);
 
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
         sutProvider.GetDependency<ICurrentContext>().ManageGroups(organization.Id).Returns(true);

--- a/test/Api.Test/AdminConsole/Controllers/GroupsControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/GroupsControllerTests.cs
@@ -2,7 +2,6 @@
 using Bit.Api.AdminConsole.Controllers;
 using Bit.Api.AdminConsole.Models.Request;
 using Bit.Api.Vault.AuthorizationHandlers.Collections;
-using Bit.Core;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.OrganizationFeatures.Groups.Interfaces;
 using Bit.Core.Context;

--- a/test/Api.Test/Vault/AuthorizationHandlers/BulkCollectionAuthorizationHandlerTests.cs
+++ b/test/Api.Test/Vault/AuthorizationHandlers/BulkCollectionAuthorizationHandlerTests.cs
@@ -537,44 +537,6 @@ public class BulkCollectionAuthorizationHandlerTests
     [Theory, CollectionCustomization]
     [BitAutoData(OrganizationUserType.Admin)]
     [BitAutoData(OrganizationUserType.Owner)]
-    public async Task CanUpdateCollection_WhenAdminOrOwner_WithoutV1Enabled_Success(
-        OrganizationUserType userType,
-        Guid userId, SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
-        ICollection<Collection> collections,
-        CurrentContextOrganization organization)
-    {
-        organization.Type = userType;
-        organization.Permissions = new Permissions();
-
-        var operationsToTest = new[]
-        {
-            BulkCollectionOperations.Update,
-            BulkCollectionOperations.ModifyUserAccess,
-            BulkCollectionOperations.ModifyGroupAccess,
-        };
-
-        foreach (var op in operationsToTest)
-        {
-            sutProvider.GetDependency<ICurrentContext>().UserId.Returns(userId);
-            sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
-
-            var context = new AuthorizationHandlerContext(
-                new[] { op },
-                new ClaimsPrincipal(),
-                collections);
-
-            await sutProvider.Sut.HandleAsync(context);
-
-            Assert.True(context.HasSucceeded);
-
-            // Recreate the SUT to reset the mocks/dependencies between tests
-            sutProvider.Recreate();
-        }
-    }
-
-    [Theory, CollectionCustomization]
-    [BitAutoData(OrganizationUserType.Admin)]
-    [BitAutoData(OrganizationUserType.Owner)]
     public async Task CanUpdateCollection_WhenAdminOrOwner_WithV1Enabled_PermittedByCollectionManagementSettings_Success(
         OrganizationUserType userType,
         Guid userId, SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
@@ -828,32 +790,6 @@ public class BulkCollectionAuthorizationHandlerTests
     }
 
     [Theory, BitAutoData, CollectionCustomization]
-    public async Task CanUpdateUsers_WithManageUsersCustomPermission_V1Disabled_Success(
-        SutProvider<BulkCollectionAuthorizationHandler> sutProvider, ICollection<Collection> collections,
-        CurrentContextOrganization organization, Guid actingUserId)
-    {
-        organization.Type = OrganizationUserType.Custom;
-        organization.Permissions = new Permissions
-        {
-            ManageUsers = true
-        };
-
-        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
-        sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
-        sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1)
-            .Returns(false);
-
-        var context = new AuthorizationHandlerContext(
-            new[] { BulkCollectionOperations.ModifyUserAccess },
-            new ClaimsPrincipal(),
-            collections);
-
-        await sutProvider.Sut.HandleAsync(context);
-
-        Assert.True(context.HasSucceeded);
-    }
-
-    [Theory, BitAutoData, CollectionCustomization]
     public async Task CanUpdateUsers_WithManageUsersCustomPermission_AllowAdminAccessIsTrue_Success(
         SutProvider<BulkCollectionAuthorizationHandler> sutProvider, ICollection<Collection> collections,
         CurrentContextOrganization organization, Guid actingUserId)
@@ -907,32 +843,6 @@ public class BulkCollectionAuthorizationHandlerTests
         await sutProvider.Sut.HandleAsync(context);
 
         Assert.False(context.HasSucceeded);
-    }
-
-    [Theory, BitAutoData, CollectionCustomization]
-    public async Task CanUpdateGroups_WithManageGroupsCustomPermission_V1Disabled_Success(
-        SutProvider<BulkCollectionAuthorizationHandler> sutProvider, ICollection<Collection> collections,
-        CurrentContextOrganization organization, Guid actingUserId)
-    {
-        organization.Type = OrganizationUserType.Custom;
-        organization.Permissions = new Permissions
-        {
-            ManageGroups = true
-        };
-
-        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
-        sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
-        sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1)
-            .Returns(false);
-
-        var context = new AuthorizationHandlerContext(
-            new[] { BulkCollectionOperations.ModifyGroupAccess },
-            new ClaimsPrincipal(),
-            collections);
-
-        await sutProvider.Sut.HandleAsync(context);
-
-        Assert.True(context.HasSucceeded);
     }
 
     [Theory, BitAutoData, CollectionCustomization]
@@ -1041,34 +951,6 @@ public class BulkCollectionAuthorizationHandlerTests
 
         sutProvider.GetDependency<ICurrentContext>().UserId.Returns(userId);
         sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
-
-        await sutProvider.Sut.HandleAsync(context);
-
-        Assert.True(context.HasSucceeded);
-    }
-
-    [Theory, CollectionCustomization]
-    [BitAutoData(OrganizationUserType.Admin)]
-    [BitAutoData(OrganizationUserType.Owner)]
-    public async Task CanDeleteAsync_WhenAdminOrOwner_V1FlagDisabled_Success(
-        OrganizationUserType userType,
-        Guid userId, SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
-        ICollection<Collection> collections,
-        CurrentContextOrganization organization)
-    {
-        organization.Type = userType;
-        organization.Permissions = new Permissions();
-
-        ArrangeOrganizationAbility(sutProvider, organization, true, false);
-
-        var context = new AuthorizationHandlerContext(
-            new[] { BulkCollectionOperations.Delete },
-            new ClaimsPrincipal(),
-            collections);
-
-        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(userId);
-        sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
-        sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1).Returns(false);
 
         await sutProvider.Sut.HandleAsync(context);
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10291


## 📔 Objective

> Remove all instances of Flexible Collections v1 feature flag conditionals within the API layer


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team


## 🦮 Reviewer guidelines

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
