### PR TITLE
Auth/PM-19629 - Entity Framework -  WebAuthnCredentialRepository - fix reading entire table into memory

### DIFF
--- a/src/Infrastructure.EntityFramework/Auth/Repositories/WebAuthnCredentialRepository.cs
+++ b/src/Infrastructure.EntityFramework/Auth/Repositories/WebAuthnCredentialRepository.cs
@@ -68,12 +68,11 @@ public class WebAuthnCredentialRepository : Repository<Core.Auth.Entities.WebAut
             var newCreds = credentials.ToList();
             using var scope = ServiceScopeFactory.CreateScope();
             var dbContext = GetDatabaseContext(scope);
-            var userWebauthnCredentials = await GetDbSet(dbContext)
-                .Where(wc => wc.Id == wc.Id)
+
+            var newCredIds = newCreds.Select(nwc => nwc.Id).ToList();
+            var validUserWebauthnCredentials = await GetDbSet(dbContext)
+                .Where(wc => wc.UserId == userId && newCredIds.Contains(wc.Id))
                 .ToListAsync();
-            var validUserWebauthnCredentials = userWebauthnCredentials
-                .Where(wc => newCreds.Any(nwc => nwc.Id == wc.Id))
-                .Where(wc => wc.UserId == userId);
 
             foreach (var wc in validUserWebauthnCredentials)
             {


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-19629

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
For WebAuthn Key Rotation, we incorrectly would read the entire WebAuthn credential table into memory to then filter down the data set. This has been resolved. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
