### PR TITLE
[PM-16053] Add DeviceType enum to AuthRequest response model

### DIFF
--- a/src/Api/Auth/Models/Response/AuthRequestResponseModel.cs
+++ b/src/Api/Auth/Models/Response/AuthRequestResponseModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using Bit.Core.Auth.Entities;
+using Bit.Core.Enums;
 using Bit.Core.Models.Api;
 
 namespace Bit.Api.Auth.Models.Response;
@@ -17,6 +18,7 @@ public class AuthRequestResponseModel : ResponseModel
 
         Id = authRequest.Id;
         PublicKey = authRequest.PublicKey;
+        RequestDeviceTypeValue = authRequest.RequestDeviceType;
         RequestDeviceType = authRequest.RequestDeviceType.GetType().GetMember(authRequest.RequestDeviceType.ToString())
             .FirstOrDefault()?.GetCustomAttribute<DisplayAttribute>()?.GetName();
         RequestIpAddress = authRequest.RequestIpAddress;
@@ -30,6 +32,7 @@ public class AuthRequestResponseModel : ResponseModel
 
     public Guid Id { get; set; }
     public string PublicKey { get; set; }
+    public DeviceType RequestDeviceTypeValue { get; set; }
     public string RequestDeviceType { get; set; }
     public string RequestIpAddress { get; set; }
     public string Key { get; set; }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16053

## 📔 Objective

In #5152 we added a new endpoint to retrieve the combined Device and AuthRequest data to feed our new Device Management screen.

That API endpoint returns the `DeviceType` enum in the response.

In this task, we'll be responding to the notification message indicating that a new AuthRequest has been triggered for a device.  In order to allow the client to use the same logic for determining the device type, we'd like the `DeviceType` enum on the AuthRequest `GET` endpoint - so that the same mapping can be done on the client.

📓 I'm open to suggestions for a better name, but we can't change `RequestDeviceType` without breaking existing clients 😢 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
