### PR TITLE
[AC-2942] Sync seat minimum updates from Admin to Stripe

### DIFF
--- a/bitwarden_license/src/Commercial.Core/Billing/ProviderBillingService.cs
+++ b/bitwarden_license/src/Commercial.Core/Billing/ProviderBillingService.cs
@@ -9,7 +9,6 @@ using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Entities;
 using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Extensions;
-using Bit.Core.Billing.Models;
 using Bit.Core.Billing.Repositories;
 using Bit.Core.Billing.Services;
 using Bit.Core.Context;
@@ -23,7 +22,6 @@ using Bit.Core.Utilities;
 using CsvHelper;
 using Microsoft.Extensions.Logging;
 using Stripe;
-using Plan = Bit.Core.Models.StaticStore.Plan;
 
 namespace Bit.Commercial.Core.Billing;
 

--- a/bitwarden_license/test/Commercial.Core.Test/Billing/ProviderBillingServiceTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/Billing/ProviderBillingServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Globalization;
 using System.Net;
-using System.Runtime.CompilerServices;
 using Bit.Commercial.Core.Billing;
 using Bit.Commercial.Core.Billing.Models;
 using Bit.Core.AdminConsole.Entities;
@@ -12,7 +11,6 @@ using Bit.Core.Billing;
 using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Entities;
 using Bit.Core.Billing.Enums;
-using Bit.Core.Billing.Models.StaticStore.Plans;
 using Bit.Core.Billing.Repositories;
 using Bit.Core.Billing.Services;
 using Bit.Core.Context;

--- a/bitwarden_license/test/Commercial.Core.Test/Billing/ProviderBillingServiceTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/Billing/ProviderBillingServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Net;
+using System.Runtime.CompilerServices;
 using Bit.Commercial.Core.Billing;
 using Bit.Commercial.Core.Billing.Models;
 using Bit.Core.AdminConsole.Entities;
@@ -11,11 +12,13 @@ using Bit.Core.Billing;
 using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Entities;
 using Bit.Core.Billing.Enums;
+using Bit.Core.Billing.Models.StaticStore.Plans;
 using Bit.Core.Billing.Repositories;
 using Bit.Core.Billing.Services;
 using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
+using Bit.Core.Exceptions;
 using Bit.Core.Models.Business;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
@@ -1006,6 +1009,261 @@ public class ProviderBillingServiceTests
         var actual = await sutProvider.Sut.SetupSubscription(provider);
 
         Assert.Equivalent(expected, actual);
+    }
+
+    #endregion
+
+    #region UpdateSeatMinimums
+
+    [Theory, BitAutoData]
+    public async Task UpdateSeatMinimums_NullProvider_ThrowsArgumentNullException(
+        SutProvider<ProviderBillingService> sutProvider) =>
+        await Assert.ThrowsAsync<ArgumentNullException>(() => sutProvider.Sut.UpdateSeatMinimums(null, 0, 0));
+
+    [Theory, BitAutoData]
+    public async Task UpdateSeatMinimums_NegativeSeatMinimum_ThrowsBadRequestException(
+        Provider provider,
+        SutProvider<ProviderBillingService> sutProvider) =>
+        await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.UpdateSeatMinimums(provider, -10, 100));
+
+    [Theory, BitAutoData]
+    public async Task UpdateSeatMinimums_NoPurchasedSeats_SyncsStripeWithNewSeatMinimum(
+        Provider provider,
+        SutProvider<ProviderBillingService> sutProvider)
+    {
+        var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
+        var providerPlanRepository = sutProvider.GetDependency<IProviderPlanRepository>();
+
+        const string enterpriseLineItemId = "enterprise_line_item_id";
+        const string teamsLineItemId = "teams_line_item_id";
+
+        var enterprisePriceId = StaticStore.GetPlan(PlanType.EnterpriseMonthly).PasswordManager.StripeProviderPortalSeatPlanId;
+        var teamsPriceId = StaticStore.GetPlan(PlanType.TeamsMonthly).PasswordManager.StripeProviderPortalSeatPlanId;
+
+        var subscription = new Subscription
+        {
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Id = enterpriseLineItemId,
+                        Price = new Price { Id = enterprisePriceId }
+                    },
+                    new SubscriptionItem
+                    {
+                        Id = teamsLineItemId,
+                        Price = new Price { Id = teamsPriceId }
+                    }
+                ]
+            }
+        };
+
+        stripeAdapter.SubscriptionGetAsync(provider.GatewaySubscriptionId).Returns(subscription);
+
+        var providerPlans = new List<ProviderPlan>
+        {
+            new() { PlanType = PlanType.EnterpriseMonthly, SeatMinimum = 50, PurchasedSeats = 0 },
+            new() { PlanType = PlanType.TeamsMonthly, SeatMinimum = 30, PurchasedSeats = 0 }
+        };
+
+        providerPlanRepository.GetByProviderId(provider.Id).Returns(providerPlans);
+
+        await sutProvider.Sut.UpdateSeatMinimums(provider, 70, 50);
+
+        await providerPlanRepository.Received(1).ReplaceAsync(Arg.Is<ProviderPlan>(
+            providerPlan => providerPlan.PlanType == PlanType.EnterpriseMonthly && providerPlan.SeatMinimum == 70));
+
+        await providerPlanRepository.Received(1).ReplaceAsync(Arg.Is<ProviderPlan>(
+            providerPlan => providerPlan.PlanType == PlanType.TeamsMonthly && providerPlan.SeatMinimum == 50));
+
+        await stripeAdapter.Received(1).SubscriptionUpdateAsync(provider.GatewaySubscriptionId,
+            Arg.Is<SubscriptionUpdateOptions>(
+                options =>
+                    options.Items.Count == 2 &&
+                    options.Items.ElementAt(0).Id == enterpriseLineItemId &&
+                    options.Items.ElementAt(0).Quantity == 70 &&
+                    options.Items.ElementAt(1).Id == teamsLineItemId &&
+                    options.Items.ElementAt(1).Quantity == 50));
+    }
+
+    [Theory, BitAutoData]
+    public async Task UpdateSeatMinimums_PurchasedSeats_NewMinimumLessThanTotal_UpdatesPurchasedSeats(
+        Provider provider,
+        SutProvider<ProviderBillingService> sutProvider)
+    {
+        var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
+        var providerPlanRepository = sutProvider.GetDependency<IProviderPlanRepository>();
+
+        const string enterpriseLineItemId = "enterprise_line_item_id";
+        const string teamsLineItemId = "teams_line_item_id";
+
+        var enterprisePriceId = StaticStore.GetPlan(PlanType.EnterpriseMonthly).PasswordManager.StripeProviderPortalSeatPlanId;
+        var teamsPriceId = StaticStore.GetPlan(PlanType.TeamsMonthly).PasswordManager.StripeProviderPortalSeatPlanId;
+
+        var subscription = new Subscription
+        {
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Id = enterpriseLineItemId,
+                        Price = new Price { Id = enterprisePriceId }
+                    },
+                    new SubscriptionItem
+                    {
+                        Id = teamsLineItemId,
+                        Price = new Price { Id = teamsPriceId }
+                    }
+                ]
+            }
+        };
+
+        stripeAdapter.SubscriptionGetAsync(provider.GatewaySubscriptionId).Returns(subscription);
+
+        var providerPlans = new List<ProviderPlan>
+        {
+            new() { PlanType = PlanType.EnterpriseMonthly, SeatMinimum = 50, PurchasedSeats = 20 },
+            new() { PlanType = PlanType.TeamsMonthly, SeatMinimum = 50, PurchasedSeats = 20 }
+        };
+
+        providerPlanRepository.GetByProviderId(provider.Id).Returns(providerPlans);
+
+        await sutProvider.Sut.UpdateSeatMinimums(provider, 60, 60);
+
+        await providerPlanRepository.Received(1).ReplaceAsync(Arg.Is<ProviderPlan>(
+            providerPlan => providerPlan.PlanType == PlanType.EnterpriseMonthly && providerPlan.SeatMinimum == 60 && providerPlan.PurchasedSeats == 10));
+
+        await providerPlanRepository.Received(1).ReplaceAsync(Arg.Is<ProviderPlan>(
+            providerPlan => providerPlan.PlanType == PlanType.TeamsMonthly && providerPlan.SeatMinimum == 60 && providerPlan.PurchasedSeats == 10));
+
+        await stripeAdapter.DidNotReceiveWithAnyArgs()
+            .SubscriptionUpdateAsync(Arg.Any<string>(), Arg.Any<SubscriptionUpdateOptions>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task UpdateSeatMinimums_PurchasedSeats_NewMinimumGreaterThanTotal_ClearsPurchasedSeats_SyncsStripeWithNewSeatMinimum(
+        Provider provider,
+        SutProvider<ProviderBillingService> sutProvider)
+    {
+        var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
+        var providerPlanRepository = sutProvider.GetDependency<IProviderPlanRepository>();
+
+        const string enterpriseLineItemId = "enterprise_line_item_id";
+        const string teamsLineItemId = "teams_line_item_id";
+
+        var enterprisePriceId = StaticStore.GetPlan(PlanType.EnterpriseMonthly).PasswordManager.StripeProviderPortalSeatPlanId;
+        var teamsPriceId = StaticStore.GetPlan(PlanType.TeamsMonthly).PasswordManager.StripeProviderPortalSeatPlanId;
+
+        var subscription = new Subscription
+        {
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Id = enterpriseLineItemId,
+                        Price = new Price { Id = enterprisePriceId }
+                    },
+                    new SubscriptionItem
+                    {
+                        Id = teamsLineItemId,
+                        Price = new Price { Id = teamsPriceId }
+                    }
+                ]
+            }
+        };
+
+        stripeAdapter.SubscriptionGetAsync(provider.GatewaySubscriptionId).Returns(subscription);
+
+        var providerPlans = new List<ProviderPlan>
+        {
+            new() { PlanType = PlanType.EnterpriseMonthly, SeatMinimum = 50, PurchasedSeats = 20 },
+            new() { PlanType = PlanType.TeamsMonthly, SeatMinimum = 50, PurchasedSeats = 20 }
+        };
+
+        providerPlanRepository.GetByProviderId(provider.Id).Returns(providerPlans);
+
+        await sutProvider.Sut.UpdateSeatMinimums(provider, 80, 80);
+
+        await providerPlanRepository.Received(1).ReplaceAsync(Arg.Is<ProviderPlan>(
+            providerPlan => providerPlan.PlanType == PlanType.EnterpriseMonthly && providerPlan.SeatMinimum == 80 && providerPlan.PurchasedSeats == 0));
+
+        await providerPlanRepository.Received(1).ReplaceAsync(Arg.Is<ProviderPlan>(
+            providerPlan => providerPlan.PlanType == PlanType.TeamsMonthly && providerPlan.SeatMinimum == 80 && providerPlan.PurchasedSeats == 0));
+
+        await stripeAdapter.Received(1).SubscriptionUpdateAsync(provider.GatewaySubscriptionId,
+            Arg.Is<SubscriptionUpdateOptions>(
+                options =>
+                    options.Items.Count == 2 &&
+                    options.Items.ElementAt(0).Id == enterpriseLineItemId &&
+                    options.Items.ElementAt(0).Quantity == 80 &&
+                    options.Items.ElementAt(1).Id == teamsLineItemId &&
+                    options.Items.ElementAt(1).Quantity == 80));
+    }
+
+    [Theory, BitAutoData]
+    public async Task UpdateSeatMinimums_SinglePlanTypeUpdate_Succeeds(
+        Provider provider,
+        SutProvider<ProviderBillingService> sutProvider)
+    {
+        var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
+        var providerPlanRepository = sutProvider.GetDependency<IProviderPlanRepository>();
+
+        const string enterpriseLineItemId = "enterprise_line_item_id";
+        const string teamsLineItemId = "teams_line_item_id";
+
+        var enterprisePriceId = StaticStore.GetPlan(PlanType.EnterpriseMonthly).PasswordManager.StripeProviderPortalSeatPlanId;
+        var teamsPriceId = StaticStore.GetPlan(PlanType.TeamsMonthly).PasswordManager.StripeProviderPortalSeatPlanId;
+
+        var subscription = new Subscription
+        {
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Id = enterpriseLineItemId,
+                        Price = new Price { Id = enterprisePriceId }
+                    },
+                    new SubscriptionItem
+                    {
+                        Id = teamsLineItemId,
+                        Price = new Price { Id = teamsPriceId }
+                    }
+                ]
+            }
+        };
+
+        stripeAdapter.SubscriptionGetAsync(provider.GatewaySubscriptionId).Returns(subscription);
+
+        var providerPlans = new List<ProviderPlan>
+        {
+            new() { PlanType = PlanType.EnterpriseMonthly, SeatMinimum = 50, PurchasedSeats = 0 },
+            new() { PlanType = PlanType.TeamsMonthly, SeatMinimum = 30, PurchasedSeats = 0 }
+        };
+
+        providerPlanRepository.GetByProviderId(provider.Id).Returns(providerPlans);
+
+        await sutProvider.Sut.UpdateSeatMinimums(provider, 70, 30);
+
+        await providerPlanRepository.Received(1).ReplaceAsync(Arg.Is<ProviderPlan>(
+            providerPlan => providerPlan.PlanType == PlanType.EnterpriseMonthly && providerPlan.SeatMinimum == 70));
+
+        await providerPlanRepository.DidNotReceive().ReplaceAsync(Arg.Is<ProviderPlan>(
+            providerPlan => providerPlan.PlanType == PlanType.TeamsMonthly));
+
+        await stripeAdapter.Received(1).SubscriptionUpdateAsync(provider.GatewaySubscriptionId,
+            Arg.Is<SubscriptionUpdateOptions>(
+                options =>
+                    options.Items.Count == 1 &&
+                    options.Items.ElementAt(0).Id == enterpriseLineItemId &&
+                    options.Items.ElementAt(0).Quantity == 70));
     }
 
     #endregion

--- a/src/Core/Billing/Services/IProviderBillingService.cs
+++ b/src/Core/Billing/Services/IProviderBillingService.cs
@@ -88,4 +88,9 @@ public interface IProviderBillingService
     /// <remarks>This method requires the <paramref name="provider"/> to already have a linked Stripe <see cref="Stripe.Customer"/> via its <see cref="Provider.GatewayCustomerId"/> field.</remarks>
     Task<Subscription> SetupSubscription(
         Provider provider);
+
+    Task UpdateSeatMinimums(
+        Provider provider,
+        int enterpriseSeatMinimum,
+        int teamsSeatMinimum);
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/AC-2942

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This PR ensures that whenever someone updates the seat minimums for a billable provider in the Bitwarden admin portal, that change is reflected in Stripe. 

- If the provider has not purchased any seats (has not gone over the seat minimum), the line item quantities in Stripe should exactly match the updated seat minimum for the updated plan.

- If the provider has purchased seats (has gone over the seat minimum) and the updated seat minimum for the updated plan is less than or equal to the provider’s total seat count (seat minimum + purchased seats), then no change will be reflected in Stripe; only in the Bitwarden Admin Portal.

- If the provider has purchased seats (has gone over the seat minimum) and the updated seat minimum for the updated plan is greater than the provider’s total seat count (seat minimum + purchased seats), then the line item quantities in Stripe should exactly match the updated seat minimum for the updated plan.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
