### PR TITLE
Add RequestDeviceIdentifier to auth-requests GET response

### DIFF
--- a/src/Api/Auth/Models/Response/AuthRequestResponseModel.cs
+++ b/src/Api/Auth/Models/Response/AuthRequestResponseModel.cs
@@ -18,6 +18,7 @@ public class AuthRequestResponseModel : ResponseModel
 
         Id = authRequest.Id;
         PublicKey = authRequest.PublicKey;
+        RequestDeviceIdentifier = authRequest.RequestDeviceIdentifier;
         RequestDeviceTypeValue = authRequest.RequestDeviceType;
         RequestDeviceType = authRequest.RequestDeviceType.GetType().GetMember(authRequest.RequestDeviceType.ToString())
             .FirstOrDefault()?.GetCustomAttribute<DisplayAttribute>()?.GetName();
@@ -32,6 +33,7 @@ public class AuthRequestResponseModel : ResponseModel
 
     public Guid Id { get; set; }
     public string PublicKey { get; set; }
+    public string RequestDeviceIdentifier { get; set; }
     public DeviceType RequestDeviceTypeValue { get; set; }
     public string RequestDeviceType { get; set; }
     public string RequestIpAddress { get; set; }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15063

## 📔 Objective

For the work in https://github.com/bitwarden/clients/pull/13147, we've identified the need to have the `RequestDeviceIdentifier` for the requesting device in the response from the `/auth-requests` endpoint.

This will be used on the client in order to determine which entry on the Device Management screen the request should be correlated to.

Why can't we use the `Id` of the requesting device?  Because if the auth request is for a device that has not yet logged in, there will be no record in the `Device` table for that device yet; we need to use the `RequestDeviceIdentifier` from the `AuthRequest` as the source of the information.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
