### PR TITLE
[PM-11408] domain verification stat in portal and add cs delete permission

### DIFF
--- a/src/Admin/Models/UserEditModel.cs
+++ b/src/Admin/Models/UserEditModel.cs
@@ -21,10 +21,11 @@ public class UserEditModel
         BillingInfo billingInfo,
         BillingHistoryInfo billingHistoryInfo,
         GlobalSettings globalSettings,
-        bool domainVerified
+        bool domainVerified,
+        bool accountDeprovisioningEnabled
         )
     {
-        User = UserViewModel.MapViewModel(user, isTwoFactorEnabled, ciphers, domainVerified);
+        User = UserViewModel.MapViewModel(user, isTwoFactorEnabled, ciphers, domainVerified, accountDeprovisioningEnabled);
 
         BillingInfo = billingInfo;
         BillingHistoryInfo = billingHistoryInfo;

--- a/src/Admin/Models/UserEditModel.cs
+++ b/src/Admin/Models/UserEditModel.cs
@@ -20,9 +20,11 @@ public class UserEditModel
         IEnumerable<Cipher> ciphers,
         BillingInfo billingInfo,
         BillingHistoryInfo billingHistoryInfo,
-        GlobalSettings globalSettings)
+        GlobalSettings globalSettings,
+        bool domainVerified
+        )
     {
-        User = UserViewModel.MapViewModel(user, isTwoFactorEnabled, ciphers);
+        User = UserViewModel.MapViewModel(user, isTwoFactorEnabled, ciphers, domainVerified);
 
         BillingInfo = billingInfo;
         BillingHistoryInfo = billingHistoryInfo;

--- a/src/Admin/Models/UserViewModel.cs
+++ b/src/Admin/Models/UserViewModel.cs
@@ -14,6 +14,7 @@ public class UserViewModel
     public bool Premium { get; }
     public short? MaxStorageGb { get; }
     public bool EmailVerified { get; }
+    public bool DomainVerified { get; }
     public bool TwoFactorEnabled { get; }
     public DateTime AccountRevisionDate { get; }
     public DateTime RevisionDate { get; }
@@ -35,6 +36,7 @@ public class UserViewModel
         bool premium,
         short? maxStorageGb,
         bool emailVerified,
+        bool domainVerified,
         bool twoFactorEnabled,
         DateTime accountRevisionDate,
         DateTime revisionDate,
@@ -56,6 +58,7 @@ public class UserViewModel
         Premium = premium;
         MaxStorageGb = maxStorageGb;
         EmailVerified = emailVerified;
+        DomainVerified = domainVerified;
         TwoFactorEnabled = twoFactorEnabled;
         AccountRevisionDate = accountRevisionDate;
         RevisionDate = revisionDate;
@@ -73,10 +76,10 @@ public class UserViewModel
     public static IEnumerable<UserViewModel> MapViewModels(
         IEnumerable<User> users,
         IEnumerable<(Guid userId, bool twoFactorIsEnabled)> lookup) =>
-        users.Select(user => MapViewModel(user, lookup));
+        users.Select(user => MapViewModel(user, lookup, true));
 
     public static UserViewModel MapViewModel(User user,
-        IEnumerable<(Guid userId, bool twoFactorIsEnabled)> lookup) =>
+        IEnumerable<(Guid userId, bool twoFactorIsEnabled)> lookup, bool domainVerified) =>
         new(
             user.Id,
             user.Name,
@@ -86,6 +89,7 @@ public class UserViewModel
             user.Premium,
             user.MaxStorageGb,
             user.EmailVerified,
+            domainVerified,
             IsTwoFactorEnabled(user, lookup),
             user.AccountRevisionDate,
             user.RevisionDate,
@@ -100,9 +104,9 @@ public class UserViewModel
             Array.Empty<Cipher>());
 
     public static UserViewModel MapViewModel(User user, bool isTwoFactorEnabled) =>
-        MapViewModel(user, isTwoFactorEnabled, Array.Empty<Cipher>());
+        MapViewModel(user, isTwoFactorEnabled, Array.Empty<Cipher>(), true);
 
-    public static UserViewModel MapViewModel(User user, bool isTwoFactorEnabled, IEnumerable<Cipher> ciphers) =>
+    public static UserViewModel MapViewModel(User user, bool isTwoFactorEnabled, IEnumerable<Cipher> ciphers, bool domainVerified) =>
         new(
             user.Id,
             user.Name,
@@ -112,6 +116,7 @@ public class UserViewModel
             user.Premium,
             user.MaxStorageGb,
             user.EmailVerified,
+            domainVerified,
             isTwoFactorEnabled,
             user.AccountRevisionDate,
             user.RevisionDate,

--- a/src/Admin/Models/UserViewModel.cs
+++ b/src/Admin/Models/UserViewModel.cs
@@ -15,6 +15,7 @@ public class UserViewModel
     public short? MaxStorageGb { get; }
     public bool EmailVerified { get; }
     public bool DomainVerified { get; }
+    public bool AccountDeprovisioningEnabled { get; }
     public bool TwoFactorEnabled { get; }
     public DateTime AccountRevisionDate { get; }
     public DateTime RevisionDate { get; }
@@ -37,6 +38,7 @@ public class UserViewModel
         short? maxStorageGb,
         bool emailVerified,
         bool domainVerified,
+        bool accountDeprovisioningEnabled,
         bool twoFactorEnabled,
         DateTime accountRevisionDate,
         DateTime revisionDate,
@@ -59,6 +61,7 @@ public class UserViewModel
         MaxStorageGb = maxStorageGb;
         EmailVerified = emailVerified;
         DomainVerified = domainVerified;
+        AccountDeprovisioningEnabled = accountDeprovisioningEnabled;
         TwoFactorEnabled = twoFactorEnabled;
         AccountRevisionDate = accountRevisionDate;
         RevisionDate = revisionDate;
@@ -76,10 +79,10 @@ public class UserViewModel
     public static IEnumerable<UserViewModel> MapViewModels(
         IEnumerable<User> users,
         IEnumerable<(Guid userId, bool twoFactorIsEnabled)> lookup) =>
-        users.Select(user => MapViewModel(user, lookup, true));
+        users.Select(user => MapViewModel(user, lookup, false, false));
 
     public static UserViewModel MapViewModel(User user,
-        IEnumerable<(Guid userId, bool twoFactorIsEnabled)> lookup, bool domainVerified) =>
+        IEnumerable<(Guid userId, bool twoFactorIsEnabled)> lookup, bool domainVerified, bool accountDeprovisioningEnabled = false) =>
         new(
             user.Id,
             user.Name,
@@ -89,6 +92,7 @@ public class UserViewModel
             user.Premium,
             user.MaxStorageGb,
             user.EmailVerified,
+            accountDeprovisioningEnabled,
             domainVerified,
             IsTwoFactorEnabled(user, lookup),
             user.AccountRevisionDate,
@@ -104,9 +108,9 @@ public class UserViewModel
             Array.Empty<Cipher>());
 
     public static UserViewModel MapViewModel(User user, bool isTwoFactorEnabled) =>
-        MapViewModel(user, isTwoFactorEnabled, Array.Empty<Cipher>(), true);
+        MapViewModel(user, isTwoFactorEnabled, Array.Empty<Cipher>(), false, false);
 
-    public static UserViewModel MapViewModel(User user, bool isTwoFactorEnabled, IEnumerable<Cipher> ciphers, bool domainVerified) =>
+    public static UserViewModel MapViewModel(User user, bool isTwoFactorEnabled, IEnumerable<Cipher> ciphers, bool domainVerified, bool accountDeprovisioningEnabled = false) =>
         new(
             user.Id,
             user.Name,
@@ -117,6 +121,7 @@ public class UserViewModel
             user.MaxStorageGb,
             user.EmailVerified,
             domainVerified,
+            accountDeprovisioningEnabled,
             isTwoFactorEnabled,
             user.AccountRevisionDate,
             user.RevisionDate,

--- a/src/Admin/Utilities/RolePermissionMapping.cs
+++ b/src/Admin/Utilities/RolePermissionMapping.cs
@@ -110,6 +110,7 @@ public static class RolePermissionMapping
                 Permission.User_Licensing_View,
                 Permission.User_Billing_View,
                 Permission.User_Billing_LaunchGateway,
+                Permission.User_Delete,
                 Permission.Org_List_View,
                 Permission.Org_OrgInformation_View,
                 Permission.Org_GeneralDetails_View,

--- a/src/Admin/Views/Users/_ViewInformation.cshtml
+++ b/src/Admin/Views/Users/_ViewInformation.cshtml
@@ -1,4 +1,4 @@
-﻿@model UserViewModel
+@model UserViewModel
 <dl class="row">
     <dt class="col-sm-4 col-lg-3">Id</dt>
     <dd class="col-sm-8 col-lg-9"><code>@Model.Id</code></dd>
@@ -11,6 +11,9 @@
 
     <dt class="col-sm-4 col-lg-3">Email Verified</dt>
     <dd class="col-sm-8 col-lg-9">@(Model.EmailVerified ? "Yes" : "No")</dd>
+
+    <dt class="col-sm-4 col-lg-3">Domain Verified</dt>
+    <dd class="col-sm-8 col-lg-9">@(Model.DomainVerified? "Yes" : "No")</dd>
 
     <dt class="col-sm-4 col-lg-3">Using 2FA</dt>
     <dd class="col-sm-8 col-lg-9">@(Model.TwoFactorEnabled ? "Yes" : "No")</dd>

--- a/src/Admin/Views/Users/_ViewInformation.cshtml
+++ b/src/Admin/Views/Users/_ViewInformation.cshtml
@@ -12,8 +12,11 @@
     <dt class="col-sm-4 col-lg-3">Email Verified</dt>
     <dd class="col-sm-8 col-lg-9">@(Model.EmailVerified ? "Yes" : "No")</dd>
 
+    @* FEATURE FLAG TO CONTROLL IF THIS SHOULD ACTUALLY SHOW *@
+    @if(Model.AccountDeprovisioningEnabled){
     <dt class="col-sm-4 col-lg-3">Domain Verified</dt>
     <dd class="col-sm-8 col-lg-9">@(Model.DomainVerified? "Yes" : "No")</dd>
+    }
 
     <dt class="col-sm-4 col-lg-3">Using 2FA</dt>
     <dd class="col-sm-8 col-lg-9">@(Model.TwoFactorEnabled ? "Yes" : "No")</dd>

--- a/test/Admin.Test/Models/UserViewModelTests.cs
+++ b/test/Admin.Test/Models/UserViewModelTests.cs
@@ -2,6 +2,7 @@
 
 using Bit.Admin.Models;
 using Bit.Core.Entities;
+using Bit.Core.Vault.Entities;
 using Bit.Test.Common.AutoFixture.Attributes;
 
 namespace Admin.Test.Models;
@@ -79,7 +80,7 @@ public class UserViewModelTests
     {
         var lookup = new List<(Guid, bool)> { (user.Id, true) };
 
-        var actual = UserViewModel.MapViewModel(user, lookup);
+        var actual = UserViewModel.MapViewModel(user, lookup, false);
 
         Assert.True(actual.TwoFactorEnabled);
     }
@@ -90,19 +91,65 @@ public class UserViewModelTests
     {
         var lookup = new List<(Guid, bool)> { (user.Id, false) };
 
-        var actual = UserViewModel.MapViewModel(user, lookup);
+        var actual = UserViewModel.MapViewModel(user, lookup, false);
 
         Assert.False(actual.TwoFactorEnabled);
     }
 
     [Theory]
     [BitAutoData]
-    public void MapUserViewModel_GivenUser_WhenNotInLookUpList_ThenTwoFactorIsDisabled(User user)
+    public void MapUserViewModel_WithVerifiedDomain_WhenAccountDeprovisioningDisabled_ReturnsUserViewModel(User user)
     {
-        var lookup = new List<(Guid, bool)> { (Guid.NewGuid(), true) };
 
-        var actual = UserViewModel.MapViewModel(user, lookup);
+        var verifiedDomain = true;
+        var accountDeprovisioning = false;
 
-        Assert.False(actual.TwoFactorEnabled);
+        var actual = UserViewModel.MapViewModel(user, true, Array.Empty<Cipher>(), verifiedDomain, accountDeprovisioning);
+
+        Assert.True(actual.DomainVerified);
+        Assert.False(actual.AccountDeprovisioningEnabled);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public void MapUserViewModel_WithoutVerifiedDomain_WhenAccountDeprovisioningDisabled_ReturnsUserViewModel(User user)
+    {
+
+        var verifiedDomain = false;
+        var accountDeprovisioning = false;
+
+        var actual = UserViewModel.MapViewModel(user, true, Array.Empty<Cipher>(), verifiedDomain, accountDeprovisioning);
+
+        Assert.False(actual.DomainVerified);
+        Assert.False(actual.AccountDeprovisioningEnabled);
+    }
+
+    // Test with feature flag ON
+    [Theory]
+    [BitAutoData]
+    public void MapUserViewModel_WithVerifiedDomain_WhenAccountDeprovisioningEnabled_ReturnsUserViewModel(User user)
+    {
+
+        var verifiedDomain = true;
+        var accountDeprovisioning = true;
+
+        var actual = UserViewModel.MapViewModel(user, true, Array.Empty<Cipher>(), verifiedDomain, accountDeprovisioning);
+
+        Assert.True(actual.DomainVerified);
+        Assert.True(actual.AccountDeprovisioningEnabled);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public void MapUserViewModel_WithoutVerifiedDomain_WhenAccountDeprovisioningEnabled_ReturnsUserViewModel(User user)
+    {
+
+        var verifiedDomain = false;
+        var accountDeprovisioning = true;
+
+        var actual = UserViewModel.MapViewModel(user, true, Array.Empty<Cipher>(), verifiedDomain, accountDeprovisioning);
+
+        Assert.False(actual.DomainVerified);
+        Assert.True(actual.AccountDeprovisioningEnabled);
     }
 }

--- a/test/Admin.Test/Models/UserViewModelTests.cs
+++ b/test/Admin.Test/Models/UserViewModelTests.cs
@@ -98,6 +98,17 @@ public class UserViewModelTests
 
     [Theory]
     [BitAutoData]
+    public void MapUserViewModel_GivenUser_WhenNotInLookUpList_ThenTwoFactorIsDisabled(User user)
+    {
+        var lookup = new List<(Guid, bool)> { (Guid.NewGuid(), true) };
+
+        var actual = UserViewModel.MapViewModel(user, lookup, false);
+
+        Assert.False(actual.TwoFactorEnabled);
+    }
+
+    [Theory]
+    [BitAutoData]
     public void MapUserViewModel_WithVerifiedDomain_WhenAccountDeprovisioningDisabled_ReturnsUserViewModel(User user)
     {
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11408

## 📔 Objective

Adds the domain verification state in the admin portal when viewing a user, gated behind a feature flag. Adds the User.delete permission to the cs role. 

## 📸 Screenshots
![Screenshot 2024-10-24 at 12 39 52 PM](https://github.com/user-attachments/assets/b0b90a58-6377-49e9-892f-397d34395b2d)

![Screenshot 2024-10-24 at 12 40 08 PM](https://github.com/user-attachments/assets/ca774431-ed2a-40d6-86cd-45caa6a5a6e5)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
