### PR TITLE
[PM-11749] Add device type to device trust loss logging

### DIFF
--- a/src/Api/Controllers/DevicesController.cs
+++ b/src/Api/Controllers/DevicesController.cs
@@ -252,8 +252,8 @@ public class DevicesController : Controller
             throw new BadRequestException("Please provide a device identifier");
         }
 
-        _logger.LogError("User {id} has a device key, but didn't receive decryption keys for device {device}", userId,
-            deviceId);
+        _logger.LogError("User {id} has a device key, but didn't receive decryption keys for device {device} of type {deviceType}", userId,
+            deviceId, _currentContext.DeviceType);
     }
 
 }

--- a/src/Api/Controllers/DevicesController.cs
+++ b/src/Api/Controllers/DevicesController.cs
@@ -252,8 +252,14 @@ public class DevicesController : Controller
             throw new BadRequestException("Please provide a device identifier");
         }
 
+        var deviceType = _currentContext.DeviceType;
+        if (deviceType == null)
+        {
+            throw new BadRequestException("Please provide a device type");
+        }
+
         _logger.LogError("User {id} has a device key, but didn't receive decryption keys for device {device} of type {deviceType}", userId,
-            deviceId, _currentContext.DeviceType);
+            deviceId, deviceType);
     }
 
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11749

## 📔 Objective

Adding device type to the log of device trust loss.

This should be already logged via the log context, but that is currently broken pending https://github.com/bitwarden/server/pull/4740.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
