### PR TITLE
[PM-19883] Add untrust devices endpoint

### DIFF
--- a/src/Api/Auth/Models/Request/UntrustDevicesModel.cs
+++ b/src/Api/Auth/Models/Request/UntrustDevicesModel.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+#nullable enable
+
+namespace Bit.Api.Auth.Models.Request;
+
+public class UntrustDevicesRequestModel
+{
+    [Required]
+    public IEnumerable<Guid> Devices { get; set; } = null!;
+}

--- a/src/Core/Auth/UserFeatures/DeviceTrust/Interfaces/IUntrustDevicesCommand.cs
+++ b/src/Core/Auth/UserFeatures/DeviceTrust/Interfaces/IUntrustDevicesCommand.cs
@@ -1,0 +1,8 @@
+﻿using Bit.Core.Entities;
+
+namespace Bit.Core.Auth.UserFeatures.DeviceTrust;
+
+public interface IUntrustDevicesCommand
+{
+    public Task UntrustDevices(User user, IEnumerable<Guid> devicesToUntrust);
+}

--- a/src/Core/Auth/UserFeatures/DeviceTrust/UntrustDevicesCommand.cs
+++ b/src/Core/Auth/UserFeatures/DeviceTrust/UntrustDevicesCommand.cs
@@ -17,7 +17,7 @@ public class UntrustDevicesCommand : IUntrustDevicesCommand
     {
         var userDevices = await _deviceRepository.GetManyByUserIdAsync(user.Id);
         var deviceIdDict = userDevices.ToDictionary(device => device.Id);
-        
+
         // Validate that the user owns all devices that they passed in
         foreach (var deviceId in devicesToUntrust)
         {

--- a/src/Core/Auth/UserFeatures/DeviceTrust/UntrustDevicesCommand.cs
+++ b/src/Core/Auth/UserFeatures/DeviceTrust/UntrustDevicesCommand.cs
@@ -1,0 +1,36 @@
+﻿using Bit.Core.Entities;
+using Bit.Core.Repositories;
+
+namespace Bit.Core.Auth.UserFeatures.DeviceTrust;
+
+public class UntrustDevicesCommand : IUntrustDevicesCommand
+{
+    private readonly IDeviceRepository _deviceRepository;
+
+    public UntrustDevicesCommand(
+        IDeviceRepository deviceRepository)
+    {
+        _deviceRepository = deviceRepository;
+    }
+
+    public async Task UntrustDevices(User user, IEnumerable<Guid> devicesToUntrust)
+    {
+        var userDevices = await _deviceRepository.GetManyByUserIdAsync(user.Id);
+        foreach (var deviceId in devicesToUntrust)
+        {
+            if (!userDevices.Any(d => d.Id == deviceId))
+            {
+                throw new UnauthorizedAccessException($"User {user.Id} does not have access to device {deviceId}");
+            }
+        }
+
+        foreach (var deviceId in devicesToUntrust)
+        {
+            var device = userDevices.First(d => d.Id == deviceId);
+            device.EncryptedPrivateKey = null;
+            device.EncryptedPublicKey = null;
+            device.EncryptedUserKey = null;
+            await _deviceRepository.UpsertAsync(device);
+        }
+    }
+}

--- a/src/Core/Auth/UserFeatures/UserServiceCollectionExtensions.cs
+++ b/src/Core/Auth/UserFeatures/UserServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿
 
+using Bit.Core.Auth.UserFeatures.DeviceTrust;
 using Bit.Core.Auth.UserFeatures.Registration;
 using Bit.Core.Auth.UserFeatures.Registration.Implementations;
 using Bit.Core.Auth.UserFeatures.TdeOffboardingPassword.Interfaces;
@@ -22,11 +23,17 @@ public static class UserServiceCollectionExtensions
     public static void AddUserServices(this IServiceCollection services, IGlobalSettings globalSettings)
     {
         services.AddScoped<IUserService, UserService>();
+        services.AddDeviceTrustCommands();
         services.AddUserPasswordCommands();
         services.AddUserRegistrationCommands();
         services.AddWebAuthnLoginCommands();
         services.AddTdeOffboardingPasswordCommands();
         services.AddTwoFactorQueries();
+    }
+
+    public static void AddDeviceTrustCommands(this IServiceCollection services)
+    {
+        services.AddScoped<IUntrustDevicesCommand, UntrustDevicesCommand>();
     }
 
     public static void AddUserKeyCommands(this IServiceCollection services, IGlobalSettings globalSettings)

--- a/test/Api.Test/Auth/Controllers/DevicesControllerTests.cs
+++ b/test/Api.Test/Auth/Controllers/DevicesControllerTests.cs
@@ -2,6 +2,7 @@
 using Bit.Api.Models.Response;
 using Bit.Core.Auth.Models.Api.Response;
 using Bit.Core.Auth.Models.Data;
+using Bit.Core.Auth.UserFeatures.DeviceTrust;
 using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
@@ -19,6 +20,7 @@ public class DevicesControllerTest
     private readonly IDeviceRepository _deviceRepositoryMock;
     private readonly IDeviceService _deviceServiceMock;
     private readonly IUserService _userServiceMock;
+    private readonly IUntrustDevicesCommand _untrustDevicesCommand;
     private readonly IUserRepository _userRepositoryMock;
     private readonly ICurrentContext _currentContextMock;
     private readonly IGlobalSettings _globalSettingsMock;
@@ -30,6 +32,7 @@ public class DevicesControllerTest
         _deviceRepositoryMock = Substitute.For<IDeviceRepository>();
         _deviceServiceMock = Substitute.For<IDeviceService>();
         _userServiceMock = Substitute.For<IUserService>();
+        _untrustDevicesCommand = Substitute.For<IUntrustDevicesCommand>();
         _userRepositoryMock = Substitute.For<IUserRepository>();
         _currentContextMock = Substitute.For<ICurrentContext>();
         _loggerMock = Substitute.For<ILogger<DevicesController>>();
@@ -38,6 +41,7 @@ public class DevicesControllerTest
             _deviceRepositoryMock,
             _deviceServiceMock,
             _userServiceMock,
+            _untrustDevicesCommand,
             _userRepositoryMock,
             _currentContextMock,
             _loggerMock);

--- a/test/Core.Test/Auth/UserFeatures/DeviceTrust/UntrustDevicesCommandTests.cs
+++ b/test/Core.Test/Auth/UserFeatures/DeviceTrust/UntrustDevicesCommandTests.cs
@@ -1,0 +1,55 @@
+﻿using Bit.Core.Auth.UserFeatures.DeviceTrust;
+using Bit.Core.Entities;
+using Bit.Core.Repositories;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Auth.UserFeatures.WebAuthnLogin;
+
+[SutProviderCustomize]
+public class UntrustDevicesCommandTests
+{
+    [Theory, BitAutoData]
+    public async Task SetsKeysToNull(SutProvider<UntrustDevicesCommand> sutProvider, User user)
+    {
+        var deviceId = Guid.NewGuid();
+        // Arrange
+        sutProvider.GetDependency<IDeviceRepository>()
+            .GetManyByUserIdAsync(user.Id)
+            .Returns([new Device
+            {
+                Id = deviceId,
+                EncryptedPrivateKey = "encryptedPrivateKey",
+                EncryptedPublicKey = "encryptedPublicKey",
+                EncryptedUserKey = "encryptedUserKey"
+            }]);
+
+        // Act
+        await sutProvider.Sut.UntrustDevices(user, new List<Guid> { deviceId });
+
+        // Assert
+        await sutProvider.GetDependency<IDeviceRepository>()
+            .Received()
+            .UpsertAsync(Arg.Is<Device>(d =>
+                d.Id == deviceId &&
+                d.EncryptedPrivateKey == null &&
+                d.EncryptedPublicKey == null &&
+                d.EncryptedUserKey == null));
+    }
+
+    [Theory, BitAutoData]
+    public async Task RejectsWrongUser(SutProvider<UntrustDevicesCommand> sutProvider, User user)
+    {
+        var deviceId = Guid.NewGuid();
+        // Arrange
+        sutProvider.GetDependency<IDeviceRepository>()
+            .GetManyByUserIdAsync(user.Id)
+            .Returns([]);
+
+        // Act
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(async () =>
+            await sutProvider.Sut.UntrustDevices(user, new List<Guid> { deviceId }));
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19883

## 📔 Objective

Adds an endpoint to untrust a list of the users devices, removing their encryption keys. The untrusting operation has a separate command with provided unit tests.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
