### PR TITLE
Add env variable to override /installations domain

### DIFF
--- a/util/Setup/Program.cs
+++ b/util/Setup/Program.cs
@@ -279,9 +279,10 @@ public class Program
                     break;
             }
 
-            if (Environment.GetEnvironmentVariable("BW_INSTALLATION_URL") != null)
+            string installationUrl = Environment.GetEnvironmentVariable("BW_INSTALLATION_URL");
+            if (!string.IsNullOrEmpty(installationUrl))
             {
-                url = $"{Environment.GetEnvironmentVariable("BW_INSTALLATION_URL")}/installations/";
+                url = $"{installationUrl}/installations/";
             }
 
             var response = new HttpClient().GetAsync(url + _context.Install.InstallationId).GetAwaiter().GetResult();

--- a/util/Setup/Program.cs
+++ b/util/Setup/Program.cs
@@ -278,6 +278,12 @@ public class Program
                     url = "https://api.bitwarden.com/installations/";
                     break;
             }
+
+            if (Environment.GetEnvironmentVariable("BW_INSTALLATION_URL") != null)
+            {
+                url = $"{Environment.GetEnvironmentVariable("BW_INSTALLATION_URL")}/installations/";
+            }
+
             var response = new HttpClient().GetAsync(url + _context.Install.InstallationId).GetAwaiter().GetResult();
 
             if (!response.IsSuccessStatusCode)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
For local and QA environments, we need to be able to validate our `.pw` installation keys. This isn't possible with the current structure, forcing us to modify installation keys _post_ install. This isn't ideal and is often confusing. 

This change introduces support for using an environment variable to override the `/installations` domain.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
