### PR TITLE
[SM-1433] Update SM Event Logs

### DIFF
--- a/src/Api/AdminConsole/Public/Models/Response/EventResponseModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Response/EventResponseModel.cs
@@ -27,6 +27,8 @@ public class EventResponseModel : IResponseModel
         Device = ev.DeviceType;
         IpAddress = ev.IpAddress;
         InstallationId = ev.InstallationId;
+        SecretId = ev.SecretId;
+        ServiceAccountId = ev.ServiceAccountId;
     }
 
     /// <summary>
@@ -89,4 +91,14 @@ public class EventResponseModel : IResponseModel
     /// </summary>
     /// <example>172.16.254.1</example>
     public string IpAddress { get; set; }
+    /// <summary>
+    /// The unique identifier of the related secret that the event describes.
+    /// </summary>
+    /// <example>e68b8629-85eb-4929-92c0-b84464976ba4</example>
+    public Guid? SecretId { get; set; }
+    /// <summary>
+    /// The unique identifier of the related service account that the event describes.
+    /// </summary>
+    /// <example>e68b8629-85eb-4929-92c0-b84464976ba4</example>
+    public Guid? ServiceAccountId { get; set; }
 }

--- a/src/Core/AdminConsole/Models/Data/EventTableEntity.cs
+++ b/src/Core/AdminConsole/Models/Data/EventTableEntity.cs
@@ -211,7 +211,7 @@ public class EventTableEntity : IEvent
             entities.Add(new EventTableEntity(e)
             {
                 PartitionKey = pKey,
-                RowKey = $"SecretId={e.CipherId}__Date={dateKey}__Uniquifier={uniquifier}"
+                RowKey = $"SecretId={e.SecretId}__Date={dateKey}__Uniquifier={uniquifier}"
             });
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-1433

## 📔 Objective

### EventResponseModel.cs

The public API for event logs was not including `secretId` or `serviceAccountId` for SM events (`2100`).

### EventTableEntity.cs

Maciej discovered this bug. However, because `cipherId` is empty, we aren't storing `secretId` here.

### Note

@eliykat it doesn't seem like we have an integration test suite setup for event logging. That's probably something we want to add in the future! Do we have any plans for integration testing of events as a whole in the future?

I verified locally using Postman hitting the public api, but please let me know if there is more I need to test manually.

@mzieniukbw thanks for pairing!

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
