### PR TITLE
[PM-17562] Revert event route optimization

### DIFF
--- a/src/Core/AdminConsole/Services/Implementations/EventRouteService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/EventRouteService.cs
@@ -1,0 +1,34 @@
+﻿using Bit.Core.Models.Data;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bit.Core.Services;
+
+public class EventRouteService(
+    [FromKeyedServices("broadcast")] IEventWriteService broadcastEventWriteService,
+    [FromKeyedServices("storage")] IEventWriteService storageEventWriteService,
+    IFeatureService _featureService) : IEventWriteService
+{
+    public async Task CreateAsync(IEvent e)
+    {
+        if (_featureService.IsEnabled(FeatureFlagKeys.EventBasedOrganizationIntegrations))
+        {
+            await broadcastEventWriteService.CreateAsync(e);
+        }
+        else
+        {
+            await storageEventWriteService.CreateAsync(e);
+        }
+    }
+
+    public async Task CreateManyAsync(IEnumerable<IEvent> e)
+    {
+        if (_featureService.IsEnabled(FeatureFlagKeys.EventBasedOrganizationIntegrations))
+        {
+            await broadcastEventWriteService.CreateManyAsync(e);
+        }
+        else
+        {
+            await storageEventWriteService.CreateManyAsync(e);
+        }
+    }
+}

--- a/src/Events/Startup.cs
+++ b/src/Events/Startup.cs
@@ -1,5 +1,4 @@
 ﻿using System.Globalization;
-using Bit.Core;
 using Bit.Core.AdminConsole.Services.Implementations;
 using Bit.Core.AdminConsole.Services.NoopImplementations;
 using Bit.Core.Context;
@@ -94,13 +93,7 @@ public class Startup
                 services.AddKeyedSingleton<IEventWriteService, NoopEventWriteService>("broadcast");
             }
         }
-        services.AddScoped<IEventWriteService>(sp =>
-        {
-            var featureService = sp.GetRequiredService<IFeatureService>();
-            var key = featureService.IsEnabled(FeatureFlagKeys.EventBasedOrganizationIntegrations)
-                ? "broadcast" : "storage";
-            return sp.GetRequiredKeyedService<IEventWriteService>(key);
-        });
+        services.AddScoped<IEventWriteService, EventRouteService>();
         services.AddScoped<IEventService, EventService>();
 
         services.AddOptionality();

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -4,7 +4,6 @@ using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
 using AspNetCoreRateLimit;
 using Azure.Storage.Queues;
-using Bit.Core;
 using Bit.Core.AdminConsole.Models.Business.Tokenables;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
 using Bit.Core.AdminConsole.Services;
@@ -366,13 +365,7 @@ public static class ServiceCollectionExtensions
             services.AddKeyedSingleton<IEventWriteService, NoopEventWriteService>("storage");
             services.AddKeyedSingleton<IEventWriteService, NoopEventWriteService>("broadcast");
         }
-        services.AddScoped<IEventWriteService>(sp =>
-        {
-            var featureService = sp.GetRequiredService<IFeatureService>();
-            var key = featureService.IsEnabled(FeatureFlagKeys.EventBasedOrganizationIntegrations)
-                ? "broadcast" : "storage";
-            return sp.GetRequiredKeyedService<IEventWriteService>(key);
-        });
+        services.AddScoped<IEventWriteService, EventRouteService>();
 
         if (CoreHelpers.SettingHasValue(globalSettings.Attachment.ConnectionString))
         {

--- a/test/Core.Test/AdminConsole/Services/EventRouteServiceTests.cs
+++ b/test/Core.Test/AdminConsole/Services/EventRouteServiceTests.cs
@@ -1,0 +1,65 @@
+﻿using Bit.Core.Models.Data;
+using Bit.Core.Services;
+using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services;
+
+[SutProviderCustomize]
+public class EventRouteServiceTests
+{
+    private readonly IEventWriteService _broadcastEventWriteService = Substitute.For<IEventWriteService>();
+    private readonly IEventWriteService _storageEventWriteService = Substitute.For<IEventWriteService>();
+    private readonly IFeatureService _featureService = Substitute.For<IFeatureService>();
+    private readonly EventRouteService Subject;
+
+    public EventRouteServiceTests()
+    {
+        Subject = new EventRouteService(_broadcastEventWriteService, _storageEventWriteService, _featureService);
+    }
+
+    [Theory, BitAutoData]
+    public async Task CreateAsync_FlagDisabled_EventSentToStorageService(EventMessage eventMessage)
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.EventBasedOrganizationIntegrations).Returns(false);
+
+        await Subject.CreateAsync(eventMessage);
+
+        _broadcastEventWriteService.DidNotReceiveWithAnyArgs().CreateAsync(Arg.Any<EventMessage>());
+        _storageEventWriteService.Received(1).CreateAsync(eventMessage);
+    }
+
+    [Theory, BitAutoData]
+    public async Task CreateAsync_FlagEnabled_EventSentToBroadcastService(EventMessage eventMessage)
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.EventBasedOrganizationIntegrations).Returns(true);
+
+        await Subject.CreateAsync(eventMessage);
+
+        _broadcastEventWriteService.Received(1).CreateAsync(eventMessage);
+        _storageEventWriteService.DidNotReceiveWithAnyArgs().CreateAsync(Arg.Any<EventMessage>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task CreateManyAsync_FlagDisabled_EventsSentToStorageService(IEnumerable<EventMessage> eventMessages)
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.EventBasedOrganizationIntegrations).Returns(false);
+
+        await Subject.CreateManyAsync(eventMessages);
+
+        _broadcastEventWriteService.DidNotReceiveWithAnyArgs().CreateManyAsync(Arg.Any<IEnumerable<EventMessage>>());
+        _storageEventWriteService.Received(1).CreateManyAsync(eventMessages);
+    }
+
+    [Theory, BitAutoData]
+    public async Task CreateManyAsync_FlagEnabled_EventsSentToBroadcastService(IEnumerable<EventMessage> eventMessages)
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.EventBasedOrganizationIntegrations).Returns(true);
+
+        await Subject.CreateManyAsync(eventMessages);
+
+        _broadcastEventWriteService.Received(1).CreateManyAsync(eventMessages);
+        _storageEventWriteService.DidNotReceiveWithAnyArgs().CreateManyAsync(Arg.Any<IEnumerable<EventMessage>>());
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17562](https://bitwarden.atlassian.net/browse/PM-17562)

## 📔 Objective

On the last commit for #5710, I added a commit to remove the EventRouteService and replace it with a just-in-time factory to do the feature flag switching. This works on the first event. However, since it was scoped, DI would send a Dispose to it once it had completed its task, which closes the connections.

This change reverts that commit and returns the `EventRouteService`. The `EventRouteService` can be scoped and disposed of safely, while the singletons get injected each time (and thus maintain their connections). 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17562]: https://bitwarden.atlassian.net/browse/PM-17562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ