### PR TITLE
Add UpdateCiphersAsync Test

### DIFF
--- a/src/Infrastructure.Dapper/Vault/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.Dapper/Vault/Repositories/CipherRepository.cs
@@ -711,7 +711,7 @@ public class CipherRepository : Repository<Cipher, Guid>, ICipherRepository
             row[creationDateColumn] = cipher.CreationDate;
             row[revisionDateColumn] = cipher.RevisionDate;
             row[deletedDateColumn] = cipher.DeletedDate.HasValue ? (object)cipher.DeletedDate : DBNull.Value;
-            row[repromptColumn] = cipher.Reprompt;
+            row[repromptColumn] = cipher.Reprompt.HasValue ? cipher.Reprompt.Value : DBNull.Value;
             row[keyColummn] = cipher.Key;
 
             ciphersTable.Rows.Add(row);

--- a/src/Infrastructure.EntityFramework/Vault/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.EntityFramework/Vault/Repositories/CipherRepository.cs
@@ -864,7 +864,10 @@ public class CipherRepository : Repository<Core.Vault.Entities.Cipher, Cipher, G
         {
             var dbContext = GetDatabaseContext(scope);
             var entities = Mapper.Map<List<Cipher>>(ciphers);
-            await dbContext.BulkCopyAsync(base.DefaultBulkCopyOptions, entities);
+            foreach (var cipher in entities)
+            {
+                dbContext.Ciphers.Attach(cipher);
+            }
             await dbContext.UserBumpAccountRevisionDateAsync(userId);
             await dbContext.SaveChangesAsync();
         }

--- a/src/Infrastructure.EntityFramework/Vault/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.EntityFramework/Vault/Repositories/CipherRepository.cs
@@ -16,7 +16,6 @@ using LinqToDB.EntityFrameworkCore;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using NSec.Cryptography;
 using NS = Newtonsoft.Json;
 using NSL = Newtonsoft.Json.Linq;
 

--- a/test/Infrastructure.IntegrationTest/Vault/Repositories/CipherRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/Vault/Repositories/CipherRepositoryTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.Json;
-using System.Text.Json.Nodes;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Entities;
@@ -899,11 +898,8 @@ public class CipherRepositoryTests
         var cipher1 = await CreatePersonalCipher(user, cipherRepository);
         var cipher2 = await CreatePersonalCipher(user, cipherRepository);
 
-        cipher1.Reprompt = CipherRepromptType.Password;
-        cipher2.Favorites = new JsonObject
-        {
-            [user.Id.ToString()] = true,
-        }.ToJsonString();
+        cipher1.Type = CipherType.SecureNote;
+        cipher2.Attachments = "new_attachments";
 
         await cipherRepository.UpdateCiphersAsync(user.Id, [cipher1, cipher2]);
 
@@ -913,6 +909,7 @@ public class CipherRepositoryTests
         Assert.NotNull(updatedCipher1);
         Assert.NotNull(updatedCipher2);
 
-        Assert.Equal(CipherRepromptType.Password, updatedCipher1.Reprompt);
+        Assert.Equal(CipherType.SecureNote, updatedCipher1.Type);
+        Assert.Equal("new_attachments", updatedCipher2.Attachments);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

I encountered the following error while trying to move personal vault items to an org vault.

```
SQLite Error 19: 'UNIQUE constraint failed: Cipher.Id'.
      Microsoft.Data.Sqlite.SqliteException (0x80004005): SQLite Error 19: 'UNIQUE constraint failed: Cipher.Id'.
         at Microsoft.Data.Sqlite.SqliteException.ThrowExceptionForRC(Int32 rc, sqlite3 db)
         at Microsoft.Data.Sqlite.SqliteDataReader.NextResult()
         at Microsoft.Data.Sqlite.SqliteCommand.ExecuteReader(CommandBehavior behavior)
         at Microsoft.Data.Sqlite.SqliteCommand.ExecuteReader()
         at Microsoft.Data.Sqlite.SqliteCommand.ExecuteNonQuery()
         at System.Data.Common.DbCommand.ExecuteNonQueryAsync(CancellationToken cancellationToken)
```

ad2a9673680cd43def91e73b0ff602f8e8d73891 - Adds a test that fails, as [seen here](https://github.com/bitwarden/server/actions/runs/14018692568/job/39247686129#step:16:106) for all EF variants. 

c513424 - Attempted a first fix but it doesn't work actually.

acce299 - Is the second attempt and it works, it has to do an extra call to the database to get the existing and tracked ciphers first. It updates all the [same columns that SQL Server/Dapper does](https://github.com/bitwarden/server/blob/d345937ecca07aefd07f8cea421ae7ca2b6fcf98/src/Infrastructure.Dapper/Vault/Repositories/CipherRepository.cs#L448-L455).

8c689bd - Is a fix I had to do for SQL Server, it matches what all the other nullable value types have to do, I can fully accept that the enum is possibly never null here and has been normalized to `CipherRepromptType.None` outside of this method ever being called but it still seems right that this is done. 

29fd241 - Formatting fix from an accidental import.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
