### PR TITLE
[PM-18583] Separate Desktop and CLI ClientTypes

### DIFF
--- a/src/Core/Enums/ClientType.cs
+++ b/src/Core/Enums/ClientType.cs
@@ -14,5 +14,7 @@ public enum ClientType : byte
     [Display(Name = "Desktop App")]
     Desktop = 3,
     [Display(Name = "Mobile App")]
-    Mobile = 4
+    Mobile = 4,
+    [Display(Name = "CLI")]
+    Cli = 5
 }

--- a/src/Core/Utilities/DeviceTypes.cs
+++ b/src/Core/Utilities/DeviceTypes.cs
@@ -16,7 +16,11 @@ public static class DeviceTypes
         DeviceType.LinuxDesktop,
         DeviceType.MacOsDesktop,
         DeviceType.WindowsDesktop,
-        DeviceType.UWP,
+        DeviceType.UWP
+    ];
+
+    public static IReadOnlyCollection<DeviceType> CliTypes { get; } =
+    [
         DeviceType.WindowsCLI,
         DeviceType.MacOsCLI,
         DeviceType.LinuxCLI
@@ -50,6 +54,7 @@ public static class DeviceTypes
         {
             not null when MobileTypes.Contains(deviceType.Value) => ClientType.Mobile,
             not null when DesktopTypes.Contains(deviceType.Value) => ClientType.Desktop,
+            not null when CliTypes.Contains(deviceType.Value) => ClientType.Cli,
             not null when BrowserExtensionTypes.Contains(deviceType.Value) => ClientType.Browser,
             not null when BrowserTypes.Contains(deviceType.Value) => ClientType.Web,
             _ => ClientType.All


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18583

## 📔 Objective

We currently group the desktop and CLI clients together in the `DesktopTypes`.

This causes downstream issues for feature flag targeting, as the `ClientType` is used [here](https://github.com/bitwarden/server/blob/a86741413a4e2268c1e1824d51af8ed193dcfc25/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs#L156-L157) to assign to the LaunchDarkly context for feature flag targeting.

This means that it is impossible to target a different CLI version than desktop version, without specifying individual device types in LaunchDarkly (bypassing the convenience of the `ClientType`).

The reason for this request related to the linked issue is that for New Device Verification, we will have different versions for the CLI and the desktop in the upcoming release (`2025.2.1` vs. `2025.2.0`), and in setting up the feature flags for this release I noticed the grouping.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
