### PR TITLE
[PM-20586] - Fixing allowing seats to increase to limit

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/Validation/PasswordManager/InviteUsersPasswordManagerValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/Validation/PasswordManager/InviteUsersPasswordManagerValidator.cs
@@ -44,7 +44,7 @@ public class InviteUsersPasswordManagerValidator(
             return new Invalid<PasswordManagerSubscriptionUpdate>(new PasswordManagerMustHaveSeatsError(subscriptionUpdate));
         }
 
-        if (subscriptionUpdate.MaxSeatsReached)
+        if (subscriptionUpdate.MaxSeatsExceeded)
         {
             return new Invalid<PasswordManagerSubscriptionUpdate>(
                 new PasswordManagerSeatLimitHasBeenReachedError(subscriptionUpdate));

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/Validation/PasswordManager/PasswordManagerSubscriptionUpdate.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/Validation/PasswordManager/PasswordManagerSubscriptionUpdate.cs
@@ -48,6 +48,11 @@ public class PasswordManagerSubscriptionUpdate
     /// </summary>
     public bool MaxSeatsReached => UpdatedSeatTotal.HasValue && MaxAutoScaleSeats.HasValue && UpdatedSeatTotal.Value >= MaxAutoScaleSeats.Value;
 
+    /// <summary>
+    /// If the new seat total exceeds the organization's auto-scale seat limit
+    /// </summary>
+    public bool MaxSeatsExceeded => UpdatedSeatTotal.HasValue && MaxAutoScaleSeats.HasValue && UpdatedSeatTotal.Value > MaxAutoScaleSeats.Value;
+
     public Plan.PasswordManagerPlanFeatures PasswordManagerPlan { get; }
 
     public InviteOrganization InviteOrganization { get; }


### PR DESCRIPTION
## 🎟️ Tracking
[PM-20586](https://bitwarden.atlassian.net/browse/PM-20586)

## 📔 Objective
This adds a new property to signify when the max seats have been exceeded to mark the request as invalid.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20586]: https://bitwarden.atlassian.net/browse/PM-20586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ