### PR TITLE
Use .db extension for SQLite configuration example

### DIFF
--- a/dev/secrets.json.example
+++ b/dev/secrets.json.example
@@ -21,7 +21,7 @@
       "connectionString": "server=localhost;uid=root;pwd=SET_A_PASSWORD_HERE_123;database=vault_dev"
     },
     "sqlite": {
-      "connectionString": "Data Source=/path/to/bitwardenServer/repository/server/dev/db/bitwarden.sqlite"
+      "connectionString": "Data Source=/path/to/bitwardenServer/repository/server/dev/db/bitwarden.db"
     },
     "identityServer": {
       "certificateThumbprint": "<your Identity certificate thumbprint with no spaces>"


### PR DESCRIPTION
## 🎟️ Tracking

Noticed during a new local setup.

## 📔 Objective

Our user secrets example has an extension of `.sqlite` but our `.gitignore` in `dev/` expects `.db` so update the example.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
