### PR TITLE
Fix logic error in a handwritten MySql `UPDATE` migration

### DIFF
--- a/util/MySqlMigrations/Migrations/20240925202356_SyncOrganizationLimitCollectionCreationDeletionColumn.cs
+++ b/util/MySqlMigrations/Migrations/20240925202356_SyncOrganizationLimitCollectionCreationDeletionColumn.cs
@@ -15,7 +15,7 @@ public partial class SyncOrganizationLimitCollectionCreationDeletionColumn : Mig
                     UPDATE Organization
                     SET
                       LimitCollectionCreation = LimitCollectionCreationDeletion,
-                      LimitCollectionDeletion = LimitCollectionDeletion;
+                      LimitCollectionDeletion = LimitCollectionCreationDeletion;
                 ");
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/server/pull/4709

## 📔 Objective

On https://github.com/bitwarden/server/pull/4709 I hand-wrote `UPDATE` migrations that perform initial population of data in a pair of new database columns.

In the MySQL migration I committed a logic error, setting the value of one of the new columns to itself.

This one line PR set this value correctly.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
