### PR TITLE
[PM- 20231] Correcting seats sent to Stripe

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/InviteOrganizationUsersCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/InviteOrganizationUsersCommand.cs
@@ -159,13 +159,13 @@ public class InviteOrganizationUsersCommand(IEventService eventService,
 
     private async Task RevertPasswordManagerChangesAsync(Valid<InviteOrganizationUsersValidationRequest> validatedResult, Organization organization)
     {
-        if (validatedResult.Value.PasswordManagerSubscriptionUpdate.SeatsRequiredToAdd > 0)
+        if (validatedResult.Value.PasswordManagerSubscriptionUpdate is { Seats: > 0, SeatsRequiredToAdd: > 0 })
         {
-            // When reverting seats, we have to tell payments service that the seats are going back down by what we attempted to add.
-            // However, this might lead to a problem if we don't actually update stripe but throw any ways.
-            // stripe could not be updated, and then we would decrement the number of seats in stripe accidentally.
-            var seatsToRemove = validatedResult.Value.PasswordManagerSubscriptionUpdate.SeatsRequiredToAdd;
-            await paymentService.AdjustSeatsAsync(organization, validatedResult.Value.InviteOrganization.Plan, -seatsToRemove);
+
+
+            await paymentService.AdjustSeatsAsync(organization,
+                validatedResult.Value.InviteOrganization.Plan,
+                validatedResult.Value.PasswordManagerSubscriptionUpdate.Seats.Value);
 
             organization.Seats = (short?)validatedResult.Value.PasswordManagerSubscriptionUpdate.Seats;
 
@@ -258,25 +258,25 @@ public class InviteOrganizationUsersCommand(IEventService eventService,
 
     private async Task AdjustPasswordManagerSeatsAsync(Valid<InviteOrganizationUsersValidationRequest> validatedResult, Organization organization)
     {
-        if (validatedResult.Value.PasswordManagerSubscriptionUpdate.SeatsRequiredToAdd <= 0)
+        if (validatedResult.Value.PasswordManagerSubscriptionUpdate is { SeatsRequiredToAdd: > 0, UpdatedSeatTotal: > 0 })
         {
-            return;
+            await paymentService.AdjustSeatsAsync(organization,
+                validatedResult.Value.InviteOrganization.Plan,
+                validatedResult.Value.PasswordManagerSubscriptionUpdate.UpdatedSeatTotal.Value);
+
+            organization.Seats = (short?)validatedResult.Value.PasswordManagerSubscriptionUpdate.UpdatedSeatTotal;
+
+            await organizationRepository.ReplaceAsync(organization); // could optimize this with only a property update
+            await applicationCacheService.UpsertOrganizationAbilityAsync(organization);
+
+            await referenceEventService.RaiseEventAsync(
+                new ReferenceEvent(ReferenceEventType.AdjustSeats, organization, currentContext)
+                {
+                    PlanName = validatedResult.Value.InviteOrganization.Plan.Name,
+                    PlanType = validatedResult.Value.InviteOrganization.Plan.Type,
+                    Seats = validatedResult.Value.PasswordManagerSubscriptionUpdate.UpdatedSeatTotal,
+                    PreviousSeats = validatedResult.Value.PasswordManagerSubscriptionUpdate.Seats
+                });
         }
-
-        await paymentService.AdjustSeatsAsync(organization, validatedResult.Value.InviteOrganization.Plan, validatedResult.Value.PasswordManagerSubscriptionUpdate.SeatsRequiredToAdd);
-
-        organization.Seats = (short?)validatedResult.Value.PasswordManagerSubscriptionUpdate.UpdatedSeatTotal;
-
-        await organizationRepository.ReplaceAsync(organization); // could optimize this with only a property update
-        await applicationCacheService.UpsertOrganizationAbilityAsync(organization);
-
-        await referenceEventService.RaiseEventAsync(
-            new ReferenceEvent(ReferenceEventType.AdjustSeats, organization, currentContext)
-            {
-                PlanName = validatedResult.Value.InviteOrganization.Plan.Name,
-                PlanType = validatedResult.Value.InviteOrganization.Plan.Type,
-                Seats = validatedResult.Value.PasswordManagerSubscriptionUpdate.UpdatedSeatTotal,
-                PreviousSeats = validatedResult.Value.PasswordManagerSubscriptionUpdate.Seats
-            });
     }
 }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/InviteOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/InviteOrganizationUserCommandTests.cs
@@ -349,7 +349,7 @@ public class InviteOrganizationUserCommandTests
         Assert.IsType<Success<ScimInviteOrganizationUsersResponse>>(result);
 
         await sutProvider.GetDependency<IPaymentService>()
-            .AdjustSeatsAsync(organization, inviteOrganization.Plan, passwordManagerUpdate.SeatsRequiredToAdd);
+            .AdjustSeatsAsync(organization, inviteOrganization.Plan, passwordManagerUpdate.UpdatedSeatTotal!.Value);
 
         await orgRepository.Received(1).ReplaceAsync(Arg.Is<Organization>(x => x.Seats == passwordManagerUpdate.UpdatedSeatTotal));
 


### PR DESCRIPTION
## 🎟️ Tracking
[PM-20231](https://bitwarden.atlassian.net/browse/PM-20231)

## 📔 Objective
The number sent to the payment service needs to be the new seat total. Not the amount of new seats needed to add to the current seat total.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20231]: https://bitwarden.atlassian.net/browse/PM-20231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ