### PR TITLE
[PM-17177] Added additional validation to ensure license claim values aren't null

### DIFF
--- a/src/Core/Billing/Licenses/Services/Implementations/OrganizationLicenseClaimsFactory.cs
+++ b/src/Core/Billing/Licenses/Services/Implementations/OrganizationLicenseClaimsFactory.cs
@@ -22,16 +22,12 @@ public class OrganizationLicenseClaimsFactory : ILicenseClaimsFactory<Organizati
         var claims = new List<Claim>
         {
             new(nameof(OrganizationLicenseConstants.LicenseType), LicenseType.Organization.ToString()),
-            new Claim(nameof(OrganizationLicenseConstants.LicenseKey), entity.LicenseKey),
-            new(nameof(OrganizationLicenseConstants.InstallationId), licenseContext.InstallationId.ToString()),
             new(nameof(OrganizationLicenseConstants.Id), entity.Id.ToString()),
             new(nameof(OrganizationLicenseConstants.Name), entity.Name),
             new(nameof(OrganizationLicenseConstants.BillingEmail), entity.BillingEmail),
             new(nameof(OrganizationLicenseConstants.Enabled), entity.Enabled.ToString()),
             new(nameof(OrganizationLicenseConstants.Plan), entity.Plan),
             new(nameof(OrganizationLicenseConstants.PlanType), entity.PlanType.ToString()),
-            new(nameof(OrganizationLicenseConstants.Seats), entity.Seats.ToString()),
-            new(nameof(OrganizationLicenseConstants.MaxCollections), entity.MaxCollections.ToString()),
             new(nameof(OrganizationLicenseConstants.UsePolicies), entity.UsePolicies.ToString()),
             new(nameof(OrganizationLicenseConstants.UseSso), entity.UseSso.ToString()),
             new(nameof(OrganizationLicenseConstants.UseKeyConnector), entity.UseKeyConnector.ToString()),
@@ -43,21 +39,18 @@ public class OrganizationLicenseClaimsFactory : ILicenseClaimsFactory<Organizati
             new(nameof(OrganizationLicenseConstants.Use2fa), entity.Use2fa.ToString()),
             new(nameof(OrganizationLicenseConstants.UseApi), entity.UseApi.ToString()),
             new(nameof(OrganizationLicenseConstants.UseResetPassword), entity.UseResetPassword.ToString()),
-            new(nameof(OrganizationLicenseConstants.MaxStorageGb), entity.MaxStorageGb.ToString()),
             new(nameof(OrganizationLicenseConstants.SelfHost), entity.SelfHost.ToString()),
             new(nameof(OrganizationLicenseConstants.UsersGetPremium), entity.UsersGetPremium.ToString()),
             new(nameof(OrganizationLicenseConstants.UseCustomPermissions), entity.UseCustomPermissions.ToString()),
-            new(nameof(OrganizationLicenseConstants.Issued), DateTime.UtcNow.ToString(CultureInfo.InvariantCulture)),
             new(nameof(OrganizationLicenseConstants.UsePasswordManager), entity.UsePasswordManager.ToString()),
             new(nameof(OrganizationLicenseConstants.UseSecretsManager), entity.UseSecretsManager.ToString()),
-            new(nameof(OrganizationLicenseConstants.SmSeats), entity.SmSeats.ToString()),
-            new(nameof(OrganizationLicenseConstants.SmServiceAccounts), entity.SmServiceAccounts.ToString()),
             // LimitCollectionCreationDeletion was split and removed from the
             // license. Left here with an assignment from the new values for
             // backwards compatibility.
             new(nameof(OrganizationLicenseConstants.LimitCollectionCreationDeletion),
                 (entity.LimitCollectionCreation || entity.LimitCollectionDeletion).ToString()),
             new(nameof(OrganizationLicenseConstants.AllowAdminAccessToAllCollectionItems), entity.AllowAdminAccessToAllCollectionItems.ToString()),
+            new(nameof(OrganizationLicenseConstants.Issued), DateTime.UtcNow.ToString(CultureInfo.InvariantCulture)),
             new(nameof(OrganizationLicenseConstants.Expires), expires.ToString(CultureInfo.InvariantCulture)),
             new(nameof(OrganizationLicenseConstants.Refresh), refresh.ToString(CultureInfo.InvariantCulture)),
             new(nameof(OrganizationLicenseConstants.ExpirationWithoutGracePeriod), expirationWithoutGracePeriod.ToString(CultureInfo.InvariantCulture)),
@@ -67,6 +60,41 @@ public class OrganizationLicenseClaimsFactory : ILicenseClaimsFactory<Organizati
         if (entity.BusinessName is not null)
         {
             claims.Add(new Claim(nameof(OrganizationLicenseConstants.BusinessName), entity.BusinessName));
+        }
+
+        if (entity.LicenseKey is not null)
+        {
+            claims.Add(new Claim(nameof(OrganizationLicenseConstants.LicenseKey), entity.LicenseKey));
+        }
+
+        if (licenseContext.InstallationId.HasValue)
+        {
+            claims.Add(new Claim(nameof(OrganizationLicenseConstants.InstallationId), licenseContext.InstallationId.ToString()));
+        }
+
+        if (entity.Seats.HasValue)
+        {
+            claims.Add(new Claim(nameof(OrganizationLicenseConstants.Seats), entity.Seats.ToString()));
+        }
+
+        if (entity.MaxCollections.HasValue)
+        {
+            claims.Add(new Claim(nameof(OrganizationLicenseConstants.MaxCollections), entity.MaxCollections.ToString()));
+        }
+
+        if (entity.MaxStorageGb.HasValue)
+        {
+            claims.Add(new Claim(nameof(OrganizationLicenseConstants.MaxStorageGb), entity.MaxStorageGb.ToString()));
+        }
+
+        if (entity.SmSeats.HasValue)
+        {
+            claims.Add(new Claim(nameof(OrganizationLicenseConstants.SmSeats), entity.SmSeats.ToString()));
+        }
+
+        if (entity.SmServiceAccounts.HasValue)
+        {
+            claims.Add(new Claim(nameof(OrganizationLicenseConstants.SmServiceAccounts), entity.SmServiceAccounts.ToString()));
         }
 
         return Task.FromResult(claims);

--- a/src/Core/Billing/Licenses/Services/Implementations/UserLicenseClaimsFactory.cs
+++ b/src/Core/Billing/Licenses/Services/Implementations/UserLicenseClaimsFactory.cs
@@ -21,31 +21,35 @@ public class UserLicenseClaimsFactory : ILicenseClaimsFactory<User>
         {
             new(nameof(UserLicenseConstants.LicenseType), LicenseType.User.ToString()),
             new(nameof(UserLicenseConstants.Id), entity.Id.ToString()),
-            new(nameof(UserLicenseConstants.Name), entity.Name),
             new(nameof(UserLicenseConstants.Email), entity.Email),
             new(nameof(UserLicenseConstants.Premium), entity.Premium.ToString()),
             new(nameof(UserLicenseConstants.Issued), DateTime.UtcNow.ToString(CultureInfo.InvariantCulture)),
             new(nameof(UserLicenseConstants.Trial), trial.ToString()),
         };
 
+        if (entity.Name is not null)
+        {
+            claims.Add(new(nameof(UserLicenseConstants.Name), entity.Name));
+        }
+
         if (entity.LicenseKey is not null)
         {
             claims.Add(new(nameof(UserLicenseConstants.LicenseKey), entity.LicenseKey));
         }
 
-        if (entity.MaxStorageGb is not null)
+        if (entity.MaxStorageGb.HasValue)
         {
             claims.Add(new(nameof(UserLicenseConstants.MaxStorageGb), entity.MaxStorageGb.ToString()));
         }
 
-        if (expires is not null)
+        if (expires.HasValue)
         {
-            claims.Add(new(nameof(UserLicenseConstants.Expires), expires.ToString()));
+            claims.Add(new(nameof(UserLicenseConstants.Expires), expires.Value.ToString(CultureInfo.InvariantCulture)));
         }
 
-        if (refresh is not null)
+        if (refresh.HasValue)
         {
-            claims.Add(new(nameof(UserLicenseConstants.Refresh), refresh.ToString()));
+            claims.Add(new(nameof(UserLicenseConstants.Refresh), refresh.Value.ToString(CultureInfo.InvariantCulture)));
         }
 
         return Task.FromResult(claims);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-17177

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Make license claims nullable and add proper null value handling for both Organization and User licenses. This change ensures that optional license properties are only included when they have a value. Key changes include:

- Made several Organization license claims conditional based on null checks (`LicenseKey`, `InstallationId`, `Seats`, `MaxCollections`, `MaxStorageGb`, `SmSeats`, `SmServiceAccounts`)
- Added proper null handling for User license claims (`Name`, `LicenseKey`, `MaxStorageGb`, `Expires`, `Refresh`)
- Standardized date formatting using `CultureInfo.InvariantCulture`

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
