### PR TITLE
BRE-311 Fix the MsSqlMigratorUtility failing silently

### DIFF
--- a/util/MsSqlMigratorUtility/Program.cs
+++ b/util/MsSqlMigratorUtility/Program.cs
@@ -9,7 +9,7 @@ internal class Program
     }
 
     [DefaultCommand]
-    public void Execute(
+    public int Execute(
         [Operand(Description = "Database connection string")]
         string databaseConnectionString,
         [Option('r', "repeatable", Description = "Mark scripts as repeatable")]
@@ -20,7 +20,11 @@ internal class Program
         bool dryRun = false,
         [Option("no-transaction", Description = "Run without adding transaction per script or all scripts")]
         bool noTransactionMigration = false
-        ) => MigrateDatabase(databaseConnectionString, repeatable, folderName, dryRun, noTransactionMigration);
+        )
+        {
+            return MigrateDatabase(databaseConnectionString, repeatable, folderName, dryRun, noTransactionMigration) ? 0 : -1;
+        }
+
 
     private static bool MigrateDatabase(string databaseConnectionString,
         bool repeatable = false, string folderName = "", bool dryRun = false, bool noTransactionMigration = false)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/BRE-311

## 📔 Objective

The DB Migrator tool will sometimes fail applying a SQL migration script, but the job will report success in the workflow causing the rest of the workflow to execute.  When the migrator tool fails when applying a SQL migration script, it should fail the job and the workflow should reflect that accordingly.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
