### PR TITLE
[PM-17715] Remove feature flag from New Device Verification opt-out endpoint

### DIFF
--- a/src/Api/Auth/Controllers/AccountsController.cs
+++ b/src/Api/Auth/Controllers/AccountsController.cs
@@ -974,7 +974,6 @@ public class AccountsController : Controller
         await _userService.ResendNewDeviceVerificationEmail(request.Email, request.Secret);
     }
 
-    [RequireFeature(FeatureFlagKeys.NewDeviceVerification)]
     [HttpPost("verify-devices")]
     [HttpPut("verify-devices")]
     public async Task SetUserVerifyDevicesAsync([FromBody] SetVerifyDevicesRequestModel request)


### PR DESCRIPTION
## 🎟️ Tracking

[bitwarden.atlassian.net/browse/PM-17715](https://bitwarden.atlassian.net/browse/PM-17715)

## 📔 Objective

In https://github.com/bitwarden/server/pull/5264 we added the ability for users to opt out of New Device Verification.

In the original PR, the functionality was gated behind the new-device-verification feature flag. However, we want to let users enable this feature prior to the larger feature being released.

This PR removes the feature flag gate from the endpoint required to opt out of new device verification.

See https://github.com/bitwarden/clients/pull/13130 for corresponding clients PR.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
