### PR TITLE
Clear device keys on deactivate

### DIFF
--- a/src/Core/Services/Implementations/DeviceService.cs
+++ b/src/Core/Services/Implementations/DeviceService.cs
@@ -77,6 +77,9 @@ public class DeviceService : IDeviceService
 
         device.Active = false;
         device.RevisionDate = DateTime.UtcNow;
+        device.EncryptedPrivateKey = null;
+        device.EncryptedPublicKey = null;
+        device.EncryptedUserKey = null;
         await _deviceRepository.UpsertAsync(device);
 
         await _pushRegistrationService.DeleteRegistrationAsync(device.Id.ToString());

--- a/util/Migrator/DbScripts/2025-04-02_00_Remove_Inactive_Device_Keys.sql
+++ b/util/Migrator/DbScripts/2025-04-02_00_Remove_Inactive_Device_Keys.sql
@@ -1,0 +1,12 @@
+UPDATE [dbo].[Device]
+SET 
+    EncryptedUserKey = NULL,
+    EncryptedPublicKey = NULL,
+    EncryptedPrivateKey = NULL
+WHERE Active = 1
+  AND (
+      EncryptedUserKey IS NOT NULL OR
+      EncryptedPublicKey IS NOT NULL OR
+      EncryptedPrivateKey IS NOT NULL
+  );
+GO;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19801

## 📔 Objective

Encryption keys need to be removed from the device table once a device is deactivated, because the user expects to have revoked access, but e.g. key rotation and other operation will continuously re-share the new encryption keys to the devices. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
