### PR TITLE
Auth/PM-16947 - Device Management - Adjust Device + pending auth request get query

### DIFF
--- a/src/Sql/Auth/dbo/Stored Procedures/Device_ReadActiveWithPendingAuthRequestsByUserId.sql
+++ b/src/Sql/Auth/dbo/Stored Procedures/Device_ReadActiveWithPendingAuthRequestsByUserId.sql
@@ -13,6 +13,7 @@ BEGIN
              LEFT JOIN (
         SELECT TOP 1 -- Take only the top record sorted by auth request creation date
                      Id,
+                     UserId,
                      CreationDate,
                      RequestDeviceIdentifier
         FROM dbo.AuthRequestView

--- a/src/Sql/Auth/dbo/Stored Procedures/Device_ReadActiveWithPendingAuthRequestsByUserId.sql
+++ b/src/Sql/Auth/dbo/Stored Procedures/Device_ReadActiveWithPendingAuthRequestsByUserId.sql
@@ -20,8 +20,9 @@ BEGIN
         WHERE Type IN (0, 1) -- Include only AuthenticateAndUnlock and Unlock types, excluding Admin Approval (type 2)
           AND CreationDate >= DATEADD(MINUTE, -@ExpirationMinutes, GETUTCDATE()) -- Ensure the request hasn't expired
           AND Approved IS NULL -- Include only requests that haven't been acknowledged or approved
+          AND UserId = @UserId
         ORDER BY CreationDate DESC
-    ) AR ON D.Identifier = AR.RequestDeviceIdentifier AND D.UserId = AR.UserId
+    ) AR ON D.Identifier = AR.RequestDeviceIdentifier
     WHERE
         D.UserId = @UserId
       AND D.Active = 1; -- Include only active devices

--- a/src/Sql/Auth/dbo/Stored Procedures/Device_ReadActiveWithPendingAuthRequestsByUserId.sql
+++ b/src/Sql/Auth/dbo/Stored Procedures/Device_ReadActiveWithPendingAuthRequestsByUserId.sql
@@ -19,7 +19,7 @@ BEGIN
             ROW_NUMBER() OVER (PARTITION BY RequestDeviceIdentifier ORDER BY CreationDate DESC) as rn
         FROM dbo.AuthRequestView
         WHERE Type IN (0, 1)  -- AuthenticateAndUnlock and Unlock types only
-            AND CreationDate >= DATEADD(MINUTE, @ExpirationMinutes, GETUTCDATE()) -- Ensure the request hasn't expired
+            AND CreationDate >= DATEADD(MINUTE, -@ExpirationMinutes, GETUTCDATE()) -- Ensure the request hasn't expired
             AND UserId = @UserId --  Requests for this user only
     ) AR -- This join will get the most recent request per device, regardless of approval status 
     ON D.Identifier = AR.RequestDeviceIdentifier AND AR.rn = 1 AND AR.Approved IS NULL  -- Get only the most recent unapproved request per device

--- a/src/Sql/Auth/dbo/Stored Procedures/Device_ReadActiveWithPendingAuthRequestsByUserId.sql
+++ b/src/Sql/Auth/dbo/Stored Procedures/Device_ReadActiveWithPendingAuthRequestsByUserId.sql
@@ -15,13 +15,14 @@ BEGIN
             Id,
             CreationDate,
             RequestDeviceIdentifier,
+            Approved,
             ROW_NUMBER() OVER (PARTITION BY RequestDeviceIdentifier ORDER BY CreationDate DESC) as rn
         FROM dbo.AuthRequestView
         WHERE Type IN (0, 1)  -- AuthenticateAndUnlock and Unlock types only
             AND CreationDate >= DATEADD(MINUTE, @ExpirationMinutes, GETUTCDATE()) -- Ensure the request hasn't expired
-            AND Approved IS NULL  -- Pending requests only
             AND UserId = @UserId --  Requests for this user only
-    ) AR ON D.Identifier = AR.RequestDeviceIdentifier AND AR.rn = 1  -- Get only the most recent request per device
+    ) AR -- This join will get the most recent request per device, regardless of approval status 
+    ON D.Identifier = AR.RequestDeviceIdentifier AND AR.rn = 1 AND AR.Approved = 0  -- Get only the most recent unapproved request per device
     WHERE
         D.UserId = @UserId -- Include only devices for this user
       AND D.Active = 1; -- Include only active devices

--- a/src/Sql/Auth/dbo/Stored Procedures/Device_ReadActiveWithPendingAuthRequestsByUserId.sql
+++ b/src/Sql/Auth/dbo/Stored Procedures/Device_ReadActiveWithPendingAuthRequestsByUserId.sql
@@ -10,20 +10,20 @@ BEGIN
         AR.Id as AuthRequestId,
         AR.CreationDate as AuthRequestCreationDate
     FROM dbo.DeviceView D
-             LEFT JOIN (
-        SELECT TOP 1 -- Take only the top record sorted by auth request creation date
-                     Id,
-                     UserId,
-                     CreationDate,
-                     RequestDeviceIdentifier
+    LEFT JOIN (
+        SELECT 
+            Id,
+            CreationDate,
+            RequestDeviceIdentifier,
+            ROW_NUMBER() OVER (PARTITION BY RequestDeviceIdentifier ORDER BY CreationDate DESC) as rn
         FROM dbo.AuthRequestView
-        WHERE Type IN (0, 1) -- Include only AuthenticateAndUnlock and Unlock types, excluding Admin Approval (type 2)
-          AND CreationDate >= DATEADD(MINUTE, -@ExpirationMinutes, GETUTCDATE()) -- Ensure the request hasn't expired
-          AND Approved IS NULL -- Include only requests that haven't been acknowledged or approved
-          AND UserId = @UserId
-        ORDER BY CreationDate DESC
-    ) AR ON D.Identifier = AR.RequestDeviceIdentifier
+        WHERE Type IN (0, 1)  -- AuthenticateAndUnlock and Unlock types only
+            AND CreationDate >= DATEADD(MINUTE, @ExpirationMinutes, GETUTCDATE()) -- Ensure the request hasn't expired
+            AND Approved IS NULL  -- Pending requests only
+            AND UserId = @UserId --  Requests for this user only
+    ) AR ON D.Identifier = AR.RequestDeviceIdentifier AND AR.rn = 1  -- Get only the most recent request per device
     WHERE
-        D.UserId = @UserId
+        D.UserId = @UserId -- Include only devices for this user
       AND D.Active = 1; -- Include only active devices
 END;
+

--- a/src/Sql/Auth/dbo/Stored Procedures/Device_ReadActiveWithPendingAuthRequestsByUserId.sql
+++ b/src/Sql/Auth/dbo/Stored Procedures/Device_ReadActiveWithPendingAuthRequestsByUserId.sql
@@ -22,7 +22,7 @@ BEGIN
             AND CreationDate >= DATEADD(MINUTE, @ExpirationMinutes, GETUTCDATE()) -- Ensure the request hasn't expired
             AND UserId = @UserId --  Requests for this user only
     ) AR -- This join will get the most recent request per device, regardless of approval status 
-    ON D.Identifier = AR.RequestDeviceIdentifier AND AR.rn = 1 AND AR.Approved = 0  -- Get only the most recent unapproved request per device
+    ON D.Identifier = AR.RequestDeviceIdentifier AND AR.rn = 1 AND AR.Approved IS NULL  -- Get only the most recent unapproved request per device
     WHERE
         D.UserId = @UserId -- Include only devices for this user
       AND D.Active = 1; -- Include only active devices

--- a/util/Migrator/DbScripts/2025-01-10_00_ReadActiveWithPendingAuthRequestsByUserId
+++ b/util/Migrator/DbScripts/2025-01-10_00_ReadActiveWithPendingAuthRequestsByUserId
@@ -1,4 +1,4 @@
-CREATE PROCEDURE [dbo].[Device_ReadActiveWithPendingAuthRequestsByUserId]
+CREATE OR ALTER PROCEDURE [dbo].[Device_ReadActiveWithPendingAuthRequestsByUserId]
     @UserId UNIQUEIDENTIFIER,
     @ExpirationMinutes INT
 AS

--- a/util/Migrator/DbScripts/2025-01-10_00_ReadActiveWithPendingAuthRequestsByUserId.sql
+++ b/util/Migrator/DbScripts/2025-01-10_00_ReadActiveWithPendingAuthRequestsByUserId.sql
@@ -13,6 +13,7 @@ BEGIN
              LEFT JOIN (
         SELECT TOP 1 -- Take only the top record sorted by auth request creation date
                      Id,
+                     UserId,
                      CreationDate,
                      RequestDeviceIdentifier
         FROM dbo.AuthRequestView

--- a/util/Migrator/DbScripts/2025-01-10_00_ReadActiveWithPendingAuthRequestsByUserId.sql
+++ b/util/Migrator/DbScripts/2025-01-10_00_ReadActiveWithPendingAuthRequestsByUserId.sql
@@ -10,20 +10,19 @@ BEGIN
         AR.Id as AuthRequestId,
         AR.CreationDate as AuthRequestCreationDate
     FROM dbo.DeviceView D
-             LEFT JOIN (
-        SELECT TOP 1 -- Take only the top record sorted by auth request creation date
-                     Id,
-                     UserId,
-                     CreationDate,
-                     RequestDeviceIdentifier
+    LEFT JOIN (
+        SELECT 
+            Id,
+            CreationDate,
+            RequestDeviceIdentifier,
+            ROW_NUMBER() OVER (PARTITION BY RequestDeviceIdentifier ORDER BY CreationDate DESC) as rn
         FROM dbo.AuthRequestView
-        WHERE Type IN (0, 1) -- Include only AuthenticateAndUnlock and Unlock types, excluding Admin Approval (type 2)
-          AND CreationDate >= DATEADD(MINUTE, -@ExpirationMinutes, GETUTCDATE()) -- Ensure the request hasn't expired
-          AND Approved IS NULL -- Include only requests that haven't been acknowledged or approved
-          AND UserId = @UserId
-        ORDER BY CreationDate DESC
-    ) AR ON D.Identifier = AR.RequestDeviceIdentifier
+        WHERE Type IN (0, 1)  -- AuthenticateAndUnlock and Unlock types only
+            AND CreationDate >= DATEADD(MINUTE, @ExpirationMinutes, GETUTCDATE()) -- Ensure the request hasn't expired
+            AND Approved IS NULL  -- Pending requests only
+            AND UserId = @UserId --  Requests for this user only
+    ) AR ON D.Identifier = AR.RequestDeviceIdentifier AND AR.rn = 1  -- Get only the most recent request per device
     WHERE
-        D.UserId = @UserId
+        D.UserId = @UserId -- Include only devices for this user
       AND D.Active = 1; -- Include only active devices
 END;

--- a/util/Migrator/DbScripts/2025-01-10_00_ReadActiveWithPendingAuthRequestsByUserId.sql
+++ b/util/Migrator/DbScripts/2025-01-10_00_ReadActiveWithPendingAuthRequestsByUserId.sql
@@ -20,8 +20,9 @@ BEGIN
         WHERE Type IN (0, 1) -- Include only AuthenticateAndUnlock and Unlock types, excluding Admin Approval (type 2)
           AND CreationDate >= DATEADD(MINUTE, -@ExpirationMinutes, GETUTCDATE()) -- Ensure the request hasn't expired
           AND Approved IS NULL -- Include only requests that haven't been acknowledged or approved
+          AND UserId = @UserId
         ORDER BY CreationDate DESC
-    ) AR ON D.Identifier = AR.RequestDeviceIdentifier AND D.UserId = AR.UserId
+    ) AR ON D.Identifier = AR.RequestDeviceIdentifier
     WHERE
         D.UserId = @UserId
       AND D.Active = 1; -- Include only active devices

--- a/util/Migrator/DbScripts/2025-01-10_00_ReadActiveWithPendingAuthRequestsByUserId.sql
+++ b/util/Migrator/DbScripts/2025-01-10_00_ReadActiveWithPendingAuthRequestsByUserId.sql
@@ -19,7 +19,7 @@ BEGIN
             ROW_NUMBER() OVER (PARTITION BY RequestDeviceIdentifier ORDER BY CreationDate DESC) as rn
         FROM dbo.AuthRequestView
         WHERE Type IN (0, 1)  -- AuthenticateAndUnlock and Unlock types only
-            AND CreationDate >= DATEADD(MINUTE, @ExpirationMinutes, GETUTCDATE()) -- Ensure the request hasn't expired
+            AND CreationDate >= DATEADD(MINUTE, -@ExpirationMinutes, GETUTCDATE()) -- Ensure the request hasn't expired
             AND UserId = @UserId --  Requests for this user only
     ) AR -- This join will get the most recent request per device, regardless of approval status 
     ON D.Identifier = AR.RequestDeviceIdentifier AND AR.rn = 1 AND AR.Approved IS NULL  -- Get only the most recent unapproved request per device

--- a/util/Migrator/DbScripts/2025-01-10_00_ReadActiveWithPendingAuthRequestsByUserId.sql
+++ b/util/Migrator/DbScripts/2025-01-10_00_ReadActiveWithPendingAuthRequestsByUserId.sql
@@ -15,13 +15,14 @@ BEGIN
             Id,
             CreationDate,
             RequestDeviceIdentifier,
+            Approved,
             ROW_NUMBER() OVER (PARTITION BY RequestDeviceIdentifier ORDER BY CreationDate DESC) as rn
         FROM dbo.AuthRequestView
         WHERE Type IN (0, 1)  -- AuthenticateAndUnlock and Unlock types only
             AND CreationDate >= DATEADD(MINUTE, @ExpirationMinutes, GETUTCDATE()) -- Ensure the request hasn't expired
-            AND Approved IS NULL  -- Pending requests only
             AND UserId = @UserId --  Requests for this user only
-    ) AR ON D.Identifier = AR.RequestDeviceIdentifier AND AR.rn = 1  -- Get only the most recent request per device
+    ) AR -- This join will get the most recent request per device, regardless of approval status 
+    ON D.Identifier = AR.RequestDeviceIdentifier AND AR.rn = 1 AND AR.Approved = 0  -- Get only the most recent unapproved request per device
     WHERE
         D.UserId = @UserId -- Include only devices for this user
       AND D.Active = 1; -- Include only active devices

--- a/util/Migrator/DbScripts/2025-01-10_00_ReadActiveWithPendingAuthRequestsByUserId.sql
+++ b/util/Migrator/DbScripts/2025-01-10_00_ReadActiveWithPendingAuthRequestsByUserId.sql
@@ -22,7 +22,7 @@ BEGIN
             AND CreationDate >= DATEADD(MINUTE, @ExpirationMinutes, GETUTCDATE()) -- Ensure the request hasn't expired
             AND UserId = @UserId --  Requests for this user only
     ) AR -- This join will get the most recent request per device, regardless of approval status 
-    ON D.Identifier = AR.RequestDeviceIdentifier AND AR.rn = 1 AND AR.Approved = 0  -- Get only the most recent unapproved request per device
+    ON D.Identifier = AR.RequestDeviceIdentifier AND AR.rn = 1 AND AR.Approved IS NULL  -- Get only the most recent unapproved request per device
     WHERE
         D.UserId = @UserId -- Include only devices for this user
       AND D.Active = 1; -- Include only active devices


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-16947
https://bitwarden.atlassian.net/browse/PM-16959

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We have to filter the get devices with pending auth requests stored proc to properly isolate to a single user id. One user was getting back the most recent auth request for a different user on the same device. 

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
See clients: https://github.com/bitwarden/clients/pull/12809

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
