### PR TITLE
[PM-17562] Add Dapper and EF Repositories For Ogranization Integrations and Configurations

### DIFF
--- a/src/Core/AdminConsole/Models/Data/Organizations/OrganizationIntegrationConfigurationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Organizations/OrganizationIntegrationConfigurationDetails.cs
@@ -36,7 +36,7 @@ public class OrganizationIntegrationConfigurationDetails
         {
             try
             {
-                var configuration = Configuration ?? "{}";
+                var configuration = Configuration ?? string.Empty;
                 return JsonNode.Parse(configuration) as JsonObject ?? new JsonObject();
             }
             catch
@@ -52,7 +52,7 @@ public class OrganizationIntegrationConfigurationDetails
         {
             try
             {
-                var integration = IntegrationConfiguration ?? "{}";
+                var integration = IntegrationConfiguration ?? string.Empty;
                 return JsonNode.Parse(integration) as JsonObject ?? new JsonObject();
             }
             catch

--- a/src/Core/AdminConsole/Models/Data/Organizations/OrganizationIntegrationConfigurationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Organizations/OrganizationIntegrationConfigurationDetails.cs
@@ -1,0 +1,64 @@
+﻿using System.Text.Json.Nodes;
+using Bit.Core.Enums;
+
+#nullable enable
+
+namespace Bit.Core.Models.Data.Organizations;
+
+public class OrganizationIntegrationConfigurationDetails
+{
+    public Guid Id { get; set; }
+    public Guid OrganizationIntegrationId { get; set; }
+    public IntegrationType IntegrationType { get; set; }
+    public EventType EventType { get; set; }
+    public string? Configuration { get; set; }
+    public string? IntegrationConfiguration { get; set; }
+    public string? Template { get; set; }
+
+    public JsonObject MergedConfiguration
+    {
+        get
+        {
+            var integrationJson = IntegrationConfigurationJson;
+
+            foreach (var kvp in ConfigurationJson)
+            {
+                integrationJson[kvp.Key] = kvp.Value?.DeepClone();
+            }
+
+            return integrationJson;
+        }
+    }
+
+    private JsonObject ConfigurationJson
+    {
+        get
+        {
+            try
+            {
+                var configuration = Configuration ?? "{}";
+                return JsonNode.Parse(configuration) as JsonObject ?? new JsonObject();
+            }
+            catch
+            {
+                return new JsonObject();
+            }
+        }
+    }
+
+    private JsonObject IntegrationConfigurationJson
+    {
+        get
+        {
+            try
+            {
+                var integration = IntegrationConfiguration ?? "{}";
+                return JsonNode.Parse(integration) as JsonObject ?? new JsonObject();
+            }
+            catch
+            {
+                return new JsonObject();
+            }
+        }
+    }
+}

--- a/src/Core/AdminConsole/Repositories/IOrganizationIntegrationConfigurationRepository.cs
+++ b/src/Core/AdminConsole/Repositories/IOrganizationIntegrationConfigurationRepository.cs
@@ -1,0 +1,13 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data.Organizations;
+
+namespace Bit.Core.Repositories;
+
+public interface IOrganizationIntegrationConfigurationRepository : IRepository<OrganizationIntegrationConfiguration, Guid>
+{
+    Task<List<OrganizationIntegrationConfigurationDetails>> GetConfigurationsAsync(
+        Guid organizationId,
+        IntegrationType integrationType,
+        EventType eventType);
+}

--- a/src/Core/AdminConsole/Repositories/IOrganizationIntegrationConfigurationRepository.cs
+++ b/src/Core/AdminConsole/Repositories/IOrganizationIntegrationConfigurationRepository.cs
@@ -6,7 +6,7 @@ namespace Bit.Core.Repositories;
 
 public interface IOrganizationIntegrationConfigurationRepository : IRepository<OrganizationIntegrationConfiguration, Guid>
 {
-    Task<List<OrganizationIntegrationConfigurationDetails>> GetConfigurationsAsync(
+    Task<List<OrganizationIntegrationConfigurationDetails>> GetConfigurationDetailsAsync(
         Guid organizationId,
         IntegrationType integrationType,
         EventType eventType);

--- a/src/Core/AdminConsole/Repositories/IOrganizationIntegrationRepository.cs
+++ b/src/Core/AdminConsole/Repositories/IOrganizationIntegrationRepository.cs
@@ -1,0 +1,7 @@
+﻿using Bit.Core.AdminConsole.Entities;
+
+namespace Bit.Core.Repositories;
+
+public interface IOrganizationIntegrationRepository : IRepository<OrganizationIntegration, Guid>
+{
+}

--- a/src/Infrastructure.Dapper/AdminConsole/Repositories/OrganizationIntegrationConfigurationRepository.cs
+++ b/src/Infrastructure.Dapper/AdminConsole/Repositories/OrganizationIntegrationConfigurationRepository.cs
@@ -20,7 +20,7 @@ public class OrganizationIntegrationConfigurationRepository : Repository<Organiz
         : base(connectionString, readOnlyConnectionString)
     { }
 
-    public async Task<List<OrganizationIntegrationConfigurationDetails>> GetConfigurationsAsync(
+    public async Task<List<OrganizationIntegrationConfigurationDetails>> GetConfigurationDetailsAsync(
         Guid organizationId,
         IntegrationType integrationType,
         EventType eventType)

--- a/src/Infrastructure.Dapper/AdminConsole/Repositories/OrganizationIntegrationConfigurationRepository.cs
+++ b/src/Infrastructure.Dapper/AdminConsole/Repositories/OrganizationIntegrationConfigurationRepository.cs
@@ -1,0 +1,43 @@
+﻿using System.Data;
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data.Organizations;
+using Bit.Core.Repositories;
+using Bit.Core.Settings;
+using Bit.Infrastructure.Dapper.Repositories;
+using Dapper;
+using Microsoft.Data.SqlClient;
+
+namespace Bit.Infrastructure.Dapper.AdminConsole.Repositories;
+
+public class OrganizationIntegrationConfigurationRepository : Repository<OrganizationIntegrationConfiguration, Guid>, IOrganizationIntegrationConfigurationRepository
+{
+    public OrganizationIntegrationConfigurationRepository(GlobalSettings globalSettings)
+        : this(globalSettings.SqlServer.ConnectionString, globalSettings.SqlServer.ReadOnlyConnectionString)
+    { }
+
+    public OrganizationIntegrationConfigurationRepository(string connectionString, string readOnlyConnectionString)
+        : base(connectionString, readOnlyConnectionString)
+    { }
+
+    public async Task<List<OrganizationIntegrationConfigurationDetails>> GetConfigurationsAsync(
+        Guid organizationId,
+        IntegrationType integrationType,
+        EventType eventType)
+    {
+        using (var connection = new SqlConnection(ConnectionString))
+        {
+            var results = await connection.QueryAsync<OrganizationIntegrationConfigurationDetails>(
+                "[dbo].[OrganizationIntegrationConfigurationDetails_ReadManyByEventTypeOrganizationIdIntegrationType]",
+                new
+                {
+                    EventType = eventType,
+                    OrganizationId = organizationId,
+                    IntegrationType = integrationType
+                },
+                commandType: CommandType.StoredProcedure);
+
+            return results.ToList();
+        }
+    }
+}

--- a/src/Infrastructure.Dapper/AdminConsole/Repositories/OrganizationIntegrationRepository.cs
+++ b/src/Infrastructure.Dapper/AdminConsole/Repositories/OrganizationIntegrationRepository.cs
@@ -1,0 +1,16 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.Repositories;
+using Bit.Core.Settings;
+
+namespace Bit.Infrastructure.Dapper.Repositories;
+
+public class OrganizationIntegrationRepository : Repository<OrganizationIntegration, Guid>, IOrganizationIntegrationRepository
+{
+    public OrganizationIntegrationRepository(GlobalSettings globalSettings)
+        : this(globalSettings.SqlServer.ConnectionString, globalSettings.SqlServer.ReadOnlyConnectionString)
+    { }
+
+    public OrganizationIntegrationRepository(string connectionString, string readOnlyConnectionString)
+        : base(connectionString, readOnlyConnectionString)
+    { }
+}

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationIntegrationConfigurationRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationIntegrationConfigurationRepository.cs
@@ -1,0 +1,33 @@
+﻿using AutoMapper;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data.Organizations;
+using Bit.Core.Repositories;
+using Bit.Infrastructure.EntityFramework.AdminConsole.Models;
+using Bit.Infrastructure.EntityFramework.Repositories;
+using Bit.Infrastructure.EntityFramework.Repositories.Queries;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bit.Infrastructure.EntityFramework.AdminConsole.Repositories;
+
+public class OrganizationIntegrationConfigurationRepository : Repository<Core.AdminConsole.Entities.OrganizationIntegrationConfiguration, OrganizationIntegrationConfiguration, Guid>, IOrganizationIntegrationConfigurationRepository
+{
+    public OrganizationIntegrationConfigurationRepository(IServiceScopeFactory serviceScopeFactory, IMapper mapper)
+        : base(serviceScopeFactory, mapper, context => context.OrganizationIntegrationConfigurations)
+    { }
+
+    public async Task<List<OrganizationIntegrationConfigurationDetails>> GetConfigurationsAsync(
+        Guid organizationId,
+        IntegrationType integrationType,
+        EventType eventType)
+    {
+        using (var scope = ServiceScopeFactory.CreateScope())
+        {
+            var dbContext = GetDatabaseContext(scope);
+            var query = new OrganizationIntegrationConfigurationDetailsReadManyByEventTypeOrganizationIdIntegrationTypeQuery(
+                organizationId, eventType, integrationType
+                );
+            return await query.Run(dbContext).ToListAsync();
+        }
+    }
+}

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationIntegrationConfigurationRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationIntegrationConfigurationRepository.cs
@@ -16,7 +16,7 @@ public class OrganizationIntegrationConfigurationRepository : Repository<Core.Ad
         : base(serviceScopeFactory, mapper, context => context.OrganizationIntegrationConfigurations)
     { }
 
-    public async Task<List<OrganizationIntegrationConfigurationDetails>> GetConfigurationsAsync(
+    public async Task<List<OrganizationIntegrationConfigurationDetails>> GetConfigurationDetailsAsync(
         Guid organizationId,
         IntegrationType integrationType,
         EventType eventType)

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationIntegrationRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationIntegrationRepository.cs
@@ -1,0 +1,14 @@
+﻿using AutoMapper;
+using Bit.Core.Repositories;
+using Bit.Infrastructure.EntityFramework.AdminConsole.Models;
+using Bit.Infrastructure.EntityFramework.Repositories;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bit.Infrastructure.EntityFramework.AdminConsole.Repositories;
+
+public class OrganizationIntegrationRepository : Repository<Core.AdminConsole.Entities.OrganizationIntegration, OrganizationIntegration, Guid>, IOrganizationIntegrationRepository
+{
+    public OrganizationIntegrationRepository(IServiceScopeFactory serviceScopeFactory, IMapper mapper)
+        : base(serviceScopeFactory, mapper, (DatabaseContext context) => context.OrganizationIntegrations)
+    { }
+}

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/OrganizationIntegrationConfigurationDetailsReadManyByEventTypeOrganizationIdIntegrationTypeQuery.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/OrganizationIntegrationConfigurationDetailsReadManyByEventTypeOrganizationIdIntegrationTypeQuery.cs
@@ -1,0 +1,39 @@
+﻿using Bit.Core.Enums;
+using Bit.Core.Models.Data.Organizations;
+
+namespace Bit.Infrastructure.EntityFramework.Repositories.Queries;
+
+public class OrganizationIntegrationConfigurationDetailsReadManyByEventTypeOrganizationIdIntegrationTypeQuery : IQuery<OrganizationIntegrationConfigurationDetails>
+{
+    private readonly Guid _organizationId;
+    private readonly EventType _eventType;
+    private readonly IntegrationType _integrationType;
+
+    public OrganizationIntegrationConfigurationDetailsReadManyByEventTypeOrganizationIdIntegrationTypeQuery(Guid organizationId, EventType eventType, IntegrationType integrationType)
+    {
+        _organizationId = organizationId;
+        _eventType = eventType;
+        _integrationType = integrationType;
+    }
+
+    public IQueryable<OrganizationIntegrationConfigurationDetails> Run(DatabaseContext dbContext)
+    {
+        var query = from oic in dbContext.OrganizationIntegrationConfigurations
+                    join oi in dbContext.OrganizationIntegrations on oic.OrganizationIntegrationId equals oi.Id into oioic
+                    from oi in dbContext.OrganizationIntegrations
+                    where oi.OrganizationId == _organizationId &&
+                          oi.Type == _integrationType &&
+                          oic.EventType == _eventType
+                    select new OrganizationIntegrationConfigurationDetails()
+                    {
+                        Id = oic.Id,
+                        OrganizationIntegrationId = oic.OrganizationIntegrationId,
+                        IntegrationType = oi.Type,
+                        EventType = oic.EventType,
+                        Configuration = oic.Configuration,
+                        IntegrationConfiguration = oi.Configuration,
+                        Template = oic.Template
+                    };
+        return query;
+    }
+}

--- a/src/Infrastructure.EntityFramework/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/Infrastructure.EntityFramework/EntityFrameworkServiceCollectionExtensions.cs
@@ -78,6 +78,8 @@ public static class EntityFrameworkServiceCollectionExtensions
         services.AddSingleton<IMaintenanceRepository, MaintenanceRepository>();
         services.AddSingleton<IOrganizationApiKeyRepository, OrganizationApiKeyRepository>();
         services.AddSingleton<IOrganizationConnectionRepository, OrganizationConnectionRepository>();
+        services.AddSingleton<IOrganizationIntegrationRepository, OrganizationIntegrationRepository>();
+        services.AddSingleton<IOrganizationIntegrationConfigurationRepository, OrganizationIntegrationConfigurationRepository>();
         services.AddSingleton<IOrganizationRepository, OrganizationRepository>();
         services.AddSingleton<IOrganizationSponsorshipRepository, OrganizationSponsorshipRepository>();
         services.AddSingleton<IOrganizationUserRepository, OrganizationUserRepository>();

--- a/src/Infrastructure.EntityFramework/Repositories/DatabaseContext.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/DatabaseContext.cs
@@ -55,6 +55,8 @@ public class DatabaseContext : DbContext
     public DbSet<OrganizationApiKey> OrganizationApiKeys { get; set; }
     public DbSet<OrganizationSponsorship> OrganizationSponsorships { get; set; }
     public DbSet<OrganizationConnection> OrganizationConnections { get; set; }
+    public DbSet<OrganizationIntegration> OrganizationIntegrations { get; set; }
+    public DbSet<OrganizationIntegrationConfiguration> OrganizationIntegrationConfigurations { get; set; }
     public DbSet<OrganizationUser> OrganizationUsers { get; set; }
     public DbSet<Policy> Policies { get; set; }
     public DbSet<Provider> Providers { get; set; }

--- a/test/Core.Test/AdminConsole/Models/Data/Organizations/OrganizationIntegrationConfigurationDetailsTests.cs
+++ b/test/Core.Test/AdminConsole/Models/Data/Organizations/OrganizationIntegrationConfigurationDetailsTests.cs
@@ -7,7 +7,7 @@ namespace Bit.Core.Test.Models.Data.Organizations;
 public class OrganizationIntegrationConfigurationDetailsTests
 {
     [Fact]
-    public void MergedConfiguration_BothHaveValues()
+    public void MergedConfiguration_WithValidConfigAndIntegration_ReturnsMergedJson()
     {
         var config = new { config = "A new config value" };
         var integration = new { integration = "An integration value" };
@@ -23,7 +23,7 @@ public class OrganizationIntegrationConfigurationDetailsTests
     }
 
     [Fact]
-    public void MergedConfiguration_BothNotJson()
+    public void MergedConfiguration_WithInvalidJsonConfigAndIntegration_ReturnsEmptyJson()
     {
         var expectedObj = new { };
         var expected = JsonSerializer.Serialize(expectedObj);
@@ -37,7 +37,7 @@ public class OrganizationIntegrationConfigurationDetailsTests
     }
 
     [Fact]
-    public void MergedConfiguration_BothNull()
+    public void MergedConfiguration_WithNullConfigAndIntegration_ReturnsEmptyJson()
     {
         var expectedObj = new { };
         var expected = JsonSerializer.Serialize(expectedObj);
@@ -51,7 +51,7 @@ public class OrganizationIntegrationConfigurationDetailsTests
     }
 
     [Fact]
-    public void MergedConfiguration_ConfigNull()
+    public void MergedConfiguration_WithValidIntegrationAndNullConfig_ReturnsIntegrationJson()
     {
         var integration = new { integration = "An integration value" };
         var expectedObj = new { integration = "An integration value" };
@@ -66,7 +66,7 @@ public class OrganizationIntegrationConfigurationDetailsTests
     }
 
     [Fact]
-    public void MergedConfiguration_IntegrationNull()
+    public void MergedConfiguration_WithValidConfigAndNullIntegration_ReturnsConfigJson()
     {
         var config = new { config = "A new config value" };
         var expectedObj = new { config = "A new config value" };

--- a/test/Core.Test/AdminConsole/Models/Data/Organizations/OrganizationIntegrationConfigurationDetailsTests.cs
+++ b/test/Core.Test/AdminConsole/Models/Data/Organizations/OrganizationIntegrationConfigurationDetailsTests.cs
@@ -1,0 +1,82 @@
+﻿using System.Text.Json;
+using Bit.Core.Models.Data.Organizations;
+using Xunit;
+
+namespace Bit.Core.Test.Models.Data.Organizations;
+
+public class OrganizationIntegrationConfigurationDetailsTests
+{
+    [Fact]
+    public void MergedConfiguration_BothHaveValues()
+    {
+        var config = new { config = "A new config value" };
+        var integration = new { integration = "An integration value" };
+        var expectedObj = new { integration = "An integration value", config = "A new config value" };
+        var expected = JsonSerializer.Serialize(expectedObj);
+
+        var sut = new OrganizationIntegrationConfigurationDetails();
+        sut.Configuration = JsonSerializer.Serialize(config);
+        sut.IntegrationConfiguration = JsonSerializer.Serialize(integration);
+
+        var result = sut.MergedConfiguration;
+        Assert.Equal(expected, result.ToJsonString());
+    }
+
+    [Fact]
+    public void MergedConfiguration_BothNotJson()
+    {
+        var expectedObj = new { };
+        var expected = JsonSerializer.Serialize(expectedObj);
+
+        var sut = new OrganizationIntegrationConfigurationDetails();
+        sut.Configuration = "Not JSON";
+        sut.IntegrationConfiguration = "Not JSON";
+
+        var result = sut.MergedConfiguration;
+        Assert.Equal(expected, result.ToJsonString());
+    }
+
+    [Fact]
+    public void MergedConfiguration_BothNull()
+    {
+        var expectedObj = new { };
+        var expected = JsonSerializer.Serialize(expectedObj);
+
+        var sut = new OrganizationIntegrationConfigurationDetails();
+        sut.Configuration = null;
+        sut.IntegrationConfiguration = null;
+
+        var result = sut.MergedConfiguration;
+        Assert.Equal(expected, result.ToJsonString());
+    }
+
+    [Fact]
+    public void MergedConfiguration_ConfigNull()
+    {
+        var integration = new { integration = "An integration value" };
+        var expectedObj = new { integration = "An integration value" };
+        var expected = JsonSerializer.Serialize(expectedObj);
+
+        var sut = new OrganizationIntegrationConfigurationDetails();
+        sut.Configuration = null;
+        sut.IntegrationConfiguration = JsonSerializer.Serialize(integration);
+
+        var result = sut.MergedConfiguration;
+        Assert.Equal(expected, result.ToJsonString());
+    }
+
+    [Fact]
+    public void MergedConfiguration_IntegrationNull()
+    {
+        var config = new { config = "A new config value" };
+        var expectedObj = new { config = "A new config value" };
+        var expected = JsonSerializer.Serialize(expectedObj);
+
+        var sut = new OrganizationIntegrationConfigurationDetails();
+        sut.Configuration = JsonSerializer.Serialize(config);
+        sut.IntegrationConfiguration = null;
+
+        var result = sut.MergedConfiguration;
+        Assert.Equal(expected, result.ToJsonString());
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17562](https://bitwarden.atlassian.net/browse/PM-17562)

## 📔 Objective

This builds on the database PRs that @withinfocus put up earlier (#5553 and #5568) and adds Dapper and EF repositories for working with `OrganizationIntegration` and `OrganizationIntegrationConfigurations`. These allow us to configure custom actions that will occur when a specific Event fires (e.g. message Slack, hit a web hook, etc). 

This PR adds the basic repositories and the query that will return OrganizationIntegrationConfigurationDetails - which are the combination of `OrganizationIntegration` and `OrganizationIntegrationConfigurations` for a specific organization, event type and integration type.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17562]: https://bitwarden.atlassian.net/browse/PM-17562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ