### PR TITLE
Ac/pm 17217/add use policy check for accept endpoint 2

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -328,9 +328,9 @@ public class OrganizationUsersController : Controller
 
     private async Task<bool> ShouldHandleResetPasswordAsync(Guid orgId)
     {
-        var organization = await _organizationRepository.GetByIdAsync(orgId);
+        var organizationAbility = await _applicationCacheService.GetOrganizationAbilityAsync(orgId);
 
-        if (organization is not { UsePolicies: true })
+        if (organizationAbility is not { UsePolicies: true })
         {
             return false;
         }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17217

## 📔 Objective

**Problem**: When a policy is enabled, a record is created in the Policy table. However, downgrading an organization does not update this record, causing the system to behave as if the policy is still active.

**Solution**: Add a check to ensure the policy is applied only if the organization has "Use Policies" enabled.

## 📸 Screenshots

Manually tests the happy path.

![image](https://github.com/user-attachments/assets/5be031f3-4275-4963-a955-bf69e8855e4e)

The unit tests should cover both happy and sad paths.
## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
