### PR TITLE
[PM-5237] Add new Settings property to config endpoint

### DIFF
--- a/src/Api/Models/Response/ConfigResponseModel.cs
+++ b/src/Api/Models/Response/ConfigResponseModel.cs
@@ -11,7 +11,7 @@ public class ConfigResponseModel : ResponseModel
     public ServerConfigResponseModel Server { get; set; }
     public EnvironmentConfigResponseModel Environment { get; set; }
     public IDictionary<string, object> FeatureStates { get; set; }
-    public ServerSettingsResponseModel Settings { get; set; } 
+    public ServerSettingsResponseModel Settings { get; set; }
 
     public ConfigResponseModel() : base("config")
     {

--- a/src/Api/Models/Response/ConfigResponseModel.cs
+++ b/src/Api/Models/Response/ConfigResponseModel.cs
@@ -11,6 +11,7 @@ public class ConfigResponseModel : ResponseModel
     public ServerConfigResponseModel Server { get; set; }
     public EnvironmentConfigResponseModel Environment { get; set; }
     public IDictionary<string, object> FeatureStates { get; set; }
+    public ServerSettingsResponseModel Settings { get; set; } 
 
     public ConfigResponseModel() : base("config")
     {
@@ -18,6 +19,7 @@ public class ConfigResponseModel : ResponseModel
         GitHash = AssemblyHelpers.GetGitHash();
         Environment = new EnvironmentConfigResponseModel();
         FeatureStates = new Dictionary<string, object>();
+        Settings = new ServerSettingsResponseModel();
     }
 
     public ConfigResponseModel(
@@ -36,6 +38,10 @@ public class ConfigResponseModel : ResponseModel
             Sso = globalSettings.BaseServiceUri.Sso
         };
         FeatureStates = featureStates;
+        Settings = new ServerSettingsResponseModel
+        {
+            DisableUserRegistration = globalSettings.DisableUserRegistration
+        };
     }
 }
 
@@ -53,4 +59,9 @@ public class EnvironmentConfigResponseModel
     public string Identity { get; set; }
     public string Notifications { get; set; }
     public string Sso { get; set; }
+}
+
+public class ServerSettingsResponseModel
+{
+    public bool DisableUserRegistration { get; set; }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-5237

## 📔 Objective

We need the client to be responsive to the `globalSettings.DisableUserRegistration` setting, by hiding the registration link in the UI.  To do this we will expose a new property on the `ConfigResponseModel` to pass along this setting.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
