### PR TITLE
[PM-15814]Alert owners of reseller-managed orgs to renewal events

### DIFF
--- a/src/Api/Billing/Models/Responses/OrganizationMetadataResponse.cs
+++ b/src/Api/Billing/Models/Responses/OrganizationMetadataResponse.cs
@@ -7,7 +7,11 @@ public record OrganizationMetadataResponse(
     bool IsManaged,
     bool IsOnSecretsManagerStandalone,
     bool IsSubscriptionUnpaid,
-    bool HasSubscription)
+    bool HasSubscription,
+    bool HasOpenInvoice,
+    DateTime? InvoiceDueDate,
+    DateTime? InvoiceCreatedDate,
+    DateTime? SubPeriodEndDate)
 {
     public static OrganizationMetadataResponse From(OrganizationMetadata metadata)
         => new(
@@ -15,5 +19,9 @@ public record OrganizationMetadataResponse(
             metadata.IsManaged,
             metadata.IsOnSecretsManagerStandalone,
             metadata.IsSubscriptionUnpaid,
-            metadata.HasSubscription);
+            metadata.HasSubscription,
+            metadata.HasOpenInvoice,
+            metadata.InvoiceDueDate,
+            metadata.InvoiceCreatedDate,
+            metadata.SubPeriodEndDate);
 }

--- a/src/Core/Billing/Models/OrganizationMetadata.cs
+++ b/src/Core/Billing/Models/OrganizationMetadata.cs
@@ -5,4 +5,8 @@ public record OrganizationMetadata(
     bool IsManaged,
     bool IsOnSecretsManagerStandalone,
     bool IsSubscriptionUnpaid,
-    bool HasSubscription);
+    bool HasSubscription,
+    bool HasOpenInvoice,
+    DateTime? InvoiceDueDate,
+    DateTime? InvoiceCreatedDate,
+    DateTime? SubPeriodEndDate);

--- a/src/Core/Billing/Services/Implementations/OrganizationBillingService.cs
+++ b/src/Core/Billing/Services/Implementations/OrganizationBillingService.cs
@@ -83,7 +83,7 @@ public class OrganizationBillingService(
         var hasOpenInvoice = openInvoice.HasOpenInvoice;
         var invoiceDueDate = openInvoice.DueDate;
         var invoiceCreatedDate = openInvoice.CreatedDate;
-        var subPeriodEndDate = subscription.CurrentPeriodEnd;
+        var subPeriodEndDate = subscription?.CurrentPeriodEnd;
 
         return new OrganizationMetadata(isEligibleForSelfHost, isManaged, isOnSecretsManagerStandalone,
             isSubscriptionUnpaid, hasSubscription, hasOpenInvoice, invoiceDueDate, invoiceCreatedDate, subPeriodEndDate);

--- a/src/Core/Billing/Services/Implementations/OrganizationBillingService.cs
+++ b/src/Core/Billing/Services/Implementations/OrganizationBillingService.cs
@@ -68,19 +68,25 @@ public class OrganizationBillingService(
         if (string.IsNullOrWhiteSpace(organization.GatewaySubscriptionId))
         {
             return new OrganizationMetadata(isEligibleForSelfHost, isManaged, false,
-                false, false);
+                false, false, false, null, null, null);
         }
 
         var customer = await subscriberService.GetCustomer(organization,
             new CustomerGetOptions { Expand = ["discount.coupon.applies_to"] });
 
         var subscription = await subscriberService.GetSubscription(organization);
+
         var isOnSecretsManagerStandalone = IsOnSecretsManagerStandalone(organization, customer, subscription);
         var isSubscriptionUnpaid = IsSubscriptionUnpaid(subscription);
         var hasSubscription = true;
+        var openInvoice = await HasOpenInvoiceAsync(subscription);
+        var hasOpenInvoice = openInvoice.HasOpenInvoice;
+        var invoiceDueDate = openInvoice.DueDate;
+        var invoiceCreatedDate = openInvoice.CreatedDate;
+        var subPeriodEndDate = subscription.CurrentPeriodEnd;
 
         return new OrganizationMetadata(isEligibleForSelfHost, isManaged, isOnSecretsManagerStandalone,
-            isSubscriptionUnpaid, hasSubscription);
+            isSubscriptionUnpaid, hasSubscription, hasOpenInvoice, invoiceDueDate, invoiceCreatedDate, subPeriodEndDate);
     }
 
     public async Task UpdatePaymentMethod(
@@ -393,6 +399,18 @@ public class OrganizationBillingService(
         return subscription.Status == "unpaid";
     }
 
+    private async Task<(bool HasOpenInvoice, DateTime? CreatedDate, DateTime? DueDate)> HasOpenInvoiceAsync(Subscription subscription)
+    {
+        if (subscription?.LatestInvoiceId == null)
+        {
+            return (false, null, null);
+        }
 
+        var invoice = await stripeAdapter.InvoiceGetAsync(subscription.LatestInvoiceId, new InvoiceGetOptions());
+
+        return invoice?.Status == "open"
+            ? (true, invoice.Created, invoice.DueDate)
+            : (false, null, null);
+    }
     #endregion
 }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -163,6 +163,7 @@ public static class FeatureFlagKeys
     public const string AuthenticatorSynciOS = "enable-authenticator-sync-ios";
     public const string AuthenticatorSyncAndroid = "enable-authenticator-sync-android";
     public const string AppReviewPrompt = "app-review-prompt";
+    public const string ResellerManagedOrgAlert = "PM-15814-alert-owners-of-reseller-managed-orgs";
 
     public static List<string> GetAllKeys()
     {

--- a/test/Api.Test/Billing/Controllers/OrganizationBillingControllerTests.cs
+++ b/test/Api.Test/Billing/Controllers/OrganizationBillingControllerTests.cs
@@ -52,7 +52,7 @@ public class OrganizationBillingControllerTests
     {
         sutProvider.GetDependency<ICurrentContext>().OrganizationUser(organizationId).Returns(true);
         sutProvider.GetDependency<IOrganizationBillingService>().GetMetadata(organizationId)
-            .Returns(new OrganizationMetadata(true, true, true, true, true));
+            .Returns(new OrganizationMetadata(true, true, true, true, true, true, null, null, null));
 
         var result = await sutProvider.Sut.GetMetadataAsync(organizationId);
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-15814
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Organizations that are managed by a reseller have a higher probability of churning. This happens because of a breakdown in communication around renewal dates. 

the managed org does not have visibility into when their renewal date is, because their billing is managed by the reseller. Without knowing their renewal date, the managed org cannot issue a purchase order to their reseller.

the reseller does not respond to invoices from Bitwarden because they do not include a purchase order number matching one from a customer of theirs (the managed org). 

the first indication the managed org has that something has gone wrong is when the organization is suspended. This happens 30 days after the automatic invoice we send to the reseller is marked as unpaid, which is usually 45 days after it was issued (resellers get net-45 by default).

To help prevent this issue, we will show in-product messaging to owners of reseller-managed organizations, alerting them that their renewal date is upcoming, and to reach out to their reseller to insure uninterrupted service.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="1728" alt="Screenshot 2024-12-27 at 18 24 16" src="https://github.com/user-attachments/assets/72692122-4be1-4b01-bdc1-5fca53461fda" />
<img width="1728" alt="Screenshot 2024-12-27 at 22 21 32" src="https://github.com/user-attachments/assets/cff45a53-1f1a-4393-ad10-b528d2d3c706" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
