### PR TITLE
[PM-19575] Allow enabling Single Org policy 

### DIFF
--- a/src/Api/AdminConsole/Models/Response/Helpers/PolicyDetailResponses.cs
+++ b/src/Api/AdminConsole/Models/Response/Helpers/PolicyDetailResponses.cs
@@ -13,7 +13,17 @@ public static class PolicyDetailResponses
         {
             throw new ArgumentException($"'{nameof(policy)}' must be of type '{nameof(PolicyType.SingleOrg)}'.", nameof(policy));
         }
+        return new PolicyDetailResponseModel(policy, await CanToggleState());
 
-        return new PolicyDetailResponseModel(policy, !await hasVerifiedDomainsQuery.HasVerifiedDomainsAsync(policy.OrganizationId));
+        async Task<bool> CanToggleState()
+        {
+            if (!await hasVerifiedDomainsQuery.HasVerifiedDomainsAsync(policy.OrganizationId))
+            {
+                return true;
+            }
+
+            return !policy.Enabled;
+        }
     }
+
 }

--- a/test/Api.Test/AdminConsole/Models/Response/Helpers/PolicyDetailResponsesTests.cs
+++ b/test/Api.Test/AdminConsole/Models/Response/Helpers/PolicyDetailResponsesTests.cs
@@ -10,14 +10,19 @@ namespace Bit.Api.Test.AdminConsole.Models.Response.Helpers;
 
 public class PolicyDetailResponsesTests
 {
-    [Fact]
-    public async Task GetSingleOrgPolicyDetailResponseAsync_GivenPolicyEntity_WhenIsSingleOrgTypeAndHasVerifiedDomains_ThenShouldNotBeAbleToToggle()
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task GetSingleOrgPolicyDetailResponseAsync_WhenIsSingleOrgTypeAndHasVerifiedDomains_ShouldReturnExpectedToggleState(
+        bool policyEnabled,
+        bool expectedCanToggle)
     {
         var fixture = new Fixture();
 
         var policy = fixture.Build<Policy>()
             .Without(p => p.Data)
             .With(p => p.Type, PolicyType.SingleOrg)
+            .With(p => p.Enabled, policyEnabled)
             .Create();
 
         var querySub = Substitute.For<IOrganizationHasVerifiedDomainsQuery>();
@@ -26,11 +31,11 @@ public class PolicyDetailResponsesTests
 
         var result = await policy.GetSingleOrgPolicyDetailResponseAsync(querySub);
 
-        Assert.False(result.CanToggleState);
+        Assert.Equal(expectedCanToggle, result.CanToggleState);
     }
 
     [Fact]
-    public async Task GetSingleOrgPolicyDetailResponseAsync_GivenPolicyEntity_WhenIsNotSingleOrgType_ThenShouldThrowArgumentException()
+    public async Task GetSingleOrgPolicyDetailResponseAsync_WhenIsNotSingleOrgType_ThenShouldThrowArgumentException()
     {
         var fixture = new Fixture();
 
@@ -49,7 +54,7 @@ public class PolicyDetailResponsesTests
     }
 
     [Fact]
-    public async Task GetSingleOrgPolicyDetailResponseAsync_GivenPolicyEntity_WhenIsSingleOrgTypeAndDoesNotHaveVerifiedDomains_ThenShouldBeAbleToToggle()
+    public async Task GetSingleOrgPolicyDetailResponseAsync_WhenIsSingleOrgTypeAndDoesNotHaveVerifiedDomains_ThenShouldBeAbleToToggle()
     {
         var fixture = new Fixture();
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-19575

## 📔 Objective
Allow enabling Single Org policy when the organization has claimed domains.

1. Add check for use cases
2. Add test coverage. 

Use cases 
HasVerifiedDomains | policy | Final Result
-- | -- | --
True | Enabled | False
True | Disabled | True
False | Enabled | True
False | Disabled | True


## 📸 Screenshots


https://github.com/user-attachments/assets/546d00ea-c028-437b-b127-1c63b70e63af



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
