### PR TITLE
[PM-11409] prevent managed user from leaving managing organization

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationsController.cs
@@ -252,8 +252,8 @@ public class OrganizationsController : Controller
             throw new BadRequestException("Your organization's Single Sign-On settings prevent you from leaving.");
         }
 
-        var managingOrgs = await _userService.GetOrganizationsManagingUserAsync(user.Id);
-        if (_featureService.IsEnabled(FeatureFlagKeys.AccountDeprovisioning) && managingOrgs.Where(o => o.Id == id).Count() > 0)
+        if (_featureService.IsEnabled(FeatureFlagKeys.AccountDeprovisioning)
+            && (await _userService.GetOrganizationsManagingUserAsync(user.Id)).Any(x => x.Id == id))
         {
             throw new BadRequestException("Managed user account cannot leave managing organization. Contact your organization administrator for additional details.");
         }

--- a/src/Api/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationsController.cs
@@ -252,6 +252,12 @@ public class OrganizationsController : Controller
             throw new BadRequestException("Your organization's Single Sign-On settings prevent you from leaving.");
         }
 
+        if (_featureService.IsEnabled(FeatureFlagKeys.AccountDeprovisioning)
+            && await _userService.IsManagedByAnyOrganizationAsync(user.Id))
+        {
+            throw new BadRequestException("Managed user account cannot leave managing organization. Contact your organization administrator for additional details.");
+        }
+
         await _removeOrganizationUserCommand.RemoveUserAsync(id, user.Id);
     }
 

--- a/src/Api/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationsController.cs
@@ -252,8 +252,8 @@ public class OrganizationsController : Controller
             throw new BadRequestException("Your organization's Single Sign-On settings prevent you from leaving.");
         }
 
-        if (_featureService.IsEnabled(FeatureFlagKeys.AccountDeprovisioning)
-            && await _userService.IsManagedByAnyOrganizationAsync(user.Id))
+        var managingOrgs = await _userService.GetOrganizationsManagingUserAsync(user.Id);
+        if (_featureService.IsEnabled(FeatureFlagKeys.AccountDeprovisioning) && managingOrgs.Where(o => o.Id == id).Count() > 0)
         {
             throw new BadRequestException("Managed user account cannot leave managing organization. Contact your organization administrator for additional details.");
         }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11409

## 📔 Objective

This PR implements a server side check to ensure that users that are managed by the org they may be attempting to leave will throw `BadRequestException`.

## 📸 Screenshots

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
