### PR TITLE
[PM-19203] Duplicate Security Tasks

### DIFF
--- a/src/Api/Vault/Controllers/SecurityTaskController.cs
+++ b/src/Api/Vault/Controllers/SecurityTaskController.cs
@@ -5,6 +5,7 @@ using Bit.Core;
 using Bit.Core.Services;
 using Bit.Core.Utilities;
 using Bit.Core.Vault.Commands.Interfaces;
+using Bit.Core.Vault.Entities;
 using Bit.Core.Vault.Enums;
 using Bit.Core.Vault.Queries;
 using Microsoft.AspNetCore.Authorization;
@@ -89,11 +90,28 @@ public class SecurityTaskController : Controller
     public async Task<ListResponseModel<SecurityTasksResponseModel>> BulkCreateTasks(Guid orgId,
         [FromBody] BulkCreateSecurityTasksRequestModel model)
     {
-        var securityTasks = await _createManyTasksCommand.CreateAsync(orgId, model.Tasks);
+        // Retrieve existing pending security tasks for the organization
+        var pendingSecurityTasks = await _getTasksForOrganizationQuery.GetTasksAsync(orgId, SecurityTaskStatus.Pending);
 
-        await _createManyTaskNotificationsCommand.CreateAsync(orgId, securityTasks);
+        // Get the security tasks that are already associated with a cipher within the submitted model
+        var existingTasks = pendingSecurityTasks.Where(x => model.Tasks.Any(y => y.CipherId == x.CipherId)).ToList();
 
-        var response = securityTasks.Select(x => new SecurityTasksResponseModel(x)).ToList();
+        // Get tasks that need to be created
+        var tasksToCreateFromModel = model.Tasks.Where(x => !existingTasks.Any(y => y.CipherId == x.CipherId)).ToList();
+
+        ICollection<SecurityTask> newSecurityTasks = new List<SecurityTask>();
+
+        if (tasksToCreateFromModel.Count != 0)
+        {
+            newSecurityTasks = await _createManyTasksCommand.CreateAsync(orgId, tasksToCreateFromModel);
+        }
+
+        // Combine existing tasks and newly created tasks
+        var allTasks = existingTasks.Concat(newSecurityTasks);
+
+        await _createManyTaskNotificationsCommand.CreateAsync(orgId, allTasks);
+
+        var response = allTasks.Select(x => new SecurityTasksResponseModel(x)).ToList();
         return new ListResponseModel<SecurityTasksResponseModel>(response);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19203](https://bitwarden.atlassian.net/browse/PM-19203)

## 📔 Objective

### Previously

Security tasks would be created for all of the ciphers within the payload. This resulted in the same cipher being shown multiple times in the at-risk password page.

### Now

The server will find all pending security tasks for the organization. When a task is found that is associated with a cipher in the payload a new task will not be created.
- The notification to users _will_ contain all tasks applicable to them so they will receive a count that is the total tasks, not just newly created tasks.

## 📸 Screenshots

|All Tasks exist|Partial list of tasks exist|Browser - not showing duplicate ciphers|
|-|-|-|
|<video src="https://github.com/user-attachments/assets/a1d13c3f-d244-4ae3-a6a4-f0596b07ad88" /> |<video src="https://github.com/user-attachments/assets/21dc5562-deea-454d-bfa9-31c040329a15" />|<img width="386" alt="ciphers-only-showing-once" src="https://github.com/user-attachments/assets/d5d78c70-8854-4505-a766-52be629fe113" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19203]: https://bitwarden.atlassian.net/browse/PM-19203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ