### PR TITLE
[PM-14544] Update Duo migration for MariaDB Compatibility

### DIFF
--- a/util/MySqlMigrations/HelperScripts/2024-09-05_00_SyncDuoVersionFourMetadataToVersionTwo.sql
+++ b/util/MySqlMigrations/HelperScripts/2024-09-05_00_SyncDuoVersionFourMetadataToVersionTwo.sql
@@ -5,9 +5,9 @@ SET
 	U.TwoFactorProviders = JSON_SET(
         JSON_SET(
             U.TwoFactorProviders, '$."2".MetaData.ClientSecret',
-	JSON_UNQUOTE(U.TwoFactorProviders ->'$."2".MetaData.SKey')),
+	JSON_UNQUOTE(JSON_EXTRACT(U.TwoFactorProviders,'$."2".MetaData.SKey'))),
 	'$."2".MetaData.ClientId',
-	JSON_UNQUOTE(U.TwoFactorProviders -> '$."2".MetaData.IKey'))
+	JSON_UNQUOTE(JSON_EXTRACT(U.TwoFactorProviders,'$."2".MetaData.IKey')))
 WHERE
 	JSON_CONTAINS(TwoFactorProviders,
 	'{"2":{}}')
@@ -20,9 +20,9 @@ SET
 	o.TwoFactorProviders = JSON_SET(
         JSON_SET(
             o.TwoFactorProviders, '$."6".MetaData.ClientSecret',
-	JSON_UNQUOTE(o.TwoFactorProviders ->'$."6".MetaData.SKey')),
+	JSON_UNQUOTE(JSON_EXTRACT(o.TwoFactorProviders,'$."6".MetaData.SKey'))),
 	'$."6".MetaData.ClientId',
-	JSON_UNQUOTE(o.TwoFactorProviders -> '$."6".MetaData.IKey'))
+	JSON_UNQUOTE(JSON_EXTRACT(o.TwoFactorProviders,'$."6".MetaData.IKey')))
 WHERE
 	JSON_CONTAINS(o.TwoFactorProviders,
 	'{"6":{}}')


### PR DESCRIPTION
Fix MariaDB compatibility with JSON_EXTRACT

## 🎟️ Tracking

https://github.com/bitwarden/server/issues/4882

## 📔 Objective

Keep MariaDB compatibility in migrations by changing '->' shortcut to JSON_EXTRACT().


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
