### PR TITLE
Support use of organizationId parameter in authorization

### DIFF
--- a/src/Api/AdminConsole/Authorization/HttpContextExtensions.cs
+++ b/src/Api/AdminConsole/Authorization/HttpContextExtensions.cs
@@ -68,13 +68,15 @@ public static class HttpContextExtensions
     /// <exception cref="InvalidOperationException"></exception>
     public static Guid GetOrganizationId(this HttpContext httpContext)
     {
-        httpContext.GetRouteData().Values.TryGetValue("orgId", out var orgIdParam);
+        var routeValues = httpContext.GetRouteData().Values;
+
+        routeValues.TryGetValue("orgId", out var orgIdParam);
         if (orgIdParam != null && Guid.TryParse(orgIdParam.ToString(), out var orgId))
         {
             return orgId;
         }
 
-        httpContext.GetRouteData().Values.TryGetValue("organizationId", out var organizationIdParam);
+        routeValues.TryGetValue("organizationId", out var organizationIdParam);
         if (organizationIdParam != null && Guid.TryParse(organizationIdParam.ToString(), out var organizationId))
         {
             return organizationId;

--- a/src/Api/AdminConsole/Authorization/HttpContextExtensions.cs
+++ b/src/Api/AdminConsole/Authorization/HttpContextExtensions.cs
@@ -9,7 +9,7 @@ namespace Bit.Api.AdminConsole.Authorization;
 public static class HttpContextExtensions
 {
     public const string NoOrgIdError =
-        "A route decorated with with '[Authorize<Requirement>]' must include a route value named 'orgId' either through the [Controller] attribute or through a '[Http*]' attribute.";
+        "A route decorated with with '[Authorize<Requirement>]' must include a route value named 'orgId' or 'organizationId' either through the [Controller] attribute or through a '[Http*]' attribute.";
 
     /// <summary>
     /// Returns the result of the callback, caching it in HttpContext.Features for the lifetime of the request.
@@ -61,7 +61,7 @@ public static class HttpContextExtensions
 
 
     /// <summary>
-    /// Parses the {orgId} route parameter into a Guid, or throws if the {orgId} is not present or not a valid guid.
+    /// Parses the {orgId} or {organizationId} route parameter into a Guid, or throws if neither are present or are not valid guids.
     /// </summary>
     /// <param name="httpContext"></param>
     /// <returns></returns>
@@ -69,11 +69,17 @@ public static class HttpContextExtensions
     public static Guid GetOrganizationId(this HttpContext httpContext)
     {
         httpContext.GetRouteData().Values.TryGetValue("orgId", out var orgIdParam);
-        if (orgIdParam == null || !Guid.TryParse(orgIdParam.ToString(), out var orgId))
+        if (orgIdParam != null && Guid.TryParse(orgIdParam.ToString(), out var orgId))
         {
-            throw new InvalidOperationException(NoOrgIdError);
+            return orgId;
         }
 
-        return orgId;
+        httpContext.GetRouteData().Values.TryGetValue("organizationId", out var organizationIdParam);
+        if (organizationIdParam != null && Guid.TryParse(organizationIdParam.ToString(), out var organizationId))
+        {
+            return organizationId;
+        }
+
+        throw new InvalidOperationException(NoOrgIdError);
     }
 }

--- a/test/Api.Test/AdminConsole/Authorization/HttpContextExtensionsTests.cs
+++ b/test/Api.Test/AdminConsole/Authorization/HttpContextExtensionsTests.cs
@@ -1,5 +1,7 @@
-﻿using Bit.Api.AdminConsole.Authorization;
+﻿using AutoFixture.Xunit2;
+using Bit.Api.AdminConsole.Authorization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using NSubstitute;
 using Xunit;
 
@@ -25,4 +27,42 @@ public class HttpContextExtensionsTests
         await callback.ReceivedWithAnyArgs(1).Invoke();
     }
 
+    [Theory]
+    [InlineAutoData("orgId")]
+    [InlineAutoData("organizationId")]
+    public void GetOrganizationId_GivenValidParameter_ReturnsOrganizationId(string paramName, Guid orgId)
+    {
+        var httpContext = new DefaultHttpContext
+        {
+            Request = { RouteValues = new RouteValueDictionary
+            {
+                { "userId", "someGuid" },
+                { paramName, orgId.ToString() }
+            }
+        }
+        };
+
+        var result = httpContext.GetOrganizationId();
+        Assert.Equal(orgId, result);
+    }
+
+    [Theory]
+    [InlineAutoData("orgId")]
+    [InlineAutoData("organizationId")]
+    [InlineAutoData("missingParameter")]
+    public void GetOrganizationId_GivenMissingOrInvalidGuid_Throws(string paramName)
+    {
+        var httpContext = new DefaultHttpContext
+        {
+            Request = { RouteValues = new RouteValueDictionary
+            {
+                { "userId", "someGuid" },
+                { paramName, "invalidGuid" }
+            }
+        }
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => httpContext.GetOrganizationId());
+        Assert.Equal(HttpContextExtensions.NoOrgIdError, exception.Message);
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
N/A
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Billing controllers use an `organizationId` route param instead of `orgId` which is used elsewhere. This PR updates the `HttpContext.GetOrganizationId` extension method to support both options, which in turn allows Billing Team to use the `IOrganizationRequirement` added in #5555.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
