### PR TITLE
Added ports for mailcatcher to internal dev docker container

### DIFF
--- a/.devcontainer/bitwarden_common/docker-compose.yml
+++ b/.devcontainer/bitwarden_common/docker-compose.yml
@@ -7,6 +7,9 @@ services:
       - ../../:/workspace:cached
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
+    ports:
+      - "1080:1080"
+      - "1025:1025"
 
   bitwarden_mssql:
     image: mcr.microsoft.com/mssql/server:2022-latest


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This PR adds the ports `1080` and `1025` to the `bitwarden_common/docker-compose.yml` file. Without these ports bound, developers could not previously access MailCatcher from the host system via the browser when running `server` from within a docker container.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
