### PR TITLE
PM 12001 - Fix Empty User Search 500

### DIFF
--- a/src/Admin/Controllers/UsersController.cs
+++ b/src/Admin/Controllers/UsersController.cs
@@ -68,7 +68,10 @@ public class UsersController : Controller
         {
             var user2Fa = (await _twoFactorIsEnabledQuery.TwoFactorIsEnabledAsync(users.Select(u => u.Id))).ToList();
             // TempDataSerializer is having an issue serializing an empty IEnumerable<Tuple<T1,T2>>, do not set if empty.
-            if (user2Fa.Count != 0) TempData["UsersTwoFactorIsEnabled"] = user2Fa;
+            if (user2Fa.Count != 0)
+            {
+                TempData["UsersTwoFactorIsEnabled"] = user2Fa;
+            }
         }
 
         return View(new UsersModel

--- a/src/Admin/Controllers/UsersController.cs
+++ b/src/Admin/Controllers/UsersController.cs
@@ -66,7 +66,9 @@ public class UsersController : Controller
 
         if (_featureService.IsEnabled(FeatureFlagKeys.MembersTwoFAQueryOptimization))
         {
-            TempData["UsersTwoFactorIsEnabled"] = await _twoFactorIsEnabledQuery.TwoFactorIsEnabledAsync(users.Select(u => u.Id));
+            var user2Fa = (await _twoFactorIsEnabledQuery.TwoFactorIsEnabledAsync(users.Select(u => u.Id))).ToList();
+            // TempDataSerializer is having an issue serializing an empty IEnumerable<Tuple<T1,T2>> so sending null if empty
+            TempData["UsersTwoFactorIsEnabled"] = user2Fa.Count != 0 ? user2Fa : null;
         }
 
         return View(new UsersModel

--- a/src/Admin/Controllers/UsersController.cs
+++ b/src/Admin/Controllers/UsersController.cs
@@ -67,7 +67,7 @@ public class UsersController : Controller
         if (_featureService.IsEnabled(FeatureFlagKeys.MembersTwoFAQueryOptimization))
         {
             var user2Fa = (await _twoFactorIsEnabledQuery.TwoFactorIsEnabledAsync(users.Select(u => u.Id))).ToList();
-            // TempDataSerializer is having an issue serializing an empty IEnumerable<Tuple<T1,T2>>, only set if not empty
+            // TempDataSerializer is having an issue serializing an empty IEnumerable<Tuple<T1,T2>>, do not set if empty.
             if (user2Fa.Count != 0) TempData["UsersTwoFactorIsEnabled"] = user2Fa;
         }
 

--- a/src/Admin/Controllers/UsersController.cs
+++ b/src/Admin/Controllers/UsersController.cs
@@ -67,8 +67,8 @@ public class UsersController : Controller
         if (_featureService.IsEnabled(FeatureFlagKeys.MembersTwoFAQueryOptimization))
         {
             var user2Fa = (await _twoFactorIsEnabledQuery.TwoFactorIsEnabledAsync(users.Select(u => u.Id))).ToList();
-            // TempDataSerializer is having an issue serializing an empty IEnumerable<Tuple<T1,T2>> so sending null if empty
-            TempData["UsersTwoFactorIsEnabled"] = user2Fa.Count != 0 ? user2Fa : null;
+            // TempDataSerializer is having an issue serializing an empty IEnumerable<Tuple<T1,T2>> so not setting the header if empty
+            if (user2Fa.Count != 0) TempData["UsersTwoFactorIsEnabled"] = user2Fa;
         }
 
         return View(new UsersModel

--- a/src/Admin/Controllers/UsersController.cs
+++ b/src/Admin/Controllers/UsersController.cs
@@ -67,7 +67,7 @@ public class UsersController : Controller
         if (_featureService.IsEnabled(FeatureFlagKeys.MembersTwoFAQueryOptimization))
         {
             var user2Fa = (await _twoFactorIsEnabledQuery.TwoFactorIsEnabledAsync(users.Select(u => u.Id))).ToList();
-            // TempDataSerializer is having an issue serializing an empty IEnumerable<Tuple<T1,T2>> so not setting the header if empty
+            // TempDataSerializer is having an issue serializing an empty IEnumerable<Tuple<T1,T2>>, only set if not empty
             if (user2Fa.Count != 0) TempData["UsersTwoFactorIsEnabled"] = user2Fa;
         }
 

--- a/src/Admin/Views/Users/Index.cshtml
+++ b/src/Admin/Views/Users/Index.cshtml
@@ -72,8 +72,8 @@
                             }
                             @if (featureService.IsEnabled(Bit.Core.FeatureFlagKeys.MembersTwoFAQueryOptimization))
                             {
-                                var usersTwoFactorIsEnabled = TempData["UsersTwoFactorIsEnabled"] as IEnumerable<(Guid userId, bool twoFactorIsEnabled)>;
-                                @if(usersTwoFactorIsEnabled.FirstOrDefault(tuple => tuple.userId == user.Id).twoFactorIsEnabled)
+                                @if(TempData["UsersTwoFactorIsEnabled"] is IEnumerable<(Guid userId, bool twoFactorIsEnabled)> usersTwoFactorIsEnabled
+                                    && usersTwoFactorIsEnabled.FirstOrDefault(tuple => tuple.userId == user.Id).twoFactorIsEnabled)
                                 {
                                     <i class="fa fa-lock fa-lg fa-fw" title="2FA Enabled"></i>
                                 }

--- a/src/Admin/Views/Users/Index.cshtml
+++ b/src/Admin/Views/Users/Index.cshtml
@@ -72,8 +72,10 @@
                             }
                             @if (featureService.IsEnabled(Bit.Core.FeatureFlagKeys.MembersTwoFAQueryOptimization))
                             {
-                                @if(TempData["UsersTwoFactorIsEnabled"] is IEnumerable<(Guid userId, bool twoFactorIsEnabled)> usersTwoFactorIsEnabled
-                                    && usersTwoFactorIsEnabled.FirstOrDefault(tuple => tuple.userId == user.Id).twoFactorIsEnabled)
+                                var usersTwoFactorIsEnabled = TempData["UsersTwoFactorIsEnabled"] as IEnumerable<(Guid userId, bool twoFactorIsEnabled)>;
+                                var matchingUser2Fa = usersTwoFactorIsEnabled?.FirstOrDefault(tuple => tuple.userId == user.Id);
+
+                                @if(matchingUser2Fa is { twoFactorIsEnabled: true })
                                 {
                                     <i class="fa fa-lock fa-lg fa-fw" title="2FA Enabled"></i>
                                 }


### PR DESCRIPTION
## 🎟️ Tracking

JIRA: https://bitwarden.atlassian.net/browse/PM-12001

## 📔 Objective

When searching for a user that does not exist in the given organization, the serialization fails for sending an empty `IEnumerable<ValueTuple<T1, T2>>`. This is a quick fix to not set the temp data if the enumerable is empty. Also added some null checking to the razor template.

I suspect the DefaultTempDataSerializer has an issue because if an `IEnumerable<ValueTuple<T1, T2>>` with a value in it is returned, it will serialize the data no problem. It only has an issue with an empty enumerable. I did try converting the value over to a `Dictionary<Guid, bool>` and it failed when evaluating during the render. There seems to be a weird interaction between there.

Ideally, we would create a new model to represent the `User` instead of the database model and populate the value on that.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
