### PR TITLE
[PM-18427] Prevent organization disablement on addition to provider

### DIFF
--- a/src/Billing/Services/Implementations/SubscriptionDeletedHandler.cs
+++ b/src/Billing/Services/Implementations/SubscriptionDeletedHandler.cs
@@ -33,13 +33,16 @@ public class SubscriptionDeletedHandler : ISubscriptionDeletedHandler
         var subCanceled = subscription.Status == StripeSubscriptionStatus.Canceled;
 
         const string providerMigrationCancellationComment = "Cancelled as part of provider migration to Consolidated Billing";
+        const string addedToProviderCancellationComment = "Organization was added to Provider";
 
         if (!subCanceled)
         {
             return;
         }
 
-        if (organizationId.HasValue && subscription is not { CancellationDetails.Comment: providerMigrationCancellationComment })
+        if (organizationId.HasValue &&
+            subscription.CancellationDetails.Comment != providerMigrationCancellationComment &&
+            !subscription.CancellationDetails.Comment.Contains(addedToProviderCancellationComment))
         {
             await _organizationService.DisableAsync(organizationId.Value, subscription.CurrentPeriodEnd);
         }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-18427

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When adding an existing organization to a provider, I forgot to ensure I skipped the part where the organization's subscription cancellation results in disablement. This PR updates the check to ensure that organizations having subscriptions cancelled because they're being added to a provider aren't disabled.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/2985b350-9cd1-4055-b6ac-6bbacfa63f6f



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
