### PR TITLE
[AC-3005] Fix seat minimum scaling bug when provider has assigned seats

### DIFF
--- a/bitwarden_license/src/Commercial.Core/Billing/ProviderBillingService.cs
+++ b/bitwarden_license/src/Commercial.Core/Billing/ProviderBillingService.cs
@@ -486,12 +486,27 @@ public class ProviderBillingService(
 
             if (enterpriseProviderPlan.PurchasedSeats == 0)
             {
-                subscriptionItemOptionsList.Add(new SubscriptionItemOptions
+                if (enterpriseProviderPlan.AllocatedSeats > enterpriseSeatMinimum)
                 {
-                    Id = enterpriseSubscriptionItem.Id,
-                    Price = enterprisePriceId,
-                    Quantity = enterpriseSeatMinimum
-                });
+                    enterpriseProviderPlan.PurchasedSeats =
+                        enterpriseProviderPlan.AllocatedSeats - enterpriseSeatMinimum;
+
+                    subscriptionItemOptionsList.Add(new SubscriptionItemOptions
+                    {
+                        Id = enterpriseSubscriptionItem.Id,
+                        Price = enterprisePriceId,
+                        Quantity = enterpriseProviderPlan.AllocatedSeats
+                    });
+                }
+                else
+                {
+                    subscriptionItemOptionsList.Add(new SubscriptionItemOptions
+                    {
+                        Id = enterpriseSubscriptionItem.Id,
+                        Price = enterprisePriceId,
+                        Quantity = enterpriseSeatMinimum
+                    });
+                }
             }
             else
             {
@@ -530,12 +545,26 @@ public class ProviderBillingService(
 
             if (teamsProviderPlan.PurchasedSeats == 0)
             {
-                subscriptionItemOptionsList.Add(new SubscriptionItemOptions
+                if (teamsProviderPlan.AllocatedSeats > teamsSeatMinimum)
                 {
-                    Id = teamsSubscriptionItem.Id,
-                    Price = teamsPriceId,
-                    Quantity = teamsSeatMinimum
-                });
+                    teamsProviderPlan.PurchasedSeats = teamsProviderPlan.AllocatedSeats - teamsSeatMinimum;
+
+                    subscriptionItemOptionsList.Add(new SubscriptionItemOptions
+                    {
+                        Id = teamsSubscriptionItem.Id,
+                        Price = teamsPriceId,
+                        Quantity = teamsProviderPlan.AllocatedSeats
+                    });
+                }
+                else
+                {
+                    subscriptionItemOptionsList.Add(new SubscriptionItemOptions
+                    {
+                        Id = teamsSubscriptionItem.Id,
+                        Price = teamsPriceId,
+                        Quantity = teamsSeatMinimum
+                    });
+                }
             }
             else
             {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/AC-3005

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

> When the client org assigned seats are equal to or below the set minimum seats value in the Admin Portal, and the Minimum Seats are changed to a value lower than the assigned seats, the Stripe seat line item is updated to match the minimum value rather than the assigned seats. It should match the assigned seats rather than the minimum in this case, as that number is larger.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/869ce346-c31c-47a7-a8ff-8b5cd567de18



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
