### PR TITLE
[PM-13839][PM-13840] Admin Console Collections

### DIFF
--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -99,7 +99,10 @@ public class CiphersController : Controller
             throw new NotFoundException();
         }
 
-        return new CipherMiniResponseModel(cipher, _globalSettings, cipher.OrganizationUseTotp);
+        var collectionCiphers = await _collectionCipherRepository.GetManyByOrganizationIdAsync(cipher.OrganizationId.Value);
+        var collectionCiphersGroupDict = collectionCiphers.GroupBy(c => c.CipherId).ToDictionary(s => s.Key);
+
+        return new CipherMiniDetailsResponseModel(cipher, _globalSettings, collectionCiphersGroupDict, cipher.OrganizationUseTotp);
     }
 
     [HttpGet("{id}/full-details")]


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13839](https://bitwarden.atlassian.net/browse/PM-13839)
[PM-13840](https://bitwarden.atlassian.net/browse/PM-13840)
[Client Side PR](https://github.com/bitwarden/clients/pull/11649)

## 📔 Objective

Add collectionIds to the response of `{id}/admin`
- They're now needed in the admin console when add/editing a cipher.
- Prior to this there was no way to edit collection when editing a cipher. Assigning collections was a separate workflow
- Looking through the change in model, `collectionsIds` are the only difference in the new [CipherMiniDetailsResponseModel](https://github.com/bitwarden/server/blob/main/src/Api/Vault/Models/Response/CipherResponseModel.cs#L162)
- On the client side, the [CipherResponse](https://github.com/bitwarden/clients/blob/c6f8b7990e6586978c9a05f3166935ea9bab2cdf/libs/common/src/vault/models/response/cipher.response.ts#L31) is expecting a `string[]` rather than `null/undefined`. This change would be more accurate with those types.

## 📸 Screenshots

See [Client Side PR](https://github.com/bitwarden/clients/pull/11649)

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13839]: https://bitwarden.atlassian.net/browse/PM-13839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-13840]: https://bitwarden.atlassian.net/browse/PM-13840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ