### PR TITLE
[AC-2947] Fix provider account credit display

### DIFF
--- a/src/Api/Billing/Models/Responses/ProviderSubscriptionResponse.cs
+++ b/src/Api/Billing/Models/Responses/ProviderSubscriptionResponse.cs
@@ -11,7 +11,7 @@ public record ProviderSubscriptionResponse(
     decimal? DiscountPercentage,
     string CollectionMethod,
     IEnumerable<ProviderPlanResponse> Plans,
-    long AccountCredit,
+    decimal AccountCredit,
     TaxInformation TaxInformation,
     DateTime? CancelAt,
     SubscriptionSuspension Suspension)
@@ -42,13 +42,15 @@ public record ProviderSubscriptionResponse(
                     cadence);
             });
 
+        var accountCredit = Convert.ToDecimal(subscription.Customer?.Balance) * -1 / 100;
+
         return new ProviderSubscriptionResponse(
             subscription.Status,
             subscription.CurrentPeriodEnd,
             subscription.Customer?.Discount?.Coupon?.PercentOff,
             subscription.CollectionMethod,
             providerPlanResponses,
-            subscription.Customer?.Balance ?? 0,
+            accountCredit,
             taxInformation,
             subscription.CancelAt,
             subscriptionSuspension);

--- a/test/Api.Test/Billing/Controllers/ProviderBillingControllerTests.cs
+++ b/test/Api.Test/Billing/Controllers/ProviderBillingControllerTests.cs
@@ -323,7 +323,7 @@ public class ProviderBillingControllerTests
                     City = "Example Town",
                     State = "NY"
                 },
-                Balance = 100000,
+                Balance = -100000,
                 Discount = new Discount { Coupon = new Coupon { PercentOff = 10 } },
                 TaxIds = new StripeList<TaxId> { Data = [new TaxId { Value = "123456789" }] }
             },
@@ -404,7 +404,7 @@ public class ProviderBillingControllerTests
         Assert.Equal(100 * enterprisePlan.PasswordManager.ProviderPortalSeatPrice, providerEnterprisePlan.Cost);
         Assert.Equal("Monthly", providerEnterprisePlan.Cadence);
 
-        Assert.Equal(100000, response.AccountCredit);
+        Assert.Equal(1000.00M, response.AccountCredit);
 
         var customer = subscription.Customer;
         Assert.Equal(customer.Address.Country, response.TaxInformation.Country);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/AC-2947

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Provider account credit was not being translated to our normal currency display from how Stripe returns it from their API.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/d2897c48-3b4f-4c25-afdf-318492a5a43f



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
