### PR TITLE
[PM-15182] Remove remove-provider-export-permission feature flag

### DIFF
--- a/src/Api/Tools/Controllers/OrganizationExportController.cs
+++ b/src/Api/Tools/Controllers/OrganizationExportController.cs
@@ -1,16 +1,11 @@
-﻿using Bit.Api.Models.Response;
-using Bit.Api.Tools.Authorization;
+﻿using Bit.Api.Tools.Authorization;
 using Bit.Api.Tools.Models.Response;
-using Bit.Api.Vault.Models.Response;
-using Bit.Core;
 using Bit.Core.AdminConsole.OrganizationFeatures.Shared.Authorization;
 using Bit.Core.Context;
-using Bit.Core.Entities;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Settings;
-using Bit.Core.Vault.Models.Data;
 using Bit.Core.Vault.Queries;
 using Bit.Core.Vault.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -57,39 +52,6 @@ public class OrganizationExportController : Controller
     [HttpGet("export")]
     public async Task<IActionResult> Export(Guid organizationId)
     {
-        if (_featureService.IsEnabled(FeatureFlagKeys.PM11360RemoveProviderExportPermission))
-        {
-            return await Export_vNext(organizationId);
-        }
-
-        var userId = _userService.GetProperUserId(User).Value;
-
-        IEnumerable<Collection> orgCollections = await _collectionService.GetOrganizationCollectionsAsync(organizationId);
-        (IEnumerable<CipherOrganizationDetails> orgCiphers, Dictionary<Guid, IGrouping<Guid, CollectionCipher>> collectionCiphersGroupDict) = await _cipherService.GetOrganizationCiphers(userId, organizationId);
-
-        if (_currentContext.ClientVersion == null || _currentContext.ClientVersion >= new Version("2023.1.0"))
-        {
-            var organizationExportResponseModel = new OrganizationExportResponseModel
-            {
-                Collections = orgCollections.Select(c => new CollectionResponseModel(c)),
-                Ciphers = orgCiphers.Select(c => new CipherMiniDetailsResponseModel(c, _globalSettings, collectionCiphersGroupDict, c.OrganizationUseTotp))
-            };
-
-            return Ok(organizationExportResponseModel);
-        }
-
-        // Backward compatibility with versions before 2023.1.0 that use ListResponseModel
-        var organizationExportListResponseModel = new OrganizationExportListResponseModel
-        {
-            Collections = GetOrganizationCollectionsResponse(orgCollections),
-            Ciphers = GetOrganizationCiphersResponse(orgCiphers, collectionCiphersGroupDict)
-        };
-
-        return Ok(organizationExportListResponseModel);
-    }
-
-    private async Task<IActionResult> Export_vNext(Guid organizationId)
-    {
         var canExportAll = await _authorizationService.AuthorizeAsync(User, new OrganizationScope(organizationId),
             VaultExportOperations.ExportWholeVault);
         if (canExportAll.Succeeded)
@@ -115,20 +77,5 @@ public class OrganizationExportController : Controller
 
         // Unauthorized
         throw new NotFoundException();
-    }
-
-    private ListResponseModel<CollectionResponseModel> GetOrganizationCollectionsResponse(IEnumerable<Collection> orgCollections)
-    {
-        var collections = orgCollections.Select(c => new CollectionResponseModel(c));
-        return new ListResponseModel<CollectionResponseModel>(collections);
-    }
-
-    private ListResponseModel<CipherMiniDetailsResponseModel> GetOrganizationCiphersResponse(IEnumerable<CipherOrganizationDetails> orgCiphers,
-        Dictionary<Guid, IGrouping<Guid, CollectionCipher>> collectionCiphersGroupDict)
-    {
-        var responses = orgCiphers.Select(c => new CipherMiniDetailsResponseModel(c, _globalSettings,
-            collectionCiphersGroupDict, c.OrganizationUseTotp));
-
-        return new ListResponseModel<CipherMiniDetailsResponseModel>(responses);
     }
 }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -150,7 +150,6 @@ public static class FeatureFlagKeys
     public const string NewDeviceVerificationTemporaryDismiss = "new-device-temporary-dismiss";
     public const string NewDeviceVerificationPermanentDismiss = "new-device-permanent-dismiss";
     public const string SecurityTasks = "security-tasks";
-    public const string PM11360RemoveProviderExportPermission = "pm-11360-remove-provider-export-permission";
     public const string DisableFreeFamiliesSponsorship = "PM-12274-disable-free-families-sponsorship";
     public const string MacOsNativeCredentialSync = "macos-native-credential-sync";
     public const string PM9111ExtensionPersistAddEditForm = "pm-9111-extension-persist-add-edit-form";

--- a/src/Core/Context/ICurrentContext.cs
+++ b/src/Core/Context/ICurrentContext.cs
@@ -43,7 +43,9 @@ public interface ICurrentContext
     Task<bool> AccessEventLogs(Guid orgId);
     Task<bool> AccessImportExport(Guid orgId);
     Task<bool> AccessReports(Guid orgId);
+    [Obsolete("Deprecated. Use an authorization handler checking the specific permissions required instead.")]
     Task<bool> EditAnyCollection(Guid orgId);
+    [Obsolete("Deprecated. Use an authorization handler checking the specific permissions required instead.")]
     Task<bool> ViewAllCollections(Guid orgId);
     Task<bool> ManageGroups(Guid orgId);
     Task<bool> ManagePolicies(Guid orgId);

--- a/src/Core/Services/ICollectionService.cs
+++ b/src/Core/Services/ICollectionService.cs
@@ -7,6 +7,4 @@ public interface ICollectionService
 {
     Task SaveAsync(Collection collection, IEnumerable<CollectionAccessSelection> groups = null, IEnumerable<CollectionAccessSelection> users = null);
     Task DeleteUserAsync(Collection collection, Guid organizationUserId);
-    [Obsolete("Pre-Flexible Collections logic.")]
-    Task<IEnumerable<Collection>> GetOrganizationCollectionsAsync(Guid organizationId);
 }

--- a/src/Core/Services/Implementations/CollectionService.cs
+++ b/src/Core/Services/Implementations/CollectionService.cs
@@ -95,31 +95,4 @@ public class CollectionService : ICollectionService
         await _collectionRepository.DeleteUserAsync(collection.Id, organizationUserId);
         await _eventService.LogOrganizationUserEventAsync(orgUser, Enums.EventType.OrganizationUser_Updated);
     }
-
-    public async Task<IEnumerable<Collection>> GetOrganizationCollectionsAsync(Guid organizationId)
-    {
-        if (
-            !await _currentContext.ViewAllCollections(organizationId) &&
-            !await _currentContext.ManageUsers(organizationId) &&
-            !await _currentContext.ManageGroups(organizationId) &&
-            !await _currentContext.AccessImportExport(organizationId)
-        )
-        {
-            throw new NotFoundException();
-        }
-
-        IEnumerable<Collection> orgCollections;
-        if (await _currentContext.ViewAllCollections(organizationId) || await _currentContext.AccessImportExport(organizationId))
-        {
-            // Admins, Owners, Providers and Custom (with collection management or import/export permissions) can access all items even if not assigned to them
-            orgCollections = await _collectionRepository.GetManyByOrganizationIdAsync(organizationId);
-        }
-        else
-        {
-            var collections = await _collectionRepository.GetManyByUserIdAsync(_currentContext.UserId.Value);
-            orgCollections = collections.Where(c => c.OrganizationId == organizationId);
-        }
-
-        return orgCollections;
-    }
 }

--- a/src/Core/Vault/Services/ICipherService.cs
+++ b/src/Core/Vault/Services/ICipherService.cs
@@ -39,5 +39,4 @@ public interface ICipherService
     Task UploadFileForExistingAttachmentAsync(Stream stream, Cipher cipher, CipherAttachment.MetaData attachmentId);
     Task<AttachmentResponseData> GetAttachmentDownloadDataAsync(Cipher cipher, string attachmentId);
     Task<bool> ValidateCipherAttachmentFile(Cipher cipher, CipherAttachment.MetaData attachmentData);
-    Task<(IEnumerable<CipherOrganizationDetails>, Dictionary<Guid, IGrouping<Guid, CollectionCipher>>)> GetOrganizationCiphers(Guid userId, Guid organizationId);
 }

--- a/src/Core/Vault/Services/Implementations/CipherService.cs
+++ b/src/Core/Vault/Services/Implementations/CipherService.cs
@@ -956,35 +956,6 @@ public class CipherService : ICipherService
         return restoringCiphers;
     }
 
-    public async Task<(IEnumerable<CipherOrganizationDetails>, Dictionary<Guid, IGrouping<Guid, CollectionCipher>>)> GetOrganizationCiphers(Guid userId, Guid organizationId)
-    {
-        if (!await _currentContext.ViewAllCollections(organizationId) && !await _currentContext.AccessReports(organizationId) && !await _currentContext.AccessImportExport(organizationId))
-        {
-            throw new NotFoundException();
-        }
-
-        IEnumerable<CipherOrganizationDetails> orgCiphers;
-        if (await _currentContext.AccessImportExport(organizationId))
-        {
-            // Admins, Owners, Providers and Custom (with import/export permission) can access all items even if not assigned to them
-            orgCiphers = await _cipherRepository.GetManyOrganizationDetailsByOrganizationIdAsync(organizationId);
-        }
-        else
-        {
-            var ciphers = await _cipherRepository.GetManyByUserIdAsync(userId, withOrganizations: true);
-            orgCiphers = ciphers.Where(c => c.OrganizationId == organizationId);
-        }
-
-        var orgCipherIds = orgCiphers.Select(c => c.Id);
-
-        var collectionCiphers = await _collectionCipherRepository.GetManyByOrganizationIdAsync(organizationId);
-        var collectionCiphersGroupDict = collectionCiphers
-            .Where(c => orgCipherIds.Contains(c.CipherId))
-            .GroupBy(c => c.CipherId).ToDictionary(s => s.Key);
-
-        return (orgCiphers, collectionCiphersGroupDict);
-    }
-
     private async Task<bool> UserCanEditAsync(Cipher cipher, Guid userId)
     {
         if (!cipher.OrganizationId.HasValue && cipher.UserId.HasValue && cipher.UserId.Value == userId)

--- a/test/Core.Test/Services/CollectionServiceTests.cs
+++ b/test/Core.Test/Services/CollectionServiceTests.cs
@@ -1,5 +1,4 @@
 ﻿using Bit.Core.AdminConsole.Entities;
-using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
@@ -175,34 +174,5 @@ public class CollectionServiceTest
         await sutProvider.GetDependency<ICollectionRepository>().DidNotReceiveWithAnyArgs().DeleteUserAsync(default, default);
         await sutProvider.GetDependency<IEventService>().DidNotReceiveWithAnyArgs()
             .LogOrganizationUserEventAsync<OrganizationUser>(default, default);
-    }
-
-    [Theory, BitAutoData]
-    public async Task GetOrganizationCollectionsAsync_WithViewAllCollectionsTrue_ReturnsAllOrganizationCollections(
-        Collection collection, Guid organizationId, Guid userId, SutProvider<CollectionService> sutProvider)
-    {
-        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(userId);
-        sutProvider.GetDependency<ICollectionRepository>()
-            .GetManyByOrganizationIdAsync(organizationId)
-            .Returns(new List<Collection> { collection });
-        sutProvider.GetDependency<ICurrentContext>().ViewAllCollections(organizationId).Returns(true);
-
-        var result = await sutProvider.Sut.GetOrganizationCollectionsAsync(organizationId);
-
-        Assert.Single(result);
-        Assert.Equal(collection, result.First());
-
-        await sutProvider.GetDependency<ICollectionRepository>().Received(1).GetManyByOrganizationIdAsync(organizationId);
-        await sutProvider.GetDependency<ICollectionRepository>().DidNotReceiveWithAnyArgs().GetManyByUserIdAsync(default);
-    }
-
-    [Theory, BitAutoData]
-    public async Task GetOrganizationCollectionsAsync_WithViewAssignedCollectionsFalse_ThrowsBadRequestException(
-        Guid organizationId, SutProvider<CollectionService> sutProvider)
-    {
-        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.GetOrganizationCollectionsAsync(organizationId));
-
-        await sutProvider.GetDependency<ICollectionRepository>().DidNotReceiveWithAnyArgs().GetManyByOrganizationIdAsync(default);
-        await sutProvider.GetDependency<ICollectionRepository>().DidNotReceiveWithAnyArgs().GetManyByUserIdAsync(default);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-15182
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Remove the `pm-11360-remove-provider-export-permission` feature flag, which was turned on in the 2025.1 release.

It only affected server + web so we can remove it immediately.

Also remove now unused code:
- old controller endpoint
- CipherService code not used or usable by any other flow
- CollectionService code not used or usable by any other flow

Client PR: https://github.com/bitwarden/clients/pull/12878

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
