### PR TITLE
Auth/pm 17233/tests for multiple users on single device for web approvals

### DIFF
--- a/test/Infrastructure.IntegrationTest/Auth/Repositories/DeviceRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/Auth/Repositories/DeviceRepositoryTests.cs
@@ -129,7 +129,6 @@ public class DeviceRepositoryTests
             AccessCode = "AccessCode_1234",
             PublicKey = "PublicKey_1234"
         });
-        await authRequestRepository.ReplaceAsync(userAAuthRequest);
 
         // Act
         var response = await sutRepository.GetManyByUserIdWithDeviceAuth(userB.Id);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17233

## 📔 Objective

There was a bug with the original stored procedure and how it fetched based on device and not scoped to users properly. It was fixed in https://bitwarden.atlassian.net/browse/PM-16959 and this is to write a test proving it's fixed.

## 📸 Screenshots

New test failing on the old stored procedure:
<img width="1728" alt="Screenshot 2025-01-22 at 7 16 38 PM" src="https://github.com/user-attachments/assets/012cf698-2bf9-4ba0-a241-84e7b82a66d0" />

New test successful on the new stored procedure:
<img width="1728" alt="Screenshot 2025-01-22 at 9 20 41 PM" src="https://github.com/user-attachments/assets/6244f75d-7aed-42af-9325-7cebd0973b9b" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
