### PR TITLE
PM-10600: Push notification with full notification center content.

### DIFF
--- a/src/Core/Models/PushNotification.cs
+++ b/src/Core/Models/PushNotification.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Core.Enums;
+using Bit.Core.NotificationCenter.Enums;
 
 namespace Bit.Core.Models;
 
@@ -45,14 +46,21 @@ public class SyncSendPushNotification
     public DateTime RevisionDate { get; set; }
 }
 
-public class SyncNotificationPushNotification
+#nullable enable
+public class NotificationPushNotification
 {
     public Guid Id { get; set; }
+    public Priority Priority { get; set; }
+    public bool Global { get; set; }
+    public ClientType ClientType { get; set; }
     public Guid? UserId { get; set; }
     public Guid? OrganizationId { get; set; }
-    public ClientType ClientType { get; set; }
+    public string? Title { get; set; }
+    public string? Body { get; set; }
+    public DateTime CreationDate { get; set; }
     public DateTime RevisionDate { get; set; }
 }
+#nullable disable
 
 public class AuthRequestPushNotification
 {

--- a/src/Core/NotificationCenter/Commands/CreateNotificationCommand.cs
+++ b/src/Core/NotificationCenter/Commands/CreateNotificationCommand.cs
@@ -37,7 +37,7 @@ public class CreateNotificationCommand : ICreateNotificationCommand
 
         var newNotification = await _notificationRepository.CreateAsync(notification);
 
-        await _pushNotificationService.PushSyncNotificationAsync(newNotification);
+        await _pushNotificationService.PushNotificationAsync(newNotification);
 
         return newNotification;
     }

--- a/src/Core/NotificationCenter/Entities/Notification.cs
+++ b/src/Core/NotificationCenter/Entities/Notification.cs
@@ -15,9 +15,8 @@ public class Notification : ITableObject<Guid>
     public ClientType ClientType { get; set; }
     public Guid? UserId { get; set; }
     public Guid? OrganizationId { get; set; }
-    [MaxLength(256)]
-    public string? Title { get; set; }
-    public string? Body { get; set; }
+    [MaxLength(256)] public string? Title { get; set; }
+    [MaxLength(3000)] public string? Body { get; set; }
     public DateTime CreationDate { get; set; }
     public DateTime RevisionDate { get; set; }
 

--- a/src/Core/NotificationHub/NotificationHubPushNotificationService.cs
+++ b/src/Core/NotificationHub/NotificationHubPushNotificationService.cs
@@ -180,14 +180,19 @@ public class NotificationHubPushNotificationService : IPushNotificationService
         await PushAuthRequestAsync(authRequest, PushType.AuthRequestResponse);
     }
 
-    public async Task PushSyncNotificationAsync(Notification notification)
+    public async Task PushNotificationAsync(Notification notification)
     {
-        var message = new SyncNotificationPushNotification
+        var message = new NotificationPushNotification
         {
             Id = notification.Id,
+            Priority = notification.Priority,
+            Global = notification.Global,
+            ClientType = notification.ClientType,
             UserId = notification.UserId,
             OrganizationId = notification.OrganizationId,
-            ClientType = notification.ClientType,
+            Title = notification.Title,
+            Body = notification.Body,
+            CreationDate = notification.CreationDate,
             RevisionDate = notification.RevisionDate
         };
 

--- a/src/Core/Services/IPushNotificationService.cs
+++ b/src/Core/Services/IPushNotificationService.cs
@@ -23,7 +23,7 @@ public interface IPushNotificationService
     Task PushSyncSendCreateAsync(Send send);
     Task PushSyncSendUpdateAsync(Send send);
     Task PushSyncSendDeleteAsync(Send send);
-    Task PushSyncNotificationAsync(Notification notification);
+    Task PushNotificationAsync(Notification notification);
     Task PushAuthRequestAsync(AuthRequest authRequest);
     Task PushAuthRequestResponseAsync(AuthRequest authRequest);
 

--- a/src/Core/Services/Implementations/AzureQueuePushNotificationService.cs
+++ b/src/Core/Services/Implementations/AzureQueuePushNotificationService.cs
@@ -164,14 +164,19 @@ public class AzureQueuePushNotificationService : IPushNotificationService
         await PushSendAsync(send, PushType.SyncSendDelete);
     }
 
-    public async Task PushSyncNotificationAsync(Notification notification)
+    public async Task PushNotificationAsync(Notification notification)
     {
-        var message = new SyncNotificationPushNotification
+        var message = new NotificationPushNotification
         {
             Id = notification.Id,
+            Priority = notification.Priority,
+            Global = notification.Global,
+            ClientType = notification.ClientType,
             UserId = notification.UserId,
             OrganizationId = notification.OrganizationId,
-            ClientType = notification.ClientType,
+            Title = notification.Title,
+            Body = notification.Body,
+            CreationDate = notification.CreationDate,
             RevisionDate = notification.RevisionDate
         };
 

--- a/src/Core/Services/Implementations/MultiServicePushNotificationService.cs
+++ b/src/Core/Services/Implementations/MultiServicePushNotificationService.cs
@@ -145,9 +145,9 @@ public class MultiServicePushNotificationService : IPushNotificationService
         return Task.FromResult(0);
     }
 
-    public Task PushSyncNotificationAsync(Notification notification)
+    public Task PushNotificationAsync(Notification notification)
     {
-        PushToServices((s) => s.PushSyncNotificationAsync(notification));
+        PushToServices((s) => s.PushNotificationAsync(notification));
         return Task.CompletedTask;
     }
 

--- a/src/Core/Services/Implementations/NotificationsApiPushNotificationService.cs
+++ b/src/Core/Services/Implementations/NotificationsApiPushNotificationService.cs
@@ -173,14 +173,19 @@ public class NotificationsApiPushNotificationService : BaseIdentityClientService
         await PushSendAsync(send, PushType.SyncSendDelete);
     }
 
-    public async Task PushSyncNotificationAsync(Notification notification)
+    public async Task PushNotificationAsync(Notification notification)
     {
-        var message = new SyncNotificationPushNotification
+        var message = new NotificationPushNotification
         {
             Id = notification.Id,
+            Priority = notification.Priority,
+            Global = notification.Global,
+            ClientType = notification.ClientType,
             UserId = notification.UserId,
             OrganizationId = notification.OrganizationId,
-            ClientType = notification.ClientType,
+            Title = notification.Title,
+            Body = notification.Body,
+            CreationDate = notification.CreationDate,
             RevisionDate = notification.RevisionDate
         };
 

--- a/src/Core/Services/Implementations/RelayPushNotificationService.cs
+++ b/src/Core/Services/Implementations/RelayPushNotificationService.cs
@@ -189,14 +189,19 @@ public class RelayPushNotificationService : BaseIdentityClientService, IPushNoti
         await SendPayloadToUserAsync(authRequest.UserId, type, message, true);
     }
 
-    public async Task PushSyncNotificationAsync(Notification notification)
+    public async Task PushNotificationAsync(Notification notification)
     {
-        var message = new SyncNotificationPushNotification
+        var message = new NotificationPushNotification
         {
             Id = notification.Id,
+            Priority = notification.Priority,
+            Global = notification.Global,
+            ClientType = notification.ClientType,
             UserId = notification.UserId,
             OrganizationId = notification.OrganizationId,
-            ClientType = notification.ClientType,
+            Title = notification.Title,
+            Body = notification.Body,
+            CreationDate = notification.CreationDate,
             RevisionDate = notification.RevisionDate
         };
 

--- a/src/Core/Services/NoopImplementations/NoopPushNotificationService.cs
+++ b/src/Core/Services/NoopImplementations/NoopPushNotificationService.cs
@@ -105,5 +105,5 @@ public class NoopPushNotificationService : IPushNotificationService
         return Task.FromResult(0);
     }
 
-    public Task PushSyncNotificationAsync(Notification notification) => Task.CompletedTask;
+    public Task PushNotificationAsync(Notification notification) => Task.CompletedTask;
 }

--- a/src/Notifications/HubHelpers.cs
+++ b/src/Notifications/HubHelpers.cs
@@ -91,7 +91,7 @@ public static class HubHelpers
                 break;
             case PushType.SyncNotification:
                 var syncNotification =
-                    JsonSerializer.Deserialize<PushNotificationData<SyncNotificationPushNotification>>(
+                    JsonSerializer.Deserialize<PushNotificationData<NotificationPushNotification>>(
                         notificationJson, _deserializerOptions);
                 if (syncNotification.Payload.UserId.HasValue)
                 {

--- a/test/Core.Test/NotificationCenter/Commands/CreateNotificationCommandTest.cs
+++ b/test/Core.Test/NotificationCenter/Commands/CreateNotificationCommandTest.cs
@@ -58,6 +58,6 @@ public class CreateNotificationCommandTest
         Assert.Equal(notification.CreationDate, notification.RevisionDate);
         await sutProvider.GetDependency<IPushNotificationService>()
             .Received(1)
-            .PushSyncNotificationAsync(newNotification);
+            .PushNotificationAsync(newNotification);
     }
 }

--- a/test/Core.Test/NotificationHub/NotificationHubPushNotificationServiceTests.cs
+++ b/test/Core.Test/NotificationHub/NotificationHubPushNotificationServiceTests.cs
@@ -20,10 +20,10 @@ public class NotificationHubPushNotificationServiceTests
     [Theory]
     [BitAutoData]
     [NotificationCustomize]
-    public async void PushSyncNotificationAsync_Global_NotSent(
+    public async void PushNotificationAsync_Global_NotSent(
         SutProvider<NotificationHubPushNotificationService> sutProvider, Notification notification)
     {
-        await sutProvider.Sut.PushSyncNotificationAsync(notification);
+        await sutProvider.Sut.PushNotificationAsync(notification);
 
         await sutProvider.GetDependency<INotificationHubPool>()
             .Received(0)
@@ -39,7 +39,7 @@ public class NotificationHubPushNotificationServiceTests
     [BitAutoData(false)]
     [BitAutoData(true)]
     [NotificationCustomize(false)]
-    public async void PushSyncNotificationAsync_UserIdProvidedClientTypeAll_SentToUser(
+    public async void PushNotificationAsync_UserIdProvidedClientTypeAll_SentToUser(
         bool organizationIdNull, SutProvider<NotificationHubPushNotificationService> sutProvider,
         Notification notification)
     {
@@ -51,7 +51,7 @@ public class NotificationHubPushNotificationServiceTests
         notification.ClientType = ClientType.All;
         var expectedSyncNotification = ToSyncNotificationPushNotification(notification);
 
-        await sutProvider.Sut.PushSyncNotificationAsync(notification);
+        await sutProvider.Sut.PushNotificationAsync(notification);
 
         await AssertSendTemplateNotificationAsync(sutProvider, PushType.SyncNotification, expectedSyncNotification,
             $"(template:payload_userId:{notification.UserId})");
@@ -70,7 +70,7 @@ public class NotificationHubPushNotificationServiceTests
     [BitAutoData(true, ClientType.Web)]
     [BitAutoData(true, ClientType.Mobile)]
     [NotificationCustomize(false)]
-    public async void PushSyncNotificationAsync_UserIdProvidedClientTypeNotAll_SentToUser(bool organizationIdNull,
+    public async void PushNotificationAsync_UserIdProvidedClientTypeNotAll_SentToUser(bool organizationIdNull,
         ClientType clientType, SutProvider<NotificationHubPushNotificationService> sutProvider,
         Notification notification)
     {
@@ -82,7 +82,7 @@ public class NotificationHubPushNotificationServiceTests
         notification.ClientType = clientType;
         var expectedSyncNotification = ToSyncNotificationPushNotification(notification);
 
-        await sutProvider.Sut.PushSyncNotificationAsync(notification);
+        await sutProvider.Sut.PushNotificationAsync(notification);
 
         await AssertSendTemplateNotificationAsync(sutProvider, PushType.SyncNotification, expectedSyncNotification,
             $"(template:payload_userId:{notification.UserId} && clientType:{clientType})");
@@ -94,14 +94,14 @@ public class NotificationHubPushNotificationServiceTests
     [Theory]
     [BitAutoData]
     [NotificationCustomize(false)]
-    public async void PushSyncNotificationAsync_UserIdNullOrganizationIdProvidedClientTypeAll_SentToOrganization(
+    public async void PushNotificationAsync_UserIdNullOrganizationIdProvidedClientTypeAll_SentToOrganization(
         SutProvider<NotificationHubPushNotificationService> sutProvider, Notification notification)
     {
         notification.UserId = null;
         notification.ClientType = ClientType.All;
         var expectedSyncNotification = ToSyncNotificationPushNotification(notification);
 
-        await sutProvider.Sut.PushSyncNotificationAsync(notification);
+        await sutProvider.Sut.PushNotificationAsync(notification);
 
         await AssertSendTemplateNotificationAsync(sutProvider, PushType.SyncNotification, expectedSyncNotification,
             $"(template:payload && organizationId:{notification.OrganizationId})");
@@ -116,7 +116,7 @@ public class NotificationHubPushNotificationServiceTests
     [BitAutoData(ClientType.Web)]
     [BitAutoData(ClientType.Mobile)]
     [NotificationCustomize(false)]
-    public async void PushSyncNotificationAsync_UserIdNullOrganizationIdProvidedClientTypeNotAll_SentToOrganization(
+    public async void PushNotificationAsync_UserIdNullOrganizationIdProvidedClientTypeNotAll_SentToOrganization(
         ClientType clientType, SutProvider<NotificationHubPushNotificationService> sutProvider,
         Notification notification)
     {
@@ -125,7 +125,7 @@ public class NotificationHubPushNotificationServiceTests
 
         var expectedSyncNotification = ToSyncNotificationPushNotification(notification);
 
-        await sutProvider.Sut.PushSyncNotificationAsync(notification);
+        await sutProvider.Sut.PushNotificationAsync(notification);
 
         await AssertSendTemplateNotificationAsync(sutProvider, PushType.SyncNotification, expectedSyncNotification,
             $"(template:payload && organizationId:{notification.OrganizationId} && clientType:{clientType})");
@@ -206,13 +206,18 @@ public class NotificationHubPushNotificationServiceTests
             .UpsertAsync(Arg.Any<InstallationDeviceEntity>());
     }
 
-    private static SyncNotificationPushNotification ToSyncNotificationPushNotification(Notification notification) =>
+    private static NotificationPushNotification ToSyncNotificationPushNotification(Notification notification) =>
         new()
         {
             Id = notification.Id,
+            Priority = notification.Priority,
+            Global = notification.Global,
+            ClientType = notification.ClientType,
             UserId = notification.UserId,
             OrganizationId = notification.OrganizationId,
-            ClientType = notification.ClientType,
+            Title = notification.Title,
+            Body = notification.Body,
+            CreationDate = notification.CreationDate,
             RevisionDate = notification.RevisionDate
         };
 

--- a/test/Core.Test/Services/MultiServicePushNotificationServiceTests.cs
+++ b/test/Core.Test/Services/MultiServicePushNotificationServiceTests.cs
@@ -16,15 +16,15 @@ public class MultiServicePushNotificationServiceTests
     [Theory]
     [BitAutoData]
     [NotificationCustomize]
-    public async Task PushSyncNotificationAsync_Notification_Sent(
+    public async Task PushNotificationAsync_Notification_Sent(
         SutProvider<MultiServicePushNotificationService> sutProvider, Notification notification)
     {
-        await sutProvider.Sut.PushSyncNotificationAsync(notification);
+        await sutProvider.Sut.PushNotificationAsync(notification);
 
         await sutProvider.GetDependency<IEnumerable<IPushNotificationService>>()
             .First()
             .Received(1)
-            .PushSyncNotificationAsync(notification);
+            .PushNotificationAsync(notification);
     }
 
     [Theory]


### PR DESCRIPTION
Notification Center push notification now includes all the fields.

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10600

## 📔 Objective

Continuation of #4923

Notification Center push notification now includes all the fields.

The push notification have a limit of 4KB for payload (limitation of Azure Notification Hub, FCM and APNS). For notification center push notification, only `Body` field needs to have a max length, since other fields have deterministic max length. No other push notifications are affected. 
To fix this, a separate PR will follow once the API PR is merged  #4852 that will have the max length of 3000 on the `Body` field in the request and optionally in db column too.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
