### PR TITLE
[PM-16482]NullReferenceException in CustomerUpdatedHandler due to uninitialized dependency

### DIFF
--- a/src/Billing/Services/Implementations/CustomerUpdatedHandler.cs
+++ b/src/Billing/Services/Implementations/CustomerUpdatedHandler.cs
@@ -22,7 +22,7 @@ public class CustomerUpdatedHandler : ICustomerUpdatedHandler
         IStripeEventService stripeEventService,
         IStripeEventUtilityService stripeEventUtilityService)
     {
-        _organizationRepository = organizationRepository;
+        _organizationRepository = organizationRepository ?? throw new ArgumentNullException(nameof(organizationRepository));
         _referenceEventService = referenceEventService;
         _currentContext = currentContext;
         _stripeEventService = stripeEventService;
@@ -35,13 +35,33 @@ public class CustomerUpdatedHandler : ICustomerUpdatedHandler
     /// <param name="parsedEvent"></param>
     public async Task HandleAsync(Event parsedEvent)
     {
+        if (parsedEvent == null)
+        {
+            throw new ArgumentNullException(nameof(parsedEvent));
+        }
+
+        if (_stripeEventService == null)
+        {
+            throw new InvalidOperationException($"{nameof(_stripeEventService)} is not initialized");
+        }
+
         var customer = await _stripeEventService.GetCustomer(parsedEvent, true, ["subscriptions"]);
-        if (customer.Subscriptions == null || !customer.Subscriptions.Any())
+        if (customer?.Subscriptions == null || !customer.Subscriptions.Any())
         {
             return;
         }
 
         var subscription = customer.Subscriptions.First();
+
+        if (subscription.Metadata == null)
+        {
+            return;
+        }
+
+        if (_stripeEventUtilityService == null)
+        {
+            throw new InvalidOperationException($"{nameof(_stripeEventUtilityService)} is not initialized");
+        }
 
         var (organizationId, _, providerId) = _stripeEventUtilityService.GetIdsFromMetadata(subscription.Metadata);
 
@@ -50,9 +70,30 @@ public class CustomerUpdatedHandler : ICustomerUpdatedHandler
             return;
         }
 
+        if (_organizationRepository == null)
+        {
+            throw new InvalidOperationException($"{nameof(_organizationRepository)} is not initialized");
+        }
+
         var organization = await _organizationRepository.GetByIdAsync(organizationId.Value);
+
+        if (organization == null)
+        {
+            return;
+        }
+
         organization.BillingEmail = customer.Email;
         await _organizationRepository.ReplaceAsync(organization);
+
+        if (_referenceEventService == null)
+        {
+            throw new InvalidOperationException($"{nameof(_referenceEventService)} is not initialized");
+        }
+
+        if (_currentContext == null)
+        {
+            throw new InvalidOperationException($"{nameof(_currentContext)} is not initialized");
+        }
 
         await _referenceEventService.RaiseEventAsync(
             new ReferenceEvent(ReferenceEventType.OrganizationEditedInStripe, organization, _currentContext));

--- a/test/Infrastructure.Dapper.Test/Infrastructure.Dapper.Test.csproj
+++ b/test/Infrastructure.Dapper.Test/Infrastructure.Dapper.Test.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-16482

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
A NullReferenceException is being thrown in CustomerUpdatedHandler when attempting to access the OrganizationRepository. This indicates that dependency injection is failing to initialize the repository properly.

I added more exact logs to know where the issue  is coming exactly
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
