### PR TITLE
[PM-13982] [Defect] Can no longer create providers due to foreign key…

### DIFF
--- a/bitwarden_license/src/Commercial.Core/AdminConsole/Providers/CreateProviderCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/AdminConsole/Providers/CreateProviderCommand.cs
@@ -41,13 +41,15 @@ public class CreateProviderCommand : ICreateProviderCommand
 
     public async Task CreateMspAsync(Provider provider, string ownerEmail, int teamsMinimumSeats, int enterpriseMinimumSeats)
     {
-        var providerPlans = new List<ProviderPlan>
-        {
-            CreateProviderPlan(provider.Id, PlanType.TeamsMonthly, teamsMinimumSeats),
-            CreateProviderPlan(provider.Id, PlanType.EnterpriseMonthly, enterpriseMinimumSeats)
-        };
+        var providerId = await CreateProviderAsync(provider, ownerEmail);
 
-        await CreateProviderAsync(provider, ownerEmail, providerPlans);
+        var isConsolidatedBillingEnabled = _featureService.IsEnabled(FeatureFlagKeys.EnableConsolidatedBilling);
+
+        if (isConsolidatedBillingEnabled)
+        {
+            await CreateProviderPlanAsync(providerId, PlanType.TeamsMonthly, teamsMinimumSeats);
+            await CreateProviderPlanAsync(providerId, PlanType.EnterpriseMonthly, enterpriseMinimumSeats);
+        }
     }
 
     public async Task CreateResellerAsync(Provider provider)
@@ -57,15 +59,17 @@ public class CreateProviderCommand : ICreateProviderCommand
 
     public async Task CreateMultiOrganizationEnterpriseAsync(Provider provider, string ownerEmail, PlanType plan, int minimumSeats)
     {
-        var providerPlans = new List<ProviderPlan>
-        {
-            CreateProviderPlan(provider.Id, plan, minimumSeats)
-        };
+        var providerId = await CreateProviderAsync(provider, ownerEmail);
 
-        await CreateProviderAsync(provider, ownerEmail, providerPlans);
+        var isConsolidatedBillingEnabled = _featureService.IsEnabled(FeatureFlagKeys.EnableConsolidatedBilling);
+
+        if (isConsolidatedBillingEnabled)
+        {
+            await CreateProviderPlanAsync(providerId, plan, minimumSeats);
+        }
     }
 
-    private async Task CreateProviderAsync(Provider provider, string ownerEmail, List<ProviderPlan> providerPlans)
+    private async Task<Guid> CreateProviderAsync(Provider provider, string ownerEmail)
     {
         var owner = await _userRepository.GetByEmailAsync(ownerEmail);
         if (owner == null)
@@ -90,16 +94,10 @@ public class CreateProviderCommand : ICreateProviderCommand
             Status = ProviderUserStatusType.Confirmed,
         };
 
-        if (isConsolidatedBillingEnabled)
-        {
-            foreach (var providerPlan in providerPlans)
-            {
-                await _providerPlanRepository.CreateAsync(providerPlan);
-            }
-        }
-
         await _providerUserRepository.CreateAsync(providerUser);
         await _providerService.SendProviderSetupInviteEmailAsync(provider, owner.Email);
+
+        return provider.Id;
     }
 
     private async Task ProviderRepositoryCreateAsync(Provider provider, ProviderStatusType status)
@@ -110,9 +108,9 @@ public class CreateProviderCommand : ICreateProviderCommand
         await _providerRepository.CreateAsync(provider);
     }
 
-    private ProviderPlan CreateProviderPlan(Guid providerId, PlanType planType, int seatMinimum)
+    private async Task CreateProviderPlanAsync(Guid providerId, PlanType planType, int seatMinimum)
     {
-        return new ProviderPlan
+        var plan = new ProviderPlan
         {
             ProviderId = providerId,
             PlanType = planType,
@@ -120,5 +118,6 @@ public class CreateProviderCommand : ICreateProviderCommand
             PurchasedSeats = 0,
             AllocatedSeats = 0
         };
+        await _providerPlanRepository.CreateAsync(plan);
     }
 }


### PR DESCRIPTION
… conflict

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13982

## 📔 Objective

We were incorrectly creating the ProviderPlan objects with the provider id before the `Provider` entity was inserted into the database when the `enable-consolidated-billing` flag was enabled. This was caused by changes from https://bitwarden.atlassian.net/browse/PM-13447

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
