### PR TITLE
Ac/pm 17217/add use policy check for accept endpoint

### DIFF
--- a/src/Api/AdminConsole/Models/Response/Organizations/OrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/Organizations/OrganizationResponseModel.cs
@@ -57,6 +57,7 @@ public class OrganizationResponseModel : ResponseModel
         MaxAutoscaleSmServiceAccounts = organization.MaxAutoscaleSmServiceAccounts;
         LimitCollectionCreation = organization.LimitCollectionCreation;
         LimitCollectionDeletion = organization.LimitCollectionDeletion;
+        LimitItemDeletion = organization.LimitItemDeletion;
         AllowAdminAccessToAllCollectionItems = organization.AllowAdminAccessToAllCollectionItems;
         UseRiskInsights = organization.UseRiskInsights;
     }
@@ -102,6 +103,7 @@ public class OrganizationResponseModel : ResponseModel
     public int? MaxAutoscaleSmServiceAccounts { get; set; }
     public bool LimitCollectionCreation { get; set; }
     public bool LimitCollectionDeletion { get; set; }
+    public bool LimitItemDeletion { get; set; }
     public bool AllowAdminAccessToAllCollectionItems { get; set; }
     public bool UseRiskInsights { get; set; }
 }

--- a/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
@@ -67,6 +67,7 @@ public class ProfileOrganizationResponseModel : ResponseModel
         AccessSecretsManager = organization.AccessSecretsManager;
         LimitCollectionCreation = organization.LimitCollectionCreation;
         LimitCollectionDeletion = organization.LimitCollectionDeletion;
+        LimitItemDeletion = organization.LimitItemDeletion;
         AllowAdminAccessToAllCollectionItems = organization.AllowAdminAccessToAllCollectionItems;
         UserIsManagedByOrganization = organizationIdsManagingUser.Contains(organization.OrganizationId);
         UseRiskInsights = organization.UseRiskInsights;
@@ -128,6 +129,7 @@ public class ProfileOrganizationResponseModel : ResponseModel
     public bool AccessSecretsManager { get; set; }
     public bool LimitCollectionCreation { get; set; }
     public bool LimitCollectionDeletion { get; set; }
+    public bool LimitItemDeletion { get; set; }
     public bool AllowAdminAccessToAllCollectionItems { get; set; }
     /// <summary>
     /// Indicates if the organization manages the user.

--- a/src/Api/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModel.cs
@@ -47,6 +47,7 @@ public class ProfileProviderOrganizationResponseModel : ProfileOrganizationRespo
         ProductTierType = StaticStore.GetPlan(organization.PlanType).ProductTier;
         LimitCollectionCreation = organization.LimitCollectionCreation;
         LimitCollectionDeletion = organization.LimitCollectionDeletion;
+        LimitItemDeletion = organization.LimitItemDeletion;
         AllowAdminAccessToAllCollectionItems = organization.AllowAdminAccessToAllCollectionItems;
         UseRiskInsights = organization.UseRiskInsights;
     }

--- a/src/Api/Models/Request/Organizations/OrganizationCollectionManagementUpdateRequestModel.cs
+++ b/src/Api/Models/Request/Organizations/OrganizationCollectionManagementUpdateRequestModel.cs
@@ -7,12 +7,14 @@ public class OrganizationCollectionManagementUpdateRequestModel
 {
     public bool LimitCollectionCreation { get; set; }
     public bool LimitCollectionDeletion { get; set; }
+    public bool LimitItemDeletion { get; set; }
     public bool AllowAdminAccessToAllCollectionItems { get; set; }
 
     public virtual Organization ToOrganization(Organization existingOrganization, IFeatureService featureService)
     {
         existingOrganization.LimitCollectionCreation = LimitCollectionCreation;
         existingOrganization.LimitCollectionDeletion = LimitCollectionDeletion;
+        existingOrganization.LimitItemDeletion = LimitItemDeletion;
         existingOrganization.AllowAdminAccessToAllCollectionItems = AllowAdminAccessToAllCollectionItems;
         return existingOrganization;
     }

--- a/src/Core/AdminConsole/Models/Data/Organizations/OrganizationAbility.cs
+++ b/src/Core/AdminConsole/Models/Data/Organizations/OrganizationAbility.cs
@@ -23,6 +23,7 @@ public class OrganizationAbility
         UsePolicies = organization.UsePolicies;
         LimitCollectionCreation = organization.LimitCollectionCreation;
         LimitCollectionDeletion = organization.LimitCollectionDeletion;
+        LimitItemDeletion = organization.LimitItemDeletion;
         AllowAdminAccessToAllCollectionItems = organization.AllowAdminAccessToAllCollectionItems;
         UseRiskInsights = organization.UseRiskInsights;
     }
@@ -41,6 +42,7 @@ public class OrganizationAbility
     public bool UsePolicies { get; set; }
     public bool LimitCollectionCreation { get; set; }
     public bool LimitCollectionDeletion { get; set; }
+    public bool LimitItemDeletion { get; set; }
     public bool AllowAdminAccessToAllCollectionItems { get; set; }
     public bool UseRiskInsights { get; set; }
 }

--- a/src/Core/AdminConsole/Models/Data/Organizations/OrganizationUsers/OrganizationUserOrganizationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Organizations/OrganizationUsers/OrganizationUserOrganizationDetails.cs
@@ -56,6 +56,7 @@ public class OrganizationUserOrganizationDetails
     public int? SmServiceAccounts { get; set; }
     public bool LimitCollectionCreation { get; set; }
     public bool LimitCollectionDeletion { get; set; }
+    public bool LimitItemDeletion { get; set; }
     public bool AllowAdminAccessToAllCollectionItems { get; set; }
     public bool UseRiskInsights { get; set; }
 }

--- a/src/Core/AdminConsole/Models/Data/Organizations/SelfHostedOrganizationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Organizations/SelfHostedOrganizationDetails.cs
@@ -146,6 +146,7 @@ public class SelfHostedOrganizationDetails : Organization
             OwnersNotifiedOfAutoscaling = OwnersNotifiedOfAutoscaling,
             LimitCollectionCreation = LimitCollectionCreation,
             LimitCollectionDeletion = LimitCollectionDeletion,
+            LimitItemDeletion = LimitItemDeletion,
             AllowAdminAccessToAllCollectionItems = AllowAdminAccessToAllCollectionItems,
             Status = Status
         };

--- a/src/Core/AdminConsole/Models/Data/Provider/ProviderUserOrganizationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Provider/ProviderUserOrganizationDetails.cs
@@ -42,6 +42,7 @@ public class ProviderUserOrganizationDetails
     public PlanType PlanType { get; set; }
     public bool LimitCollectionCreation { get; set; }
     public bool LimitCollectionDeletion { get; set; }
+    public bool LimitItemDeletion { get; set; }
     public bool AllowAdminAccessToAllCollectionItems { get; set; }
     public bool UseRiskInsights { get; set; }
     public ProviderType ProviderType { get; set; }

--- a/src/Core/Billing/Licenses/LicenseConstants.cs
+++ b/src/Core/Billing/Licenses/LicenseConstants.cs
@@ -35,6 +35,7 @@ public static class OrganizationLicenseConstants
     public const string SmSeats = nameof(SmSeats);
     public const string SmServiceAccounts = nameof(SmServiceAccounts);
     public const string LimitCollectionCreationDeletion = nameof(LimitCollectionCreationDeletion);
+    public const string LimitItemDeletion = nameof(LimitItemDeletion);
     public const string AllowAdminAccessToAllCollectionItems = nameof(AllowAdminAccessToAllCollectionItems);
     public const string Expires = nameof(Expires);
     public const string Refresh = nameof(Refresh);

--- a/src/Core/Billing/Licenses/Services/Implementations/OrganizationLicenseClaimsFactory.cs
+++ b/src/Core/Billing/Licenses/Services/Implementations/OrganizationLicenseClaimsFactory.cs
@@ -47,6 +47,7 @@ public class OrganizationLicenseClaimsFactory : ILicenseClaimsFactory<Organizati
             new(nameof(OrganizationLicenseConstants.LimitCollectionCreationDeletion),
                 (entity.LimitCollectionCreation || entity.LimitCollectionDeletion).ToString()),
             new(nameof(OrganizationLicenseConstants.AllowAdminAccessToAllCollectionItems), entity.AllowAdminAccessToAllCollectionItems.ToString()),
+            new(nameof(OrganizationLicenseConstants.LimitItemDeletion), entity.LimitItemDeletion.ToString()),
             new(nameof(OrganizationLicenseConstants.Issued), DateTime.UtcNow.ToString(CultureInfo.InvariantCulture)),
             new(nameof(OrganizationLicenseConstants.Expires), expires.ToString(CultureInfo.InvariantCulture)),
             new(nameof(OrganizationLicenseConstants.Refresh), refresh.ToString(CultureInfo.InvariantCulture)),

--- a/src/Core/Models/Business/OrganizationLicense.cs
+++ b/src/Core/Models/Business/OrganizationLicense.cs
@@ -59,7 +59,6 @@ public class OrganizationLicense : ILicense
         // Deprecated. Left for backwards compatibility with old license versions.
         LimitCollectionCreationDeletion = org.LimitCollectionCreation || org.LimitCollectionDeletion;
         AllowAdminAccessToAllCollectionItems = org.AllowAdminAccessToAllCollectionItems;
-        LimitItemDeletion = org.LimitItemDeletion;
         //
 
         if (subscriptionInfo?.Subscription == null)
@@ -147,7 +146,6 @@ public class OrganizationLicense : ILicense
 
     // Deprecated. Left for backwards compatibility with old license versions.
     public bool LimitCollectionCreationDeletion { get; set; } = true;
-    public bool LimitItemDeletion { get; set; }
     public bool AllowAdminAccessToAllCollectionItems { get; set; } = true;
     //
 

--- a/src/Core/Models/Business/OrganizationLicense.cs
+++ b/src/Core/Models/Business/OrganizationLicense.cs
@@ -59,6 +59,7 @@ public class OrganizationLicense : ILicense
         // Deprecated. Left for backwards compatibility with old license versions.
         LimitCollectionCreationDeletion = org.LimitCollectionCreation || org.LimitCollectionDeletion;
         AllowAdminAccessToAllCollectionItems = org.AllowAdminAccessToAllCollectionItems;
+        LimitItemDeletion = org.LimitItemDeletion;
         //
 
         if (subscriptionInfo?.Subscription == null)
@@ -146,6 +147,7 @@ public class OrganizationLicense : ILicense
 
     // Deprecated. Left for backwards compatibility with old license versions.
     public bool LimitCollectionCreationDeletion { get; set; } = true;
+    public bool LimitItemDeletion { get; set; }
     public bool AllowAdminAccessToAllCollectionItems { get; set; } = true;
     //
 

--- a/src/Core/Models/PushNotification.cs
+++ b/src/Core/Models/PushNotification.cs
@@ -62,4 +62,5 @@ public class OrganizationCollectionManagementPushNotification
     public Guid OrganizationId { get; init; }
     public bool LimitCollectionCreation { get; init; }
     public bool LimitCollectionDeletion { get; init; }
+    public bool LimitItemDeletion { get; init; }
 }

--- a/src/Core/NotificationHub/NotificationHubPushNotificationService.cs
+++ b/src/Core/NotificationHub/NotificationHubPushNotificationService.cs
@@ -246,7 +246,8 @@ public class NotificationHubPushNotificationService : IPushNotificationService
             {
                 OrganizationId = organization.Id,
                 LimitCollectionCreation = organization.LimitCollectionCreation,
-                LimitCollectionDeletion = organization.LimitCollectionDeletion
+                LimitCollectionDeletion = organization.LimitCollectionDeletion,
+                LimitItemDeletion = organization.LimitItemDeletion
             },
             false
         );

--- a/src/Core/Platform/Push/Services/AzureQueuePushNotificationService.cs
+++ b/src/Core/Platform/Push/Services/AzureQueuePushNotificationService.cs
@@ -239,6 +239,7 @@ public class AzureQueuePushNotificationService : IPushNotificationService
             {
                 OrganizationId = organization.Id,
                 LimitCollectionCreation = organization.LimitCollectionCreation,
-                LimitCollectionDeletion = organization.LimitCollectionDeletion
+                LimitCollectionDeletion = organization.LimitCollectionDeletion,
+                LimitItemDeletion = organization.LimitItemDeletion
             }, false);
 }

--- a/src/Core/Platform/Push/Services/NotificationsApiPushNotificationService.cs
+++ b/src/Core/Platform/Push/Services/NotificationsApiPushNotificationService.cs
@@ -248,6 +248,7 @@ public class NotificationsApiPushNotificationService : BaseIdentityClientService
             {
                 OrganizationId = organization.Id,
                 LimitCollectionCreation = organization.LimitCollectionCreation,
-                LimitCollectionDeletion = organization.LimitCollectionDeletion
+                LimitCollectionDeletion = organization.LimitCollectionDeletion,
+                LimitItemDeletion = organization.LimitItemDeletion
             }, false);
 }

--- a/src/Core/Platform/Push/Services/RelayPushNotificationService.cs
+++ b/src/Core/Platform/Push/Services/RelayPushNotificationService.cs
@@ -273,7 +273,8 @@ public class RelayPushNotificationService : BaseIdentityClientService, IPushNoti
             {
                 OrganizationId = organization.Id,
                 LimitCollectionCreation = organization.LimitCollectionCreation,
-                LimitCollectionDeletion = organization.LimitCollectionDeletion
+                LimitCollectionDeletion = organization.LimitCollectionDeletion,
+                LimitItemDeletion = organization.LimitItemDeletion
             },
             false
         );

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationRepository.cs
@@ -101,6 +101,7 @@ public class OrganizationRepository : Repository<Core.AdminConsole.Entities.Orga
                 UsePolicies = e.UsePolicies,
                 LimitCollectionCreation = e.LimitCollectionCreation,
                 LimitCollectionDeletion = e.LimitCollectionDeletion,
+                LimitItemDeletion = e.LimitItemDeletion,
                 AllowAdminAccessToAllCollectionItems = e.AllowAdminAccessToAllCollectionItems,
                 UseRiskInsights = e.UseRiskInsights
             }).ToListAsync();

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/OrganizationUserOrganizationDetailsViewQuery.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/OrganizationUserOrganizationDetailsViewQuery.cs
@@ -68,6 +68,7 @@ public class OrganizationUserOrganizationDetailsViewQuery : IQuery<OrganizationU
                         SmServiceAccounts = o.SmServiceAccounts,
                         LimitCollectionCreation = o.LimitCollectionCreation,
                         LimitCollectionDeletion = o.LimitCollectionDeletion,
+                        LimitItemDeletion = o.LimitItemDeletion,
                         AllowAdminAccessToAllCollectionItems = o.AllowAdminAccessToAllCollectionItems,
                         UseRiskInsights = o.UseRiskInsights,
                     };

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/ProviderUserOrganizationDetailsViewQuery.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/ProviderUserOrganizationDetailsViewQuery.cs
@@ -46,6 +46,7 @@ public class ProviderUserOrganizationDetailsViewQuery : IQuery<ProviderUserOrgan
             PlanType = x.o.PlanType,
             LimitCollectionCreation = x.o.LimitCollectionCreation,
             LimitCollectionDeletion = x.o.LimitCollectionDeletion,
+            LimitItemDeletion = x.o.LimitItemDeletion,
             AllowAdminAccessToAllCollectionItems = x.o.AllowAdminAccessToAllCollectionItems,
             UseRiskInsights = x.o.UseRiskInsights,
             ProviderType = x.p.Type


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17217

## 📔 Objective

**Problem**: When a policy is enabled, a record is created in the Policy table. However, downgrading an organization does not update this record, causing the system to behave as if the policy is still active.

**Solution**: Add a check to ensure the policy is applied only if the organization has "Use Policies" enabled.

## 📸 Screenshots

Manually tests the happy path.

![image](https://github.com/user-attachments/assets/5be031f3-4275-4963-a955-bf69e8855e4e)

The unit tests should cover both happy and sad paths.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
