### PR TITLE
[PM-18578] Don't enable automatic tax for non-taxable non-US businesses during `invoice.upcoming`

### DIFF
--- a/src/Billing/Services/Implementations/UpcomingInvoiceHandler.cs
+++ b/src/Billing/Services/Implementations/UpcomingInvoiceHandler.cs
@@ -144,7 +144,8 @@ public class UpcomingInvoiceHandler(
         await stripeFacade.UpdateSubscription(subscription.Id,
             new SubscriptionUpdateOptions
             {
-                DefaultTaxRates = [], AutomaticTax = new SubscriptionAutomaticTaxOptions { Enabled = true }
+                DefaultTaxRates = [],
+                AutomaticTax = new SubscriptionAutomaticTaxOptions { Enabled = true }
             });
 
         return;

--- a/src/Billing/Services/Implementations/UpcomingInvoiceHandler.cs
+++ b/src/Billing/Services/Implementations/UpcomingInvoiceHandler.cs
@@ -1,6 +1,7 @@
-﻿using Bit.Billing.Constants;
-using Bit.Core.AdminConsole.Entities;
+﻿using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Billing.Constants;
+using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Extensions;
 using Bit.Core.OrganizationFeatures.OrganizationSponsorships.FamiliesForEnterprise.Interfaces;
 using Bit.Core.Repositories;
@@ -11,94 +12,66 @@ using Event = Stripe.Event;
 
 namespace Bit.Billing.Services.Implementations;
 
-public class UpcomingInvoiceHandler : IUpcomingInvoiceHandler
+public class UpcomingInvoiceHandler(
+    ILogger<StripeEventProcessor> logger,
+    IMailService mailService,
+    IOrganizationRepository organizationRepository,
+    IProviderRepository providerRepository,
+    IStripeFacade stripeFacade,
+    IStripeEventService stripeEventService,
+    IStripeEventUtilityService stripeEventUtilityService,
+    IUserRepository userRepository,
+    IValidateSponsorshipCommand validateSponsorshipCommand)
+    : IUpcomingInvoiceHandler
 {
-    private readonly ILogger<StripeEventProcessor> _logger;
-    private readonly IStripeEventService _stripeEventService;
-    private readonly IUserService _userService;
-    private readonly IStripeFacade _stripeFacade;
-    private readonly IMailService _mailService;
-    private readonly IProviderRepository _providerRepository;
-    private readonly IValidateSponsorshipCommand _validateSponsorshipCommand;
-    private readonly IOrganizationRepository _organizationRepository;
-    private readonly IStripeEventUtilityService _stripeEventUtilityService;
-
-    public UpcomingInvoiceHandler(
-        ILogger<StripeEventProcessor> logger,
-        IStripeEventService stripeEventService,
-        IUserService userService,
-        IStripeFacade stripeFacade,
-        IMailService mailService,
-        IProviderRepository providerRepository,
-        IValidateSponsorshipCommand validateSponsorshipCommand,
-        IOrganizationRepository organizationRepository,
-        IStripeEventUtilityService stripeEventUtilityService)
-    {
-        _logger = logger;
-        _stripeEventService = stripeEventService;
-        _userService = userService;
-        _stripeFacade = stripeFacade;
-        _mailService = mailService;
-        _providerRepository = providerRepository;
-        _validateSponsorshipCommand = validateSponsorshipCommand;
-        _organizationRepository = organizationRepository;
-        _stripeEventUtilityService = stripeEventUtilityService;
-    }
-
-    /// <summary>
-    /// Handles the <see cref="HandledStripeWebhook.UpcomingInvoice"/> event type from Stripe.
-    /// </summary>
-    /// <param name="parsedEvent"></param>
-    /// <exception cref="Exception"></exception>
     public async Task HandleAsync(Event parsedEvent)
     {
-        var invoice = await _stripeEventService.GetInvoice(parsedEvent);
+        var invoice = await stripeEventService.GetInvoice(parsedEvent);
+
         if (string.IsNullOrEmpty(invoice.SubscriptionId))
         {
-            _logger.LogWarning("Received 'invoice.upcoming' Event with ID '{eventId}' that did not include a Subscription ID", parsedEvent.Id);
+            logger.LogInformation("Received 'invoice.upcoming' Event with ID '{eventId}' that did not include a Subscription ID", parsedEvent.Id);
             return;
         }
 
-        var subscription = await _stripeFacade.GetSubscription(invoice.SubscriptionId);
-
-        if (subscription == null)
+        var subscription = await stripeFacade.GetSubscription(invoice.SubscriptionId, new SubscriptionGetOptions
         {
-            throw new Exception(
-                $"Received null Subscription from Stripe for ID '{invoice.SubscriptionId}' while processing Event with ID '{parsedEvent.Id}'");
-        }
+            Expand = ["customer.tax", "customer.tax_ids"]
+        });
 
-        var updatedSubscription = await TryEnableAutomaticTaxAsync(subscription);
-
-        var (organizationId, userId, providerId) = _stripeEventUtilityService.GetIdsFromMetadata(updatedSubscription.Metadata);
-
-        var invoiceLineItemDescriptions = invoice.Lines.Select(i => i.Description).ToList();
+        var (organizationId, userId, providerId) = stripeEventUtilityService.GetIdsFromMetadata(subscription.Metadata);
 
         if (organizationId.HasValue)
         {
-            if (_stripeEventUtilityService.IsSponsoredSubscription(updatedSubscription))
-            {
-                var sponsorshipIsValid =
-                    await _validateSponsorshipCommand.ValidateSponsorshipAsync(organizationId.Value);
-                if (!sponsorshipIsValid)
-                {
-                    // If the sponsorship is invalid, then the subscription was updated to use the regular families plan
-                    // price. Given that this is the case, we need the new invoice amount
-                    subscription = await _stripeFacade.GetSubscription(subscription.Id,
-                        new SubscriptionGetOptions { Expand = ["latest_invoice"] });
+            var organization = await organizationRepository.GetByIdAsync(organizationId.Value);
 
-                    invoice = subscription.LatestInvoice;
-                    invoiceLineItemDescriptions = invoice.Lines.Select(i => i.Description).ToList();
-                }
-            }
-
-            var organization = await _organizationRepository.GetByIdAsync(organizationId.Value);
-
-            if (organization == null || !OrgPlanForInvoiceNotifications(organization))
+            if (organization == null)
             {
                 return;
             }
 
-            await SendEmails(new List<string> { organization.BillingEmail });
+            await TryEnableAutomaticTaxAsync(subscription);
+
+            if (!HasAnnualPlan(organization))
+            {
+                return;
+            }
+
+            if (stripeEventUtilityService.IsSponsoredSubscription(subscription))
+            {
+                var sponsorshipIsValid = await validateSponsorshipCommand.ValidateSponsorshipAsync(organizationId.Value);
+
+                if (!sponsorshipIsValid)
+                {
+                    /*
+                     * If the sponsorship is invalid, then the subscription was updated to use the regular families plan
+                     * price. Given that this is the case, we need the new invoice amount
+                     */
+                    invoice = await stripeFacade.GetInvoice(subscription.LatestInvoiceId);
+                }
+            }
+
+            await SendUpcomingInvoiceEmailsAsync(new List<string> { organization.BillingEmail }, invoice);
 
             /*
              * TODO: https://bitwarden.atlassian.net/browse/PM-4862
@@ -113,66 +86,84 @@ public class UpcomingInvoiceHandler : IUpcomingInvoiceHandler
         }
         else if (userId.HasValue)
         {
-            var user = await _userService.GetUserByIdAsync(userId.Value);
+            var user = await userRepository.GetByIdAsync(userId.Value);
 
-            if (user?.Premium == true)
+            if (user == null)
             {
-                await SendEmails(new List<string> { user.Email });
+                return;
+            }
+
+            await TryEnableAutomaticTaxAsync(subscription);
+
+            if (user.Premium)
+            {
+                await SendUpcomingInvoiceEmailsAsync(new List<string> { user.Email }, invoice);
             }
         }
         else if (providerId.HasValue)
         {
-            var provider = await _providerRepository.GetByIdAsync(providerId.Value);
+            var provider = await providerRepository.GetByIdAsync(providerId.Value);
 
             if (provider == null)
             {
-                _logger.LogError(
-                    "Received invoice.Upcoming webhook ({EventID}) for Provider ({ProviderID}) that does not exist",
-                    parsedEvent.Id,
-                    providerId.Value);
-
                 return;
             }
 
-            await SendEmails(new List<string> { provider.BillingEmail });
+            await TryEnableAutomaticTaxAsync(subscription);
 
+            await SendUpcomingInvoiceEmailsAsync(new List<string> { provider.BillingEmail }, invoice);
         }
+    }
+
+    private async Task SendUpcomingInvoiceEmailsAsync(IEnumerable<string> emails, Invoice invoice)
+    {
+        var validEmails = emails.Where(e => !string.IsNullOrEmpty(e));
+
+        var items = invoice.Lines.Select(i => i.Description).ToList();
+
+        if (invoice.NextPaymentAttempt.HasValue && invoice.AmountDue > 0)
+        {
+            await mailService.SendInvoiceUpcoming(
+                validEmails,
+                invoice.AmountDue / 100M,
+                invoice.NextPaymentAttempt.Value,
+                items,
+                true);
+        }
+    }
+
+    private async Task TryEnableAutomaticTaxAsync(Subscription subscription)
+    {
+        if (subscription.AutomaticTax.Enabled ||
+            !subscription.Customer.HasBillingLocation() ||
+            IsNonTaxableNonUSBusinessUseSubscription(subscription))
+        {
+            return;
+        }
+
+        await stripeFacade.UpdateSubscription(subscription.Id,
+            new SubscriptionUpdateOptions
+            {
+                DefaultTaxRates = [], AutomaticTax = new SubscriptionAutomaticTaxOptions { Enabled = true }
+            });
 
         return;
 
-        /*
-         * Sends emails to the given email addresses.
-         */
-        async Task SendEmails(IEnumerable<string> emails)
+        bool IsNonTaxableNonUSBusinessUseSubscription(Subscription localSubscription)
         {
-            var validEmails = emails.Where(e => !string.IsNullOrEmpty(e));
-
-            if (invoice.NextPaymentAttempt.HasValue && invoice.AmountDue > 0)
+            var familyPriceIds = new List<string>
             {
-                await _mailService.SendInvoiceUpcoming(
-                    validEmails,
-                    invoice.AmountDue / 100M,
-                    invoice.NextPaymentAttempt.Value,
-                    invoiceLineItemDescriptions,
-                    true);
-            }
+                // TODO: Replace with the PricingClient
+                StaticStore.GetPlan(PlanType.FamiliesAnnually2019).PasswordManager.StripePlanId,
+                StaticStore.GetPlan(PlanType.FamiliesAnnually).PasswordManager.StripePlanId
+            };
+
+            return localSubscription.Customer.Address.Country != "US" &&
+                   localSubscription.Metadata.ContainsKey(StripeConstants.MetadataKeys.OrganizationId) &&
+                   !localSubscription.Items.Select(item => item.Price.Id).Intersect(familyPriceIds).Any() &&
+                   !localSubscription.Customer.TaxIds.Any();
         }
     }
 
-    private async Task<Subscription> TryEnableAutomaticTaxAsync(Subscription subscription)
-    {
-        var customerGetOptions = new CustomerGetOptions { Expand = ["tax"] };
-        var customer = await _stripeFacade.GetCustomer(subscription.CustomerId, customerGetOptions);
-
-        var subscriptionUpdateOptions = new SubscriptionUpdateOptions();
-
-        if (!subscriptionUpdateOptions.EnableAutomaticTax(customer, subscription))
-        {
-            return subscription;
-        }
-
-        return await _stripeFacade.UpdateSubscription(subscription.Id, subscriptionUpdateOptions);
-    }
-
-    private static bool OrgPlanForInvoiceNotifications(Organization org) => StaticStore.GetPlan(org.PlanType).IsAnnual;
+    private static bool HasAnnualPlan(Organization org) => StaticStore.GetPlan(org.PlanType).IsAnnual;
 }

--- a/src/Core/Billing/Extensions/CustomerExtensions.cs
+++ b/src/Core/Billing/Extensions/CustomerExtensions.cs
@@ -5,6 +5,15 @@ namespace Bit.Core.Billing.Extensions;
 
 public static class CustomerExtensions
 {
+    public static bool HasBillingLocation(this Customer customer)
+        => customer is
+        {
+            Address:
+            {
+                Country: not null and not "",
+                PostalCode: not null and not ""
+            }
+        };
 
     /// <summary>
     /// Determines if a Stripe customer supports automatic tax


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-18578

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When we enabled automatic tax in our system, we started trying to enable it for every subscription where automatic tax was "supported" by Stripe.

All this means is "The customer is located in a country or state where you’re collecting tax."

However, this is not yet correct for our business use cases (Teams/Enterprise organizations) that are not in the United States.

The goal of [PM-17654](https://bitwarden.atlassian.net/browse/PM-17654) is to ensure automatic tax is only enabled for businesses outside of the US when they've given us a Tax ID. We want to get to a state where, for businesses outside of the US, no tax ID = no automatic tax.

I wrote a script that accomplishes that. But because of this existing logic, when those customers receive an Upcoming Invoice webhook, our system is re-enabling automatic tax for them again; thereby wiping out the script effects.

This PR resolves that.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17654]: https://bitwarden.atlassian.net/browse/PM-17654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ