### PR TITLE
[PM-12765] Change error message when subscription canceled and attemp…

### DIFF
--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -1304,7 +1304,7 @@ public class OrganizationService : IOrganizationService
         var subscription = await _paymentService.GetSubscriptionAsync(organization);
         if (subscription?.Subscription?.Status == StripeConstants.SubscriptionStatus.Canceled)
         {
-            return (false, "Cannot autoscale with a canceled subscription.");
+            return (false, "You do not have an active subscription. Reinstate your subscription to make changes");
         }
 
         return (true, failureReason);

--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -1294,17 +1294,17 @@ public class OrganizationService : IOrganizationService
             }
         }
 
+        var subscription = await _paymentService.GetSubscriptionAsync(organization);
+        if (subscription?.Subscription?.Status == StripeConstants.SubscriptionStatus.Canceled)
+        {
+            return (false, "You do not have an active subscription. Reinstate your subscription to make changes");
+        }
+
         if (organization.Seats.HasValue &&
             organization.MaxAutoscaleSeats.HasValue &&
             organization.MaxAutoscaleSeats.Value < organization.Seats.Value + seatsToAdd)
         {
             return (false, $"Seat limit has been reached.");
-        }
-
-        var subscription = await _paymentService.GetSubscriptionAsync(organization);
-        if (subscription?.Subscription?.Status == StripeConstants.SubscriptionStatus.Canceled)
-        {
-            return (false, "You do not have an active subscription. Reinstate your subscription to make changes");
         }
 
         return (true, failureReason);


### PR DESCRIPTION
…ting to autoscale

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-12765

## 📔 Objective

Change the error message to match the requirements by 'Product'.

## 📸 Screenshots

See [ticket](https://bitwarden.atlassian.net/browse/PM-12765), for any screenshots or recordings.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
