### PR TITLE
Support overriding organization context for feature flags

### DIFF
--- a/src/Core/Services/IFeatureService.cs
+++ b/src/Core/Services/IFeatureService.cs
@@ -13,28 +13,32 @@ public interface IFeatureService
     /// </summary>
     /// <param name="key">The key of the feature to check.</param>
     /// <param name="defaultValue">The default value for the feature.</param>
+    /// <param name="overridingOrganizationId">Sole overriding organization ID, used with context assessment.</param>
     /// <returns>True if the feature is enabled, otherwise false.</returns>
-    bool IsEnabled(string key, bool defaultValue = false);
+    bool IsEnabled(string key, bool defaultValue = false, Guid? overridingOrganizationId = null);
 
     /// <summary>
     /// Gets the integer variation of a feature.
     /// </summary>
     /// <param name="key">The key of the feature to check.</param>
     /// <param name="defaultValue">The default value for the feature.</param>
+    /// <param name="overridingOrganizationId">Sole overriding organization ID, used with context assessment.</param>
     /// <returns>The feature variation value.</returns>
-    int GetIntVariation(string key, int defaultValue = 0);
+    int GetIntVariation(string key, int defaultValue = 0, Guid? overridingOrganizationId = null);
 
     /// <summary>
     /// Gets the string variation of a feature.
     /// </summary>
     /// <param name="key">The key of the feature to check.</param>
     /// <param name="defaultValue">The default value for the feature.</param>
+    /// <param name="overridingOrganizationId">Sole overriding organization ID, used with context assessment.</param>
     /// <returns>The feature variation value.</returns>
-    string GetStringVariation(string key, string defaultValue = null);
+    string GetStringVariation(string key, string defaultValue = null, Guid? overridingOrganizationId = null);
 
     /// <summary>
     /// Gets all feature values.
     /// </summary>
+    /// <param name="overridingOrganizationId">Sole overriding organization ID, used with context assessment.</param>
     /// <returns>A dictionary of feature keys and their values.</returns>
-    Dictionary<string, object> GetAll();
+    Dictionary<string, object> GetAll(Guid? overridingOrganizationId = null);
 }

--- a/test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs
+++ b/test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs
@@ -63,6 +63,16 @@ public class LaunchDarklyFeatureServiceTests
     }
 
     [Fact(Skip = "For local development")]
+    public void FeatureValue_BooleanWithOverridingOrganization()
+    {
+        var settings = new Settings.GlobalSettings { LaunchDarkly = { SdkKey = _fakeSdkKey } };
+
+        var sutProvider = GetSutProvider(settings);
+
+        Assert.False(sutProvider.Sut.IsEnabled(_fakeFeatureKey, overridingOrganizationId: Guid.NewGuid()));
+    }
+
+    [Fact(Skip = "For local development")]
     public void FeatureValue_Int()
     {
         var settings = new Settings.GlobalSettings { LaunchDarkly = { SdkKey = _fakeSdkKey } };


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-6014

## 📔 Objective

Allows for server code to pass an overriding organization ID in to force context assessments to just that organization.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
