### PR TITLE
[PM-18175] Remove flag check for 2FA recovery code login

### DIFF
--- a/src/Identity/IdentityServer/RequestValidators/TwoFactorAuthenticationValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/TwoFactorAuthenticationValidator.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.Json;
-using Bit.Core;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.Auth.Enums;
 using Bit.Core.Auth.Identity.TokenProviders;

--- a/src/Identity/IdentityServer/RequestValidators/TwoFactorAuthenticationValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/TwoFactorAuthenticationValidator.cs
@@ -155,12 +155,9 @@ public class TwoFactorAuthenticationValidator(
             return false;
         }
 
-        if (_featureService.IsEnabled(FeatureFlagKeys.RecoveryCodeLogin))
+        if (type is TwoFactorProviderType.RecoveryCode)
         {
-            if (type is TwoFactorProviderType.RecoveryCode)
-            {
-                return await _userService.RecoverTwoFactorAsync(user, token);
-            }
+            return await _userService.RecoverTwoFactorAsync(user, token);
         }
 
         // These cases we want to always return false, U2f is deprecated and OrganizationDuo

--- a/test/Identity.Test/IdentityServer/TwoFactorAuthenticationValidatorTests.cs
+++ b/test/Identity.Test/IdentityServer/TwoFactorAuthenticationValidatorTests.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Core;
-using Bit.Core.AdminConsole.Entities;
+﻿using Bit.Core.AdminConsole.Entities;
 using Bit.Core.Auth.Enums;
 using Bit.Core.Auth.Identity.TokenProviders;
 using Bit.Core.Auth.Models.Business.Tokenables;

--- a/test/Identity.Test/IdentityServer/TwoFactorAuthenticationValidatorTests.cs
+++ b/test/Identity.Test/IdentityServer/TwoFactorAuthenticationValidatorTests.cs
@@ -464,7 +464,6 @@ public class TwoFactorAuthenticationValidatorTests
         user.TwoFactorRecoveryCode = token;
 
         _userService.RecoverTwoFactorAsync(Arg.Is(user), Arg.Is(token)).Returns(true);
-        _featureService.IsEnabled(FeatureFlagKeys.RecoveryCodeLogin).Returns(true);
 
         // Act
         var result = await _sut.VerifyTwoFactorAsync(
@@ -486,7 +485,6 @@ public class TwoFactorAuthenticationValidatorTests
         user.TwoFactorRecoveryCode = token;
 
         _userService.RecoverTwoFactorAsync(Arg.Is(user), Arg.Is(token)).Returns(false);
-        _featureService.IsEnabled(FeatureFlagKeys.RecoveryCodeLogin).Returns(true);
 
         // Act
         var result = await _sut.VerifyTwoFactorAsync(


### PR DESCRIPTION
## 🎟️ Tracking

[bitwarden.atlassian.net/browse/PM-18175](https://bitwarden.atlassian.net/browse/PM-18175)

## 📔 Objective

Remove flagged logic to allow processing of `RecoveryCode` as a 2FA method without the flag being set.

The removal of the obsolete `POST` method will need to wait 3 releases for backward compatibility.  This is tracked in https://bitwarden.atlassian.net/browse/PM-18179.

See corresponding client PR: https://github.com/bitwarden/clients/pull/13875

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
