### PR TITLE
chore/SRE-583 Deprecate usage of Auth-Email Header

### DIFF
--- a/perf/load/helpers/auth.js
+++ b/perf/load/helpers/auth.js
@@ -40,8 +40,7 @@ export function authenticate(
     payload["deviceName"] = "chrome";
     payload["username"] = username;
     payload["password"] = password;
-
-    params.headers["Auth-Email"] = encoding.b64encode(username);
+    // Auth-Email header is deprecated and no longer needed
   } else {
     payload["scope"] = "api.organization";
     payload["grant_type"] = "client_credentials";

--- a/src/Identity/IdentityServer/RequestValidators/ResourceOwnerPasswordValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/ResourceOwnerPasswordValidator.cs
@@ -203,27 +203,8 @@ public class ResourceOwnerPasswordValidator : BaseRequestValidator<ResourceOwner
 
     private bool AuthEmailHeaderIsValid(ResourceOwnerPasswordValidationContext context)
     {
-        if (_currentContext.HttpContext.Request.Headers.TryGetValue("Auth-Email", out var authEmailHeader))
-        {
-            try
-            {
-                var authEmailDecoded = CoreHelpers.Base64UrlDecodeString(authEmailHeader);
-                if (authEmailDecoded != context.UserName)
-                {
-                    return false;
-                }
-            }
-            catch (Exception e) when (e is InvalidOperationException || e is FormatException)
-            {
-                // Invalid B64 encoding
-                return false;
-            }
-        }
-        else
-        {
-            return false;
-        }
-
+        // Auth-Email header is now deprecated and completely optional
+        // We no longer validate it even if it's present
         return true;
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SRE-583

## 📔 Objective

Deprecate usage of Auth-Email Header

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
