### PR TITLE
[PM-18221] Update credited user's billing location when purchasing premium subscription

### DIFF
--- a/src/Billing/Controllers/BitPayController.cs
+++ b/src/Billing/Controllers/BitPayController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Globalization;
 using Bit.Billing.Models;
 using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Billing.Services;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Repositories;
@@ -25,6 +26,7 @@ public class BitPayController : Controller
     private readonly IMailService _mailService;
     private readonly IPaymentService _paymentService;
     private readonly ILogger<BitPayController> _logger;
+    private readonly IPremiumUserBillingService _premiumUserBillingService;
 
     public BitPayController(
         IOptions<BillingSettings> billingSettings,
@@ -35,7 +37,8 @@ public class BitPayController : Controller
         IProviderRepository providerRepository,
         IMailService mailService,
         IPaymentService paymentService,
-        ILogger<BitPayController> logger)
+        ILogger<BitPayController> logger,
+        IPremiumUserBillingService premiumUserBillingService)
     {
         _billingSettings = billingSettings?.Value;
         _bitPayClient = bitPayClient;
@@ -46,6 +49,7 @@ public class BitPayController : Controller
         _mailService = mailService;
         _paymentService = paymentService;
         _logger = logger;
+        _premiumUserBillingService = premiumUserBillingService;
     }
 
     [HttpPost("ipn")]
@@ -145,10 +149,7 @@ public class BitPayController : Controller
                 if (user != null)
                 {
                     billingEmail = user.BillingEmailAddress();
-                    if (await _paymentService.CreditAccountAsync(user, tx.Amount))
-                    {
-                        await _userRepository.ReplaceAsync(user);
-                    }
+                    await _premiumUserBillingService.Credit(user, tx.Amount);
                 }
             }
             else if (tx.ProviderId.HasValue)

--- a/src/Core/Billing/Services/IPremiumUserBillingService.cs
+++ b/src/Core/Billing/Services/IPremiumUserBillingService.cs
@@ -6,6 +6,8 @@ namespace Bit.Core.Billing.Services;
 
 public interface IPremiumUserBillingService
 {
+    Task Credit(User user, decimal amount);
+
     /// <summary>
     /// <para>Establishes the Stripe entities necessary for a Bitwarden <see cref="User"/> using the provided <paramref name="sale"/>.</para>
     /// <para>

--- a/src/Core/Billing/Services/Implementations/PremiumUserBillingService.cs
+++ b/src/Core/Billing/Services/Implementations/PremiumUserBillingService.cs
@@ -9,7 +9,6 @@ using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Settings;
 using Braintree;
-using Fido2NetLib.Objects;
 using Microsoft.Extensions.Logging;
 using Stripe;
 using Customer = Stripe.Customer;

--- a/test/Billing.Test/Controllers/PayPalControllerTests.cs
+++ b/test/Billing.Test/Controllers/PayPalControllerTests.cs
@@ -3,6 +3,7 @@ using Bit.Billing.Controllers;
 using Bit.Billing.Test.Utilities;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Billing.Services;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Repositories;
@@ -33,6 +34,7 @@ public class PayPalControllerTests
     private readonly ITransactionRepository _transactionRepository = Substitute.For<ITransactionRepository>();
     private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
     private readonly IProviderRepository _providerRepository = Substitute.For<IProviderRepository>();
+    private readonly IPremiumUserBillingService _premiumUserBillingService = Substitute.For<IPremiumUserBillingService>();
 
     private const string _defaultWebhookKey = "webhook-key";
 
@@ -544,7 +546,8 @@ public class PayPalControllerTests
             _paymentService,
             _transactionRepository,
             _userRepository,
-            _providerRepository);
+            _providerRepository,
+            _premiumUserBillingService);
 
         var httpContext = new DefaultHttpContext();
 

--- a/test/Billing.Test/Controllers/PayPalControllerTests.cs
+++ b/test/Billing.Test/Controllers/PayPalControllerTests.cs
@@ -387,8 +387,6 @@ public class PayPalControllerTests
 
         _userRepository.GetByIdAsync(userId).Returns(user);
 
-        _paymentService.CreditAccountAsync(user, 48M).Returns(true);
-
         var controller = ConfigureControllerContextWith(logger, _defaultWebhookKey, ipnBody);
 
         var result = await controller.PostIpn();
@@ -400,9 +398,7 @@ public class PayPalControllerTests
             transaction.UserId == userId &&
             transaction.Amount == 48M));
 
-        await _paymentService.Received(1).CreditAccountAsync(user, 48M);
-
-        await _userRepository.Received(1).ReplaceAsync(user);
+        await _premiumUserBillingService.Received(1).Credit(user, 48M);
 
         await _mailService.Received(1).SendAddedCreditAsync(billingEmail, 48M);
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-18221

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When users add account credit before they have a subscription, we create a Stripe `Customer` for them. However, no billing location is supplied at this time. 

Therefore, when they would go to sign up for a premium subscription, their tax location would be rejected by Stripe. 

This PR updates that process to update the customer billing location for the user before we purchase the subscription for them, as this is the point they've supplied us with that information.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/89423e61-8ab8-43f2-8f96-f4778e2309b4


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
