### PR TITLE
[AC-3004] Add UserId and UsesKeyConnector to member access report

### DIFF
--- a/src/Api/Tools/Models/Response/MemberAccessReportModel.cs
+++ b/src/Api/Tools/Models/Response/MemberAccessReportModel.cs
@@ -38,6 +38,8 @@ public class MemberAccessReportResponseModel
     public int GroupsCount { get; set; }
     public int CollectionsCount { get; set; }
     public int TotalItemCount { get; set; }
+    public Guid? UserGuid { get; set; }
+    public bool UsesKeyConnector { get; set; }
     public IEnumerable<MemberAccessReportAccessDetails> AccessDetails { get; set; }
 
     /// <summary>
@@ -120,7 +122,9 @@ public class MemberAccessReportResponseModel
                 Email = user.Email,
                 TwoFactorEnabled = organizationUsersTwoFactorEnabled.FirstOrDefault(u => u.user.Id == user.Id).twoFactorIsEnabled,
                 // Both the user's ResetPasswordKey must be set and the organization can UseResetPassword
-                AccountRecoveryEnabled = !string.IsNullOrEmpty(user.ResetPasswordKey) && orgAbility.UseResetPassword
+                AccountRecoveryEnabled = !string.IsNullOrEmpty(user.ResetPasswordKey) && orgAbility.UseResetPassword,
+                UserGuid = user.Id,
+                UsesKeyConnector = user.UsesKeyConnector
             };
 
             var userAccessDetails = new List<MemberAccessReportAccessDetails>();


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/AC-3004

## 📔 Objective

Added `Id` and `UsesKeyConnector` to the `MemberAccessReportModel` as they will be needed for the edit member on the client

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
