### PR TITLE
[PM-18914] Fix user context on importing into individual vaults

### DIFF
--- a/src/Api/Tools/Controllers/ImportCiphersController.cs
+++ b/src/Api/Tools/Controllers/ImportCiphersController.cs
@@ -56,7 +56,7 @@ public class ImportCiphersController : Controller
         var userId = _userService.GetProperUserId(User).Value;
         var folders = model.Folders.Select(f => f.ToFolder(userId)).ToList();
         var ciphers = model.Ciphers.Select(c => c.ToCipherDetails(userId, false)).ToList();
-        await _importCiphersCommand.ImportIntoIndividualVaultAsync(folders, ciphers, model.FolderRelationships);
+        await _importCiphersCommand.ImportIntoIndividualVaultAsync(folders, ciphers, model.FolderRelationships, userId);
     }
 
     [HttpPost("import-organization")]

--- a/src/Core/Tools/ImportFeatures/Interfaces/IImportCiphersCommand.cs
+++ b/src/Core/Tools/ImportFeatures/Interfaces/IImportCiphersCommand.cs
@@ -7,7 +7,7 @@ namespace Bit.Core.Tools.ImportFeatures.Interfaces;
 public interface IImportCiphersCommand
 {
     Task ImportIntoIndividualVaultAsync(List<Folder> folders, List<CipherDetails> ciphers,
-        IEnumerable<KeyValuePair<int, int>> folderRelationships);
+        IEnumerable<KeyValuePair<int, int>> folderRelationships, Guid importingUserId);
 
     Task ImportIntoOrganizationalVaultAsync(List<Collection> collections, List<CipherDetails> ciphers,
         IEnumerable<KeyValuePair<int, int>> collectionRelationships, Guid importingUserId);

--- a/test/Api.Test/Tools/Controllers/ImportCiphersControllerTests.cs
+++ b/test/Api.Test/Tools/Controllers/ImportCiphersControllerTests.cs
@@ -79,7 +79,8 @@ public class ImportCiphersControllerTests
             .ImportIntoIndividualVaultAsync(
             Arg.Any<List<Folder>>(),
             Arg.Any<List<CipherDetails>>(),
-            Arg.Any<IEnumerable<KeyValuePair<int, int>>>()
+            Arg.Any<IEnumerable<KeyValuePair<int, int>>>(),
+            user.Id
             );
     }
 

--- a/test/Core.Test/Tools/ImportFeatures/ImportCiphersAsyncCommandTests.cs
+++ b/test/Core.Test/Tools/ImportFeatures/ImportCiphersAsyncCommandTests.cs
@@ -44,7 +44,7 @@ public class ImportCiphersAsyncCommandTests
         var folderRelationships = new List<KeyValuePair<int, int>>();
 
         // Act
-        await sutProvider.Sut.ImportIntoIndividualVaultAsync(folders, ciphers, folderRelationships);
+        await sutProvider.Sut.ImportIntoIndividualVaultAsync(folders, ciphers, folderRelationships, importingUserId);
 
         // Assert
         await sutProvider.GetDependency<ICipherRepository>().Received(1).CreateAsync(ciphers, Arg.Any<List<Folder>>());
@@ -68,7 +68,7 @@ public class ImportCiphersAsyncCommandTests
         var folderRelationships = new List<KeyValuePair<int, int>>();
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
-            sutProvider.Sut.ImportIntoIndividualVaultAsync(folders, ciphers, folderRelationships));
+            sutProvider.Sut.ImportIntoIndividualVaultAsync(folders, ciphers, folderRelationships, userId));
 
         Assert.Equal("You cannot import items into your personal vault because you are a member of an organization which forbids it.", exception.Message);
     }


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-18914

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix user context on importing into individual vaults

Pass in the current userId instead of trying to infer it from the folders or ciphers passed into the ImportCiphersCommand

Kudos go to @MJebran who pointed this out on https://github.com/bitwarden/server/pull/4896

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
