### PR TITLE
[AC-2915] Upgrade Stripe.net to v45.7.0

### DIFF
--- a/src/Billing/BillingSettings.cs
+++ b/src/Billing/BillingSettings.cs
@@ -6,6 +6,7 @@ public class BillingSettings
     public virtual string StripeWebhookKey { get; set; }
     public virtual string StripeWebhookSecret { get; set; }
     public virtual string StripeWebhookSecret20231016 { get; set; }
+    public virtual string StripeWebhookSecret20240620 { get; set; }
     public virtual string BitPayWebhookKey { get; set; }
     public virtual string AppleWebhookKey { get; set; }
     public virtual FreshDeskSettings FreshDesk { get; set; } = new FreshDeskSettings();

--- a/src/Billing/Models/StripeWebhookDeliveryContainer.cs
+++ b/src/Billing/Models/StripeWebhookDeliveryContainer.cs
@@ -1,0 +1,21 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Bit.Billing.Models;
+
+public class StripeWebhookDeliveryContainer
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+    [JsonPropertyName("api_version")]
+    public string ApiVersion { get; set; }
+    [JsonPropertyName("request")]
+    public StripeWebhookRequestData Request { get; set; }
+    [JsonPropertyName("type")]
+    public string Type { get; set; }
+}
+
+public class StripeWebhookRequestData
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+}

--- a/src/Billing/Models/StripeWebhookVersionContainer.cs
+++ b/src/Billing/Models/StripeWebhookVersionContainer.cs
@@ -1,9 +1,0 @@
-﻿using System.Text.Json.Serialization;
-
-namespace Bit.Billing.Models;
-
-public class StripeWebhookVersionContainer
-{
-    [JsonPropertyName("api_version")]
-    public string ApiVersion { get; set; }
-}

--- a/src/Billing/appsettings.json
+++ b/src/Billing/appsettings.json
@@ -59,6 +59,7 @@
     "stripeWebhookKey": "SECRET",
     "stripeWebhookSecret": "SECRET",
     "stripeWebhookSecret20231016": "SECRET",
+    "stripeWebhookSecret20240620": "SECRET",
     "bitPayWebhookKey": "SECRET",
     "appleWebhookKey": "SECRET",
     "payPal": {

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -55,7 +55,7 @@
     <PackageReference Include="Serilog.Sinks.SyslogMessages" Version="3.0.2" />
     <PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
     <PackageReference Include="Braintree" Version="5.26.0" />
-    <PackageReference Include="Stripe.net" Version="43.20.0" />
+    <PackageReference Include="Stripe.net" Version="45.7.0" />
     <PackageReference Include="Otp.NET" Version="1.4.0" />
     <PackageReference Include="YubicoDotNetClient" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.8" />

--- a/test/Billing.Test/Resources/Events/charge.succeeded.json
+++ b/test/Billing.Test/Resources/Events/charge.succeeded.json
@@ -1,7 +1,7 @@
 {
   "id": "evt_3NvKgBIGBnsLynRr0pJJqudS",
   "object": "event",
-  "api_version": "2023-10-16",
+  "api_version": "2024-06-20",
   "created": 1695909300,
   "data": {
     "object": {

--- a/test/Billing.Test/Resources/Events/customer.subscription.updated.json
+++ b/test/Billing.Test/Resources/Events/customer.subscription.updated.json
@@ -1,7 +1,7 @@
 {
   "id": "evt_1NvLMDIGBnsLynRr6oBxebrE",
   "object": "event",
-  "api_version": "2023-10-16",
+  "api_version": "2024-06-20",
   "created": 1695911902,
   "data": {
     "object": {

--- a/test/Billing.Test/Resources/Events/customer.updated.json
+++ b/test/Billing.Test/Resources/Events/customer.updated.json
@@ -2,7 +2,7 @@
   "id": "evt_1NvKjSIGBnsLynRrS3MTK4DZ",
   "object": "event",
   "account": "acct_19smIXIGBnsLynRr",
-  "api_version": "2023-10-16",
+  "api_version": "2024-06-20",
   "created": 1695909502,
   "data": {
     "object": {

--- a/test/Billing.Test/Resources/Events/invoice.created.json
+++ b/test/Billing.Test/Resources/Events/invoice.created.json
@@ -1,7 +1,7 @@
 {
   "id": "evt_1NvKzfIGBnsLynRr0SkwrlkE",
   "object": "event",
-  "api_version": "2023-10-16",
+  "api_version": "2024-06-20",
   "created": 1695910506,
   "data": {
     "object": {

--- a/test/Billing.Test/Resources/Events/invoice.finalized.json
+++ b/test/Billing.Test/Resources/Events/invoice.finalized.json
@@ -2,7 +2,7 @@
   "id": "evt_1PQaABIGBnsLynRrhoJjGnyz",
   "object": "event",
   "account": "acct_19smIXIGBnsLynRr",
-  "api_version": "2023-10-16",
+  "api_version": "2024-06-20",
   "created": 1718133319,
   "data": {
     "object": {

--- a/test/Billing.Test/Resources/Events/invoice.upcoming.json
+++ b/test/Billing.Test/Resources/Events/invoice.upcoming.json
@@ -1,7 +1,7 @@
 {
   "id": "evt_1Nv0w8IGBnsLynRrZoDVI44u",
   "object": "event",
-  "api_version": "2023-10-16",
+  "api_version": "2024-06-20",
   "created": 1695833408,
   "data": {
     "object": {

--- a/test/Billing.Test/Resources/Events/payment_method.attached.json
+++ b/test/Billing.Test/Resources/Events/payment_method.attached.json
@@ -1,7 +1,7 @@
 {
   "id": "evt_1NvKzcIGBnsLynRrPJ3hybkd",
   "object": "event",
-  "api_version": "2023-10-16",
+  "api_version": "2024-06-20",
   "created": 1695910504,
   "data": {
     "object": {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/AC-2915

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This PR upgrades [Stripe.net](https://github.com/stripe/stripe-dotnet) in `Core` from `v43.20.0` to `v45.7.0`.

Additionally, because this major version bump includes an update to Stripe's latest [API version](https://docs.stripe.com/api/versioning) (2024-06-20), it also adds a new configuration to the `BillingSettings`: `StripeWebhookSecret20240620`. This setting will contain the webhook secret for the newly created webhooks using version 2024-06-20. It also makes sure to handle that version when picking a Stripe webhook secret to use in the webhook processor.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
