### PR TITLE
Auth/PM-11969 - Registration with Email Verification - Accept Emergency Access Invite Flow 

### DIFF
--- a/src/Core/Auth/Models/Api/Request/Accounts/RegisterFinishRequestModel.cs
+++ b/src/Core/Auth/Models/Api/Request/Accounts/RegisterFinishRequestModel.cs
@@ -33,6 +33,9 @@ public class RegisterFinishRequestModel : IValidatableObject
 
     public string? OrgSponsoredFreeFamilyPlanToken { get; set; }
 
+    public string? AcceptEmergencyAccessInviteToken { get; set; }
+    public Guid? AcceptEmergencyAccessId { get; set; }
+
     public User ToUser()
     {
         var user = new User

--- a/src/Core/Auth/UserFeatures/Registration/IRegisterUserCommand.cs
+++ b/src/Core/Auth/UserFeatures/Registration/IRegisterUserCommand.cs
@@ -34,9 +34,31 @@ public interface IRegisterUserCommand
     /// <param name="user">The <see cref="User"/> to create</param>
     /// <param name="masterPasswordHash">The hashed master password the user entered</param>
     /// <param name="emailVerificationToken">The email verification token sent to the user via email</param>
-    /// <returns></returns>
+    /// <returns><see cref="IdentityResult"/></returns>
     public Task<IdentityResult> RegisterUserViaEmailVerificationToken(User user, string masterPasswordHash, string emailVerificationToken);
 
+    /// <summary>
+    /// Creates a new user with a given master password hash, sends a welcome email, and raises the signup reference event.
+    /// If a valid org sponsored free family plan invite token is provided, the user will be created with their email verified.
+    /// If the token is invalid or expired, an error will be thrown.
+    /// </summary>
+    /// <param name="user">The <see cref="User"/> to create</param>
+    /// <param name="masterPasswordHash">The hashed master password the user entered</param>
+    /// <param name="orgSponsoredFreeFamilyPlanInviteToken">The org sponsored free family plan invite token sent to the user via email</param>
+    /// <returns><see cref="IdentityResult"/></returns>
     public Task<IdentityResult> RegisterUserViaOrganizationSponsoredFreeFamilyPlanInviteToken(User user, string masterPasswordHash, string orgSponsoredFreeFamilyPlanInviteToken);
+
+    /// <summary>
+    /// Creates a new user with a given master password hash, sends a welcome email, and raises the signup reference event.
+    /// If a valid token is provided, the user will be created with their email verified.
+    /// If the token is invalid or expired, an error will be thrown.
+    /// </summary>
+    /// <param name="user">The <see cref="User"/> to create</param>
+    /// <param name="masterPasswordHash">The hashed master password the user entered</param>
+    /// <param name="acceptEmergencyAccessInviteToken">The emergency access invite token sent to the user via email</param>
+    /// <param name="acceptEmergencyAccessId">The emergency access id (used to validate the token)</param>
+    /// <returns><see cref="IdentityResult"/></returns>
+    public Task<IdentityResult> RegisterUserViaAcceptEmergencyAccessInviteToken(User user, string masterPasswordHash,
+        string acceptEmergencyAccessInviteToken, Guid acceptEmergencyAccessId);
 
 }

--- a/test/Identity.IntegrationTest/Controllers/AccountsControllerTests.cs
+++ b/test/Identity.IntegrationTest/Controllers/AccountsControllerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core;
+using Bit.Core.Auth.Entities;
 using Bit.Core.Auth.Models.Api.Request.Accounts;
 using Bit.Core.Auth.Models.Business.Tokenables;
 using Bit.Core.Entities;
@@ -368,6 +369,75 @@ public class AccountsControllerTests : IClassFixture<IdentityApplicationFactory>
             MasterPasswordHash = masterPasswordHash,
             MasterPasswordHint = masterPasswordHint,
             OrgSponsoredFreeFamilyPlanToken = orgSponsoredFreeFamilyPlanToken,
+            Kdf = KdfType.PBKDF2_SHA256,
+            KdfIterations = AuthConstants.PBKDF2_ITERATIONS.Default,
+            UserSymmetricKey = userSymmetricKey,
+            UserAsymmetricKeys = userAsymmetricKeys,
+            KdfMemory = kdfMemory,
+            KdfParallelism = kdfParallelism
+        };
+
+        var postRegisterFinishHttpContext = await localFactory.PostRegisterFinishAsync(registerFinishReqModel);
+
+        Assert.Equal(StatusCodes.Status200OK, postRegisterFinishHttpContext.Response.StatusCode);
+
+        var database = localFactory.GetDatabaseContext();
+        var user = await database.Users
+            .SingleAsync(u => u.Email == email);
+
+        Assert.NotNull(user);
+
+        // Assert user properties match the request model
+        Assert.Equal(email, user.Email);
+        Assert.NotEqual(masterPasswordHash, user.MasterPassword);  // We execute server side hashing
+        Assert.NotNull(user.MasterPassword);
+        Assert.Equal(masterPasswordHint, user.MasterPasswordHint);
+        Assert.Equal(userSymmetricKey, user.Key);
+        Assert.Equal(userAsymmetricKeys.EncryptedPrivateKey, user.PrivateKey);
+        Assert.Equal(userAsymmetricKeys.PublicKey, user.PublicKey);
+        Assert.Equal(KdfType.PBKDF2_SHA256, user.Kdf);
+        Assert.Equal(AuthConstants.PBKDF2_ITERATIONS.Default, user.KdfIterations);
+        Assert.Equal(kdfMemory, user.KdfMemory);
+        Assert.Equal(kdfParallelism, user.KdfParallelism);
+    }
+
+    [Theory, BitAutoData]
+    public async Task RegistrationWithEmailVerification_WithAcceptEmergencyAccessInviteToken_Succeeds(
+     [StringLength(1000)] string masterPasswordHash, [StringLength(50)] string masterPasswordHint, string userSymmetricKey,
+    KeysRequestModel userAsymmetricKeys, int kdfMemory, int kdfParallelism, EmergencyAccess emergencyAccess)
+    {
+
+        // Localize factory to just this test.
+        var localFactory = new IdentityApplicationFactory();
+
+        // Hardcoded, valid data
+        var email = "jsnider+local79813655659549@bitwarden.com";
+        var acceptEmergencyAccessInviteToken = "CfDJ8HFsgwUNr89EtnCal5H72cwjvdjWmBp3J0ry7KoG6zDFub-EeoA3cfLBXONq7thKq7QTBh6KJ--jU0Det7t3P9EXqxmEacxIlgFlBgtywIUho9N8nVQeNcltkQO9g0vj_ASshnn6fWK3zpqS6Z8JueVZ2TMtdks5uc7DjZurWFLX27Dpii-UusFD78Z5tCY-D79bkjHy43g1ULk2F2ZtwiJvp3C9QvXW1-12IEsyHHSxU-9RELe-_joo2iDIR-cvMmEfbEXK7uvuzNT2V0r22jalaAKFvd84Gza9Q0YSFn8z_nAJxVqEXsAVKdG8SRN5Wa3K2mdNoBMt20RrzNuuJhe6vzX0yP35HtC4e1YXXzWB";
+        var acceptEmergencyAccessId = new Guid("8bc5e574-cef6-4ee7-b9ed-b1e90158c016");
+
+        emergencyAccess.Id = acceptEmergencyAccessId;
+        emergencyAccess.Email = email;
+
+        var emergencyAccessInviteTokenable = new EmergencyAccessInviteTokenable(emergencyAccess, 10) { };
+
+        localFactory.SubstituteService<IDataProtectorTokenFactory<EmergencyAccessInviteTokenable>>(dataProtectorTokenFactory =>
+        {
+            dataProtectorTokenFactory.TryUnprotect(Arg.Is(acceptEmergencyAccessInviteToken), out Arg.Any<EmergencyAccessInviteTokenable>())
+                .Returns(callInfo =>
+                {
+                    callInfo[1] = emergencyAccessInviteTokenable;
+                    return true;
+                });
+        });
+
+
+        var registerFinishReqModel = new RegisterFinishRequestModel
+        {
+            Email = email,
+            MasterPasswordHash = masterPasswordHash,
+            MasterPasswordHint = masterPasswordHint,
+            AcceptEmergencyAccessInviteToken = acceptEmergencyAccessInviteToken,
+            AcceptEmergencyAccessId = acceptEmergencyAccessId,
             Kdf = KdfType.PBKDF2_SHA256,
             KdfIterations = AuthConstants.PBKDF2_ITERATIONS.Default,
             UserSymmetricKey = userSymmetricKey,


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-11969
Clients PR: https://github.com/bitwarden/clients/pull/11018

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To add support for the accept emergency access invite flow in the new registration with email verification flow. 

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
See clients PR. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
