### PR TITLE
[PM-18268] SM Marketing Initiated Trials cause invoice previewing to …

### DIFF
--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -1852,7 +1852,6 @@ public class StripePaymentService : IPaymentService
                 Enabled = true,
             },
             Currency = "usd",
-            Discounts = new List<InvoiceDiscountOptions>(),
             SubscriptionDetails = new InvoiceSubscriptionDetailsOptions
             {
                 Items =
@@ -1903,29 +1902,23 @@ public class StripePaymentService : IPaymentService
             ];
         }
 
-        if (gatewayCustomerId != null)
+        if (!string.IsNullOrWhiteSpace(gatewayCustomerId))
         {
             var gatewayCustomer = await _stripeAdapter.CustomerGetAsync(gatewayCustomerId);
 
             if (gatewayCustomer.Discount != null)
             {
-                options.Discounts.Add(new InvoiceDiscountOptions
-                {
-                    Discount = gatewayCustomer.Discount.Id
-                });
+                options.Coupon = gatewayCustomer.Discount.Coupon.Id;
             }
+        }
 
-            if (gatewaySubscriptionId != null)
+        if (!string.IsNullOrWhiteSpace(gatewaySubscriptionId))
+        {
+            var gatewaySubscription = await _stripeAdapter.SubscriptionGetAsync(gatewaySubscriptionId);
+
+            if (gatewaySubscription?.Discount != null)
             {
-                var gatewaySubscription = await _stripeAdapter.SubscriptionGetAsync(gatewaySubscriptionId);
-
-                if (gatewaySubscription?.Discount != null)
-                {
-                    options.Discounts.Add(new InvoiceDiscountOptions
-                    {
-                        Discount = gatewaySubscription.Discount.Id
-                    });
-                }
+                options.Coupon ??= gatewaySubscription.Discount.Coupon.Id;
             }
         }
 
@@ -1976,7 +1969,6 @@ public class StripePaymentService : IPaymentService
                 Enabled = true,
             },
             Currency = "usd",
-            Discounts = new List<InvoiceDiscountOptions>(),
             SubscriptionDetails = new InvoiceSubscriptionDetailsOptions
             {
                 Items =
@@ -2065,7 +2057,12 @@ public class StripePaymentService : IPaymentService
 
         if (!string.IsNullOrWhiteSpace(gatewayCustomerId))
         {
-            options.Customer = gatewayCustomerId;
+            var gatewayCustomer = await _stripeAdapter.CustomerGetAsync(gatewayCustomerId);
+
+            if (gatewayCustomer.Discount != null)
+            {
+                options.Coupon = gatewayCustomer.Discount.Coupon.Id;
+            }
         }
 
         if (!string.IsNullOrWhiteSpace(gatewaySubscriptionId))
@@ -2074,10 +2071,7 @@ public class StripePaymentService : IPaymentService
 
             if (gatewaySubscription?.Discount != null)
             {
-                options.Discounts.Add(new InvoiceDiscountOptions
-                {
-                    Discount = gatewaySubscription.Discount.Id
-                });
+                options.Coupon ??= gatewaySubscription.Discount.Coupon.Id;
             }
         }
 

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -2065,12 +2065,7 @@ public class StripePaymentService : IPaymentService
 
         if (!string.IsNullOrWhiteSpace(gatewayCustomerId))
         {
-            var gatewayCustomer = await _stripeAdapter.CustomerGetAsync(gatewayCustomerId);
-
-            if (gatewayCustomer.Discount != null)
-            {
-                options.Discounts.Add(new InvoiceDiscountOptions { Discount = gatewayCustomer.Discount.Id });
-            }
+            options.Customer = gatewayCustomerId;
         }
 
         if (!string.IsNullOrWhiteSpace(gatewaySubscriptionId))


### PR DESCRIPTION
…crash when attempting to upgrade

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18268

## 📔 Objective

Couldn't apply the discount applied to the customer to the invoice preview when attempting to upgrade. Was receiving error message:

`The discount di_xxx is not the current discount on the subscription's customer cus_xxx. Discounts can only be applied to a subscription when they are the current customer discount or already exist on the subscription.`

## 📸 Screenshots

<img width="1103" alt="image" src="https://github.com/user-attachments/assets/9e772e3b-916e-46ef-98e1-98a9ade8057b" />

<img width="2056" alt="image" src="https://github.com/user-attachments/assets/806ecd4a-2783-4fe8-a8a3-0d287608b93d" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
