### PR TITLE
[PM-12600] Check if user is managed by an org before delete

### DIFF
--- a/src/Api/Auth/Controllers/AccountsController.cs
+++ b/src/Api/Auth/Controllers/AccountsController.cs
@@ -559,6 +559,12 @@ public class AccountsController : Controller
             throw new UnauthorizedAccessException();
         }
 
+        var isManagedUser = await _userService.IsManagedByAnyOrganizationAsync(user.Id);
+        if (isManagedUser)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
         if (!await _userService.VerifySecretAsync(user, model.Secret))
         {
             ModelState.AddModelError(string.Empty, "User verification failed.");

--- a/src/Api/Auth/Controllers/AccountsController.cs
+++ b/src/Api/Auth/Controllers/AccountsController.cs
@@ -559,8 +559,9 @@ public class AccountsController : Controller
             throw new UnauthorizedAccessException();
         }
 
+        var accountDeprovisioningEnabled = _featureService.IsEnabled(FeatureFlagKeys.AccountDeprovisioning);
         var isManagedUser = await _userService.IsManagedByAnyOrganizationAsync(user.Id);
-        if (isManagedUser)
+        if (accountDeprovisioningEnabled && isManagedUser)
         {
             throw new UnauthorizedAccessException();
         }

--- a/test/Api.Test/Auth/Controllers/AccountsControllerTests.cs
+++ b/test/Api.Test/Auth/Controllers/AccountsControllerTests.cs
@@ -506,6 +506,28 @@ public class AccountsControllerTests : IDisposable
 
     [Theory]
     [BitAutoData]
+    public async Task Delete_WhenDeleteAsyncSucceeds_UserIsNull(
+        User user,
+        SecretVerificationRequestModel model)
+    {
+        // Arrange
+        EnableFeatureFlag();
+        _userService.GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>()).Returns(Task.FromResult(user));
+        _userService.IsManagedByAnyOrganizationAsync(user.Id).Returns(false);
+        _userService.VerifySecretAsync(user, model.Secret).Returns(true);
+        var result = IdentityResult.Success;
+        _userService.DeleteAsync(user).Returns(result);
+
+        // Act
+        await _sut.Delete(model);
+        var nullUser = await _userService.GetUserByIdAsync(user.Id);
+
+        // Assert
+        Assert.Null(nullUser);
+    }
+
+    [Theory]
+    [BitAutoData]
     public async Task Delete_WhenDeleteAsyncFails_ShouldThrowBadRequestException(
         User user,
         SecretVerificationRequestModel model)
@@ -568,6 +590,27 @@ public class AccountsControllerTests : IDisposable
 
         // Act & Assert
         await Assert.ThrowsAsync<BadRequestException>(() => _sut.Delete(model));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task FlagDisabled_Delete_WhenDeleteAsyncSucceeds_UserIsNull(
+    User user,
+    SecretVerificationRequestModel model)
+    {
+        // Arrange
+        _userService.GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>()).Returns(Task.FromResult(user));
+        _userService.IsManagedByAnyOrganizationAsync(user.Id).Returns(false);
+        _userService.VerifySecretAsync(user, model.Secret).Returns(true);
+        var result = IdentityResult.Success;
+        _userService.DeleteAsync(user).Returns(result);
+
+        // Act
+        await _sut.Delete(model);
+        var nullUser = await _userService.GetUserByIdAsync(user.Id);
+
+        // Assert
+        Assert.Null(nullUser);
     }
 
     // Below are helper functions that currently belong to this


### PR DESCRIPTION
## 🎟️ Tracking
Client PR: https://github.com/bitwarden/clients/pull/11665

[PM-12600](https://bitwarden.atlassian.net/browse/PM-12600)

## 📔 Objective

This PR implements a server side check for if the user requesting to delete their account is managed by an organization. If they are, we throw an UnauthorizedAccessException

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12600]: https://bitwarden.atlassian.net/browse/PM-12600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ