### PR TITLE
[PM-19588] Ensure custom users cannot delete or remove admins.

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/DeleteManagedOrganizationUserAccountCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/DeleteManagedOrganizationUserAccountCommand.cs
@@ -154,6 +154,12 @@ public class DeleteManagedOrganizationUserAccountCommand : IDeleteManagedOrganiz
             }
         }
 
+        if (orgUser.Type == OrganizationUserType.Admin && await _currentContext.OrganizationCustom(organizationId))
+        {
+            throw new BadRequestException("Custom users can not delete admins.");
+        }
+
+
         if (!managementStatus.TryGetValue(orgUser.Id, out var isManaged) || !isManaged)
         {
             throw new BadRequestException("Member is not managed by the organization.");

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RemoveOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RemoveOrganizationUserCommand.cs
@@ -25,7 +25,8 @@ public class RemoveOrganizationUserCommand : IRemoveOrganizationUserCommand
     public const string UserNotFoundErrorMessage = "User not found.";
     public const string UsersInvalidErrorMessage = "Users invalid.";
     public const string RemoveYourselfErrorMessage = "You cannot remove yourself.";
-    public const string RemoveOwnerByNonOwnerErrorMessage = "Only owners can delete other owners.";
+    public const string RemoveOwnerByNonOwnerErrorMessage = "Only owners can remove other owners.";
+    public const string RemoveAdminByCustomUserErrorMessage = "Custom users can not remove admins.";
     public const string RemoveLastConfirmedOwnerErrorMessage = "Organization must have at least one confirmed owner.";
     public const string RemoveClaimedAccountErrorMessage = "Cannot remove member accounts claimed by the organization. To offboard a member, revoke or delete the account.";
 
@@ -151,6 +152,11 @@ public class RemoveOrganizationUserCommand : IRemoveOrganizationUserCommand
             {
                 throw new BadRequestException(RemoveLastConfirmedOwnerErrorMessage);
             }
+        }
+
+        if (orgUser.Type == OrganizationUserType.Admin && await _currentContext.OrganizationCustom(orgUser.OrganizationId))
+        {
+            throw new BadRequestException(RemoveAdminByCustomUserErrorMessage);
         }
 
         if (_featureService.IsEnabled(FeatureFlagKeys.AccountDeprovisioning) && deletingUserId.HasValue && eventSystemUser == null)

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/DeleteManagedOrganizationUserAccountCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/DeleteManagedOrganizationUserAccountCommandTests.cs
@@ -133,6 +133,38 @@ public class DeleteManagedOrganizationUserAccountCommandTests
 
     [Theory]
     [BitAutoData]
+    public async Task DeleteUserAsync_WhenCustomUserDeletesAdmin_ThrowsException(
+        SutProvider<DeleteManagedOrganizationUserAccountCommand> sutProvider, User user,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.Admin)] OrganizationUser organizationUser,
+        Guid deletingUserId)
+    {
+        // Arrange
+        organizationUser.UserId = user.Id;
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByIdAsync(organizationUser.Id)
+            .Returns(organizationUser);
+
+        sutProvider.GetDependency<IUserRepository>().GetByIdAsync(user.Id)
+            .Returns(user);
+
+        sutProvider.GetDependency<ICurrentContext>()
+            .OrganizationCustom(organizationUser.OrganizationId)
+            .Returns(true);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
+            sutProvider.Sut.DeleteUserAsync(organizationUser.OrganizationId, organizationUser.Id, deletingUserId));
+
+        // Assert
+        Assert.Equal("Custom users can not delete admins.", exception.Message);
+        await sutProvider.GetDependency<IUserService>().Received(0).DeleteAsync(Arg.Any<User>());
+        await sutProvider.GetDependency<IEventService>().Received(0)
+            .LogOrganizationUserEventAsync(Arg.Any<OrganizationUser>(), Arg.Any<EventType>(), Arg.Any<DateTime?>());
+    }
+
+    [Theory]
+    [BitAutoData]
     public async Task DeleteUserAsync_DeletingOwnerWhenNotOwner_ThrowsException(
         SutProvider<DeleteManagedOrganizationUserAccountCommand> sutProvider, User user,
         [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.Owner)] OrganizationUser organizationUser,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19588

## 📔 Objective


We don't want custom users to be able to remove or delete admins from an organization.
Code changes:
1. Add checks and throw exceptions to prevent this.
3. Add test coverage.


## 📸 Screenshots

It should raise an error when a custom user attempts to delete or remove an admin.

https://github.com/user-attachments/assets/0c856679-353b-4b28-89b5-dab3beb0579f


It should succeed when a custom user attempts to delete or remove a user.

https://github.com/user-attachments/assets/aa4ceff8-fc78-4e72-aa95-8cae21279f1f




## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
