### PR TITLE
[PM-14876] Update admin panel copy from 'Domain Verified' to 'Claimed Account' and rename associated ViewModel properties

### DIFF
--- a/src/Admin/Models/UserEditModel.cs
+++ b/src/Admin/Models/UserEditModel.cs
@@ -9,10 +9,7 @@ namespace Bit.Admin.Models;
 
 public class UserEditModel
 {
-    public UserEditModel()
-    {
-
-    }
+    public UserEditModel() { }
 
     public UserEditModel(
         User user,
@@ -21,10 +18,9 @@ public class UserEditModel
         BillingInfo billingInfo,
         BillingHistoryInfo billingHistoryInfo,
         GlobalSettings globalSettings,
-        bool? domainVerified
-        )
+        bool? claimedAccount)
     {
-        User = UserViewModel.MapViewModel(user, isTwoFactorEnabled, ciphers, domainVerified);
+        User = UserViewModel.MapViewModel(user, isTwoFactorEnabled, ciphers, claimedAccount);
 
         BillingInfo = billingInfo;
         BillingHistoryInfo = billingHistoryInfo;

--- a/src/Admin/Models/UserViewModel.cs
+++ b/src/Admin/Models/UserViewModel.cs
@@ -14,7 +14,7 @@ public class UserViewModel
     public bool Premium { get; }
     public short? MaxStorageGb { get; }
     public bool EmailVerified { get; }
-    public bool? DomainVerified { get; }
+    public bool? ClaimedAccount { get; }
     public bool TwoFactorEnabled { get; }
     public DateTime AccountRevisionDate { get; }
     public DateTime RevisionDate { get; }
@@ -36,7 +36,7 @@ public class UserViewModel
         bool premium,
         short? maxStorageGb,
         bool emailVerified,
-        bool? domainVerified,
+        bool? claimedAccount,
         bool twoFactorEnabled,
         DateTime accountRevisionDate,
         DateTime revisionDate,
@@ -58,7 +58,7 @@ public class UserViewModel
         Premium = premium;
         MaxStorageGb = maxStorageGb;
         EmailVerified = emailVerified;
-        DomainVerified = domainVerified;
+        ClaimedAccount = claimedAccount;
         TwoFactorEnabled = twoFactorEnabled;
         AccountRevisionDate = accountRevisionDate;
         RevisionDate = revisionDate;
@@ -79,7 +79,7 @@ public class UserViewModel
         users.Select(user => MapViewModel(user, lookup, false));
 
     public static UserViewModel MapViewModel(User user,
-        IEnumerable<(Guid userId, bool twoFactorIsEnabled)> lookup, bool? domainVerified) =>
+        IEnumerable<(Guid userId, bool twoFactorIsEnabled)> lookup, bool? claimedAccount) =>
         new(
             user.Id,
             user.Name,
@@ -89,7 +89,7 @@ public class UserViewModel
             user.Premium,
             user.MaxStorageGb,
             user.EmailVerified,
-            domainVerified,
+            claimedAccount,
             IsTwoFactorEnabled(user, lookup),
             user.AccountRevisionDate,
             user.RevisionDate,
@@ -106,7 +106,7 @@ public class UserViewModel
     public static UserViewModel MapViewModel(User user, bool isTwoFactorEnabled) =>
         MapViewModel(user, isTwoFactorEnabled, Array.Empty<Cipher>(), false);
 
-    public static UserViewModel MapViewModel(User user, bool isTwoFactorEnabled, IEnumerable<Cipher> ciphers, bool? domainVerified) =>
+    public static UserViewModel MapViewModel(User user, bool isTwoFactorEnabled, IEnumerable<Cipher> ciphers, bool? claimedAccount) =>
         new(
             user.Id,
             user.Name,
@@ -116,7 +116,7 @@ public class UserViewModel
             user.Premium,
             user.MaxStorageGb,
             user.EmailVerified,
-            domainVerified,
+            claimedAccount,
             isTwoFactorEnabled,
             user.AccountRevisionDate,
             user.RevisionDate,

--- a/src/Admin/Views/Users/_ViewInformation.cshtml
+++ b/src/Admin/Views/Users/_ViewInformation.cshtml
@@ -12,9 +12,10 @@
     <dt class="col-sm-4 col-lg-3">Email Verified</dt>
     <dd class="col-sm-8 col-lg-9">@(Model.EmailVerified ? "Yes" : "No")</dd>
 
-    @if(Model.DomainVerified.HasValue){
-    <dt class="col-sm-4 col-lg-3">Domain Verified</dt>
-    <dd class="col-sm-8 col-lg-9">@(Model.DomainVerified.Value == true ? "Yes" : "No")</dd>
+    @if(Model.ClaimedAccount.HasValue)
+    {
+        <dt class="col-sm-4 col-lg-3">Claimed Account</dt>
+        <dd class="col-sm-8 col-lg-9">@(Model.ClaimedAccount.Value ? "Yes" : "No")</dd>
     }
 
     <dt class="col-sm-4 col-lg-3">Using 2FA</dt>

--- a/test/Admin.Test/Models/UserViewModelTests.cs
+++ b/test/Admin.Test/Models/UserViewModelTests.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Bit.Admin.Models;
+﻿using Bit.Admin.Models;
 using Bit.Core.Entities;
 using Bit.Core.Vault.Entities;
 using Bit.Test.Common.AutoFixture.Attributes;
@@ -116,30 +114,26 @@ public class UserViewModelTests
 
         var actual = UserViewModel.MapViewModel(user, true, Array.Empty<Cipher>(), verifiedDomain);
 
-        Assert.True(actual.DomainVerified);
+        Assert.True(actual.ClaimedAccount);
     }
 
     [Theory]
     [BitAutoData]
     public void MapUserViewModel_WithoutVerifiedDomain_ReturnsUserViewModel(User user)
     {
-
         var verifiedDomain = false;
 
         var actual = UserViewModel.MapViewModel(user, true, Array.Empty<Cipher>(), verifiedDomain);
 
-        Assert.False(actual.DomainVerified);
+        Assert.False(actual.ClaimedAccount);
     }
 
     [Theory]
     [BitAutoData]
     public void MapUserViewModel_WithNullVerifiedDomain_ReturnsUserViewModel(User user)
     {
-
         var actual = UserViewModel.MapViewModel(user, true, Array.Empty<Cipher>(), null);
 
-        Assert.Null(actual.DomainVerified);
+        Assert.Null(actual.ClaimedAccount);
     }
-
-
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14876

## 📔 Objective

> As a result of the copy updates we have been making (replacing Verified domains as Claimed accounts, using ownership terminology instead of managed) we would like to replace the Domain verified stat with Claimed account
> 
> [Figma](https://www.figma.com/proto/lHZXTF0bl9fEB42FroKNOb/Account-management-and-deprovisioning?page-id=1%3A12&node-id=530-48330&node-type=frame&viewport=-7977%2C-4940%2C0.6&t=K2zyFUntUvVbQqj6-1&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=530%3A48330&show-proto-sidebar=1)

## 📸 Screenshots

<img width="667" alt="image" src="https://github.com/user-attachments/assets/0f06acd0-009c-4cf6-bb27-d68a0d8d252f">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
