### PR TITLE
[PM-20465] Only automatically set collection method for MSP

### DIFF
--- a/src/Billing/Services/Implementations/PaymentMethodAttachedHandler.cs
+++ b/src/Billing/Services/Implementations/PaymentMethodAttachedHandler.cs
@@ -1,5 +1,7 @@
 ﻿using Bit.Billing.Constants;
 using Bit.Core;
+using Bit.Core.AdminConsole.Enums.Provider;
+using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Extensions;
 using Bit.Core.Services;
@@ -15,19 +17,22 @@ public class PaymentMethodAttachedHandler : IPaymentMethodAttachedHandler
     private readonly IStripeFacade _stripeFacade;
     private readonly IStripeEventUtilityService _stripeEventUtilityService;
     private readonly IFeatureService _featureService;
+    private readonly IProviderRepository _providerRepository;
 
     public PaymentMethodAttachedHandler(
         ILogger<PaymentMethodAttachedHandler> logger,
         IStripeEventService stripeEventService,
         IStripeFacade stripeFacade,
         IStripeEventUtilityService stripeEventUtilityService,
-        IFeatureService featureService)
+        IFeatureService featureService,
+        IProviderRepository providerRepository)
     {
         _logger = logger;
         _stripeEventService = stripeEventService;
         _stripeFacade = stripeFacade;
         _stripeEventUtilityService = stripeEventUtilityService;
         _featureService = featureService;
+        _providerRepository = providerRepository;
     }
 
     public async Task HandleAsync(Event parsedEvent)
@@ -68,42 +73,49 @@ public class PaymentMethodAttachedHandler : IPaymentMethodAttachedHandler
          * If we have an invoiced provider subscription where the customer hasn't been marked as invoice-approved,
          * we need to try and set the default payment method and update the collection method to be "charge_automatically".
          */
-        if (invoicedProviderSubscription != null && !customer.ApprovedToPayByInvoice())
+        if (invoicedProviderSubscription != null &&
+            !customer.ApprovedToPayByInvoice() &&
+            Guid.TryParse(invoicedProviderSubscription.Metadata[StripeConstants.MetadataKeys.ProviderId], out var providerId))
         {
-            if (customer.InvoiceSettings.DefaultPaymentMethodId != paymentMethod.Id)
+            var provider = await _providerRepository.GetByIdAsync(providerId);
+
+            if (provider is { Type: ProviderType.Msp })
             {
+                if (customer.InvoiceSettings.DefaultPaymentMethodId != paymentMethod.Id)
+                {
+                    try
+                    {
+                        await _stripeFacade.UpdateCustomer(customer.Id,
+                            new CustomerUpdateOptions
+                            {
+                                InvoiceSettings = new CustomerInvoiceSettingsOptions
+                                {
+                                    DefaultPaymentMethod = paymentMethod.Id
+                                }
+                            });
+                    }
+                    catch (Exception exception)
+                    {
+                        _logger.LogWarning(exception,
+                            "Failed to set customer's ({CustomerID}) default payment method during 'payment_method.attached' webhook",
+                            customer.Id);
+                    }
+                }
+
                 try
                 {
-                    await _stripeFacade.UpdateCustomer(customer.Id,
-                        new CustomerUpdateOptions
+                    await _stripeFacade.UpdateSubscription(invoicedProviderSubscription.Id,
+                        new SubscriptionUpdateOptions
                         {
-                            InvoiceSettings = new CustomerInvoiceSettingsOptions
-                            {
-                                DefaultPaymentMethod = paymentMethod.Id
-                            }
+                            CollectionMethod = StripeConstants.CollectionMethod.ChargeAutomatically
                         });
                 }
                 catch (Exception exception)
                 {
                     _logger.LogWarning(exception,
-                        "Failed to set customer's ({CustomerID}) default payment method during 'payment_method.attached' webhook",
+                        "Failed to set subscription's ({SubscriptionID}) collection method to 'charge_automatically' during 'payment_method.attached' webhook",
                         customer.Id);
                 }
-            }
-
-            try
-            {
-                await _stripeFacade.UpdateSubscription(invoicedProviderSubscription.Id,
-                    new SubscriptionUpdateOptions
-                    {
-                        CollectionMethod = StripeConstants.CollectionMethod.ChargeAutomatically
-                    });
-            }
-            catch (Exception exception)
-            {
-                _logger.LogWarning(exception,
-                    "Failed to set subscription's ({SubscriptionID}) collection method to 'charge_automatically' during 'payment_method.attached' webhook",
-                    customer.Id);
             }
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-20465

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Ally found a defect in the feature-flagged implementation where the collection method was being updated for Business Units and not just MSPs. This PR resolves that.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/adcc65b0-5b25-4b05-a4ba-53876c7fed9e



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
