### PR TITLE
[PM-14406] Fix security task email sends

### DIFF
--- a/src/Core/MailTemplates/Handlebars/SecurityTasksNotification.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/SecurityTasksNotification.html.hbs
@@ -14,18 +14,17 @@
     </td>
   </tr>
 </table>
-<table width="100%" border="0" cellpadding="0" cellspacing="0"
-  style="display: block; width:100%; padding-bottom: 24px; text-align: center;" align="center">
+<table width="100%" border="0" cellpadding="0" cellspacing="0" style="padding-bottom: 24px; padding-left: 24px; padding-right: 24px; text-align: center;" align="center">
   <tr>
-    <td display="display: table-cell">
+    <td>
       <a href="{{ReviewPasswordsUrl}}" clicktracking=off target="_blank"
         style="display: inline-block; font-weight: bold; color: #ffffff; text-decoration: none; text-align: center; cursor: pointer; border-radius: 999px; background-color: #175DDC; border-color: #175DDC; border-style: solid; border-width: 10px 20px; margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
         Review at-risk passwords
       </a>
     </td>
   </tr>
-<table width="100%" border="0" cellpadding="0" cellspacing="0"
-  style="display: block; width:100%; padding-bottom: 24px; text-align: center;" align="center">
+</table>
+<table width="100%" border="0" cellpadding="0" cellspacing="0" style="padding-bottom: 24px; padding-left: 24px; padding-right: 24px; text-align: center;" align="center">
   <tr>
     <td display="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-style: normal; font-weight: 400; font-size: 12px; line-height: 16px;">
       {{formatAdminOwnerEmails AdminOwnerEmails}}

--- a/src/Core/MailTemplates/Handlebars/SecurityTasksNotification.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/SecurityTasksNotification.html.hbs
@@ -15,7 +15,7 @@
   </tr>
 </table>
 <table width="100%" border="0" cellpadding="0" cellspacing="0"
-  style="display: table; width:100%; padding-bottom: 24px; text-align: center;" align="center">
+  style="display: block; width:100%; padding-bottom: 24px; text-align: center;" align="center">
   <tr>
     <td display="display: table-cell">
       <a href="{{ReviewPasswordsUrl}}" clicktracking=off target="_blank"
@@ -25,7 +25,7 @@
     </td>
   </tr>
 <table width="100%" border="0" cellpadding="0" cellspacing="0"
-  style="display: table; width:100%; padding-bottom: 24px; text-align: center;" align="center">
+  style="display: block; width:100%; padding-bottom: 24px; text-align: center;" align="center">
   <tr>
     <td display="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-style: normal; font-weight: 400; font-size: 12px; line-height: 16px;">
       {{formatAdminOwnerEmails AdminOwnerEmails}}

--- a/src/Core/Models/Mail/SecurityTaskNotificationViewModel.cs
+++ b/src/Core/Models/Mail/SecurityTaskNotificationViewModel.cs
@@ -8,7 +8,7 @@ public class SecurityTaskNotificationViewModel : BaseMailModel
 
     public bool TaskCountPlural => TaskCount != 1;
 
-    public IEnumerable<string> AdminOwnerEmails { get; set; }
+    public List<string> AdminOwnerEmails { get; set; }
 
     public string ReviewPasswordsUrl => $"{WebVaultUrl}/browser-extension-prompt";
 }

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -789,7 +789,7 @@ public class HandlebarsMailService : IMailService
             {
                 outputMessage += string.Join(", ", emailList.Take(emailList.Count - 1)
                     .Select(email => constructAnchorElement(email)));
-                outputMessage += $", and {constructAnchorElement(emailList.Last())}.";
+                outputMessage += $" and {constructAnchorElement(emailList.Last())}.";
             }
 
             writer.WriteSafeString($"{outputMessage}");

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -1,5 +1,6 @@
-using System.Net;
+﻿using System.Net;
 using System.Reflection;
+using System.Text.Json;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Models.Mail;
@@ -752,7 +753,21 @@ public class HandlebarsMailService : IMailService
                 return;
             }
 
-            var emailList = ((IEnumerable<string>)parameters[0]).ToList();
+            var emailList = new List<string>();
+            if (parameters[0] is JsonElement jsonElement && jsonElement.ValueKind == JsonValueKind.Array)
+            {
+                emailList = jsonElement.EnumerateArray().Select(e => e.GetString()).ToList();
+            }
+            else if (parameters[0] is IEnumerable<string> emails)
+            {
+                emailList = emails.ToList();
+            }
+            else
+            {
+                writer.WriteSafeString(string.Empty);
+                return;
+            }
+
             if (emailList.Count == 0)
             {
                 writer.WriteSafeString(string.Empty);

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Reflection;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Entities.Provider;
@@ -1250,7 +1250,7 @@ public class HandlebarsMailService : IMailService
             {
                 OrgName = CoreHelpers.SanitizeForEmail(sanitizedOrgName, false),
                 TaskCount = notification.TaskCount,
-                AdminOwnerEmails = adminOwnerEmails,
+                AdminOwnerEmails = adminOwnerEmails.ToList(),
                 WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
             };
             message.Category = "SecurityTasksNotification";

--- a/src/Core/Vault/Commands/CreateManyTaskNotificationsCommand.cs
+++ b/src/Core/Vault/Commands/CreateManyTaskNotificationsCommand.cs
@@ -48,9 +48,16 @@ public class CreateManyTaskNotificationsCommand : ICreateManyTaskNotificationsCo
         }).ToList();
 
         var organization = await _organizationRepository.GetByIdAsync(orgId);
-        var orgAdminEmails = await _organizationUserRepository.GetManyDetailsByRoleAsync(orgId, OrganizationUserType.Admin);
-        var orgOwnerEmails = await _organizationUserRepository.GetManyDetailsByRoleAsync(orgId, OrganizationUserType.Owner);
-        var orgAdminAndOwnerEmails = orgAdminEmails.Concat(orgOwnerEmails).Select(x => x.Email).Distinct().ToList();
+        var orgAdminEmails = (await _organizationUserRepository.GetManyDetailsByRoleAsync(orgId, OrganizationUserType.Admin))
+            .Select(u => u.Email)
+            .ToList();
+
+        var orgOwnerEmails = (await _organizationUserRepository.GetManyDetailsByRoleAsync(orgId, OrganizationUserType.Owner))
+            .Select(u => u.Email)
+            .ToList();
+
+        // Ensure proper deserialization of emails
+        var orgAdminAndOwnerEmails = orgAdminEmails.Concat(orgOwnerEmails).Distinct().ToList();
 
         await _mailService.SendBulkSecurityTaskNotificationsAsync(organization, userTaskCount, orgAdminAndOwnerEmails);
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14406](https://bitwarden.atlassian.net/browse/PM-14406)

## 📔 Objective

Emails sends are failing in the QA environment with the following stack trace: [exception.txt](https://github.com/user-attachments/files/19510932/exception.txt). This isn't occurring locally using the `MailCatcher` instance so I'm not positive on the root cause.

The documentation/forums I could read pointed towards one of two things:
- Handlebars doesn't like `IEnumerable`
  - Easy enough, I converted the AdminOwnerEmails to List rather than IEnumerable: https://github.com/bitwarden/server/commit/b764da2ea61fd435bddadad8fa4815ffc80770b1
- Handlebars serializing the complex type to JSON. This would make sense to me and the error message in the exception. I added logic to check for a JSON element and enumerate it to get the emails back: https://github.com/bitwarden/server/commit/721926ddbe5531bedd13bb9570125b2d45a5e190

### Testing

@bitwarden/team-vault-dev - I'm not able to recreate this locally and cannot point my local server to the QA permissions. Would anyone be able to help me test on this feature branch to verify the change before I go back to QA with it? (if that is possible)

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14406]: https://bitwarden.atlassian.net/browse/PM-14406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ