### PR TITLE
[PM-14818]  Update `migrate.ps1` to support test database used by integration tests

### DIFF
--- a/dev/migrate.ps1
+++ b/dev/migrate.ps1
@@ -7,11 +7,13 @@ param(
   [switch]$mysql,
   [switch]$mssql,
   [switch]$sqlite,
-  [switch]$selfhost
+  [switch]$selfhost,
+  [switch]$test
 )
 
 # Abort on any error
 $ErrorActionPreference = "Stop"
+$currentDir = Get-Location
 
 if (!$all -and !$postgres -and !$mysql -and !$sqlite) {
   $mssql = $true;
@@ -25,36 +27,62 @@ if ($all -or $postgres -or $mysql -or $sqlite) {
   }
 }
 
-if ($all -or $mssql) {
-  function Get-UserSecrets {
-    # The dotnet cli command sometimes adds //BEGIN and //END comments to the output, Where-Object removes comments
-    # to ensure a valid json
-    return dotnet user-secrets list --json --project ../src/Api | Where-Object { $_ -notmatch "^//" } | ConvertFrom-Json
-  }
-
-  if ($selfhost) {
-    $msSqlConnectionString = $(Get-UserSecrets).'dev:selfHostOverride:globalSettings:sqlServer:connectionString'
-    $envName = "self-host"
-  } else {
-    $msSqlConnectionString = $(Get-UserSecrets).'globalSettings:sqlServer:connectionString'
-    $envName = "cloud"
-  }
-
-  Write-Host "Starting Microsoft SQL Server Migrations for $envName"
-
-  dotnet run --project ../util/MsSqlMigratorUtility/ "$msSqlConnectionString"
+function Get-UserSecrets {
+  # The dotnet cli command sometimes adds //BEGIN and //END comments to the output, Where-Object removes comments
+  # to ensure a valid json
+  return dotnet user-secrets list --json --project "$currentDir/../src/Api" | Where-Object { $_ -notmatch "^//" } | ConvertFrom-Json
 }
 
-$currentDir = Get-Location
+if ($all -or $mssql) {
+  if ($all -or !$test) {
+    if ($selfhost) {
+      $msSqlConnectionString = $(Get-UserSecrets).'dev:selfHostOverride:globalSettings:sqlServer:connectionString'
+      $envName = "self-host"
+    } else {
+      $msSqlConnectionString = $(Get-UserSecrets).'globalSettings:sqlServer:connectionString'
+      $envName = "cloud"
+    }
 
-Foreach ($item in @(@($mysql, "MySQL", "MySqlMigrations"), @($postgres, "PostgreSQL", "PostgresMigrations"), @($sqlite, "SQLite", "SqliteMigrations"))) {
+    Write-Host "Starting Microsoft SQL Server Migrations for $envName"
+    dotnet run --project ../util/MsSqlMigratorUtility/ "$msSqlConnectionString"
+  }
+
+  if ($all -or $test) {
+    $testMsSqlConnectionString = $(Get-UserSecrets).'databases:3:connectionString'
+    if ($testMsSqlConnectionString) {
+      $testEnvName = "test databases"
+      Write-Host "Starting Microsoft SQL Server Migrations for $testEnvName"
+      dotnet run --project ../util/MsSqlMigratorUtility/ "$testMsSqlConnectionString"
+    } else {
+      Write-Host "Connection string for a test MSSQL database not found in secrets.json!"
+    }
+  }
+}
+
+Foreach ($item in @(
+    @($mysql, "MySQL", "MySqlMigrations", "mySql", 2),
+    @($postgres, "PostgreSQL", "PostgresMigrations", "postgreSql", 0),
+    @($sqlite, "SQLite", "SqliteMigrations", "sqlite", 1)
+)) {
   if (!$item[0] -and !$all) {
     continue
   }
 
-  Write-Host "Starting $($item[1]) Migrations"
   Set-Location "$currentDir/../util/$($item[2])/"
-  dotnet ef database update
+  if(!$test -or $all) {
+    Write-Host "Starting $($item[1]) Migrations"
+    $connectionString = $(Get-UserSecrets)."globalSettings:$($item[3]):connectionString"
+    dotnet ef database update --connection "$connectionString"
+  }
+  if ($test -or $all) {
+    $testConnectionString = $(Get-UserSecrets)."databases:$($item[4]):connectionString"
+    if ($testConnectionString) {
+      Write-Host "Starting $($item[1]) Migrations for test databases"
+      dotnet ef database update --connection "$testConnectionString"
+    } else {
+      Write-Host "Connection string for a test $($item[1]) database not found in secrets.json!"
+    }
+  }
 }
 
 Set-Location "$currentDir"

--- a/util/MySqlMigrations/Migrations/20231214162533_GrantIdWithIndexes.cs
+++ b/util/MySqlMigrations/Migrations/20231214162533_GrantIdWithIndexes.cs
@@ -74,13 +74,13 @@ public partial class GrantIdWithIndexes : Migration
 
         migrationBuilder.Sql(@"
             DROP PROCEDURE IF EXISTS GrantSchemaChange;
-            
+
             CREATE PROCEDURE GrantSchemaChange()
             BEGIN
-                IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'Grant' AND COLUMN_NAME = 'Id') THEN
+                IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'Grant' AND COLUMN_NAME = 'Id' AND TABLE_SCHEMA=database()) THEN
                     ALTER TABLE `Grant` DROP COLUMN `Id`;
                 END IF;
- 
+
                 ALTER TABLE `Grant` ADD COLUMN `Id` INT AUTO_INCREMENT UNIQUE;
             END;
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10863

## 📔 Objective

The integration tests for databases use different `secrets.json` properties than the ones used by locally running servers. This is to support not corrupting folk's local test data. 

Currently these test databases are not supported by `migrate.ps1` and other tooling. This PR updates `migrate.ps1` with a `--test` switch, and adds logic for connecting to and migrating these databases.

The `--all` switch was modified to include running migrations against test databases as well.

### 🧮 Side Effects

As part of this work I had to modify an old MySql migration because of an error in its manually written logic. The script in question checks for the existence of a column from system tables before trying to drop it. This doesn't check for a specific databases, and so can cause false positives if you try to have multiple databases on the same server.

## 📸 Screenshots

In this demo I build fresh databases from scratch and run some migrations using `migrate.ps1`. It: 

1. starts with a `pwsh migrate.ps1 --all` command that skips test databases because no connection strings are found.
2. Runs `pwsh migrate.ps1 --all` again, this time with connection strings set
3. Shows examples of `pwsh migrate.ps1 --test --{DATABASE}` for targeting specific test databases.
4. Shows the newly created databases in Azure Data Studio.

https://github.com/user-attachments/assets/32ee43c0-3c27-41d4-9c27-7f5a540e642e

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
