### PR TITLE
Adjust handling of GH action dependencies for CI/CD partnership

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,20 +12,20 @@
     {
       "groupName": "dockerfile minor",
       "matchManagers": ["dockerfile"],
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchUpdateTypes": ["minor"]
     },
     {
       "groupName": "docker-compose minor",
       "matchManagers": ["docker-compose"],
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchUpdateTypes": ["minor"]
     },
     {
-      "groupName": "gh minor",
+      "groupName": "github-action minor",
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchUpdateTypes": ["minor"]
     },
     {
-      "matchManagers": ["github-actions", "dockerfile", "docker-compose"],
+      "matchManagers": ["dockerfile", "docker-compose"],
       "commitMessagePrefix": "[deps] BRE:"
     },
     {


### PR DESCRIPTION
## 🎟️ Tracking

[bitwarden.atlassian.net/browse/PM-14640](https://bitwarden.atlassian.net/browse/PM-14640)

## 📔 Objective

Analog to https://github.com/bitwarden/clients/pull/12818 on the clients repo.

As we have started to share ownership of our build pipelines between BRE and Platform, BRE no longer owns all of the github-action-managed dependencies. The current renovate.json results in misleading PR titles like https://github.com/bitwarden/clients/pull/12706.

This PR does the following:
- Removes the addition of the BRE prefix for all github-action dependencies.  It is left for `dockerfile` and `docker-compose` managers as those are owned by BRE.
- Removes patch updates from the scope of PR creation.

❓ What will upcoming PRs look like?
- Patch updates will be ignored
- Minor workflow dependency updates will be grouped into a single PR, with no team-specific prefix, with the PR reviewer(s) determined by who owns the workflow files in which the dependencies are used (e.g. Platform would need to review build/lint/test workflows, BRE would need to review deploy/publish workflows).
  - 🤔 Note that we can do this since the workflow files have explicit CODEOWNERs defined, whereas other dependencies are updated in package.json which doesn't have an owner, so we have to assign the ownership in renovate.json.
- Major workflow updates will be handled independently with PRs for each, with no team-specific prefix with the PR reviewer(s) determined by who owns the workflow files in which the dependencies are used

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
