### PR TITLE
[PM-10292] Remove Flexible Collections v1 from Core

### DIFF
--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -437,9 +437,6 @@ public class OrganizationService : IOrganizationService
 
         ValidatePlan(plan, signup.AdditionalSeats, "Password Manager");
 
-        var flexibleCollectionsV1Enabled =
-            _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1);
-
         var organization = new Organization
         {
             // Pre-generate the org id so that we can save it with the Stripe subscription.
@@ -476,10 +473,6 @@ public class OrganizationService : IOrganizationService
             UsePasswordManager = true,
             // Secrets Manager not available for purchase with Consolidated Billing.
             UseSecretsManager = false,
-
-            // This is a transitional setting that defaults to ON until Flexible Collections v1 is released
-            // (to preserve existing behavior) and defaults to OFF after release (enabling new behavior)
-            AllowAdminAccessToAllCollectionItems = !flexibleCollectionsV1Enabled
         };
 
         var returnValue = await SignUpAsync(organization, default, signup.OwnerKey, signup.CollectionName, false);
@@ -522,9 +515,6 @@ public class OrganizationService : IOrganizationService
             await ValidateSignUpPoliciesAsync(signup.Owner.Id);
         }
 
-        var flexibleCollectionsV1IsEnabled =
-            _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1);
-
         var organization = new Organization
         {
             // Pre-generate the org id so that we can save it with the Stripe subscription..
@@ -561,11 +551,7 @@ public class OrganizationService : IOrganizationService
             RevisionDate = DateTime.UtcNow,
             Status = OrganizationStatusType.Created,
             UsePasswordManager = true,
-            UseSecretsManager = signup.UseSecretsManager,
-
-            // This is a transitional setting that defaults to ON until Flexible Collections v1 is released
-            // (to preserve existing behavior) and defaults to OFF after release (enabling new behavior)
-            AllowAdminAccessToAllCollectionItems = !flexibleCollectionsV1IsEnabled
+            UseSecretsManager = signup.UseSecretsManager
         };
 
         if (signup.UseSecretsManager)

--- a/src/Core/Services/Implementations/CollectionService.cs
+++ b/src/Core/Services/Implementations/CollectionService.cs
@@ -17,7 +17,6 @@ public class CollectionService : ICollectionService
     private readonly ICollectionRepository _collectionRepository;
     private readonly IReferenceEventService _referenceEventService;
     private readonly ICurrentContext _currentContext;
-    private readonly IFeatureService _featureService;
 
     public CollectionService(
         IEventService eventService,
@@ -25,8 +24,7 @@ public class CollectionService : ICollectionService
         IOrganizationUserRepository organizationUserRepository,
         ICollectionRepository collectionRepository,
         IReferenceEventService referenceEventService,
-        ICurrentContext currentContext,
-        IFeatureService featureService)
+        ICurrentContext currentContext)
     {
         _eventService = eventService;
         _organizationRepository = organizationRepository;
@@ -34,7 +32,6 @@ public class CollectionService : ICollectionService
         _collectionRepository = collectionRepository;
         _referenceEventService = referenceEventService;
         _currentContext = currentContext;
-        _featureService = featureService;
     }
 
     public async Task SaveAsync(Collection collection, IEnumerable<CollectionAccessSelection> groups = null,
@@ -56,16 +53,13 @@ public class CollectionService : ICollectionService
             throw new BadRequestException("The Manage property is mutually exclusive and cannot be true while the ReadOnly or HidePasswords properties are also true.");
         }
 
-        // If using Flexible Collections V1 - a collection should always have someone with Can Manage permissions
-        if (_featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1))
+        // A collection should always have someone with Can Manage permissions
+        var groupHasManageAccess = groupsList?.Any(g => g.Manage) ?? false;
+        var userHasManageAccess = usersList?.Any(u => u.Manage) ?? false;
+        if (!groupHasManageAccess && !userHasManageAccess && !org.AllowAdminAccessToAllCollectionItems)
         {
-            var groupHasManageAccess = groupsList?.Any(g => g.Manage) ?? false;
-            var userHasManageAccess = usersList?.Any(u => u.Manage) ?? false;
-            if (!groupHasManageAccess && !userHasManageAccess && !org.AllowAdminAccessToAllCollectionItems)
-            {
-                throw new BadRequestException(
-                    "At least one member or group must have can manage permission.");
-            }
+            throw new BadRequestException(
+                "At least one member or group must have can manage permission.");
         }
 
         if (collection.Id == default(Guid))

--- a/src/Core/Vault/Queries/OrganizationCiphersQuery.cs
+++ b/src/Core/Vault/Queries/OrganizationCiphersQuery.cs
@@ -1,6 +1,4 @@
-﻿using Bit.Core.Exceptions;
-using Bit.Core.Repositories;
-using Bit.Core.Services;
+﻿using Bit.Core.Repositories;
 using Bit.Core.Vault.Models.Data;
 using Bit.Core.Vault.Repositories;
 
@@ -10,15 +8,11 @@ public class OrganizationCiphersQuery : IOrganizationCiphersQuery
 {
     private readonly ICipherRepository _cipherRepository;
     private readonly ICollectionCipherRepository _collectionCipherRepository;
-    private readonly IFeatureService _featureService;
 
-    private bool FlexibleCollectionsV1Enabled => _featureService.IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1);
-
-    public OrganizationCiphersQuery(ICipherRepository cipherRepository, ICollectionCipherRepository collectionCipherRepository, IFeatureService featureService)
+    public OrganizationCiphersQuery(ICipherRepository cipherRepository, ICollectionCipherRepository collectionCipherRepository)
     {
         _cipherRepository = cipherRepository;
         _collectionCipherRepository = collectionCipherRepository;
-        _featureService = featureService;
     }
 
     /// <summary>
@@ -26,12 +20,6 @@ public class OrganizationCiphersQuery : IOrganizationCiphersQuery
     /// </summary>
     public async Task<IEnumerable<CipherDetailsWithCollections>> GetOrganizationCiphersForUser(Guid organizationId, Guid userId)
     {
-        if (!FlexibleCollectionsV1Enabled)
-        {
-            // Flexible collections is OFF, should not be using this query
-            throw new FeatureUnavailableException("Flexible collections is OFF when it should be ON.");
-        }
-
         var ciphers = await _cipherRepository.GetManyByUserIdAsync(userId, withOrganizations: true);
         var orgCiphers = ciphers.Where(c => c.OrganizationId == organizationId).ToList();
         var orgCipherIds = orgCiphers.Select(c => c.Id);
@@ -50,12 +38,6 @@ public class OrganizationCiphersQuery : IOrganizationCiphersQuery
     /// <param name="organizationId"></param>
     public async Task<IEnumerable<CipherOrganizationDetailsWithCollections>> GetAllOrganizationCiphers(Guid organizationId)
     {
-        if (!FlexibleCollectionsV1Enabled)
-        {
-            // Flexible collections is OFF, should not be using this query
-            throw new FeatureUnavailableException("Flexible collections is OFF when it should be ON.");
-        }
-
         var orgCiphers = await _cipherRepository.GetManyOrganizationDetailsByOrganizationIdAsync(organizationId);
         var collectionCiphers = await _collectionCipherRepository.GetManyByOrganizationIdAsync(organizationId);
         var collectionCiphersGroupDict = collectionCiphers.GroupBy(c => c.CipherId).ToDictionary(s => s.Key);
@@ -68,12 +50,6 @@ public class OrganizationCiphersQuery : IOrganizationCiphersQuery
     /// </summary>
     public async Task<IEnumerable<CipherOrganizationDetails>> GetUnassignedOrganizationCiphers(Guid organizationId)
     {
-        if (!FlexibleCollectionsV1Enabled)
-        {
-            // Flexible collections is OFF, should not be using this query
-            throw new FeatureUnavailableException("Flexible collections is OFF when it should be ON.");
-        }
-
         return await _cipherRepository.GetManyUnassignedOrganizationDetailsByOrganizationIdAsync(organizationId);
     }
 }

--- a/test/Core.Test/Services/CollectionServiceTests.cs
+++ b/test/Core.Test/Services/CollectionServiceTests.cs
@@ -113,9 +113,6 @@ public class CollectionServiceTest
     {
         collection.Id = default;
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
-        sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.FlexibleCollectionsV1, Arg.Any<bool>())
-            .Returns(true);
         organization.AllowAdminAccessToAllCollectionItems = false;
 
         var ex = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.SaveAsync(collection, null, users));


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10292


## 📔 Objective

> Remove Flexible Collections v1 from Core


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team


## 🦮 Reviewer guidelines

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
