### PR TITLE
[pm-5966] Fix Entity Framework query for MySQL

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/OrganizationDomainRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/OrganizationDomainRepository.cs
@@ -147,13 +147,13 @@ public class OrganizationDomainRepository : Repository<Core.Entities.Organizatio
         using var scope = ServiceScopeFactory.CreateScope();
         var dbContext = GetDatabaseContext(scope);
 
-        var unverifiedDomainsInLast72Hours = await dbContext.OrganizationDomains
-            .Where(x => x.CreationDate.Date >= DateTime.UtcNow.AddDays(-4).Date
+        var threeDaysOldUnverifiedDomains = await dbContext.OrganizationDomains
+            .Where(x => x.CreationDate.Date == DateTime.UtcNow.AddDays(-4).Date
                       && x.VerifiedDate == null)
             .AsNoTracking()
             .ToListAsync();
 
-        return Mapper.Map<List<Core.Entities.OrganizationDomain>>(unverifiedDomainsInLast72Hours);
+        return Mapper.Map<List<Core.Entities.OrganizationDomain>>(threeDaysOldUnverifiedDomains);
     }
 
     public async Task<bool> DeleteExpiredAsync(int expirationPeriod)

--- a/src/Infrastructure.EntityFramework/Repositories/OrganizationDomainRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/OrganizationDomainRepository.cs
@@ -147,14 +147,13 @@ public class OrganizationDomainRepository : Repository<Core.Entities.Organizatio
         using var scope = ServiceScopeFactory.CreateScope();
         var dbContext = GetDatabaseContext(scope);
 
-        //Get domains that have not been verified after 72 hours
-        var domains = await dbContext.OrganizationDomains
-            .Where(x => (DateTime.UtcNow - x.CreationDate).Days == 4
-                        && x.VerifiedDate == null)
+        var unverifiedDomainsInLast72Hours = await dbContext.OrganizationDomains
+            .Where(x => x.CreationDate.Date >= DateTime.UtcNow.AddDays(-4).Date
+                      && x.VerifiedDate == null)
             .AsNoTracking()
             .ToListAsync();
 
-        return Mapper.Map<List<Core.Entities.OrganizationDomain>>(domains);
+        return Mapper.Map<List<Core.Entities.OrganizationDomain>>(unverifiedDomainsInLast72Hours);
     }
 
     public async Task<bool> DeleteExpiredAsync(int expirationPeriod)

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationDomainRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationDomainRepositoryTests.cs
@@ -68,6 +68,49 @@ public class OrganizationDomainRepositoryTests
         Assert.NotNull(expectedDomain2);
     }
 
+    [DatabaseTheory, DatabaseData]
+    public async Task GetExpiredOrganizationDomainsAsync_ShouldReturnNotReturnDomainsPast72Hours(
+     IUserRepository userRepository,
+     IOrganizationRepository organizationRepository,
+     IOrganizationDomainRepository organizationDomainRepository)
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        var user = await userRepository.CreateAsync(new User
+        {
+            Name = "Test User",
+            Email = $"test+{id}@example.com",
+            ApiKey = "TEST",
+            SecurityStamp = "stamp",
+        });
+
+        var organization = await organizationRepository.CreateAsync(new Organization
+        {
+            Name = $"Test Org {id}",
+            BillingEmail = user.Email,
+            Plan = "Test",
+            PrivateKey = "privatekey",
+
+        });
+
+        var pastDateForValidation = DateTime.UtcNow.AddDays(-6).Date;
+        var organizationDomain = new OrganizationDomain
+        {
+            OrganizationId = organization.Id,
+            DomainName = $"domain{id}@example.com",
+            Txt = "btw+12345",
+            CreationDate = pastDateForValidation
+        };
+        await organizationDomainRepository.CreateAsync(organizationDomain);
+
+        // Act
+        var domains = await organizationDomainRepository.GetExpiredOrganizationDomainsAsync();
+
+        var expectedDomain2 = domains.FirstOrDefault(domain => domain.DomainName == organizationDomain.DomainName);
+        Assert.Null(expectedDomain2);
+    }
+
 
     [DatabaseTheory, DatabaseData]
     public async Task GetExpiredOrganizationDomainsAsync_ShouldNotReturnVerifiedDomains(

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationDomainRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationDomainRepositoryTests.cs
@@ -1,0 +1,136 @@
+﻿
+using Bit.Core.Repositories;
+using Bit.Infrastructure.EntityFramework.AdminConsole.Models;
+using Bit.Infrastructure.EntityFramework.Models;
+using Xunit;
+
+namespace Bit.Infrastructure.IntegrationTest.Repositories;
+
+public class OrganizationDomainRepositoryTests
+{
+    [DatabaseTheory, DatabaseData]
+    public async Task GetExpiredOrganizationDomainsAsync_ShouldReturnExpiredOrganizationDomains(
+     IUserRepository userRepository,
+     IOrganizationRepository organizationRepository,
+     IOrganizationDomainRepository organizationDomainRepository)
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        var user1 = await userRepository.CreateAsync(new User
+        {
+            Name = "Test User 1",
+            Email = $"test+{id}@example.com",
+            ApiKey = "TEST",
+            SecurityStamp = "stamp",
+        });
+
+        var organization1 = await organizationRepository.CreateAsync(new Organization
+        {
+            Name = $"Test Org {id}",
+            BillingEmail = user1.Email,
+            Plan = "Test",
+            PrivateKey = "privatekey",
+
+        });
+
+        var organizationDomain1 = new OrganizationDomain
+        {
+            OrganizationId = organization1.Id,
+            DomainName = $"domain2+{id}@example.com",
+            Txt = "btw+12345"
+        };
+        await organizationDomainRepository.CreateAsync(organizationDomain1);
+        var organization2 = await organizationRepository.CreateAsync(new Organization
+        {
+            Name = $"Test Org {id}",
+            BillingEmail = user1.Email,
+            Plan = "Test",
+            PrivateKey = "privatekey",
+
+        });
+        var organizationDomain2 = new OrganizationDomain
+        {
+            OrganizationId = organization2.Id,
+            DomainName = $"domain2+{id}@example.com",
+            Txt = "btw+12345"
+        };
+        await organizationDomainRepository.CreateAsync(organizationDomain2);
+
+        // Act
+        var domains = await organizationDomainRepository.GetExpiredOrganizationDomainsAsync();
+
+        // Assert
+        var expectedDomain1 = domains.FirstOrDefault(domain => domain.DomainName == organizationDomain1.DomainName);
+        Assert.NotNull(expectedDomain1);
+
+        var expectedDomain2 = domains.FirstOrDefault(domain => domain.DomainName == organizationDomain2.DomainName);
+        Assert.NotNull(expectedDomain2);
+    }
+
+
+    [DatabaseTheory, DatabaseData]
+    public async Task GetExpiredOrganizationDomainsAsync_ShouldNotReturnVerifiedDomains(
+     IUserRepository userRepository,
+     IOrganizationRepository organizationRepository,
+     IOrganizationDomainRepository organizationDomainRepository)
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        var user = await userRepository.CreateAsync(new User
+        {
+            Name = "Test User 1",
+            Email = $"test+{id}@example.com",
+            ApiKey = "TEST",
+            SecurityStamp = "stamp",
+        });
+
+        var organization1 = await organizationRepository.CreateAsync(new Organization
+        {
+            Name = $"Test Org {id}",
+            BillingEmail = user.Email,
+            Plan = "Test",
+            PrivateKey = "privatekey",
+
+        });
+
+        var organizationDomain1 = new OrganizationDomain
+        {
+            OrganizationId = organization1.Id,
+            DomainName = $"domain2+{id}@example.com",
+            Txt = "btw+12345"
+        };
+        organizationDomain1.SetVerifiedDate();
+
+        await organizationDomainRepository.CreateAsync(organizationDomain1);
+
+        var organization2 = await organizationRepository.CreateAsync(new Organization
+        {
+            Name = $"Test Org {id}",
+            BillingEmail = user.Email,
+            Plan = "Test",
+            PrivateKey = "privatekey",
+        });
+
+        var organizationDomain2 = new OrganizationDomain
+        {
+            OrganizationId = organization2.Id,
+            DomainName = $"domain2+{id}@example.com",
+            Txt = "btw+12345"
+        };
+        organizationDomain2.SetVerifiedDate();
+
+        await organizationDomainRepository.CreateAsync(organizationDomain2);
+
+        // Act
+        var domains = await organizationDomainRepository.GetExpiredOrganizationDomainsAsync();
+
+        // Assert
+        var expectedDomain1 = domains.FirstOrDefault(domain => domain.DomainName == organizationDomain1.DomainName);
+        Assert.Null(expectedDomain1);
+
+        var expectedDomain2 = domains.FirstOrDefault(domain => domain.DomainName == organizationDomain2.DomainName);
+        Assert.Null(expectedDomain2);
+    }
+}

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationDomainRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationDomainRepositoryTests.cs
@@ -107,6 +107,7 @@ public class OrganizationDomainRepositoryTests
         // Act
         var domains = await organizationDomainRepository.GetExpiredOrganizationDomainsAsync();
 
+        // Assert
         var expectedDomain2 = domains.FirstOrDefault(domain => domain.DomainName == organizationDomain.DomainName);
         Assert.Null(expectedDomain2);
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-5966

## 📔 Objective

Problem: The Entity Framework query was causing a compile-time error.

Changes:

1. Fixed the query.
2. Renamed the variable to replace the comment.

## 📸 Screenshots

Manual testing 

Generated SQL query.
![image](https://github.com/user-attachments/assets/ce2710ee-d439-4eb9-b6c7-47ae9bcda106)

With results

<img width="754" alt="image" src="https://github.com/user-attachments/assets/18a0e1de-99b7-4afa-921b-c03dabf2034f" />



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
