### PR TITLE
Use `ILogger.BeginScope` For Better Scopes

### DIFF
--- a/src/SharedWeb/Utilities/RequestLoggingMiddleware.cs
+++ b/src/SharedWeb/Utilities/RequestLoggingMiddleware.cs
@@ -1,0 +1,106 @@
+using System.Collections;
+using Bit.Core.Settings;
+using Bit.Core.Utilities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+#nullable enable
+
+namespace Bit.SharedWeb.Utilities;
+
+public sealed class RequestLoggingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<RequestLoggingMiddleware> _logger;
+    private readonly GlobalSettings _globalSettings;
+
+    public RequestLoggingMiddleware(RequestDelegate next, ILogger<RequestLoggingMiddleware> logger, GlobalSettings globalSettings)
+    {
+        _next = next;
+        _logger = logger;
+        _globalSettings = globalSettings;
+    }
+
+    public Task Invoke(HttpContext context)
+    {
+        using (_logger.BeginScope(
+          new RequestLogScope(context.GetIpAddress(_globalSettings),
+            GetHeaderValue(context, "user-agent"),
+            GetHeaderValue(context, "device-type"),
+            GetHeaderValue(context, "device-type"))))
+        {
+            return _next(context);
+        }
+
+        static string? GetHeaderValue(HttpContext httpContext, string header)
+        {
+            if (httpContext.Request.Headers.TryGetValue(header, out var value))
+            {
+                return value;
+            }
+
+            return null;
+        }
+    }
+
+
+    private sealed class RequestLogScope : IReadOnlyList<KeyValuePair<string, object?>>
+    {
+        private string? _cachedToString;
+
+        public RequestLogScope(string? ipAddress, string? userAgent, string? deviceType, string? origin)
+        {
+            IpAddress = ipAddress;
+            UserAgent = userAgent;
+            DeviceType = deviceType;
+            Origin = origin;
+        }
+
+        public KeyValuePair<string, object?> this[int index]
+        {
+            get
+            {
+                if (index == 0)
+                {
+                    return new KeyValuePair<string, object?>(nameof(IpAddress), IpAddress);
+                }
+                else if (index == 1)
+                {
+                    return new KeyValuePair<string, object?>(nameof(UserAgent), UserAgent);
+                }
+                else if (index == 2)
+                {
+                    return new KeyValuePair<string, object?>(nameof(DeviceType), DeviceType);
+                }
+                else if (index == 3)
+                {
+                    return new KeyValuePair<string, object?>(nameof(Origin), Origin);
+                }
+
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+        }
+
+        public int Count => 4;
+
+        public string? IpAddress { get; }
+        public string? UserAgent { get; }
+        public string? DeviceType { get; }
+        public string? Origin { get; }
+
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+        {
+            for (var i = 0; i < Count; i++)
+            {
+                yield return this[i];
+            }
+        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public override string ToString()
+        {
+            _cachedToString ??= $"IpAddress:{IpAddress} UserAgent:{UserAgent} DeviceType:{DeviceType} Origin:{Origin}";
+            return _cachedToString;
+        }
+    }
+}

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -537,31 +537,7 @@ public static class ServiceCollectionExtensions
     public static void UseDefaultMiddleware(this IApplicationBuilder app,
         IWebHostEnvironment env, GlobalSettings globalSettings)
     {
-        string GetHeaderValue(HttpContext httpContext, string header)
-        {
-            if (httpContext.Request.Headers.ContainsKey(header))
-            {
-                return httpContext.Request.Headers[header];
-            }
-            return null;
-        }
-
-        // Add version information to response headers
-        app.Use(async (httpContext, next) =>
-        {
-            using (LogContext.PushProperty("IPAddress", httpContext.GetIpAddress(globalSettings)))
-            using (LogContext.PushProperty("UserAgent", GetHeaderValue(httpContext, "user-agent")))
-            using (LogContext.PushProperty("DeviceType", GetHeaderValue(httpContext, "device-type")))
-            using (LogContext.PushProperty("Origin", GetHeaderValue(httpContext, "origin")))
-            {
-                httpContext.Response.OnStarting((state) =>
-                {
-                    httpContext.Response.Headers.Append("Server-Version", AssemblyHelpers.GetVersion());
-                    return Task.FromResult(0);
-                }, null);
-                await next.Invoke();
-            }
-        });
+        app.UseMiddleware<RequestLoggingMiddleware>();
     }
 
     public static void UseForwardedHeaders(this IApplicationBuilder app, IGlobalSettings globalSettings)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Using `LogContext.PushProperty()` does not translate to additional scopes when using `Microsoft.Extensions.Logging` but when using `Serilog.Extensions.Logging` `ILogger.BeginScope` will translate to `LogContext.Push()` so we should prefer to use the version in MEL for better compatibility. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
