### PR TITLE
Ac/pm 17449/add managed user validation to email token

### DIFF
--- a/src/Api/Auth/Controllers/AccountsController.cs
+++ b/src/Api/Auth/Controllers/AccountsController.cs
@@ -149,6 +149,12 @@ public class AccountsController : Controller
             throw new BadRequestException("MasterPasswordHash", "Invalid password.");
         }
 
+        var managedUserValidationResult = await _userService.ValidateManagedUserDomainAsync(user, model.NewEmail);
+
+        if (!managedUserValidationResult.Succeeded)
+        {
+            throw new BadRequestException(managedUserValidationResult.Errors);
+        }
 
         await _userService.InitiateEmailChangeAsync(user, model.NewEmail);
     }
@@ -166,7 +172,6 @@ public class AccountsController : Controller
         {
             throw new BadRequestException("You cannot change your email when using Key Connector.");
         }
-
 
         var result = await _userService.ChangeEmailAsync(user, model.MasterPasswordHash, model.NewEmail,
             model.NewMasterPasswordHash, model.Token, model.Key);

--- a/src/Core/Exceptions/BadRequestException.cs
+++ b/src/Core/Exceptions/BadRequestException.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Bit.Core.Exceptions;
 
@@ -27,6 +28,17 @@ public class BadRequestException : Exception
         }
 
         ModelState = modelState;
+    }
+
+    public BadRequestException(IEnumerable<IdentityError> identityErrors)
+    : base("The model state is invalid.")
+    {
+        ModelState = new ModelStateDictionary();
+
+        foreach (var error in identityErrors)
+        {
+            ModelState.AddModelError(error.Code, error.Description);
+        }
     }
 
     public ModelStateDictionary ModelState { get; set; }

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -137,6 +137,16 @@ public interface IUserService
     Task<bool> IsManagedByAnyOrganizationAsync(Guid userId);
 
     /// <summary>
+    /// Verify whether the new email domain meets the requirements for managed users.
+    /// </summary>
+    /// <remarks>
+    /// </remarks>
+    /// <returns>
+    /// IdentityResult 
+    /// </returns>
+    Task<IdentityResult> ValidateManagedUserDomainAsync(User user, string newEmail);
+
+    /// <summary>
     /// Gets the organizations that manage the user.
     /// </summary>
     /// <returns>

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -545,7 +545,7 @@ public class UserService : UserManager<User>, IUserService, IDisposable
             return IdentityResult.Failed(_identityErrorDescriber.PasswordMismatch());
         }
 
-        var managedUserValidationResult = await ValidateManagedUserAsync(user, newEmail);
+        var managedUserValidationResult = await ValidateManagedUserDomainAsync(user, newEmail);
 
         if (!managedUserValidationResult.Succeeded)
         {
@@ -617,7 +617,7 @@ public class UserService : UserManager<User>, IUserService, IDisposable
         return IdentityResult.Success;
     }
 
-    private async Task<IdentityResult> ValidateManagedUserAsync(User user, string newEmail)
+    public async Task<IdentityResult> ValidateManagedUserDomainAsync(User user, string newEmail)
     {
         var managingOrganizations = await GetOrganizationsManagingUserAsync(user.Id);
 

--- a/test/Api.Test/Auth/Controllers/AccountsControllerTests.cs
+++ b/test/Api.Test/Auth/Controllers/AccountsControllerTests.cs
@@ -134,29 +134,43 @@ public class AccountsControllerTests : IDisposable
     [Fact]
     public async Task PostEmailToken_ShouldInitiateEmailChange()
     {
+        // Arrange
         var user = GenerateExampleUser();
         ConfigureUserServiceToReturnValidPrincipalFor(user);
         ConfigureUserServiceToAcceptPasswordFor(user);
-        var newEmail = "example@user.com";
+        const string newEmail = "example@user.com";
+        _userService.ValidateManagedUserDomainAsync(user, newEmail).Returns(IdentityResult.Success);
 
+        // Act
         await _sut.PostEmailToken(new EmailTokenRequestModel { NewEmail = newEmail });
 
+        // Assert
         await _userService.Received(1).InitiateEmailChangeAsync(user, newEmail);
     }
 
     [Fact]
-    public async Task PostEmailToken_WithAccountDeprovisioningEnabled_WhenUserIsNotManagedByAnOrganization_ShouldInitiateEmailChange()
+    public async Task PostEmailToken_WhenValidateManagedUserDomainAsyncFails_ShouldReturnError()
     {
+        // Arrange
         var user = GenerateExampleUser();
         ConfigureUserServiceToReturnValidPrincipalFor(user);
         ConfigureUserServiceToAcceptPasswordFor(user);
-        _featureService.IsEnabled(FeatureFlagKeys.AccountDeprovisioning).Returns(true);
-        _userService.IsManagedByAnyOrganizationAsync(user.Id).Returns(false);
-        var newEmail = "example@user.com";
 
-        await _sut.PostEmailToken(new EmailTokenRequestModel { NewEmail = newEmail });
+        const string newEmail = "example@user.com";
 
-        await _userService.Received(1).InitiateEmailChangeAsync(user, newEmail);
+        _userService.ValidateManagedUserDomainAsync(user, newEmail)
+            .Returns(IdentityResult.Failed(new IdentityError
+            {
+                Code = "TestFailure",
+                Description = "This is a test."
+            }));
+
+
+        // Act
+        // Assert
+        await Assert.ThrowsAsync<BadRequestException>(
+            () => _sut.PostEmailToken(new EmailTokenRequestModel { NewEmail = newEmail })
+        );
     }
 
     [Fact]


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-17449

## 📔 Objective

Make `ValidateManagedUserDomainAsync` public so it can be used in the email token endpoint.

## 📸 Screenshots


https://github.com/user-attachments/assets/849fdb8e-e6ac-4f7c-bf50-1f51cc58c573



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
