### PR TITLE
Relax nullable in test projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,11 @@
     <RootNamespace>Bit.$(MSBuildProjectName)</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+    <!-- Treat it as a test project if the project hasn't set their own value and it follows our test project conventions -->
+    <IsTestProject Condition="'$(IsTestProject)' == '' and ($(MSBuildProjectName.EndsWith('.Test')) or $(MSBuildProjectName.EndsWith('.IntegrationTest')))">true</IsTestProject>
+    <Nullable Condition="'$(Nullable)' == '' and '$(IsTestProject)' == 'true'">annotations</Nullable>
+    <!-- Uncomment the below line when we are ready to enable nullable repo wide -->
+    <!-- <Nullable Condition="'$(Nullable)' == '' and '$(IsTestProject)' != 'true'">enable</Nullable> -->
   </PropertyGroup>
 
   <!--

--- a/bitwarden_license/test/Scim.IntegrationTest/Controllers/v2/GroupsControllerTests.cs
+++ b/bitwarden_license/test/Scim.IntegrationTest/Controllers/v2/GroupsControllerTests.cs
@@ -248,7 +248,7 @@ public class GroupsControllerTests : IClassFixture<ScimApplicationFactory>, IAsy
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
-    public async Task Post_InvalidDisplayName_BadRequest(string displayName)
+    public async Task Post_InvalidDisplayName_BadRequest(string? displayName)
     {
         var organizationId = ScimApplicationFactory.TestOrganizationId1;
         var model = new ScimGroupRequestModel

--- a/bitwarden_license/test/Scim.IntegrationTest/Controllers/v2/UsersControllerTests.cs
+++ b/bitwarden_license/test/Scim.IntegrationTest/Controllers/v2/UsersControllerTests.cs
@@ -324,7 +324,7 @@ public class UsersControllerTests : IClassFixture<ScimApplicationFactory>, IAsyn
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
-    public async Task Post_InvalidEmail_BadRequest(string email)
+    public async Task Post_InvalidEmail_BadRequest(string? email)
     {
         var displayName = "Test User 5";
         var externalId = "UE";

--- a/test/Api.IntegrationTest/Api.IntegrationTest.csproj
+++ b/test/Api.IntegrationTest/Api.IntegrationTest.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
@@ -41,8 +41,6 @@ using Xunit;
 using Organization = Bit.Core.AdminConsole.Entities.Organization;
 using OrganizationUser = Bit.Core.Entities.OrganizationUser;
 
-#nullable enable
-
 namespace Bit.Core.Test.Services;
 
 [SutProviderCustomize]

--- a/test/Core.Test/Auth/Models/Business/Tokenables/OrgUserInviteTokenableTests.cs
+++ b/test/Core.Test/Auth/Models/Business/Tokenables/OrgUserInviteTokenableTests.cs
@@ -109,7 +109,7 @@ public class OrgUserInviteTokenableTests
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void Valid_NullOrEmptyOrgUserEmail_ReturnsFalse(string email)
+    public void Valid_NullOrEmptyOrgUserEmail_ReturnsFalse(string? email)
     {
         var token = new OrgUserInviteTokenable
         {

--- a/test/Core.Test/Utilities/CoreHelpersTests.cs
+++ b/test/Core.Test/Utilities/CoreHelpersTests.cs
@@ -271,7 +271,7 @@ public class CoreHelpersTests
     [InlineData("ascii.com", "ascii.com")]
     [InlineData("", "")]
     [InlineData(null, null)]
-    public void PunyEncode_Success(string text, string expected)
+    public void PunyEncode_Success(string? text, string? expected)
     {
         var actual = CoreHelpers.PunyEncode(text);
         Assert.Equal(expected, actual);
@@ -435,7 +435,7 @@ public class CoreHelpersTests
     [InlineData("name@", "name@")] // @ symbol but no domain
     [InlineData("", "")] // Empty string
     [InlineData(null, null)] // null
-    public void ObfuscateEmail_Success(string input, string expected)
+    public void ObfuscateEmail_Success(string? input, string? expected)
     {
         Assert.Equal(expected, CoreHelpers.ObfuscateEmail(input));
     }
@@ -456,7 +456,7 @@ public class CoreHelpersTests
     [InlineData("user@")]
     [InlineData("@example.com")]
     [InlineData("user@ex@ample.com")]
-    public void GetEmailDomain_ReturnsNull(string wrongEmail)
+    public void GetEmailDomain_ReturnsNull(string? wrongEmail)
     {
         Assert.Null(CoreHelpers.GetEmailDomain(wrongEmail));
     }

--- a/test/Core.Test/Utilities/EncryptedStringAttributeTests.cs
+++ b/test/Core.Test/Utilities/EncryptedStringAttributeTests.cs
@@ -25,7 +25,7 @@ public class EncryptedStringAttributeTests
     [InlineData("Rsa2048_OaepSha256_HmacSha256_B64.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==")] // Valid Rsa2048_OaepSha256_HmacSha256_B64 as a string
     [InlineData("6.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==")] // Valid Rsa2048_OaepSha1_HmacSha256_B64 as a number
     [InlineData("Rsa2048_OaepSha1_HmacSha256_B64.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==")]
-    public void IsValid_ReturnsTrue_WhenValid(string input)
+    public void IsValid_ReturnsTrue_WhenValid(string? input)
     {
         var sut = new EncryptedStringAttribute();
 

--- a/test/Core.Test/Utilities/StrictEmailAddressAttributeTests.cs
+++ b/test/Core.Test/Utilities/StrictEmailAddressAttributeTests.cs
@@ -47,7 +47,7 @@ public class StrictEmailAttributeTests
     [InlineData("hellothere@world.com-")]               // domain ending in hyphen
     [InlineData("hellö@world.com")]                     // unicode at end of local-part
     [InlineData("héllo@world.com")]                     // unicode in middle of local-part
-    public void IsValid_ReturnsFalseWhenInvalid(string email)
+    public void IsValid_ReturnsFalseWhenInvalid(string? email)
     {
         var sut = new StrictEmailAddressAttribute();
 

--- a/test/Core.Test/Utilities/StrictEmailAddressListAttributeTests.cs
+++ b/test/Core.Test/Utilities/StrictEmailAddressListAttributeTests.cs
@@ -42,7 +42,7 @@ public class StrictEmailAddressListAttributeTests
     [Theory]
     [InlineData("single@email.com", false)]
     [InlineData(null, false)]
-    public void IsValid_ReturnsTrue_WhenValid(string email, bool valid)
+    public void IsValid_ReturnsTrue_WhenValid(string? email, bool valid)
     {
         var sut = new StrictEmailAddressListAttribute();
 

--- a/test/Events.IntegrationTest/Events.IntegrationTest.csproj
+++ b/test/Events.IntegrationTest/Events.IntegrationTest.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/test/Icons.Test/Models/IconLinkTests.cs
+++ b/test/Icons.Test/Models/IconLinkTests.cs
@@ -45,7 +45,7 @@ public class IconLinkTests
     [InlineData(" ", false)]
     [InlineData("unusable", false)]
     [InlineData("ico", true)]
-    public void WithNoRel_IsUsable(string extension, bool expectedResult)
+    public void WithNoRel_IsUsable(string? extension, bool expectedResult)
     {
         SetAttributeValue("href", $"/favicon.{extension}");
 

--- a/test/Identity.Test/Identity.Test.csproj
+++ b/test/Identity.Test/Identity.Test.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <Nullable>enable</Nullable>
-      <IsPackable>false</IsPackable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Infrastructure.Dapper.Test/Infrastructure.Dapper.Test.csproj
+++ b/test/Infrastructure.Dapper.Test/Infrastructure.Dapper.Test.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/test/Infrastructure.IntegrationTest/Infrastructure.IntegrationTest.csproj
+++ b/test/Infrastructure.IntegrationTest/Infrastructure.IntegrationTest.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <UserSecretsId>6570f288-5c2c-47ad-8978-f3da255079c2</UserSecretsId>
   </PropertyGroup>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This relaxes `nullable` requirements for test projects, you are not required to abide by all null rules but still allows you to use the annotations to make intent clearer when you want to. This takes from how [`dotnet/runtime`](https://github.com/dotnet/runtime/blob/fc8b63c3b36744b4012210e67cabb7fd96c938b5/src/libraries/Directory.Build.props#L49-L50) does things.

A few examples of why you may not want null warnings in tests:

```c#
organizationUserRepository.GetManyAsync(default).ReturnsForAnyArgs(orgUsers);
```

Here default warns, because GetManyAsync accepts a non-nullable IEnumerable<Guid> but it's never going to be executed with that arg because of the chained `ReturnsForAnyArgs` match statement.

Or you might do:
```c#
Assert.ThrowsAsync<ArgumentNullException>(
    async () => await organizationUserRepository.GetManyAsync(null)
);
```
null will complain but that is the point of this test so I am forced to suppress it. It's easy enough to suppress but _should you have to_? In test code, generally not.

This also brings our warnings down to 43 vs 109 before.

By turning annotations on for all test projects it does seem to have triggered a few more xUnit analyzer warnings though. Those had to be addressed to pass linting.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
