### PR TITLE
[PM-10319] - Revoke Non-Compliant 2FA Users

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyValidators/TwoFactorAuthenticationPolicyValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyValidators/TwoFactorAuthenticationPolicyValidator.cs
@@ -87,16 +87,23 @@ public class TwoFactorAuthenticationPolicyValidator : IPolicyValidator
             return;
         }
 
-        var organizationUsersTwoFactorEnabled =
+        var revocableUsersWithTwoFactorStatus =
             await _twoFactorIsEnabledQuery.TwoFactorIsEnabledAsync(currentActiveRevocableOrganizationUsers);
 
-        if (NonCompliantMembersWillLoseAccess(currentActiveRevocableOrganizationUsers, organizationUsersTwoFactorEnabled))
+        var nonCompliantUsers = revocableUsersWithTwoFactorStatus.Where(x => !x.twoFactorIsEnabled);
+
+        if (!nonCompliantUsers.Any())
+        {
+            return;
+        }
+
+        if (MembersWithNoMasterPasswordWillLoseAccess(currentActiveRevocableOrganizationUsers, nonCompliantUsers))
         {
             throw new BadRequestException(NonCompliantMembersWillLoseAccessMessage);
         }
 
         var commandResult = await _revokeNonCompliantOrganizationUserCommand.RevokeNonCompliantOrganizationUsersAsync(
-            new RevokeOrganizationUsersRequest(organizationId, currentActiveRevocableOrganizationUsers, performedBy));
+            new RevokeOrganizationUsersRequest(organizationId, nonCompliantUsers.Select(x => x.user), performedBy));
 
         if (commandResult.HasErrors)
         {
@@ -141,7 +148,7 @@ public class TwoFactorAuthenticationPolicyValidator : IPolicyValidator
         }
     }
 
-    private static bool NonCompliantMembersWillLoseAccess(
+    private static bool MembersWithNoMasterPasswordWillLoseAccess(
         IEnumerable<OrganizationUserUserDetails> orgUserDetails,
         IEnumerable<(OrganizationUserUserDetails user, bool isTwoFactorEnabled)> organizationUsersTwoFactorEnabled) =>
             orgUserDetails.Any(x =>

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyValidators/TwoFactorAuthenticationPolicyValidatorTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyValidators/TwoFactorAuthenticationPolicyValidatorTests.cs
@@ -336,7 +336,7 @@ public class TwoFactorAuthenticationPolicyValidatorTests
             .TwoFactorIsEnabledAsync(Arg.Any<IEnumerable<OrganizationUserUserDetails>>())
             .Returns(new List<(OrganizationUserUserDetails user, bool hasTwoFactor)>()
             {
-                (orgUserDetailUserWithout2Fa, true),
+                (orgUserDetailUserWithout2Fa, false)
             });
 
         sutProvider.GetDependency<IRevokeNonCompliantOrganizationUserCommand>()


### PR DESCRIPTION
## 🎟️ Tracking
[PM-10319](https://bitwarden.atlassian.net/browse/PM-10319)

## 📔 Objective
This fixes a bug where all non-admin and non-owner users are revoked when 2FA is enabled. Now, users who do not have 2FA enabled will be revoked when the policy is turned on.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
