### PR TITLE
[PM-15808]Show suspended org modals for orgs in 'unpaid' & 'canceled' status

### DIFF
--- a/src/Api/Billing/Controllers/OrganizationBillingController.cs
+++ b/src/Api/Billing/Controllers/OrganizationBillingController.cs
@@ -1,7 +1,9 @@
 ﻿#nullable enable
+using Bit.Api.AdminConsole.Models.Request.Organizations;
 using Bit.Api.Billing.Models.Requests;
 using Bit.Api.Billing.Models.Responses;
 using Bit.Core;
+using Bit.Core.Billing.Models.Sales;
 using Bit.Core.Billing.Services;
 using Bit.Core.Context;
 using Bit.Core.Repositories;
@@ -21,7 +23,8 @@ public class OrganizationBillingController(
     IOrganizationRepository organizationRepository,
     IPaymentService paymentService,
     ISubscriberService subscriberService,
-    IPaymentHistoryService paymentHistoryService) : BaseBillingController
+    IPaymentHistoryService paymentHistoryService,
+    IUserService userService) : BaseBillingController
 {
     [HttpGet("metadata")]
     public async Task<IResult> GetMetadataAsync([FromRoute] Guid organizationId)
@@ -275,6 +278,38 @@ public class OrganizationBillingController(
         var taxInformation = requestBody.ToDomain();
 
         await subscriberService.UpdateTaxInformation(organization, taxInformation);
+
+        return TypedResults.Ok();
+    }
+
+    [HttpPost("restart-subscription")]
+    public async Task<IResult> RestartSubscriptionAsync([FromRoute] Guid organizationId, [FromBody] OrganizationCreateRequestModel model)
+    {
+        var user = await userService.GetUserByPrincipalAsync(User);
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
+        if (!featureService.IsEnabled(FeatureFlagKeys.AC2476_DeprecateStripeSourcesAPI))
+        {
+            return Error.NotFound();
+        }
+
+        if (!await currentContext.EditPaymentMethods(organizationId))
+        {
+            return Error.Unauthorized();
+        }
+
+        var organization = await organizationRepository.GetByIdAsync(organizationId);
+
+        if (organization == null)
+        {
+            return Error.NotFound();
+        }
+        var organizationSignup = model.ToOrganizationSignup(user);
+        var sale = OrganizationSale.From(organization, organizationSignup);
+        await organizationBillingService.Finalize(sale);
 
         return TypedResults.Ok();
     }

--- a/src/Api/Billing/Models/Responses/OrganizationMetadataResponse.cs
+++ b/src/Api/Billing/Models/Responses/OrganizationMetadataResponse.cs
@@ -7,7 +7,8 @@ public record OrganizationMetadataResponse(
     bool IsManaged,
     bool IsOnSecretsManagerStandalone,
     bool IsSubscriptionUnpaid,
-    bool HasSubscription)
+    bool HasSubscription,
+    bool IsSubscriptionCanceled)
 {
     public static OrganizationMetadataResponse From(OrganizationMetadata metadata)
         => new(
@@ -15,5 +16,6 @@ public record OrganizationMetadataResponse(
             metadata.IsManaged,
             metadata.IsOnSecretsManagerStandalone,
             metadata.IsSubscriptionUnpaid,
-            metadata.HasSubscription);
+            metadata.HasSubscription,
+            metadata.IsSubscriptionCanceled);
 }

--- a/src/Core/Billing/Models/OrganizationMetadata.cs
+++ b/src/Core/Billing/Models/OrganizationMetadata.cs
@@ -5,4 +5,5 @@ public record OrganizationMetadata(
     bool IsManaged,
     bool IsOnSecretsManagerStandalone,
     bool IsSubscriptionUnpaid,
-    bool HasSubscription);
+    bool HasSubscription,
+    bool IsSubscriptionCanceled);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-15808

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
display a modal (see figma)

there will be different versions of the modal depending on the user role and whether the organization is independent, MSP managed, or reseller managed.

For the independent org Owner

when subscription is in unpaid, keep the existing flow where they see the notice, and then they are taken to the payment method section of the admin console.

when the subscription is in canceled, then we show them the upgrade path UI.

we show them the current equivalent to their previous subscription. So, if they were on a Family, we show them Family, if they were on Enterprise 2019, we show them CURRENT Enterprise.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Uploading Screen Recording 2024-12-20 at 16.55.32.mov…

<img width="1728" alt="Screenshot 2024-12-20 at 16 53 28" src="https://github.com/user-attachments/assets/30d80f2c-629d-4f03-9834-72e511f2cf2f" />

Uploading Screen Recording 2024-12-20 at 16.56.47.mov…

Uploading Screen Recording 2024-12-20 at 17.09.00.mov…



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes

Uploading Screen Recording 2024-12-20 at 17.09.00.mov…

