### PR TITLE
Renovate: Assign DbOps to Microsoft.Extensions.Caching.Cosmos

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -105,6 +105,7 @@
         "Microsoft.EntityFrameworkCore.Relational",
         "Microsoft.EntityFrameworkCore.Sqlite",
         "Microsoft.EntityFrameworkCore.SqlServer",
+        "Microsoft.Extensions.Caching.Cosmos",
         "Microsoft.Extensions.Caching.SqlServer",
         "Microsoft.Extensions.Caching.StackExchangeRedis",
         "Npgsql.EntityFrameworkCore.PostgreSQL",


### PR DESCRIPTION
## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Seeing that https://github.com/bitwarden/server/pull/4721 has no reviewer/owner attached I looked for an good owner. As Microsoft.Extensions.Caching.SqlServer is already assigned to DbOps, I opted to also assign them caching for Cosmos.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
