### PR TITLE
[PM-18608] Don't require new device verification on newly created accounts

### DIFF
--- a/src/Identity/IdentityServer/RequestValidators/DeviceValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/DeviceValidator.cs
@@ -120,6 +120,13 @@ public class DeviceValidator(
             return DeviceValidationResultType.Success;
         }
 
+        // User is newly registered, so don't require new device verification
+        var createdSpan = DateTime.UtcNow - user.CreationDate;
+        if (createdSpan < TimeSpan.FromHours(24))
+        {
+            return DeviceValidationResultType.Success;
+        }
+
         // CS exception flow
         // Check cache for user information
         var cacheKey = string.Format(AuthConstants.NewDeviceVerificationExceptionCacheKeyFormat, user.Id.ToString());

--- a/test/Identity.Test/IdentityServer/DeviceValidatorTests.cs
+++ b/test/Identity.Test/IdentityServer/DeviceValidatorTests.cs
@@ -448,6 +448,31 @@ public class DeviceValidatorTests
     }
 
     [Theory, BitAutoData]
+    public async void HandleNewDeviceVerificationAsync_NewlyCreated_ReturnsSuccess(
+        CustomValidatorRequestContext context,
+        [AuthFixtures.ValidatedTokenRequest] ValidatedTokenRequest request)
+    {
+        // Arrange
+        ArrangeForHandleNewDeviceVerificationTest(context, request);
+        _featureService.IsEnabled(FeatureFlagKeys.NewDeviceVerification).Returns(true);
+        _globalSettings.EnableNewDeviceVerification = true;
+        _distributedCache.GetAsync(Arg.Any<string>()).Returns(null as byte[]);
+        context.User.CreationDate = DateTime.UtcNow - TimeSpan.FromHours(23);
+
+        // Act
+        var result = await _sut.ValidateRequestDeviceAsync(request, context);
+
+        // Assert
+        await _userService.Received(0).SendOTPAsync(context.User);
+        await _deviceService.Received(1).SaveAsync(Arg.Any<Device>());
+
+        Assert.True(result);
+        Assert.False(context.CustomResponse.ContainsKey("ErrorModel"));
+        Assert.Equal(context.User.Id, context.Device.UserId);
+        Assert.NotNull(context.Device);
+    }
+
+    [Theory, BitAutoData]
     public async void HandleNewDeviceVerificationAsync_UserHasCacheValue_ReturnsSuccess(
         CustomValidatorRequestContext context,
         [AuthFixtures.ValidatedTokenRequest] ValidatedTokenRequest request)

--- a/test/Identity.Test/IdentityServer/DeviceValidatorTests.cs
+++ b/test/Identity.Test/IdentityServer/DeviceValidatorTests.cs
@@ -658,7 +658,7 @@ public class DeviceValidatorTests
         request.GrantType = "password";
         context.TwoFactorRequired = false;
         context.SsoRequired = false;
-        if(context.User != null)
+        if (context.User != null)
         {
             context.User.CreationDate = DateTime.UtcNow - TimeSpan.FromDays(365);
         }

--- a/test/Identity.Test/IdentityServer/DeviceValidatorTests.cs
+++ b/test/Identity.Test/IdentityServer/DeviceValidatorTests.cs
@@ -658,5 +658,9 @@ public class DeviceValidatorTests
         request.GrantType = "password";
         context.TwoFactorRequired = false;
         context.SsoRequired = false;
+        if(context.User != null)
+        {
+            context.User.CreationDate = DateTime.UtcNow - TimeSpan.FromDays(365);
+        }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18608

## 📔 Objective

When a user first creates their account, they are expected to be onboarding lots of new devices. Limit new device verification during this critical "getting started" time. 