### PR TITLE
[PM-17709] Send New Device Login email for all new devices

### DIFF
--- a/src/Identity/IdentityServer/RequestValidators/DeviceValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/DeviceValidator.cs
@@ -91,8 +91,8 @@ public class DeviceValidator(
         await _deviceService.SaveAsync(requestDevice);
         context.Device = requestDevice;
 
-        if(!_globalSettings.DisableEmailNewDevice)
-        {  
+        if (!_globalSettings.DisableEmailNewDevice)
+        {
             await SendNewDeviceLoginEmail(context.User, requestDevice);
         }
 

--- a/test/Identity.Test/IdentityServer/DeviceValidatorTests.cs
+++ b/test/Identity.Test/IdentityServer/DeviceValidatorTests.cs
@@ -227,7 +227,7 @@ public class DeviceValidatorTests
     }
 
     [Theory, BitAutoData]
-    public async void ValidateRequestDeviceAsync_NewDeviceVerificationFeatureFlagFalse_SendsEmail_ReturnsTrue(
+    public async void ValidateRequestDeviceAsync_ExistingUserNewDeviceLogin_SendNewDeviceLoginEmail_ReturnsTrue(
         CustomValidatorRequestContext context,
         [AuthFixtures.ValidatedTokenRequest] ValidatedTokenRequest request)
     {
@@ -237,8 +237,6 @@ public class DeviceValidatorTests
         _globalSettings.DisableEmailNewDevice = false;
         _deviceRepository.GetByIdentifierAsync(context.Device.Identifier, context.User.Id)
             .Returns(null as Device);
-        _featureService.IsEnabled(FeatureFlagKeys.NewDeviceVerification)
-            .Returns(false);
         // set user creation to more than 10 minutes ago
         context.User.CreationDate = DateTime.UtcNow - TimeSpan.FromMinutes(11);
 
@@ -253,7 +251,7 @@ public class DeviceValidatorTests
     }
 
     [Theory, BitAutoData]
-    public async void ValidateRequestDeviceAsync_NewDeviceVerificationFeatureFlagFalse_NewUser_DoesNotSendEmail_ReturnsTrue(
+    public async void ValidateRequestDeviceAsync_NewUserNewDeviceLogin_DoesNotSendEmail_ReturnsTrue(
     CustomValidatorRequestContext context,
     [AuthFixtures.ValidatedTokenRequest] ValidatedTokenRequest request)
     {
@@ -263,8 +261,6 @@ public class DeviceValidatorTests
         _globalSettings.DisableEmailNewDevice = false;
         _deviceRepository.GetByIdentifierAsync(context.Device.Identifier, context.User.Id)
             .Returns(null as Device);
-        _featureService.IsEnabled(FeatureFlagKeys.NewDeviceVerification)
-            .Returns(false);
         // set user creation to less than 10 minutes ago
         context.User.CreationDate = DateTime.UtcNow - TimeSpan.FromMinutes(9);
 
@@ -279,7 +275,7 @@ public class DeviceValidatorTests
     }
 
     [Theory, BitAutoData]
-    public async void ValidateRequestDeviceAsync_NewDeviceVerificationFeatureFlagFalse_DisableEmailTrue_DoesNotSendEmail_ReturnsTrue(
+    public async void ValidateRequestDeviceAsynce_DisableEmailTrue_DoesNotSendEmail_ReturnsTrue(
         CustomValidatorRequestContext context,
         [AuthFixtures.ValidatedTokenRequest] ValidatedTokenRequest request)
     {
@@ -289,8 +285,6 @@ public class DeviceValidatorTests
         _globalSettings.DisableEmailNewDevice = true;
         _deviceRepository.GetByIdentifierAsync(context.Device.Identifier, context.User.Id)
             .Returns(null as Device);
-        _featureService.IsEnabled(FeatureFlagKeys.NewDeviceVerification)
-            .Returns(false);
 
         // Act
         var result = await _sut.ValidateRequestDeviceAsync(request, context);

--- a/test/Identity.Test/IdentityServer/DeviceValidatorTests.cs
+++ b/test/Identity.Test/IdentityServer/DeviceValidatorTests.cs
@@ -251,7 +251,7 @@ public class DeviceValidatorTests
     }
 
     [Theory, BitAutoData]
-    public async void ValidateRequestDeviceAsync_NewUserNewDeviceLogin_DoesNotSendEmail_ReturnsTrue(
+    public async void ValidateRequestDeviceAsync_NewUserNewDeviceLogin_DoesNotSendNewDeviceLoginEmail_ReturnsTrue(
     CustomValidatorRequestContext context,
     [AuthFixtures.ValidatedTokenRequest] ValidatedTokenRequest request)
     {
@@ -275,7 +275,7 @@ public class DeviceValidatorTests
     }
 
     [Theory, BitAutoData]
-    public async void ValidateRequestDeviceAsynce_DisableEmailTrue_DoesNotSendEmail_ReturnsTrue(
+    public async void ValidateRequestDeviceAsynce_DisableNewDeviceLoginEmailTrue_DoesNotSendNewDeviceEmail_ReturnsTrue(
         CustomValidatorRequestContext context,
         [AuthFixtures.ValidatedTokenRequest] ValidatedTokenRequest request)
     {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17709

## 📔 Objective

In #5084, we gated the sending of the New Device Login email behind the `new-device-verification` feature flag.  The assumption being that if we were using New Device Verification, we didn't want to "double up" the emails to our users.

However, after discussions with the team we have decided that it would present a better security surface to our customers to always send this email, for every login on a new device that happens > 10 minutes after the account is created.

This PR restores the functionality that was in place before the New Device Verification changes, which can be seen [here])https://github.com/bitwarden/server/blob/c028c68d9ca89d522c8c9fab006b885235311eb1/src/Identity/IdentityServer/RequestValidators/DeviceValidator.cs#L55).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
