### PR TITLE
Prefer record to implementing IEquatable

### DIFF
--- a/src/Core/NotificationHub/PushRegistrationData.cs
+++ b/src/Core/NotificationHub/PushRegistrationData.cs
@@ -1,23 +1,13 @@
 ﻿namespace Bit.Core.NotificationHub;
 
-public struct WebPushRegistrationData : IEquatable<WebPushRegistrationData>
+public record struct WebPushRegistrationData
 {
     public string Endpoint { get; init; }
     public string P256dh { get; init; }
     public string Auth { get; init; }
-
-    public bool Equals(WebPushRegistrationData other)
-    {
-        return Endpoint == other.Endpoint && P256dh == other.P256dh && Auth == other.Auth;
-    }
-
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(Endpoint, P256dh, Auth);
-    }
 }
 
-public class PushRegistrationData : IEquatable<PushRegistrationData>
+public record class PushRegistrationData
 {
     public string Token { get; set; }
     public WebPushRegistrationData? WebPush { get; set; }
@@ -37,14 +27,5 @@ public class PushRegistrationData : IEquatable<PushRegistrationData>
     public PushRegistrationData(WebPushRegistrationData webPush)
     {
         WebPush = webPush;
-    }
-    public bool Equals(PushRegistrationData other)
-    {
-        return Token == other.Token && WebPush.Equals(other.WebPush);
-    }
-
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(Token, WebPush.GetHashCode());
     }
 }

--- a/test/Api.Test/Platform/Push/Controllers/PushControllerTests.cs
+++ b/test/Api.Test/Platform/Push/Controllers/PushControllerTests.cs
@@ -280,7 +280,7 @@ public class PushControllerTests
         await sutProvider.Sut.RegisterAsync(model);
 
         await sutProvider.GetDependency<IPushRegistrationService>().Received(1)
-            .CreateOrUpdateRegistrationAsync(Arg.Is<PushRegistrationData>(data => data.Equals(new PushRegistrationData(model.PushToken))), expectedDeviceId, expectedUserId,
+            .CreateOrUpdateRegistrationAsync(Arg.Is<PushRegistrationData>(data => data == new PushRegistrationData(model.PushToken)), expectedDeviceId, expectedUserId,
                 expectedIdentifier, DeviceType.Android, Arg.Do<IEnumerable<string>>(organizationIds =>
                 {
                     var organizationIdsList = organizationIds.ToList();


### PR DESCRIPTION
## 📔 Objective

Quick fixup for #5395. Prefers records to IEquatable implementations and `==` operators to calls to `.Equals`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
