### PR TITLE
[PM-19811] fix ResetPasswordEnrolled check

### DIFF
--- a/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
@@ -51,7 +51,7 @@ public class ProfileOrganizationResponseModel : ResponseModel
         SsoBound = !string.IsNullOrWhiteSpace(organization.SsoExternalId);
         Identifier = organization.Identifier;
         Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(organization.Permissions);
-        ResetPasswordEnrolled = organization.ResetPasswordKey != null;
+        ResetPasswordEnrolled = !string.IsNullOrWhiteSpace(organization.ResetPasswordKey);
         UserId = organization.UserId;
         OrganizationUserId = organization.OrganizationUserId;
         ProviderId = organization.ProviderId;

--- a/src/Api/AdminConsole/Public/Models/Response/MemberResponseModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Response/MemberResponseModel.cs
@@ -30,7 +30,7 @@ public class MemberResponseModel : MemberBaseModel, IResponseModel
         Email = user.Email;
         Status = user.Status;
         Collections = collections?.Select(c => new AssociationWithPermissionsResponseModel(c));
-        ResetPasswordEnrolled = user.ResetPasswordKey != null;
+        ResetPasswordEnrolled = !string.IsNullOrWhiteSpace(user.ResetPasswordKey);
     }
 
     [SetsRequiredMembers]
@@ -49,7 +49,7 @@ public class MemberResponseModel : MemberBaseModel, IResponseModel
         TwoFactorEnabled = twoFactorEnabled;
         Status = user.Status;
         Collections = collections?.Select(c => new AssociationWithPermissionsResponseModel(c));
-        ResetPasswordEnrolled = user.ResetPasswordKey != null;
+        ResetPasswordEnrolled = !string.IsNullOrWhiteSpace(user.ResetPasswordKey);
         SsoExternalId = user.SsoExternalId;
     }
 

--- a/test/Api.Test/AdminConsole/Public/Models/Response/MemberResponseModelTests.cs
+++ b/test/Api.Test/AdminConsole/Public/Models/Response/MemberResponseModelTests.cs
@@ -25,11 +25,16 @@ public class MemberResponseModelTests
         Assert.True(sut.ResetPasswordEnrolled);
     }
 
-    [Fact]
-    public void ResetPasswordEnrolled_ShouldBeFalse_WhenUserDoesNotHaveResetPasswordKey()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResetPasswordEnrolled_ShouldBeFalse_WhenResetPasswordKeyIsInvalid(string? resetPasswordKey)
     {
         // Arrange
         var user = Substitute.For<OrganizationUser>();
+        user.ResetPasswordKey = resetPasswordKey;
+
         var collections = Substitute.For<IEnumerable<CollectionAccessSelection>>();
 
         // Act


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-19811

## 📔 Objective
**Root cause**: ResetPasswordEnrolled is a derived value based on whether we have a valid ResetPasswordKey. In some areas of the code, we account for empty strings, while in others, we do not. A [change](https://github.com/bitwarden/clients/pull/13889/files#diff-274ebd9695ac7bc9c2b0787c13c7401f756216ffcf0a1d2e24cab622387fd6e1R235) last week modified the ResetPasswordKey value from a null to an empty string, which caused this part of [the code](https://github.com/bitwarden/server/blob/main/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs#L54) to always evaluate as true.


1. Fix the ResetPasswordEnrolled check to handle empty and whitespace strings.
2. Update tests.

## 📸 Screenshots


https://github.com/user-attachments/assets/a876e4f5-bda2-4a75-8ecc-ca8ea5a93bf1



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
