### PR TITLE
[PM-19523] Filter expected webauthn keys for rotations by prf enabled

### DIFF
--- a/test/Api.Test/KeyManagement/Validators/WebauthnLoginKeyRotationValidatorTests.cs
+++ b/test/Api.Test/KeyManagement/Validators/WebauthnLoginKeyRotationValidatorTests.cs
@@ -24,12 +24,17 @@ public class WebAuthnLoginKeyRotationValidatorTests
 
         var webauthnKeysToRotate = webauthnRotateCredentialData.Select(e => new WebAuthnLoginRotateKeyRequestModel
         {
-            Id = guid, EncryptedPublicKey = e.EncryptedPublicKey, EncryptedUserKey = e.EncryptedUserKey
+            Id = guid,
+            EncryptedPublicKey = e.EncryptedPublicKey,
+            EncryptedUserKey = e.EncryptedUserKey
         }).ToList();
 
         var data = new WebAuthnCredential
         {
-            Id = guid, SupportsPrf = true, EncryptedPublicKey = "TestKey", EncryptedUserKey = "Test"
+            Id = guid,
+            SupportsPrf = true,
+            EncryptedPublicKey = "TestKey",
+            EncryptedUserKey = "Test"
         };
         sutProvider.GetDependency<IWebAuthnCredentialRepository>().GetManyByUserIdAsync(user.Id)
             .Returns(new List<WebAuthnCredential> { data });
@@ -48,7 +53,9 @@ public class WebAuthnLoginKeyRotationValidatorTests
         var guid = Guid.NewGuid();
         var webauthnKeysToRotate = webauthnRotateCredentialData.Select(e => new WebAuthnLoginRotateKeyRequestModel
         {
-            Id = guid, EncryptedUserKey = e.EncryptedUserKey, EncryptedPublicKey = e.EncryptedPublicKey,
+            Id = guid,
+            EncryptedUserKey = e.EncryptedUserKey,
+            EncryptedPublicKey = e.EncryptedPublicKey,
         }).ToList();
 
         var data = new WebAuthnCredential { Id = guid, EncryptedUserKey = "Test", EncryptedPublicKey = "TestKey" };

--- a/test/Api.Test/KeyManagement/Validators/WebauthnLoginKeyRotationValidatorTests.cs
+++ b/test/Api.Test/KeyManagement/Validators/WebauthnLoginKeyRotationValidatorTests.cs
@@ -16,6 +16,52 @@ public class WebAuthnLoginKeyRotationValidatorTests
 {
     [Theory]
     [BitAutoData]
+    public async Task ValidateAsync_Succeeds_ReturnsValidCredentials(
+        SutProvider<WebAuthnLoginKeyRotationValidator> sutProvider, User user,
+        IEnumerable<WebAuthnLoginRotateKeyRequestModel> webauthnRotateCredentialData)
+    {
+        var guid = Guid.NewGuid();
+
+        var webauthnKeysToRotate = webauthnRotateCredentialData.Select(e => new WebAuthnLoginRotateKeyRequestModel
+        {
+            Id = guid, EncryptedPublicKey = e.EncryptedPublicKey, EncryptedUserKey = e.EncryptedUserKey
+        }).ToList();
+
+        var data = new WebAuthnCredential
+        {
+            Id = guid, SupportsPrf = true, EncryptedPublicKey = "TestKey", EncryptedUserKey = "Test"
+        };
+        sutProvider.GetDependency<IWebAuthnCredentialRepository>().GetManyByUserIdAsync(user.Id)
+            .Returns(new List<WebAuthnCredential> { data });
+
+        var result = await sutProvider.Sut.ValidateAsync(user, webauthnKeysToRotate);
+        Assert.Single(result);
+        Assert.Equal(guid, result.First().Id);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task ValidateAsync_DoesNotSupportPRF_Ignores(
+        SutProvider<WebAuthnLoginKeyRotationValidator> sutProvider, User user,
+        IEnumerable<WebAuthnLoginRotateKeyRequestModel> webauthnRotateCredentialData)
+    {
+        var guid = Guid.NewGuid();
+        var webauthnKeysToRotate = webauthnRotateCredentialData.Select(e => new WebAuthnLoginRotateKeyRequestModel
+        {
+            Id = guid, EncryptedUserKey = e.EncryptedUserKey, EncryptedPublicKey = e.EncryptedPublicKey,
+        }).ToList();
+
+        var data = new WebAuthnCredential { Id = guid, EncryptedUserKey = "Test", EncryptedPublicKey = "TestKey" };
+
+        sutProvider.GetDependency<IWebAuthnCredentialRepository>().GetManyByUserIdAsync(user.Id)
+            .Returns(new List<WebAuthnCredential> { data });
+
+        var result = await sutProvider.Sut.ValidateAsync(user, webauthnKeysToRotate);
+        Assert.Empty(result);
+    }
+
+    [Theory]
+    [BitAutoData]
     public async Task ValidateAsync_WrongWebAuthnKeys_Throws(
         SutProvider<WebAuthnLoginKeyRotationValidator> sutProvider, User user,
         IEnumerable<WebAuthnLoginRotateKeyRequestModel> webauthnRotateCredentialData)
@@ -30,6 +76,7 @@ public class WebAuthnLoginKeyRotationValidatorTests
         var data = new WebAuthnCredential
         {
             Id = Guid.Parse("00000000-0000-0000-0000-000000000002"),
+            SupportsPrf = true,
             EncryptedPublicKey = "TestKey",
             EncryptedUserKey = "Test"
         };
@@ -55,6 +102,7 @@ public class WebAuthnLoginKeyRotationValidatorTests
         var data = new WebAuthnCredential
         {
             Id = guid,
+            SupportsPrf = true,
             EncryptedPublicKey = "TestKey",
             EncryptedUserKey = "Test"
         };
@@ -81,6 +129,7 @@ public class WebAuthnLoginKeyRotationValidatorTests
         var data = new WebAuthnCredential
         {
             Id = guid,
+            SupportsPrf = true,
             EncryptedPublicKey = "TestKey",
             EncryptedUserKey = "Test"
         };


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-19523
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
During key rotations, we check to make sure that the webauthn keys in the database all have corresponding keys sent in the request. When grabbing the webauthn credentials from the database, we were using all of them instead of only the ones that are PRF enabled. This filters the credentials so we only look for ones that are required.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
