### PR TITLE
Auth/pm 17129/login with 2fa recovery code bugfix

### DIFF
--- a/src/Identity/IdentityServer/CustomValidatorRequestContext.cs
+++ b/src/Identity/IdentityServer/CustomValidatorRequestContext.cs
@@ -28,6 +28,11 @@ public class CustomValidatorRequestContext
     /// </summary>
     public bool SsoRequired { get; set; } = false;
     /// <summary>
+    /// This communicates if we are in a recovery flow and thus need to make new device verification
+    /// skip a part of the flow in order to allow the recovery code to log in the user.
+    /// </summary>
+    public bool InRecoveryFlowAndValidCode = false;
+    /// <summary>
     /// We use the parent class for both GrantValidationResult and TokenRequestValidationResult here for
     /// flexibility when building an error response.
     /// This will be null if the authentication request is successful.

--- a/src/Identity/IdentityServer/RequestValidators/BaseRequestValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/BaseRequestValidator.cs
@@ -146,7 +146,7 @@ public abstract class BaseRequestValidator<T> where T : class
 
             var twoFactorTokenValid =
                 await _twoFactorAuthenticationValidator
-                    .VerifyTwoFactorAsync(user, twoFactorOrganization, twoFactorProviderType, twoFactorToken);
+                    .VerifyTwoFactorAsync(user, twoFactorOrganization, twoFactorProviderType, twoFactorToken, validatorContext);
 
             // 3b. Response for 2FA required but request is not valid or remember token expired state.
             if (!twoFactorTokenValid)

--- a/src/Identity/IdentityServer/RequestValidators/DeviceValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/DeviceValidator.cs
@@ -69,6 +69,10 @@ public class DeviceValidator(
             request.GrantType == "password" &&
             request.Raw["AuthRequest"] == null &&
             !context.TwoFactorRequired &&
+            // Here we want to allow a successful recovery code flow through. In the recovery
+            // code flow we disable TwoFactorRequired so we want to be able to skip this check
+            // in the event the recovery code is valid.
+            !context.InRecoveryFlowAndValidCode &&
             !context.SsoRequired &&
             _globalSettings.EnableNewDeviceVerification)
         {

--- a/test/Identity.Test/IdentityServer/DeviceValidatorTests.cs
+++ b/test/Identity.Test/IdentityServer/DeviceValidatorTests.cs
@@ -461,59 +461,6 @@ public class DeviceValidatorTests
         Assert.NotNull(context.Device);
     }
 
-    // [Theory, BitAutoData]
-    // public async void ValidateRequestDeviceAsync_DeviceNull_RecoveryFlow_ReturnsTrue(
-    //     CustomValidatorRequestContext context,
-    //     [AuthFixtures.ValidatedTokenRequest] ValidatedTokenRequest request)
-    // {
-    //     // Arrange
-    //     context.KnownDevice = false;
-    //     context.InRecoveryFlowAndValidCode = true;
-    //
-    //     _featureService.IsEnabled(FeatureFlagKeys.NewDeviceVerification)
-    //         .Returns(true);
-    //
-    //     // Act
-    //     Assert.NotNull(context.User);
-    //     var result = await _sut.ValidateRequestDeviceAsync(request, context);
-    //
-    //     // Assert
-    //     await _deviceService.Received(1).SaveAsync(Arg.Any<Device>());
-    //
-    //     Assert.True(result);
-    // }
-    //
-    // [Theory, BitAutoData]
-    // public async void ValidateRequestDeviceAsync_DeviceNull_InvalidRecoveryFlow_ReturnsFalse(
-    //     CustomValidatorRequestContext context,
-    //     [AuthFixtures.ValidatedTokenRequest] ValidatedTokenRequest request)
-    // {
-    //     // Arrange
-    //     context.KnownDevice = false;
-    //     context.InRecoveryFlowAndValidCode = false;
-    //
-    //     ArrangeForHandleNewDeviceVerificationTest(context, request);
-    //     AddValidDeviceToRequest(request);
-    //     _deviceRepository.GetByIdentifierAsync(context.Device.Identifier, context.User.Id)
-    //         .Returns(null as Device);
-    //     _featureService.IsEnabled(FeatureFlagKeys.NewDeviceVerification)
-    //         .Returns(true);
-    //     _globalSettings.EnableNewDeviceVerification = true;
-    //
-    //     // Act
-    //     Assert.NotNull(context.User);
-    //     var result = await _sut.ValidateRequestDeviceAsync(request, context);
-    //
-    //     // Assert
-    //     await _deviceService.Received(0).SaveAsync(Arg.Any<Device>());
-    //
-    //     Assert.False(result);
-    //     Assert.NotNull(context.CustomResponse["ErrorModel"]);
-    //     var expectedErrorModel = new ErrorResponseModel("no device information provided");
-    //     var actualResponse = (ErrorResponseModel)context.CustomResponse["ErrorModel"];
-    //     Assert.Equal(expectedErrorModel.Message, actualResponse.Message);
-    // }
-
     [Theory, BitAutoData]
     public async void HandleNewDeviceVerificationAsync_UserNull_ContextModified_ReturnsInvalidUser(
         CustomValidatorRequestContext context,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17128

This was born out of Lauren discovering that with the new device verification flag being on the user would not be properly logged into the app when trying to recover from a new device.

## 📔 Objective

Fixed the flow to track whether we are in a special recovery code flow in the device verification.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
