### PR TITLE
[PM-18858] Use int.TryParse for plurality helper

### DIFF
--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -804,12 +804,10 @@ public class HandlebarsMailService : IMailService
                 return;
             }
 
-            var numeric = parameters[0];
-            var singularText = parameters[1].ToString();
-            var pluralText = parameters[2].ToString();
-
-            if (numeric is int number)
+            if (int.TryParse(parameters[0].ToString(), out var number))
             {
+                var singularText = parameters[1].ToString();
+                var pluralText = parameters[2].ToString();
                 writer.WriteSafeString(number == 1 ? singularText : pluralText);
             }
             else


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18858](https://bitwarden.atlassian.net/browse/PM-18858)

## 📔 Objective

The `AzureQueueMailService` serializes the mail message request which is then processed by the `AzureQueueMailHostedService`. During this serialization process, the "number" argument for the new `plurality` helper is converted to a string and needs to be `TryParsed` into an integer before being evaluated.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18858]: https://bitwarden.atlassian.net/browse/PM-18858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ