### PR TITLE
[PM-3503] Feature flag: Mobile AnonAddy self host alias generation

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -175,6 +175,7 @@ public static class FeatureFlagKeys
     public const string EnablePMAuthenticatorSync = "enable-pm-bwa-sync";
     public const string P15179_AddExistingOrgsFromProviderPortal = "pm-15179-add-existing-orgs-from-provider-portal";
     public const string AndroidMutualTls = "mutual-tls";
+    public const string PM3553_MobileAnonAddySelfHostAlias = "anon-addy-self-host-alias";
 
     public static List<string> GetAllKeys()
     {

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -174,7 +174,7 @@ public static class FeatureFlagKeys
     public const string EnablePMAuthenticatorSync = "enable-pm-bwa-sync";
     public const string P15179_AddExistingOrgsFromProviderPortal = "pm-15179-add-existing-orgs-from-provider-portal";
     public const string AndroidMutualTls = "mutual-tls";
-    public const string PM3553_MobileAnonAddySelfHostAlias = "anon-addy-self-host-alias";
+    public const string PM3503_MobileAnonAddySelfHostAlias = "anon-addy-self-host-alias";
 
     public static List<string> GetAllKeys()
     {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-3503](https://bitwarden.atlassian.net/browse/PM-3503)

## 📔 Objective

Add a feature flag to control the ability to generate aliases using a self-hosted AnonAddy (addy.io) server.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-3553]: https://bitwarden.atlassian.net/browse/PM-3553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-3503]: https://bitwarden.atlassian.net/browse/PM-3503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ