### PR TITLE
[PM-14798] Update ProviderEventService for multi-organization enterprises

### DIFF
--- a/src/Billing/Services/Implementations/ProviderEventService.cs
+++ b/src/Billing/Services/Implementations/ProviderEventService.cs
@@ -61,13 +61,11 @@ public class ProviderEventService(
                             continue;
                         }
 
-                        var plan = StaticStore.Plans.Single(x => x.Name == client.Plan);
+                        var plan = StaticStore.Plans.Single(x => x.Name == client.Plan && providerPlans.Any(y => y.PlanType == x.Type));
 
                         var discountedPercentage = (100 - (invoice.Discount?.Coupon?.PercentOff ?? 0)) / 100;
 
                         var discountedSeatPrice = plan.PasswordManager.ProviderPortalSeatPrice * discountedPercentage;
-
-
 
                         invoiceItems.Add(new ProviderInvoiceItem
                         {

--- a/src/Billing/Services/Implementations/ProviderEventService.cs
+++ b/src/Billing/Services/Implementations/ProviderEventService.cs
@@ -45,13 +45,6 @@ public class ProviderEventService(
 
                     var providerPlans = await providerPlanRepository.GetByProviderId(parsedProviderId);
 
-                    if (providerPlans.Any(x => !x.IsConfigured()))
-                    {
-                        logger.LogError("Provider {ProviderID} is missing or has misconfigured provider plans", parsedProviderId);
-
-                        throw new Exception("Cannot record invoice line items for Provider with missing or misconfigured provider plans");
-                    }
-
                     var invoiceItems = new List<ProviderInvoiceItem>();
 
                     foreach (var client in clients)


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14798

## 📔 Objective

Just refactored the `ProviderEventService` to support the new provider type. The validation should have already been completed elsewhere for assigned specific plans with each provider type, which can simplify the code quite a bit.

Or should we keep these extra lines of validation to detect any corruption before it has caused enough trouble?

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
