### PR TITLE
[PM-18858] Security Task email bugs

### DIFF
--- a/src/Core/MailTemplates/Handlebars/SecurityTasksNotification.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/SecurityTasksNotification.html.hbs
@@ -19,7 +19,7 @@
   <tr>
     <td display="display: table-cell">
       <a href="{{ReviewPasswordsUrl}}" clicktracking=off target="_blank"
-        style="display: inline-block; color: #ffffff; text-decoration: none; text-align: center; cursor: pointer; border-radius: 999px; background-color: #175DDC; border-color: #175DDC; border-style: solid; border-width: 10px 20px; margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        style="display: inline-block; font-weight: bold; color: #ffffff; text-decoration: none; text-align: center; cursor: pointer; border-radius: 999px; background-color: #175DDC; border-color: #175DDC; border-style: solid; border-width: 10px 20px; margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
         Review at-risk passwords
       </a>
     </td>

--- a/src/Core/MailTemplates/Handlebars/SecurityTasksNotification.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/SecurityTasksNotification.html.hbs
@@ -15,13 +15,20 @@
   </tr>
 </table>
 <table width="100%" border="0" cellpadding="0" cellspacing="0"
-  style="display: table; width:100%; padding-bottom: 35px; text-align: center;" align="center">
+  style="display: table; width:100%; padding-bottom: 24px; text-align: center;" align="center">
   <tr>
     <td display="display: table-cell">
       <a href="{{ReviewPasswordsUrl}}" clicktracking=off target="_blank"
         style="display: inline-block; font-weight: bold; color: #ffffff; text-decoration: none; text-align: center; cursor: pointer; border-radius: 999px; background-color: #175DDC; border-color: #175DDC; border-style: solid; border-width: 10px 20px; margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
         Review at-risk passwords
       </a>
+    </td>
+  </tr>
+<table width="100%" border="0" cellpadding="0" cellspacing="0"
+  style="display: table; width:100%; padding-bottom: 24px; text-align: center;" align="center">
+  <tr>
+    <td display="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-style: normal; font-weight: 400; font-size: 12px; line-height: 16px;">
+      {{formatAdminOwnerEmails AdminOwnerEmails}}
     </td>
   </tr>
 </table>

--- a/src/Core/MailTemplates/Handlebars/SecurityTasksNotification.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/SecurityTasksNotification.text.hbs
@@ -5,4 +5,6 @@ breach.
 Launch the Bitwarden extension to review your at-risk passwords.
 
 Review at-risk passwords ({{{ReviewPasswordsUrl}}})
+
+This request was initiated by {{#each AdminOwnerEmails}} {{this}}, {{/each}}.
 {{/SecurityTasksHtmlLayout}}

--- a/src/Core/MailTemplates/Handlebars/SecurityTasksNotification.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/SecurityTasksNotification.text.hbs
@@ -6,5 +6,12 @@ Launch the Bitwarden extension to review your at-risk passwords.
 
 Review at-risk passwords ({{{ReviewPasswordsUrl}}})
 
-This request was initiated by {{#each AdminOwnerEmails}} {{this}}, {{/each}}.
+{{#if (eq (length AdminOwnerEmails) 1)}}
+This request was initiated by {{AdminOwnerEmails.[0]}}.
+{{else}}
+This request was initiated by
+{{#each AdminOwnerEmails}}
+  {{#if @last}}and {{/if}}{{this}}{{#unless @last}}, {{/unless}}
+{{/each}}.
+{{/if}}
 {{/SecurityTasksHtmlLayout}}

--- a/src/Core/Models/Mail/SecurityTaskNotificationViewModel.cs
+++ b/src/Core/Models/Mail/SecurityTaskNotificationViewModel.cs
@@ -8,5 +8,7 @@ public class SecurityTaskNotificationViewModel : BaseMailModel
 
     public bool TaskCountPlural => TaskCount != 1;
 
+    public IEnumerable<string> AdminOwnerEmails { get; set; }
+
     public string ReviewPasswordsUrl => $"{WebVaultUrl}/browser-extension-prompt";
 }

--- a/src/Core/Services/IMailService.cs
+++ b/src/Core/Services/IMailService.cs
@@ -99,5 +99,5 @@ public interface IMailService
         string organizationName);
     Task SendClaimedDomainUserEmailAsync(ManagedUserDomainClaimedEmails emailList);
     Task SendDeviceApprovalRequestedNotificationEmailAsync(IEnumerable<string> adminEmails, Guid organizationId, string email, string userName);
-    Task SendBulkSecurityTaskNotificationsAsync(string orgName, IEnumerable<UserSecurityTasksCount> securityTaskNotificaitons);
+    Task SendBulkSecurityTaskNotificationsAsync(string orgName, IEnumerable<UserSecurityTasksCount> securityTaskNotificaitons, IEnumerable<string> adminOwnerEmails);
 }

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -740,6 +740,45 @@ public class HandlebarsMailService : IMailService
             var clickTrackingText = (clickTrackingOff ? "clicktracking=off" : string.Empty);
             writer.WriteSafeString($"<a href=\"{href}\" target=\"_blank\" {clickTrackingText}>{text}</a>");
         });
+
+        // Construct markup for admin and owner email addresses.
+        // Using conditionals within the handlebar syntax was including extra spaces around
+        // concatenated strings, which this helper avoids.
+        Handlebars.RegisterHelper("formatAdminOwnerEmails", (writer, context, parameters) =>
+        {
+            if (parameters.Length == 0)
+            {
+                writer.WriteSafeString(string.Empty);
+                return;
+            }
+
+            var emailList = ((IEnumerable<string>)parameters[0]).ToList();
+            if (emailList.Count == 0)
+            {
+                writer.WriteSafeString(string.Empty);
+                return;
+            }
+
+            string constructAnchorElement(string email)
+            {
+                return $"<a style=\"color: #175DDC\" href=\"mailto:{email}\">{email}</a>";
+            }
+
+            var outputMessage = "This request was initiated by ";
+
+            if (emailList.Count == 1)
+            {
+                outputMessage += $"{constructAnchorElement(emailList[0])}.";
+            }
+            else
+            {
+                outputMessage += string.Join(", ", emailList.Take(emailList.Count - 1)
+                    .Select(email => constructAnchorElement(email)));
+                outputMessage += $", and {constructAnchorElement(emailList.Last())}.";
+            }
+
+            writer.WriteSafeString($"{outputMessage}");
+        });
     }
 
     public async Task SendEmergencyAccessInviteEmailAsync(EmergencyAccess emergencyAccess, string name, string token)
@@ -1201,7 +1240,7 @@ public class HandlebarsMailService : IMailService
         await _mailDeliveryService.SendEmailAsync(message);
     }
 
-    public async Task SendBulkSecurityTaskNotificationsAsync(string orgName, IEnumerable<UserSecurityTasksCount> securityTaskNotificaitons)
+    public async Task SendBulkSecurityTaskNotificationsAsync(string orgName, IEnumerable<UserSecurityTasksCount> securityTaskNotificaitons, IEnumerable<string> adminOwnerEmails)
     {
         MailQueueMessage CreateMessage(UserSecurityTasksCount notification)
         {
@@ -1210,6 +1249,7 @@ public class HandlebarsMailService : IMailService
             {
                 OrgName = orgName,
                 TaskCount = notification.TaskCount,
+                AdminOwnerEmails = adminOwnerEmails,
                 WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
             };
             message.Category = "SecurityTasksNotification";

--- a/src/Core/Services/NoopImplementations/NoopMailService.cs
+++ b/src/Core/Services/NoopImplementations/NoopMailService.cs
@@ -324,7 +324,7 @@ public class NoopMailService : IMailService
         return Task.FromResult(0);
     }
 
-    public Task SendBulkSecurityTaskNotificationsAsync(string orgName, IEnumerable<UserSecurityTasksCount> securityTaskNotificaitons)
+    public Task SendBulkSecurityTaskNotificationsAsync(string orgName, IEnumerable<UserSecurityTasksCount> securityTaskNotificaitons, IEnumerable<string> adminOwnerEmails)
     {
         return Task.FromResult(0);
     }

--- a/src/Core/Vault/Commands/CreateManyTaskNotificationsCommand.cs
+++ b/src/Core/Vault/Commands/CreateManyTaskNotificationsCommand.cs
@@ -17,19 +17,22 @@ public class CreateManyTaskNotificationsCommand : ICreateManyTaskNotificationsCo
     private readonly IMailService _mailService;
     private readonly ICreateNotificationCommand _createNotificationCommand;
     private readonly IPushNotificationService _pushNotificationService;
+    private readonly IOrganizationUserRepository _organizationUserRepository;
 
     public CreateManyTaskNotificationsCommand(
         IGetSecurityTasksNotificationDetailsQuery getSecurityTasksNotificationDetailsQuery,
         IOrganizationRepository organizationRepository,
         IMailService mailService,
         ICreateNotificationCommand createNotificationCommand,
-        IPushNotificationService pushNotificationService)
+        IPushNotificationService pushNotificationService,
+        IOrganizationUserRepository organizationUserRepository)
     {
         _getSecurityTasksNotificationDetailsQuery = getSecurityTasksNotificationDetailsQuery;
         _organizationRepository = organizationRepository;
         _mailService = mailService;
         _createNotificationCommand = createNotificationCommand;
         _pushNotificationService = pushNotificationService;
+        _organizationUserRepository = organizationUserRepository;
     }
 
     public async Task CreateAsync(Guid orgId, IEnumerable<SecurityTask> securityTasks)
@@ -45,8 +48,11 @@ public class CreateManyTaskNotificationsCommand : ICreateManyTaskNotificationsCo
         }).ToList();
 
         var organization = await _organizationRepository.GetByIdAsync(orgId);
+        var orgAdminEmails = await _organizationUserRepository.GetManyDetailsByRoleAsync(orgId, OrganizationUserType.Admin);
+        var orgOwnerEmails = await _organizationUserRepository.GetManyDetailsByRoleAsync(orgId, OrganizationUserType.Owner);
+        var orgAdminAndOwnerEmails = orgAdminEmails.Concat(orgOwnerEmails).Select(x => x.Email).Distinct().ToList();
 
-        await _mailService.SendBulkSecurityTaskNotificationsAsync(organization.Name, userTaskCount);
+        await _mailService.SendBulkSecurityTaskNotificationsAsync(organization.Name, userTaskCount, orgAdminAndOwnerEmails);
 
         // Break securityTaskCiphers into separate lists by user Id
         var securityTaskCiphersByUser = securityTaskCiphers.GroupBy(x => x.UserId)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18858](https://bitwarden.atlassian.net/browse/PM-18858)

## 📔 Objective

Fix bugs associated with the security task email:
- The “Review at-risk passwords” button text to be bold
- Add "This request was initiated by" text

## 📸 Screenshots

|Single Admin/Owner| Multiple Admin/Owner|
|-|-|
|<img width="631" alt="Screenshot 2025-03-20 at 10 36 57 AM" src="https://github.com/user-attachments/assets/328b2f1b-a341-458f-9d1d-8e5bdd4bf4ee" />|<img width="635" alt="Screenshot 2025-03-20 at 10 43 52 AM" src="https://github.com/user-attachments/assets/13b154d6-6008-4c10-872c-5bc6fa8f0574" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18858]: https://bitwarden.atlassian.net/browse/PM-18858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ