### PR TITLE
Complete feature flag grouping by team

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -154,7 +154,7 @@ public static class FeatureFlagKeys
     public const string PrivateKeyRegeneration = "pm-12241-private-key-regeneration";
     public const string Argon2Default = "argon2-default";
     public const string UserkeyRotationV2 = "userkey-rotation-v2";
-    
+
     /* Mobile Team */
     public const string NativeCarouselFlow = "native-carousel-flow";
     public const string NativeCreateAccountFlow = "native-create-account-flow";
@@ -192,7 +192,7 @@ public static class FeatureFlagKeys
     public const string RestrictProviderAccess = "restrict-provider-access";
     public const string SecurityTasks = "security-tasks";
     public const string SSHKeyItemVaultItem = "ssh-key-vault-item";
-    public const string CipherKeyEncryption = "cipher-key-encryption";  
+    public const string CipherKeyEncryption = "cipher-key-encryption";
 
     public static List<string> GetAllKeys()
     {

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -108,7 +108,8 @@ public static class FeatureFlagKeys
     public const string LimitItemDeletion = "pm-15493-restrict-item-deletion-to-can-manage-permission";
     public const string PushSyncOrgKeysOnRevokeRestore = "pm-17168-push-sync-org-keys-on-revoke-restore";
     public const string PolicyRequirements = "pm-14439-policy-requirements";
-    public const string SsoExternalIdVisibility = "pm-18630-sso-external-id-visibility";
+       public const string SsoExternalIdVisibility = "pm-18630-sso-external-id-visibility";
+
 
     /* Tools Team */
     public const string ItemShare = "item-share";
@@ -128,66 +129,87 @@ public static class FeatureFlagKeys
 
     /* Auth Team */
     public const string PM9112DeviceApprovalPersistence = "pm-9112-device-approval-persistence";
-
-    /* Key Management Team */
-    public const string SSHKeyItemVaultItem = "ssh-key-vault-item";
-    public const string SSHAgent = "ssh-agent";
-    public const string SSHVersionCheckQAOverride = "ssh-version-check-qa-override";
-    public const string Argon2Default = "argon2-default";
-    public const string PM4154BulkEncryptionService = "PM-4154-bulk-encryption-service";
-    public const string PrivateKeyRegeneration = "pm-12241-private-key-regeneration";
-    public const string UserkeyRotationV2 = "userkey-rotation-v2";
-
-    /* Unsorted */
-    public const string ReturnErrorOnExistingKeypair = "return-error-on-existing-keypair";
-    public const string UseTreeWalkerApiForPageDetailsCollection = "use-tree-walker-api-for-page-details-collection";
     public const string DuoRedirect = "duo-redirect";
-    public const string AC2101UpdateTrialInitiationEmail = "AC-2101-update-trial-initiation-email";
     public const string EmailVerification = "email-verification";
     public const string EmailVerificationDisableTimingDelays = "email-verification-disable-timing-delays";
-    public const string InlineMenuFieldQualification = "inline-menu-field-qualification";
-    public const string InlineMenuPositioningImprovements = "inline-menu-positioning-improvements";
     public const string DeviceTrustLogging = "pm-8285-device-trust-logging";
     public const string AuthenticatorTwoFactorToken = "authenticator-2fa-token";
     public const string IdpAutoSubmitLogin = "idp-auto-submit-login";
     public const string UnauthenticatedExtensionUIRefresh = "unauth-ui-refresh";
+    public const string NewDeviceVerification = "new-device-verification";
+    public const string SetInitialPasswordRefactor = "pm-16117-set-initial-password-refactor";
+    public const string ChangeExistingPasswordRefactor = "pm-16117-change-existing-password-refactor";
+    public const string RecoveryCodeLogin = "pm-17128-recovery-code-login";
+
+    /* Autofill Team */
+    public const string UseTreeWalkerApiForPageDetailsCollection = "use-tree-walker-api-for-page-details-collection";
+    public const string InlineMenuFieldQualification = "inline-menu-field-qualification";
+    public const string InlineMenuPositioningImprovements = "inline-menu-positioning-improvements";
+    public const string SSHAgent = "ssh-agent";
+    public const string SSHVersionCheckQAOverride = "ssh-version-check-qa-override";
     public const string GenerateIdentityFillScriptRefactor = "generate-identity-fill-script-refactor";
     public const string DelayFido2PageScriptInitWithinMv2 = "delay-fido2-page-script-init-within-mv2";
-    public const string NativeCarouselFlow = "native-carousel-flow";
-    public const string NativeCreateAccountFlow = "native-create-account-flow";
     public const string NotificationBarAddLoginImprovements = "notification-bar-add-login-improvements";
     public const string BlockBrowserInjectionsByDomain = "block-browser-injections-by-domain";
     public const string NotificationRefresh = "notification-refresh";
-    public const string PersistPopupView = "persist-popup-view";
-    public const string CipherKeyEncryption = "cipher-key-encryption";
     public const string EnableNewCardCombinedExpiryAutofill = "enable-new-card-combined-expiry-autofill";
-    public const string StorageReseedRefactor = "storage-reseed-refactor";
-    public const string TrialPayment = "PM-8163-trial-payment";
-    public const string GeneratorToolsModernization = "generator-tools-modernization";
-    public const string NewDeviceVerification = "new-device-verification";
     public const string MacOsNativeCredentialSync = "macos-native-credential-sync";
     public const string InlineMenuTotp = "inline-menu-totp";
-    public const string AppReviewPrompt = "app-review-prompt";
+
+    /* Billing Team */
+    public const string AC2101UpdateTrialInitiationEmail = "AC-2101-update-trial-initiation-email";
+    public const string TrialPayment = "PM-8163-trial-payment";
     public const string ResellerManagedOrgAlert = "PM-15814-alert-owners-of-reseller-managed-orgs";
     public const string UsePricingService = "use-pricing-service";
-    public const string RecordInstallationLastActivityDate = "installation-last-activity-date";
+    public const string P15179_AddExistingOrgsFromProviderPortal = "pm-15179-add-existing-orgs-from-provider-portal";
+    public const string PM12276Breadcrumbing = "pm-12276-breadcrumbing-for-business-features";
+    public const string PM18794_ProviderPaymentMethod = "pm-18794-provider-payment-method";
+
+    /* Key Management Team */
+    public const string ReturnErrorOnExistingKeypair = "return-error-on-existing-keypair";
+    public const string PM4154BulkEncryptionService = "PM-4154-bulk-encryption-service";
+    public const string PrivateKeyRegeneration = "pm-12241-private-key-regeneration";
+    public const string Argon2Default = "argon2-default";
+    public const string UserkeyRotationV2 = "userkey-rotation-v2";
+    
+    /* Mobile Team */
+    public const string NativeCarouselFlow = "native-carousel-flow";
+    public const string NativeCreateAccountFlow = "native-create-account-flow";
+    public const string AndroidImportLoginsFlow = "import-logins-flow";
+    public const string AppReviewPrompt = "app-review-prompt";
     public const string EnablePasswordManagerSyncAndroid = "enable-password-manager-sync-android";
     public const string EnablePasswordManagerSynciOS = "enable-password-manager-sync-ios";
-    public const string AccountDeprovisioningBanner = "pm-17120-account-deprovisioning-admin-console-banner";
+    public const string AndroidMutualTls = "mutual-tls";
     public const string SingleTapPasskeyCreation = "single-tap-passkey-creation";
     public const string SingleTapPasskeyAuthentication = "single-tap-passkey-authentication";
     public const string EnablePMAuthenticatorSync = "enable-pm-bwa-sync";
-    public const string P15179_AddExistingOrgsFromProviderPortal = "pm-15179-add-existing-orgs-from-provider-portal";
-    public const string AndroidMutualTls = "mutual-tls";
-    public const string RecoveryCodeLogin = "pm-17128-recovery-code-login";
     public const string PM3503_MobileAnonAddySelfHostAlias = "anon-addy-self-host-alias";
-    public const string WebPush = "web-push";
-    public const string AndroidImportLoginsFlow = "import-logins-flow";
-    public const string PM12276Breadcrumbing = "pm-12276-breadcrumbing-for-business-features";
-    public const string PM18794_ProviderPaymentMethod = "pm-18794-provider-payment-method";
     public const string PM3553_MobileSimpleLoginSelfHostAlias = "simple-login-self-host-alias";
-    public const string SetInitialPasswordRefactor = "pm-16117-set-initial-password-refactor";
-    public const string ChangeExistingPasswordRefactor = "pm-16117-change-existing-password-refactor";
+
+    /* Platform Team */
+    public const string PersistPopupView = "persist-popup-view";
+    public const string StorageReseedRefactor = "storage-reseed-refactor";
+    public const string WebPush = "web-push";
+    public const string RecordInstallationLastActivityDate = "installation-last-activity-date";
+
+    /* Tools Team */
+    public const string ItemShare = "item-share";
+    public const string RiskInsightsCriticalApplication = "pm-14466-risk-insights-critical-application";
+    public const string EnableRiskInsightsNotifications = "enable-risk-insights-notifications";
+    public const string DesktopSendUIRefresh = "desktop-send-ui-refresh";
+    public const string ExportAttachments = "export-attachments";
+    public const string GeneratorToolsModernization = "generator-tools-modernization";
+
+    /* Vault Team */
+    public const string PM8851_BrowserOnboardingNudge = "pm-8851-browser-onboarding-nudge";
+    public const string PM9111ExtensionPersistAddEditForm = "pm-9111-extension-persist-add-edit-form";
+    public const string NewDeviceVerificationPermanentDismiss = "new-device-permanent-dismiss";
+    public const string NewDeviceVerificationTemporaryDismiss = "new-device-temporary-dismiss";
+    public const string VaultBulkManagementAction = "vault-bulk-management-action";
+    public const string RestrictProviderAccess = "restrict-provider-access";
+    public const string SecurityTasks = "security-tasks";
+    public const string SSHKeyItemVaultItem = "ssh-key-vault-item";
+    public const string CipherKeyEncryption = "cipher-key-encryption";  
 
     public static List<string> GetAllKeys()
     {

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -117,7 +117,6 @@ public static class FeatureFlagKeys
     public const string EmailVerificationDisableTimingDelays = "email-verification-disable-timing-delays";
     public const string DeviceTrustLogging = "pm-8285-device-trust-logging";
     public const string AuthenticatorTwoFactorToken = "authenticator-2fa-token";
-    public const string IdpAutoSubmitLogin = "idp-auto-submit-login";
     public const string UnauthenticatedExtensionUIRefresh = "unauth-ui-refresh";
     public const string NewDeviceVerification = "new-device-verification";
     public const string SetInitialPasswordRefactor = "pm-16117-set-initial-password-refactor";
@@ -125,6 +124,7 @@ public static class FeatureFlagKeys
     public const string RecoveryCodeLogin = "pm-17128-recovery-code-login";
 
     /* Autofill Team */
+    public const string IdpAutoSubmitLogin = "idp-auto-submit-login";
     public const string UseTreeWalkerApiForPageDetailsCollection = "use-tree-walker-api-for-page-details-collection";
     public const string InlineMenuFieldQualification = "inline-menu-field-qualification";
     public const string InlineMenuPositioningImprovements = "inline-menu-positioning-improvements";

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -108,24 +108,7 @@ public static class FeatureFlagKeys
     public const string LimitItemDeletion = "pm-15493-restrict-item-deletion-to-can-manage-permission";
     public const string PushSyncOrgKeysOnRevokeRestore = "pm-17168-push-sync-org-keys-on-revoke-restore";
     public const string PolicyRequirements = "pm-14439-policy-requirements";
-       public const string SsoExternalIdVisibility = "pm-18630-sso-external-id-visibility";
-
-
-    /* Tools Team */
-    public const string ItemShare = "item-share";
-    public const string RiskInsightsCriticalApplication = "pm-14466-risk-insights-critical-application";
-    public const string EnableRiskInsightsNotifications = "enable-risk-insights-notifications";
-    public const string DesktopSendUIRefresh = "desktop-send-ui-refresh";
-    public const string ExportAttachments = "export-attachments";
-
-    /* Vault Team */
-    public const string PM8851_BrowserOnboardingNudge = "pm-8851-browser-onboarding-nudge";
-    public const string PM9111ExtensionPersistAddEditForm = "pm-9111-extension-persist-add-edit-form";
-    public const string NewDeviceVerificationPermanentDismiss = "new-device-permanent-dismiss";
-    public const string NewDeviceVerificationTemporaryDismiss = "new-device-temporary-dismiss";
-    public const string VaultBulkManagementAction = "vault-bulk-management-action";
-    public const string RestrictProviderAccess = "restrict-provider-access";
-    public const string SecurityTasks = "security-tasks";
+    public const string SsoExternalIdVisibility = "pm-18630-sso-external-id-visibility";
 
     /* Auth Team */
     public const string PM9112DeviceApprovalPersistence = "pm-9112-device-approval-persistence";

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -154,6 +154,7 @@ public static class FeatureFlagKeys
     public const string PrivateKeyRegeneration = "pm-12241-private-key-regeneration";
     public const string Argon2Default = "argon2-default";
     public const string UserkeyRotationV2 = "userkey-rotation-v2";
+    public const string SSHKeyItemVaultItem = "ssh-key-vault-item";
 
     /* Mobile Team */
     public const string NativeCarouselFlow = "native-carousel-flow";
@@ -191,7 +192,6 @@ public static class FeatureFlagKeys
     public const string VaultBulkManagementAction = "vault-bulk-management-action";
     public const string RestrictProviderAccess = "restrict-provider-access";
     public const string SecurityTasks = "security-tasks";
-    public const string SSHKeyItemVaultItem = "ssh-key-vault-item";
     public const string CipherKeyEncryption = "cipher-key-encryption";
 
     public static List<string> GetAllKeys()


### PR DESCRIPTION
## 📔 Objective

Completed the grouping of feature flags started in https://github.com/bitwarden/server/pull/5309, moving the rest into their owning teams.

I verified that the same 72 feature flags exist both before and after the re-ordering.

See https://github.com/bitwarden/clients/pull/14054 for corresponding work on clients.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
