### PR TITLE
[PM-13722] Refactor `ValidateOrganizationsDomainAsync`

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationDomainController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationDomainController.cs
@@ -101,7 +101,7 @@ public class OrganizationDomainController : Controller
             throw new NotFoundException();
         }
 
-        organizationDomain = await _verifyOrganizationDomainCommand.VerifyOrganizationDomainAsync(organizationDomain);
+        organizationDomain = await _verifyOrganizationDomainCommand.UserVerifyOrganizationDomainAsync(organizationDomain);
 
         return new OrganizationDomainResponseModel(organizationDomain);
     }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationDomains/CreateOrganizationDomainCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationDomains/CreateOrganizationDomainCommand.cs
@@ -6,7 +6,6 @@ using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Settings;
 using Bit.Core.Utilities;
-using Microsoft.Extensions.Logging;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationDomains;
 
@@ -14,21 +13,15 @@ public class CreateOrganizationDomainCommand : ICreateOrganizationDomainCommand
 {
     private readonly IOrganizationDomainRepository _organizationDomainRepository;
     private readonly IEventService _eventService;
-    private readonly IDnsResolverService _dnsResolverService;
-    private readonly ILogger<VerifyOrganizationDomainCommand> _logger;
     private readonly IGlobalSettings _globalSettings;
 
     public CreateOrganizationDomainCommand(
         IOrganizationDomainRepository organizationDomainRepository,
         IEventService eventService,
-        IDnsResolverService dnsResolverService,
-        ILogger<VerifyOrganizationDomainCommand> logger,
         IGlobalSettings globalSettings)
     {
         _organizationDomainRepository = organizationDomainRepository;
         _eventService = eventService;
-        _dnsResolverService = dnsResolverService;
-        _logger = logger;
         _globalSettings = globalSettings;
     }
 

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationDomains/Interfaces/IVerifyOrganizationDomainCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationDomains/Interfaces/IVerifyOrganizationDomainCommand.cs
@@ -4,5 +4,6 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationDomains.Interfa
 
 public interface IVerifyOrganizationDomainCommand
 {
-    Task<OrganizationDomain> VerifyOrganizationDomainAsync(OrganizationDomain organizationDomain);
+    Task<OrganizationDomain> UserVerifyOrganizationDomainAsync(OrganizationDomain organizationDomain);
+    Task<OrganizationDomain> SystemVerifyOrganizationDomainAsync(OrganizationDomain organizationDomain);
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs
@@ -90,7 +90,7 @@ public class VerifyOrganizationDomainCommand : IVerifyOrganizationDomainCommand
         var claimedDomain =
             await _organizationDomainRepository.GetClaimedDomainsByDomainNameAsync(domain.DomainName);
 
-        if (claimedDomain.Any())
+        if (claimedDomain.Count > 0)
         {
             await _organizationDomainRepository.ReplaceAsync(domain);
             throw new ConflictException("The domain is not available to be claimed.");

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs
@@ -77,7 +77,8 @@ public class VerifyOrganizationDomainCommand : IVerifyOrganizationDomainCommand
                 EventType.OrganizationDomain_NotVerified,
                 EventSystemUser.DomainVerification);
 
-            _logger.LogInformation(Constants.BypassFiltersEventId, "Verification for organization {OrgId} with domain {Domain} failed",
+            _logger.LogInformation(Constants.BypassFiltersEventId,
+                "Verification for organization {OrgId} with domain {Domain} failed",
                 domainVerificationResult.OrganizationId, domainVerificationResult.DomainName);
         }
 
@@ -111,12 +112,7 @@ public class VerifyOrganizationDomainCommand : IVerifyOrganizationDomainCommand
             {
                 domain.SetVerifiedDate();
 
-                await _policyService.SaveAsync(new Policy
-                {
-                    OrganizationId = domain.OrganizationId,
-                    Type = PolicyType.SingleOrg,
-                    Enabled = true,
-                }, _organizationService, null);
+                await EnableSingleOrganizationPolicyAsync(domain.OrganizationId);
             }
         }
         catch (Exception e)
@@ -128,4 +124,8 @@ public class VerifyOrganizationDomainCommand : IVerifyOrganizationDomainCommand
         return domain;
     }
 
+    private async Task EnableSingleOrganizationPolicyAsync(Guid organizationId)
+        => await _policyService.SaveAsync(
+            new Policy { OrganizationId = organizationId, Type = PolicyType.SingleOrg, Enabled = true, },
+            _organizationService, null);
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationDomains/VerifyOrganizationDomainCommand.cs
@@ -1,7 +1,4 @@
-﻿using Bit.Core.AdminConsole.Entities;
-using Bit.Core.AdminConsole.Enums;
-using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationDomains.Interfaces;
-using Bit.Core.AdminConsole.Services;
+﻿using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationDomains.Interfaces;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
@@ -15,28 +12,22 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationDomains;
 public class VerifyOrganizationDomainCommand : IVerifyOrganizationDomainCommand
 {
     private readonly IOrganizationDomainRepository _organizationDomainRepository;
-    private readonly IOrganizationService _organizationService;
     private readonly IDnsResolverService _dnsResolverService;
     private readonly IEventService _eventService;
     private readonly IGlobalSettings _globalSettings;
-    private readonly IPolicyService _policyService;
     private readonly ILogger<VerifyOrganizationDomainCommand> _logger;
 
     public VerifyOrganizationDomainCommand(
         IOrganizationDomainRepository organizationDomainRepository,
-        IOrganizationService organizationService,
         IDnsResolverService dnsResolverService,
         IEventService eventService,
         IGlobalSettings globalSettings,
-        IPolicyService policyService,
         ILogger<VerifyOrganizationDomainCommand> logger)
     {
         _organizationDomainRepository = organizationDomainRepository;
-        _organizationService = organizationService;
         _dnsResolverService = dnsResolverService;
         _eventService = eventService;
         _globalSettings = globalSettings;
-        _policyService = policyService;
         _logger = logger;
     }
 
@@ -111,8 +102,6 @@ public class VerifyOrganizationDomainCommand : IVerifyOrganizationDomainCommand
             if (await _dnsResolverService.ResolveAsync(domain.DomainName, domain.Txt))
             {
                 domain.SetVerifiedDate();
-
-                await EnableSingleOrganizationPolicyAsync(domain.OrganizationId);
             }
         }
         catch (Exception e)
@@ -123,9 +112,4 @@ public class VerifyOrganizationDomainCommand : IVerifyOrganizationDomainCommand
 
         return domain;
     }
-
-    private async Task EnableSingleOrganizationPolicyAsync(Guid organizationId)
-        => await _policyService.SaveAsync(
-            new Policy { OrganizationId = organizationId, Type = PolicyType.SingleOrg, Enabled = true, },
-            _organizationService, null);
 }

--- a/src/Core/AdminConsole/Services/Implementations/OrganizationDomainService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationDomainService.cs
@@ -56,8 +56,6 @@ public class OrganizationDomainService : IOrganizationDomainService
 
             try
             {
-                domain.SetJobRunCount();
-
                 _ = await _verifyOrganizationDomainCommand.SystemVerifyOrganizationDomainAsync(domain);
             }
             catch (Exception ex)

--- a/src/Core/AdminConsole/Services/Implementations/OrganizationDomainService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationDomainService.cs
@@ -47,7 +47,12 @@ public class OrganizationDomainService : IOrganizationDomainService
         {
             try
             {
-                _logger.LogInformation(Constants.BypassFiltersEventId, "Attempting verification for organization {OrgId} with domain {Domain}", domain.OrganizationId, domain.DomainName);
+                _logger.LogInformation(Constants.BypassFiltersEventId,
+                    "Attempting verification for organization {OrgId} with domain {Domain}",
+                    domain.OrganizationId,
+                    domain.DomainName);
+
+                domain.SetJobRunCount();
 
                 var status = await _dnsResolverService.ResolveAsync(domain.DomainName, domain.Txt);
                 if (status)
@@ -57,7 +62,6 @@ public class OrganizationDomainService : IOrganizationDomainService
                     // Update entry on OrganizationDomain table
                     domain.SetLastCheckedDate();
                     domain.SetVerifiedDate();
-                    domain.SetJobRunCount();
                     await _domainRepository.ReplaceAsync(domain);
 
                     await _eventService.LogOrganizationDomainEventAsync(domain, EventType.OrganizationDomain_Verified,
@@ -67,7 +71,6 @@ public class OrganizationDomainService : IOrganizationDomainService
                 {
                     // Update entry on OrganizationDomain table
                     domain.SetLastCheckedDate();
-                    domain.SetJobRunCount();
                     domain.SetNextRunDate(_globalSettings.DomainVerification.VerificationInterval);
                     await _domainRepository.ReplaceAsync(domain);
 
@@ -81,7 +84,6 @@ public class OrganizationDomainService : IOrganizationDomainService
             {
                 // Update entry on OrganizationDomain table
                 domain.SetLastCheckedDate();
-                domain.SetJobRunCount();
                 domain.SetNextRunDate(_globalSettings.DomainVerification.VerificationInterval);
                 await _domainRepository.ReplaceAsync(domain);
 

--- a/src/Core/AdminConsole/Services/Implementations/OrganizationDomainService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationDomainService.cs
@@ -14,6 +14,7 @@ public class OrganizationDomainService : IOrganizationDomainService
     private readonly IEventService _eventService;
     private readonly IMailService _mailService;
     private readonly IVerifyOrganizationDomainCommand _verifyOrganizationDomainCommand;
+    private readonly TimeProvider _timeProvider;
     private readonly ILogger<OrganizationDomainService> _logger;
     private readonly IGlobalSettings _globalSettings;
 
@@ -23,6 +24,7 @@ public class OrganizationDomainService : IOrganizationDomainService
         IEventService eventService,
         IMailService mailService,
         IVerifyOrganizationDomainCommand verifyOrganizationDomainCommand,
+        TimeProvider timeProvider,
         ILogger<OrganizationDomainService> logger,
         IGlobalSettings globalSettings)
     {
@@ -31,6 +33,7 @@ public class OrganizationDomainService : IOrganizationDomainService
         _eventService = eventService;
         _mailService = mailService;
         _verifyOrganizationDomainCommand = verifyOrganizationDomainCommand;
+        _timeProvider = timeProvider;
         _logger = logger;
         _globalSettings = globalSettings;
     }
@@ -38,7 +41,7 @@ public class OrganizationDomainService : IOrganizationDomainService
     public async Task ValidateOrganizationsDomainAsync()
     {
         //Date should be set 1 hour behind to ensure it selects all domains that should be verified
-        var runDate = DateTime.UtcNow.AddHours(-1);
+        var runDate = _timeProvider.GetUtcNow().UtcDateTime.AddHours(-1);
 
         var verifiableDomains = await _domainRepository.GetManyByNextRunDateAsync(runDate);
 

--- a/src/Core/AdminConsole/Services/Implementations/PolicyService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/PolicyService.cs
@@ -25,7 +25,7 @@ public class PolicyService : IPolicyService
     private readonly ISsoConfigRepository _ssoConfigRepository;
     private readonly IMailService _mailService;
     private readonly GlobalSettings _globalSettings;
-    private readonly IOrganizationDomainService _organizationDomainService;
+    private readonly IOrganizationDomainRepository _organizationDomainRepository;
     private readonly ITwoFactorIsEnabledQuery _twoFactorIsEnabledQuery;
 
     public PolicyService(
@@ -37,7 +37,7 @@ public class PolicyService : IPolicyService
         ISsoConfigRepository ssoConfigRepository,
         IMailService mailService,
         GlobalSettings globalSettings,
-        IOrganizationDomainService organizationDomainService,
+        IOrganizationDomainRepository organizationDomainRepository,
         ITwoFactorIsEnabledQuery twoFactorIsEnabledQuery)
     {
         _applicationCacheService = applicationCacheService;
@@ -48,7 +48,7 @@ public class PolicyService : IPolicyService
         _ssoConfigRepository = ssoConfigRepository;
         _mailService = mailService;
         _globalSettings = globalSettings;
-        _organizationDomainService = organizationDomainService;
+        _organizationDomainRepository = organizationDomainRepository;
         _twoFactorIsEnabledQuery = twoFactorIsEnabledQuery;
     }
 
@@ -258,7 +258,7 @@ public class PolicyService : IPolicyService
 
     private async Task HasNoVerifiedDomainsAsync(Organization org)
     {
-        if (await _organizationDomainService.HasVerifiedDomainsAsync(org.Id))
+        if ((await _organizationDomainRepository.GetDomainsByOrganizationIdAsync(org.Id)).Count > 0)
         {
             throw new BadRequestException("Organization still has verified domains.");
         }

--- a/src/Core/AdminConsole/Services/Implementations/PolicyService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/PolicyService.cs
@@ -25,7 +25,6 @@ public class PolicyService : IPolicyService
     private readonly ISsoConfigRepository _ssoConfigRepository;
     private readonly IMailService _mailService;
     private readonly GlobalSettings _globalSettings;
-    private readonly IOrganizationDomainRepository _organizationDomainRepository;
     private readonly ITwoFactorIsEnabledQuery _twoFactorIsEnabledQuery;
 
     public PolicyService(
@@ -37,7 +36,6 @@ public class PolicyService : IPolicyService
         ISsoConfigRepository ssoConfigRepository,
         IMailService mailService,
         GlobalSettings globalSettings,
-        IOrganizationDomainRepository organizationDomainRepository,
         ITwoFactorIsEnabledQuery twoFactorIsEnabledQuery)
     {
         _applicationCacheService = applicationCacheService;
@@ -48,7 +46,6 @@ public class PolicyService : IPolicyService
         _ssoConfigRepository = ssoConfigRepository;
         _mailService = mailService;
         _globalSettings = globalSettings;
-        _organizationDomainRepository = organizationDomainRepository;
         _twoFactorIsEnabledQuery = twoFactorIsEnabledQuery;
     }
 
@@ -215,7 +212,6 @@ public class PolicyService : IPolicyService
             case PolicyType.SingleOrg:
                 if (!policy.Enabled)
                 {
-                    await HasNoVerifiedDomainsAsync(org);
                     await RequiredBySsoAsync(org);
                     await RequiredByVaultTimeoutAsync(org);
                     await RequiredByKeyConnectorAsync(org);
@@ -253,14 +249,6 @@ public class PolicyService : IPolicyService
                     await DependsOnSingleOrgAsync(org);
                 }
                 break;
-        }
-    }
-
-    private async Task HasNoVerifiedDomainsAsync(Organization org)
-    {
-        if ((await _organizationDomainRepository.GetDomainsByOrganizationIdAsync(org.Id)).Count > 0)
-        {
-            throw new BadRequestException("Organization still has verified domains.");
         }
     }
 

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationDomainControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationDomainControllerTests.cs
@@ -229,13 +229,13 @@ public class OrganizationDomainControllerTests
         sutProvider.GetDependency<IOrganizationDomainRepository>()
             .GetDomainByIdOrganizationIdAsync(organizationDomain.Id, organizationDomain.OrganizationId)
             .Returns(organizationDomain);
-        sutProvider.GetDependency<IVerifyOrganizationDomainCommand>().VerifyOrganizationDomainAsync(organizationDomain)
+        sutProvider.GetDependency<IVerifyOrganizationDomainCommand>().UserVerifyOrganizationDomainAsync(organizationDomain)
             .Returns(new OrganizationDomain());
 
         var result = await sutProvider.Sut.Verify(organizationDomain.OrganizationId, organizationDomain.Id);
 
         await sutProvider.GetDependency<IVerifyOrganizationDomainCommand>().Received(1)
-            .VerifyOrganizationDomainAsync(organizationDomain);
+            .UserVerifyOrganizationDomainAsync(organizationDomain);
         Assert.IsType<OrganizationDomainResponseModel>(result);
     }
 

--- a/test/Core.Test/AdminConsole/Services/OrganizationDomainServiceTests.cs
+++ b/test/Core.Test/AdminConsole/Services/OrganizationDomainServiceTests.cs
@@ -1,8 +1,7 @@
-﻿using Bit.Core.AdminConsole.Services.Implementations;
+﻿using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationDomains.Interfaces;
+using Bit.Core.AdminConsole.Services.Implementations;
 using Bit.Core.Entities;
-using Bit.Core.Enums;
 using Bit.Core.Repositories;
-using Bit.Core.Services;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
@@ -36,18 +35,14 @@ public class OrganizationDomainServiceTests
                 Txt = "btw+6789"
             }
         };
+
         sutProvider.GetDependency<IOrganizationDomainRepository>().GetManyByNextRunDateAsync(default)
             .ReturnsForAnyArgs(domains);
 
         await sutProvider.Sut.ValidateOrganizationsDomainAsync();
 
-        await sutProvider.GetDependency<IDnsResolverService>().ReceivedWithAnyArgs(2)
-            .ResolveAsync(default, default);
-        await sutProvider.GetDependency<IOrganizationDomainRepository>().ReceivedWithAnyArgs(2)
-            .ReplaceAsync(default);
-        await sutProvider.GetDependency<IEventService>().ReceivedWithAnyArgs(2)
-            .LogOrganizationDomainEventAsync(default, EventType.OrganizationDomain_NotVerified,
-                EventSystemUser.DomainVerification);
+        await sutProvider.GetDependency<IVerifyOrganizationDomainCommand>().ReceivedWithAnyArgs(2)
+            .SystemVerifyOrganizationDomainAsync(default);
     }
 
     [Theory, BitAutoData]


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-13722

## 📔 Objective
There was some duplicate logic between `OrganizationDomainService#ValidateOrganizationsDomainAsync()` and `VerifyOrganizationDomainCommand#VerifyOrganizationDomainAsync()`.  This adds two new methods to keep the differences between the two implementations separate.   The differences in `EventService` and logging calls should be preserved.  A few tests were migrated as well.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
