### PR TITLE
[PM-10961] Cannot delete MSP with apostrophe in name

### DIFF
--- a/src/Admin/AdminConsole/Controllers/ProvidersController.cs
+++ b/src/Admin/AdminConsole/Controllers/ProvidersController.cs
@@ -367,7 +367,7 @@ public class ProvidersController : Controller
             return BadRequest("Provider does not exist");
         }
 
-        if (!string.Equals(providerName.Trim(), provider.Name, StringComparison.OrdinalIgnoreCase))
+        if (!string.Equals(providerName.Trim(), provider.DisplayName(), StringComparison.OrdinalIgnoreCase))
         {
             return BadRequest("Invalid provider name");
         }

--- a/src/Admin/AdminConsole/Views/Providers/_ProviderScripts.cshtml
+++ b/src/Admin/AdminConsole/Views/Providers/_ProviderScripts.cshtml
@@ -20,9 +20,10 @@
 
     function deleteProvider(id) {
         const providerName = $('#DeleteModal input#provider-name').val();
+        const encodedProviderName = encodeURIComponent(providerName);
         $.ajax({
             type: "POST",
-            url: `@Url.Action("Delete", "Providers")?id=${id}&providerName=${providerName}`,
+            url: `@Url.Action("Delete", "Providers")?id=${id}&providerName=${encodedProviderName}`,
             dataType: 'json',
             contentType: false,
             processData: false,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10961

## 📔 Objective

1. Call the back-end with Ajax with the provider name URL encoded. So the entire query parameter would be received correctly by the server.
2. Compare it in the back-end with the provider name's HTML decoded value.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
