### PR TITLE
Move Azure.Extensions.AspNetCore.DataProtection.Blobs dependency to Platform

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,7 +42,6 @@
     },
     {
       matchPackageNames: [
-        "Azure.Extensions.AspNetCore.DataProtection.Blobs",
         "DuoUniversal",
         "Fido2.AspNet",
         "Duende.IdentityServer",
@@ -125,6 +124,7 @@
         "AspNetCoreRateLimit",
         "AspNetCoreRateLimit.Redis",
         "Azure.Data.Tables",
+        "Azure.Extensions.AspNetCore.DataProtection.Blobs",
         "Azure.Messaging.EventGrid",
         "Azure.Messaging.ServiceBus",
         "Azure.Storage.Blobs",


### PR DESCRIPTION
## 📔 Objective

As shown in https://github.com/bitwarden/server/pull/4815, the `Azure.Extensions.AspNetCore.DataProtection.Blobs` dependency - which is part of the `azure-sdk-for-net` monorepo grouping in Renovate - is isolated on the Auth team, whereas the rest of the dependencies are owned by Platform.

This splits the responsibilities between two teams.  Our standard practice is to try to have a single team own a dependency group.

This PR moves the responsibility for this dependency to the Platform team along with the other `azure-sdk-for-net` dependencies for future updates.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
