### PR TITLE
[PM-18858] Security Task email plurality

### DIFF
--- a/src/Core/MailTemplates/Handlebars/Layouts/SecurityTasks.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/Layouts/SecurityTasks.html.hbs
@@ -6,11 +6,8 @@
       <table border="0" cellpadding="0" cellspacing="0" width="100%"
         style="padding-left:30px; padding-right: 5px; padding-top: 20px;">
         <tr>
-          <td
-            style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 24px; color: #ffffff; line-height: 32px; font-weight: 500; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
-            {{OrgName}} has identified {{TaskCount}} critical login{{#if TaskCountPlural}}s{{/if}} that require{{#unless
-            TaskCountPlural}}s{{/unless}} a
-            password change
+          <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 24px; color: #ffffff; line-height: 32px; font-weight: 500; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+            {{OrgName}} has identified {{TaskCount}} critical {{plurality TaskCount "login" "logins"}} that {{plurality TaskCount "requires" "require"}} a password change
           </td>
         </tr>
       </table>

--- a/src/Core/MailTemplates/Handlebars/Layouts/SecurityTasks.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/Layouts/SecurityTasks.text.hbs
@@ -1,7 +1,5 @@
 ﻿{{#>FullTextLayout}}
-{{OrgName}} has identified {{TaskCount}} critical login{{#if TaskCountPlural}}s{{/if}} that require{{#unless
-TaskCountPlural}}s{{/unless}} a
-password change
+{{OrgName}} has identified {{TaskCount}} critical {{plurality TaskCount "login" "logins"}} that {{plurality TaskCount "requires" "require"}} a password change
 
 {{>@partial-block}}
 

--- a/src/Core/Models/Mail/SecurityTaskNotificationViewModel.cs
+++ b/src/Core/Models/Mail/SecurityTaskNotificationViewModel.cs
@@ -6,8 +6,6 @@ public class SecurityTaskNotificationViewModel : BaseMailModel
 
     public int TaskCount { get; set; }
 
-    public bool TaskCountPlural => TaskCount != 1;
-
     public List<string> AdminOwnerEmails { get; set; }
 
     public string ReviewPasswordsUrl => $"{WebVaultUrl}/browser-extension-prompt";

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -794,6 +794,29 @@ public class HandlebarsMailService : IMailService
 
             writer.WriteSafeString($"{outputMessage}");
         });
+
+        // Returns the singular or plural form of a word based on the provided numeric value.
+        Handlebars.RegisterHelper("plurality", (writer, context, parameters) =>
+        {
+            if (parameters.Length != 3)
+            {
+                writer.WriteSafeString(string.Empty);
+                return;
+            }
+
+            var numeric = parameters[0];
+            var singularText = parameters[1].ToString();
+            var pluralText = parameters[2].ToString();
+
+            if (numeric is int number)
+            {
+                writer.WriteSafeString(number == 1 ? singularText : pluralText);
+            }
+            else
+            {
+                writer.WriteSafeString(string.Empty);
+            }
+        });
     }
 
     public async Task SendEmergencyAccessInviteEmailAsync(EmergencyAccess emergencyAccess, string name, string token)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18858](https://bitwarden.atlassian.net/browse/PM-18858)

## 📔 Objective

Kyra was able to recreate an issue when a single task was created the verbiage would still be plural. After trying to figure out why, I came across [this issue](https://github.com/Handlebars-Net/Handlebars.Net/issues/594) where handlebars can interrupt `"False"` as truthy like JS does.

To remediate, I moved the logic from the template to the a helper function so C# can handle the logic and decide the plurality. 

@bitwarden/team-vault-dev - When reviewing, could this be tested against the QA environment? I do not have permissions to do that. 

## 📸 Screenshots

|Kyra's screenshot|My local - single|My local - plural|
|-|-|-|
|<img width="635" alt="Screenshot 2025-04-01 at 10 45 14 AM" src="https://github.com/user-attachments/assets/9f902a9e-a19b-4c8a-aa65-35976fbdee5d" />|<img width="672" alt="Screenshot 2025-04-01 at 10 32 55 AM" src="https://github.com/user-attachments/assets/f15330b1-5968-4227-83ef-f98b1e8c0fbc" />|<img width="656" alt="Screenshot 2025-04-01 at 10 33 14 AM" src="https://github.com/user-attachments/assets/6d81af5f-bafe-4b93-87da-d4d9bfc93a63" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18858]: https://bitwarden.atlassian.net/browse/PM-18858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ