### PR TITLE
Turn on TreatWarningsAsError

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,7 @@
     <Nullable Condition="'$(Nullable)' == '' and '$(IsTestProject)' == 'true'">annotations</Nullable>
     <!-- Uncomment the below line when we are ready to enable nullable repo wide -->
     <!-- <Nullable Condition="'$(Nullable)' == '' and '$(IsTestProject)' != 'true'">enable</Nullable> -->
+    <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)' == '' and '$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <!--

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <Nullable Condition="'$(Nullable)' == '' and '$(IsTestProject)' == 'true'">annotations</Nullable>
     <!-- Uncomment the below line when we are ready to enable nullable repo wide -->
     <!-- <Nullable Condition="'$(Nullable)' == '' and '$(IsTestProject)' != 'true'">enable</Nullable> -->
-    <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)' == '' and '$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)' == ''">true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <!--

--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -5,7 +5,7 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <ANCMPreConfiguredForIIS>true</ANCMPreConfiguredForIIS>
     <!-- Temp exclusions until warnings are fixed -->
-    <!-- <WarningsNotAsErrors>$(WarningsNotAsErrors);CS8604</WarningsNotAsErrors> -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CS8604</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -4,6 +4,8 @@
     <MvcRazorCompileOnPublish>false</MvcRazorCompileOnPublish>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <ANCMPreConfiguredForIIS>true</ANCMPreConfiguredForIIS>
+    <!-- Temp exclusions until warnings are fixed -->
+    <!-- <WarningsNotAsErrors>$(WarningsNotAsErrors);CS8604</WarningsNotAsErrors> -->
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Billing/Billing.csproj
+++ b/src/Billing/Billing.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <UserSecretsId>bitwarden-Billing</UserSecretsId>
     <MvcRazorCompileOnPublish>false</MvcRazorCompileOnPublish>
+    <!-- Temp exclusions until warnings are fixed -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CS9113</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Billing' " />

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <GenerateUserSecretsAttribute>false</GenerateUserSecretsAttribute>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <!-- Temp exclusions until warnings are fixed -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CS1570;CS1574;CS8602;CS9113;CS1998;CS8604</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Identity/Identity.csproj
+++ b/src/Identity/Identity.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <UserSecretsId>bitwarden-Identity</UserSecretsId>
     <MvcRazorCompileOnPublish>false</MvcRazorCompileOnPublish>
+    <!-- Temp exclusions until warnings are fixed -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CS0162</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Identity' " />

--- a/src/Infrastructure.Dapper/Infrastructure.Dapper.csproj
+++ b/src/Infrastructure.Dapper/Infrastructure.Dapper.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <PropertyGroup>
+      <!-- Temp exclusions until warnings are fixed -->
+      <WarningsNotAsErrors>$(WarningsNotAsErrors);CS8618;CS4014</WarningsNotAsErrors>
+    </PropertyGroup>
+
     <ItemGroup>
       <ProjectReference Include="..\Core\Core.csproj" />
     </ItemGroup>

--- a/src/Infrastructure.EntityFramework/Infrastructure.EntityFramework.csproj
+++ b/src/Infrastructure.EntityFramework/Infrastructure.EntityFramework.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <PropertyGroup>
+      <!-- Temp exclusions until warnings are fixed -->
+      <WarningsNotAsErrors>$(WarningsNotAsErrors);CS0108;CS8632</WarningsNotAsErrors>
+    </PropertyGroup>
+
     <ItemGroup>
       <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
       <PackageReference Include="linq2db" Version="5.4.1" />

--- a/test/Api.Test/Api.Test.csproj
+++ b/test/Api.Test/Api.Test.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <!-- Temp exclusions until warnings are fixed -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CS8620;CS0169</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Core.Test/Core.Test.csproj
+++ b/test/Core.Test/Core.Test.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <RootNamespace>Bit.Core.Test</RootNamespace>
+    <!-- Temp exclusions until warnings are fixed -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CS4014</WarningsNotAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorVersion)">

--- a/test/Identity.Test/Identity.Test.csproj
+++ b/test/Identity.Test/Identity.Test.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <!-- Temp exclusions until warnings are fixed -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CS0672;CS1998</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Add `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` which means it should be a bad idea to merge to `main` with new warnings. I have temporarily excluded issues that exist today. It does technically allow new warnings of those types to get introduced but all new warnings types will block.

~~NOTE: This only blocks warnings for `Configuration=Release` builds, not during normal development when you would run with `Configuration=Debug` this can be nice as it allows you to experiment and test your changes easier but it can also suck when the build works locally but fails in CI. Luckily it it pretty easy to recreate the CI behavior with `dotnet build -c Release`.~~

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
