### PR TITLE
Sign main branch container builds with cosign

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       security-events: write
+      id-token: write
     needs:
       - build-artifacts
     strategy:
@@ -276,6 +277,7 @@ jobs:
             -d ${{ matrix.base_path }}/${{ matrix.project_name }}/obj/build-output/publish
 
       - name: Build Docker image
+        id: build-docker
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           context: ${{ matrix.base_path }}/${{ matrix.project_name }}
@@ -285,6 +287,22 @@ jobs:
           tags: ${{ steps.image-tags.outputs.tags }}
           secrets: |
             "GH_PAT=${{ steps.retrieve-secret-pat.outputs.github-pat-bitwarden-devops-bot-repo-scope }}"
+
+      - name: Install Cosign
+        if: github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main'
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+
+      - name: Sign image with a key
+        if: github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main'
+        env:
+          TAGS: ${{ steps.image-tags.outputs.tags }}
+          DIGEST: ${{ steps.build-docker.outputs.digest }}
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign ${images}
 
       - name: Scan Docker image
         id: container-scan

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,17 +292,17 @@ jobs:
         if: github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main'
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
-      - name: Sign image with a key
+      - name: Sign images with Cosign
         if: github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main'
         env:
-          TAGS: ${{ steps.image-tags.outputs.tags }}
           DIGEST: ${{ steps.build-docker.outputs.digest }}
+          TAGS: ${{ steps.image-tags.outputs.tags }}
         run: |
           images=""
           for tag in ${TAGS}; do
             images+="${tag}@${DIGEST} "
           done
-          cosign sign ${images}
+          cosign sign --yes ${images}
 
       - name: Scan Docker image
         id: container-scan


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/VULN-130

## 📔 Objective

Signs container images built off `main` with [Cosign](https://github.com/sigstore/cosign). This uses Sigstore's in-house certificate authority with short-lived keys that are all self-managed with the tool, which will also utilize GitHub's provided OIDC entity. As part of an effort to increase transparency of what we build as an open source company, these signatures are also sent to [Rekor](https://search.sigstore.dev/) -- users of our images are then free to verify the images against that log.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
