### PR TITLE
[PM-18430] Scale seats before linking client when adding existing organization

### DIFF
--- a/bitwarden_license/src/Commercial.Core/Billing/ProviderBillingService.cs
+++ b/bitwarden_license/src/Commercial.Core/Billing/ProviderBillingService.cs
@@ -111,10 +111,15 @@ public class ProviderBillingService(
             Key = key
         };
 
+        /*
+         * We have to scale the provider's seats before the ProviderOrganization
+         * row is inserted so the added organization's seats don't get double counted.
+         */
+        await ScaleSeats(provider, organization.PlanType, organization.Seats!.Value);
+
         await Task.WhenAll(
             organizationRepository.ReplaceAsync(organization),
-            providerOrganizationRepository.CreateAsync(providerOrganization),
-            ScaleSeats(provider, organization.PlanType, organization.Seats!.Value)
+            providerOrganizationRepository.CreateAsync(providerOrganization)
         );
 
         await eventService.LogProviderOrganizationEventAsync(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-18430

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

There was an order of operations issue when adding an existing client organization. We scaled the provider's seats at the same time we inserted the new `ProviderOrganization` record. This means the added organization's seats were being double counted when scaling; resulting in double the seat minimum. The fix was just to call `ScaleSeats` earlier in the process.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/4b63b187-e243-4c4a-bbec-0f22703cfe53


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
