### PR TITLE
[PM-13975] Create ProviderInvoiceItem records for empty invoices

### DIFF
--- a/src/Billing/Services/Implementations/ProviderEventService.cs
+++ b/src/Billing/Services/Implementations/ProviderEventService.cs
@@ -94,20 +94,17 @@ public class ProviderEventService(
 
                         var unassignedEnterpriseSeats = enterpriseProviderPlan.SeatMinimum - enterpriseClientSeats ?? 0;
 
-                        if (unassignedEnterpriseSeats > 0)
+                        invoiceItems.Add(new ProviderInvoiceItem
                         {
-                            invoiceItems.Add(new ProviderInvoiceItem
-                            {
-                                ProviderId = parsedProviderId,
-                                InvoiceId = invoice.Id,
-                                InvoiceNumber = invoice.Number,
-                                ClientName = "Unassigned seats",
-                                PlanName = enterprisePlan.Name,
-                                AssignedSeats = unassignedEnterpriseSeats,
-                                UsedSeats = 0,
-                                Total = unassignedEnterpriseSeats * discountedEnterpriseSeatPrice
-                            });
-                        }
+                            ProviderId = parsedProviderId,
+                            InvoiceId = invoice.Id,
+                            InvoiceNumber = invoice.Number,
+                            ClientName = "Unassigned seats",
+                            PlanName = enterprisePlan.Name,
+                            AssignedSeats = unassignedEnterpriseSeats,
+                            UsedSeats = 0,
+                            Total = unassignedEnterpriseSeats * discountedEnterpriseSeatPrice
+                        });
                     }
 
                     if (teamsProviderPlan.PurchasedSeats is null or 0)
@@ -118,20 +115,17 @@ public class ProviderEventService(
 
                         var unassignedTeamsSeats = teamsProviderPlan.SeatMinimum - teamsClientSeats ?? 0;
 
-                        if (unassignedTeamsSeats > 0)
+                        invoiceItems.Add(new ProviderInvoiceItem
                         {
-                            invoiceItems.Add(new ProviderInvoiceItem
-                            {
-                                ProviderId = parsedProviderId,
-                                InvoiceId = invoice.Id,
-                                InvoiceNumber = invoice.Number,
-                                ClientName = "Unassigned seats",
-                                PlanName = teamsPlan.Name,
-                                AssignedSeats = unassignedTeamsSeats,
-                                UsedSeats = 0,
-                                Total = unassignedTeamsSeats * discountedTeamsSeatPrice
-                            });
-                        }
+                            ProviderId = parsedProviderId,
+                            InvoiceId = invoice.Id,
+                            InvoiceNumber = invoice.Number,
+                            ClientName = "Unassigned seats",
+                            PlanName = teamsPlan.Name,
+                            AssignedSeats = unassignedTeamsSeats,
+                            UsedSeats = 0,
+                            Total = unassignedTeamsSeats * discountedTeamsSeatPrice
+                        });
                     }
 
                     await Task.WhenAll(invoiceItems.Select(providerInvoiceItemRepository.CreateAsync));


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-13975

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Removes a check that ensured the `Provider` had at least 1 unassigned seat for a plan type in order to record a `ProviderInvoiceItem`. Now we'll just record $0 `ProviderInvoiceItem` records for empty invoices.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/bc5f2b30-41ca-444c-8007-c854550b16f0


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
