### PR TITLE
[PM-15808]Show suspended org modals for orgs in 'unpaid' & 'canceled' status

### DIFF
--- a/src/Api/Billing/Controllers/OrganizationBillingController.cs
+++ b/src/Api/Billing/Controllers/OrganizationBillingController.cs
@@ -1,7 +1,9 @@
 ﻿#nullable enable
+using Bit.Api.AdminConsole.Models.Request.Organizations;
 using Bit.Api.Billing.Models.Requests;
 using Bit.Api.Billing.Models.Responses;
 using Bit.Core;
+using Bit.Core.Billing.Models.Sales;
 using Bit.Core.Billing.Services;
 using Bit.Core.Context;
 using Bit.Core.Repositories;
@@ -21,7 +23,8 @@ public class OrganizationBillingController(
     IOrganizationRepository organizationRepository,
     IPaymentService paymentService,
     ISubscriberService subscriberService,
-    IPaymentHistoryService paymentHistoryService) : BaseBillingController
+    IPaymentHistoryService paymentHistoryService,
+    IUserService userService) : BaseBillingController
 {
     [HttpGet("metadata")]
     public async Task<IResult> GetMetadataAsync([FromRoute] Guid organizationId)
@@ -275,6 +278,39 @@ public class OrganizationBillingController(
         var taxInformation = requestBody.ToDomain();
 
         await subscriberService.UpdateTaxInformation(organization, taxInformation);
+
+        return TypedResults.Ok();
+    }
+
+    [HttpPost("restart-subscription")]
+    public async Task<IResult> RestartSubscriptionAsync([FromRoute] Guid organizationId,
+        [FromBody] OrganizationCreateRequestModel model)
+    {
+        var user = await userService.GetUserByPrincipalAsync(User);
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
+        if (!featureService.IsEnabled(FeatureFlagKeys.AC2476_DeprecateStripeSourcesAPI))
+        {
+            return Error.NotFound();
+        }
+
+        if (!await currentContext.EditPaymentMethods(organizationId))
+        {
+            return Error.Unauthorized();
+        }
+
+        var organization = await organizationRepository.GetByIdAsync(organizationId);
+
+        if (organization == null)
+        {
+            return Error.NotFound();
+        }
+        var organizationSignup = model.ToOrganizationSignup(user);
+        var sale = OrganizationSale.From(organization, organizationSignup);
+        await organizationBillingService.Finalize(sale);
 
         return TypedResults.Ok();
     }

--- a/src/Api/Billing/Models/Responses/OrganizationMetadataResponse.cs
+++ b/src/Api/Billing/Models/Responses/OrganizationMetadataResponse.cs
@@ -9,6 +9,7 @@ public record OrganizationMetadataResponse(
     bool IsSubscriptionUnpaid,
     bool HasSubscription,
     bool HasOpenInvoice,
+    bool IsSubscriptionCanceled,
     DateTime? InvoiceDueDate,
     DateTime? InvoiceCreatedDate,
     DateTime? SubPeriodEndDate)
@@ -21,6 +22,7 @@ public record OrganizationMetadataResponse(
             metadata.IsSubscriptionUnpaid,
             metadata.HasSubscription,
             metadata.HasOpenInvoice,
+            metadata.IsSubscriptionCanceled,
             metadata.InvoiceDueDate,
             metadata.InvoiceCreatedDate,
             metadata.SubPeriodEndDate);

--- a/src/Core/Billing/Models/OrganizationMetadata.cs
+++ b/src/Core/Billing/Models/OrganizationMetadata.cs
@@ -7,6 +7,7 @@ public record OrganizationMetadata(
     bool IsSubscriptionUnpaid,
     bool HasSubscription,
     bool HasOpenInvoice,
+    bool IsSubscriptionCanceled,
     DateTime? InvoiceDueDate,
     DateTime? InvoiceCreatedDate,
     DateTime? SubPeriodEndDate);

--- a/src/Core/Billing/Services/Implementations/OrganizationBillingService.cs
+++ b/src/Core/Billing/Services/Implementations/OrganizationBillingService.cs
@@ -29,7 +29,9 @@ public class OrganizationBillingService(
     ISetupIntentCache setupIntentCache,
     IStripeAdapter stripeAdapter,
     ISubscriberService subscriberService,
-    ITaxService taxService) : IOrganizationBillingService
+    ITaxService taxService,
+    IPaymentService paymentService,
+    IFeatureService featureService) : IOrganizationBillingService
 {
     public async Task Finalize(OrganizationSale sale)
     {
@@ -69,7 +71,7 @@ public class OrganizationBillingService(
         if (string.IsNullOrWhiteSpace(organization.GatewaySubscriptionId))
         {
             return new OrganizationMetadata(isEligibleForSelfHost, isManaged, false,
-                false, false, false, null, null, null);
+                false, false, false, false, null, null, null);
         }
 
         var customer = await subscriberService.GetCustomer(organization,
@@ -79,6 +81,7 @@ public class OrganizationBillingService(
 
         var isOnSecretsManagerStandalone = IsOnSecretsManagerStandalone(organization, customer, subscription);
         var isSubscriptionUnpaid = IsSubscriptionUnpaid(subscription);
+        var isSubscriptionCanceled = IsSubscriptionCanceled(subscription);
         var hasSubscription = true;
         var openInvoice = await HasOpenInvoiceAsync(subscription);
         var hasOpenInvoice = openInvoice.HasOpenInvoice;
@@ -87,7 +90,7 @@ public class OrganizationBillingService(
         var subPeriodEndDate = subscription?.CurrentPeriodEnd;
 
         return new OrganizationMetadata(isEligibleForSelfHost, isManaged, isOnSecretsManagerStandalone,
-            isSubscriptionUnpaid, hasSubscription, hasOpenInvoice, invoiceDueDate, invoiceCreatedDate, subPeriodEndDate);
+            isSubscriptionUnpaid, hasSubscription, hasOpenInvoice, isSubscriptionCanceled, invoiceDueDate, invoiceCreatedDate, subPeriodEndDate);
     }
 
     public async Task UpdatePaymentMethod(
@@ -436,6 +439,16 @@ public class OrganizationBillingService(
         return invoice?.Status == "open"
             ? (true, invoice.Created, invoice.DueDate)
             : (false, null, null);
+    }
+
+    private static bool IsSubscriptionCanceled(Subscription subscription)
+    {
+        if (subscription == null)
+        {
+            return false;
+        }
+
+        return subscription.Status == "canceled";
     }
     #endregion
 }

--- a/src/Core/Billing/Services/Implementations/OrganizationBillingService.cs
+++ b/src/Core/Billing/Services/Implementations/OrganizationBillingService.cs
@@ -29,9 +29,7 @@ public class OrganizationBillingService(
     ISetupIntentCache setupIntentCache,
     IStripeAdapter stripeAdapter,
     ISubscriberService subscriberService,
-    ITaxService taxService,
-    IPaymentService paymentService,
-    IFeatureService featureService) : IOrganizationBillingService
+    ITaxService taxService) : IOrganizationBillingService
 {
     public async Task Finalize(OrganizationSale sale)
     {

--- a/test/Api.Test/Billing/Controllers/OrganizationBillingControllerTests.cs
+++ b/test/Api.Test/Billing/Controllers/OrganizationBillingControllerTests.cs
@@ -52,7 +52,7 @@ public class OrganizationBillingControllerTests
     {
         sutProvider.GetDependency<ICurrentContext>().OrganizationUser(organizationId).Returns(true);
         sutProvider.GetDependency<IOrganizationBillingService>().GetMetadata(organizationId)
-            .Returns(new OrganizationMetadata(true, true, true, true, true, true, null, null, null));
+            .Returns(new OrganizationMetadata(true, true, true, true, true, true, true, null, null, null));
 
         var result = await sutProvider.Sut.GetMetadataAsync(organizationId);
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
https://bitwarden.atlassian.net/browse/PM-15808
display a modal (see figma)

there will be different versions of the modal depending on the user role and whether the organization is independent, MSP managed, or reseller managed.

For the independent org Owner

when subscription is in unpaid, keep the existing flow where they see the notice, and then they are taken to the payment method section of the admin console.

when the subscription is in canceled, then we show them the upgrade path UI.

we show them the current equivalent to their previous subscription. So, if they were on a Family, we show them Family, if they were on Enterprise 2019, we show them CURRENT Enterprise.

Uploading Screen Recording 2024-12-20 at 16.56.47.mov…


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/05adfd3b-528d-4034-9330-6e3c1fb3d9ed


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
