### PR TITLE
IValidator<T> and ValidationResult<T>

### DIFF
--- a/src/Api/Utilities/CommandResultExtensions.cs
+++ b/src/Api/Utilities/CommandResultExtensions.cs
@@ -12,7 +12,7 @@ public static class CommandResultExtensions
             NoRecordFoundFailure<T> failure => new ObjectResult(failure.ErrorMessages) { StatusCode = StatusCodes.Status404NotFound },
             BadRequestFailure<T> failure => new ObjectResult(failure.ErrorMessages) { StatusCode = StatusCodes.Status400BadRequest },
             Failure<T> failure => new ObjectResult(failure.ErrorMessages) { StatusCode = StatusCodes.Status400BadRequest },
-            Success<T> success => new ObjectResult(success.Data) { StatusCode = StatusCodes.Status200OK },
+            Success<T> success => new ObjectResult(success.Value) { StatusCode = StatusCodes.Status200OK },
             _ => throw new InvalidOperationException($"Unhandled commandResult type: {commandResult.GetType().Name}")
         };
     }

--- a/src/Core/AdminConsole/Shared/Validation/IValidator.cs
+++ b/src/Core/AdminConsole/Shared/Validation/IValidator.cs
@@ -1,0 +1,6 @@
+﻿namespace Bit.Core.AdminConsole.Shared.Validation;
+
+public interface IValidator<T>
+{
+    public Task<ValidationResult<T>> ValidateAsync(T value);
+}

--- a/src/Core/AdminConsole/Shared/Validation/ValidationResult.cs
+++ b/src/Core/AdminConsole/Shared/Validation/ValidationResult.cs
@@ -1,0 +1,15 @@
+﻿using Bit.Core.Models.Commands;
+
+namespace Bit.Core.AdminConsole.Shared.Validation;
+
+public abstract record ValidationResult<T>;
+
+public record Valid<T> : ValidationResult<T>
+{
+    public T Value { get; init; }
+}
+
+public record Invalid<T> : ValidationResult<T>
+{
+    public IEnumerable<Error<T>> Errors { get; init; }
+}

--- a/src/Core/Models/Commands/CommandResult.cs
+++ b/src/Core/Models/Commands/CommandResult.cs
@@ -9,7 +9,6 @@ public class CommandResult(IEnumerable<string> errors)
     public bool Success => ErrorMessages.Count == 0;
     public bool HasErrors => ErrorMessages.Count > 0;
     public List<string> ErrorMessages { get; } = errors.ToList();
-
     public CommandResult() : this(Array.Empty<string>()) { }
 }
 
@@ -29,22 +28,51 @@ public class Success : CommandResult
 {
 }
 
-public abstract class CommandResult<T>
-{
+public abstract class CommandResult<T>;
 
+public class Success<T>(T value) : CommandResult<T>
+{
+    public T Value { get; } = value;
 }
 
-public class Success<T>(T data) : CommandResult<T>
+public class Failure<T>(IEnumerable<string> errorMessages) : CommandResult<T>
 {
-    public T? Data { get; init; } = data;
+    public List<string> ErrorMessages { get; } = errorMessages.ToList();
+
+    public string ErrorMessage => string.Join(" ", ErrorMessages);
+
+    public Failure(string error) : this([error]) { }
 }
 
-public class Failure<T>(IEnumerable<string> errorMessage) : CommandResult<T>
+public class Partial<T> : CommandResult<T>
 {
-    public IEnumerable<string> ErrorMessages { get; init; } = errorMessage;
+    public T[] Successes { get; set; } = [];
+    public Error<T>[] Failures { get; set; } = [];
 
-    public Failure(string errorMessage) : this(new[] { errorMessage })
+    public Partial(IEnumerable<T> successfulItems, IEnumerable<Error<T>> failedItems)
     {
+
     }
 }
 
+public record Error<T>(string Message, T ErroredValue);
+
+public record RecordNotFoundError<T>(string Message, T ErroredValue) : Error<T>(Message, ErroredValue)
+{
+    public const string Code = "Record Not Found";
+
+    public RecordNotFoundError(T ErroredValue) : this(Code, ErroredValue)
+    {
+
+    }
+}
+
+public record InsufficientPermissionsError<T>(string Message, T ErroredValue) : Error<T>(Message, ErroredValue)
+{
+    public const string Code = "Insufficient Permissions";
+
+    public InsufficientPermissionsError(T ErroredValue) : this(Code, ErroredValue)
+    {
+
+    }
+}

--- a/src/Core/Models/Commands/CommandResult.cs
+++ b/src/Core/Models/Commands/CommandResult.cs
@@ -51,7 +51,8 @@ public class Partial<T> : CommandResult<T>
 
     public Partial(IEnumerable<T> successfulItems, IEnumerable<Error<T>> failedItems)
     {
-
+        Successes = successfulItems.ToArray();
+        Failures = failedItems.ToArray();
     }
 }
 

--- a/src/Core/Models/Commands/CommandResult.cs
+++ b/src/Core/Models/Commands/CommandResult.cs
@@ -56,7 +56,7 @@ public class Partial<T> : CommandResult<T>
     }
 }
 
-public record Error<T>(string Message, T ErroredValue);
+public abstract record Error<T>(string Message, T ErroredValue);
 
 public record RecordNotFoundError<T>(string Message, T ErroredValue) : Error<T>(Message, ErroredValue)
 {
@@ -73,6 +73,16 @@ public record InsufficientPermissionsError<T>(string Message, T ErroredValue) : 
     public const string Code = "Insufficient Permissions";
 
     public InsufficientPermissionsError(T ErroredValue) : this(Code, ErroredValue)
+    {
+
+    }
+}
+
+public record InvalidRequestError<T>(string Message, T ErroredValue) : Error<T>(Message, ErroredValue)
+{
+    public const string Code = "Invalid Request";
+
+    public InvalidRequestError(T ErroredValue) : this(Code, ErroredValue)
     {
 
     }

--- a/test/Core.Test/AdminConsole/Shared/IValidatorTests.cs
+++ b/test/Core.Test/AdminConsole/Shared/IValidatorTests.cs
@@ -1,0 +1,53 @@
+﻿using Bit.Core.AdminConsole.Shared.Validation;
+using Bit.Core.Models.Commands;
+using Xunit;
+
+namespace Bit.Core.Test.AdminConsole.Shared;
+
+public class IValidatorTests
+{
+    public class TestClass
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public class TestClassValidator : IValidator<TestClass>
+    {
+        public Task<ValidationResult<TestClass>> ValidateAsync(TestClass value)
+        {
+            if (string.IsNullOrWhiteSpace(value.Name))
+            {
+                return Task.FromResult<ValidationResult<TestClass>>(new Invalid<TestClass>
+                {
+                    Errors = [new InvalidRequestError<TestClass>(value)]
+                });
+            }
+
+            return Task.FromResult<ValidationResult<TestClass>>(new Valid<TestClass> { Value = value });
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WhenSomethingIsInvalid_ReturnsInvalidWithError()
+    {
+        var example = new TestClass();
+
+        var result = await new TestClassValidator().ValidateAsync(example);
+
+        Assert.IsType<Invalid<TestClass>>(result);
+        var invalidResult = result as Invalid<TestClass>;
+        Assert.Equal(InvalidRequestError<TestClass>.Code, invalidResult.Errors.First().Message);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WhenIsValid_ReturnsValid()
+    {
+        var example = new TestClass { Name = "Valid" };
+
+        var result = await new TestClassValidator().ValidateAsync(example);
+
+        Assert.IsType<Valid<TestClass>>(result);
+        var validResult = result as Valid<TestClass>;
+        Assert.Equal(example.Name, validResult.Value.Name);
+    }
+}

--- a/test/Core.Test/Models/Commands/CommandResultTests.cs
+++ b/test/Core.Test/Models/Commands/CommandResultTests.cs
@@ -1,0 +1,46 @@
+﻿using Bit.Core.Models.Commands;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Xunit;
+
+namespace Bit.Core.Test.Models.Commands;
+
+public class CommandResultTests
+{
+    public class TestItem
+    {
+        public Guid Id { get; set; }
+        public string Value { get; set; }
+    }
+
+    public CommandResult<TestItem> BulkAction(IEnumerable<TestItem> items)
+    {
+        var itemList = items.ToList();
+        var successfulItems = items.Where(x => x.Value == "SuccessfulRequest").ToArray();
+
+        var failedItems = itemList.Except(successfulItems).ToArray();
+
+        var notFound = failedItems.First(x => x.Value == "Failed due to not found");
+        var invalidPermissions = failedItems.First(x => x.Value == "Failed due to invalid permissions");
+
+        var notFoundError = new RecordNotFoundError<TestItem>(notFound);
+        var insufficientPermissionsError = new InsufficientPermissionsError<TestItem>(invalidPermissions);
+
+        return new Partial<TestItem>(successfulItems.ToArray(), [notFoundError, insufficientPermissionsError]);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public void Partial_CommandResult_BulkRequestWithSuccessAndFailures(Guid successId1, Guid failureId1, Guid failureId2)
+    {
+        var listOfRecords = new List<TestItem>
+        {
+            new TestItem() { Id = successId1, Value = "SuccessfulRequest" },
+            new TestItem() { Id = failureId1, Value = "Failed due to not found" },
+            new TestItem() { Id = failureId2, Value = "Failed due to invalid permissions" }
+        };
+
+        var result = BulkAction(listOfRecords);
+
+        Assert.IsType<Partial<TestItem>>(listOfRecords);
+    }
+}

--- a/test/Core.Test/Models/Commands/CommandResultTests.cs
+++ b/test/Core.Test/Models/Commands/CommandResultTests.cs
@@ -41,6 +41,12 @@ public class CommandResultTests
 
         var result = BulkAction(listOfRecords);
 
-        Assert.IsType<Partial<TestItem>>(listOfRecords);
+        Assert.IsType<Partial<TestItem>>(result);
+
+        var failures = (result as Partial<TestItem>).Failures.ToArray();
+        var success = (result as Partial<TestItem>).Successes.First();
+
+        Assert.Equal(listOfRecords.First(), success);
+        Assert.Equal(2, failures.Length);
     }
 }


### PR DESCRIPTION

## 📔 Objective
This is a POC of how `IValidator<T>` can be used to produce a `ValidationResult<T>`.

The idea behind `IValidator<T>` is to be used within a command to validate the request against the 

`Valid<T>` will be an object that has been run through the normal business logic to ensure the action can be performed. 

`Invalid<T>` should be used to pass any `Error<T>` back to the command. Here it can be programmatically dealt with and potentially passed back onto the client.

`IValidtor<T>` should only be "validation" logic with no side effects. Logging could potentially done, but it might be best to just allow the command to decide what to do with the error.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
