### PR TITLE
[PM-15981] Rename access insights to access intelligence

### DIFF
--- a/src/Admin/AdminConsole/Views/Shared/_OrganizationForm.cshtml
+++ b/src/Admin/AdminConsole/Views/Shared/_OrganizationForm.cshtml
@@ -165,7 +165,7 @@
                 </div>
             </div>
             <div class="col-2">
-                <h3>Access Insights</h3>
+                <h3>Access Intelligence</h3>
                 <div class="form-check">
                     <input type="checkbox" class="form-check-input" asp-for="UseRiskInsights" disabled='@(canEditPlan ? null : "disabled")'>
                     <label class="form-check-label" asp-for="UseRiskInsights"></label>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13227

## 📔 Objective

Replace header "Access Insights" to "Access Intelligence"

## 📸 Screenshots

Old screen shot:
![image](https://github.com/user-attachments/assets/06180981-9088-421f-a457-10855031d3c3)

New screen shot:
![image](https://github.com/user-attachments/assets/666159ca-b724-4d8e-91eb-b10043227893)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
