### PR TITLE
[PM-17449] Add stored proc, EF query, and an integration test for them

### DIFF
--- a/src/Core/Repositories/IOrganizationDomainRepository.cs
+++ b/src/Core/Repositories/IOrganizationDomainRepository.cs
@@ -12,6 +12,7 @@ public interface IOrganizationDomainRepository : IRepository<OrganizationDomain,
     Task<ICollection<OrganizationDomain>> GetManyByNextRunDateAsync(DateTime date);
     Task<OrganizationDomainSsoDetailsData?> GetOrganizationDomainSsoDetailsAsync(string email);
     Task<IEnumerable<VerifiedOrganizationDomainSsoDetail>> GetVerifiedOrganizationDomainSsoDetailsAsync(string email);
+    Task<IEnumerable<OrganizationDomain>> GetVerifiedDomainsByOrganizationIdsAsync(IEnumerable<Guid> organizationIds);
     Task<OrganizationDomain?> GetDomainByIdOrganizationIdAsync(Guid id, Guid organizationId);
     Task<OrganizationDomain?> GetDomainByOrgIdAndDomainNameAsync(Guid orgId, string domainName);
     Task<ICollection<OrganizationDomain>> GetExpiredOrganizationDomainsAsync();

--- a/src/Infrastructure.Dapper/Repositories/OrganizationDomainRepository.cs
+++ b/src/Infrastructure.Dapper/Repositories/OrganizationDomainRepository.cs
@@ -46,6 +46,20 @@ public class OrganizationDomainRepository : Repository<OrganizationDomain, Guid>
         }
     }
 
+    public async Task<IEnumerable<OrganizationDomain>> GetVerifiedDomainsByOrganizationIdsAsync(IEnumerable<Guid> organizationIds)
+    {
+
+        using (var connection = new SqlConnection(ConnectionString))
+        {
+            var results = await connection.QueryAsync<OrganizationDomain>(
+                $"[{Schema}].[OrganizationDomain_ReadByOrganizationIds]",
+                new { OrganizationIds = organizationIds.ToGuidIdArrayTVP() },
+                commandType: CommandType.StoredProcedure);
+
+            return results.ToList();
+        }
+    }
+
     public async Task<ICollection<OrganizationDomain>> GetManyByNextRunDateAsync(DateTime date)
     {
         using var connection = new SqlConnection(ConnectionString);

--- a/src/Infrastructure.EntityFramework/Repositories/OrganizationDomainRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/OrganizationDomainRepository.cs
@@ -157,4 +157,25 @@ public class OrganizationDomainRepository : Repository<Core.Entities.Organizatio
         dbContext.OrganizationDomains.RemoveRange(expiredDomains);
         return await dbContext.SaveChangesAsync() > 0;
     }
+
+    public async Task<IEnumerable<Core.Entities.OrganizationDomain>> GetVerifiedDomainsByOrganizationIdsAsync(
+        IEnumerable<Guid> organizationIds)
+    {
+        using var scope = ServiceScopeFactory.CreateScope();
+        var dbContext = GetDatabaseContext(scope);
+
+        var verifiedDomains = await (from d in dbContext.OrganizationDomains
+                                     where organizationIds.Contains(d.OrganizationId) && d.VerifiedDate != null
+                                     select new OrganizationDomain
+                                     {
+                                         OrganizationId = d.OrganizationId,
+                                         DomainName = d.DomainName
+                                     })
+            .AsNoTracking()
+            .ToListAsync();
+
+        return Mapper.Map<List<OrganizationDomain>>(verifiedDomains);
+    }
+
 }
+

--- a/src/Sql/dbo/Stored Procedures/OrganizationDomain_ReadByOrganizationIds.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationDomain_ReadByOrganizationIds.sql
@@ -1,4 +1,4 @@
-CREATE OR ALTER PROCEDURE [dbo].[OrganizationDomain_ReadByOrganizationIds]
+CREATE PROCEDURE [dbo].[OrganizationDomain_ReadByOrganizationIds]
     @OrganizationIds AS [dbo].[GuidIdArray] READONLY
 AS
 BEGIN

--- a/src/Sql/dbo/Stored Procedures/OrganizationDomain_ReadByOrganizationIds.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationDomain_ReadByOrganizationIds.sql
@@ -1,4 +1,3 @@
-/* Add OrganizationDomain_ReadByOrganizationIds */
 CREATE OR ALTER PROCEDURE [dbo].[OrganizationDomain_ReadByOrganizationIds]
     @OrganizationIds AS [dbo].[GuidIdArray] READONLY
 AS

--- a/src/Sql/dbo/Stored Procedures/OrganizationDomain_ReadByOrganizationIds.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationDomain_ReadByOrganizationIds.sql
@@ -1,0 +1,15 @@
+/* Add OrganizationDomain_ReadByOrganizationIds */
+CREATE OR ALTER PROCEDURE [dbo].[OrganizationDomain_ReadByOrganizationIds]
+    @OrganizationIds AS [dbo].[GuidIdArray] READONLY
+AS
+BEGIN
+
+    SET NOCOUNT ON
+        
+    SELECT
+        d.OrganizationId,
+        d.DomainName
+    FROM dbo.OrganizationDomainView AS d
+    WHERE d.OrganizationId IN (SELECT [Id] FROM @OrganizationIds)
+        AND d.VerifiedDate IS NOT NULL;
+END

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationDomainRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationDomainRepositoryTests.cs
@@ -306,4 +306,81 @@ public class OrganizationDomainRepositoryTests
         var expectedDomain = domains.FirstOrDefault(domain => domain.DomainName == organizationDomain.DomainName);
         Assert.Null(expectedDomain);
     }
+
+    [DatabaseTheory, DatabaseData]
+    public async Task GetVerifiedDomainsByOrganizationIdsAsync_ShouldVerifiedDomainsMatchesOrganizationIds(
+        IOrganizationRepository organizationRepository,
+        IOrganizationDomainRepository organizationDomainRepository)
+    {
+        // Arrange
+        var guid1 = Guid.NewGuid();
+        var guid2 = Guid.NewGuid();
+
+        var organization1 = await organizationRepository.CreateAsync(new Organization
+        {
+            Name = $"Test Org {guid1}",
+            BillingEmail = $"test+{guid1}@example.com",
+            Plan = "Test",
+            PrivateKey = "privatekey",
+
+        });
+
+        var organization1Domain1 = new OrganizationDomain
+        {
+            OrganizationId = organization1.Id,
+            DomainName = $"domain1+{guid1}@example.com",
+            Txt = "btw+12345"
+        };
+
+        const int arbitraryNextIteration = 1;
+        organization1Domain1.SetNextRunDate(arbitraryNextIteration);
+        organization1Domain1.SetVerifiedDate();
+
+        await organizationDomainRepository.CreateAsync(organization1Domain1);
+
+        var organization1Domain2 = new OrganizationDomain
+        {
+            OrganizationId = organization1.Id,
+            DomainName = $"domain2+{guid1}@example.com",
+            Txt = "btw+12345"
+        };
+
+        organization1Domain2.SetNextRunDate(arbitraryNextIteration);
+
+        await organizationDomainRepository.CreateAsync(organization1Domain2);
+
+        var organization2 = await organizationRepository.CreateAsync(new Organization
+        {
+            Name = $"Test Org {guid2}",
+            BillingEmail = $"test+{guid2}@example.com",
+            Plan = "Test",
+            PrivateKey = "privatekey",
+
+        });
+
+        var organization2Domain1 = new OrganizationDomain
+        {
+            OrganizationId = organization2.Id,
+            DomainName = $"domain+{guid2}@example.com",
+            Txt = "btw+12345"
+        };
+        organization2Domain1.SetVerifiedDate();
+        organization2Domain1.SetNextRunDate(arbitraryNextIteration);
+
+        await organizationDomainRepository.CreateAsync(organization2Domain1);
+
+
+        // Act
+        var domains = await organizationDomainRepository.GetVerifiedDomainsByOrganizationIdsAsync(new[] { organization1.Id });
+
+        // Assert
+        var expectedDomain = domains.FirstOrDefault(domain => domain.DomainName == organization1Domain1.DomainName);
+        Assert.NotNull(expectedDomain);
+
+        var unverifiedDomain = domains.FirstOrDefault(domain => domain.DomainName == organization1Domain2.DomainName);
+        var otherOrganizationDomain = domains.FirstOrDefault(domain => domain.DomainName == organization2Domain1.DomainName);
+
+        Assert.Null(otherOrganizationDomain);
+        Assert.Null(unverifiedDomain);
+    }
 }

--- a/util/Migrator/DbScripts/2025-02-17_00_OrganizationDomain_ReadByOrganizationIds.sql
+++ b/util/Migrator/DbScripts/2025-02-17_00_OrganizationDomain_ReadByOrganizationIds.sql
@@ -1,4 +1,4 @@
-/* Add OrganizationDomain_ReadByOrganizationIds */
+
 CREATE OR ALTER PROCEDURE [dbo].[OrganizationDomain_ReadByOrganizationIds]
     @OrganizationIds AS [dbo].[GuidIdArray] READONLY
 AS

--- a/util/Migrator/DbScripts/2025-02-17_00_OrganizationDomain_ReadByOrganizationIds.sql
+++ b/util/Migrator/DbScripts/2025-02-17_00_OrganizationDomain_ReadByOrganizationIds.sql
@@ -1,0 +1,15 @@
+/* Add OrganizationDomain_ReadByOrganizationIds */
+CREATE OR ALTER PROCEDURE [dbo].[OrganizationDomain_ReadByOrganizationIds]
+    @OrganizationIds AS [dbo].[GuidIdArray] READONLY
+AS
+BEGIN
+
+    SET NOCOUNT ON
+        
+    SELECT
+        d.OrganizationId,
+        d.DomainName
+    FROM dbo.OrganizationDomainView AS d
+    WHERE d.OrganizationId IN (SELECT [Id] FROM @OrganizationIds)
+        AND d.VerifiedDate IS NOT NULL;
+END


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17449

## 📔 Objective

1. Add stored proc to retrieve verified domains and the associated organization ID.
2. Add Entity Framework to mirror the stored proc behavior.
3. Add an integration test to validate both. 

## 📸 Screenshots

MS SQL Migration 

<img width="928" alt="image" src="https://github.com/user-attachments/assets/b16dee4f-ba4e-41df-9ce0-e7c52301b441" />


Query plan

<img width="1354" alt="image" src="https://github.com/user-attachments/assets/3d0dc8c4-cf41-48c6-b353-71232ae6d760" />



Entity Framework does not need a migration.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
