### PR TITLE
[PM-20230] - Send owners email when autoscaling

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/InviteOrganizationUsersCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/InviteOrganizationUsersCommand.cs
@@ -206,11 +206,11 @@ public class InviteOrganizationUsersCommand(IEventService eventService,
 
     private async Task SendAdditionalEmailsAsync(Valid<InviteOrganizationUsersValidationRequest> validatedResult, Organization organization)
     {
-        await SendNotifyOwnersOfAutoscaleIncreaseAsync(validatedResult, organization);
-        await SendPasswordManagerMaxSeatLimitEmailsAsync(validatedResult, organization);
+        await NotifyOwnersIfAutoscaleOccursAsync(validatedResult, organization);
+        await NotifyOwnersIfPasswordManagerMaxSeatLimitReachedAsync(validatedResult, organization);
     }
 
-    private async Task SendNotifyOwnersOfAutoscaleIncreaseAsync(Valid<InviteOrganizationUsersValidationRequest> validatedResult, Organization organization)
+    private async Task NotifyOwnersIfAutoscaleOccursAsync(Valid<InviteOrganizationUsersValidationRequest> validatedResult, Organization organization)
     {
         if (validatedResult.Value.PasswordManagerSubscriptionUpdate.SeatsRequiredToAdd > 0
             && !organization.OwnersNotifiedOfAutoscaling.HasValue)
@@ -225,7 +225,7 @@ public class InviteOrganizationUsersCommand(IEventService eventService,
         }
     }
 
-    private async Task SendPasswordManagerMaxSeatLimitEmailsAsync(Valid<InviteOrganizationUsersValidationRequest> validatedResult, Organization organization)
+    private async Task NotifyOwnersIfPasswordManagerMaxSeatLimitReachedAsync(Valid<InviteOrganizationUsersValidationRequest> validatedResult, Organization organization)
     {
         if (!validatedResult.Value.PasswordManagerSubscriptionUpdate.MaxSeatsReached)
         {

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/InviteOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/InviteOrganizationUserCommandTests.cs
@@ -289,6 +289,77 @@ public class InviteOrganizationUserCommandTests
 
     [Theory]
     [BitAutoData]
+    public async Task InviteScimOrganizationUserAsync_WhenValidInviteCausesOrgToAutoscale_ThenOrganizationOwnersShouldBeNotified(
+            MailAddress address,
+            Organization organization,
+            OrganizationUser user,
+            FakeTimeProvider timeProvider,
+            string externalId,
+            OrganizationUserUserDetails ownerDetails,
+            SutProvider<InviteOrganizationUsersCommand> sutProvider)
+    {
+        // Arrange
+        user.Email = address.Address;
+        organization.Seats = 1;
+        organization.MaxAutoscaleSeats = 2;
+        organization.OwnersNotifiedOfAutoscaling = null;
+        ownerDetails.Type = OrganizationUserType.Owner;
+
+        var inviteOrganization = new InviteOrganization(organization, new Enterprise2019Plan(true));
+
+        var request = new InviteOrganizationUsersRequest(
+            invites:
+            [
+                new OrganizationUserInvite(
+                    email: user.Email,
+                    assignedCollections: [],
+                    groups: [],
+                    type: OrganizationUserType.User,
+                    permissions: new Permissions(),
+                    externalId: externalId,
+                    accessSecretsManager: true)
+            ],
+            inviteOrganization: inviteOrganization,
+            performedBy: Guid.Empty,
+            timeProvider.GetUtcNow());
+
+        var orgUserRepository = sutProvider.GetDependency<IOrganizationUserRepository>();
+
+        orgUserRepository
+            .SelectKnownEmailsAsync(inviteOrganization.OrganizationId, Arg.Any<IEnumerable<string>>(), false)
+            .Returns([]);
+        orgUserRepository
+            .GetManyByMinimumRoleAsync(inviteOrganization.OrganizationId, OrganizationUserType.Owner)
+            .Returns([ownerDetails]);
+
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetByIdAsync(organization.Id)
+            .Returns(organization);
+
+        sutProvider.GetDependency<IInviteUsersValidator>()
+            .ValidateAsync(Arg.Any<InviteOrganizationUsersValidationRequest>())
+            .Returns(new Valid<InviteOrganizationUsersValidationRequest>(
+                GetInviteValidationRequestMock(request, inviteOrganization, organization)
+                    .WithPasswordManagerUpdate(
+                        new PasswordManagerSubscriptionUpdate(inviteOrganization, organization.Seats.Value, 1))));
+
+        // Act
+        var result = await sutProvider.Sut.InviteScimOrganizationUserAsync(request);
+
+        // Assert
+        Assert.IsType<Success<ScimInviteOrganizationUsersResponse>>(result);
+
+        Assert.NotNull(inviteOrganization.MaxAutoScaleSeats);
+
+        await sutProvider.GetDependency<IMailService>()
+            .Received(1)
+            .SendOrganizationAutoscaledEmailAsync(organization,
+                inviteOrganization.Seats.Value,
+                Arg.Is<IEnumerable<string>>(emails => emails.Any(email => email == ownerDetails.Email)));
+    }
+
+    [Theory]
+    [BitAutoData]
     public async Task InviteScimOrganizationUserAsync_WhenValidInviteIncreasesSeats_ThenSeatTotalShouldBeUpdated(
         MailAddress address,
         Organization organization,
@@ -608,6 +679,97 @@ public class InviteOrganizationUserCommandTests
 
         sutProvider.GetDependency<IMailService>().Received(1)
             .SendOrganizationMaxSeatLimitReachedEmailAsync(organization, 2,
+                Arg.Is<IEnumerable<string>>(emails => emails.Any(email => email == "provider@email.com")));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task InviteScimOrganizationUserAsync_WhenAnOrganizationIsManagedByAProviderAndAutoscaleOccurs_ThenAnEmailShouldBeSentToTheProvider(
+        MailAddress address,
+        Organization organization,
+        OrganizationUser user,
+        FakeTimeProvider timeProvider,
+        string externalId,
+        OrganizationUserUserDetails ownerDetails,
+        ProviderOrganization providerOrganization,
+        SutProvider<InviteOrganizationUsersCommand> sutProvider)
+    {
+        // Arrange
+        user.Email = address.Address;
+        organization.Seats = 1;
+        organization.SmSeats = 1;
+        organization.MaxAutoscaleSeats = 2;
+        organization.MaxAutoscaleSmSeats = 2;
+        organization.OwnersNotifiedOfAutoscaling = null;
+        ownerDetails.Type = OrganizationUserType.Owner;
+
+        providerOrganization.OrganizationId = organization.Id;
+
+        var inviteOrganization = new InviteOrganization(organization, new Enterprise2019Plan(true));
+
+        var request = new InviteOrganizationUsersRequest(
+            invites: [
+                new OrganizationUserInvite(
+                    email: user.Email,
+                    assignedCollections: [],
+                    groups: [],
+                    type: OrganizationUserType.User,
+                    permissions: new Permissions(),
+                    externalId: externalId,
+                    accessSecretsManager: true)
+            ],
+            inviteOrganization: inviteOrganization,
+            performedBy: Guid.Empty,
+            timeProvider.GetUtcNow());
+
+        var secretsManagerSubscriptionUpdate = new SecretsManagerSubscriptionUpdate(organization, inviteOrganization.Plan, true)
+            .AdjustSeats(request.Invites.Count(x => x.AccessSecretsManager));
+
+        var passwordManagerSubscriptionUpdate =
+            new PasswordManagerSubscriptionUpdate(inviteOrganization, 1, request.Invites.Length);
+
+        var orgUserRepository = sutProvider.GetDependency<IOrganizationUserRepository>();
+
+        orgUserRepository
+            .SelectKnownEmailsAsync(inviteOrganization.OrganizationId, Arg.Any<IEnumerable<string>>(), false)
+            .Returns([]);
+        orgUserRepository
+            .GetManyByMinimumRoleAsync(inviteOrganization.OrganizationId, OrganizationUserType.Owner)
+            .Returns([ownerDetails]);
+
+        var orgRepository = sutProvider.GetDependency<IOrganizationRepository>();
+
+        orgRepository.GetByIdAsync(organization.Id)
+            .Returns(organization);
+
+        sutProvider.GetDependency<IInviteUsersValidator>()
+            .ValidateAsync(Arg.Any<InviteOrganizationUsersValidationRequest>())
+            .Returns(new Valid<InviteOrganizationUsersValidationRequest>(GetInviteValidationRequestMock(request, inviteOrganization, organization)
+                .WithPasswordManagerUpdate(passwordManagerSubscriptionUpdate)
+                .WithSecretsManagerUpdate(secretsManagerSubscriptionUpdate)));
+
+        sutProvider.GetDependency<IProviderOrganizationRepository>()
+            .GetByOrganizationId(organization.Id)
+            .Returns(providerOrganization);
+
+        sutProvider.GetDependency<IProviderUserRepository>()
+            .GetManyDetailsByProviderAsync(providerOrganization.ProviderId, ProviderUserStatusType.Confirmed)
+            .Returns(new List<ProviderUserUserDetails>
+            {
+                new()
+                {
+                    Email = "provider@email.com"
+                }
+            });
+
+        // Act
+        var result = await sutProvider.Sut.InviteScimOrganizationUserAsync(request);
+
+        // Assert
+        Assert.IsType<Success<ScimInviteOrganizationUsersResponse>>(result);
+
+        sutProvider.GetDependency<IMailService>().Received(1)
+            .SendOrganizationAutoscaledEmailAsync(organization, 1,
                 Arg.Is<IEnumerable<string>>(emails => emails.Any(email => email == "provider@email.com")));
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking
[PM-20230](https://bitwarden.atlassian.net/browse/PM-20230)

## 📔 Objective
This sends an email to the owner or provider of the organization when the organization autoscales.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20230]: https://bitwarden.atlassian.net/browse/PM-20230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ