### PR TITLE
Remove explicit client version attributes

### DIFF
--- a/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
+++ b/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
@@ -19,9 +19,6 @@ public class LaunchDarklyFeatureService : IFeatureService
     private const string _contextKindServiceAccount = "service-account";
 
     private const string _contextAttributeClientVersion = "client-version";
-    private const string _contextAttributeClientVersionMajor = "client-version-major";
-    private const string _contextAttributeClientVersionMinor = "client-version-minor";
-    private const string _contextAttributeClientVersionBuild = "client-version-build";
     private const string _contextAttributeDeviceType = "device-type";
     private const string _contextAttributeOrganizations = "organizations";
 
@@ -146,9 +143,6 @@ public class LaunchDarklyFeatureService : IFeatureService
             if (_currentContext.ClientVersion != null)
             {
                 builder.Set(_contextAttributeClientVersion, _currentContext.ClientVersion.ToString());
-                builder.Set(_contextAttributeClientVersionMajor, _currentContext.ClientVersion.Major);
-                builder.Set(_contextAttributeClientVersionMinor, _currentContext.ClientVersion.Minor);
-                builder.Set(_contextAttributeClientVersionBuild, _currentContext.ClientVersion.Build);
             }
 
             if (_currentContext.DeviceType.HasValue)


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11913

## 📔 Objective

After working in the Launch Darkly targeting interface, we can use [SemVer operators](https://docs.launchdarkly.com/home/flags/target-rules#operators) on the string version and don't need the individual attributes.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
