### PR TITLE
[PM-17778] Updated consumed seat count logic

### DIFF
--- a/util/Migrator/DbScripts/2025-04-24_00_UpdateOrgUserReadOccupiedSeatCountForSponsorships.sql
+++ b/util/Migrator/DbScripts/2025-04-24_00_UpdateOrgUserReadOccupiedSeatCountForSponsorships.sql
@@ -1,3 +1,9 @@
+IF OBJECT_ID('[dbo].[OrganizationUser_ReadOccupiedSeatCountByOrganizationId]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[OrganizationUser_ReadOccupiedSeatCountByOrganizationId]
+END
+GO
+
 CREATE PROCEDURE [dbo].[OrganizationUser_ReadOccupiedSeatCountByOrganizationId]
     @OrganizationId UNIQUEIDENTIFIER
 AS
@@ -6,15 +12,12 @@ BEGIN
     
     SELECT
         (
-            -- Count organization users
             SELECT COUNT(1)
             FROM [dbo].[OrganizationUserView]
             WHERE OrganizationId = @OrganizationId
             AND Status >= 0 --Invited
         ) + 
         (
-            -- Count admin-initiated sponsorships towards the seat count
-            -- Introduced in https://bitwarden.atlassian.net/browse/PM-17772
             SELECT COUNT(1)
             FROM [dbo].[OrganizationSponsorship]
             WHERE SponsoringOrganizationId = @OrganizationId
@@ -35,3 +38,4 @@ BEGIN
             )
         )
 END
+GO


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-17778

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The above Jira ticket added some clarification on which admin-initiated sponsorships should be included in the organization's "consumed" seat count. This PR aims to ensure that all the following sponsorships are counted:

- Only sponsorships that are admin-initiated (`IsAdminInitiated = 1`)
- The sponsorship is not marked for deletion (`ToDelete = 0`)  OR
- The sponsorship IS marked for deletion, but has a future expiration date (`ToDelete = 1 AND ValidUntil IS NOT NULL AND ValidUntil > GETUTCDATE()`)
- The sponsorship is either
  - In the SENT status (`SponsoredOrganizationId IS NULL`) OR
  - In the ACCEPTED status and not expired (`SponsoredOrganizationId IS NOT NULL AND (ValidUntil IS NULL OR ValidUntil > GETUTCDATE())`) 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
