### PR TITLE
[PM-18890] Import errors because permissions are reversed

### DIFF
--- a/src/Api/Tools/Controllers/ImportCiphersController.cs
+++ b/src/Api/Tools/Controllers/ImportCiphersController.cs
@@ -108,7 +108,7 @@ public class ImportCiphersController : Controller
         // Do we have new collections?
         var hasNewCollections = collections.Any(tc => !orgCollectionIds.Contains(tc.Id));
 
-        //suppose are are going to be creating new collections and we have existing collections
+        //suppose we are going to be creating new collections and we have existing collections
         if (hasNewCollections && existingCollections.Any())
         {
             // since we are creating new collection, user must have import/manage and create collection permission

--- a/src/Api/Tools/Controllers/ImportCiphersController.cs
+++ b/src/Api/Tools/Controllers/ImportCiphersController.cs
@@ -107,17 +107,17 @@ public class ImportCiphersController : Controller
         var existingCollections = collections.Where(tc => orgCollectionIds.Contains(tc.Id));
 
         //When importing into existing collection, we need to verify if the user has permissions
-        if (existingCollections.Any() && !(await _authorizationService.AuthorizeAsync(User, existingCollections, BulkCollectionOperations.ImportCiphers)).Succeeded)
+        if (existingCollections.Any() && (await _authorizationService.AuthorizeAsync(User, existingCollections, BulkCollectionOperations.ImportCiphers)).Succeeded)
         {
-            return false;
+            return true;
         };
 
         //Users allowed to import if they CanCreate Collections
-        if (!(await _authorizationService.AuthorizeAsync(User, collections, BulkCollectionOperations.Create)).Succeeded)
+        if ((await _authorizationService.AuthorizeAsync(User, collections, BulkCollectionOperations.Create)).Succeeded)
         {
-            return false;
+            return true;
         }
 
-        return true;
+        return false;
     }
 }

--- a/test/Api.Test/Tools/Controllers/ImportCiphersControllerTests.cs
+++ b/test/Api.Test/Tools/Controllers/ImportCiphersControllerTests.cs
@@ -2,6 +2,7 @@
 using AutoFixture;
 using Bit.Api.Models.Request;
 using Bit.Api.Tools.Controllers;
+using Bit.Api.Tools.Models.Request.Accounts;
 using Bit.Api.Tools.Models.Request.Organizations;
 using Bit.Api.Vault.AuthorizationHandlers.Collections;
 using Bit.Api.Vault.Models.Request;
@@ -10,6 +11,7 @@ using Bit.Core.Entities;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.Tools.ImportFeatures.Interfaces;
+using Bit.Core.Vault.Entities;
 using Bit.Core.Vault.Models.Data;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
@@ -29,58 +31,58 @@ public class ImportCiphersControllerTests
     /*************************
      * PostImport - Individual
      *************************/
-    // [Theory, BitAutoData]
-    // public async Task PostImportIndividual_ImportCiphersRequestModel_BadRequestException(SutProvider<ImportCiphersController> sutProvider, IFixture fixture)
-    // {
-    //     // Arrange
-    //     sutProvider.GetDependency<Core.Settings.GlobalSettings>()
-    //         .SelfHosted = false;
-    //     var ciphers = fixture.CreateMany<CipherRequestModel>(7001).ToArray();
-    //     var model = new ImportCiphersRequestModel
-    //     {
-    //         Ciphers = ciphers,
-    //         FolderRelationships = null,
-    //         Folders = null
-    //     };
+    [Theory, BitAutoData]
+    public async Task PostImportIndividual_ImportCiphersRequestModel_BadRequestException(SutProvider<ImportCiphersController> sutProvider, IFixture fixture)
+    {
+        // Arrange
+        sutProvider.GetDependency<Core.Settings.GlobalSettings>()
+            .SelfHosted = false;
+        var ciphers = fixture.CreateMany<CipherRequestModel>(7001).ToArray();
+        var model = new ImportCiphersRequestModel
+        {
+            Ciphers = ciphers,
+            FolderRelationships = null,
+            Folders = null
+        };
 
-    //     // Act
-    //     var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.PostImport(model));
+        // Act
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.PostImport(model));
 
-    //     // Assert
-    //     Assert.Equal("You cannot import this much data at once.", exception.Message);
-    // }
+        // Assert
+        Assert.Equal("You cannot import this much data at once.", exception.Message);
+    }
 
-    // [Theory, BitAutoData]
-    // public async Task PostImportIndividual_ImportCiphersRequestModel_Success(User user,
-    //     IFixture fixture, SutProvider<ImportCiphersController> sutProvider)
-    // {
-    //     // Arrange
-    //     sutProvider.GetDependency<GlobalSettings>()
-    //         .SelfHosted = false;
+    [Theory, BitAutoData]
+    public async Task PostImportIndividual_ImportCiphersRequestModel_Success(User user,
+        IFixture fixture, SutProvider<ImportCiphersController> sutProvider)
+    {
+        // Arrange
+        sutProvider.GetDependency<GlobalSettings>()
+            .SelfHosted = false;
 
-    //     sutProvider.GetDependency<Bit.Core.Services.IUserService>()
-    //         .GetProperUserId(Arg.Any<ClaimsPrincipal>())
-    //         .Returns(user.Id);
+        sutProvider.GetDependency<Bit.Core.Services.IUserService>()
+            .GetProperUserId(Arg.Any<ClaimsPrincipal>())
+            .Returns(user.Id);
 
-    //     var request = fixture.Build<ImportCiphersRequestModel>()
-    //         .With(x => x.Ciphers, fixture.Build<CipherRequestModel>()
-    //             .With(c => c.OrganizationId, Guid.NewGuid().ToString())
-    //             .With(c => c.FolderId, Guid.NewGuid().ToString())
-    //             .CreateMany(1).ToArray())
-    //         .Create();
+        var request = fixture.Build<ImportCiphersRequestModel>()
+            .With(x => x.Ciphers, fixture.Build<CipherRequestModel>()
+                .With(c => c.OrganizationId, Guid.NewGuid().ToString())
+                .With(c => c.FolderId, Guid.NewGuid().ToString())
+                .CreateMany(1).ToArray())
+            .Create();
 
-    //     // Act
-    //     await sutProvider.Sut.PostImport(request);
+        // Act
+        await sutProvider.Sut.PostImport(request);
 
-    //     // Assert
-    //     await sutProvider.GetDependency<IImportCiphersCommand>()
-    //         .Received()
-    //         .ImportIntoIndividualVaultAsync(
-    //         Arg.Any<List<Folder>>(),
-    //         Arg.Any<List<CipherDetails>>(),
-    //         Arg.Any<IEnumerable<KeyValuePair<int, int>>>()
-    //         );
-    // }
+        // Assert
+        await sutProvider.GetDependency<IImportCiphersCommand>()
+            .Received()
+            .ImportIntoIndividualVaultAsync(
+            Arg.Any<List<Folder>>(),
+            Arg.Any<List<CipherDetails>>(),
+            Arg.Any<IEnumerable<KeyValuePair<int, int>>>()
+            );
+    }
 
     /****************************
      * PostImport - Organization
@@ -246,7 +248,7 @@ public class ImportCiphersControllerTests
     }
 
     [Theory, BitAutoData]
-    public async Task PostImportOrganization_WithExistingCollectionsAndWithoutImportCiphersPermissions_NotFoundException(
+    public async Task PostImportOrganization_WithExistingCollectionsAndWithoutImportCiphersPermissions_ThrowsException(
         SutProvider<ImportCiphersController> sutProvider,
         IFixture fixture,
         User user)
@@ -258,9 +260,7 @@ public class ImportCiphersControllerTests
 
         sutProvider.GetDependency<GlobalSettings>().SelfHosted = false;
 
-        sutProvider.GetDependency<Bit.Core.Services.IUserService>()
-            .GetProperUserId(Arg.Any<ClaimsPrincipal>())
-            .Returns(user.Id);
+        SetupUserService(sutProvider, user);
 
         var request = fixture.Build<ImportOrganizationCiphersRequestModel>()
             .With(x => x.Ciphers, fixture.Build<CipherRequestModel>()
@@ -306,7 +306,7 @@ public class ImportCiphersControllerTests
     }
 
     [Theory, BitAutoData]
-    public async Task PostImportOrganization_WithoutCreatePermissions_NotFoundException(
+    public async Task PostImportOrganization_WithoutCreatePermissions_ThrowsException(
         SutProvider<ImportCiphersController> sutProvider,
         IFixture fixture,
         User user)
@@ -367,22 +367,21 @@ public class ImportCiphersControllerTests
 
     [Theory, BitAutoData]
     public async Task PostImportOrganization_CanCreateChildCollectionsWithCreateAndImportPermissionsAsync(
-    SutProvider<ImportCiphersController> sutProvider,
-    IFixture fixture,
-    User user)
+        SutProvider<ImportCiphersController> sutProvider,
+        IFixture fixture,
+        User user)
     {
         // Arrange
         var orgId = Guid.NewGuid();
 
         sutProvider.GetDependency<GlobalSettings>().SelfHosted = false;
 
-        sutProvider.GetDependency<Bit.Core.Services.IUserService>()
-            .GetProperUserId(Arg.Any<ClaimsPrincipal>())
-            .Returns(user.Id);
+        SetupUserService(sutProvider, user);
 
         // Create new collections
         var newCollections = fixture.Build<CollectionWithIdRequestModel>()
                 .CreateMany(2).ToArray();
+
         // define existing collections
         var existingCollections = fixture.CreateMany<CollectionWithIdRequestModel>(2).ToArray();
 
@@ -425,9 +424,8 @@ public class ImportCiphersControllerTests
                 .ToList());
 
         // Act
-        // User import consists of new and existing collections
+        // User imports into collections and creates new collections
         // User has ImportCiphers and Create ciphers permission
-        // expected to be successful. 
         await sutProvider.Sut.PostImport(orgId.ToString(), request);
 
         // Assert
@@ -451,13 +449,12 @@ public class ImportCiphersControllerTests
 
         sutProvider.GetDependency<GlobalSettings>().SelfHosted = false;
 
-        sutProvider.GetDependency<Bit.Core.Services.IUserService>()
-            .GetProperUserId(Arg.Any<ClaimsPrincipal>())
-            .Returns(user.Id);
+        SetupUserService(sutProvider, user);
 
         // Create new collections
         var newCollections = fixture.Build<CollectionWithIdRequestModel>()
                 .CreateMany(2).ToArray();
+
         // define existing collections
         var existingCollections = fixture.CreateMany<CollectionWithIdRequestModel>(2).ToArray();
 
@@ -500,9 +497,8 @@ public class ImportCiphersControllerTests
                 .ToList());
 
         // Act
-        // User import consists of new and existing collections
-        // User has ImportCiphers and Create ciphers permission
-        // expected to throw an error
+        // User imports into an existing collection and creates new collections
+        // User has ImportCiphers permission only and doesn't have Create permission
         var exception = await Assert.ThrowsAsync<BadRequestException>(async () =>
         {
             await sutProvider.Sut.PostImport(orgId.ToString(), request);
@@ -520,7 +516,7 @@ public class ImportCiphersControllerTests
     }
 
     [Theory, BitAutoData]
-    public async Task PostImportOrganization_NoNewCollectionsBeingImportedSoOnlyImportPermissionNeededAsync(
+    public async Task PostImportOrganization_ImportIntoNewCollectionWithCreatePermissionsOnlyAsync(
       SutProvider<ImportCiphersController> sutProvider,
       IFixture fixture,
       User user)
@@ -532,6 +528,76 @@ public class ImportCiphersControllerTests
         SetupUserService(sutProvider, user);
 
         // Create new collections
+        var newCollections = fixture.CreateMany<CollectionWithIdRequestModel>(1).ToArray();
+
+        // Define existing collections
+        var existingCollections = new List<CollectionWithIdRequestModel>();
+
+        // Import model includes new and existing collection
+        var request = new ImportOrganizationCiphersRequestModel
+        {
+            Collections = newCollections.Concat(existingCollections).ToArray(),
+            Ciphers = fixture.Build<CipherRequestModel>()
+                .With(_ => _.OrganizationId, orgId.ToString())
+                .With(_ => _.FolderId, Guid.NewGuid().ToString())
+                .CreateMany(2).ToArray(),
+            CollectionRelationships = new List<KeyValuePair<int, int>>().ToArray(),
+        };
+
+        // AccessImportExport permission - false
+        sutProvider.GetDependency<ICurrentContext>()
+            .AccessImportExport(Arg.Any<Guid>())
+            .Returns(false);
+
+        // BulkCollectionOperations.ImportCiphers permission - FALSE
+        sutProvider.GetDependency<IAuthorizationService>()
+            .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(),
+                Arg.Any<IEnumerable<Collection>>(),
+                Arg.Is<IEnumerable<IAuthorizationRequirement>>(reqs =>
+                    reqs.Contains(BulkCollectionOperations.ImportCiphers)))
+            .Returns(AuthorizationResult.Failed());
+
+        // BulkCollectionOperations.Create permission - TRUE
+        sutProvider.GetDependency<IAuthorizationService>()
+            .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(),
+                Arg.Any<IEnumerable<Collection>>(),
+                Arg.Is<IEnumerable<IAuthorizationRequirement>>(reqs =>
+                    reqs.Contains(BulkCollectionOperations.Create)))
+            .Returns(AuthorizationResult.Success());
+
+        sutProvider.GetDependency<ICollectionRepository>()
+            .GetManyByOrganizationIdAsync(orgId)
+            .Returns(new List<Collection>());
+
+        // Act
+        // User imports/creates a new collection - existing collections not affected
+        // User has create permissions and doesn't need import permissions
+        await sutProvider.Sut.PostImport(orgId.ToString(), request);
+
+        // Assert
+        await sutProvider.GetDependency<IImportCiphersCommand>()
+            .Received(1)
+            .ImportIntoOrganizationalVaultAsync(
+                Arg.Any<List<Collection>>(),
+                Arg.Any<List<CipherDetails>>(),
+                Arg.Any<IEnumerable<KeyValuePair<int, int>>>(),
+                Arg.Any<Guid>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task PostImportOrganization_ImportIntoExistingCollectionWithImportPermissionsOnlySuccessAsync(
+      SutProvider<ImportCiphersController> sutProvider,
+      IFixture fixture,
+      User user)
+    {
+        // Arrange
+        var orgId = Guid.NewGuid();
+
+        sutProvider.GetDependency<GlobalSettings>().SelfHosted = false;
+
+        SetupUserService(sutProvider, user);
+
+        // No new collections
         var newCollections = new List<CollectionWithIdRequestModel>();
 
         // Define existing collections
@@ -576,9 +642,73 @@ public class ImportCiphersControllerTests
                 .ToList());
 
         // Act
-        // User import consists of new and existing collections
-        // User has ImportCiphers and Create ciphers permission
-        // expected to throw an error
+        // User import into existing collection
+        // User has ImportCiphers permission only and doesn't need create permission
+        await sutProvider.Sut.PostImport(orgId.ToString(), request);
+
+        // Assert
+        await sutProvider.GetDependency<IImportCiphersCommand>()
+            .Received(1)
+            .ImportIntoOrganizationalVaultAsync(
+                Arg.Any<List<Collection>>(),
+                Arg.Any<List<CipherDetails>>(),
+                Arg.Any<IEnumerable<KeyValuePair<int, int>>>(),
+                Arg.Any<Guid>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task PostImportOrganization_ImportWithNoCollectionsWithCreatePermissionsOnlySuccessAsync(
+      SutProvider<ImportCiphersController> sutProvider,
+      IFixture fixture,
+      User user)
+    {
+        // Arrange
+        var orgId = Guid.NewGuid();
+
+        sutProvider.GetDependency<GlobalSettings>().SelfHosted = false;
+
+        SetupUserService(sutProvider, user);
+
+        // Import model includes new and existing collection
+        var request = new ImportOrganizationCiphersRequestModel
+        {
+            Collections = new List<CollectionWithIdRequestModel>().ToArray(),   // No collections
+            Ciphers = fixture.Build<CipherRequestModel>()
+                .With(_ => _.OrganizationId, orgId.ToString())
+                .With(_ => _.FolderId, Guid.NewGuid().ToString())
+                .CreateMany(2).ToArray(),
+            CollectionRelationships = new List<KeyValuePair<int, int>>().ToArray(),
+        };
+
+        // AccessImportExport permission - false
+        sutProvider.GetDependency<ICurrentContext>()
+            .AccessImportExport(Arg.Any<Guid>())
+            .Returns(false);
+
+        // BulkCollectionOperations.ImportCiphers permission - false
+        sutProvider.GetDependency<IAuthorizationService>()
+            .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(),
+                Arg.Any<IEnumerable<Collection>>(),
+                Arg.Is<IEnumerable<IAuthorizationRequirement>>(reqs =>
+                    reqs.Contains(BulkCollectionOperations.ImportCiphers)))
+            .Returns(AuthorizationResult.Failed());
+
+        // BulkCollectionOperations.Create permission - TRUE
+        sutProvider.GetDependency<IAuthorizationService>()
+            .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(),
+                Arg.Any<IEnumerable<Collection>>(),
+                Arg.Is<IEnumerable<IAuthorizationRequirement>>(reqs =>
+                    reqs.Contains(BulkCollectionOperations.Create)))
+            .Returns(AuthorizationResult.Success());
+
+        sutProvider.GetDependency<ICollectionRepository>()
+            .GetManyByOrganizationIdAsync(orgId)
+            .Returns(new List<Collection>());
+
+        // Act
+        // import ciphers only and no collections
+        // User has Create permissions
+        // expected to be successful
         await sutProvider.Sut.PostImport(orgId.ToString(), request);
 
         // Assert
@@ -593,6 +723,10 @@ public class ImportCiphersControllerTests
 
     private static void SetupUserService(SutProvider<ImportCiphersController> sutProvider, User user)
     {
+        // This is a workaround for the NSubstitute issue with ambiguous arguments
+        // when using Arg.Any<ClaimsPrincipal>() in the GetProperUserId method
+        // It clears the previous calls to the userService and sets up a new call
+        // with the same argument
         var userService = sutProvider.GetDependency<Bit.Core.Services.IUserService>();
         try
         {

--- a/test/Api.Test/Tools/Controllers/ImportCiphersControllerTests.cs
+++ b/test/Api.Test/Tools/Controllers/ImportCiphersControllerTests.cs
@@ -287,7 +287,7 @@ public class ImportCiphersControllerTests
                 Arg.Any<IEnumerable<Collection>>(),
                 Arg.Is<IEnumerable<IAuthorizationRequirement>>(reqs =>
                     reqs.Contains(BulkCollectionOperations.Create)))
-            .Returns(AuthorizationResult.Success());
+            .Returns(AuthorizationResult.Failed());
 
         sutProvider.GetDependency<ICollectionRepository>()
             .GetManyByOrganizationIdAsync(orgIdGuid)
@@ -339,7 +339,7 @@ public class ImportCiphersControllerTests
                 Arg.Any<IEnumerable<Collection>>(),
                 Arg.Is<IEnumerable<IAuthorizationRequirement>>(reqs =>
                     reqs.Contains(BulkCollectionOperations.ImportCiphers)))
-            .Returns(AuthorizationResult.Success());
+            .Returns(AuthorizationResult.Failed());
 
         // BulkCollectionOperations.Create permission setup
         sutProvider.GetDependency<IAuthorizationService>()


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18890

## 📔 Objective

Given a user, who is not the owner or admin of an organization, but has been giving privileges to Manage a collection, the user must be able to import into that org.
The reason for the failure is this:
 - if the user did not have `ImportCipher` privileges - the program would return `no privilege`
 - if the user did not have `Create` privileges - the program would return `no privilege`
 
This PR changes it to this:
- if the user has `Import Cipher` privileges - then return 'yes`
- Or if the user has `Create` privilege - then return `yes`

## 📸 Screenshots

None at this time

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
