### PR TITLE
[PM-18028] Enabling automatic tax for customers without country or with manual tax rates set

### DIFF
--- a/src/Billing/Services/Implementations/UpcomingInvoiceHandler.cs
+++ b/src/Billing/Services/Implementations/UpcomingInvoiceHandler.cs
@@ -1,7 +1,7 @@
 ﻿using Bit.Billing.Constants;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Repositories;
-using Bit.Core.Billing.Constants;
+using Bit.Core.Billing.Extensions;
 using Bit.Core.OrganizationFeatures.OrganizationSponsorships.FamiliesForEnterprise.Interfaces;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
@@ -164,17 +164,12 @@ public class UpcomingInvoiceHandler : IUpcomingInvoiceHandler
         var customerGetOptions = new CustomerGetOptions { Expand = ["tax"] };
         var customer = await _stripeFacade.GetCustomer(subscription.CustomerId, customerGetOptions);
 
-        if (subscription.AutomaticTax.Enabled ||
-            customer.Tax?.AutomaticTax != StripeConstants.AutomaticTaxStatus.Supported)
+        var subscriptionUpdateOptions = new SubscriptionUpdateOptions();
+
+        if (!subscriptionUpdateOptions.EnableAutomaticTax(customer, subscription))
         {
             return subscription;
         }
-
-        var subscriptionUpdateOptions = new SubscriptionUpdateOptions
-        {
-            DefaultTaxRates = [],
-            AutomaticTax = new SubscriptionAutomaticTaxOptions { Enabled = true }
-        };
 
         return await _stripeFacade.UpdateSubscription(subscription.Id, subscriptionUpdateOptions);
     }

--- a/src/Billing/Services/Implementations/UpcomingInvoiceHandler.cs
+++ b/src/Billing/Services/Implementations/UpcomingInvoiceHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Bit.Billing.Constants;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Billing.Constants;
 using Bit.Core.OrganizationFeatures.OrganizationSponsorships.FamiliesForEnterprise.Interfaces;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
@@ -160,13 +161,18 @@ public class UpcomingInvoiceHandler : IUpcomingInvoiceHandler
 
     private async Task<Subscription> TryEnableAutomaticTaxAsync(Subscription subscription)
     {
-        if (subscription.AutomaticTax.Enabled)
+        var customerGetOptions = new CustomerGetOptions { Expand = ["tax"] };
+        var customer = await _stripeFacade.GetCustomer(subscription.CustomerId, customerGetOptions);
+
+        if (subscription.AutomaticTax.Enabled ||
+            customer.Tax?.AutomaticTax != StripeConstants.AutomaticTaxStatus.Supported)
         {
             return subscription;
         }
 
         var subscriptionUpdateOptions = new SubscriptionUpdateOptions
         {
+            DefaultTaxRates = [],
             AutomaticTax = new SubscriptionAutomaticTaxOptions { Enabled = true }
         };
 

--- a/src/Core/Billing/Extensions/CustomerExtensions.cs
+++ b/src/Core/Billing/Extensions/CustomerExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Bit.Core.Billing.Constants;
+using Stripe;
+
+namespace Bit.Core.Billing.Extensions;
+
+public static class CustomerExtensions
+{
+
+    /// <summary>
+    /// Determines if a Stripe customer supports automatic tax
+    /// </summary>
+    /// <param name="customer"></param>
+    /// <returns></returns>
+    public static bool HasTaxLocationVerified(this Customer customer) =>
+        customer?.Tax?.AutomaticTax == StripeConstants.AutomaticTaxStatus.Supported;
+}

--- a/src/Core/Billing/Extensions/SubscriptionCreateOptionsExtensions.cs
+++ b/src/Core/Billing/Extensions/SubscriptionCreateOptionsExtensions.cs
@@ -1,0 +1,26 @@
+﻿using Stripe;
+
+namespace Bit.Core.Billing.Extensions;
+
+public static class SubscriptionCreateOptionsExtensions
+{
+    /// <summary>
+    /// Attempts to enable automatic tax for given new subscription options.
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="customer">The existing customer.</param>
+    /// <returns>Returns true when successful, false when conditions are not met.</returns>
+    public static bool EnableAutomaticTax(this SubscriptionCreateOptions options, Customer customer)
+    {
+        // We might only need to check the automatic tax status.
+        if (!customer.HasTaxLocationVerified() && string.IsNullOrWhiteSpace(customer?.Address.Country))
+        {
+            return false;
+        }
+
+        options.DefaultTaxRates = [];
+        options.AutomaticTax = new SubscriptionAutomaticTaxOptions { Enabled = true };
+
+        return true;
+    }
+}

--- a/src/Core/Billing/Extensions/SubscriptionCreateOptionsExtensions.cs
+++ b/src/Core/Billing/Extensions/SubscriptionCreateOptionsExtensions.cs
@@ -13,7 +13,7 @@ public static class SubscriptionCreateOptionsExtensions
     public static bool EnableAutomaticTax(this SubscriptionCreateOptions options, Customer customer)
     {
         // We might only need to check the automatic tax status.
-        if (!customer.HasTaxLocationVerified() && string.IsNullOrWhiteSpace(customer?.Address.Country))
+        if (!customer.HasTaxLocationVerified() && string.IsNullOrWhiteSpace(customer.Address?.Country))
         {
             return false;
         }

--- a/src/Core/Billing/Extensions/SubscriptionUpdateOptionsExtensions.cs
+++ b/src/Core/Billing/Extensions/SubscriptionUpdateOptionsExtensions.cs
@@ -22,7 +22,7 @@ public static class SubscriptionUpdateOptionsExtensions
         }
 
         // We might only need to check the automatic tax status.
-        if (!customer.HasTaxLocationVerified() && string.IsNullOrWhiteSpace(customer?.Address.Country))
+        if (!customer.HasTaxLocationVerified() && string.IsNullOrWhiteSpace(customer.Address?.Country))
         {
             return false;
         }

--- a/src/Core/Billing/Extensions/SubscriptionUpdateOptionsExtensions.cs
+++ b/src/Core/Billing/Extensions/SubscriptionUpdateOptionsExtensions.cs
@@ -1,0 +1,35 @@
+﻿using Stripe;
+
+namespace Bit.Core.Billing.Extensions;
+
+public static class SubscriptionUpdateOptionsExtensions
+{
+    /// <summary>
+    /// Attempts to enable automatic tax for given subscription options.
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="customer">The existing customer to which the subscription belongs.</param>
+    /// <param name="subscription">The existing subscription.</param>
+    /// <returns>Returns true when successful, false when conditions are not met.</returns>
+    public static bool EnableAutomaticTax(
+        this SubscriptionUpdateOptions options,
+        Customer customer,
+        Subscription subscription)
+    {
+        if (subscription.AutomaticTax.Enabled)
+        {
+            return false;
+        }
+
+        // We might only need to check the automatic tax status.
+        if (!customer.HasTaxLocationVerified() && string.IsNullOrWhiteSpace(customer?.Address.Country))
+        {
+            return false;
+        }
+
+        options.DefaultTaxRates = [];
+        options.AutomaticTax = new SubscriptionAutomaticTaxOptions { Enabled = true };
+
+        return true;
+    }
+}

--- a/src/Core/Billing/Extensions/UpcomingInvoiceOptionsExtensions.cs
+++ b/src/Core/Billing/Extensions/UpcomingInvoiceOptionsExtensions.cs
@@ -22,7 +22,7 @@ public static class UpcomingInvoiceOptionsExtensions
         }
 
         // We might only need to check the automatic tax status.
-        if (!customer.HasTaxLocationVerified() && string.IsNullOrWhiteSpace(customer?.Address.Country))
+        if (!customer.HasTaxLocationVerified() && string.IsNullOrWhiteSpace(customer.Address?.Country))
         {
             return false;
         }

--- a/src/Core/Billing/Extensions/UpcomingInvoiceOptionsExtensions.cs
+++ b/src/Core/Billing/Extensions/UpcomingInvoiceOptionsExtensions.cs
@@ -1,0 +1,35 @@
+﻿using Stripe;
+
+namespace Bit.Core.Billing.Extensions;
+
+public static class UpcomingInvoiceOptionsExtensions
+{
+    /// <summary>
+    /// Attempts to enable automatic tax for given upcoming invoice options.
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="customer">The existing customer to which the upcoming invoice belongs.</param>
+    /// <param name="subscription">The existing subscription to which the upcoming invoice belongs.</param>
+    /// <returns>Returns true when successful, false when conditions are not met.</returns>
+    public static bool EnableAutomaticTax(
+        this UpcomingInvoiceOptions options,
+        Customer customer,
+        Subscription subscription)
+    {
+        if (subscription != null && subscription.AutomaticTax.Enabled)
+        {
+            return false;
+        }
+
+        // We might only need to check the automatic tax status.
+        if (!customer.HasTaxLocationVerified() && string.IsNullOrWhiteSpace(customer?.Address.Country))
+        {
+            return false;
+        }
+
+        options.AutomaticTax = new InvoiceAutomaticTaxOptions { Enabled = true };
+        options.SubscriptionDefaultTaxRates = [];
+
+        return true;
+    }
+}

--- a/src/Core/Billing/Services/Implementations/PremiumUserBillingService.cs
+++ b/src/Core/Billing/Services/Implementations/PremiumUserBillingService.cs
@@ -258,7 +258,7 @@ public class PremiumUserBillingService(
         {
             AutomaticTax = new SubscriptionAutomaticTaxOptions
             {
-                Enabled = true
+                Enabled = customer.Tax?.AutomaticTax == StripeConstants.AutomaticTaxStatus.Supported,
             },
             CollectionMethod = StripeConstants.CollectionMethod.ChargeAutomatically,
             Customer = customer.Id,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18028

## 📔 Objective

Enabling automatic tax for customers without a country set or with tax rates causes issues in certain situations:

### Scenario 1

1. Create a Bitwarden account

2. Upgrade to Premium

3. In Stripe, remove the billing location for the customer.

4. Remove automatic tax for the subscription.

5. Upgrade the additional storage.

6. Verify in Stripe the additional storage is upgraded.

7. Verify automatic tax is still disabled for the subscription in Stripe.

### Scenario 2

1. Create a Bitwarden account

2. Upgrade to Premium

3. In Stripe, remove automatic tax for the subscription.

4. Upgrade the additional storage.

5. Verify in Stripe the additional storage is upgraded.

6. Verify automatic tax is enabled for the subscription in Stripe.

### Scenario 3

1. Create a Bitwarden account

2. Upgrade to Premium

3. Verify automatic tax is enabled for the subscription in Stripe.

### Scenario 4

1. Create a Bitwarden account

2. Upgrade to Premium

3. Disable automatic tax in Stripe.

4. Add tax rates using the API with a script and Stripe’s test API keys: https://docs.stripe.com/billing/taxes/tax-rates 

5. Upgrade the additional storage in the Bitwarden Web portal.

6. Verify the storage is upgraded correctly, and automatic tax is now correctly enabled.



## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
