### PR TITLE
[PM-16528] Fix entity framework query

### DIFF
--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationDomainRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationDomainRepositoryTests.cs
@@ -188,4 +188,122 @@ public class OrganizationDomainRepositoryTests
         var expectedDomain2 = domains.FirstOrDefault(domain => domain.DomainName == organizationDomain2.DomainName);
         Assert.Null(expectedDomain2);
     }
+
+    [DatabaseTheory, DatabaseData]
+    public async Task GetManyByNextRunDateAsync_ShouldReturnUnverifiedDomains(
+     IOrganizationRepository organizationRepository,
+     IOrganizationDomainRepository organizationDomainRepository)
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        var organization1 = await organizationRepository.CreateAsync(new Organization
+        {
+            Name = $"Test Org {id}",
+            BillingEmail = $"test+{id}@example.com",
+            Plan = "Test",
+            PrivateKey = "privatekey",
+
+        });
+
+        var organizationDomain = new OrganizationDomain
+        {
+            OrganizationId = organization1.Id,
+            DomainName = $"domain2+{id}@example.com",
+            Txt = "btw+12345"
+        };
+
+        var within36HoursWindow = 1;
+        organizationDomain.SetNextRunDate(within36HoursWindow);
+
+        await organizationDomainRepository.CreateAsync(organizationDomain);
+
+        var date = organizationDomain.NextRunDate;
+
+        // Act
+        var domains = await organizationDomainRepository.GetManyByNextRunDateAsync(date);
+
+        // Assert
+        var expectedDomain = domains.FirstOrDefault(domain => domain.DomainName == organizationDomain.DomainName);
+        Assert.NotNull(expectedDomain);
+    }
+
+    [DatabaseTheory, DatabaseData]
+    public async Task GetManyByNextRunDateAsync_ShouldNotReturnUnverifiedDomains_WhenNextRunDateIsOutside36hoursWindow(
+        IOrganizationRepository organizationRepository,
+        IOrganizationDomainRepository organizationDomainRepository)
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        var organization1 = await organizationRepository.CreateAsync(new Organization
+        {
+            Name = $"Test Org {id}",
+            BillingEmail = $"test+{id}@example.com",
+            Plan = "Test",
+            PrivateKey = "privatekey",
+
+        });
+
+        var organizationDomain = new OrganizationDomain
+        {
+            OrganizationId = organization1.Id,
+            DomainName = $"domain2+{id}@example.com",
+            Txt = "btw+12345"
+        };
+
+        var outside36HoursWindow = 20;
+        organizationDomain.SetNextRunDate(outside36HoursWindow);
+
+        await organizationDomainRepository.CreateAsync(organizationDomain);
+
+        var date = DateTimeOffset.UtcNow.Date.AddDays(1);
+
+        // Act
+        var domains = await organizationDomainRepository.GetManyByNextRunDateAsync(date);
+
+        // Assert
+        var expectedDomain = domains.FirstOrDefault(domain => domain.DomainName == organizationDomain.DomainName);
+        Assert.Null(expectedDomain);
+    }
+
+    [DatabaseTheory, DatabaseData]
+    public async Task GetManyByNextRunDateAsync_ShouldNotReturnVerifiedDomains(
+        IOrganizationRepository organizationRepository,
+        IOrganizationDomainRepository organizationDomainRepository)
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        var organization1 = await organizationRepository.CreateAsync(new Organization
+        {
+            Name = $"Test Org {id}",
+            BillingEmail = $"test+{id}@example.com",
+            Plan = "Test",
+            PrivateKey = "privatekey",
+
+        });
+
+        var organizationDomain = new OrganizationDomain
+        {
+            OrganizationId = organization1.Id,
+            DomainName = $"domain2+{id}@example.com",
+            Txt = "btw+12345"
+        };
+
+        var within36HoursWindow = 1;
+        organizationDomain.SetNextRunDate(within36HoursWindow);
+        organizationDomain.SetVerifiedDate();
+
+        await organizationDomainRepository.CreateAsync(organizationDomain);
+
+        var date = DateTimeOffset.UtcNow.Date.AddDays(1);
+
+        // Act
+        var domains = await organizationDomainRepository.GetManyByNextRunDateAsync(date);
+
+        // Assert
+        var expectedDomain = domains.FirstOrDefault(domain => domain.DomainName == organizationDomain.DomainName);
+        Assert.Null(expectedDomain);
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16528

## 📔 Objective

**Problem**: The old query attempted to replicate the behavior of [OrganizationDomain_ReadByNextRunDate](https://github.com/bitwarden/server/blob/main/src/Sql/dbo/StoredProcedures/OrganizationDomain_ReadByNextRunDate.sql#L1); however, it had several issues:

1. It was incompatible with PostgreSQL.
2. It executed `.AsEnumerable()` before the Where clause in the second query, resulting in all records being pulled from the database unnecessarily.
3. It appeared to directly translate the SQL logic into Entity Framework using `Union`, which was inefficient and unnecessary.

**Solution**: The stored procedure is designed to identify all unverified domains within the last 36-hour window. I rewrote the query in Entity Framework to achieve this functionality and added integration tests to validate the behavior.

## 📸 Screenshots

The integration tests should cover all cases since they interact with real databases.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
