### PR TITLE
Provide client type in LD context

### DIFF
--- a/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
+++ b/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
@@ -21,6 +21,7 @@ public class LaunchDarklyFeatureService : IFeatureService
 
     private const string _contextAttributeClientVersion = "client-version";
     private const string _contextAttributeDeviceType = "device-type";
+    private const string _contextAttributeClientType = "client-type";
     private const string _contextAttributeOrganizations = "organizations";
 
     public LaunchDarklyFeatureService(
@@ -149,6 +150,7 @@ public class LaunchDarklyFeatureService : IFeatureService
             if (_currentContext.DeviceType.HasValue)
             {
                 builder.Set(_contextAttributeDeviceType, (int)_currentContext.DeviceType.Value);
+                builder.Set(_contextAttributeClientType, (int)DeviceTypes.ToClientType(_currentContext.DeviceType.Value));
             }
         }
 

--- a/src/Core/Utilities/DeviceTypes.cs
+++ b/src/Core/Utilities/DeviceTypes.cs
@@ -22,7 +22,6 @@ public static class DeviceTypes
         DeviceType.LinuxCLI
     ];
 
-
     public static IReadOnlyCollection<DeviceType> BrowserExtensionTypes { get; } =
     [
         DeviceType.ChromeExtension,
@@ -45,7 +44,7 @@ public static class DeviceTypes
         DeviceType.UnknownBrowser
     ];
 
-    private static ClientType ToClientType(DeviceType? deviceType)
+    public static ClientType ToClientType(DeviceType? deviceType)
     {
         return deviceType switch
         {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11984

## 📔 Objective

Send the client type to Launch Darkly for context, based on the device type.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
