### PR TITLE
Provide new feature flag context for devices

### DIFF
--- a/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
+++ b/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
@@ -16,6 +16,7 @@ public class LaunchDarklyFeatureService : IFeatureService
     private readonly ICurrentContext _currentContext;
     private const string _anonymousUser = "25a15cac-58cf-4ac0-ad0f-b17c4bd92294";
 
+    private const string _contextKindDevice = "device";
     private const string _contextKindOrganization = "organization";
     private const string _contextKindServiceAccount = "service-account";
 
@@ -157,6 +158,16 @@ public class LaunchDarklyFeatureService : IFeatureService
         }
 
         var builder = LaunchDarkly.Sdk.Context.MultiBuilder();
+
+        if (!string.IsNullOrWhiteSpace(_currentContext.DeviceIdentifier))
+        {
+            var ldDevice = LaunchDarkly.Sdk.Context.Builder(_currentContext.DeviceIdentifier);
+
+            ldDevice.Kind(_contextKindDevice);
+            SetCommonContextAttributes(ldDevice);
+
+            builder.Add(ldDevice.Build());
+        }
 
         switch (_currentContext.IdentityClientType)
         {

--- a/test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs
+++ b/test/Core.Test/Services/LaunchDarklyFeatureServiceTests.cs
@@ -22,6 +22,7 @@ public class LaunchDarklyFeatureServiceTests
         globalSettings.ProjectName = "LaunchDarkly Tests";
 
         var currentContext = Substitute.For<ICurrentContext>();
+        currentContext.DeviceIdentifier.Returns(Guid.NewGuid().ToString());
         currentContext.UserId.Returns(Guid.NewGuid());
         currentContext.ClientVersion.Returns(new Version(AssemblyHelpers.GetVersion()));
         currentContext.ClientVersionIsPrerelease.Returns(true);


### PR DESCRIPTION
## 🎟️ Tracking

Via Slack conversations.

## 📔 Objective

Adds a new context "kind" in LD for devices. When a device identifier is present, add the context so that targeting can be used against it -- this is needed for when a user has yet to be established so that context will not be available for anything other than the anonymous catch-all user.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
