### PR TITLE
fix: ensure vault URI is propagated from `config.yml`

### DIFF
--- a/util/Setup/EnvironmentFileBuilder.cs
+++ b/util/Setup/EnvironmentFileBuilder.cs
@@ -51,7 +51,7 @@ public class EnvironmentFileBuilder
             _globalOverrideValues.Remove("globalSettings__pushRelayBaseUri");
         }
 
-        if (_globalOverrideValues.TryGetValue("globalSettings__baseServiceUri__vault", out var vaulturi) && vaulturi != _context.Config.Url)
+        if (_globalOverrideValues.TryGetValue("globalSettings__baseServiceUri__vault", out var vaultUri) && vaultUri != _context.Config.Url)
         {
             _globalOverrideValues["globalSettings__baseServiceUri__vault"] = _context.Config.Url;
             Helpers.WriteLine(_context, "Updated globalSettings__baseServiceUri__vault to match value in config.yml");

--- a/util/Setup/EnvironmentFileBuilder.cs
+++ b/util/Setup/EnvironmentFileBuilder.cs
@@ -51,6 +51,12 @@ public class EnvironmentFileBuilder
             _globalOverrideValues.Remove("globalSettings__pushRelayBaseUri");
         }
 
+        if (_globalOverrideValues.TryGetValue("globalSettings__baseServiceUri__vault", out var vaulturi) && vaulturi != _context.Config.Url)
+        {
+            _globalOverrideValues["globalSettings__baseServiceUri__vault"] = _context.Config.Url;
+            Helpers.WriteLine(_context, "Updated globalSettings__baseServiceUri__vault to match value in config.yml");
+        }
+
         Build();
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-2449

## 📔 Objective

Fixes https://github.com/bitwarden/self-host/issues/108. When the URL is updated in `config.yml`, we should propagate the new URL to `global.override.env` as per the [docs](https://bitwarden.com/help/hosting-faqs/#q-how-do-i-change-the-name-of-my-server).

## 📸 Screenshots

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
