### PR TITLE
[PM-18962] ArgumentNullException: Value cannot be null in POST /push/register

### DIFF
--- a/src/Api/Platform/Push/Controllers/PushController.cs
+++ b/src/Api/Platform/Push/Controllers/PushController.cs
@@ -43,8 +43,9 @@ public class PushController : Controller
     public async Task RegisterAsync([FromBody] PushRegistrationRequestModel model)
     {
         CheckUsage();
-        await _pushRegistrationService.CreateOrUpdateRegistrationAsync(new PushRegistrationData(model.PushToken), Prefix(model.DeviceId),
-            Prefix(model.UserId), Prefix(model.Identifier), model.Type, model.OrganizationIds.Select(Prefix), model.InstallationId);
+        await _pushRegistrationService.CreateOrUpdateRegistrationAsync(new PushRegistrationData(model.PushToken),
+            Prefix(model.DeviceId), Prefix(model.UserId), Prefix(model.Identifier), model.Type,
+            model.OrganizationIds?.Select(Prefix) ?? [], model.InstallationId);
     }
 
     [HttpPost("delete")]

--- a/test/Api.Test/Platform/Push/Controllers/PushControllerTests.cs
+++ b/test/Api.Test/Platform/Push/Controllers/PushControllerTests.cs
@@ -243,20 +243,22 @@ public class PushControllerTests
                 PushToken = "test-push-token",
                 UserId = userId.ToString(),
                 Type = DeviceType.Android,
-                Identifier = identifier.ToString()
+                Identifier = identifier.ToString(),
             }));
 
         Assert.Equal("Not correctly configured for push relays.", exception.Message);
 
         await sutProvider.GetDependency<IPushRegistrationService>().Received(0)
-            .CreateOrUpdateRegistrationAsync(Arg.Any<PushRegistrationData>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<DeviceType>(), Arg.Any<IEnumerable<string>>(), Arg.Any<Guid>());
+            .CreateOrUpdateRegistrationAsync(Arg.Any<PushRegistrationData>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<DeviceType>(), Arg.Any<IEnumerable<string>>(), Arg.Any<Guid>());
     }
 
     [Theory]
-    [BitAutoData]
-    public async Task? RegisterAsync_ValidModel_CreatedOrUpdatedRegistration(SutProvider<PushController> sutProvider,
-        Guid installationId, Guid userId, Guid identifier, Guid deviceId, Guid organizationId)
+    [BitAutoData(false)]
+    [BitAutoData(true)]
+    public async Task RegisterAsync_ValidModel_CreatedOrUpdatedRegistration(bool haveOrganizationId,
+        SutProvider<PushController> sutProvider, Guid installationId, Guid userId, Guid identifier, Guid deviceId,
+        Guid organizationId)
     {
         sutProvider.GetDependency<IGlobalSettings>().SelfHosted = false;
         sutProvider.GetDependency<ICurrentContext>().InstallationId.Returns(installationId);
@@ -273,19 +275,29 @@ public class PushControllerTests
             UserId = userId.ToString(),
             Type = DeviceType.Android,
             Identifier = identifier.ToString(),
-            OrganizationIds = [organizationId.ToString()],
+            OrganizationIds = haveOrganizationId ? [organizationId.ToString()] : null,
             InstallationId = installationId
         };
 
         await sutProvider.Sut.RegisterAsync(model);
 
         await sutProvider.GetDependency<IPushRegistrationService>().Received(1)
-            .CreateOrUpdateRegistrationAsync(Arg.Is<PushRegistrationData>(data => data == new PushRegistrationData(model.PushToken)), expectedDeviceId, expectedUserId,
+            .CreateOrUpdateRegistrationAsync(
+                Arg.Is<PushRegistrationData>(data => data == new PushRegistrationData(model.PushToken)),
+                expectedDeviceId, expectedUserId,
                 expectedIdentifier, DeviceType.Android, Arg.Do<IEnumerable<string>>(organizationIds =>
                 {
+                    Assert.NotNull(organizationIds);
                     var organizationIdsList = organizationIds.ToList();
-                    Assert.Contains(expectedOrganizationId, organizationIdsList);
-                    Assert.Single(organizationIdsList);
+                    if (haveOrganizationId)
+                    {
+                        Assert.Contains(expectedOrganizationId, organizationIdsList);
+                        Assert.Single(organizationIdsList);
+                    }
+                    else
+                    {
+                        Assert.Empty(organizationIdsList);
+                    }
                 }), installationId);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18962

## 📔 Objective

`OrganizationIds` can be null, because older versions of server (and self-hosted) does not know about this property.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
