### PR TITLE
[PM-5450] Add check for admin/org access for events

### DIFF
--- a/src/Events/Controllers/CollectController.cs
+++ b/src/Events/Controllers/CollectController.cs
@@ -1,4 +1,4 @@
-﻿using Bit.Core.Context;
+using Bit.Core.Context;
 using Bit.Core.Enums;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
@@ -79,6 +79,11 @@ public class CollectController : Controller
                     {
                         // When the user cannot access the cipher directly, check if the organization allows for
                         // admin/owners access to all collections and the user can access the cipher from that perspective.
+                        if (!eventModel.OrganizationId.HasValue)
+                        {
+                            continue;
+                        }
+
                         var org = await _organizationRepository.GetByIdAsync(eventModel.OrganizationId.Value);
                         cipher = await _cipherRepository.GetByIdAsync(eventModel.CipherId.Value);
 

--- a/src/Events/Controllers/CollectController.cs
+++ b/src/Events/Controllers/CollectController.cs
@@ -87,16 +87,10 @@ public class CollectController : Controller
                             continue;
                         }
 
-                        var org = _currentContext.GetOrganization(eventModel.OrganizationId.Value);
-                        var orgAbility = await _applicationCacheService.GetOrganizationAbilityAsync(eventModel.OrganizationId.Value);
                         cipher = await _cipherRepository.GetByIdAsync(eventModel.CipherId.Value);
-
                         var cipherBelongsToOrg = cipher.OrganizationId == eventModel.OrganizationId;
-                        var customOrgAllowsAnyCollection = org is { Type: OrganizationUserType.Custom, Permissions.EditAnyCollection: true };
-                        var orgAllowsOwnerAdminAccess = orgAbility is { AllowAdminAccessToAllCollectionItems: true } && org is
-                        { Type: OrganizationUserType.Admin or OrganizationUserType.Owner };
 
-                        if (!cipherBelongsToOrg || !(customOrgAllowsAnyCollection || orgAllowsOwnerAdminAccess))
+                        if (!cipherBelongsToOrg || cipher == null)
                         {
                             continue;
                         }

--- a/src/Events/Controllers/CollectController.cs
+++ b/src/Events/Controllers/CollectController.cs
@@ -82,7 +82,7 @@ public class CollectController : Controller
                         var org = await _organizationRepository.GetByIdAsync(eventModel.OrganizationId.Value);
                         cipher = await _cipherRepository.GetByIdAsync(eventModel.CipherId.Value);
 
-                        if(!org.AllowAdminAccessToAllCollectionItems || cipher == null)
+                        if (!org.AllowAdminAccessToAllCollectionItems || cipher == null)
                         {
                             continue;
                         }

--- a/src/Events/Controllers/CollectController.cs
+++ b/src/Events/Controllers/CollectController.cs
@@ -77,7 +77,15 @@ public class CollectController : Controller
                     }
                     if (cipher == null)
                     {
-                        continue;
+                        // When the user cannot access the cipher directly, check if the organization allows for
+                        // admin/owners access to all collections and the user can access the cipher from that perspective.
+                        var org = await _organizationRepository.GetByIdAsync(eventModel.OrganizationId.Value);
+                        cipher = await _cipherRepository.GetByIdAsync(eventModel.CipherId.Value);
+
+                        if(!org.AllowAdminAccessToAllCollectionItems || cipher == null)
+                        {
+                            continue;
+                        }
                     }
                     if (!ciphersCache.ContainsKey(eventModel.CipherId.Value))
                     {

--- a/src/Events/Controllers/CollectController.cs
+++ b/src/Events/Controllers/CollectController.cs
@@ -89,8 +89,9 @@ public class CollectController : Controller
 
                         cipher = await _cipherRepository.GetByIdAsync(eventModel.CipherId.Value);
                         var cipherBelongsToOrg = cipher.OrganizationId == eventModel.OrganizationId;
+                        var org = _currentContext.GetOrganization(eventModel.OrganizationId.Value);
 
-                        if (!cipherBelongsToOrg || cipher == null)
+                        if (!cipherBelongsToOrg || org == null || cipher == null)
                         {
                             continue;
                         }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-5450](https://bitwarden.atlassian.net/browse/PM-5450)

## 📔 Objective

Issue: When a user only has access to a cipher from the `AllowAdminAccessToAllCollectionItems` policy on an organization, events aren't collected.
Fix: Add check for events to account for organizations that have `AllowAdminAccessToAllCollectionItems` enabled and fetch the cipher without the users id.

Respective [Client side PR](https://github.com/bitwarden/clients/pull/10678)

## 📸 Screenshots

https://github.com/user-attachments/assets/c4932d05-60ae-44a0-8eea-37c93c2ccc34

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-5450]: https://bitwarden.atlassian.net/browse/PM-5450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ