### PR TITLE
PM-6939 - Onyx Integration into freshdesk controller

### DIFF
--- a/src/Billing/Billing.csproj
+++ b/src/Billing/Billing.csproj
@@ -10,5 +10,8 @@
     <ProjectReference Include="..\SharedWeb\SharedWeb.csproj" />
     <ProjectReference Include="..\Core\Core.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+  </ItemGroup>
 
 </Project>

--- a/src/Billing/BillingSettings.cs
+++ b/src/Billing/BillingSettings.cs
@@ -12,6 +12,7 @@ public class BillingSettings
     public virtual FreshDeskSettings FreshDesk { get; set; } = new FreshDeskSettings();
     public virtual string FreshsalesApiKey { get; set; }
     public virtual PayPalSettings PayPal { get; set; } = new PayPalSettings();
+    public virtual OnyxSettings Onyx { get; set; } = new OnyxSettings();
 
     public class PayPalSettings
     {
@@ -30,5 +31,11 @@ public class BillingSettings
         public virtual string Region { get; set; }
         public virtual string UserFieldName { get; set; }
         public virtual string OrgFieldName { get; set; }
+    }
+
+    public class OnyxSettings
+    {
+        public virtual string ApiKey { get; set; }
+        public virtual string BaseUrl { get; set; }
     }
 }

--- a/src/Billing/Controllers/BitPayController.cs
+++ b/src/Billing/Controllers/BitPayController.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Options;
 namespace Bit.Billing.Controllers;
 
 [Route("bitpay")]
+[ApiExplorerSettings(IgnoreApi = true)]
 public class BitPayController : Controller
 {
     private readonly BillingSettings _billingSettings;

--- a/src/Billing/Controllers/FreshdeskController.cs
+++ b/src/Billing/Controllers/FreshdeskController.cs
@@ -1,6 +1,8 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Net.Http.Headers;
 using System.Reflection;
 using System.Text;
+using System.Text.Json;
 using System.Web;
 using Bit.Billing.Models;
 using Bit.Core.Repositories;
@@ -145,6 +147,116 @@ public class FreshdeskController : Controller
         }
     }
 
+    [HttpPost("webhook-onyx-ai")]
+    public async Task<IActionResult> PostWebhookOnyxAi([FromQuery, Required] string key,
+        [FromBody, Required] FreshdeskWebhookModel model)
+    {
+        // ensure that the key is from Freshdesk
+        if (!IsValidRequestFromFreshdesk(key))
+        {
+            return new BadRequestResult();
+        }
+
+        // get ticket info from Freshdesk
+        var getTicketRequest = new HttpRequestMessage(HttpMethod.Get,
+            string.Format("https://bitwarden.freshdesk.com/api/v2/tickets/{0}", model.TicketId));
+        var getTicketResponse = await CallFreshdeskApiAsync(getTicketRequest);
+
+        // check if we have a valid response from freshdesk
+        if (getTicketResponse.StatusCode != System.Net.HttpStatusCode.OK)
+        {
+            _logger.LogError("Error getting ticket info from Freshdesk. Ticket Id: {0}. Status code: {1}",
+                            model.TicketId, getTicketResponse.StatusCode);
+            return BadRequest("Failed to retrieve ticket info from Freshdesk");
+        }
+
+        // extract info from the response
+        var ticketInfo = await ExtractTicketInfoFromResponse(getTicketResponse);
+        if (ticketInfo == null)
+        {
+            return BadRequest("Failed to extract ticket info from Freshdesk response");
+        }
+
+        // create the onyx `answer-with-citation` request
+        var onyxRequestModel = new OnyxAnswerWithCitationRequestModel(ticketInfo.DescriptionText);
+        var onyxRequest = new HttpRequestMessage(
+                            HttpMethod.Post,
+                            string.Format("{0}/query/answer-with-citation", _billingSettings.Onyx.BaseUrl))
+        {
+            Content = JsonContent.Create(onyxRequestModel, mediaType: new MediaTypeHeaderValue("application/json")),
+        };
+        var (onyxResponse, onyxJsonResponse) = await CallOnyxApi<OnyxAnswerWithCitationResponseModel>(onyxRequest);
+
+        // the CallOnyxApi will return a null if we have an error response
+        if (onyxJsonResponse?.Answer == null)
+        {
+            return BadRequest("Failed to get a valid response from Onyx API");
+        }
+
+        // add the answer as a note to the ticket
+        await AddAnswerNoteToTicketAsync(onyxJsonResponse.Answer, model.TicketId);
+
+        return Ok();
+    }
+
+    private bool IsValidRequestFromFreshdesk(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key)
+                || !CoreHelpers.FixedTimeEquals(key, _billingSettings.FreshDesk.WebhookKey))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private async Task AddAnswerNoteToTicketAsync(string note, string ticketId)
+    {
+        // if there is no content, then we don't need to add a note
+        if (string.IsNullOrWhiteSpace(note))
+        {
+            return;
+        }
+
+        var noteBody = new Dictionary<string, object>
+                {
+                    { "body", $"<b>Onyx AI:</b><ul>{note}</ul>" },
+                    { "private", true }
+                };
+
+        var noteRequest = new HttpRequestMessage(HttpMethod.Post,
+                    string.Format("https://bitwarden.freshdesk.com/api/v2/tickets/{0}/notes", ticketId))
+        {
+            Content = JsonContent.Create(noteBody),
+        };
+
+        await CallFreshdeskApiAsync(noteRequest);
+    }
+
+    private async Task<FreshdeskViewTicketModel> ExtractTicketInfoFromResponse(HttpResponseMessage getTicketResponse)
+    {
+        var responseString = string.Empty;
+        try
+        {
+            responseString = await getTicketResponse.Content.ReadAsStringAsync();
+            var ticketInfo = JsonSerializer.Deserialize<FreshdeskViewTicketModel>(responseString,
+                options: new System.Text.Json.JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true,
+                    PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.SnakeCaseLower,
+                });
+
+            return ticketInfo;
+        }
+        catch (System.Exception ex)
+        {
+            _logger.LogError("Error deserializing ticket info from Freshdesk response. Response: {0}. Exception {1}",
+                            responseString, ex.ToString());
+        }
+
+        return null;
+    }
+
     private async Task<HttpResponseMessage> CallFreshdeskApiAsync(HttpRequestMessage request, int retriedCount = 0)
     {
         try
@@ -167,6 +279,26 @@ public class FreshdeskController : Controller
         }
         await Task.Delay(30000 * (retriedCount + 1));
         return await CallFreshdeskApiAsync(request, retriedCount++);
+    }
+
+    private async Task<(HttpResponseMessage, T)> CallOnyxApi<T>(HttpRequestMessage request)
+    {
+        var httpClient = _httpClientFactory.CreateClient("OnyxApi");
+        var response = await httpClient.SendAsync(request);
+
+        if (response.StatusCode != System.Net.HttpStatusCode.OK)
+        {
+            _logger.LogError("Error calling Onyx AI API. Status code: {0}. Response {1}",
+                response.StatusCode, JsonSerializer.Serialize(response));
+            return (null, default);
+        }
+        var responseStr = await response.Content.ReadAsStringAsync();
+        var responseJson = JsonSerializer.Deserialize<T>(responseStr, options: new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+        });
+        return (response, responseJson);
     }
 
     private TAttribute GetAttribute<TAttribute>(Enum enumValue) where TAttribute : Attribute

--- a/src/Billing/Controllers/FreshdeskController.cs
+++ b/src/Billing/Controllers/FreshdeskController.cs
@@ -232,7 +232,7 @@ public class FreshdeskController : Controller
         };
 
         var addNoteResponse = await CallFreshdeskApiAsync(noteRequest);
-        if (addNoteResponse.StatusCode != System.Net.HttpStatusCode.OK)
+        if (addNoteResponse.StatusCode != System.Net.HttpStatusCode.Created)
         {
             _logger.LogError("Error adding note to Freshdesk ticket. Ticket Id: {0}. Status: {1}",
                             ticketId, addNoteResponse.ToString());

--- a/src/Billing/Models/FreshdeskViewTicketModel.cs
+++ b/src/Billing/Models/FreshdeskViewTicketModel.cs
@@ -1,0 +1,17 @@
+﻿namespace Bit.Billing.Models;
+
+public class FreshdeskViewTicketModel
+{
+    public bool? Spam { get; set; }
+    public int? Priority { get; set; }
+    public int? Source { get; set; }
+    public int? Status { get; set; }
+    public string Subject { get; set; }
+    public string SupportEmail { get; set; }
+    public int Id { get; set; }
+    public string Description { get; set; }
+    public string DescriptionText { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public List<string> Tags { get; set; }
+}

--- a/src/Billing/Models/FreshdeskViewTicketModel.cs
+++ b/src/Billing/Models/FreshdeskViewTicketModel.cs
@@ -1,17 +1,44 @@
 ﻿namespace Bit.Billing.Models;
 
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
 public class FreshdeskViewTicketModel
 {
+    [JsonPropertyName("spam")]
     public bool? Spam { get; set; }
+
+    [JsonPropertyName("priority")]
     public int? Priority { get; set; }
+
+    [JsonPropertyName("source")]
     public int? Source { get; set; }
+
+    [JsonPropertyName("status")]
     public int? Status { get; set; }
+
+    [JsonPropertyName("subject")]
     public string Subject { get; set; }
+
+    [JsonPropertyName("support_email")]
     public string SupportEmail { get; set; }
+
+    [JsonPropertyName("id")]
     public int Id { get; set; }
+
+    [JsonPropertyName("description")]
     public string Description { get; set; }
+
+    [JsonPropertyName("description_text")]
     public string DescriptionText { get; set; }
+
+    [JsonPropertyName("created_at")]
     public DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("updated_at")]
     public DateTime UpdatedAt { get; set; }
+
+    [JsonPropertyName("tags")]
     public List<string> Tags { get; set; }
 }

--- a/src/Billing/Models/OnyxAnswerWithCitationRequestModel.cs
+++ b/src/Billing/Models/OnyxAnswerWithCitationRequestModel.cs
@@ -1,0 +1,54 @@
+﻿
+using System.Text.Json.Serialization;
+
+namespace Bit.Billing.Models;
+
+public class OnyxAnswerWithCitationRequestModel
+{
+    [JsonPropertyName("messages")]
+    public List<Message> Messages { get; set; }
+
+    [JsonPropertyName("persona_id")]
+    public int PersonaId { get; set; } = 1;
+
+    [JsonPropertyName("prompt_id")]
+    public int PromptId { get; set; } = 1;
+
+    [JsonPropertyName("retrieval_options")]
+    public RetrievalOptions RetrievalOptions { get; set; }
+
+    public OnyxAnswerWithCitationRequestModel(string message)
+    {
+        message = message.Replace(Environment.NewLine, " ").Replace('\r', ' ').Replace('\n', ' ');
+        Messages = new List<Message>() { new Message() { MessageText = message } };
+        RetrievalOptions = new RetrievalOptions();
+    }
+}
+
+public class Message
+{
+    [JsonPropertyName("message")]
+    public string MessageText { get; set; }
+
+    [JsonPropertyName("sender")]
+    public string Sender { get; set; } = "user";
+}
+
+public class RetrievalOptions
+{
+    [JsonPropertyName("run_search")]
+    public string RunSearch { get; set; } = RetrievalOptionsRunSearch.Auto;
+
+    [JsonPropertyName("real_time")]
+    public bool RealTime { get; set; } = true;
+
+    [JsonPropertyName("limit")]
+    public int? Limit { get; set; } = 3;
+}
+
+public class RetrievalOptionsRunSearch
+{
+    public const string Always = "always";
+    public const string Never = "never";
+    public const string Auto = "auto";
+}

--- a/src/Billing/Models/OnyxAnswerWithCitationResponseModel.cs
+++ b/src/Billing/Models/OnyxAnswerWithCitationResponseModel.cs
@@ -1,16 +1,30 @@
-﻿namespace Bit.Billing.Models;
+﻿using System.Text.Json.Serialization;
+
+namespace Bit.Billing.Models;
 
 public class OnyxAnswerWithCitationResponseModel
 {
+    [JsonPropertyName("answer")]
     public string Answer { get; set; }
+
+    [JsonPropertyName("rephrase")]
     public string Rephrase { get; set; }
+
+    [JsonPropertyName("citations")]
     public List<Citation> Citations { get; set; }
+
+    [JsonPropertyName("llm_selected_doc_indices")]
     public List<int> LlmSelectedDocIndices { get; set; }
+
+    [JsonPropertyName("error_msg")]
     public string ErrorMsg { get; set; }
 }
 
 public class Citation
 {
+    [JsonPropertyName("citation_num")]
     public int CitationNum { get; set; }
+
+    [JsonPropertyName("document_id")]
     public string DocumentId { get; set; }
 }

--- a/src/Billing/Models/OnyxAnswerWithCitationResponseModel.cs
+++ b/src/Billing/Models/OnyxAnswerWithCitationResponseModel.cs
@@ -1,0 +1,16 @@
+﻿namespace Bit.Billing.Models;
+
+public class OnyxAnswerWithCitationResponseModel
+{
+    public string Answer { get; set; }
+    public string Rephrase { get; set; }
+    public List<Citation> Citations { get; set; }
+    public List<int> LlmSelectedDocIndices { get; set; }
+    public string ErrorMsg { get; set; }
+}
+
+public class Citation
+{
+    public int CitationNum { get; set; }
+    public string DocumentId { get; set; }
+}

--- a/src/Billing/Startup.cs
+++ b/src/Billing/Startup.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Net.Http.Headers;
 using Bit.Billing.Services;
 using Bit.Billing.Services.Implementations;
 using Bit.Core.Billing.Extensions;
@@ -33,6 +34,7 @@ public class Startup
         // Settings
         var globalSettings = services.AddGlobalSettingsServices(Configuration, Environment);
         services.Configure<BillingSettings>(Configuration.GetSection("BillingSettings"));
+        var billingSettings = Configuration.GetSection("BillingSettings").Get<BillingSettings>();
 
         // Stripe Billing
         StripeConfiguration.ApiKey = globalSettings.Stripe.ApiKey;
@@ -96,6 +98,10 @@ public class Startup
 
         // Set up HttpClients
         services.AddHttpClient("FreshdeskApi");
+        services.AddHttpClient("OnyxApi", client =>
+        {
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", billingSettings.Onyx.ApiKey);
+        });
 
         services.AddScoped<IStripeFacade, StripeFacade>();
         services.AddScoped<IStripeEventService, StripeEventService>();
@@ -104,6 +110,10 @@ public class Startup
         // Jobs service
         Jobs.JobsHostedService.AddJobsServices(services);
         services.AddHostedService<Jobs.JobsHostedService>();
+
+        // Swagger
+        services.AddEndpointsApiExplorer();
+        services.AddSwaggerGen();
     }
 
     public void Configure(
@@ -120,6 +130,11 @@ public class Startup
         if (env.IsDevelopment())
         {
             app.UseDeveloperExceptionPage();
+            app.UseSwagger();
+            app.UseSwaggerUI(c =>
+            {
+                c.SwaggerEndpoint("/swagger/v1/swagger.json", "Billing API V1");
+            });
         }
 
         app.UseStaticFiles();

--- a/src/Billing/appsettings.json
+++ b/src/Billing/appsettings.json
@@ -73,6 +73,10 @@
       "region": "US",
       "userFieldName": "cf_user",
       "orgFieldName": "cf_org"
-    }
+    },
+    "onyx": {
+      "apiKey": "SECRET",
+      "baseUrl": "https://cloud.onyx.app/api"
+    }    
   }
 }

--- a/test/Billing.Test/Controllers/FreshdeskControllerTests.cs
+++ b/test/Billing.Test/Controllers/FreshdeskControllerTests.cs
@@ -206,6 +206,7 @@ public class FreshdeskControllerTests
 
         // mocking Onyx api response given a ticket description
         var mockOnyxHttpMessageHandler = Substitute.ForPartsOf<MockHttpMessageHandler>();
+        onyxResponse.ErrorMsg = string.Empty;
         var mockOnyxResponse = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
         {
             Content = new StringContent(JsonSerializer.Serialize(onyxResponse))


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-6939


## 📔 Objective

Freshdesk reaches out to a webhook on bitwarden.eu to get additional information on tickets.
We have a new endpoint  "webhook-onyx-ai" which has the same signature as "webhook". The new endpoint extracts the description from the freshdesk ticket and forwards it to Onyx API for a response.
The response is then appended to the freskdesk ticket as a private note.

## 📸 Screenshots

No screen shots at this time.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
