### PR TITLE
[PM-18436] Only cancel subscriptions when creating or renewing

### DIFF
--- a/src/Billing/Jobs/SubscriptionCancellationJob.cs
+++ b/src/Billing/Jobs/SubscriptionCancellationJob.cs
@@ -23,9 +23,9 @@ public class SubscriptionCancellationJob(
         }
 
         var subscription = await stripeFacade.GetSubscription(subscriptionId);
-        if (subscription?.Status != "unpaid")
+        if (subscription?.Status != "unpaid" ||
+            subscription.LatestInvoice?.BillingReason is not ("subscription_cycle" or "subscription_create"))
         {
-            // Subscription is no longer unpaid, skip cancellation
             return;
         }
 

--- a/src/Billing/Services/Implementations/SubscriptionUpdatedHandler.cs
+++ b/src/Billing/Services/Implementations/SubscriptionUpdatedHandler.cs
@@ -208,9 +208,11 @@ public class SubscriptionUpdatedHandler : ISubscriptionUpdatedHandler
     private async Task ScheduleCancellationJobAsync(string subscriptionId, Guid organizationId)
     {
         var isResellerManagedOrgAlertEnabled = _featureService.IsEnabled(FeatureFlagKeys.ResellerManagedOrgAlert);
-
-        if (isResellerManagedOrgAlertEnabled)
+        if (!isResellerManagedOrgAlertEnabled)
         {
+            return;
+        }
+
         var scheduler = await _schedulerFactory.GetScheduler();
 
         var job = JobBuilder.Create<SubscriptionCancellationJob>()
@@ -226,5 +228,4 @@ public class SubscriptionUpdatedHandler : ISubscriptionUpdatedHandler
 
         await scheduler.ScheduleJob(job, trigger);
     }
-}
 }

--- a/src/Billing/Services/Implementations/SubscriptionUpdatedHandler.cs
+++ b/src/Billing/Services/Implementations/SubscriptionUpdatedHandler.cs
@@ -97,7 +97,10 @@ public class SubscriptionUpdatedHandler : ISubscriptionUpdatedHandler
                 {
                     await _organizationEnableCommand.EnableAsync(organizationId.Value);
                     var organization = await _organizationRepository.GetByIdAsync(organizationId.Value);
+                    if (organization != null)
+                    {
                         await _pushNotificationService.PushSyncOrganizationStatusAsync(organization);
+                    }
                     break;
                 }
             case StripeSubscriptionStatus.Active:


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-18436

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Updated `SubscriptionUpdatedHandler.cs` and `SubscriptionCancellationJob.cs` to only cancel subscriptions when the billing reason is either `subscription_cycle` or `subscription_create`.

Also resolved possible null reference compiler warning.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
