### PR TITLE
[PM-16979] Avoid returning BillingTaxIdTypeInterferenceError when an …

### DIFF
--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -119,7 +119,7 @@ public class StripePaymentService : IPaymentService
         Subscription subscription;
         try
         {
-            if (taxInfo.TaxIdNumber != null && taxInfo.TaxIdType == null)
+            if (!string.IsNullOrWhiteSpace(taxInfo.TaxIdNumber))
             {
                 taxInfo.TaxIdType = _taxService.GetStripeTaxCode(taxInfo.BillingAddressCountry,
                     taxInfo.TaxIdNumber);
@@ -2058,7 +2058,7 @@ public class StripePaymentService : IPaymentService
             }
         }
 
-        if (!string.IsNullOrEmpty(parameters.TaxInformation.TaxId))
+        if (!string.IsNullOrWhiteSpace(parameters.TaxInformation.TaxId))
         {
             var taxIdType = _taxService.GetStripeTaxCode(
                 options.CustomerDetails.Address.Country,

--- a/test/Core.Test/Services/StripePaymentServiceTests.cs
+++ b/test/Core.Test/Services/StripePaymentServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Core.AdminConsole.Entities;
 using Bit.Core.Billing.Enums;
+using Bit.Core.Billing.Services;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Business;
@@ -609,6 +610,43 @@ public class StripePaymentServiceTests
         await stripeAdapter.Received(1).CustomerDeleteAsync("C-1");
         await braintreeGateway.Customer.Received(1).DeleteAsync("Braintree-Id");
     }
+
+    [Theory]
+    [BitAutoData("ES", "A5372895732985327895237")]
+    public async Task PurchaseOrganizationAsync_ThrowsBadRequestException_WhenTaxIdInvalid(string country, string taxId, SutProvider<StripePaymentService> sutProvider, Organization organization, string paymentToken, TaxInfo taxInfo)
+    {
+        taxInfo.BillingAddressCountry = country;
+        taxInfo.TaxIdNumber = taxId;
+        taxInfo.TaxIdType = null;
+
+        var plan = StaticStore.GetPlan(PlanType.EnterpriseAnnually);
+        organization.UseSecretsManager = true;
+        var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
+        stripeAdapter.CustomerCreateAsync(default).ReturnsForAnyArgs(new Stripe.Customer
+        {
+            Id = "C-1",
+        });
+        stripeAdapter.SubscriptionCreateAsync(default).ReturnsForAnyArgs(new Stripe.Subscription
+        {
+            Id = "S-1",
+            CurrentPeriodEnd = DateTime.Today.AddDays(10),
+        });
+        sutProvider.GetDependency<IGlobalSettings>()
+            .BaseServiceUri.CloudRegion
+            .Returns("US");
+        sutProvider
+            .GetDependency<ITaxService>()
+            .GetStripeTaxCode(Arg.Is<string>(p => p == country), Arg.Is<string>(p => p == taxId))
+            .Returns((string)null);
+
+        var actual = await Assert.ThrowsAsync<BadRequestException>(async () => await sutProvider.Sut.PurchaseOrganizationAsync(organization, PaymentMethodType.Card, paymentToken, plan, 0, 0, false, taxInfo, false, 8, 10));
+
+        Assert.Equal("billingTaxIdTypeInferenceError", actual.Message);
+
+        await stripeAdapter.Received(0).CustomerCreateAsync(Arg.Any<Stripe.CustomerCreateOptions>());
+        await stripeAdapter.Received(0).SubscriptionCreateAsync(Arg.Any<Stripe.SubscriptionCreateOptions>());
+    }
+
 
     [Theory, BitAutoData]
     public async Task UpgradeFreeOrganizationAsync_Success(SutProvider<StripePaymentService> sutProvider,

--- a/test/Core.Test/Services/StripePaymentServiceTests.cs
+++ b/test/Core.Test/Services/StripePaymentServiceTests.cs
@@ -40,6 +40,11 @@ public class StripePaymentServiceTests
     {
         var plan = StaticStore.GetPlan(PlanType.EnterpriseAnnually);
 
+        sutProvider
+            .GetDependency<ITaxService>()
+            .GetStripeTaxCode(Arg.Is<string>(p => p == taxInfo.BillingAddressCountry), Arg.Is<string>(p => p == taxInfo.TaxIdNumber))
+            .Returns(taxInfo.TaxIdType);
+
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
         stripeAdapter.CustomerCreateAsync(default).ReturnsForAnyArgs(new Stripe.Customer
         {
@@ -96,6 +101,12 @@ public class StripePaymentServiceTests
     {
         var plan = StaticStore.GetPlan(PlanType.EnterpriseAnnually);
         organization.UseSecretsManager = true;
+
+        sutProvider
+            .GetDependency<ITaxService>()
+            .GetStripeTaxCode(Arg.Is<string>(p => p == taxInfo.BillingAddressCountry), Arg.Is<string>(p => p == taxInfo.TaxIdNumber))
+            .Returns(taxInfo.TaxIdType);
+
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
         stripeAdapter.CustomerCreateAsync(default).ReturnsForAnyArgs(new Stripe.Customer
         {
@@ -153,6 +164,12 @@ public class StripePaymentServiceTests
     {
         var plan = StaticStore.GetPlan(PlanType.EnterpriseAnnually);
         organization.UseSecretsManager = true;
+
+        sutProvider
+            .GetDependency<ITaxService>()
+            .GetStripeTaxCode(Arg.Is<string>(p => p == taxInfo.BillingAddressCountry), Arg.Is<string>(p => p == taxInfo.TaxIdNumber))
+            .Returns(taxInfo.TaxIdType);
+
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
         stripeAdapter.CustomerCreateAsync(default).ReturnsForAnyArgs(new Stripe.Customer
         {
@@ -210,6 +227,11 @@ public class StripePaymentServiceTests
     {
         var plan = StaticStore.GetPlan(PlanType.EnterpriseAnnually);
         paymentToken = "pm_" + paymentToken;
+
+        sutProvider
+            .GetDependency<ITaxService>()
+            .GetStripeTaxCode(Arg.Is<string>(p => p == taxInfo.BillingAddressCountry), Arg.Is<string>(p => p == taxInfo.TaxIdNumber))
+            .Returns(taxInfo.TaxIdType);
 
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
         stripeAdapter.CustomerCreateAsync(default).ReturnsForAnyArgs(new Stripe.Customer
@@ -398,6 +420,11 @@ public class StripePaymentServiceTests
     {
         var plan = StaticStore.GetPlan(PlanType.EnterpriseAnnually);
 
+        sutProvider
+            .GetDependency<ITaxService>()
+            .GetStripeTaxCode(Arg.Is<string>(p => p == taxInfo.BillingAddressCountry), Arg.Is<string>(p => p == taxInfo.TaxIdNumber))
+            .Returns(taxInfo.TaxIdType);
+
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
         stripeAdapter.CustomerCreateAsync(default).ReturnsForAnyArgs(new Stripe.Customer
         {
@@ -463,6 +490,12 @@ public class StripePaymentServiceTests
     {
         var plan = StaticStore.GetPlan(PlanType.EnterpriseAnnually);
         organization.UseSecretsManager = true;
+
+        sutProvider
+            .GetDependency<ITaxService>()
+            .GetStripeTaxCode(Arg.Is<string>(p => p == taxInfo.BillingAddressCountry), Arg.Is<string>(p => p == taxInfo.TaxIdNumber))
+            .Returns(taxInfo.TaxIdType);
+
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
         stripeAdapter.CustomerCreateAsync(default).ReturnsForAnyArgs(new Stripe.Customer
         {


### PR DESCRIPTION
…empty tax id string is passed

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16979

## 📔 Objective

When the tax id field has been touched, an empty string is being attempted to be passed to the back-end. But we were only doing a null check when creating an organization. This pull request avoids that empty and whitespace tax ids are processed.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
