### PR TITLE
Add an endpoint to get policy status

### DIFF
--- a/src/Api/AdminConsole/Controllers/PoliciesController.cs
+++ b/src/Api/AdminConsole/Controllers/PoliciesController.cs
@@ -85,6 +85,23 @@ public class PoliciesController : Controller
         return new PolicyDetailResponseModel(policy);
     }
 
+    [HttpGet("{type}/policy-status")]
+    public async Task<bool> GetPolicyStatusAsync(Guid orgId, int type)
+    {
+        var user = await _userService.GetUserByPrincipalAsync(User);
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
+        var policy = await _policyRepository.GetByOrganizationIdTypeAsync(orgId, (PolicyType)type);
+
+        var isPolicyEnabled = policy?.Enabled ?? false;
+
+        return isPolicyEnabled;
+    }
+
+
     [HttpGet("")]
     public async Task<ListResponseModel<PolicyResponseModel>> Get(string orgId)
     {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-13347

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When the Remove Bitwarden Families policy is on, the product will follow the following behaviors depending on the # of organizations the user is part of.

Individual vault impacts - [Scenario 1](https://www.figma.com/proto/XvSu6yBd1AkP01YLQIp8J2/Disable-Families-for-Enterprise-policy?page-id=1%3A12&node-id=5250-4466&node-type=frame&viewport=717%2C513%2C0.05&t=c3oK6XgitCYGfS1o-1&scaling=scale-down&content-scaling=fixed&starting-point-node-id=5250%3A4466&show-proto-sidebar=1)

Given the users email address is only associated with 1 enterprise organization, when the policy is turned on, then hide the Free Bitwarden Families page from the navigation

Individual vault impacts - [Scenario 2](https://www.figma.com/proto/XvSu6yBd1AkP01YLQIp8J2/Disable-Families-for-Enterprise-policy?page-id=1%3A12&node-id=5250-4513&node-type=frame&viewport=717%2C513%2C0.05&t=c3oK6XgitCYGfS1o-1&scaling=scale-down&content-scaling=fixed&starting-point-node-id=5250%3A4490&show-proto-sidebar=1)

Given the email address is associated with multiple enterprise organization, the policy is turned on, and my sponsorship is status is active, when the user attempts to interact with the three dot menu, then the only option is to remove the sponsorship 

Individual vault impacts - [Scenario 3](https://www.figma.com/proto/XvSu6yBd1AkP01YLQIp8J2/Disable-Families-for-Enterprise-policy?page-id=1%3A12&node-id=5250-4579&node-type=frame&viewport=717%2C513%2C0.05&t=c3oK6XgitCYGfS1o-1&scaling=scale-down&content-scaling=fixed&starting-point-node-id=5250%3A4556&show-proto-sidebar=1)

Given the email address is associated with multiple enterprise organization, the policy is turned on, and my sponsorship is status is sent, when the user attempts to interact with the three dot menu, then the only option is to remove the sponsorship and we hide the Resend email option

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
