### PR TITLE
[PM-17563] Add missing TaskId and HubHelper for PendingSecurityTasks

### DIFF
--- a/src/Api/NotificationCenter/Models/Response/NotificationResponseModel.cs
+++ b/src/Api/NotificationCenter/Models/Response/NotificationResponseModel.cs
@@ -22,6 +22,7 @@ public class NotificationResponseModel : ResponseModel
         Title = notificationStatusDetails.Title;
         Body = notificationStatusDetails.Body;
         Date = notificationStatusDetails.RevisionDate;
+        TaskId = notificationStatusDetails.TaskId;
         ReadDate = notificationStatusDetails.ReadDate;
         DeletedDate = notificationStatusDetails.DeletedDate;
     }
@@ -39,6 +40,8 @@ public class NotificationResponseModel : ResponseModel
     public string? Body { get; set; }
 
     public DateTime Date { get; set; }
+
+    public Guid? TaskId { get; set; }
 
     public DateTime? ReadDate { get; set; }
 

--- a/src/Core/NotificationCenter/Models/Data/NotificationStatusDetails.cs
+++ b/src/Core/NotificationCenter/Models/Data/NotificationStatusDetails.cs
@@ -19,6 +19,7 @@ public class NotificationStatusDetails
     public string? Body { get; set; }
     public DateTime CreationDate { get; set; }
     public DateTime RevisionDate { get; set; }
+    public Guid? TaskId { get; set; }
     // Notification Status fields
     public DateTime? ReadDate { get; set; }
     public DateTime? DeletedDate { get; set; }

--- a/src/Infrastructure.EntityFramework/NotificationCenter/Repositories/Queries/NotificationStatusDetailsViewQuery.cs
+++ b/src/Infrastructure.EntityFramework/NotificationCenter/Repositories/Queries/NotificationStatusDetailsViewQuery.cs
@@ -52,6 +52,7 @@ public class NotificationStatusDetailsViewQuery(Guid userId, ClientType clientTy
             ClientType = x.n.ClientType,
             UserId = x.n.UserId,
             OrganizationId = x.n.OrganizationId,
+            TaskId = x.n.TaskId,
             Title = x.n.Title,
             Body = x.n.Body,
             CreationDate = x.n.CreationDate,

--- a/src/Notifications/HubHelpers.cs
+++ b/src/Notifications/HubHelpers.cs
@@ -135,6 +135,11 @@ public static class HubHelpers
                 }
 
                 break;
+            case PushType.PendingSecurityTasks:
+                var pendingTasksData = JsonSerializer.Deserialize<PushNotificationData<UserPushNotification>>(notificationJson, _deserializerOptions);
+                await hubContext.Clients.User(pendingTasksData.Payload.UserId.ToString())
+                    .SendAsync(_receiveMessageMethod, pendingTasksData, cancellationToken);
+                break;
             default:
                 break;
         }

--- a/src/Sql/NotificationCenter/dbo/Views/NotificationStatusDetailsView.sql
+++ b/src/Sql/NotificationCenter/dbo/Views/NotificationStatusDetailsView.sql
@@ -1,10 +1,20 @@
 ﻿CREATE VIEW [dbo].[NotificationStatusDetailsView]
 AS
 SELECT
-    N.*,
-    NS.UserId AS NotificationStatusUserId,
-    NS.ReadDate,
-    NS.DeletedDate
+    N.[Id],
+    N.[Priority],
+    N.[Global],
+    N.[ClientType],
+    N.[UserId],
+    N.[OrganizationId],
+    N.[Title],
+    N.[Body],
+    N.[CreationDate],
+    N.[RevisionDate],
+    N.[TaskId],
+    NS.[UserId] AS [NotificationStatusUserId],
+    NS.[ReadDate],
+    NS.[DeletedDate]
 FROM
     [dbo].[Notification] AS N
 LEFT JOIN

--- a/test/Api.Test/NotificationCenter/Controllers/NotificationsControllerTests.cs
+++ b/test/Api.Test/NotificationCenter/Controllers/NotificationsControllerTests.cs
@@ -67,6 +67,7 @@ public class NotificationsControllerTests
             Assert.Equal(expectedNotificationStatusDetails.RevisionDate, notificationResponseModel.Date);
             Assert.Equal(expectedNotificationStatusDetails.ReadDate, notificationResponseModel.ReadDate);
             Assert.Equal(expectedNotificationStatusDetails.DeletedDate, notificationResponseModel.DeletedDate);
+            Assert.Equal(expectedNotificationStatusDetails.TaskId, notificationResponseModel.TaskId);
         });
         Assert.Null(listResponse.ContinuationToken);
 
@@ -116,6 +117,7 @@ public class NotificationsControllerTests
             Assert.Equal(expectedNotificationStatusDetails.RevisionDate, notificationResponseModel.Date);
             Assert.Equal(expectedNotificationStatusDetails.ReadDate, notificationResponseModel.ReadDate);
             Assert.Equal(expectedNotificationStatusDetails.DeletedDate, notificationResponseModel.DeletedDate);
+            Assert.Equal(expectedNotificationStatusDetails.TaskId, notificationResponseModel.TaskId);
         });
         Assert.Equal("2", listResponse.ContinuationToken);
 
@@ -164,6 +166,7 @@ public class NotificationsControllerTests
             Assert.Equal(expectedNotificationStatusDetails.RevisionDate, notificationResponseModel.Date);
             Assert.Equal(expectedNotificationStatusDetails.ReadDate, notificationResponseModel.ReadDate);
             Assert.Equal(expectedNotificationStatusDetails.DeletedDate, notificationResponseModel.DeletedDate);
+            Assert.Equal(expectedNotificationStatusDetails.TaskId, notificationResponseModel.TaskId);
         });
         Assert.Null(listResponse.ContinuationToken);
 

--- a/test/Api.Test/NotificationCenter/Models/Response/NotificationResponseModelTests.cs
+++ b/test/Api.Test/NotificationCenter/Models/Response/NotificationResponseModelTests.cs
@@ -26,6 +26,7 @@ public class NotificationResponseModelTests
             ClientType = ClientType.All,
             Title = "Test Title",
             Body = "Test Body",
+            TaskId = Guid.NewGuid(),
             RevisionDate = DateTime.UtcNow - TimeSpan.FromMinutes(3),
             ReadDate = DateTime.UtcNow - TimeSpan.FromMinutes(1),
             DeletedDate = DateTime.UtcNow,
@@ -39,5 +40,6 @@ public class NotificationResponseModelTests
         Assert.Equal(model.Date, notificationStatusDetails.RevisionDate);
         Assert.Equal(model.ReadDate, notificationStatusDetails.ReadDate);
         Assert.Equal(model.DeletedDate, notificationStatusDetails.DeletedDate);
+        Assert.Equal(model.TaskId, notificationStatusDetails.TaskId);
     }
 }

--- a/util/Migrator/DbScripts/2025-04-01_00_RecreateNotificationStatusView.sql
+++ b/util/Migrator/DbScripts/2025-04-01_00_RecreateNotificationStatusView.sql
@@ -1,0 +1,16 @@
+-- Recreate the NotificationStatusView to include the Notification.TaskId column
+CREATE OR ALTER VIEW [dbo].[NotificationStatusDetailsView]
+AS
+SELECT
+    N.*,
+    NS.UserId AS NotificationStatusUserId,
+    NS.ReadDate,
+    NS.DeletedDate
+FROM
+    [dbo].[Notification] AS N
+    LEFT JOIN
+    [dbo].[NotificationStatus] as NS
+ON
+    N.[Id] = NS.[NotificationId]
+END
+GO

--- a/util/Migrator/DbScripts/2025-04-01_00_RecreateNotificationStatusView.sql
+++ b/util/Migrator/DbScripts/2025-04-01_00_RecreateNotificationStatusView.sql
@@ -2,15 +2,24 @@
 CREATE OR ALTER VIEW [dbo].[NotificationStatusDetailsView]
 AS
 SELECT
-    N.*,
-    NS.UserId AS NotificationStatusUserId,
-    NS.ReadDate,
-    NS.DeletedDate
+    N.[Id],
+    N.[Priority],
+    N.[Global],
+    N.[ClientType],
+    N.[UserId],
+    N.[OrganizationId],
+    N.[Title],
+    N.[Body],
+    N.[CreationDate],
+    N.[RevisionDate],
+    N.[TaskId],
+    NS.[UserId] AS [NotificationStatusUserId],
+    NS.[ReadDate],
+    NS.[DeletedDate]
 FROM
     [dbo].[Notification] AS N
     LEFT JOIN
     [dbo].[NotificationStatus] as NS
 ON
     N.[Id] = NS.[NotificationId]
-END
 GO


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17563](https://bitwarden.atlassian.net/browse/PM-17563)

## 📔 Objective

Add the `TaskId` property to the `NotificationStatusDetailsView` and `NotificationResponse` that were missed originally when the column was first added.

Add switch case statement to `HubHelper` to to ensure `PendingSecurityTasks` notifications are properly sent to clients.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17563]: https://bitwarden.atlassian.net/browse/PM-17563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ