### PR TITLE
[PM-9931] Added the AccessReports permission to enable report viewing

### DIFF
--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -324,12 +324,13 @@ public class CiphersController : Controller
         var org = _currentContext.GetOrganization(organizationId);
 
         // We do NOT need to check the organization collection management setting here because Owners/Admins can
-        // ALWAYS access all ciphers in order to export them. Additionally, custom users with AccessImportExport or
-        // EditAnyCollection permissions can also always access all ciphers.
+        // ALWAYS access all ciphers in order to export them. Additionally, custom users with AccessImportExport,
+        // EditAnyCollection, or AccessReports permissions can also always access all ciphers.
         if (org is
         { Type: OrganizationUserType.Owner or OrganizationUserType.Admin } or
         { Permissions.AccessImportExport: true } or
-        { Permissions.EditAnyCollection: true })
+        { Permissions.EditAnyCollection: true } or
+        { Permissions.AccessReports: true })
         {
             return true;
         }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-9931

## 📔 Objective

`CanAccessAllCiphersAsync` in the `CiphersController` needed the `AccessReports` permission added to the check. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
