### PR TITLE
[PM-12630] support for ping identity SCIM provisioning

### DIFF
--- a/bitwarden_license/src/Scim/Context/ScimContext.cs
+++ b/bitwarden_license/src/Scim/Context/ScimContext.cs
@@ -13,7 +13,7 @@ public class ScimContext : IScimContext
     private bool _builtHttpContext;
 
     // See IP list from Ping in docs: https://support.pingidentity.com/s/article/PingOne-IP-Addresses
-    private readonly HashSet<string> _pingIpAddresses =
+    private static readonly HashSet<string> _pingIpAddresses =
     [
         "18.217.152.87",
         "52.14.10.143",

--- a/bitwarden_license/src/Scim/Context/ScimContext.cs
+++ b/bitwarden_license/src/Scim/Context/ScimContext.cs
@@ -4,12 +4,39 @@ using Bit.Core.AdminConsole.Models.OrganizationConnectionConfigs;
 using Bit.Core.Enums;
 using Bit.Core.Repositories;
 using Bit.Core.Settings;
+using Bit.Core.Utilities;
 
 namespace Bit.Scim.Context;
 
 public class ScimContext : IScimContext
 {
     private bool _builtHttpContext;
+
+    // See IP list from Ping in docs: https://support.pingidentity.com/s/article/PingOne-IP-Addresses
+    private readonly HashSet<string> _pingIpAddresses =
+    [
+        "18.217.152.87",
+        "52.14.10.143",
+        "13.58.49.148",
+        "34.211.92.81",
+        "54.214.158.219",
+        "34.218.98.164",
+        "15.223.133.47",
+        "3.97.84.38",
+        "15.223.19.71",
+        "3.97.98.120",
+        "52.60.115.173",
+        "3.97.202.223",
+        "18.184.65.93",
+        "52.57.244.92",
+        "18.195.7.252",
+        "108.128.67.71",
+        "34.246.158.102",
+        "108.128.250.27",
+        "52.63.103.92",
+        "13.54.131.18",
+        "52.62.204.36"
+    ];
 
     public ScimProviderType RequestScimProvider { get; set; } = ScimProviderType.Default;
     public ScimConfig ScimConfiguration { get; set; }
@@ -55,10 +82,18 @@ public class ScimContext : IScimContext
                 RequestScimProvider = ScimProviderType.Okta;
             }
         }
+
         if (RequestScimProvider == ScimProviderType.Default &&
             httpContext.Request.Headers.ContainsKey("Adscimversion"))
         {
             RequestScimProvider = ScimProviderType.AzureAd;
+        }
+
+        var ipAddress = CoreHelpers.GetIpAddress(httpContext, globalSettings);
+        if (RequestScimProvider == ScimProviderType.Default &&
+            _pingIpAddresses.Contains(ipAddress))
+        {
+            RequestScimProvider = ScimProviderType.Ping;
         }
     }
 }

--- a/bitwarden_license/src/Scim/Groups/PutGroupCommand.cs
+++ b/bitwarden_license/src/Scim/Groups/PutGroupCommand.cs
@@ -43,7 +43,8 @@ public class PutGroupCommand : IPutGroupCommand
 
     private async Task UpdateGroupMembersAsync(Group group, ScimGroupRequestModel model)
     {
-        if (_scimContext.RequestScimProvider != ScimProviderType.Okta)
+        if (_scimContext.RequestScimProvider != ScimProviderType.Okta &&
+            _scimContext.RequestScimProvider != ScimProviderType.Ping)
         {
             return;
         }

--- a/bitwarden_license/src/Scim/Users/GetUsersListQuery.cs
+++ b/bitwarden_license/src/Scim/Users/GetUsersListQuery.cs
@@ -20,15 +20,16 @@ public class GetUsersListQuery : IGetUsersListQuery
         string externalIdFilter = null;
         if (!string.IsNullOrWhiteSpace(filter))
         {
-            if (filter.StartsWith("userName eq "))
+            var filterLower = filter.ToLowerInvariant();
+            if (filterLower.StartsWith("username eq "))
             {
-                usernameFilter = filter.Substring(12).Trim('"').ToLowerInvariant();
+                usernameFilter = filterLower.Substring(12).Trim('"');
                 if (usernameFilter.Contains("@"))
                 {
                     emailFilter = usernameFilter;
                 }
             }
-            else if (filter.StartsWith("externalId eq "))
+            else if (filterLower.StartsWith("externalid eq "))
             {
                 externalIdFilter = filter.Substring(14).Trim('"');
             }

--- a/src/Core/AdminConsole/Enums/ScimProviderType.cs
+++ b/src/Core/AdminConsole/Enums/ScimProviderType.cs
@@ -9,4 +9,5 @@ public enum ScimProviderType : byte
     JumpCloud = 4,
     GoogleWorkspace = 5,
     Rippling = 6,
+    Ping = 7,
 }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-12630

## 📔 Objective

SCIM for Ping Identity kind of worked already out of the box, but we needed to add support for identifying Ping as a SCIM provider and allowing it to use Group PUT calls to update group/user membership.