### PR TITLE
[PM-17107] Add web browser clients to allowed approving device types

### DIFF
--- a/src/Identity/Utilities/LoginApprovingDeviceTypes.cs
+++ b/src/Identity/Utilities/LoginApprovingDeviceTypes.cs
@@ -12,6 +12,7 @@ public static class LoginApprovingDeviceTypes
         var deviceTypes = new List<DeviceType>();
         deviceTypes.AddRange(DeviceTypes.DesktopTypes);
         deviceTypes.AddRange(DeviceTypes.MobileTypes);
+        deviceTypes.AddRange(DeviceTypes.BrowserTypes);
         _deviceTypes = deviceTypes.AsReadOnly();
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17107

## 📔 Objective

With https://github.com/bitwarden/clients/pull/12809 we added the ability to approve login requests from the web client.

In order to use the web client to approve TDE login requests, we must specify that it is now a valid device type for approving requests.  This is used to set the `HasLoginApprovingDevice` property on the `TrustedDeviceUserDecryptionOption` that is returned on authentication when authenticating with an org membership that uses TDE for decryption.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
