### PR TITLE
PM-16170 removing deprecated send file endpoint

### DIFF
--- a/src/Api/Tools/Controllers/SendsController.cs
+++ b/src/Api/Tools/Controllers/SendsController.cs
@@ -9,7 +9,6 @@ using Bit.Core.Context;
 using Bit.Core.Exceptions;
 using Bit.Core.Services;
 using Bit.Core.Settings;
-using Bit.Core.Tools.Entities;
 using Bit.Core.Tools.Enums;
 using Bit.Core.Tools.Models.Data;
 using Bit.Core.Tools.Repositories;
@@ -162,32 +161,6 @@ public class SendsController : Controller
         await _sendService.SaveSendAsync(send);
         return new SendResponseModel(send, _globalSettings);
     }
-
-    [HttpPost("file")]
-    [Obsolete("Deprecated File Send API", false)]
-    [RequestSizeLimit(Constants.FileSize101mb)]
-    [DisableFormValueModelBinding]
-    public async Task<SendResponseModel> PostFile()
-    {
-        if (!Request?.ContentType.Contains("multipart/") ?? true)
-        {
-            throw new BadRequestException("Invalid content.");
-        }
-
-        Send send = null;
-        await Request.GetSendFileAsync(async (stream, fileName, model) =>
-        {
-            model.ValidateCreation();
-            var userId = _userService.GetProperUserId(User).Value;
-            var (madeSend, madeData) = model.ToSend(userId, fileName, _sendService);
-            send = madeSend;
-            await _sendService.SaveFileSendAsync(send, madeData, model.FileLength.GetValueOrDefault(0));
-            await _sendService.UploadFileToExistingSendAsync(stream, send);
-        });
-
-        return new SendResponseModel(send, _globalSettings);
-    }
-
 
     [HttpPost("file/v2")]
     public async Task<SendFileUploadDataResponseModel> PostFile([FromBody] SendRequestModel model)


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/jira/software/c/projects/BW/boards/92?selectedIssue=PM-16170

## 📔 Objective

Within server there’s a deprecated endpoint for uploading files to a Bitwarden Send (SendsController). This endpoint can be removed. In addition any backwards compatible logic on the client-side (send-api.service) can also be removed.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
