### PR TITLE
[PM-1635] Invalid license error is inaccurate

### DIFF
--- a/src/Core/Models/Business/OrganizationLicense.cs
+++ b/src/Core/Models/Business/OrganizationLicense.cs
@@ -230,35 +230,52 @@ public class OrganizationLicense : ILicense
 
     public bool CanUse(IGlobalSettings globalSettings, ILicensingService licensingService, out string exception)
     {
-        if (!Enabled || Issued > DateTime.UtcNow || Expires < DateTime.UtcNow)
+        var errorMessages = new StringBuilder();
+
+        if (!Enabled)
         {
-            exception = "Invalid license. Your organization is disabled or the license has expired.";
-            return false;
+            errorMessages.AppendLine("Invalid license. The license is not enabled.");
+        }
+
+        if (Issued > DateTime.UtcNow)
+        {
+            errorMessages.AppendLine("Invalid license. The license issue date is in the future.");
+        }
+
+        if (Expires < DateTime.UtcNow)
+        {
+            errorMessages.AppendLine("Invalid license. The license has expired.");
         }
 
         if (!ValidLicenseVersion)
         {
-            exception = $"Version {Version} is not supported.";
-            return false;
+            errorMessages.AppendLine($"Version {Version} is not supported.");
         }
 
-        if (InstallationId != globalSettings.Installation.Id || !SelfHost)
+        if (InstallationId != globalSettings.Installation.Id)
         {
-            exception = "Invalid license. Make sure your license allows for on-premise " +
-                        "hosting of organizations and that the installation id matches your current installation.";
-            return false;
+            errorMessages.AppendLine("Invalid license. The installation ID does not match the current installation.");
+        }
+
+        if (!SelfHost)
+        {
+            errorMessages.AppendLine("Invalid license. The license does not allow for on-premise hosting of organizations.");
         }
 
         if (LicenseType != null && LicenseType != Enums.LicenseType.Organization)
         {
-            exception = "Premium licenses cannot be applied to an organization. "
-                        + "Upload this license from your personal account settings page.";
-            return false;
+            errorMessages.AppendLine("Premium licenses cannot be applied to an organization. " +
+                                     "Upload this license from your personal account settings page.");
         }
 
         if (!licensingService.VerifyLicense(this))
         {
-            exception = "Invalid license.";
+            errorMessages.AppendLine("The license verification failed.");
+        }
+
+        if (errorMessages.Length > 0)
+        {
+            exception = errorMessages.ToString().TrimEnd();
             return false;
         }
 
@@ -358,10 +375,8 @@ public class OrganizationLicense : ILicense
 
             return valid;
         }
-        else
-        {
-            throw new NotSupportedException($"Version {Version} is not supported.");
-        }
+
+        throw new NotSupportedException($"Version {Version} is not supported.");
     }
 
     public bool VerifySignature(X509Certificate2 certificate)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-1635

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Common scenario: an organization loses access to the owner's cloud account, and they contact us (the CS team) to delete and recreate it. If for some reason, the CS agent in charge of the re-attachment process forgets to update in Stripe the subscription's new organizationId, the expiration date for that organization gets messed up.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
