### PR TITLE
chore: update `LastActivityDate` on installation token refresh

### DIFF
--- a/src/Api/Platform/Installations/Controllers/InstallationsController.cs
+++ b/src/Api/Platform/Installations/Controllers/InstallationsController.cs
@@ -6,6 +6,15 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Bit.Api.Platform.Installations;
 
+/// <summary>
+/// Routes used to manipulate `Installation` objects: a type used to manage
+/// a record of a self hosted installation.
+/// </summary>
+/// <remarks>
+/// This controller is not called from any clients. It's primarily referenced
+/// in the `Setup` project for creating a new self hosted installation.
+/// </remarks>
+/// <seealso>Bit.Setup.Program</seealso>
 [Route("installations")]
 [SelfHosted(NotSelfHostedOnly = true)]
 public class InstallationsController : Controller

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -165,6 +165,7 @@ public static class FeatureFlagKeys
     public const string AppReviewPrompt = "app-review-prompt";
     public const string ResellerManagedOrgAlert = "PM-15814-alert-owners-of-reseller-managed-orgs";
     public const string UsePricingService = "use-pricing-service";
+    public const string RecordInstallationLastActivityDate = "installation-last-activity-date";
 
     public static List<string> GetAllKeys()
     {

--- a/src/Core/Platform/Installations/Commands/UpdateInstallationActivityDateCommand/IUpdateInstallationCommand.cs
+++ b/src/Core/Platform/Installations/Commands/UpdateInstallationActivityDateCommand/IUpdateInstallationCommand.cs
@@ -1,0 +1,14 @@
+﻿namespace Bit.Core.Platform.Installations;
+
+/// <summary>
+/// Command interface responsible for updating data on an `Installation`
+/// record.
+/// </summary>
+/// <remarks>
+/// This interface is implemented by `UpdateInstallationCommand`
+/// </remarks>
+/// <seealso cref="Bit.Core.Platform.Installations.UpdateInstallationCommand"/>
+public interface IUpdateInstallationCommand
+{
+    Task UpdateLastActivityDateAsync(Guid installationId);
+}

--- a/src/Core/Platform/Installations/Commands/UpdateInstallationActivityDateCommand/UpdateInstallationCommand.cs
+++ b/src/Core/Platform/Installations/Commands/UpdateInstallationActivityDateCommand/UpdateInstallationCommand.cs
@@ -1,0 +1,53 @@
+﻿namespace Bit.Core.Platform.Installations;
+
+/// <summary>
+/// Commands responsible for updating an installation from
+/// `InstallationRepository`.
+/// </summary>
+/// <remarks>
+/// If referencing: you probably want the interface
+/// `IUpdateInstallationCommand` instead of directly calling this class.
+/// </remarks>
+/// <seealso cref="IUpdateInstallationCommand"/>
+public class UpdateInstallationCommand : IUpdateInstallationCommand
+{
+    private readonly IGetInstallationQuery _getInstallationQuery;
+    private readonly IInstallationRepository _installationRepository;
+    private readonly TimeProvider _timeProvider;
+
+    public UpdateInstallationCommand(
+        IGetInstallationQuery getInstallationQuery,
+        IInstallationRepository installationRepository,
+        TimeProvider timeProvider
+    )
+    {
+        _getInstallationQuery = getInstallationQuery;
+        _installationRepository = installationRepository;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task UpdateLastActivityDateAsync(Guid installationId)
+    {
+        if (installationId == default)
+        {
+            throw new Exception
+            (
+              "Tried to update the last activity date for " +
+              "an installation, but an invalid installation id was " +
+              "provided."
+            );
+        }
+        var installation = await _getInstallationQuery.GetByIdAsync(installationId);
+        if (installation == null)
+        {
+            throw new Exception
+            (
+              "Tried to update the last activity date for " +
+              $"installation {installationId.ToString()}, but no " +
+              "installation was found for that id."
+            );
+        }
+        installation.LastActivityDate = _timeProvider.GetUtcNow().UtcDateTime;
+        await _installationRepository.UpsertAsync(installation);
+    }
+}

--- a/src/Core/Platform/Installations/Entities/Installation.cs
+++ b/src/Core/Platform/Installations/Entities/Installation.cs
@@ -19,6 +19,7 @@ public class Installation : ITableObject<Guid>
     public string Key { get; set; } = null!;
     public bool Enabled { get; set; }
     public DateTime CreationDate { get; internal set; } = DateTime.UtcNow;
+    public DateTime? LastActivityDate { get; internal set; }
 
     public void SetNewId()
     {

--- a/src/Core/Platform/Installations/Queries/GetInstallationQuery/GetInstallationQuery.cs
+++ b/src/Core/Platform/Installations/Queries/GetInstallationQuery/GetInstallationQuery.cs
@@ -1,0 +1,30 @@
+﻿namespace Bit.Core.Platform.Installations;
+
+/// <summary>
+/// Queries responsible for fetching an installation from
+/// `InstallationRepository`.
+/// </summary>
+/// <remarks>
+/// If referencing: you probably want the interface `IGetInstallationQuery`
+/// instead of directly calling this class.
+/// </remarks>
+/// <seealso cref="IGetInstallationQuery"/>
+public class GetInstallationQuery : IGetInstallationQuery
+{
+    private readonly IInstallationRepository _installationRepository;
+
+    public GetInstallationQuery(IInstallationRepository installationRepository)
+    {
+        _installationRepository = installationRepository;
+    }
+
+    /// <inheritdoc cref="IGetInstallationQuery.GetByIdAsync"/>
+    public async Task<Installation> GetByIdAsync(Guid installationId)
+    {
+        if (installationId == default(Guid))
+        {
+            return null;
+        }
+        return await _installationRepository.GetByIdAsync(installationId);
+    }
+}

--- a/src/Core/Platform/Installations/Queries/GetInstallationQuery/IGetInstallationQuery.cs
+++ b/src/Core/Platform/Installations/Queries/GetInstallationQuery/IGetInstallationQuery.cs
@@ -1,0 +1,20 @@
+﻿namespace Bit.Core.Platform.Installations;
+
+/// <summary>
+/// Query interface responsible for fetching an installation from
+/// `InstallationRepository`.
+/// </summary>
+/// <remarks>
+/// This interface is implemented by `GetInstallationQuery`
+/// </remarks>
+/// <seealso cref="GetInstallationQuery"/>
+public interface IGetInstallationQuery
+{
+    /// <summary>
+    /// Retrieves an installation from the `InstallationRepository` by its id.
+    /// </summary>
+    /// <param name="installationId">The GUID id of the installation.</param>
+    /// <returns>A task containing an `Installation`.</returns>
+    /// <seealso cref="T:Bit.Core.Platform.Installations.Repositories.IInstallationRepository"/>
+    Task<Installation> GetByIdAsync(Guid installationId);
+}

--- a/src/Core/Platform/PlatformServiceCollectionExtensions.cs
+++ b/src/Core/Platform/PlatformServiceCollectionExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Bit.Core.Platform.Installations;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bit.Core.Platform;
+
+public static class PlatformServiceCollectionExtensions
+{
+    /// <summary>
+    /// Extend DI to include commands and queries exported from the Platform
+    /// domain.
+    /// </summary>
+    public static IServiceCollection AddPlatformServices(this IServiceCollection services)
+    {
+        services.AddScoped<IGetInstallationQuery, GetInstallationQuery>();
+        services.AddScoped<IUpdateInstallationCommand, UpdateInstallationCommand>();
+
+        return services;
+    }
+}

--- a/src/Core/Platform/Push/Services/RelayPushRegistrationService.cs
+++ b/src/Core/Platform/Push/Services/RelayPushRegistrationService.cs
@@ -9,7 +9,6 @@ namespace Bit.Core.Platform.Push.Internal;
 
 public class RelayPushRegistrationService : BaseIdentityClientService, IPushRegistrationService
 {
-
     public RelayPushRegistrationService(
         IHttpClientFactory httpFactory,
         GlobalSettings globalSettings,

--- a/src/Identity/IdentityServer/RequestValidators/WebAuthnGrantValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/WebAuthnGrantValidator.cs
@@ -44,8 +44,7 @@ public class WebAuthnGrantValidator : BaseRequestValidator<ExtensionGrantValidat
         IDataProtectorTokenFactory<WebAuthnLoginAssertionOptionsTokenable> assertionOptionsDataProtector,
         IFeatureService featureService,
         IUserDecryptionOptionsBuilder userDecryptionOptionsBuilder,
-        IAssertWebAuthnLoginCredentialCommand assertWebAuthnLoginCredentialCommand
-        )
+        IAssertWebAuthnLoginCredentialCommand assertWebAuthnLoginCredentialCommand)
         : base(
             userManager,
             userService,

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ using Bit.Core.KeyManagement;
 using Bit.Core.NotificationCenter;
 using Bit.Core.NotificationHub;
 using Bit.Core.OrganizationFeatures;
+using Bit.Core.Platform;
 using Bit.Core.Platform.Push;
 using Bit.Core.Platform.Push.Internal;
 using Bit.Core.Repositories;
@@ -126,6 +127,7 @@ public static class ServiceCollectionExtensions
         services.AddReportingServices();
         services.AddKeyManagementServices();
         services.AddNotificationCenterServices();
+        services.AddPlatformServices();
     }
 
     public static void AddTokenizers(this IServiceCollection services)

--- a/test/Core.Test/Platform/Installations/Commands/UpdateInstallationCommandTests.cs
+++ b/test/Core.Test/Platform/Installations/Commands/UpdateInstallationCommandTests.cs
@@ -1,0 +1,40 @@
+﻿using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Platform.Installations.Tests;
+
+[SutProviderCustomize]
+public class UpdateInstallationCommandTests
+{
+    [Theory]
+    [BitAutoData]
+    public async Task UpdateLastActivityDateAsync_ShouldUpdateLastActivityDate(
+        Installation installation
+    )
+    {
+        // Arrange
+        var sutProvider = new SutProvider<UpdateInstallationCommand>()
+            .WithFakeTimeProvider()
+            .Create();
+
+        var someDate = new DateTime(2014, 11, 3, 18, 27, 0, DateTimeKind.Utc);
+        sutProvider.GetDependency<FakeTimeProvider>().SetUtcNow(someDate);
+
+        sutProvider
+            .GetDependency<IGetInstallationQuery>()
+            .GetByIdAsync(installation.Id)
+            .Returns(installation);
+
+        // Act
+        await sutProvider.Sut.UpdateLastActivityDateAsync(installation.Id);
+
+        // Assert
+        await sutProvider
+            .GetDependency<IInstallationRepository>()
+            .Received(1)
+            .UpsertAsync(Arg.Is<Installation>(inst => inst.LastActivityDate == someDate));
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11129

## 📔 Objective

In previous commits a `LastActivityDate` field was added to the database. This commit implements that column by writing the current date whenever an installation refreshes its token for push relay.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/efda4dea-4fa9-448f-bcf8-f6a909a60633

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
