### PR TITLE
chore: expand tests of the new `UpdateInstallationCommand`

### DIFF
--- a/test/Core.Test/Platform/Installations/Commands/UpdateInstallationCommandTests.cs
+++ b/test/Core.Test/Platform/Installations/Commands/UpdateInstallationCommandTests.cs
@@ -11,6 +11,49 @@ public class UpdateInstallationCommandTests
 {
     [Theory]
     [BitAutoData]
+    public async Task UpdateLastActivityDateAsync_WithDefaultGuid_ThrowsException(SutProvider<UpdateInstallationCommand> sutProvider)
+    {
+        // Arrange
+        var defaultGuid = default(Guid);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<Exception>(
+            () => sutProvider.Sut.UpdateLastActivityDateAsync(defaultGuid));
+
+        Assert.Contains("invalid installation id", exception.Message);
+
+        await sutProvider
+            .GetDependency<IInstallationRepository>()
+            .DidNotReceive()
+            .UpsertAsync(Arg.Any<Installation>());
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task UpdateLastActivityDateAsync_WithNonExistentInstallation_ThrowsException(
+        Guid installationId,
+        SutProvider<UpdateInstallationCommand> sutProvider)
+    {
+        // Arrange
+        sutProvider
+            .GetDependency<IGetInstallationQuery>()
+            .GetByIdAsync(installationId)
+            .Returns((Installation)null);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<Exception>(
+            () => sutProvider.Sut.UpdateLastActivityDateAsync(installationId));
+
+        Assert.Contains("no installation was found", exception.Message);
+
+        await sutProvider
+            .GetDependency<IInstallationRepository>()
+            .DidNotReceive()
+            .UpsertAsync(Arg.Any<Installation>());
+    }
+
+    [Theory]
+    [BitAutoData]
     public async Task UpdateLastActivityDateAsync_ShouldUpdateLastActivityDate(
         Installation installation
     )


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11129

## 📔 Objective

Add some more tests to the new `UpdateInstallationCommand` class. Happy path
tests already existed, and this just adds some simple ones for covering error
states.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes