### PR TITLE
[AC-2953] Checking if seats and storage have values before setting them to default

### DIFF
--- a/src/Admin/AdminConsole/Views/Shared/_OrganizationFormScripts.cshtml
+++ b/src/Admin/AdminConsole/Views/Shared/_OrganizationFormScripts.cshtml
@@ -79,8 +79,13 @@
         document.getElementById('@(nameof(Model.UseTotp))').checked = plan.hasTotp;
         document.getElementById('@(nameof(Model.UsersGetPremium))').checked = plan.usersGetPremium;
 
-        document.getElementById('@(nameof(Model.MaxStorageGb))').value = plan.passwordManager.baseStorageGb || 1;
-        document.getElementById('@(nameof(Model.Seats))').value = plan.passwordManager.baseSeats || 1;
+        document.getElementById('@(nameof(Model.MaxStorageGb))').value =
+            document.getElementById('@(nameof(Model.MaxStorageGb))').value ||
+            plan.passwordManager.baseStorageGb ||
+            1;
+        document.getElementById('@(nameof(Model.Seats))').value = document.getElementById('@(nameof(Model.Seats))').value ||
+            plan.passwordManager.baseSeats ||
+            1;
     }
 
     function unlinkProvider(id) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/AC-2953

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
A defect was introduced in https://bitwarden.atlassian.net/browse/AC-2820 that would reset the values for the organization's seat count and max storage back to the selected plan's default when changing the selected plan in the Bitwarden Portal. This PR addresses this by first checking if those fields already have a value set, and if so, not changing it when the plan changes.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
