### PR TITLE
[PM-6201] Self-Host Admin Portal is reporting "10239 GB of Additional…

### DIFF
--- a/src/Admin/AdminConsole/Views/Organizations/Index.cshtml
+++ b/src/Admin/AdminConsole/Views/Organizations/Index.cshtml
@@ -81,16 +81,8 @@
                                     <i class="fa fa-smile-o fa-lg fa-fw text-body-secondary" title="Freeloader"></i>
                                 }
                             }
-                            @if(org.MaxStorageGb.HasValue && org.MaxStorageGb > 1)
-                            {
-                                <i class="fa fa-plus-square fa-lg fa-fw"
-                                   title="Additional Storage, @(org.MaxStorageGb - 1) GB"></i>
-                            }
-                            else
-                            {
-                                <i class="fa fa-plus-square-o fa-lg fa-fw text-body-secondary"
-                                   title="No Additional Storage"></i>
-                            }
+                            <i class="fa fa-plus-square fa-lg fa-fw"
+                               title="Used Storage, @org.StorageGb GB"></i>
                             @if(org.Enabled)
                             {
                                 <i class="fa fa-check-circle fa-lg fa-fw"

--- a/src/Admin/AdminConsole/Views/Organizations/Index.cshtml
+++ b/src/Admin/AdminConsole/Views/Organizations/Index.cshtml
@@ -81,7 +81,7 @@
                                     <i class="fa fa-smile-o fa-lg fa-fw text-body-secondary" title="Freeloader"></i>
                                 }
                             }
-                            <i class="fa fa-plus-square fa-lg fa-fw"
+                            <i class="fa fa-hdd-o fa-lg fa-fw"
                                title="Used Storage, @org.StorageGb GB"></i>
                             @if(org.Enabled)
                             {

--- a/src/Core/AdminConsole/Entities/Organization.cs
+++ b/src/Core/AdminConsole/Entities/Organization.cs
@@ -181,6 +181,11 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable,
 
     public bool IsExpired() => ExpirationDate.HasValue && ExpirationDate.Value <= DateTime.UtcNow;
 
+    /// <summary>
+    /// Used storage in gigabytes.
+    /// </summary>
+    public double StorageGb => Storage.HasValue ? Math.Round(Storage.Value / 1073741824D, 2) : 0;
+
     public long StorageBytesRemaining()
     {
         if (!MaxStorageGb.HasValue)


### PR DESCRIPTION
… Storage" for each org.

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-6201

## 📔 Objective

We want to now display used storage instead for organizations. I've also changed the icon accordingly to what's available and relavant in Font Awesome v4.7.0.

## 📸 Screenshots

<img width="1188" alt="image" src="https://github.com/user-attachments/assets/e218b21f-976a-4584-ad61-440d4485cff2">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
