### PR TITLE
[PM-10319] - Swapping [] for Array.Empty<string>

### DIFF
--- a/src/Core/Models/Commands/CommandResult.cs
+++ b/src/Core/Models/Commands/CommandResult.cs
@@ -8,5 +8,5 @@ public class CommandResult(IEnumerable<string> errors)
     public bool HasErrors => ErrorMessages.Count > 0;
     public List<string> ErrorMessages { get; } = errors.ToList();
 
-    public CommandResult() : this([]) { }
+    public CommandResult() : this(Array.Empty<string>()) { }
 }


### PR DESCRIPTION
## 🎟️ Tracking
[PM-10319](https://bitwarden.atlassian.net/browse/PM-10319)

## 📔 Objective
Correcting ctor for CommandResult. There were build errors on some machines not able to figure out which ctor to call between CommandResult(IEnumerable<string> errors) and CommandResult(string error) when using CommandResult() : this([])

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10319]: https://bitwarden.atlassian.net/browse/PM-10319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ