### PR TITLE
Add AuthorizeOrThrowAsync extension method

### DIFF
--- a/src/Api/AdminConsole/Controllers/GroupsController.cs
+++ b/src/Api/AdminConsole/Controllers/GroupsController.cs
@@ -11,6 +11,7 @@ using Bit.Core.Context;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
+using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 

--- a/src/Api/AdminConsole/Controllers/GroupsController.cs
+++ b/src/Api/AdminConsole/Controllers/GroupsController.cs
@@ -1,7 +1,6 @@
 ﻿using Bit.Api.AdminConsole.Models.Request;
 using Bit.Api.AdminConsole.Models.Response;
 using Bit.Api.Models.Response;
-using Bit.Api.Utilities;
 using Bit.Api.Vault.AuthorizationHandlers.Collections;
 using Bit.Api.Vault.AuthorizationHandlers.Groups;
 using Bit.Core.AdminConsole.OrganizationFeatures.Groups.Interfaces;

--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -22,6 +22,7 @@ using Bit.Core.OrganizationFeatures.OrganizationSubscriptions.Interface;
 using Bit.Core.OrganizationFeatures.OrganizationUsers.Interfaces;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
+using Bit.Core.Utilities;
 using Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interfaces;
 using Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Requests;
 using Microsoft.AspNetCore.Authorization;

--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -2,7 +2,6 @@
 using Bit.Api.AdminConsole.Models.Response.Organizations;
 using Bit.Api.Models.Request.Organizations;
 using Bit.Api.Models.Response;
-using Bit.Api.Utilities;
 using Bit.Api.Vault.AuthorizationHandlers.Collections;
 using Bit.Api.Vault.AuthorizationHandlers.OrganizationUsers;
 using Bit.Core;

--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -1,6 +1,5 @@
 ﻿using Bit.Api.Models.Request;
 using Bit.Api.Models.Response;
-using Bit.Api.Utilities;
 using Bit.Api.Vault.AuthorizationHandlers.Collections;
 using Bit.Core.Context;
 using Bit.Core.Entities;

--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -9,6 +9,7 @@ using Bit.Core.Models.Data;
 using Bit.Core.OrganizationFeatures.OrganizationCollections.Interfaces;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
+using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 

--- a/src/Core/Utilities/AuthorizationServiceExtensions.cs
+++ b/src/Core/Utilities/AuthorizationServiceExtensions.cs
@@ -1,7 +1,8 @@
 ﻿using System.Security.Claims;
+using Bit.Core.Exceptions;
 using Microsoft.AspNetCore.Authorization;
 
-namespace Bit.Api.Utilities;
+namespace Bit.Core.Utilities;
 
 public static class AuthorizationServiceExtensions
 {
@@ -28,5 +29,27 @@ public static class AuthorizationServiceExtensions
         }
 
         return service.AuthorizeAsync(user, resource: null, new[] { requirement });
+    }
+
+    /// <summary>
+    /// Performs an authorization check and throws a <see cref="Bit.Core.Exceptions.NotFoundException"/> if the
+    /// check fails or the resource is null.
+    /// </summary>
+    public static async Task AuthorizeOrThrowAsync(this IAuthorizationService service,
+        ClaimsPrincipal user, object resource, IAuthorizationRequirement requirement)
+    {
+        ArgumentNullException.ThrowIfNull(service);
+        ArgumentNullException.ThrowIfNull(requirement);
+
+        if (resource == null)
+        {
+            throw new NotFoundException();
+        }
+
+        var authorizationResult = await service.AuthorizeAsync(user, resource, requirement);
+        if (!authorizationResult.Succeeded)
+        {
+            throw new NotFoundException();
+        }
     }
 }

--- a/test/Core.Test/Utilities/AuthorizationServiceExtensionTests.cs
+++ b/test/Core.Test/Utilities/AuthorizationServiceExtensionTests.cs
@@ -1,0 +1,38 @@
+﻿using System.Security.Claims;
+using Bit.Core.Exceptions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
+using NSubstitute;
+using Xunit;
+using AuthorizationServiceExtensions = Bit.Core.Utilities.AuthorizationServiceExtensions;
+
+namespace Bit.Core.Test.Utilities;
+
+public class AuthorizationServiceExtensionTests
+{
+    [Fact]
+    async Task AuthorizeOrThrowAsync_ThrowsNotFoundException_IfResourceIsNull()
+    {
+        var authorizationService = Substitute.For<IAuthorizationService>();
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            AuthorizationServiceExtensions.AuthorizeOrThrowAsync(authorizationService, new ClaimsPrincipal(),
+                null, new OperationAuthorizationRequirement()));
+    }
+
+    [Fact]
+    async Task AuthorizeOrThrowAsync_ThrowsNotFoundException_IfAuthorizationFails()
+    {
+        var authorizationService = Substitute.For<IAuthorizationService>();
+        var claimsPrincipal = new ClaimsPrincipal();
+        var requirement = new OperationAuthorizationRequirement();
+        var resource = new object();
+
+        authorizationService
+            .AuthorizeAsync(claimsPrincipal, resource, Arg.Is<IEnumerable<IAuthorizationRequirement>>(r =>
+                r.First() == requirement))
+            .Returns(AuthorizationResult.Failed());
+
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            AuthorizationServiceExtensions.AuthorizeOrThrowAsync(authorizationService, claimsPrincipal, resource, requirement));
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
Related to https://contributing.bitwarden.com/architecture/deep-dives/authorization.

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add the `AuthorizeOrThrowAsync` extension helper method for authorization service. This encapsulates a common pattern where we want to throw a 404 if authorization fails.

This is referred to in the deep dive linked above but hadn't been implemented yet.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
