### PR TITLE
Add back provider keys on TwoFactorProviders response

### DIFF
--- a/src/Identity/IdentityServer/RequestValidators/TwoFactorAuthenticationValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/TwoFactorAuthenticationValidator.cs
@@ -121,8 +121,8 @@ public class TwoFactorAuthenticationValidator(
 
         var twoFactorResultDict = new Dictionary<string, object>
         {
-            { "TwoFactorProviders", null },
-            { "TwoFactorProviders2", providers }, // backwards compatibility
+            { "TwoFactorProviders", providers.Keys }, // backwards compatibility
+            { "TwoFactorProviders2", providers },
         };
 
         // If we have email as a 2FA provider, we might need an SsoEmail2fa Session Token


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14582
https://bitwarden.atlassian.net/browse/PM-14584

## 📔 Objective

We removed the data from the `TwoFactorProviders` response in anticipation of upcoming refactors to consolidate the `TwoFactorProviders` and `TwoFactorProviders2` response objects.  In doing so we didn't realize that the mobile apps were using that data.

This was done in #4894.  You can see the previous behavior of this mapping here: https://github.com/bitwarden/server/blob/b072fc56b13a7613586c608852fe3d8e3640c40a/src/Identity/IdentityServer/BaseRequestValidator.cs#L287 before it was moved to the new `TwoFactorAuthenticationValidator`.

This PR adds it back in for backward compatibility.  The mobile apps will correspondingly be changed no longer to rely on the data, which will free us up to do refactors in the future.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
