### PR TITLE
[BEEEP] Lazy load the current user in the `CurrentContext`

### DIFF
--- a/src/Api/Billing/Controllers/AccountsBillingController.cs
+++ b/src/Api/Billing/Controllers/AccountsBillingController.cs
@@ -2,6 +2,7 @@
 using Bit.Api.Billing.Models.Responses;
 using Bit.Core.Billing.Models.Api.Requests.Accounts;
 using Bit.Core.Billing.Services;
+using Bit.Core.Context;
 using Bit.Core.Services;
 using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Authorization;
@@ -12,15 +13,15 @@ namespace Bit.Api.Billing.Controllers;
 [Route("accounts/billing")]
 [Authorize("Application")]
 public class AccountsBillingController(
+    ICurrentContext currentContext,
     IPaymentService paymentService,
-    IUserService userService,
     IPaymentHistoryService paymentHistoryService) : Controller
 {
     [HttpGet("history")]
     [SelfHosted(NotSelfHostedOnly = true)]
     public async Task<BillingHistoryResponseModel> GetBillingHistoryAsync()
     {
-        var user = await userService.GetUserByPrincipalAsync(User);
+        var user = await currentContext.UserAsync.Value;
         if (user == null)
         {
             throw new UnauthorizedAccessException();
@@ -34,7 +35,7 @@ public class AccountsBillingController(
     [SelfHosted(NotSelfHostedOnly = true)]
     public async Task<BillingPaymentResponseModel> GetPaymentMethodAsync()
     {
-        var user = await userService.GetUserByPrincipalAsync(User);
+        var user = await currentContext.UserAsync.Value;
         if (user == null)
         {
             throw new UnauthorizedAccessException();
@@ -47,7 +48,7 @@ public class AccountsBillingController(
     [HttpGet("invoices")]
     public async Task<IResult> GetInvoicesAsync([FromQuery] string? status = null, [FromQuery] string? startAfter = null)
     {
-        var user = await userService.GetUserByPrincipalAsync(User);
+        var user = await currentContext.UserAsync.Value;
         if (user == null)
         {
             throw new UnauthorizedAccessException();
@@ -65,7 +66,7 @@ public class AccountsBillingController(
     [HttpGet("transactions")]
     public async Task<IResult> GetTransactionsAsync([FromQuery] DateTime? startAfter = null)
     {
-        var user = await userService.GetUserByPrincipalAsync(User);
+        var user = await currentContext.UserAsync.Value;
         if (user == null)
         {
             throw new UnauthorizedAccessException();
@@ -82,7 +83,7 @@ public class AccountsBillingController(
     [HttpPost("preview-invoice")]
     public async Task<IResult> PreviewInvoiceAsync([FromBody] PreviewIndividualInvoiceRequestBody model)
     {
-        var user = await userService.GetUserByPrincipalAsync(User);
+        var user = await currentContext.UserAsync.Value;
         if (user == null)
         {
             throw new UnauthorizedAccessException();

--- a/src/Core/Auth/Identity/UserStore.cs
+++ b/src/Core/Auth/Identity/UserStore.cs
@@ -44,31 +44,30 @@ public class UserStore :
 
     public async Task<User> FindByEmailAsync(string normalizedEmail, CancellationToken cancellationToken = default(CancellationToken))
     {
-        if (_currentContext?.User != null && _currentContext.User.Email == normalizedEmail)
+        var currentUser = await _currentContext.UserAsync.Value;
+        if (currentUser != null && currentUser.Email == normalizedEmail)
         {
-            return _currentContext.User;
+            return currentUser;
         }
 
-        _currentContext.User = await _userRepository.GetByEmailAsync(normalizedEmail);
-        return _currentContext.User;
+        return await _userRepository.GetByEmailAsync(normalizedEmail);
     }
 
     public async Task<User> FindByIdAsync(string userId, CancellationToken cancellationToken = default(CancellationToken))
     {
-        if (_currentContext?.User != null &&
-            string.Equals(_currentContext.User.Id.ToString(), userId, StringComparison.InvariantCultureIgnoreCase))
+        var currentUser = await _currentContext.UserAsync.Value;
+        if (currentUser != null &&
+            string.Equals(currentUser.Id.ToString(), userId, StringComparison.InvariantCultureIgnoreCase))
         {
-            return _currentContext.User;
+            return currentUser;
         }
 
-        Guid userIdGuid;
-        if (!Guid.TryParse(userId, out userIdGuid))
+        if (!Guid.TryParse(userId, out var userIdGuid))
         {
             return null;
         }
 
-        _currentContext.User = await _userRepository.GetByIdAsync(userIdGuid);
-        return _currentContext.User;
+        return await _userRepository.GetByIdAsync(userIdGuid);
     }
 
     public async Task<User> FindByNameAsync(string normalizedUserName, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -28,7 +28,7 @@ public class CurrentContext : ICurrentContext
 
     public virtual HttpContext HttpContext { get; set; }
     public virtual Guid? UserId { get; set; }
-    public virtual Lazy<Task<User>> UserAsync { get; private set; }
+    public virtual Lazy<Task<User>> UserAsync { get; private set; } = new(() => Task.FromResult<User>(null));
     public virtual string DeviceIdentifier { get; set; }
     public virtual DeviceType? DeviceType { get; set; }
     public virtual string IpAddress { get; set; }

--- a/src/Core/Context/ICurrentContext.cs
+++ b/src/Core/Context/ICurrentContext.cs
@@ -16,7 +16,7 @@ public interface ICurrentContext
 {
     HttpContext HttpContext { get; set; }
     Guid? UserId { get; set; }
-    User User { get; set; }
+    Lazy<Task<User>> UserAsync { get; }
     string DeviceIdentifier { get; set; }
     DeviceType? DeviceType { get; set; }
     string IpAddress { get; set; }

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -173,10 +173,11 @@ public class UserService : UserManager<User>, IUserService, IDisposable
 
     public async Task<User> GetUserByIdAsync(string userId)
     {
-        if (_currentContext?.User != null &&
-            string.Equals(_currentContext.User.Id.ToString(), userId, StringComparison.InvariantCultureIgnoreCase))
+        var currentUser = await _currentContext.UserAsync.Value;
+        if (currentUser != null &&
+            string.Equals(currentUser.Id.ToString(), userId, StringComparison.InvariantCultureIgnoreCase))
         {
-            return _currentContext.User;
+            return currentUser;
         }
 
         if (!Guid.TryParse(userId, out var userIdGuid))
@@ -184,19 +185,18 @@ public class UserService : UserManager<User>, IUserService, IDisposable
             return null;
         }
 
-        _currentContext.User = await _userRepository.GetByIdAsync(userIdGuid);
-        return _currentContext.User;
+        return await _userRepository.GetByIdAsync(userIdGuid);
     }
 
     public async Task<User> GetUserByIdAsync(Guid userId)
     {
-        if (_currentContext?.User != null && _currentContext.User.Id == userId)
+        var currentUser = await _currentContext.UserAsync.Value;
+        if (currentUser != null && currentUser.Id == userId)
         {
-            return _currentContext.User;
+            return currentUser;
         }
 
-        _currentContext.User = await _userRepository.GetByIdAsync(userId);
-        return _currentContext.User;
+        return await _userRepository.GetByIdAsync(userId);
     }
 
     public async Task<User> GetUserByPrincipalAsync(ClaimsPrincipal principal)

--- a/src/Notifications/NotificationsHub.cs
+++ b/src/Notifications/NotificationsHub.cs
@@ -20,7 +20,7 @@ public class NotificationsHub : Microsoft.AspNetCore.SignalR.Hub
 
     public override async Task OnConnectedAsync()
     {
-        var currentContext = new CurrentContext(null, null);
+        var currentContext = new CurrentContext(null, null, null);
         await currentContext.BuildAsync(Context.User, _globalSettings);
 
         var clientType = DeviceTypes.ToClientType(currentContext.DeviceType);
@@ -57,7 +57,7 @@ public class NotificationsHub : Microsoft.AspNetCore.SignalR.Hub
 
     public override async Task OnDisconnectedAsync(Exception exception)
     {
-        var currentContext = new CurrentContext(null, null);
+        var currentContext = new CurrentContext(null, null, null);
         await currentContext.BuildAsync(Context.User, _globalSettings);
 
         var clientType = DeviceTypes.ToClientType(currentContext.DeviceType);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

The `User` property is currently being cached in `CurrentContext` and exposed with `ICurrentContext` using dependency injection with a request scope. The properties in this object are being set using the middleware after a user is authenticated and authorized to access a specific endpoint.

I believe the `CurrentContext` should be singlehandedly responsible for populating this object as it would otherwise unnecessarily add technical debt as to where the property is being populated and when.

By lazy loading the property when it is only being used, we will not unnecessarily retrieve the user from the backend when it is not needed.

There are potential performance improvements coming from this change. Although it's very unlikely you will try to retrieve the same user multiple times in a single request scope.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
