### PR TITLE
Fix SecretAccessPoliciesUpdatesQueryTest

### DIFF
--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Queries/AccessPolicies/SecretAccessPoliciesUpdatesQueryTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Queries/AccessPolicies/SecretAccessPoliciesUpdatesQueryTests.cs
@@ -122,8 +122,8 @@ public class SecretAccessPoliciesUpdatesQueryTests
         {
             OrganizationUserId = data.UserAccessPolicies.First().OrganizationUserId,
             GrantedSecretId = data.SecretId,
-            Read = !data.ServiceAccountAccessPolicies.First().Read,
-            Write = !data.ServiceAccountAccessPolicies.First().Write
+            Read = !data.UserAccessPolicies.First().Read,
+            Write = !data.UserAccessPolicies.First().Write
         };
 
         return (updatePolicy, currentPolicyToDelete);
@@ -138,8 +138,8 @@ public class SecretAccessPoliciesUpdatesQueryTests
         {
             GroupId = data.GroupAccessPolicies.First().GroupId,
             GrantedSecretId = data.SecretId,
-            Read = !data.ServiceAccountAccessPolicies.First().Read,
-            Write = !data.ServiceAccountAccessPolicies.First().Write
+            Read = !data.GroupAccessPolicies.First().Read,
+            Write = !data.GroupAccessPolicies.First().Write
         };
 
         return (updatePolicy, currentPolicyToDelete);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This was reading from the same `ServiceAccountAccessPolicies` policy when creating a policy that would trigger an update for user and group policies.

Alter to read from the correct policy list for each entity update.

This is causing test failures here https://github.com/bitwarden/server/pull/4614

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
