### PR TITLE
fix: allowing to not use default mssql container

### DIFF
--- a/util/Setup/Configuration.cs
+++ b/util/Setup/Configuration.cs
@@ -94,6 +94,11 @@ public class Configuration
     [Description("Enable Key Connector (https://bitwarden.com/help/article/deploy-key-connector)")]
     public bool EnableKeyConnector { get; set; } = false;
 
+    [Description("Enable integrated MSSQL Database\n" +
+        "true: use default mssql configuration and start a mssql container\n" +
+        "false: use external self managned MSSQL Database")]
+    public bool MssqlEnabled { get; set; } = true;
+
     [Description("Enable SCIM")]
     public bool EnableScim { get; set; } = false;
 

--- a/util/Setup/DockerComposeBuilder.cs
+++ b/util/Setup/DockerComposeBuilder.cs
@@ -43,6 +43,7 @@ public class DockerComposeBuilder
         public TemplateModel(Context context)
         {
             MssqlDataDockerVolume = context.Config.DatabaseDockerVolume;
+            MssqlEnabled = context.Config.MssqlEnabled;
             EnableKeyConnector = context.Config.EnableKeyConnector;
             EnableScim = context.Config.EnableScim;
             HttpPort = context.Config.HttpPort;
@@ -62,6 +63,7 @@ public class DockerComposeBuilder
         }
 
         public bool MssqlDataDockerVolume { get; set; }
+        public bool MssqlEnabled { get; set; }
         public bool EnableKeyConnector { get; set; }
         public bool EnableScim { get; set; }
         public string HttpPort { get; set; }

--- a/util/Setup/Templates/DockerCompose.hbs
+++ b/util/Setup/Templates/DockerCompose.hbs
@@ -1,4 +1,4 @@
-﻿#
+#
 # Useful references:
 # https://docs.docker.com/reference/compose-file/
 # https://docs.docker.com/reference/cli/docker/compose/#use--f-to-specify-the-name-and-path-of-one-or-more-compose-files
@@ -14,6 +14,7 @@
 #########################################################################
 
 services:
+{{#if MssqlEnabled}}
   mssql:
     image: ghcr.io/bitwarden/mssql:{{{CoreVersion}}}
     container_name: bitwarden-mssql
@@ -32,6 +33,7 @@ services:
       - ../env/uid.env
       - ../env/mssql.override.env
 
+{{/if}}
   web:
     image: ghcr.io/bitwarden/web:{{{WebVersion}}}
     container_name: bitwarden-web
@@ -106,8 +108,10 @@ services:
     image: ghcr.io/bitwarden/admin:{{{CoreVersion}}}
     container_name: bitwarden-admin
     restart: always
+{{#if MssqlEnabled}}
     depends_on:
       - mssql
+{{/if}}
     volumes:
       - ../core:/etc/bitwarden/core
       - ../ca-certificates:/etc/bitwarden/ca-certificates


### PR DESCRIPTION
adding config option to use external db and not pull/start the integrated mssql container

## 🎟️ Tracking


## 📔 Objective

If your are using an external MSSQL Database, the bitwarden.sh script had no possibility of disabling the bitwarden-mssql container. The implemented config option, if set, removes the mssql part from the docker compose file. It is not needed to have a bitwarden-mssql container running if there is no connection to it. (because of external mysql).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
