### PR TITLE
[PM-19601] Introduce options for adding certificates to trust without root

### DIFF
--- a/src/Core/Platform/X509ChainCustomization/PostConfigureX509ChainOptions.cs
+++ b/src/Core/Platform/X509ChainCustomization/PostConfigureX509ChainOptions.cs
@@ -1,0 +1,94 @@
+#nullable enable
+
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Hosting;
+using Bit.Core.Settings;
+
+namespace Bit.Core.Platform.X509ChainCustomization;
+
+internal sealed class PostConfigureX509ChainOptions : IPostConfigureOptions<X509ChainOptions>
+{
+    const string CertificateSearchPattern = "*.crt";
+
+    private readonly ILogger<PostConfigureX509ChainOptions> _logger;
+    private readonly IHostEnvironment _hostEnvironment;
+    private readonly GlobalSettings _globalSettings;
+
+    public PostConfigureX509ChainOptions(
+        ILogger<PostConfigureX509ChainOptions> logger,
+        IHostEnvironment hostEnvironment,
+        GlobalSettings globalSettings)
+    {
+        _logger = logger;
+        _hostEnvironment = hostEnvironment;
+        _globalSettings = globalSettings;
+    }
+
+    public void PostConfigure(string? name, X509ChainOptions options)
+    {
+        if (name != Options.DefaultName)
+        {
+            return;
+        }
+
+        // We only allow this setting to be configured on self host.
+        if (!_globalSettings.SelfHosted)
+        {
+            options.AdditionalCustomTrustCertificatesDirectory = null;
+            return;
+        }
+
+        if (options.AdditionalCustomTrustCertificates != null)
+        {
+            // Additional certificates were added directly, this overwrites the need to
+            // read them from the directory.
+            _logger.LogInformation(
+                "Additional custom trust certificates were added directly, skipping loading them from '{Directory}'",
+                options.AdditionalCustomTrustCertificatesDirectory
+            );
+            return;
+        }
+
+        if (string.IsNullOrEmpty(options.AdditionalCustomTrustCertificatesDirectory))
+        {
+            return;
+        }
+
+        if (!Directory.Exists(options.AdditionalCustomTrustCertificatesDirectory))
+        {
+            // The default directory is volume mounted via the default Bitwarden setup process.
+            // If the directory doesn't exist it could indicate a error in configuration but this
+            // directory is never expected in a normal development environment so lower the log
+            // level in that case.
+            var logLevel = _hostEnvironment.IsDevelopment()
+                ? LogLevel.Debug
+                : LogLevel.Warning;
+            _logger.Log(
+                logLevel,
+                "An additional custom trust certificate directory was given '{Directory}' but that directory does not exist.",
+                options.AdditionalCustomTrustCertificatesDirectory
+            );
+            return;
+        }
+
+        var certificates = new List<X509Certificate2>();
+
+        foreach (var certFile in Directory.EnumerateFiles(options.AdditionalCustomTrustCertificatesDirectory, CertificateSearchPattern))
+        {
+            certificates.Add(new X509Certificate2(certFile));
+        }
+
+        if (options.AdditionalCustomTrustCertificatesDirectory != X509ChainOptions.DefaultAdditionalCustomTrustCertificatesDirectory && certificates.Count == 0)
+        {
+            // They have intentionally given us a non-default directory but there weren't certificates, that is odd.
+            _logger.LogWarning(
+                "No additional custom trust certificates were found in '{Directory}'",
+                options.AdditionalCustomTrustCertificatesDirectory
+            );
+        }
+
+        options.AdditionalCustomTrustCertificates = certificates;
+    }
+}

--- a/src/Core/Platform/X509ChainCustomization/PostConfigureX509ChainOptions.cs
+++ b/src/Core/Platform/X509ChainCustomization/PostConfigureX509ChainOptions.cs
@@ -28,6 +28,8 @@ internal sealed class PostConfigureX509ChainOptions : IPostConfigureOptions<X509
 
     public void PostConfigure(string? name, X509ChainOptions options)
     {
+        // We don't register or request a named instance of these options,
+        // so don't customize it.
         if (name != Options.DefaultName)
         {
             return;

--- a/src/Core/Platform/X509ChainCustomization/PostConfigureX509ChainOptions.cs
+++ b/src/Core/Platform/X509ChainCustomization/PostConfigureX509ChainOptions.cs
@@ -1,10 +1,10 @@
-#nullable enable
+﻿#nullable enable
 
 using System.Security.Cryptography.X509Certificates;
-using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Hosting;
 using Bit.Core.Settings;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Bit.Core.Platform.X509ChainCustomization;
 

--- a/src/Core/Platform/X509ChainCustomization/X509ChainCustomizationServiceCollectionExtensions.cs
+++ b/src/Core/Platform/X509ChainCustomization/X509ChainCustomizationServiceCollectionExtensions.cs
@@ -1,6 +1,6 @@
-using Bit.Core.Platform.X509ChainCustomization;
-using Microsoft.Extensions.Options;
+﻿using Bit.Core.Platform.X509ChainCustomization;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection;
 

--- a/src/Core/Platform/X509ChainCustomization/X509ChainCustomizationServiceCollectionExtensions.cs
+++ b/src/Core/Platform/X509ChainCustomization/X509ChainCustomizationServiceCollectionExtensions.cs
@@ -1,0 +1,53 @@
+using Bit.Core.Platform.X509ChainCustomization;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for setting up the ability to provide customization to how TLS works in an <see cref="IServiceCollection"/>.
+/// </summary>
+public static class X509ChainCustomizationServiceCollectionExtensions
+{
+    /// <summary>
+    /// Configures X509ChainPolicy customization through the root level <c>TlsOptions</c> configuration section
+    /// and configures the primary <see cref="HttpMessageHandler"/> to use custom certificate validation
+    /// when customized to do so.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+    /// <returns>The <see cref="IServiceCollection"/> for additional chaining.</returns>
+    public static IServiceCollection AddX509ChainCustomization(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddOptions<X509ChainOptions>()
+            .BindConfiguration(nameof(X509ChainOptions));
+
+        // Use TryAddEnumerable to make sure `PostConfigureTlsOptions` isn't added multiple
+        // times even if this method is called multiple times.
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<X509ChainOptions>, PostConfigureX509ChainOptions>());
+
+        services.AddHttpClient()
+            .ConfigureHttpClientDefaults(builder =>
+            {
+                builder.ConfigurePrimaryHttpMessageHandler(sp =>
+                {
+                    var tlsOptions = sp.GetRequiredService<IOptions<X509ChainOptions>>().Value;
+
+                    var handler = new HttpClientHandler();
+
+                    if (tlsOptions.TryGetCustomRemoteCertificateValidationCallback(out var callback))
+                    {
+                        handler.ServerCertificateCustomValidationCallback = (sender, certificate, chain, errors) =>
+                        {
+                            return callback(certificate, chain, errors);
+                        };
+                    }
+
+                    return handler;
+                });
+            });
+
+        return services;
+    }
+}

--- a/src/Core/Platform/X509ChainCustomization/X509ChainCustomizationServiceCollectionExtensions.cs
+++ b/src/Core/Platform/X509ChainCustomization/X509ChainCustomizationServiceCollectionExtensions.cs
@@ -5,12 +5,12 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 namespace Microsoft.Extensions.DependencyInjection;
 
 /// <summary>
-/// Extension methods for setting up the ability to provide customization to how TLS works in an <see cref="IServiceCollection"/>.
+/// Extension methods for setting up the ability to provide customization to how X509 chain validation works in an <see cref="IServiceCollection"/>.
 /// </summary>
 public static class X509ChainCustomizationServiceCollectionExtensions
 {
     /// <summary>
-    /// Configures X509ChainPolicy customization through the root level <c>TlsOptions</c> configuration section
+    /// Configures X509ChainPolicy customization through the root level <c>X509ChainOptions</c> configuration section
     /// and configures the primary <see cref="HttpMessageHandler"/> to use custom certificate validation
     /// when customized to do so.
     /// </summary>
@@ -23,7 +23,7 @@ public static class X509ChainCustomizationServiceCollectionExtensions
         services.AddOptions<X509ChainOptions>()
             .BindConfiguration(nameof(X509ChainOptions));
 
-        // Use TryAddEnumerable to make sure `PostConfigureTlsOptions` isn't added multiple
+        // Use TryAddEnumerable to make sure `PostConfigureX509ChainOptions` isn't added multiple
         // times even if this method is called multiple times.
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<X509ChainOptions>, PostConfigureX509ChainOptions>());
 
@@ -32,11 +32,11 @@ public static class X509ChainCustomizationServiceCollectionExtensions
             {
                 builder.ConfigurePrimaryHttpMessageHandler(sp =>
                 {
-                    var tlsOptions = sp.GetRequiredService<IOptions<X509ChainOptions>>().Value;
+                    var x509ChainOptions = sp.GetRequiredService<IOptions<X509ChainOptions>>().Value;
 
                     var handler = new HttpClientHandler();
 
-                    if (tlsOptions.TryGetCustomRemoteCertificateValidationCallback(out var callback))
+                    if (x509ChainOptions.TryGetCustomRemoteCertificateValidationCallback(out var callback))
                     {
                         handler.ServerCertificateCustomValidationCallback = (sender, certificate, chain, errors) =>
                         {

--- a/src/Core/Platform/X509ChainCustomization/X509ChainOptions.cs
+++ b/src/Core/Platform/X509ChainCustomization/X509ChainOptions.cs
@@ -1,0 +1,72 @@
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Bit.Core.Platform.X509ChainCustomization;
+
+/// <summary>
+/// Allows for customization of 
+/// </summary>
+public sealed class X509ChainOptions
+{
+    // This is the directory that we historically used to allow certificates be added inside our container
+    // and then on start of the container we would move them to `/usr/local/share/ca-certificates/` and call
+    // `update-ca-certificates` but since that operation requires root we can't do it in a rootless container.
+    // Ref: https://github.com/bitwarden/server/blob/67d7d685a619a5fc413f8532dacb09681ee5c956/src/Api/entrypoint.sh#L38-L41
+    public const string DefaultAdditionalCustomTrustCertificatesDirectory = "/etc/bitwarden/ca-certificates/";
+
+    /// <summary>
+    /// A directory where additional certificates should be read from and included in <see cref="X509ChainPolicy.CustomTrustStore"/>.
+    /// </summary>
+    /// <remarks>
+    /// Only certificates suffixed with <c>*.crt</c> will be read. If <see cref="AdditionalCustomTrustCertificates"/> is
+    /// set, then this directory will not be read from.
+    /// </remarks>
+    public string? AdditionalCustomTrustCertificatesDirectory { get; set; } = DefaultAdditionalCustomTrustCertificatesDirectory;
+
+    /// <summary>
+    /// A list of additional certificates that should be included in <see cref="X509ChainPolicy.CustomTrustStore"/>.
+    /// </summary>
+    /// <remarks>
+    /// If this value is set manually, then <see cref="AdditionalCustomTrustCertificatesDirectory"/> will be ignored.
+    /// </remarks>
+    public List<X509Certificate2>? AdditionalCustomTrustCertificates { get; set; }
+
+    /// <summary>
+    /// Attempts to retrieve a custom remote certificate validation callback.
+    /// </summary>
+    /// <param name="callback"></param>
+    /// <returns>Returns <see langword="true"/> when we have custom remote certification that should be added,
+    /// <see langword="false"/> when no custom validation is needed and the default validation callback should
+    /// be used instead.
+    /// </returns>
+    [MemberNotNullWhen(true, nameof(AdditionalCustomTrustCertificates))]
+    public bool TryGetCustomRemoteCertificateValidationCallback(
+        [MaybeNullWhen(false)]out Func<X509Certificate2?, X509Chain?, SslPolicyErrors, bool> callback)
+    {
+        callback = null;
+        if (AdditionalCustomTrustCertificates == null || AdditionalCustomTrustCertificates.Count == 0)
+        {
+            return false;
+        }
+
+        // Ref: https://github.com/dotnet/runtime/issues/39835#issuecomment-663020581
+        callback = (certificate, chain, errors) =>
+        {
+            if (chain == null || certificate == null)
+            {
+                return false;
+            }
+
+            chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+            foreach (var additionalCertificate in AdditionalCustomTrustCertificates)
+            {
+                chain.ChainPolicy.CustomTrustStore.Add(additionalCertificate);
+            }
+            return chain.Build(certificate);
+        };
+        return true;
+    }
+}

--- a/src/Core/Platform/X509ChainCustomization/X509ChainOptions.cs
+++ b/src/Core/Platform/X509ChainCustomization/X509ChainOptions.cs
@@ -7,7 +7,8 @@ using System.Security.Cryptography.X509Certificates;
 namespace Bit.Core.Platform.X509ChainCustomization;
 
 /// <summary>
-/// Allows for customization of 
+/// Allows for customization of the <see cref="X509ChainPolicy"/> and access to a custom server certificate validator
+/// if customization has been made.
 /// </summary>
 public sealed class X509ChainOptions
 {

--- a/src/Core/Platform/X509ChainCustomization/X509ChainOptions.cs
+++ b/src/Core/Platform/X509ChainCustomization/X509ChainOptions.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Security;
@@ -45,7 +45,7 @@ public sealed class X509ChainOptions
     /// </returns>
     [MemberNotNullWhen(true, nameof(AdditionalCustomTrustCertificates))]
     public bool TryGetCustomRemoteCertificateValidationCallback(
-        [MaybeNullWhen(false)]out Func<X509Certificate2?, X509Chain?, SslPolicyErrors, bool> callback)
+        [MaybeNullWhen(false)] out Func<X509Certificate2?, X509Chain?, SslPolicyErrors, bool> callback)
     {
         callback = null;
         if (AdditionalCustomTrustCertificates == null || AdditionalCustomTrustCertificates.Count == 0)

--- a/src/Core/Services/Implementations/MailKitSmtpMailDeliveryService.cs
+++ b/src/Core/Services/Implementations/MailKitSmtpMailDeliveryService.cs
@@ -1,7 +1,10 @@
-﻿using Bit.Core.Settings;
+﻿using System.Security.Cryptography.X509Certificates;
+using Bit.Core.Platform.X509ChainCustomization;
+using Bit.Core.Settings;
 using Bit.Core.Utilities;
 using MailKit.Net.Smtp;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using MimeKit;
 
 namespace Bit.Core.Services;
@@ -10,12 +13,14 @@ public class MailKitSmtpMailDeliveryService : IMailDeliveryService
 {
     private readonly GlobalSettings _globalSettings;
     private readonly ILogger<MailKitSmtpMailDeliveryService> _logger;
+    private readonly X509ChainOptions _x509CertificateCustomization;
     private readonly string _replyDomain;
     private readonly string _replyEmail;
 
     public MailKitSmtpMailDeliveryService(
         GlobalSettings globalSettings,
-        ILogger<MailKitSmtpMailDeliveryService> logger)
+        ILogger<MailKitSmtpMailDeliveryService> logger,
+        IOptions<X509ChainOptions> tlsOptions)
     {
         if (globalSettings.Mail?.Smtp?.Host == null)
         {
@@ -31,6 +36,7 @@ public class MailKitSmtpMailDeliveryService : IMailDeliveryService
 
         _globalSettings = globalSettings;
         _logger = logger;
+        _x509CertificateCustomization = tlsOptions.Value;
     }
 
     public async Task SendEmailAsync(Models.Mail.MailMessage message)
@@ -74,6 +80,13 @@ public class MailKitSmtpMailDeliveryService : IMailDeliveryService
             if (_globalSettings.Mail.Smtp.TrustServer)
             {
                 client.ServerCertificateValidationCallback = (s, c, h, e) => true;
+            }
+            else if (_x509CertificateCustomization.TryGetCustomRemoteCertificateValidationCallback(out var callback))
+            {
+                client.ServerCertificateValidationCallback = (sender, cert, chain, errors) =>
+                {
+                    return callback(new X509Certificate2(cert), chain, errors);
+                };
             }
 
             if (!_globalSettings.Mail.Smtp.StartTls && !_globalSettings.Mail.Smtp.Ssl &&

--- a/src/Core/Services/Implementations/MailKitSmtpMailDeliveryService.cs
+++ b/src/Core/Services/Implementations/MailKitSmtpMailDeliveryService.cs
@@ -13,14 +13,14 @@ public class MailKitSmtpMailDeliveryService : IMailDeliveryService
 {
     private readonly GlobalSettings _globalSettings;
     private readonly ILogger<MailKitSmtpMailDeliveryService> _logger;
-    private readonly X509ChainOptions _x509CertificateCustomization;
+    private readonly X509ChainOptions _x509ChainOptions;
     private readonly string _replyDomain;
     private readonly string _replyEmail;
 
     public MailKitSmtpMailDeliveryService(
         GlobalSettings globalSettings,
         ILogger<MailKitSmtpMailDeliveryService> logger,
-        IOptions<X509ChainOptions> tlsOptions)
+        IOptions<X509ChainOptions> x509ChainOptions)
     {
         if (globalSettings.Mail?.Smtp?.Host == null)
         {
@@ -36,7 +36,7 @@ public class MailKitSmtpMailDeliveryService : IMailDeliveryService
 
         _globalSettings = globalSettings;
         _logger = logger;
-        _x509CertificateCustomization = tlsOptions.Value;
+        _x509ChainOptions = x509ChainOptions.Value;
     }
 
     public async Task SendEmailAsync(Models.Mail.MailMessage message)
@@ -81,7 +81,7 @@ public class MailKitSmtpMailDeliveryService : IMailDeliveryService
             {
                 client.ServerCertificateValidationCallback = (s, c, h, e) => true;
             }
-            else if (_x509CertificateCustomization.TryGetCustomRemoteCertificateValidationCallback(out var callback))
+            else if (_x509ChainOptions.TryGetCustomRemoteCertificateValidationCallback(out var callback))
             {
                 client.ServerCertificateValidationCallback = (sender, cert, chain, errors) =>
                 {

--- a/test/Core.IntegrationTest/MailKitSmtpMailDeliveryServiceTests.cs
+++ b/test/Core.IntegrationTest/MailKitSmtpMailDeliveryServiceTests.cs
@@ -1,9 +1,9 @@
 ﻿using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Bit.Core.Models.Mail;
+using Bit.Core.Platform.X509ChainCustomization;
 using Bit.Core.Services;
 using Bit.Core.Settings;
-using Bit.Core.Platform.TlsCustomization;
 using MailKit.Security;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -103,7 +103,7 @@ public class MailKitSmtpMailDeliveryServiceTests
         var mailKitDeliveryService = new MailKitSmtpMailDeliveryService(
             globalSettings,
             NullLogger<MailKitSmtpMailDeliveryService>.Instance,
-            Options.Create(new X509CertificateCustomizationOptions())
+            Options.Create(new X509ChainOptions())
         );
 
         await Assert.ThrowsAsync<SslHandshakeException>(
@@ -133,7 +133,7 @@ public class MailKitSmtpMailDeliveryServiceTests
             gs.Mail.Smtp.Ssl = true;
         });
 
-        var tlsOptions = new X509CertificateCustomizationOptions
+        var x509ChainOptions = new X509ChainOptions
         {
             AdditionalCustomTrustCertificates =
             [
@@ -144,7 +144,7 @@ public class MailKitSmtpMailDeliveryServiceTests
         var mailKitDeliveryService = new MailKitSmtpMailDeliveryService(
             globalSettings,
             NullLogger<MailKitSmtpMailDeliveryService>.Instance,
-            Options.Create(tlsOptions)
+            Options.Create(x509ChainOptions)
         );
 
         var tcs = new TaskCompletionSource();
@@ -188,7 +188,7 @@ public class MailKitSmtpMailDeliveryServiceTests
             gs.Mail.Smtp.Ssl = true;
         });
 
-        var tlsOptions = new X509CertificateCustomizationOptions
+        var x509ChainOptions = new X509ChainOptions
         {
             AdditionalCustomTrustCertificates =
             [
@@ -200,7 +200,7 @@ public class MailKitSmtpMailDeliveryServiceTests
         var mailKitDeliveryService = new MailKitSmtpMailDeliveryService(
             globalSettings,
             NullLogger<MailKitSmtpMailDeliveryService>.Instance,
-            Options.Create(tlsOptions)
+            Options.Create(x509ChainOptions)
         );
 
         var tcs = new TaskCompletionSource();
@@ -248,7 +248,7 @@ public class MailKitSmtpMailDeliveryServiceTests
         var mailKitDeliveryService = new MailKitSmtpMailDeliveryService(
             globalSettings,
             NullLogger<MailKitSmtpMailDeliveryService>.Instance,
-            Options.Create(new X509CertificateCustomizationOptions())
+            Options.Create(new X509ChainOptions())
         );
 
         var tcs = new TaskCompletionSource();
@@ -295,7 +295,7 @@ public class MailKitSmtpMailDeliveryServiceTests
         var mailKitDeliveryService = new MailKitSmtpMailDeliveryService(
             globalSettings,
             NullLogger<MailKitSmtpMailDeliveryService>.Instance,
-            Options.Create(new X509CertificateCustomizationOptions())
+            Options.Create(new X509ChainOptions())
         );
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -331,7 +331,7 @@ public class MailKitSmtpMailDeliveryServiceTests
         var mailKitDeliveryService = new MailKitSmtpMailDeliveryService(
             globalSettings,
             NullLogger<MailKitSmtpMailDeliveryService>.Instance,
-            Options.Create(new X509CertificateCustomizationOptions())
+            Options.Create(new X509ChainOptions())
         );
 
         var tcs = new TaskCompletionSource();
@@ -398,7 +398,7 @@ public class MailKitSmtpMailDeliveryServiceTests
         var mailKitDeliveryService = new MailKitSmtpMailDeliveryService(
             globalSettings,
             NullLogger<MailKitSmtpMailDeliveryService>.Instance,
-            Options.Create(new X509CertificateCustomizationOptions())
+            Options.Create(new X509ChainOptions())
         );
 
         var tcs = new TaskCompletionSource();

--- a/test/Core.IntegrationTest/MailKitSmtpMailDeliveryServiceTests.cs
+++ b/test/Core.IntegrationTest/MailKitSmtpMailDeliveryServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Cryptography;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Bit.Core.Models.Mail;
 using Bit.Core.Platform.X509ChainCustomization;
@@ -30,11 +30,6 @@ public class MailKitSmtpMailDeliveryServiceTests
         using var rsa = RSA.Create(2048);
         var certRequest = new CertificateRequest($"CN={commonName}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
         return certRequest.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(1));
-    }
-
-    private static async Task SaveCertAsync(string filePath, X509Certificate2 certificate)
-    {
-        await File.WriteAllBytesAsync(filePath, certificate.Export(X509ContentType.Cert));
     }
 
     private static void ConfigureSmtpServerLogging(ITestOutputHelper testOutputHelper)

--- a/test/Core.IntegrationTest/MailKitSmtpMailDeliveryServiceTests.cs
+++ b/test/Core.IntegrationTest/MailKitSmtpMailDeliveryServiceTests.cs
@@ -1,4 +1,4 @@
-using System.Security.Cryptography;
+﻿using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Bit.Core.Models.Mail;
 using Bit.Core.Platform.X509ChainCustomization;
@@ -16,6 +16,7 @@ namespace Bit.Core.IntegrationTest;
 
 public class MailKitSmtpMailDeliveryServiceTests
 {
+    private static int _loggingConfigured;
     private readonly X509Certificate2 _selfSignedCert;
 
     public MailKitSmtpMailDeliveryServiceTests(ITestOutputHelper testOutputHelper)
@@ -34,6 +35,12 @@ public class MailKitSmtpMailDeliveryServiceTests
 
     private static void ConfigureSmtpServerLogging(ITestOutputHelper testOutputHelper)
     {
+        // The logging in SmtpServer is configured statically so if we add it for each test it duplicates
+        // but we cant add the logger statically either because we need ITestOutputHelper
+        if (Interlocked.CompareExchange(ref _loggingConfigured, 1, 0) == 0)
+        {
+            return;
+        }
         // Unfortunately this package doesn't public expose its logging infrastructure
         // so we use private reflection to try and access it. 
         try

--- a/test/Core.IntegrationTest/MailKitSmtpMailDeliveryServiceTests.cs
+++ b/test/Core.IntegrationTest/MailKitSmtpMailDeliveryServiceTests.cs
@@ -3,9 +3,11 @@ using System.Security.Cryptography.X509Certificates;
 using Bit.Core.Models.Mail;
 using Bit.Core.Services;
 using Bit.Core.Settings;
+using Bit.Core.Platform.TlsCustomization;
 using MailKit.Security;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Rnwood.SmtpServer;
 using Rnwood.SmtpServer.Extensions.Auth;
 using Xunit.Abstractions;
@@ -100,7 +102,8 @@ public class MailKitSmtpMailDeliveryServiceTests
 
         var mailKitDeliveryService = new MailKitSmtpMailDeliveryService(
             globalSettings,
-            NullLogger<MailKitSmtpMailDeliveryService>.Instance
+            NullLogger<MailKitSmtpMailDeliveryService>.Instance,
+            Options.Create(new X509CertificateCustomizationOptions())
         );
 
         await Assert.ThrowsAsync<SslHandshakeException>(
@@ -113,7 +116,7 @@ public class MailKitSmtpMailDeliveryServiceTests
         );
     }
 
-    [Fact(Skip = "Upcoming feature")]
+    [Fact]
     public async Task SendEmailAsync_SmtpServerUsingSelfSignedCert_CertInCustomLocation_Works()
     {
         // If an SMTP server is using a self signed cert we will in the future
@@ -130,12 +133,18 @@ public class MailKitSmtpMailDeliveryServiceTests
             gs.Mail.Smtp.Ssl = true;
         });
 
-        // TODO: Setup custom location and save self signed cert there.
-        // await SaveCertAsync("./my-location", _selfSignedCert);
+        var tlsOptions = new X509CertificateCustomizationOptions
+        {
+            AdditionalCustomTrustCertificates =
+            [
+                _selfSignedCert,
+            ],
+        };
 
         var mailKitDeliveryService = new MailKitSmtpMailDeliveryService(
             globalSettings,
-            NullLogger<MailKitSmtpMailDeliveryService>.Instance
+            NullLogger<MailKitSmtpMailDeliveryService>.Instance,
+            Options.Create(tlsOptions)
         );
 
         var tcs = new TaskCompletionSource();
@@ -162,7 +171,7 @@ public class MailKitSmtpMailDeliveryServiceTests
         await tcs.Task;
     }
 
-    [Fact(Skip = "Upcoming feature")]
+    [Fact]
     public async Task SendEmailAsync_SmtpServerUsingSelfSignedCert_CertInCustomLocation_WithUnrelatedCerts_Works()
     {
         // If an SMTP server is using a self signed cert we will in the future
@@ -179,15 +188,19 @@ public class MailKitSmtpMailDeliveryServiceTests
             gs.Mail.Smtp.Ssl = true;
         });
 
-        // TODO: Setup custom location and save self signed cert there
-        // along with another self signed cert that is not related to 
-        // the SMTP server.
-        // await SaveCertAsync("./my-location", _selfSignedCert);
-        // await SaveCertAsync("./my-location", CreateSelfSignedCert("example.com"));
+        var tlsOptions = new X509CertificateCustomizationOptions
+        {
+            AdditionalCustomTrustCertificates =
+            [
+                _selfSignedCert,
+                CreateSelfSignedCert("example.com"),
+            ],
+        };
 
         var mailKitDeliveryService = new MailKitSmtpMailDeliveryService(
             globalSettings,
-            NullLogger<MailKitSmtpMailDeliveryService>.Instance
+            NullLogger<MailKitSmtpMailDeliveryService>.Instance,
+            Options.Create(tlsOptions)
         );
 
         var tcs = new TaskCompletionSource();
@@ -234,7 +247,8 @@ public class MailKitSmtpMailDeliveryServiceTests
 
         var mailKitDeliveryService = new MailKitSmtpMailDeliveryService(
             globalSettings,
-            NullLogger<MailKitSmtpMailDeliveryService>.Instance
+            NullLogger<MailKitSmtpMailDeliveryService>.Instance,
+            Options.Create(new X509CertificateCustomizationOptions())
         );
 
         var tcs = new TaskCompletionSource();
@@ -280,7 +294,8 @@ public class MailKitSmtpMailDeliveryServiceTests
 
         var mailKitDeliveryService = new MailKitSmtpMailDeliveryService(
             globalSettings,
-            NullLogger<MailKitSmtpMailDeliveryService>.Instance
+            NullLogger<MailKitSmtpMailDeliveryService>.Instance,
+            Options.Create(new X509CertificateCustomizationOptions())
         );
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -315,7 +330,8 @@ public class MailKitSmtpMailDeliveryServiceTests
 
         var mailKitDeliveryService = new MailKitSmtpMailDeliveryService(
             globalSettings,
-            NullLogger<MailKitSmtpMailDeliveryService>.Instance
+            NullLogger<MailKitSmtpMailDeliveryService>.Instance,
+            Options.Create(new X509CertificateCustomizationOptions())
         );
 
         var tcs = new TaskCompletionSource();
@@ -381,7 +397,8 @@ public class MailKitSmtpMailDeliveryServiceTests
 
         var mailKitDeliveryService = new MailKitSmtpMailDeliveryService(
             globalSettings,
-            NullLogger<MailKitSmtpMailDeliveryService>.Instance
+            NullLogger<MailKitSmtpMailDeliveryService>.Instance,
+            Options.Create(new X509CertificateCustomizationOptions())
         );
 
         var tcs = new TaskCompletionSource();

--- a/test/Core.Test/Core.Test.csproj
+++ b/test/Core.Test/Core.Test.csproj
@@ -10,6 +10,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNetTestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="xunit" Version="$(XUnitVersion)" />

--- a/test/Core.Test/Platform/X509ChainCustomization/X509ChainCustomizationServiceCollectionExtensionsTests.cs
+++ b/test/Core.Test/Platform/X509ChainCustomization/X509ChainCustomizationServiceCollectionExtensionsTests.cs
@@ -1,0 +1,137 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Bit.Core.Platform.X509ChainCustomization;
+using Bit.Core.Settings;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Platform.TlsCustomization;
+
+public class X509ChainCustomizationServiceCollectionExtensionsTests
+{
+    private static X509Certificate2 CreateSelfSignedCert(string commonName)
+    {
+        using var rsa = RSA.Create(2048);
+        var certRequest = new CertificateRequest($"CN={commonName}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        return certRequest.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(1));
+    }
+
+    [Fact]
+    public async Task OptionsPatternReturnsCachedValue()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("certs");
+        
+        var tempCert = Path.Combine(tempDir.FullName, "test.crt");
+        await File.WriteAllBytesAsync(tempCert, CreateSelfSignedCert("localhost").Export(X509ContentType.Cert));
+
+        var services = CreateServices((gs, environment, config) =>
+        {
+            gs.SelfHosted = true;
+
+            environment.EnvironmentName = "Development";
+
+            config["X509ChainOptions:AdditionalCustomTrustCertificatesDirectory"] = tempDir.FullName;
+        });
+        
+        // Create options once
+        var firstOptions = services.GetRequiredService<IOptions<X509ChainOptions>>().Value;
+
+        Assert.NotNull(firstOptions.AdditionalCustomTrustCertificates);
+        var cert = Assert.Single(firstOptions.AdditionalCustomTrustCertificates);
+        Assert.Equal("CN=localhost", cert.Subject);
+
+        // Since the second resolution should have cached values, deleting the file during operation
+        // should have no impact.
+        File.Delete(tempCert);
+
+        // This is expected to be a cached version and doesn't actually need to go and read the file system
+        var secondOptions = services.GetRequiredService<IOptions<X509ChainOptions>>().Value;
+        Assert.Same(firstOptions, secondOptions);
+
+        // This is the same reference as the first one so it shouldn't be different but just in case.
+        Assert.NotNull(secondOptions.AdditionalCustomTrustCertificates);
+        Assert.Single(secondOptions.AdditionalCustomTrustCertificates);
+    }
+
+    [Fact]
+    public async Task DoesNotProvideCustomCallbackOnCloud()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("certs");
+        
+        var tempCert = Path.Combine(tempDir.FullName, "test.crt");
+        await File.WriteAllBytesAsync(tempCert, CreateSelfSignedCert("localhost").Export(X509ContentType.Cert));
+
+        var options = CreateOptions((gs, environment, config) =>
+        {
+            gs.SelfHosted = false;
+
+            environment.EnvironmentName = "Development";
+
+            config["X509ChainOptions:AdditionalCustomTrustCertificatesDirectory"] = tempDir.FullName;
+        });
+
+        Assert.False(options.TryGetCustomRemoteCertificateValidationCallback(out _));
+    }
+
+    [Fact]
+    public async Task ManuallyAddingOptionsTakesPrecedence()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("certs");
+        
+        var tempCert = Path.Combine(tempDir.FullName, "test.crt");
+        await File.WriteAllBytesAsync(tempCert, CreateSelfSignedCert("localhost").Export(X509ContentType.Cert));
+
+        var options = CreateOptions((gs, environment, config) =>
+        {
+            gs.SelfHosted = false;
+
+            environment.EnvironmentName = "Development";
+
+            config["X509ChainOptions:AdditionalCustomTrustCertificatesDirectory"] = tempDir.FullName;
+        }, services =>
+        {
+            services.Configure<X509ChainOptions>(options =>
+            {
+                options.AdditionalCustomTrustCertificates = [CreateSelfSignedCert("example.com")];
+            });
+        });
+
+        Assert.True(options.TryGetCustomRemoteCertificateValidationCallback(out var callback));
+        var cert = Assert.Single(options.AdditionalCustomTrustCertificates);
+        Assert.Equal("CN=example.com", cert.Subject);
+    }
+
+    private static X509ChainOptions CreateOptions(Action<GlobalSettings, IHostEnvironment, Dictionary<string, string>> configure, Action<IServiceCollection>? after = null)
+    {
+        var services = CreateServices(configure, after);
+        return services.GetRequiredService<IOptions<X509ChainOptions>>().Value;
+    }
+
+    private static IServiceProvider CreateServices(Action<GlobalSettings, IHostEnvironment, Dictionary<string, string>> configure, Action<IServiceCollection>? after = null)
+    {
+        var globalSettings = new GlobalSettings();
+        var hostEnvironment = Substitute.For<IHostEnvironment>();
+        var config = new Dictionary<string, string>();
+
+        configure(globalSettings, hostEnvironment, config);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(globalSettings);
+        services.AddSingleton(hostEnvironment);
+        services.AddSingleton<IConfiguration>(
+            new ConfigurationBuilder()
+                .AddInMemoryCollection(config)
+                .Build()
+        );
+
+        services.AddX509ChainCustomization();
+
+        after?.Invoke(services);
+
+        return services.BuildServiceProvider();
+    }
+}

--- a/test/Core.Test/Platform/X509ChainCustomization/X509ChainCustomizationServiceCollectionExtensionsTests.cs
+++ b/test/Core.Test/Platform/X509ChainCustomization/X509ChainCustomizationServiceCollectionExtensionsTests.cs
@@ -195,7 +195,7 @@ public class X509ChainCustomizationServiceCollectionExtensionsTests
             options.ServerCertificate = selfSignedCertificate;
         });
 
-        var services = CreateServices((gs, environment, config) => {}, services =>
+        var services = CreateServices((gs, environment, config) => { }, services =>
         {
             services.Configure<X509ChainOptions>(options =>
             {
@@ -218,7 +218,7 @@ public class X509ChainCustomizationServiceCollectionExtensionsTests
             options.ServerCertificate = selfSignedCertificate;
         });
 
-        var services = CreateServices((gs, environment, config) => {}, services =>
+        var services = CreateServices((gs, environment, config) => { }, services =>
         {
             services.Configure<X509ChainOptions>(options =>
             {
@@ -243,7 +243,7 @@ public class X509ChainCustomizationServiceCollectionExtensionsTests
             options.ServerCertificate = selfSignedCertificate;
         });
 
-        var services = CreateServices((gs, environment, config) => {}, services =>
+        var services = CreateServices((gs, environment, config) => { }, services =>
         {
             services.Configure<X509ChainOptions>(options =>
             {

--- a/test/Core.Test/Platform/X509ChainCustomization/X509ChainCustomizationServiceCollectionExtensionsTests.cs
+++ b/test/Core.Test/Platform/X509ChainCustomization/X509ChainCustomizationServiceCollectionExtensionsTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Options;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Core.Test.Platform.TlsCustomization;
+namespace Bit.Core.Test.Platform.X509ChainCustomization;
 
 public class X509ChainCustomizationServiceCollectionExtensionsTests
 {

--- a/test/Core.Test/Platform/X509ChainCustomization/X509ChainCustomizationServiceCollectionExtensionsTests.cs
+++ b/test/Core.Test/Platform/X509ChainCustomization/X509ChainCustomizationServiceCollectionExtensionsTests.cs
@@ -1,4 +1,4 @@
-using System.Security.Cryptography;
+﻿using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Bit.Core.Platform.X509ChainCustomization;
 using Bit.Core.Settings;
@@ -24,7 +24,7 @@ public class X509ChainCustomizationServiceCollectionExtensionsTests
     public async Task OptionsPatternReturnsCachedValue()
     {
         var tempDir = Directory.CreateTempSubdirectory("certs");
-        
+
         var tempCert = Path.Combine(tempDir.FullName, "test.crt");
         await File.WriteAllBytesAsync(tempCert, CreateSelfSignedCert("localhost").Export(X509ContentType.Cert));
 
@@ -36,7 +36,7 @@ public class X509ChainCustomizationServiceCollectionExtensionsTests
 
             config["X509ChainOptions:AdditionalCustomTrustCertificatesDirectory"] = tempDir.FullName;
         });
-        
+
         // Create options once
         var firstOptions = services.GetRequiredService<IOptions<X509ChainOptions>>().Value;
 
@@ -61,7 +61,7 @@ public class X509ChainCustomizationServiceCollectionExtensionsTests
     public async Task DoesNotProvideCustomCallbackOnCloud()
     {
         var tempDir = Directory.CreateTempSubdirectory("certs");
-        
+
         var tempCert = Path.Combine(tempDir.FullName, "test.crt");
         await File.WriteAllBytesAsync(tempCert, CreateSelfSignedCert("localhost").Export(X509ContentType.Cert));
 
@@ -81,7 +81,7 @@ public class X509ChainCustomizationServiceCollectionExtensionsTests
     public async Task ManuallyAddingOptionsTakesPrecedence()
     {
         var tempDir = Directory.CreateTempSubdirectory("certs");
-        
+
         var tempCert = Path.Combine(tempDir.FullName, "test.crt");
         await File.WriteAllBytesAsync(tempCert, CreateSelfSignedCert("localhost").Export(X509ContentType.Cert));
 

--- a/test/Core.Test/Platform/X509ChainCustomization/X509ChainCustomizationServiceCollectionExtensionsTests.cs
+++ b/test/Core.Test/Platform/X509ChainCustomization/X509ChainCustomizationServiceCollectionExtensionsTests.cs
@@ -259,9 +259,7 @@ public class X509ChainCustomizationServiceCollectionExtensionsTests
 
     private static async Task<IAsyncDisposable> CreateServerAsync(int port, Action<HttpsConnectionAdapterOptions> configure)
     {
-        // Start HTTP Server with self signed cert
-        var builder = WebApplication.CreateSlimBuilder();
-        builder.Logging.AddFakeLogging();
+        var builder = WebApplication.CreateEmptyBuilder(new WebApplicationOptions());
         builder.Services.AddRoutingCore();
         builder.WebHost.UseKestrelCore()
             .ConfigureKestrel(options =>

--- a/test/Core.Test/Services/HandlebarsMailServiceTests.cs
+++ b/test/Core.Test/Services/HandlebarsMailServiceTests.cs
@@ -4,9 +4,11 @@ using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.Auth.Entities;
 using Bit.Core.Auth.Models.Business;
 using Bit.Core.Entities;
+using Bit.Core.Platform.X509ChainCustomization;
 using Bit.Core.Services;
 using Bit.Core.Settings;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Xunit;
 
@@ -136,7 +138,7 @@ public class HandlebarsMailServiceTests
             SiteName = "Bitwarden",
         };
 
-        var mailDeliveryService = new MailKitSmtpMailDeliveryService(globalSettings, Substitute.For<ILogger<MailKitSmtpMailDeliveryService>>());
+        var mailDeliveryService = new MailKitSmtpMailDeliveryService(globalSettings, Substitute.For<ILogger<MailKitSmtpMailDeliveryService>>(), Options.Create(new X509ChainOptions()));
 
         var handlebarsService = new HandlebarsMailService(globalSettings, mailDeliveryService, new BlockingMailEnqueuingService());
 

--- a/test/Core.Test/Services/MailKitSmtpMailDeliveryServiceTests.cs
+++ b/test/Core.Test/Services/MailKitSmtpMailDeliveryServiceTests.cs
@@ -1,6 +1,8 @@
-﻿using Bit.Core.Services;
+﻿using Bit.Core.Platform.X509ChainCustomization;
+using Bit.Core.Services;
 using Bit.Core.Settings;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Xunit;
 
@@ -23,7 +25,8 @@ public class MailKitSmtpMailDeliveryServiceTests
 
         _sut = new MailKitSmtpMailDeliveryService(
             _globalSettings,
-            _logger
+            _logger,
+            Options.Create(new X509ChainOptions())
         );
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-19601
https://bitwarden.atlassian.net/browse/PM-19599

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

All for customizing trusted root certificates without the need of `update-ca-certificates`. This helps in us not needing root in containers. This sets up the usage of the custom server certificate validation callback for SMTP and all `HttpClient`s when created with `IHttpClientFactory`. I am not calling `AddX509ChainCustomization` in any project yet so this feature doesn't light up yet. But the expectation is that it would be added to all self hosted containers. 

This code is to replace [this bash](https://github.com/bitwarden/server/blob/67d7d685a619a5fc413f8532dacb09681ee5c956/src/Api/entrypoint.sh#L38-L41) in the container start.

The default of the setting maps directly to the location we used to copy certificates from so for the most part 0 customization should have to be done by anyone to get this feature if there were previously placing certificates in that directory. The setting is largely exposed for developers to map it to a custom directory.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
