### PR TITLE
BRE-757: add `hold` label for Renovate PR that touches Production workflows

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,19 @@
   ],
   packageRules: [
     {
+      // Group all release-related workflows for GitHub Actions together for BRE.
+      groupName: "github-action",
+      matchManagers: ["github-actions"],
+      matchFileNames: [
+        ".github/workflows/publish.yml",
+        ".github/workflows/release.yml",
+        ".github/workflows/repository-management.yml"
+      ],
+      commitMessagePrefix: "[deps] BRE:",
+      reviewers: ["team:dept-bre"],
+      addLabels: ["hold"]
+    },
+    {
       groupName: "dockerfile minor",
       matchManagers: ["dockerfile"],
       matchUpdateTypes: ["minor"],


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BRE-757

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- add `hold` label for Renovate PR that touches Production workflows

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
