### PR TITLE
[PM-7999] Reseller billing e-mail can be blank causing downstream err…

### DIFF
--- a/src/Admin/AdminConsole/Controllers/ProvidersController.cs
+++ b/src/Admin/AdminConsole/Controllers/ProvidersController.cs
@@ -162,27 +162,13 @@ public class ProvidersController : Controller
     [SelfHosted(NotSelfHostedOnly = true)]
     public async Task<IActionResult> Edit(Guid id)
     {
-        var provider = await _providerRepository.GetByIdAsync(id);
+        var provider = await GetEditModel(id);
         if (provider == null)
         {
             return RedirectToAction("Index");
         }
 
-        var users = await _providerUserRepository.GetManyDetailsByProviderAsync(id);
-        var providerOrganizations = await _providerOrganizationRepository.GetManyDetailsByProviderAsync(id);
-
-        var isConsolidatedBillingEnabled = _featureService.IsEnabled(FeatureFlagKeys.EnableConsolidatedBilling);
-
-        if (!isConsolidatedBillingEnabled || !provider.IsBillable())
-        {
-            return View(new ProviderEditModel(provider, users, providerOrganizations, new List<ProviderPlan>()));
-        }
-
-        var providerPlans = await _providerPlanRepository.GetByProviderId(id);
-
-        return View(new ProviderEditModel(
-            provider, users, providerOrganizations,
-            providerPlans.ToList(), GetGatewayCustomerUrl(provider), GetGatewaySubscriptionUrl(provider)));
+        return View(provider);
     }
 
     [HttpPost]
@@ -196,6 +182,20 @@ public class ProvidersController : Controller
         if (provider == null)
         {
             return RedirectToAction("Index");
+        }
+
+        if (provider.Type != model.Type)
+        {
+            var oldModel = await GetEditModel(id);
+            ModelState.AddModelError(nameof(model.Type), "Provider type cannot be changed.");
+            return View(oldModel);
+        }
+
+        if (!ModelState.IsValid)
+        {
+            var oldModel = await GetEditModel(id);
+            ModelState[nameof(ProviderEditModel.BillingEmail)]!.RawValue = oldModel.BillingEmail;
+            return View(oldModel);
         }
 
         model.ToProvider(provider);
@@ -234,6 +234,32 @@ public class ProvidersController : Controller
         }
 
         return RedirectToAction("Edit", new { id });
+    }
+
+    private async Task<ProviderEditModel> GetEditModel(Guid id)
+    {
+        var provider = await _providerRepository.GetByIdAsync(id);
+        if (provider == null)
+        {
+            return null;
+        }
+
+        var users = await _providerUserRepository.GetManyDetailsByProviderAsync(id);
+        var providerOrganizations = await _providerOrganizationRepository.GetManyDetailsByProviderAsync(id);
+
+        var isConsolidatedBillingEnabled = _featureService.IsEnabled(FeatureFlagKeys.EnableConsolidatedBilling);
+
+
+        if (!isConsolidatedBillingEnabled || !provider.IsBillable())
+        {
+            return new ProviderEditModel(provider, users, providerOrganizations, new List<ProviderPlan>());
+        }
+
+        var providerPlans = await _providerPlanRepository.GetByProviderId(id);
+
+        return new ProviderEditModel(
+            provider, users, providerOrganizations,
+            providerPlans.ToList(), GetGatewayCustomerUrl(provider), GetGatewaySubscriptionUrl(provider));
     }
 
     [RequirePermission(Permission.Provider_ResendEmailInvite)]

--- a/src/Admin/AdminConsole/Models/ProviderEditModel.cs
+++ b/src/Admin/AdminConsole/Models/ProviderEditModel.cs
@@ -1,13 +1,15 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.AdminConsole.Entities.Provider;
+using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.AdminConsole.Models.Data.Provider;
 using Bit.Core.Billing.Entities;
 using Bit.Core.Billing.Enums;
 using Bit.Core.Enums;
+using Bit.SharedWeb.Utilities;
 
 namespace Bit.Admin.AdminConsole.Models;
 
-public class ProviderEditModel : ProviderViewModel
+public class ProviderEditModel : ProviderViewModel, IValidatableObject
 {
     public ProviderEditModel() { }
 
@@ -30,6 +32,7 @@ public class ProviderEditModel : ProviderViewModel
         GatewaySubscriptionId = provider.GatewaySubscriptionId;
         GatewayCustomerUrl = gatewayCustomerUrl;
         GatewaySubscriptionUrl = gatewaySubscriptionUrl;
+        Type = provider.Type;
     }
 
     [Display(Name = "Billing Email")]
@@ -52,6 +55,8 @@ public class ProviderEditModel : ProviderViewModel
     public string GatewaySubscriptionId { get; set; }
     public string GatewayCustomerUrl { get; }
     public string GatewaySubscriptionUrl { get; }
+    [Display(Name = "Provider Type")]
+    public ProviderType Type { get; set; }
 
     public virtual Provider ToProvider(Provider existingProvider)
     {
@@ -65,4 +70,18 @@ public class ProviderEditModel : ProviderViewModel
 
     private static int GetSeatMinimum(IEnumerable<ProviderPlan> providerPlans, PlanType planType)
         => providerPlans.FirstOrDefault(providerPlan => providerPlan.PlanType == planType)?.SeatMinimum ?? 0;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        switch (Type)
+        {
+            case ProviderType.Reseller:
+                if (string.IsNullOrWhiteSpace(BillingEmail))
+                {
+                    var billingEmailDisplayName = nameof(BillingEmail).GetDisplayAttribute<CreateProviderModel>()?.GetName() ?? nameof(BillingEmail);
+                    yield return new ValidationResult($"The {billingEmailDisplayName} field is required.");
+                }
+                break;
+        }
+    }
 }

--- a/src/Admin/AdminConsole/Views/Providers/Edit.cshtml
+++ b/src/Admin/AdminConsole/Views/Providers/Edit.cshtml
@@ -16,6 +16,8 @@
 @await Html.PartialAsync("_ViewInformation", Model)
 @await Html.PartialAsync("Admins", Model)
 <form method="post" id="edit-form">
+    <div asp-validation-summary="All" class="alert alert-danger"></div>
+    <input type="hidden" asp-for="Type" readonly>
     <h2>General</h2>
     <dl class="row">
         <dt class="col-sm-4 col-lg-3">Name</dt>


### PR DESCRIPTION
…ors for org creation

## 🎟️ Tracking

[PM-7999](https://bitwarden.atlassian.net/browse/PM-7999)

## 📔 Objective

When creating a reseller provider, the billing e-mail field is required. However, when we're editing a reseller provider, we can empty the billing e-mail field and save the reseller provider. This causes errors when creating new organizations.

We will add validation when saving the reseller provider, and reset any bad fields to their original value and show an error message accordingly.

When submitting the form, all other view model values are lost, so we need to retrieve them again manually to populate the view model. It also appears to take the values in the `ModelState` by preference over the ones found in the view model.

We can I think either keep the code simple by showing the posted values in the form, or we reset the wrong values displayed in the form to their old values for an optimal user experience.

## 📸 Screenshots

<img width="1147" alt="image" src="https://github.com/user-attachments/assets/636a9645-bd2e-44eb-abfa-20c35265cd6a">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-7999]: https://bitwarden.atlassian.net/browse/PM-7999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ