### PR TITLE
[PM-17562] Refactor to Support Multiple Message Payloads

### DIFF
--- a/src/Core/AdminConsole/Services/IEventMessageHandler.cs
+++ b/src/Core/AdminConsole/Services/IEventMessageHandler.cs
@@ -5,4 +5,6 @@ namespace Bit.Core.Services;
 public interface IEventMessageHandler
 {
     Task HandleEventAsync(EventMessage eventMessage);
+
+    Task HandleManyEventAsync(IEnumerable<EventMessage> eventMessages);
 }

--- a/src/Core/AdminConsole/Services/IEventMessageHandler.cs
+++ b/src/Core/AdminConsole/Services/IEventMessageHandler.cs
@@ -6,5 +6,5 @@ public interface IEventMessageHandler
 {
     Task HandleEventAsync(EventMessage eventMessage);
 
-    Task HandleManyEventAsync(IEnumerable<EventMessage> eventMessages);
+    Task HandleManyEventsAsync(IEnumerable<EventMessage> eventMessages);
 }

--- a/src/Core/AdminConsole/Services/Implementations/AzureServiceBusEventListenerService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/AzureServiceBusEventListenerService.cs
@@ -35,8 +35,8 @@ public class AzureServiceBusEventListenerService : EventLoggingListenerService
 
                 if (root.ValueKind == JsonValueKind.Array)
                 {
-                    var eventMessages = root.Deserialize<List<EventMessage>>();
-                    await _handler.HandleManyEventAsync(eventMessages);
+                    var eventMessages = root.Deserialize<IEnumerable<EventMessage>>();
+                    await _handler.HandleManyEventsAsync(eventMessages);
                 }
                 else if (root.ValueKind == JsonValueKind.Object)
                 {

--- a/src/Core/AdminConsole/Services/Implementations/AzureServiceBusEventListenerService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/AzureServiceBusEventListenerService.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Text;
+using System.Text.Json;
 using Azure.Messaging.ServiceBus;
 using Bit.Core.Models.Data;
 using Bit.Core.Settings;
@@ -29,9 +30,20 @@ public class AzureServiceBusEventListenerService : EventLoggingListenerService
         {
             try
             {
-                var eventMessage = JsonSerializer.Deserialize<EventMessage>(args.Message.Body.ToString());
+                using var jsonDocument = JsonDocument.Parse(Encoding.UTF8.GetString(args.Message.Body));
+                var root = jsonDocument.RootElement;
 
-                await _handler.HandleEventAsync(eventMessage);
+                if (root.ValueKind == JsonValueKind.Array)
+                {
+                    var eventMessages = root.Deserialize<List<EventMessage>>();
+                    await _handler.HandleManyEventAsync(eventMessages);
+                }
+                else if (root.ValueKind == JsonValueKind.Object)
+                {
+                    var eventMessage = root.Deserialize<EventMessage>();
+                    await _handler.HandleEventAsync(eventMessage);
+
+                }
                 await args.CompleteMessageAsync(args.Message);
             }
             catch (Exception exception)

--- a/src/Core/AdminConsole/Services/Implementations/AzureServiceBusEventWriteService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/AzureServiceBusEventWriteService.cs
@@ -29,10 +29,12 @@ public class AzureServiceBusEventWriteService : IEventWriteService, IAsyncDispos
 
     public async Task CreateManyAsync(IEnumerable<IEvent> events)
     {
-        foreach (var e in events)
+        var message = new ServiceBusMessage(JsonSerializer.SerializeToUtf8Bytes(events))
         {
-            await CreateAsync(e);
-        }
+            ContentType = "application/json"
+        };
+
+        await _sender.SendMessageAsync(message);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Core/AdminConsole/Services/Implementations/AzureTableStorageEventHandler.cs
+++ b/src/Core/AdminConsole/Services/Implementations/AzureTableStorageEventHandler.cs
@@ -12,7 +12,7 @@ public class AzureTableStorageEventHandler(
         return eventWriteService.CreateManyAsync(EventTableEntity.IndexEvent(eventMessage));
     }
 
-    public Task HandleManyEventAsync(IEnumerable<EventMessage> eventMessages)
+    public Task HandleManyEventsAsync(IEnumerable<EventMessage> eventMessages)
     {
         return eventWriteService.CreateManyAsync(eventMessages.SelectMany(EventTableEntity.IndexEvent));
     }

--- a/src/Core/AdminConsole/Services/Implementations/AzureTableStorageEventHandler.cs
+++ b/src/Core/AdminConsole/Services/Implementations/AzureTableStorageEventHandler.cs
@@ -11,4 +11,9 @@ public class AzureTableStorageEventHandler(
     {
         return eventWriteService.CreateManyAsync(EventTableEntity.IndexEvent(eventMessage));
     }
+
+    public Task HandleManyEventAsync(IEnumerable<EventMessage> eventMessages)
+    {
+        return eventWriteService.CreateManyAsync(eventMessages.SelectMany(EventTableEntity.IndexEvent));
+    }
 }

--- a/src/Core/AdminConsole/Services/Implementations/EventRepositoryHandler.cs
+++ b/src/Core/AdminConsole/Services/Implementations/EventRepositoryHandler.cs
@@ -12,7 +12,7 @@ public class EventRepositoryHandler(
         return eventWriteService.CreateAsync(eventMessage);
     }
 
-    public Task HandleManyEventAsync(IEnumerable<EventMessage> eventMessages)
+    public Task HandleManyEventsAsync(IEnumerable<EventMessage> eventMessages)
     {
         return eventWriteService.CreateManyAsync(eventMessages);
     }

--- a/src/Core/AdminConsole/Services/Implementations/EventRepositoryHandler.cs
+++ b/src/Core/AdminConsole/Services/Implementations/EventRepositoryHandler.cs
@@ -11,4 +11,9 @@ public class EventRepositoryHandler(
     {
         return eventWriteService.CreateAsync(eventMessage);
     }
+
+    public Task HandleManyEventAsync(IEnumerable<EventMessage> eventMessages)
+    {
+        return eventWriteService.CreateManyAsync(eventMessages);
+    }
 }

--- a/src/Core/AdminConsole/Services/Implementations/RabbitMqEventListenerService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/RabbitMqEventListenerService.cs
@@ -68,8 +68,8 @@ public class RabbitMqEventListenerService : EventLoggingListenerService
 
                 if (root.ValueKind == JsonValueKind.Array)
                 {
-                    var eventMessages = root.Deserialize<List<EventMessage>>();
-                    await _handler.HandleManyEventAsync(eventMessages);
+                    var eventMessages = root.Deserialize<IEnumerable<EventMessage>>();
+                    await _handler.HandleManyEventsAsync(eventMessages);
                 }
                 else if (root.ValueKind == JsonValueKind.Object)
                 {

--- a/src/Core/AdminConsole/Services/Implementations/RabbitMqEventWriteService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/RabbitMqEventWriteService.cs
@@ -41,12 +41,9 @@ public class RabbitMqEventWriteService : IEventWriteService, IAsyncDisposable
         using var channel = await connection.CreateChannelAsync();
         await channel.ExchangeDeclareAsync(exchange: _exchangeName, type: ExchangeType.Fanout, durable: true);
 
-        foreach (var e in events)
-        {
-            var body = JsonSerializer.SerializeToUtf8Bytes(e);
+        var body = JsonSerializer.SerializeToUtf8Bytes(events);
 
-            await channel.BasicPublishAsync(exchange: _exchangeName, routingKey: string.Empty, body: body);
-        }
+        await channel.BasicPublishAsync(exchange: _exchangeName, routingKey: string.Empty, body: body);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Core/AdminConsole/Services/Implementations/WebhookEventHandler.cs
+++ b/src/Core/AdminConsole/Services/Implementations/WebhookEventHandler.cs
@@ -4,24 +4,26 @@ using Bit.Core.Settings;
 
 namespace Bit.Core.Services;
 
-public class WebhookEventHandler : IEventMessageHandler
+public class WebhookEventHandler(
+    IHttpClientFactory httpClientFactory,
+    GlobalSettings globalSettings)
+    : IEventMessageHandler
 {
-    private readonly HttpClient _httpClient;
-    private readonly string _webhookUrl;
+    private readonly HttpClient _httpClient = httpClientFactory.CreateClient(HttpClientName);
+    private readonly string _webhookUrl = globalSettings.EventLogging.WebhookUrl;
 
     public const string HttpClientName = "WebhookEventHandlerHttpClient";
-
-    public WebhookEventHandler(
-        IHttpClientFactory httpClientFactory,
-        GlobalSettings globalSettings)
-    {
-        _httpClient = httpClientFactory.CreateClient(HttpClientName);
-        _webhookUrl = globalSettings.EventLogging.WebhookUrl;
-    }
 
     public async Task HandleEventAsync(EventMessage eventMessage)
     {
         var content = JsonContent.Create(eventMessage);
+        var response = await _httpClient.PostAsync(_webhookUrl, content);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task HandleManyEventAsync(IEnumerable<EventMessage> eventMessages)
+    {
+        var content = JsonContent.Create(eventMessages);
         var response = await _httpClient.PostAsync(_webhookUrl, content);
         response.EnsureSuccessStatusCode();
     }

--- a/src/Core/AdminConsole/Services/Implementations/WebhookEventHandler.cs
+++ b/src/Core/AdminConsole/Services/Implementations/WebhookEventHandler.cs
@@ -21,7 +21,7 @@ public class WebhookEventHandler(
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task HandleManyEventAsync(IEnumerable<EventMessage> eventMessages)
+    public async Task HandleManyEventsAsync(IEnumerable<EventMessage> eventMessages)
     {
         var content = JsonContent.Create(eventMessages);
         var response = await _httpClient.PostAsync(_webhookUrl, content);

--- a/src/Events/Startup.cs
+++ b/src/Events/Startup.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using Bit.Core.AdminConsole.Services.Implementations;
 using Bit.Core.Context;
 using Bit.Core.IdentityServer;
 using Bit.Core.Services;
@@ -63,11 +64,29 @@ public class Startup
         services.AddScoped<IEventService, EventService>();
         if (!globalSettings.SelfHosted && CoreHelpers.SettingHasValue(globalSettings.Events.ConnectionString))
         {
-            services.AddSingleton<IEventWriteService, AzureQueueEventWriteService>();
+            if (CoreHelpers.SettingHasValue(globalSettings.EventLogging.AzureServiceBus.ConnectionString) &&
+                CoreHelpers.SettingHasValue(globalSettings.EventLogging.AzureServiceBus.TopicName))
+            {
+                services.AddSingleton<IEventWriteService, AzureServiceBusEventWriteService>();
+            }
+            else
+            {
+                services.AddSingleton<IEventWriteService, AzureQueueEventWriteService>();
+            }
         }
         else
         {
-            services.AddSingleton<IEventWriteService, RepositoryEventWriteService>();
+            if (CoreHelpers.SettingHasValue(globalSettings.EventLogging.RabbitMq.HostName) &&
+                CoreHelpers.SettingHasValue(globalSettings.EventLogging.RabbitMq.Username) &&
+                CoreHelpers.SettingHasValue(globalSettings.EventLogging.RabbitMq.Password) &&
+                CoreHelpers.SettingHasValue(globalSettings.EventLogging.RabbitMq.ExchangeName))
+            {
+                services.AddSingleton<IEventWriteService, RabbitMqEventWriteService>();
+            }
+            else
+            {
+                services.AddSingleton<IEventWriteService, RepositoryEventWriteService>();
+            }
         }
 
         services.AddOptionality();

--- a/test/Core.Test/AdminConsole/Services/EventRepositoryHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/Services/EventRepositoryHandlerTests.cs
@@ -27,7 +27,7 @@ public class EventRepositoryHandlerTests
         IEnumerable<EventMessage> eventMessages,
         SutProvider<EventRepositoryHandler> sutProvider)
     {
-        await sutProvider.Sut.HandleManyEventAsync(eventMessages);
+        await sutProvider.Sut.HandleManyEventsAsync(eventMessages);
         await sutProvider.GetDependency<IEventWriteService>().Received(1).CreateManyAsync(
             Arg.Is(AssertHelper.AssertPropertyEqual<IEvent>(eventMessages))
         );

--- a/test/Core.Test/AdminConsole/Services/EventRepositoryHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/Services/EventRepositoryHandlerTests.cs
@@ -21,4 +21,15 @@ public class EventRepositoryHandlerTests
             Arg.Is(AssertHelper.AssertPropertyEqual<IEvent>(eventMessage))
         );
     }
+
+    [Theory, BitAutoData]
+    public async Task HandleManyEventAsync_WritesEventsToIEventWriteService(
+        IEnumerable<EventMessage> eventMessages,
+        SutProvider<EventRepositoryHandler> sutProvider)
+    {
+        await sutProvider.Sut.HandleManyEventAsync(eventMessages);
+        await sutProvider.GetDependency<IEventWriteService>().Received(1).CreateManyAsync(
+            Arg.Is(AssertHelper.AssertPropertyEqual<IEvent>(eventMessages))
+        );
+    }
 }

--- a/test/Core.Test/AdminConsole/Services/WebhookEventHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/Services/WebhookEventHandlerTests.cs
@@ -68,7 +68,7 @@ public class WebhookEventHandlerTests
     {
         var sutProvider = GetSutProvider();
 
-        await sutProvider.Sut.HandleManyEventAsync(eventMessages);
+        await sutProvider.Sut.HandleManyEventsAsync(eventMessages);
         sutProvider.GetDependency<IHttpClientFactory>().Received(1).CreateClient(
             Arg.Is(AssertHelper.AssertPropertyEqual<string>(WebhookEventHandler.HttpClientName))
         );

--- a/test/Core.Test/AdminConsole/Services/WebhookEventHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/Services/WebhookEventHandlerTests.cs
@@ -44,10 +44,9 @@ public class WebhookEventHandlerTests
     }
 
     [Theory, BitAutoData]
-    public async Task HandleEventAsync_PostsEventsToUrl(EventMessage eventMessage)
+    public async Task HandleEventAsync_PostsEventToUrl(EventMessage eventMessage)
     {
         var sutProvider = GetSutProvider();
-        var content = JsonContent.Create(eventMessage);
 
         await sutProvider.Sut.HandleEventAsync(eventMessage);
         sutProvider.GetDependency<IHttpClientFactory>().Received(1).CreateClient(
@@ -62,5 +61,25 @@ public class WebhookEventHandlerTests
         Assert.Equal(HttpMethod.Post, request.Method);
         Assert.Equal(_webhookUrl, request.RequestUri.ToString());
         AssertHelper.AssertPropertyEqual(eventMessage, returned, new[] { "IdempotencyId" });
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleEventManyAsync_PostsEventsToUrl(IEnumerable<EventMessage> eventMessages)
+    {
+        var sutProvider = GetSutProvider();
+
+        await sutProvider.Sut.HandleManyEventAsync(eventMessages);
+        sutProvider.GetDependency<IHttpClientFactory>().Received(1).CreateClient(
+            Arg.Is(AssertHelper.AssertPropertyEqual<string>(WebhookEventHandler.HttpClientName))
+        );
+
+        Assert.Single(_handler.CapturedRequests);
+        var request = _handler.CapturedRequests[0];
+        Assert.NotNull(request);
+        var returned = request.Content.ReadFromJsonAsAsyncEnumerable<EventMessage>();
+
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal(_webhookUrl, request.RequestUri.ToString());
+        AssertHelper.AssertPropertyEqual(eventMessages, returned, new[] { "IdempotencyId" });
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17562](https://bitwarden.atlassian.net/browse/PM-17562)

## 📔 Objective

The previous PRs (#5357 #5382) for distributed events handled each event as a separate AMQP message. That is, if you called `CreateManyAsync` it would loop over the events and send each one as a separate message. While this keeps the implementation simple (one event per message, message are always of the same type, etc), it could result in far too many messages in practice and possibly incur larger costs with Azure Service Bus.

This PR refactors the two IEventWriteService AMQP implementations to handle `CreateManyAsync` and send the full array of events as a single message. It also refactors the two listener services to correctly account for if a message was an array of events or a single event. Lastly, it adds a `Many` variant to the IEventMessageHandler` interface and implementations to handle receiving an array instead of a single event.

Since arrays are also easily serializable to JSON, we're still using JSON as the message payload - we just have to account for that when deserializing. All of the documentation/configuration remains the same.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17562]: https://bitwarden.atlassian.net/browse/PM-17562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ