### PR TITLE
[PM-14275] Add IsManaged to OrganizationMetadata

### DIFF
--- a/src/Api/Billing/Models/Responses/OrganizationMetadataResponse.cs
+++ b/src/Api/Billing/Models/Responses/OrganizationMetadataResponse.cs
@@ -4,10 +4,12 @@ namespace Bit.Api.Billing.Models.Responses;
 
 public record OrganizationMetadataResponse(
     bool IsEligibleForSelfHost,
+    bool IsManaged,
     bool IsOnSecretsManagerStandalone)
 {
     public static OrganizationMetadataResponse From(OrganizationMetadata metadata)
         => new(
             metadata.IsEligibleForSelfHost,
+            metadata.IsManaged,
             metadata.IsOnSecretsManagerStandalone);
 }

--- a/src/Core/Billing/Models/OrganizationMetadata.cs
+++ b/src/Core/Billing/Models/OrganizationMetadata.cs
@@ -2,9 +2,5 @@
 
 public record OrganizationMetadata(
     bool IsEligibleForSelfHost,
-    bool IsOnSecretsManagerStandalone)
-{
-    public static OrganizationMetadata Default() => new(
-        IsEligibleForSelfHost: false,
-        IsOnSecretsManagerStandalone: false);
-}
+    bool IsManaged,
+    bool IsOnSecretsManagerStandalone);

--- a/src/Core/Billing/Services/Implementations/OrganizationBillingService.cs
+++ b/src/Core/Billing/Services/Implementations/OrganizationBillingService.cs
@@ -1,5 +1,4 @@
 ﻿using Bit.Core.AdminConsole.Entities;
-using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Billing.Caches;
 using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Models;

--- a/src/Core/Billing/Services/Implementations/OrganizationBillingService.cs
+++ b/src/Core/Billing/Services/Implementations/OrganizationBillingService.cs
@@ -72,10 +72,10 @@ public class OrganizationBillingService(
         var subscription = await subscriberService.GetSubscription(organization);
 
         var isEligibleForSelfHost = await IsEligibleForSelfHost(organization, subscription);
-
+        var isManaged = organization.Status == OrganizationStatusType.Managed;
         var isOnSecretsManagerStandalone = IsOnSecretsManagerStandalone(organization, customer, subscription);
 
-        return new OrganizationMetadata(isEligibleForSelfHost, isOnSecretsManagerStandalone);
+        return new OrganizationMetadata(isEligibleForSelfHost, isManaged, isOnSecretsManagerStandalone);
     }
 
     public async Task UpdatePaymentMethod(

--- a/src/Core/Billing/Services/Implementations/OrganizationBillingService.cs
+++ b/src/Core/Billing/Services/Implementations/OrganizationBillingService.cs
@@ -27,7 +27,6 @@ public class OrganizationBillingService(
     IGlobalSettings globalSettings,
     ILogger<OrganizationBillingService> logger,
     IOrganizationRepository organizationRepository,
-    IProviderRepository providerRepository,
     ISetupIntentCache setupIntentCache,
     IStripeAdapter stripeAdapter,
     ISubscriberService subscriberService) : IOrganizationBillingService

--- a/test/Api.Test/Billing/Controllers/OrganizationBillingControllerTests.cs
+++ b/test/Api.Test/Billing/Controllers/OrganizationBillingControllerTests.cs
@@ -52,16 +52,17 @@ public class OrganizationBillingControllerTests
     {
         sutProvider.GetDependency<ICurrentContext>().AccessMembersTab(organizationId).Returns(true);
         sutProvider.GetDependency<IOrganizationBillingService>().GetMetadata(organizationId)
-            .Returns(new OrganizationMetadata(true, true));
+            .Returns(new OrganizationMetadata(true, true, true));
 
         var result = await sutProvider.Sut.GetMetadataAsync(organizationId);
 
         Assert.IsType<Ok<OrganizationMetadataResponse>>(result);
 
-        var organizationMetadataResponse = ((Ok<OrganizationMetadataResponse>)result).Value;
+        var response = ((Ok<OrganizationMetadataResponse>)result).Value;
 
-        Assert.True(organizationMetadataResponse.IsEligibleForSelfHost);
-        Assert.True(organizationMetadataResponse.IsOnSecretsManagerStandalone);
+        Assert.True(response.IsEligibleForSelfHost);
+        Assert.True(response.IsManaged);
+        Assert.True(response.IsOnSecretsManagerStandalone);
     }
 
     [Theory, BitAutoData]


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-14275

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Organization owners managed by MSPs don't have access to Providers in the session state nor can they request full providers from the API because of permissions, but they need to know if they're managed so I'm returning it from Metadata.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
