### PR TITLE
[PM-14994] Remove positive number restriction from micro-deposit verification

### DIFF
--- a/src/Api/Billing/Models/Requests/VerifyBankAccountRequestBody.cs
+++ b/src/Api/Billing/Models/Requests/VerifyBankAccountRequestBody.cs
@@ -4,8 +4,8 @@ namespace Bit.Api.Billing.Models.Requests;
 
 public class VerifyBankAccountRequestBody
 {
-    [Range(0, 99)]
+    [Range(-99, 99)]
     public long Amount1 { get; set; }
-    [Range(0, 99)]
+    [Range(-99, 99)]
     public long Amount2 { get; set; }
 }

--- a/src/Core/Billing/BillingException.cs
+++ b/src/Core/Billing/BillingException.cs
@@ -5,5 +5,7 @@ public class BillingException(
     string message = null,
     Exception innerException = null) : Exception(message, innerException)
 {
-    public string Response { get; } = response ?? "Something went wrong with your request. Please contact support.";
+    public const string DefaultMessage = "Something went wrong with your request. Please contact support.";
+
+    public string Response { get; } = response ?? DefaultMessage;
 }

--- a/src/Core/Billing/Constants/StripeConstants.cs
+++ b/src/Core/Billing/Constants/StripeConstants.cs
@@ -25,6 +25,16 @@ public static class StripeConstants
     public static class ErrorCodes
     {
         public const string CustomerTaxLocationInvalid = "customer_tax_location_invalid";
+        public const string PaymentMethodMicroDepositVerificationAmountsInvalid =
+            "payment_method_microdeposit_verification_amounts_invalid";
+        public const string PaymentMethodMicroDepositVerificationAmountsMismatch =
+            "payment_method_microdeposit_verification_amounts_mismatch";
+        public const string PaymentMethodMicroDepositVerificationAttemptsExceeded =
+            "payment_method_microdeposit_verification_attempts_exceeded";
+        public const string PaymentMethodMicroDepositVerificationDescriptorCodeMismatch =
+            "payment_method_microdeposit_verification_descriptor_code_mismatch";
+        public const string PaymentMethodMicroDepositVerificationTimeout =
+            "payment_method_microdeposit_verification_timeout";
         public const string TaxIdInvalid = "tax_id_invalid";
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-14994

## 📔 Objective

After running into an issue verifying my personal bank account in the production environment with the Sources API deprecation turned on, I spoke with Stripe support who informed me that it's possible for the micro-deposit verification amounts for bank accounts to be negative. 

While I have serious reservations about whether that's actually true given it's not specified anywhere in the documentation, I'm getting this PR up and ready in case it is pending further discussion with Stripe.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
