### PR TITLE
[PM-20379] Security Tasks - Edit, Hidden Passwords

### DIFF
--- a/src/Infrastructure.EntityFramework/Vault/Repositories/Queries/SecurityTaskReadByUserIdStatusQuery.cs
+++ b/src/Infrastructure.EntityFramework/Vault/Repositories/Queries/SecurityTaskReadByUserIdStatusQuery.cs
@@ -59,7 +59,8 @@ public class SecurityTaskReadByUserIdStatusQuery : IQuery<SecurityTask>
                             (
                                 c != null &&
                                 (
-                                    (cu != null && !cu.ReadOnly) || (cg != null && !cg.ReadOnly && cu == null)
+                                    (cu != null && !cu.ReadOnly && !cu.HidePasswords) ||
+                                    (cg != null && !cg.ReadOnly && !cg.HidePasswords && cu == null)
                                 )
                             )
                         ) &&

--- a/util/Migrator/DbScripts/2025-04-25_00_SecurityTasksHiddenPassword.sql
+++ b/util/Migrator/DbScripts/2025-04-25_00_SecurityTasksHiddenPassword.sql
@@ -1,4 +1,4 @@
-CREATE PROCEDURE [dbo].[SecurityTask_ReadByUserIdStatus]
+CREATE OR ALTER PROCEDURE [dbo].[SecurityTask_ReadByUserIdStatus]
     @UserId UNIQUEIDENTIFIER,
     @Status TINYINT = NULL
 AS
@@ -54,3 +54,4 @@ BEGIN
         ST.RevisionDate
     ORDER BY ST.[CreationDate] DESC
 END
+GO


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20379](https://bitwarden.atlassian.net/browse/PM-20379)

## 📔 Objective

Users who have `Edit, hidden passwords` permissions for a cipher are currently seeing UI elements to change passwords for associated tasks. Because they cannot edit the password for the associated cipher, this leaves them in no mans land.

Add a check to the `GET /tasks` endpoint to verify that they can edit the password of the associated cipher when fetching security tasks. 

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/94a5f923-0ac6-4f60-8ed6-18be03eacbe5" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20379]: https://bitwarden.atlassian.net/browse/PM-20379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ