### PR TITLE
Add InstallationUrl for Setup to support local development

### DIFF
--- a/util/Setup/Context.cs
+++ b/util/Setup/Context.cs
@@ -185,6 +185,7 @@ public class Context
     {
         public Guid InstallationId { get; set; }
         public string InstallationKey { get; set; }
+        public string InstallationUrl { get; set; }
         public CloudRegion CloudRegion { get; set; }
         public bool DiffieHellman { get; set; }
         public bool Trusted { get; set; }

--- a/util/Setup/Enums/CloudRegion.cs
+++ b/util/Setup/Enums/CloudRegion.cs
@@ -8,4 +8,6 @@ public enum CloudRegion
     US = 0,
     [Display(Name = "EU")]
     EU = 1,
+    [Display(Name = "DEV")]
+    DEV = 2,
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
For local development, we need to be able to validate our `.pw` installation keys. This isn't possible with the current structure, forcing us to modify installation keys _post_ install. This isn't ideal and is often confusing. 

This change introduces the `.pw` domain as a `CloudRegion` and supports an environment variable for the various subdomain options that can exist, such as `stage`, `dev`, `uat`, etc. This helps route our `/installation` requests to the right API.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
