### PR TITLE
[PM-19002] Extract billing code from AccountsController

### DIFF
--- a/src/Api/Auth/Controllers/AccountsController.cs
+++ b/src/Api/Auth/Controllers/AccountsController.cs
@@ -4,11 +4,9 @@ using Bit.Api.Auth.Models.Request;
 using Bit.Api.Auth.Models.Request.Accounts;
 using Bit.Api.Auth.Models.Request.WebAuthn;
 using Bit.Api.KeyManagement.Validators;
-using Bit.Api.Models.Request;
 using Bit.Api.Models.Request.Accounts;
 using Bit.Api.Models.Response;
 using Bit.Api.Tools.Models.Request;
-using Bit.Api.Utilities;
 using Bit.Api.Vault.Models.Request;
 using Bit.Core;
 using Bit.Core.AdminConsole.Enums.Provider;
@@ -19,23 +17,15 @@ using Bit.Core.Auth.Models.Api.Request.Accounts;
 using Bit.Core.Auth.Models.Data;
 using Bit.Core.Auth.UserFeatures.TdeOffboardingPassword.Interfaces;
 using Bit.Core.Auth.UserFeatures.UserMasterPassword.Interfaces;
-using Bit.Core.Billing.Models;
-using Bit.Core.Billing.Services;
-using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.KeyManagement.Models.Data;
 using Bit.Core.KeyManagement.UserKey;
 using Bit.Core.Models.Api.Response;
-using Bit.Core.Models.Business;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
-using Bit.Core.Settings;
 using Bit.Core.Tools.Entities;
-using Bit.Core.Tools.Enums;
-using Bit.Core.Tools.Models.Business;
-using Bit.Core.Tools.Services;
 using Bit.Core.Utilities;
 using Bit.Core.Vault.Entities;
 using Microsoft.AspNetCore.Authorization;
@@ -47,20 +37,15 @@ namespace Bit.Api.Auth.Controllers;
 [Authorize("Application")]
 public class AccountsController : Controller
 {
-    private readonly GlobalSettings _globalSettings;
     private readonly IOrganizationService _organizationService;
     private readonly IOrganizationUserRepository _organizationUserRepository;
     private readonly IProviderUserRepository _providerUserRepository;
-    private readonly IPaymentService _paymentService;
     private readonly IUserService _userService;
     private readonly IPolicyService _policyService;
     private readonly ISetInitialMasterPasswordCommand _setInitialMasterPasswordCommand;
     private readonly ITdeOffboardingPasswordCommand _tdeOffboardingPasswordCommand;
     private readonly IRotateUserKeyCommand _rotateUserKeyCommand;
     private readonly IFeatureService _featureService;
-    private readonly ISubscriberService _subscriberService;
-    private readonly IReferenceEventService _referenceEventService;
-    private readonly ICurrentContext _currentContext;
 
     private readonly IRotationValidator<IEnumerable<CipherWithIdRequestModel>, IEnumerable<Cipher>> _cipherValidator;
     private readonly IRotationValidator<IEnumerable<FolderWithIdRequestModel>, IEnumerable<Folder>> _folderValidator;
@@ -75,20 +60,15 @@ public class AccountsController : Controller
 
 
     public AccountsController(
-        GlobalSettings globalSettings,
         IOrganizationService organizationService,
         IOrganizationUserRepository organizationUserRepository,
         IProviderUserRepository providerUserRepository,
-        IPaymentService paymentService,
         IUserService userService,
         IPolicyService policyService,
         ISetInitialMasterPasswordCommand setInitialMasterPasswordCommand,
         ITdeOffboardingPasswordCommand tdeOffboardingPasswordCommand,
         IRotateUserKeyCommand rotateUserKeyCommand,
         IFeatureService featureService,
-        ISubscriberService subscriberService,
-        IReferenceEventService referenceEventService,
-        ICurrentContext currentContext,
         IRotationValidator<IEnumerable<CipherWithIdRequestModel>, IEnumerable<Cipher>> cipherValidator,
         IRotationValidator<IEnumerable<FolderWithIdRequestModel>, IEnumerable<Folder>> folderValidator,
         IRotationValidator<IEnumerable<SendWithIdRequestModel>, IReadOnlyList<Send>> sendValidator,
@@ -99,20 +79,15 @@ public class AccountsController : Controller
         IRotationValidator<IEnumerable<WebAuthnLoginRotateKeyRequestModel>, IEnumerable<WebAuthnLoginRotateKeyData>> webAuthnKeyValidator
         )
     {
-        _globalSettings = globalSettings;
         _organizationService = organizationService;
         _organizationUserRepository = organizationUserRepository;
         _providerUserRepository = providerUserRepository;
-        _paymentService = paymentService;
         _userService = userService;
         _policyService = policyService;
         _setInitialMasterPasswordCommand = setInitialMasterPasswordCommand;
         _tdeOffboardingPasswordCommand = tdeOffboardingPasswordCommand;
         _rotateUserKeyCommand = rotateUserKeyCommand;
         _featureService = featureService;
-        _subscriberService = subscriberService;
-        _referenceEventService = referenceEventService;
-        _currentContext = currentContext;
         _cipherValidator = cipherValidator;
         _folderValidator = folderValidator;
         _sendValidator = sendValidator;
@@ -636,212 +611,6 @@ public class AccountsController : Controller
 
         await Task.Delay(2000);
         throw new BadRequestException(ModelState);
-    }
-
-    [HttpPost("premium")]
-    public async Task<PaymentResponseModel> PostPremium(PremiumRequestModel model)
-    {
-        var user = await _userService.GetUserByPrincipalAsync(User);
-        if (user == null)
-        {
-            throw new UnauthorizedAccessException();
-        }
-
-        var valid = model.Validate(_globalSettings);
-        UserLicense license = null;
-        if (valid && _globalSettings.SelfHosted)
-        {
-            license = await ApiHelpers.ReadJsonFileFromBody<UserLicense>(HttpContext, model.License);
-        }
-
-        if (!valid && !_globalSettings.SelfHosted && string.IsNullOrWhiteSpace(model.Country))
-        {
-            throw new BadRequestException("Country is required.");
-        }
-
-        if (!valid || (_globalSettings.SelfHosted && license == null))
-        {
-            throw new BadRequestException("Invalid license.");
-        }
-
-        var result = await _userService.SignUpPremiumAsync(user, model.PaymentToken,
-            model.PaymentMethodType.Value, model.AdditionalStorageGb.GetValueOrDefault(0), license,
-            new TaxInfo
-            {
-                BillingAddressCountry = model.Country,
-                BillingAddressPostalCode = model.PostalCode
-            });
-
-        var userTwoFactorEnabled = await _userService.TwoFactorIsEnabledAsync(user);
-        var userHasPremiumFromOrganization = await _userService.HasPremiumFromOrganization(user);
-        var organizationIdsManagingActiveUser = await GetOrganizationIdsManagingUserAsync(user.Id);
-
-        var profile = new ProfileResponseModel(user, null, null, null, userTwoFactorEnabled, userHasPremiumFromOrganization, organizationIdsManagingActiveUser);
-        return new PaymentResponseModel
-        {
-            UserProfile = profile,
-            PaymentIntentClientSecret = result.Item2,
-            Success = result.Item1
-        };
-    }
-
-    [HttpGet("subscription")]
-    public async Task<SubscriptionResponseModel> GetSubscription()
-    {
-        var user = await _userService.GetUserByPrincipalAsync(User);
-        if (user == null)
-        {
-            throw new UnauthorizedAccessException();
-        }
-
-        if (!_globalSettings.SelfHosted && user.Gateway != null)
-        {
-            var subscriptionInfo = await _paymentService.GetSubscriptionAsync(user);
-            var license = await _userService.GenerateLicenseAsync(user, subscriptionInfo);
-            return new SubscriptionResponseModel(user, subscriptionInfo, license);
-        }
-        else if (!_globalSettings.SelfHosted)
-        {
-            var license = await _userService.GenerateLicenseAsync(user);
-            return new SubscriptionResponseModel(user, license);
-        }
-        else
-        {
-            return new SubscriptionResponseModel(user);
-        }
-    }
-
-    [HttpPost("payment")]
-    [SelfHosted(NotSelfHostedOnly = true)]
-    public async Task PostPayment([FromBody] PaymentRequestModel model)
-    {
-        var user = await _userService.GetUserByPrincipalAsync(User);
-        if (user == null)
-        {
-            throw new UnauthorizedAccessException();
-        }
-
-        await _userService.ReplacePaymentMethodAsync(user, model.PaymentToken, model.PaymentMethodType.Value,
-            new TaxInfo
-            {
-                BillingAddressLine1 = model.Line1,
-                BillingAddressLine2 = model.Line2,
-                BillingAddressCity = model.City,
-                BillingAddressState = model.State,
-                BillingAddressCountry = model.Country,
-                BillingAddressPostalCode = model.PostalCode,
-                TaxIdNumber = model.TaxId
-            });
-    }
-
-    [HttpPost("storage")]
-    [SelfHosted(NotSelfHostedOnly = true)]
-    public async Task<PaymentResponseModel> PostStorage([FromBody] StorageRequestModel model)
-    {
-        var user = await _userService.GetUserByPrincipalAsync(User);
-        if (user == null)
-        {
-            throw new UnauthorizedAccessException();
-        }
-
-        var result = await _userService.AdjustStorageAsync(user, model.StorageGbAdjustment.Value);
-        return new PaymentResponseModel
-        {
-            Success = true,
-            PaymentIntentClientSecret = result
-        };
-    }
-
-    [HttpPost("license")]
-    [SelfHosted(SelfHostedOnly = true)]
-    public async Task PostLicense(LicenseRequestModel model)
-    {
-        var user = await _userService.GetUserByPrincipalAsync(User);
-        if (user == null)
-        {
-            throw new UnauthorizedAccessException();
-        }
-
-        var license = await ApiHelpers.ReadJsonFileFromBody<UserLicense>(HttpContext, model.License);
-        if (license == null)
-        {
-            throw new BadRequestException("Invalid license");
-        }
-
-        await _userService.UpdateLicenseAsync(user, license);
-    }
-
-    [HttpPost("cancel")]
-    public async Task PostCancel([FromBody] SubscriptionCancellationRequestModel request)
-    {
-        var user = await _userService.GetUserByPrincipalAsync(User);
-
-        if (user == null)
-        {
-            throw new UnauthorizedAccessException();
-        }
-
-        await _subscriberService.CancelSubscription(user,
-            new OffboardingSurveyResponse
-            {
-                UserId = user.Id,
-                Reason = request.Reason,
-                Feedback = request.Feedback
-            },
-            user.IsExpired());
-
-        await _referenceEventService.RaiseEventAsync(new ReferenceEvent(
-            ReferenceEventType.CancelSubscription,
-            user,
-            _currentContext)
-        {
-            EndOfPeriod = user.IsExpired()
-        });
-    }
-
-    [HttpPost("reinstate-premium")]
-    [SelfHosted(NotSelfHostedOnly = true)]
-    public async Task PostReinstate()
-    {
-        var user = await _userService.GetUserByPrincipalAsync(User);
-        if (user == null)
-        {
-            throw new UnauthorizedAccessException();
-        }
-
-        await _userService.ReinstatePremiumAsync(user);
-    }
-
-    [HttpGet("tax")]
-    [SelfHosted(NotSelfHostedOnly = true)]
-    public async Task<TaxInfoResponseModel> GetTaxInfo()
-    {
-        var user = await _userService.GetUserByPrincipalAsync(User);
-        if (user == null)
-        {
-            throw new UnauthorizedAccessException();
-        }
-
-        var taxInfo = await _paymentService.GetTaxInfoAsync(user);
-        return new TaxInfoResponseModel(taxInfo);
-    }
-
-    [HttpPut("tax")]
-    [SelfHosted(NotSelfHostedOnly = true)]
-    public async Task PutTaxInfo([FromBody] TaxInfoUpdateRequestModel model)
-    {
-        var user = await _userService.GetUserByPrincipalAsync(User);
-        if (user == null)
-        {
-            throw new UnauthorizedAccessException();
-        }
-
-        var taxInfo = new TaxInfo
-        {
-            BillingAddressPostalCode = model.PostalCode,
-            BillingAddressCountry = model.Country,
-        };
-        await _paymentService.SaveTaxInfoAsync(user, taxInfo);
     }
 
     [HttpDelete("sso/{organizationId}")]

--- a/src/Api/Billing/Controllers/AccountsController.cs
+++ b/src/Api/Billing/Controllers/AccountsController.cs
@@ -1,0 +1,237 @@
+﻿#nullable enable
+using Bit.Api.Models.Request;
+using Bit.Api.Models.Request.Accounts;
+using Bit.Api.Models.Response;
+using Bit.Api.Utilities;
+using Bit.Core.Billing.Models;
+using Bit.Core.Billing.Services;
+using Bit.Core.Context;
+using Bit.Core.Exceptions;
+using Bit.Core.Models.Business;
+using Bit.Core.Services;
+using Bit.Core.Settings;
+using Bit.Core.Tools.Enums;
+using Bit.Core.Tools.Models.Business;
+using Bit.Core.Tools.Services;
+using Bit.Core.Utilities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bit.Api.Billing.Controllers;
+
+[Route("accounts")]
+[Authorize("Application")]
+public class AccountsController(
+    IUserService userService) : Controller
+{
+    [HttpPost("premium")]
+    public async Task<PaymentResponseModel> PostPremium(
+        PremiumRequestModel model,
+        [FromServices] GlobalSettings globalSettings)
+    {
+        var user = await userService.GetUserByPrincipalAsync(User);
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
+        var valid = model.Validate(globalSettings);
+        UserLicense? license = null;
+        if (valid && globalSettings.SelfHosted)
+        {
+            license = await ApiHelpers.ReadJsonFileFromBody<UserLicense>(HttpContext, model.License);
+        }
+
+        if (!valid && !globalSettings.SelfHosted && string.IsNullOrWhiteSpace(model.Country))
+        {
+            throw new BadRequestException("Country is required.");
+        }
+
+        if (!valid || (globalSettings.SelfHosted && license == null))
+        {
+            throw new BadRequestException("Invalid license.");
+        }
+
+        var result = await userService.SignUpPremiumAsync(user, model.PaymentToken,
+            model.PaymentMethodType!.Value, model.AdditionalStorageGb.GetValueOrDefault(0), license,
+            new TaxInfo { BillingAddressCountry = model.Country, BillingAddressPostalCode = model.PostalCode });
+
+        var userTwoFactorEnabled = await userService.TwoFactorIsEnabledAsync(user);
+        var userHasPremiumFromOrganization = await userService.HasPremiumFromOrganization(user);
+        var organizationIdsManagingActiveUser = await GetOrganizationIdsManagingUserAsync(user.Id);
+
+        var profile = new ProfileResponseModel(user, null, null, null, userTwoFactorEnabled,
+            userHasPremiumFromOrganization, organizationIdsManagingActiveUser);
+        return new PaymentResponseModel
+        {
+            UserProfile = profile,
+            PaymentIntentClientSecret = result.Item2,
+            Success = result.Item1
+        };
+    }
+
+    [HttpGet("subscription")]
+    public async Task<SubscriptionResponseModel> GetSubscription(
+        [FromServices] GlobalSettings globalSettings,
+        [FromServices] IPaymentService _paymentService)
+    {
+        var user = await userService.GetUserByPrincipalAsync(User);
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
+        if (!globalSettings.SelfHosted && user.Gateway != null)
+        {
+            var subscriptionInfo = await _paymentService.GetSubscriptionAsync(user);
+            var license = await userService.GenerateLicenseAsync(user, subscriptionInfo);
+            return new SubscriptionResponseModel(user, subscriptionInfo, license);
+        }
+        else if (!globalSettings.SelfHosted)
+        {
+            var license = await userService.GenerateLicenseAsync(user);
+            return new SubscriptionResponseModel(user, license);
+        }
+        else
+        {
+            return new SubscriptionResponseModel(user);
+        }
+    }
+
+    [HttpPost("payment")]
+    [SelfHosted(NotSelfHostedOnly = true)]
+    public async Task PostPayment([FromBody] PaymentRequestModel model)
+    {
+        var user = await userService.GetUserByPrincipalAsync(User);
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
+        await userService.ReplacePaymentMethodAsync(user, model.PaymentToken, model.PaymentMethodType!.Value,
+            new TaxInfo
+            {
+                BillingAddressLine1 = model.Line1,
+                BillingAddressLine2 = model.Line2,
+                BillingAddressCity = model.City,
+                BillingAddressState = model.State,
+                BillingAddressCountry = model.Country,
+                BillingAddressPostalCode = model.PostalCode,
+                TaxIdNumber = model.TaxId
+            });
+    }
+
+    [HttpPost("storage")]
+    [SelfHosted(NotSelfHostedOnly = true)]
+    public async Task<PaymentResponseModel> PostStorage([FromBody] StorageRequestModel model)
+    {
+        var user = await userService.GetUserByPrincipalAsync(User);
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
+        var result = await userService.AdjustStorageAsync(user, model.StorageGbAdjustment!.Value);
+        return new PaymentResponseModel { Success = true, PaymentIntentClientSecret = result };
+    }
+
+
+
+    [HttpPost("license")]
+    [SelfHosted(SelfHostedOnly = true)]
+    public async Task PostLicense(LicenseRequestModel model)
+    {
+        var user = await userService.GetUserByPrincipalAsync(User);
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
+        var license = await ApiHelpers.ReadJsonFileFromBody<UserLicense>(HttpContext, model.License);
+        if (license == null)
+        {
+            throw new BadRequestException("Invalid license");
+        }
+
+        await userService.UpdateLicenseAsync(user, license);
+    }
+
+    [HttpPost("cancel")]
+    public async Task PostCancel(
+        [FromBody] SubscriptionCancellationRequestModel request,
+        [FromServices] ICurrentContext currentContext,
+        [FromServices] IReferenceEventService referenceEventService,
+        [FromServices] ISubscriberService _subscriberService)
+    {
+        var user = await userService.GetUserByPrincipalAsync(User);
+
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
+        await _subscriberService.CancelSubscription(user,
+            new OffboardingSurveyResponse { UserId = user.Id, Reason = request.Reason, Feedback = request.Feedback },
+            user.IsExpired());
+
+        await referenceEventService.RaiseEventAsync(new ReferenceEvent(
+            ReferenceEventType.CancelSubscription,
+            user,
+            currentContext)
+        { EndOfPeriod = user.IsExpired() });
+    }
+
+    [HttpPost("reinstate-premium")]
+    [SelfHosted(NotSelfHostedOnly = true)]
+    public async Task PostReinstate()
+    {
+        var user = await userService.GetUserByPrincipalAsync(User);
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
+        await userService.ReinstatePremiumAsync(user);
+    }
+
+    [HttpGet("tax")]
+    [SelfHosted(NotSelfHostedOnly = true)]
+    public async Task<TaxInfoResponseModel> GetTaxInfo(
+        [FromServices] IPaymentService _paymentService)
+    {
+        var user = await userService.GetUserByPrincipalAsync(User);
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
+        var taxInfo = await _paymentService.GetTaxInfoAsync(user);
+        return new TaxInfoResponseModel(taxInfo);
+    }
+
+    [HttpPut("tax")]
+    [SelfHosted(NotSelfHostedOnly = true)]
+    public async Task PutTaxInfo(
+        [FromBody] TaxInfoUpdateRequestModel model,
+        [FromServices] IPaymentService _paymentService)
+    {
+        var user = await userService.GetUserByPrincipalAsync(User);
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
+        var taxInfo = new TaxInfo
+        {
+            BillingAddressPostalCode = model.PostalCode,
+            BillingAddressCountry = model.Country,
+        };
+        await _paymentService.SaveTaxInfoAsync(user, taxInfo);
+    }
+
+    private async Task<IEnumerable<Guid>> GetOrganizationIdsManagingUserAsync(Guid userId)
+    {
+        var organizationManagingUser = await userService.GetOrganizationsManagingUserAsync(userId);
+        return organizationManagingUser.Select(o => o.Id);
+    }
+}

--- a/test/Api.Test/Auth/Controllers/AccountsControllerTests.cs
+++ b/test/Api.Test/Auth/Controllers/AccountsControllerTests.cs
@@ -15,16 +15,12 @@ using Bit.Core.Auth.Models.Api.Request.Accounts;
 using Bit.Core.Auth.Models.Data;
 using Bit.Core.Auth.UserFeatures.TdeOffboardingPassword.Interfaces;
 using Bit.Core.Auth.UserFeatures.UserMasterPassword.Interfaces;
-using Bit.Core.Billing.Services;
-using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Exceptions;
 using Bit.Core.KeyManagement.UserKey;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
-using Bit.Core.Settings;
 using Bit.Core.Tools.Entities;
-using Bit.Core.Tools.Services;
 using Bit.Core.Vault.Entities;
 using Bit.Test.Common.AutoFixture.Attributes;
 using Microsoft.AspNetCore.Identity;
@@ -37,10 +33,8 @@ public class AccountsControllerTests : IDisposable
 {
 
     private readonly AccountsController _sut;
-    private readonly GlobalSettings _globalSettings;
     private readonly IOrganizationService _organizationService;
     private readonly IOrganizationUserRepository _organizationUserRepository;
-    private readonly IPaymentService _paymentService;
     private readonly IUserService _userService;
     private readonly IProviderUserRepository _providerUserRepository;
     private readonly IPolicyService _policyService;
@@ -48,9 +42,6 @@ public class AccountsControllerTests : IDisposable
     private readonly IRotateUserKeyCommand _rotateUserKeyCommand;
     private readonly ITdeOffboardingPasswordCommand _tdeOffboardingPasswordCommand;
     private readonly IFeatureService _featureService;
-    private readonly ISubscriberService _subscriberService;
-    private readonly IReferenceEventService _referenceEventService;
-    private readonly ICurrentContext _currentContext;
 
     private readonly IRotationValidator<IEnumerable<CipherWithIdRequestModel>, IEnumerable<Cipher>> _cipherValidator;
     private readonly IRotationValidator<IEnumerable<FolderWithIdRequestModel>, IEnumerable<Folder>> _folderValidator;
@@ -70,16 +61,11 @@ public class AccountsControllerTests : IDisposable
         _organizationService = Substitute.For<IOrganizationService>();
         _organizationUserRepository = Substitute.For<IOrganizationUserRepository>();
         _providerUserRepository = Substitute.For<IProviderUserRepository>();
-        _paymentService = Substitute.For<IPaymentService>();
-        _globalSettings = new GlobalSettings();
         _policyService = Substitute.For<IPolicyService>();
         _setInitialMasterPasswordCommand = Substitute.For<ISetInitialMasterPasswordCommand>();
         _rotateUserKeyCommand = Substitute.For<IRotateUserKeyCommand>();
         _tdeOffboardingPasswordCommand = Substitute.For<ITdeOffboardingPasswordCommand>();
         _featureService = Substitute.For<IFeatureService>();
-        _subscriberService = Substitute.For<ISubscriberService>();
-        _referenceEventService = Substitute.For<IReferenceEventService>();
-        _currentContext = Substitute.For<ICurrentContext>();
         _cipherValidator =
             Substitute.For<IRotationValidator<IEnumerable<CipherWithIdRequestModel>, IEnumerable<Cipher>>>();
         _folderValidator =
@@ -93,20 +79,15 @@ public class AccountsControllerTests : IDisposable
                 IReadOnlyList<OrganizationUser>>>();
 
         _sut = new AccountsController(
-            _globalSettings,
             _organizationService,
             _organizationUserRepository,
             _providerUserRepository,
-            _paymentService,
             _userService,
             _policyService,
             _setInitialMasterPasswordCommand,
             _tdeOffboardingPasswordCommand,
             _rotateUserKeyCommand,
             _featureService,
-            _subscriberService,
-            _referenceEventService,
-            _currentContext,
             _cipherValidator,
             _folderValidator,
             _sendValidator,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19002

## 📔 Objective

- Extract related code of @bitwarden/team-billing-dev from /Api/Auth/AccountsController.cs and move it to /Api/Billing/. This will help with code reviews taking some load of @bitwarden/team-auth-dev.
- Use action injection instead of constructor injection for specific services to save memory usage across the board. This could also help us at the same time to prepare to migrate to minimal API which was brought up in a couple meetings.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
