### PR TITLE
Check run earlier during setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-22.04
+    needs:
+      - check-run
     steps:
       - name: Check out repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -38,7 +40,6 @@ jobs:
     runs-on: ubuntu-22.04
     needs:
       - lint
-      - check-run
     strategy:
       fail-fast: false
       matrix:
@@ -132,7 +133,6 @@ jobs:
       security-events: write
     needs:
       - build-artifacts
-      - check-run
     strategy:
       fail-fast: false
       matrix:
@@ -478,7 +478,8 @@ jobs:
   build-mssqlmigratorutility:
     name: Build MSSQL migrator utility
     runs-on: ubuntu-22.04
-    needs: lint
+    needs:
+      - lint
     defaults:
       run:
         shell: bash
@@ -531,7 +532,8 @@ jobs:
     name: Trigger self-host build
     if: github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
-    needs: build-docker
+    needs:
+      - build-docker
     steps:
       - name: Log in to Azure - CI subscription
         uses: Azure/login@e15b166166a8746d1a47596803bd8c1b595455cf # v1.6.0
@@ -564,7 +566,8 @@ jobs:
     name: Trigger k8s deploy
     if: github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
-    needs: build-docker
+    needs:
+      - build-docker
     steps:
       - name: Log in to Azure - CI subscription
         uses: Azure/login@e15b166166a8746d1a47596803bd8c1b595455cf # v1.6.0
@@ -600,7 +603,8 @@ jobs:
       github.event_name == 'pull_request_target'
       && contains(github.event.pull_request.labels.*.name, 'ephemeral-environment')
     runs-on: ubuntu-24.04
-    needs: build-docker
+    needs:
+      - build-docker
     steps:
       - name: Log in to Azure - CI subscription
         uses: Azure/login@e15b166166a8746d1a47596803bd8c1b595455cf # v1.6.0


### PR DESCRIPTION
## 🎟️ Tracking

Follow-up to earlier check run changes.

## 📔 Objective

To drive awareness of the need for the check run, just require it across the common lint job all the builds use, this way it's checked early and at the first time code is checked out.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
