### PR TITLE
[PM-19728] Add keys on devices list and get responses

### DIFF
--- a/src/Api/Controllers/DevicesController.cs
+++ b/src/Api/Controllers/DevicesController.cs
@@ -128,6 +128,7 @@ public class DevicesController : Controller
     }
 
     [HttpPost("{identifier}/retrieve-keys")]
+    [Obsolete("This endpoint is deprecated. The keys are on the regular device GET endpoints now.")]
     public async Task<ProtectedDeviceResponseModel> GetDeviceKeys(string identifier)
     {
         var user = await _userService.GetUserByPrincipalAsync(User);

--- a/src/Api/Models/Response/DeviceResponseModel.cs
+++ b/src/Api/Models/Response/DeviceResponseModel.cs
@@ -2,6 +2,7 @@
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Models.Api;
+using Bit.Core.Utilities;
 
 namespace Bit.Api.Models.Response;
 
@@ -21,6 +22,8 @@ public class DeviceResponseModel : ResponseModel
         Identifier = device.Identifier;
         CreationDate = device.CreationDate;
         IsTrusted = device.IsTrusted();
+        EncryptedUserKey = device.EncryptedUserKey;
+        EncryptedPublicKey = device.EncryptedPublicKey;
     }
 
     public Guid Id { get; set; }
@@ -29,4 +32,10 @@ public class DeviceResponseModel : ResponseModel
     public string Identifier { get; set; }
     public DateTime CreationDate { get; set; }
     public bool IsTrusted { get; set; }
+    [EncryptedString]
+    [EncryptedStringLength(2000)]
+    public string EncryptedUserKey { get; set; }
+    [EncryptedString]
+    [EncryptedStringLength(2000)]
+    public string EncryptedPublicKey { get; set; }
 }

--- a/src/Core/Auth/Models/Api/Response/DeviceAuthRequestResponseModel.cs
+++ b/src/Core/Auth/Models/Api/Response/DeviceAuthRequestResponseModel.cs
@@ -1,6 +1,7 @@
 ﻿using Bit.Core.Auth.Models.Data;
 using Bit.Core.Enums;
 using Bit.Core.Models.Api;
+using Bit.Core.Utilities;
 
 namespace Bit.Core.Auth.Models.Api.Response;
 
@@ -19,6 +20,8 @@ public class DeviceAuthRequestResponseModel : ResponseModel
             Identifier = deviceAuthDetails.Identifier,
             CreationDate = deviceAuthDetails.CreationDate,
             IsTrusted = deviceAuthDetails.IsTrusted,
+            EncryptedPublicKey = deviceAuthDetails.EncryptedPublicKey,
+            EncryptedUserKey = deviceAuthDetails.EncryptedUserKey
         };
 
         if (deviceAuthDetails.AuthRequestId != null && deviceAuthDetails.AuthRequestCreatedAt != null)
@@ -39,6 +42,12 @@ public class DeviceAuthRequestResponseModel : ResponseModel
     public string Identifier { get; set; }
     public DateTime CreationDate { get; set; }
     public bool IsTrusted { get; set; }
+    [EncryptedString]
+    [EncryptedStringLength(2000)]
+    public string EncryptedUserKey { get; set; }
+    [EncryptedString]
+    [EncryptedStringLength(2000)]
+    public string EncryptedPublicKey { get; set; }
 
     public PendingAuthRequest DevicePendingAuthRequest { get; set; }
 

--- a/src/Core/Auth/Models/Data/DeviceAuthDetails.cs
+++ b/src/Core/Auth/Models/Data/DeviceAuthDetails.cs
@@ -29,6 +29,8 @@ public class DeviceAuthDetails : Device
         Identifier = device.Identifier;
         CreationDate = device.CreationDate;
         IsTrusted = device.IsTrusted();
+        EncryptedPublicKey = device.EncryptedPublicKey;
+        EncryptedUserKey = device.EncryptedUserKey;
         AuthRequestId = authRequestId;
         AuthRequestCreatedAt = authRequestCreationDate;
     }
@@ -74,6 +76,8 @@ public class DeviceAuthDetails : Device
             EncryptedPrivateKey = encryptedPrivateKey,
             Active = active
         }.IsTrusted();
+        EncryptedPublicKey = encryptedPublicKey;
+        EncryptedUserKey = encryptedUserKey;
         AuthRequestId = authRequestId != Guid.Empty ? authRequestId : null;
         AuthRequestCreatedAt =
             authRequestCreationDate != DateTime.MinValue ? authRequestCreationDate : null;

--- a/test/Api.Test/Auth/Controllers/DevicesControllerTests.cs
+++ b/test/Api.Test/Auth/Controllers/DevicesControllerTests.cs
@@ -63,7 +63,9 @@ public class DevicesControllerTest
                     UserId = userId,
                     Name = "chrome",
                     Type = DeviceType.ChromeBrowser,
-                    Identifier = Guid.Parse("811E9254-F77C-48C8-AF0A-A181943F5708").ToString()
+                    Identifier = Guid.Parse("811E9254-F77C-48C8-AF0A-A181943F5708").ToString(),
+                    EncryptedPublicKey = "PublicKey",
+                    EncryptedUserKey = "UserKey",
                 },
                 Guid.Parse("E09D6943-D574-49E5-AC85-C3F12B4E019E"),
                 authDateTimeResponse)
@@ -78,6 +80,13 @@ public class DevicesControllerTest
         // Assert
         Assert.NotNull(result);
         Assert.IsType<ListResponseModel<DeviceAuthRequestResponseModel>>(result);
+        var resultDevice = result.Data.First();
+        Assert.Equal("chrome", resultDevice.Name);
+        Assert.Equal(DeviceType.ChromeBrowser, resultDevice.Type);
+        Assert.Equal(Guid.Parse("B3136B10-7818-444F-B05B-4D7A9B8C48BF"), resultDevice.Id);
+        Assert.Equal(Guid.Parse("811E9254-F77C-48C8-AF0A-A181943F5708").ToString(), resultDevice.Identifier);
+        Assert.Equal("PublicKey", resultDevice.EncryptedPublicKey);
+        Assert.Equal("UserKey", resultDevice.EncryptedUserKey);
     }
 
     [Fact]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19728
https://github.com/bitwarden/clients/pull/14216

## 📔 Objective

Currently key-rotation v2 will get device keys individually, which puts strain on the server. This PR adds the keys to the list request, so we do not need to retrieve them separately.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
