### PR TITLE
[PM-11602] Error toast when expired org attempts to auto scale is unclear

### DIFF
--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -712,6 +712,11 @@ public class StripePaymentService : IPaymentService
             throw new GatewayException("Subscription not found.");
         }
 
+        if (sub.Status == SubscriptionStatuses.Canceled)
+        {
+            throw new BadRequestException("You do not have an active subscription. Reinstate your subscription to make changes.");
+        }
+
         var collectionMethod = sub.CollectionMethod;
         var daysUntilDue = sub.DaysUntilDue;
         var chargeNow = collectionMethod == "charge_automatically";


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11602

## 📔 Objective

When an organization has a canceled subscription, and we have autoscaling enabled for that organization. Inviting a new member which results in the organization to scale up would attempt to update that subscription. Stripe does not allow updating a subscription in the canceled state. When we attempt to do so, we are bubbling up that error message back to the front-end.

The easiest way to solve this is by checking if the subscription is in a canceled state before trying to update the subscription. If it is canceled, just return a bad request with a correct error message and then abort continuing further.

I haven't yet been able to test the fix as I would require certain permissions in Stripe to test. But I'm putting up the pull request for review if someone might have a better understanding of the code / domain.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
