### PR TITLE
PM-13763 Move ResetPasswordEnrolled to response model

### DIFF
--- a/src/Api/AdminConsole/Public/Models/MemberBaseModel.cs
+++ b/src/Api/AdminConsole/Public/Models/MemberBaseModel.cs
@@ -18,7 +18,6 @@ public abstract class MemberBaseModel
 
         Type = user.Type;
         ExternalId = user.ExternalId;
-        ResetPasswordEnrolled = user.ResetPasswordKey != null;
 
         if (Type == OrganizationUserType.Custom)
         {
@@ -35,7 +34,6 @@ public abstract class MemberBaseModel
 
         Type = user.Type;
         ExternalId = user.ExternalId;
-        ResetPasswordEnrolled = user.ResetPasswordKey != null;
 
         if (Type == OrganizationUserType.Custom)
         {
@@ -55,11 +53,7 @@ public abstract class MemberBaseModel
     /// <example>external_id_123456</example>
     [StringLength(300)]
     public string ExternalId { get; set; }
-    /// <summary>
-    /// Returns <c>true</c> if the member has enrolled in Password Reset assistance within the organization
-    /// </summary>
-    [Required]
-    public bool ResetPasswordEnrolled { get; set; }
+
     /// <summary>
     /// The member's custom permissions if the member has a Custom role. If not supplied, all custom permissions will
     /// default to false.

--- a/src/Api/AdminConsole/Public/Models/Response/MemberResponseModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Response/MemberResponseModel.cs
@@ -28,6 +28,7 @@ public class MemberResponseModel : MemberBaseModel, IResponseModel
         Email = user.Email;
         Status = user.Status;
         Collections = collections?.Select(c => new AssociationWithPermissionsResponseModel(c));
+        ResetPasswordEnrolled = user.ResetPasswordKey != null;
     }
 
     public MemberResponseModel(OrganizationUserUserDetails user, bool twoFactorEnabled,
@@ -45,6 +46,7 @@ public class MemberResponseModel : MemberBaseModel, IResponseModel
         TwoFactorEnabled = twoFactorEnabled;
         Status = user.Status;
         Collections = collections?.Select(c => new AssociationWithPermissionsResponseModel(c));
+        ResetPasswordEnrolled = user.ResetPasswordKey != null;
     }
 
     /// <summary>
@@ -93,4 +95,10 @@ public class MemberResponseModel : MemberBaseModel, IResponseModel
     /// The associated collections that this member can access.
     /// </summary>
     public IEnumerable<AssociationWithPermissionsResponseModel> Collections { get; set; }
+
+    /// <summary>
+    /// Returns <c>true</c> if the member has enrolled in Password Reset assistance within the organization
+    /// </summary>
+    [Required]
+    public bool ResetPasswordEnrolled { get; }
 }

--- a/test/Api.Test/AdminConsole/Public/Models/Response/MemberResponseModelTests.cs
+++ b/test/Api.Test/AdminConsole/Public/Models/Response/MemberResponseModelTests.cs
@@ -26,7 +26,7 @@ public class MemberResponseModelTests
     }
 
     [Fact]
-    public void ResetPasswordEnrolled_ShouldBeFalse_WhenUserHasResetPasswordKey()
+    public void ResetPasswordEnrolled_ShouldBeFalse_WhenUserDoesNotHaveResetPasswordKey()
     {
         // Arrange
         var user = Substitute.For<OrganizationUser>();

--- a/test/Api.Test/AdminConsole/Public/Models/Response/MemberResponseModelTests.cs
+++ b/test/Api.Test/AdminConsole/Public/Models/Response/MemberResponseModelTests.cs
@@ -1,0 +1,41 @@
+﻿using Bit.Api.AdminConsole.Public.Models.Response;
+using Bit.Core.Entities;
+using Bit.Core.Models.Data;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Api.Test.AdminConsole.Public.Models.Response;
+
+
+public class MemberResponseModelTests
+{
+    [Fact]
+    public void ResetPasswordEnrolled_ShouldBeTrue_WhenUserHasResetPasswordKey()
+    {
+        // Arrange
+        var user = Substitute.For<OrganizationUser>();
+        var collections = Substitute.For<IEnumerable<CollectionAccessSelection>>();
+        user.ResetPasswordKey = "none-empty";
+
+
+        // Act
+        var sut = new MemberResponseModel(user, collections);
+
+        // Assert
+        Assert.True(sut.ResetPasswordEnrolled);
+    }
+
+    [Fact]
+    public void ResetPasswordEnrolled_ShouldBeFalse_WhenUserHasResetPasswordKey()
+    {
+        // Arrange
+        var user = Substitute.For<OrganizationUser>();
+        var collections = Substitute.For<IEnumerable<CollectionAccessSelection>>();
+
+        // Act
+        var sut = new MemberResponseModel(user, collections);
+
+        // Assert
+        Assert.False(sut.ResetPasswordEnrolled);
+    }
+}


### PR DESCRIPTION
Move ResetPasswordEnrolled to the response model to adhere to the Liskov Substitution Principle. Ensures request models inherit only relevant properties.

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13763

## 📔 Objective

1. Move the ResetPasswordEnrolled property to the response model, as that’s the only class that uses it.
2. Make it read-only, as it’s not updated after initialization.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
