### PR TITLE
Remove New Device Verification feature flag check from Bitwarden Portal

### DIFF
--- a/src/Admin/Views/Users/Edit.cshtml
+++ b/src/Admin/Views/Users/Edit.cshtml
@@ -9,8 +9,7 @@
 
     var canViewUserInformation = AccessControlService.UserHasPermission(Permission.User_UserInformation_View);
     var canViewNewDeviceException = AccessControlService.UserHasPermission(Permission.User_NewDeviceException_Edit) &&
-                                    GlobalSettings.EnableNewDeviceVerification &&
-                                    FeatureService.IsEnabled(Bit.Core.FeatureFlagKeys.NewDeviceVerification);
+                                    GlobalSettings.EnableNewDeviceVerification;
     var canViewBillingInformation = AccessControlService.UserHasPermission(Permission.User_BillingInformation_View);
     var canViewGeneral = AccessControlService.UserHasPermission(Permission.User_GeneralDetails_View);
     var canViewPremium = AccessControlService.UserHasPermission(Permission.User_Premium_View);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18906

## 📔 Objective

We are using a progressive rollout of the New Device Verification feature, starting at 1%.

However, we need to ensure that the bypass is always available for CS.  This means we can no longer flag this behind the `new-device-verification` feature flag; otherwise it would only display to CS 1% of the time.

This PR removes the feature flag check from the Bitwarden Portal.

## 💻 Screenshot

![image](https://github.com/user-attachments/assets/6f4218a1-2490-4a90-8ef8-60980618447a)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
