### PR TITLE
[PM-13746] Remove loggedInUserId parameter.

### DIFF
--- a/src/Api/AdminConsole/Public/Controllers/MembersController.cs
+++ b/src/Api/AdminConsole/Public/Controllers/MembersController.cs
@@ -213,7 +213,7 @@ public class MembersController : Controller
         {
             return new NotFoundResult();
         }
-        await _updateOrganizationUserGroupsCommand.UpdateUserGroupsAsync(existingUser, model.GroupIds, null);
+        await _updateOrganizationUserGroupsCommand.UpdateUserGroupsAsync(existingUser, model.GroupIds);
         return new OkResult();
     }
 

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/Interfaces/IUpdateOrganizationUserGroupsCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/Interfaces/IUpdateOrganizationUserGroupsCommand.cs
@@ -4,5 +4,5 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interface
 
 public interface IUpdateOrganizationUserGroupsCommand
 {
-    Task UpdateUserGroupsAsync(OrganizationUser organizationUser, IEnumerable<Guid> groupIds, Guid? loggedInUserId);
+    Task UpdateUserGroupsAsync(OrganizationUser organizationUser, IEnumerable<Guid> groupIds);
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserGroupsCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserGroupsCommand.cs
@@ -9,25 +9,18 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers;
 public class UpdateOrganizationUserGroupsCommand : IUpdateOrganizationUserGroupsCommand
 {
     private readonly IEventService _eventService;
-    private readonly IOrganizationService _organizationService;
     private readonly IOrganizationUserRepository _organizationUserRepository;
 
     public UpdateOrganizationUserGroupsCommand(
         IEventService eventService,
-        IOrganizationService organizationService,
         IOrganizationUserRepository organizationUserRepository)
     {
         _eventService = eventService;
-        _organizationService = organizationService;
         _organizationUserRepository = organizationUserRepository;
     }
 
-    public async Task UpdateUserGroupsAsync(OrganizationUser organizationUser, IEnumerable<Guid> groupIds, Guid? loggedInUserId)
+    public async Task UpdateUserGroupsAsync(OrganizationUser organizationUser, IEnumerable<Guid> groupIds)
     {
-        if (loggedInUserId.HasValue)
-        {
-            await _organizationService.ValidateOrganizationUserUpdatePermissions(organizationUser.OrganizationId, organizationUser.Type, null, organizationUser.GetPermissions());
-        }
         await _organizationUserRepository.UpdateGroupsAsync(organizationUser.Id, groupIds);
         await _eventService.LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_UpdatedGroups);
     }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserGroupsCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserGroupsCommandTests.cs
@@ -14,34 +14,13 @@ namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.OrganizationUsers;
 public class UpdateOrganizationUserGroupsCommandTests
 {
     [Theory, BitAutoData]
-    public async Task UpdateUserGroups_Passes(
+    public async Task UpdateUserGroups_ShouldUpdateUserGroupsAndLogUserEvent(
         OrganizationUser organizationUser,
         IEnumerable<Guid> groupIds,
         SutProvider<UpdateOrganizationUserGroupsCommand> sutProvider)
     {
-        await sutProvider.Sut.UpdateUserGroupsAsync(organizationUser, groupIds, null);
+        await sutProvider.Sut.UpdateUserGroupsAsync(organizationUser, groupIds);
 
-        await sutProvider.GetDependency<IOrganizationService>().DidNotReceiveWithAnyArgs()
-            .ValidateOrganizationUserUpdatePermissions(default, default, default, default);
-        await sutProvider.GetDependency<IOrganizationUserRepository>().Received(1)
-            .UpdateGroupsAsync(organizationUser.Id, groupIds);
-        await sutProvider.GetDependency<IEventService>().Received(1)
-            .LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_UpdatedGroups);
-    }
-
-    [Theory, BitAutoData]
-    public async Task UpdateUserGroups_WithSavingUserId_Passes(
-        OrganizationUser organizationUser,
-        IEnumerable<Guid> groupIds,
-        Guid savingUserId,
-        SutProvider<UpdateOrganizationUserGroupsCommand> sutProvider)
-    {
-        organizationUser.Permissions = null;
-
-        await sutProvider.Sut.UpdateUserGroupsAsync(organizationUser, groupIds, savingUserId);
-
-        await sutProvider.GetDependency<IOrganizationService>().Received(1)
-            .ValidateOrganizationUserUpdatePermissions(organizationUser.OrganizationId, organizationUser.Type, null, organizationUser.GetPermissions());
         await sutProvider.GetDependency<IOrganizationUserRepository>().Received(1)
             .UpdateGroupsAsync(organizationUser.Id, groupIds);
         await sutProvider.GetDependency<IEventService>().Received(1)


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13746

## 📔 Objective

1. Remove `_organizationService.ValidateOrganizationUserUpdatePermissions` since it is not needed for updating group associations.
2. Remove `loggedInUserId` since it's no longer needed.
3. Update/remove related tests.

## 📸 Screenshots

The unit test pretty much covers it, but here is a manual test for a sanity check.

<img width="730" alt="image" src="https://github.com/user-attachments/assets/4eb7df3c-ce78-4750-877b-fa09dd02df3d">

<img width="764" alt="image" src="https://github.com/user-attachments/assets/6c1bc911-1338-4c75-a06a-49896b566df2">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
