### PR TITLE
[PM-19566] Update MSPs to "charge_automatically" with Admin-based opt-out

### DIFF
--- a/src/Admin/AdminConsole/Controllers/ProvidersController.cs
+++ b/src/Admin/AdminConsole/Controllers/ProvidersController.cs
@@ -317,14 +317,14 @@ public class ProvidersController : Controller
                 {
                     var customer = await _stripeAdapter.CustomerGetAsync(provider.GatewayCustomerId);
 
-                    if (model.InvoiceApproved != customer.IsInvoiceApproved())
+                    if (model.PayByInvoice != customer.ApprovedToPayByInvoice())
                     {
-                        var invoiceApproved = model.InvoiceApproved ? "1" : "0";
+                        var approvedToPayByInvoice = model.PayByInvoice ? "1" : "0";
                         await _stripeAdapter.CustomerUpdateAsync(customer.Id, new CustomerUpdateOptions
                         {
                             Metadata = new Dictionary<string, string>
                             {
-                                [StripeConstants.MetadataKeys.InvoiceApproved] = invoiceApproved
+                                [StripeConstants.MetadataKeys.InvoiceApproved] = approvedToPayByInvoice
                             }
                         });
                     }
@@ -373,13 +373,13 @@ public class ProvidersController : Controller
 
         var providerPlans = await _providerPlanRepository.GetByProviderId(id);
 
-        var invoiceApproved =
+        var payByInvoice =
             _featureService.IsEnabled(FeatureFlagKeys.PM199566_UpdateMSPToChargeAutomatically) &&
-            (await _stripeAdapter.CustomerGetAsync(provider.GatewayCustomerId)).IsInvoiceApproved();
+            (await _stripeAdapter.CustomerGetAsync(provider.GatewayCustomerId)).ApprovedToPayByInvoice();
 
         return new ProviderEditModel(
             provider, users, providerOrganizations,
-            providerPlans.ToList(), invoiceApproved, GetGatewayCustomerUrl(provider), GetGatewaySubscriptionUrl(provider));
+            providerPlans.ToList(), payByInvoice, GetGatewayCustomerUrl(provider), GetGatewaySubscriptionUrl(provider));
     }
 
     [RequirePermission(Permission.Provider_ResendEmailInvite)]

--- a/src/Admin/AdminConsole/Controllers/ProvidersController.cs
+++ b/src/Admin/AdminConsole/Controllers/ProvidersController.cs
@@ -3,11 +3,13 @@ using System.Net;
 using Bit.Admin.AdminConsole.Models;
 using Bit.Admin.Enums;
 using Bit.Admin.Utilities;
+using Bit.Core;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.AdminConsole.Providers.Interfaces;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.AdminConsole.Services;
+using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Entities;
 using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Extensions;
@@ -23,6 +25,7 @@ using Bit.Core.Settings;
 using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Stripe;
 
 namespace Bit.Admin.AdminConsole.Controllers;
 
@@ -44,6 +47,7 @@ public class ProvidersController : Controller
     private readonly IProviderPlanRepository _providerPlanRepository;
     private readonly IProviderBillingService _providerBillingService;
     private readonly IPricingClient _pricingClient;
+    private readonly IStripeAdapter _stripeAdapter;
     private readonly string _stripeUrl;
     private readonly string _braintreeMerchantUrl;
     private readonly string _braintreeMerchantId;
@@ -63,7 +67,8 @@ public class ProvidersController : Controller
         IProviderPlanRepository providerPlanRepository,
         IProviderBillingService providerBillingService,
         IWebHostEnvironment webHostEnvironment,
-        IPricingClient pricingClient)
+        IPricingClient pricingClient,
+        IStripeAdapter stripeAdapter)
     {
         _organizationRepository = organizationRepository;
         _organizationService = organizationService;
@@ -79,6 +84,7 @@ public class ProvidersController : Controller
         _providerPlanRepository = providerPlanRepository;
         _providerBillingService = providerBillingService;
         _pricingClient = pricingClient;
+        _stripeAdapter = stripeAdapter;
         _stripeUrl = webHostEnvironment.GetStripeUrl();
         _braintreeMerchantUrl = webHostEnvironment.GetBraintreeMerchantUrl();
         _braintreeMerchantId = globalSettings.Braintree.MerchantId;
@@ -306,6 +312,23 @@ public class ProvidersController : Controller
                         (Plan: PlanType.EnterpriseMonthly, SeatsMinimum: model.EnterpriseMonthlySeatMinimum)
                     ]);
                 await _providerBillingService.UpdateSeatMinimums(updateMspSeatMinimumsCommand);
+
+                if (_featureService.IsEnabled(FeatureFlagKeys.PM199566_UpdateMSPToChargeAutomatically))
+                {
+                    var customer = await _stripeAdapter.CustomerGetAsync(provider.GatewayCustomerId);
+
+                    if (model.InvoiceApproved != customer.IsInvoiceApproved())
+                    {
+                        var invoiceApproved = model.InvoiceApproved ? "1" : "0";
+                        await _stripeAdapter.CustomerUpdateAsync(customer.Id, new CustomerUpdateOptions
+                        {
+                            Metadata = new Dictionary<string, string>
+                            {
+                                [StripeConstants.MetadataKeys.InvoiceApproved] = invoiceApproved
+                            }
+                        });
+                    }
+                }
                 break;
             case ProviderType.BusinessUnit:
                 {
@@ -345,14 +368,18 @@ public class ProvidersController : Controller
 
         if (!provider.IsBillable())
         {
-            return new ProviderEditModel(provider, users, providerOrganizations, new List<ProviderPlan>());
+            return new ProviderEditModel(provider, users, providerOrganizations, new List<ProviderPlan>(), false);
         }
 
         var providerPlans = await _providerPlanRepository.GetByProviderId(id);
 
+        var invoiceApproved =
+            _featureService.IsEnabled(FeatureFlagKeys.PM199566_UpdateMSPToChargeAutomatically) &&
+            (await _stripeAdapter.CustomerGetAsync(provider.GatewayCustomerId)).IsInvoiceApproved();
+
         return new ProviderEditModel(
             provider, users, providerOrganizations,
-            providerPlans.ToList(), GetGatewayCustomerUrl(provider), GetGatewaySubscriptionUrl(provider));
+            providerPlans.ToList(), invoiceApproved, GetGatewayCustomerUrl(provider), GetGatewaySubscriptionUrl(provider));
     }
 
     [RequirePermission(Permission.Provider_ResendEmailInvite)]

--- a/src/Admin/AdminConsole/Models/ProviderEditModel.cs
+++ b/src/Admin/AdminConsole/Models/ProviderEditModel.cs
@@ -6,6 +6,7 @@ using Bit.Core.Billing.Entities;
 using Bit.Core.Billing.Enums;
 using Bit.Core.Enums;
 using Bit.SharedWeb.Utilities;
+using BitPayLight.Models.Invoice;
 
 namespace Bit.Admin.AdminConsole.Models;
 
@@ -18,6 +19,7 @@ public class ProviderEditModel : ProviderViewModel, IValidatableObject
         IEnumerable<ProviderUserUserDetails> providerUsers,
         IEnumerable<ProviderOrganizationOrganizationDetails> organizations,
         IReadOnlyCollection<ProviderPlan> providerPlans,
+        bool invoiceApproved,
         string gatewayCustomerUrl = null,
         string gatewaySubscriptionUrl = null) : base(provider, providerUsers, organizations, providerPlans)
     {
@@ -33,6 +35,7 @@ public class ProviderEditModel : ProviderViewModel, IValidatableObject
         GatewayCustomerUrl = gatewayCustomerUrl;
         GatewaySubscriptionUrl = gatewaySubscriptionUrl;
         Type = provider.Type;
+        InvoiceApproved = invoiceApproved;
 
         if (Type == ProviderType.BusinessUnit)
         {
@@ -62,6 +65,8 @@ public class ProviderEditModel : ProviderViewModel, IValidatableObject
     public string GatewaySubscriptionId { get; set; }
     public string GatewayCustomerUrl { get; }
     public string GatewaySubscriptionUrl { get; }
+    [Display(Name = "Invoice Approved")]
+    public bool InvoiceApproved { get; set; }
     [Display(Name = "Provider Type")]
     public ProviderType Type { get; set; }
 

--- a/src/Admin/AdminConsole/Models/ProviderEditModel.cs
+++ b/src/Admin/AdminConsole/Models/ProviderEditModel.cs
@@ -19,7 +19,7 @@ public class ProviderEditModel : ProviderViewModel, IValidatableObject
         IEnumerable<ProviderUserUserDetails> providerUsers,
         IEnumerable<ProviderOrganizationOrganizationDetails> organizations,
         IReadOnlyCollection<ProviderPlan> providerPlans,
-        bool invoiceApproved,
+        bool payByInvoice,
         string gatewayCustomerUrl = null,
         string gatewaySubscriptionUrl = null) : base(provider, providerUsers, organizations, providerPlans)
     {
@@ -35,7 +35,7 @@ public class ProviderEditModel : ProviderViewModel, IValidatableObject
         GatewayCustomerUrl = gatewayCustomerUrl;
         GatewaySubscriptionUrl = gatewaySubscriptionUrl;
         Type = provider.Type;
-        InvoiceApproved = invoiceApproved;
+        PayByInvoice = payByInvoice;
 
         if (Type == ProviderType.BusinessUnit)
         {
@@ -65,8 +65,8 @@ public class ProviderEditModel : ProviderViewModel, IValidatableObject
     public string GatewaySubscriptionId { get; set; }
     public string GatewayCustomerUrl { get; }
     public string GatewaySubscriptionUrl { get; }
-    [Display(Name = "Invoice Approved")]
-    public bool InvoiceApproved { get; set; }
+    [Display(Name = "Pay By Invoice")]
+    public bool PayByInvoice { get; set; }
     [Display(Name = "Provider Type")]
     public ProviderType Type { get; set; }
 

--- a/src/Admin/AdminConsole/Models/ProviderEditModel.cs
+++ b/src/Admin/AdminConsole/Models/ProviderEditModel.cs
@@ -6,7 +6,6 @@ using Bit.Core.Billing.Entities;
 using Bit.Core.Billing.Enums;
 using Bit.Core.Enums;
 using Bit.SharedWeb.Utilities;
-using BitPayLight.Models.Invoice;
 
 namespace Bit.Admin.AdminConsole.Models;
 

--- a/src/Admin/AdminConsole/Views/Providers/Edit.cshtml
+++ b/src/Admin/AdminConsole/Views/Providers/Edit.cshtml
@@ -141,8 +141,8 @@
             <div class="row">
                 <div class="col-sm">
                     <div class="form-check mb-3">
-                        <input type="checkbox" class="form-check-input" asp-for="InvoiceApproved">
-                        <label class="form-check-label" asp-for="InvoiceApproved"></label>
+                        <input type="checkbox" class="form-check-input" asp-for="PayByInvoice">
+                        <label class="form-check-label" asp-for="PayByInvoice"></label>
                     </div>
                 </div>
             </div>

--- a/src/Admin/AdminConsole/Views/Providers/Edit.cshtml
+++ b/src/Admin/AdminConsole/Views/Providers/Edit.cshtml
@@ -136,6 +136,17 @@
                 </div>
             </div>
         </div>
+        @if (FeatureService.IsEnabled(FeatureFlagKeys.PM199566_UpdateMSPToChargeAutomatically) && Model.Provider.Type == ProviderType.Msp && Model.Provider.IsBillable())
+        {
+            <div class="row">
+                <div class="col-sm">
+                    <div class="form-check mb-3">
+                        <input type="checkbox" class="form-check-input" asp-for="InvoiceApproved">
+                        <label class="form-check-label" asp-for="InvoiceApproved"></label>
+                    </div>
+                </div>
+            </div>
+        }
     }
 </form>
 @await Html.PartialAsync("Organizations", Model)

--- a/src/Billing/Services/IStripeFacade.cs
+++ b/src/Billing/Services/IStripeFacade.cs
@@ -16,6 +16,12 @@ public interface IStripeFacade
         RequestOptions requestOptions = null,
         CancellationToken cancellationToken = default);
 
+    Task<Customer> UpdateCustomer(
+        string customerId,
+        CustomerUpdateOptions customerUpdateOptions = null,
+        RequestOptions requestOptions = null,
+        CancellationToken cancellationToken = default);
+
     Task<Event> GetEvent(
         string eventId,
         EventGetOptions eventGetOptions = null,

--- a/src/Billing/Services/Implementations/PaymentMethodAttachedHandler.cs
+++ b/src/Billing/Services/Implementations/PaymentMethodAttachedHandler.cs
@@ -68,7 +68,7 @@ public class PaymentMethodAttachedHandler : IPaymentMethodAttachedHandler
          * If we have an invoiced provider subscription where the customer hasn't been marked as invoice-approved,
          * we need to try and set the default payment method and update the collection method to be "charge_automatically".
          */
-        if (invoicedProviderSubscription != null && !customer.IsInvoiceApproved())
+        if (invoicedProviderSubscription != null && !customer.ApprovedToPayByInvoice())
         {
             if (customer.InvoiceSettings.DefaultPaymentMethodId != paymentMethod.Id)
             {

--- a/src/Billing/Services/Implementations/PaymentMethodAttachedHandler.cs
+++ b/src/Billing/Services/Implementations/PaymentMethodAttachedHandler.cs
@@ -1,4 +1,8 @@
 ﻿using Bit.Billing.Constants;
+using Bit.Core;
+using Bit.Core.Billing.Constants;
+using Bit.Core.Billing.Extensions;
+using Bit.Core.Services;
 using Stripe;
 using Event = Stripe.Event;
 
@@ -10,20 +14,114 @@ public class PaymentMethodAttachedHandler : IPaymentMethodAttachedHandler
     private readonly IStripeEventService _stripeEventService;
     private readonly IStripeFacade _stripeFacade;
     private readonly IStripeEventUtilityService _stripeEventUtilityService;
+    private readonly IFeatureService _featureService;
 
     public PaymentMethodAttachedHandler(
         ILogger<PaymentMethodAttachedHandler> logger,
         IStripeEventService stripeEventService,
         IStripeFacade stripeFacade,
-        IStripeEventUtilityService stripeEventUtilityService)
+        IStripeEventUtilityService stripeEventUtilityService,
+        IFeatureService featureService)
     {
         _logger = logger;
         _stripeEventService = stripeEventService;
         _stripeFacade = stripeFacade;
         _stripeEventUtilityService = stripeEventUtilityService;
+        _featureService = featureService;
     }
 
     public async Task HandleAsync(Event parsedEvent)
+    {
+        var updateMSPToChargeAutomatically =
+            _featureService.IsEnabled(FeatureFlagKeys.PM199566_UpdateMSPToChargeAutomatically);
+
+        if (updateMSPToChargeAutomatically)
+        {
+            await HandleVNextAsync(parsedEvent);
+        }
+        else
+        {
+            await HandleVCurrentAsync(parsedEvent);
+        }
+    }
+
+    private async Task HandleVNextAsync(Event parsedEvent)
+    {
+        var paymentMethod = await _stripeEventService.GetPaymentMethod(parsedEvent, true, ["customer.subscriptions.data.latest_invoice"]);
+
+        if (paymentMethod == null)
+        {
+            _logger.LogWarning("Attempted to handle the event payment_method.attached but paymentMethod was null");
+            return;
+        }
+
+        var customer = paymentMethod.Customer;
+        var subscriptions = customer?.Subscriptions;
+
+        // This represents a provider subscription set to "send_invoice" that was paid using a Stripe hosted invoice payment page.
+        var invoicedProviderSubscription = subscriptions?.Data.FirstOrDefault(subscription =>
+            subscription.Metadata.ContainsKey(StripeConstants.MetadataKeys.ProviderId) &&
+            subscription.Status != StripeConstants.SubscriptionStatus.Canceled &&
+            subscription.CollectionMethod == StripeConstants.CollectionMethod.SendInvoice);
+
+        /*
+         * If we have an invoiced provider subscription where the customer hasn't been marked as invoice-approved,
+         * we need to try and set the default payment method and update the collection method to be "charge_automatically".
+         */
+        if (invoicedProviderSubscription != null && !customer.IsInvoiceApproved())
+        {
+            if (customer.InvoiceSettings.DefaultPaymentMethodId != paymentMethod.Id)
+            {
+                try
+                {
+                    await _stripeFacade.UpdateCustomer(customer.Id,
+                        new CustomerUpdateOptions
+                        {
+                            InvoiceSettings = new CustomerInvoiceSettingsOptions
+                            {
+                                DefaultPaymentMethod = paymentMethod.Id
+                            }
+                        });
+                }
+                catch (Exception exception)
+                {
+                    _logger.LogWarning(exception,
+                        "Failed to set customer's ({CustomerID}) default payment method during 'payment_method.attached' webhook",
+                        customer.Id);
+                }
+            }
+
+            try
+            {
+                await _stripeFacade.UpdateSubscription(invoicedProviderSubscription.Id,
+                    new SubscriptionUpdateOptions
+                    {
+                        CollectionMethod = StripeConstants.CollectionMethod.ChargeAutomatically
+                    });
+            }
+            catch (Exception exception)
+            {
+                _logger.LogWarning(exception,
+                    "Failed to set subscription's ({SubscriptionID}) collection method to 'charge_automatically' during 'payment_method.attached' webhook",
+                    customer.Id);
+            }
+        }
+
+        var unpaidSubscriptions = subscriptions?.Data.Where(subscription =>
+            subscription.Status == StripeConstants.SubscriptionStatus.Unpaid).ToList();
+
+        if (unpaidSubscriptions == null || unpaidSubscriptions.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var unpaidSubscription in unpaidSubscriptions)
+        {
+            await AttemptToPayOpenSubscriptionAsync(unpaidSubscription);
+        }
+    }
+
+    private async Task HandleVCurrentAsync(Event parsedEvent)
     {
         var paymentMethod = await _stripeEventService.GetPaymentMethod(parsedEvent);
         if (paymentMethod is null)

--- a/src/Billing/Services/Implementations/StripeFacade.cs
+++ b/src/Billing/Services/Implementations/StripeFacade.cs
@@ -33,6 +33,13 @@ public class StripeFacade : IStripeFacade
         CancellationToken cancellationToken = default) =>
         await _customerService.GetAsync(customerId, customerGetOptions, requestOptions, cancellationToken);
 
+    public async Task<Customer> UpdateCustomer(
+        string customerId,
+        CustomerUpdateOptions customerUpdateOptions = null,
+        RequestOptions requestOptions = null,
+        CancellationToken cancellationToken = default) =>
+        await _customerService.UpdateAsync(customerId, customerUpdateOptions, requestOptions, cancellationToken);
+
     public async Task<Invoice> GetInvoice(
         string invoiceId,
         InvoiceGetOptions invoiceGetOptions = null,

--- a/src/Core/Billing/Constants/StripeConstants.cs
+++ b/src/Core/Billing/Constants/StripeConstants.cs
@@ -46,6 +46,7 @@ public static class StripeConstants
 
     public static class MetadataKeys
     {
+        public const string InvoiceApproved = "invoice_approved";
         public const string OrganizationId = "organizationId";
         public const string ProviderId = "providerId";
         public const string UserId = "userId";

--- a/src/Core/Billing/Extensions/CustomerExtensions.cs
+++ b/src/Core/Billing/Extensions/CustomerExtensions.cs
@@ -28,7 +28,7 @@ public static class CustomerExtensions
         return customer != null ? customer.Balance / 100M : default;
     }
 
-    public static bool IsInvoiceApproved(this Customer customer)
+    public static bool ApprovedToPayByInvoice(this Customer customer)
         => customer.Metadata.TryGetValue(StripeConstants.MetadataKeys.InvoiceApproved, out var value) &&
            int.TryParse(value, out var invoiceApproved) && invoiceApproved == 1;
 }

--- a/src/Core/Billing/Extensions/CustomerExtensions.cs
+++ b/src/Core/Billing/Extensions/CustomerExtensions.cs
@@ -27,4 +27,8 @@ public static class CustomerExtensions
     {
         return customer != null ? customer.Balance / 100M : default;
     }
+
+    public static bool IsInvoiceApproved(this Customer customer)
+        => customer.Metadata.TryGetValue(StripeConstants.MetadataKeys.InvoiceApproved, out var value) &&
+           int.TryParse(value, out var invoiceApproved) && invoiceApproved == 1;
 }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -148,6 +148,7 @@ public static class FeatureFlagKeys
     public const string PM19147_AutomaticTaxImprovements = "pm-19147-automatic-tax-improvements";
     public const string PM19422_AllowAutomaticTaxUpdates = "pm-19422-allow-automatic-tax-updates";
     public const string PM18770_EnableOrganizationBusinessUnitConversion = "pm-18770-enable-organization-business-unit-conversion";
+    public const string PM199566_UpdateMSPToChargeAutomatically = "pm-199566-update-msp-to-charge-automatically";
 
     /* Key Management Team */
     public const string ReturnErrorOnExistingKeypair = "return-error-on-existing-keypair";


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-19566

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This PR accomplishes two specific things:
1. It updates the Stripe `payment_method.attached` webhook handler to check if the payment method is being attached to a provider that's currently set to "send_invoice". If it is, it tries to set the payment method being attached as the default payment method as well as updates the provider's subscription to be "charge_automatically".
2. It adds a new checkbox on the Provider Edit page in Admin called "Invoice Approved". Bitwarden Admin users can set this checkbox on a specific provider in order to prevent the behavior detailed in point number 1 from occurring for that specific provider. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

**Behavior without "Invoice Approved"**

https://github.com/user-attachments/assets/3b022266-52f0-4eea-aef1-6274c6b76069

**Behavior with "Invoice Approved"**

https://github.com/user-attachments/assets/90bfc583-95a6-449d-8da3-daf9f932b5c2


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
