### PR TITLE
[PM-21257] Revert MaxProjects license changes, limit MaxProjectsQuery to cloud-only for 2-person organizations

### DIFF
--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Queries/Projects/MaxProjectsQuery.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Queries/Projects/MaxProjectsQuery.cs
@@ -1,9 +1,10 @@
 ﻿using Bit.Core.Billing.Enums;
+using Bit.Core.Billing.Pricing;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.SecretsManager.Queries.Projects.Interfaces;
 using Bit.Core.SecretsManager.Repositories;
-using Bit.Core.Utilities;
+using Bit.Core.Settings;
 
 namespace Bit.Commercial.Core.SecretsManager.Queries.Projects;
 
@@ -11,36 +12,43 @@ public class MaxProjectsQuery : IMaxProjectsQuery
 {
     private readonly IOrganizationRepository _organizationRepository;
     private readonly IProjectRepository _projectRepository;
+    private readonly IGlobalSettings _globalSettings;
+    private readonly IPricingClient _pricingClient;
 
     public MaxProjectsQuery(
         IOrganizationRepository organizationRepository,
-        IProjectRepository projectRepository)
+        IProjectRepository projectRepository,
+        IGlobalSettings globalSettings,
+        IPricingClient pricingClient)
     {
         _organizationRepository = organizationRepository;
         _projectRepository = projectRepository;
+        _globalSettings = globalSettings;
+        _pricingClient = pricingClient;
     }
 
     public async Task<(short? max, bool? overMax)> GetByOrgIdAsync(Guid organizationId, int projectsToAdd)
     {
+        // "MaxProjects" only applies to free 2-person organizations, which can't be self-hosted.
+        if (_globalSettings.SelfHosted)
+        {
+            return (null, null);
+        }
+
         var org = await _organizationRepository.GetByIdAsync(organizationId);
         if (org == null)
         {
             throw new NotFoundException();
         }
 
-        // TODO: PRICING -> https://bitwarden.atlassian.net/browse/PM-17122
-        var plan = StaticStore.GetPlan(org.PlanType);
-        if (plan?.SecretsManager == null)
+        var plan = await _pricingClient.GetPlan(org.PlanType);
+
+        if (plan is not { SecretsManager: not null, Type: PlanType.Free })
         {
-            throw new BadRequestException("Existing plan not found.");
+            return (null, null);
         }
 
-        if (plan.Type == PlanType.Free)
-        {
-            var projects = await _projectRepository.GetProjectCountByOrganizationIdAsync(organizationId);
-            return ((short? max, bool? overMax))(projects + projectsToAdd > plan.SecretsManager.MaxProjects ? (plan.SecretsManager.MaxProjects, true) : (plan.SecretsManager.MaxProjects, false));
-        }
-
-        return (null, null);
+        var projects = await _projectRepository.GetProjectCountByOrganizationIdAsync(organizationId);
+        return ((short? max, bool? overMax))(projects + projectsToAdd > plan.SecretsManager.MaxProjects ? (plan.SecretsManager.MaxProjects, true) : (plan.SecretsManager.MaxProjects, false));
     }
 }

--- a/bitwarden_license/src/Commercial.Core/SecretsManager/Queries/Projects/MaxProjectsQuery.cs
+++ b/bitwarden_license/src/Commercial.Core/SecretsManager/Queries/Projects/MaxProjectsQuery.cs
@@ -1,14 +1,9 @@
-﻿using Bit.Core.AdminConsole.Entities;
-using Bit.Core.Billing.Enums;
-using Bit.Core.Billing.Licenses;
-using Bit.Core.Billing.Licenses.Extensions;
-using Bit.Core.Billing.Pricing;
+﻿using Bit.Core.Billing.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.SecretsManager.Queries.Projects.Interfaces;
 using Bit.Core.SecretsManager.Repositories;
-using Bit.Core.Services;
-using Bit.Core.Settings;
+using Bit.Core.Utilities;
 
 namespace Bit.Commercial.Core.SecretsManager.Queries.Projects;
 
@@ -16,22 +11,13 @@ public class MaxProjectsQuery : IMaxProjectsQuery
 {
     private readonly IOrganizationRepository _organizationRepository;
     private readonly IProjectRepository _projectRepository;
-    private readonly IGlobalSettings _globalSettings;
-    private readonly ILicensingService _licensingService;
-    private readonly IPricingClient _pricingClient;
 
     public MaxProjectsQuery(
         IOrganizationRepository organizationRepository,
-        IProjectRepository projectRepository,
-        IGlobalSettings globalSettings,
-        ILicensingService licensingService,
-        IPricingClient pricingClient)
+        IProjectRepository projectRepository)
     {
         _organizationRepository = organizationRepository;
         _projectRepository = projectRepository;
-        _globalSettings = globalSettings;
-        _licensingService = licensingService;
-        _pricingClient = pricingClient;
     }
 
     public async Task<(short? max, bool? overMax)> GetByOrgIdAsync(Guid organizationId, int projectsToAdd)
@@ -42,47 +28,19 @@ public class MaxProjectsQuery : IMaxProjectsQuery
             throw new NotFoundException();
         }
 
-        var (planType, maxProjects) = await GetPlanTypeAndMaxProjectsAsync(org);
-
-        if (planType != PlanType.Free)
+        // TODO: PRICING -> https://bitwarden.atlassian.net/browse/PM-17122
+        var plan = StaticStore.GetPlan(org.PlanType);
+        if (plan?.SecretsManager == null)
         {
-            return (null, null);
+            throw new BadRequestException("Existing plan not found.");
         }
 
-        var projects = await _projectRepository.GetProjectCountByOrganizationIdAsync(organizationId);
-        return ((short? max, bool? overMax))(projects + projectsToAdd > maxProjects ? (maxProjects, true) : (maxProjects, false));
-    }
-
-    private async Task<(PlanType planType, int maxProjects)> GetPlanTypeAndMaxProjectsAsync(Organization organization)
-    {
-        if (_globalSettings.SelfHosted)
+        if (plan.Type == PlanType.Free)
         {
-            var license = await _licensingService.ReadOrganizationLicenseAsync(organization);
-
-            if (license == null)
-            {
-                throw new BadRequestException("License not found.");
-            }
-
-            var claimsPrincipal = _licensingService.GetClaimsPrincipalFromLicense(license);
-            var maxProjects = claimsPrincipal.GetValue<int?>(OrganizationLicenseConstants.SmMaxProjects);
-
-            if (!maxProjects.HasValue)
-            {
-                throw new BadRequestException("License does not contain a value for max Secrets Manager projects");
-            }
-
-            var planType = claimsPrincipal.GetValue<PlanType>(OrganizationLicenseConstants.PlanType);
-            return (planType, maxProjects.Value);
+            var projects = await _projectRepository.GetProjectCountByOrganizationIdAsync(organizationId);
+            return ((short? max, bool? overMax))(projects + projectsToAdd > plan.SecretsManager.MaxProjects ? (plan.SecretsManager.MaxProjects, true) : (plan.SecretsManager.MaxProjects, false));
         }
 
-        var plan = await _pricingClient.GetPlan(organization.PlanType);
-
-        if (plan is { SupportsSecretsManager: true })
-        {
-            return (plan.Type, plan.SecretsManager.MaxProjects);
-        }
-
-        throw new BadRequestException("Existing plan not found.");
+        return (null, null);
     }
 }

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Queries/Projects/MaxProjectsQueryTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Queries/Projects/MaxProjectsQueryTests.cs
@@ -1,9 +1,12 @@
 ﻿using Bit.Commercial.Core.SecretsManager.Queries.Projects;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.Billing.Enums;
+using Bit.Core.Billing.Pricing;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.SecretsManager.Repositories;
+using Bit.Core.Settings;
+using Bit.Core.Utilities;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
@@ -17,35 +20,30 @@ public class MaxProjectsQueryTests
 {
     [Theory]
     [BitAutoData]
+    public async Task GetByOrgIdAsync_SelfHosted_ReturnsNulls(SutProvider<MaxProjectsQuery> sutProvider,
+        Guid organizationId)
+    {
+        sutProvider.GetDependency<IGlobalSettings>().SelfHosted.Returns(true);
+
+        var (max, overMax) = await sutProvider.Sut.GetByOrgIdAsync(organizationId, 1);
+
+        Assert.Null(max);
+        Assert.Null(overMax);
+    }
+
+    [Theory]
+    [BitAutoData]
     public async Task GetByOrgIdAsync_OrganizationIsNull_ThrowsNotFound(SutProvider<MaxProjectsQuery> sutProvider,
         Guid organizationId)
     {
+        sutProvider.GetDependency<IGlobalSettings>().SelfHosted.Returns(false);
+
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(default).ReturnsNull();
 
         await Assert.ThrowsAsync<NotFoundException>(async () => await sutProvider.Sut.GetByOrgIdAsync(organizationId, 1));
 
         await sutProvider.GetDependency<IProjectRepository>().DidNotReceiveWithAnyArgs()
             .GetProjectCountByOrganizationIdAsync(organizationId);
-    }
-
-    [Theory]
-    [BitAutoData(PlanType.FamiliesAnnually2019)]
-    [BitAutoData(PlanType.Custom)]
-    [BitAutoData(PlanType.FamiliesAnnually)]
-    public async Task GetByOrgIdAsync_SmPlanIsNull_ThrowsBadRequest(PlanType planType,
-        SutProvider<MaxProjectsQuery> sutProvider, Organization organization)
-    {
-        organization.PlanType = planType;
-        sutProvider.GetDependency<IOrganizationRepository>()
-            .GetByIdAsync(organization.Id)
-            .Returns(organization);
-
-        await Assert.ThrowsAsync<BadRequestException>(
-            async () => await sutProvider.Sut.GetByOrgIdAsync(organization.Id, 1));
-
-        await sutProvider.GetDependency<IProjectRepository>()
-            .DidNotReceiveWithAnyArgs()
-            .GetProjectCountByOrganizationIdAsync(organization.Id);
     }
 
     [Theory]
@@ -65,8 +63,13 @@ public class MaxProjectsQueryTests
     public async Task GetByOrgIdAsync_SmNoneFreePlans_ReturnsNull(PlanType planType,
         SutProvider<MaxProjectsQuery> sutProvider, Organization organization)
     {
+        sutProvider.GetDependency<IGlobalSettings>().SelfHosted.Returns(false);
+
         organization.PlanType = planType;
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
+
+        sutProvider.GetDependency<IPricingClient>().GetPlan(organization.PlanType)
+            .Returns(StaticStore.GetPlan(organization.PlanType));
 
         var (limit, overLimit) = await sutProvider.Sut.GetByOrgIdAsync(organization.Id, 1);
 
@@ -109,6 +112,9 @@ public class MaxProjectsQueryTests
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
         sutProvider.GetDependency<IProjectRepository>().GetProjectCountByOrganizationIdAsync(organization.Id)
             .Returns(projects);
+
+        sutProvider.GetDependency<IPricingClient>().GetPlan(organization.PlanType)
+            .Returns(StaticStore.GetPlan(organization.PlanType));
 
         var (max, overMax) = await sutProvider.Sut.GetByOrgIdAsync(organization.Id, projectsToAdd);
 

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Queries/Projects/MaxProjectsQueryTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/Queries/Projects/MaxProjectsQueryTests.cs
@@ -1,16 +1,9 @@
-﻿using System.Security.Claims;
-using Bit.Commercial.Core.SecretsManager.Queries.Projects;
+﻿using Bit.Commercial.Core.SecretsManager.Queries.Projects;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.Billing.Enums;
-using Bit.Core.Billing.Licenses;
-using Bit.Core.Billing.Pricing;
 using Bit.Core.Exceptions;
-using Bit.Core.Models.Business;
 using Bit.Core.Repositories;
 using Bit.Core.SecretsManager.Repositories;
-using Bit.Core.Services;
-using Bit.Core.Settings;
-using Bit.Core.Utilities;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
@@ -39,41 +32,13 @@ public class MaxProjectsQueryTests
     [BitAutoData(PlanType.FamiliesAnnually2019)]
     [BitAutoData(PlanType.Custom)]
     [BitAutoData(PlanType.FamiliesAnnually)]
-    public async Task GetByOrgIdAsync_Cloud_SmPlanIsNull_ThrowsBadRequest(PlanType planType,
+    public async Task GetByOrgIdAsync_SmPlanIsNull_ThrowsBadRequest(PlanType planType,
         SutProvider<MaxProjectsQuery> sutProvider, Organization organization)
     {
         organization.PlanType = planType;
         sutProvider.GetDependency<IOrganizationRepository>()
             .GetByIdAsync(organization.Id)
             .Returns(organization);
-
-        sutProvider.GetDependency<IGlobalSettings>().SelfHosted.Returns(false);
-        var plan = StaticStore.GetPlan(planType);
-        sutProvider.GetDependency<IPricingClient>().GetPlan(organization.PlanType).Returns(plan);
-
-        await Assert.ThrowsAsync<BadRequestException>(
-            async () => await sutProvider.Sut.GetByOrgIdAsync(organization.Id, 1));
-
-        await sutProvider.GetDependency<IProjectRepository>()
-            .DidNotReceiveWithAnyArgs()
-            .GetProjectCountByOrganizationIdAsync(organization.Id);
-    }
-
-    [Theory]
-    [BitAutoData]
-    public async Task GetByOrgIdAsync_SelfHosted_NoMaxProjectsClaim_ThrowsBadRequest(
-        SutProvider<MaxProjectsQuery> sutProvider, Organization organization)
-    {
-        sutProvider.GetDependency<IOrganizationRepository>()
-            .GetByIdAsync(organization.Id)
-            .Returns(organization);
-
-        sutProvider.GetDependency<IGlobalSettings>().SelfHosted.Returns(true);
-
-        var license = new OrganizationLicense();
-        var claimsPrincipal = new ClaimsPrincipal();
-        sutProvider.GetDependency<ILicensingService>().ReadOrganizationLicenseAsync(organization).Returns(license);
-        sutProvider.GetDependency<ILicensingService>().GetClaimsPrincipalFromLicense(license).Returns(claimsPrincipal);
 
         await Assert.ThrowsAsync<BadRequestException>(
             async () => await sutProvider.Sut.GetByOrgIdAsync(organization.Id, 1));
@@ -97,57 +62,11 @@ public class MaxProjectsQueryTests
     [BitAutoData(PlanType.EnterpriseAnnually2019)]
     [BitAutoData(PlanType.EnterpriseAnnually2020)]
     [BitAutoData(PlanType.EnterpriseAnnually)]
-    public async Task GetByOrgIdAsync_Cloud_SmNoneFreePlans_ReturnsNull(PlanType planType,
+    public async Task GetByOrgIdAsync_SmNoneFreePlans_ReturnsNull(PlanType planType,
         SutProvider<MaxProjectsQuery> sutProvider, Organization organization)
     {
         organization.PlanType = planType;
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
-
-        sutProvider.GetDependency<IGlobalSettings>().SelfHosted.Returns(false);
-        var plan = StaticStore.GetPlan(planType);
-        sutProvider.GetDependency<IPricingClient>().GetPlan(organization.PlanType).Returns(plan);
-
-        var (limit, overLimit) = await sutProvider.Sut.GetByOrgIdAsync(organization.Id, 1);
-
-        Assert.Null(limit);
-        Assert.Null(overLimit);
-
-        await sutProvider.GetDependency<IProjectRepository>().DidNotReceiveWithAnyArgs()
-            .GetProjectCountByOrganizationIdAsync(organization.Id);
-    }
-
-    [Theory]
-    [BitAutoData(PlanType.TeamsMonthly2019)]
-    [BitAutoData(PlanType.TeamsMonthly2020)]
-    [BitAutoData(PlanType.TeamsMonthly)]
-    [BitAutoData(PlanType.TeamsAnnually2019)]
-    [BitAutoData(PlanType.TeamsAnnually2020)]
-    [BitAutoData(PlanType.TeamsAnnually)]
-    [BitAutoData(PlanType.TeamsStarter)]
-    [BitAutoData(PlanType.EnterpriseMonthly2019)]
-    [BitAutoData(PlanType.EnterpriseMonthly2020)]
-    [BitAutoData(PlanType.EnterpriseMonthly)]
-    [BitAutoData(PlanType.EnterpriseAnnually2019)]
-    [BitAutoData(PlanType.EnterpriseAnnually2020)]
-    [BitAutoData(PlanType.EnterpriseAnnually)]
-    public async Task GetByOrgIdAsync_SelfHosted_SmNoneFreePlans_ReturnsNull(PlanType planType,
-        SutProvider<MaxProjectsQuery> sutProvider, Organization organization)
-    {
-        organization.PlanType = planType;
-        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
-        sutProvider.GetDependency<IGlobalSettings>().SelfHosted.Returns(true);
-
-        var license = new OrganizationLicense();
-        var plan = StaticStore.GetPlan(planType);
-        var claims = new List<Claim>
-        {
-            new (nameof(OrganizationLicenseConstants.PlanType), organization.PlanType.ToString()),
-            new (nameof(OrganizationLicenseConstants.SmMaxProjects), plan.SecretsManager.MaxProjects.ToString())
-        };
-        var identity = new ClaimsIdentity(claims, "TestAuthenticationType");
-        var claimsPrincipal = new ClaimsPrincipal(identity);
-        sutProvider.GetDependency<ILicensingService>().ReadOrganizationLicenseAsync(organization).Returns(license);
-        sutProvider.GetDependency<ILicensingService>().GetClaimsPrincipalFromLicense(license).Returns(claimsPrincipal);
 
         var (limit, overLimit) = await sutProvider.Sut.GetByOrgIdAsync(organization.Id, 1);
 
@@ -183,74 +102,13 @@ public class MaxProjectsQueryTests
     [BitAutoData(PlanType.Free, 3, 4, true)]
     [BitAutoData(PlanType.Free, 4, 4, true)]
     [BitAutoData(PlanType.Free, 40, 4, true)]
-    public async Task GetByOrgIdAsync_Cloud_SmFreePlan__Success(PlanType planType, int projects, int projectsToAdd, bool expectedOverMax,
+    public async Task GetByOrgIdAsync_SmFreePlan__Success(PlanType planType, int projects, int projectsToAdd, bool expectedOverMax,
         SutProvider<MaxProjectsQuery> sutProvider, Organization organization)
     {
         organization.PlanType = planType;
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
         sutProvider.GetDependency<IProjectRepository>().GetProjectCountByOrganizationIdAsync(organization.Id)
             .Returns(projects);
-
-        sutProvider.GetDependency<IGlobalSettings>().SelfHosted.Returns(false);
-        var plan = StaticStore.GetPlan(planType);
-        sutProvider.GetDependency<IPricingClient>().GetPlan(organization.PlanType).Returns(plan);
-
-        var (max, overMax) = await sutProvider.Sut.GetByOrgIdAsync(organization.Id, projectsToAdd);
-
-        Assert.NotNull(max);
-        Assert.NotNull(overMax);
-        Assert.Equal(3, max.Value);
-        Assert.Equal(expectedOverMax, overMax);
-
-        await sutProvider.GetDependency<IProjectRepository>().Received(1)
-            .GetProjectCountByOrganizationIdAsync(organization.Id);
-    }
-
-    [Theory]
-    [BitAutoData(PlanType.Free, 0, 1, false)]
-    [BitAutoData(PlanType.Free, 1, 1, false)]
-    [BitAutoData(PlanType.Free, 2, 1, false)]
-    [BitAutoData(PlanType.Free, 3, 1, true)]
-    [BitAutoData(PlanType.Free, 4, 1, true)]
-    [BitAutoData(PlanType.Free, 40, 1, true)]
-    [BitAutoData(PlanType.Free, 0, 2, false)]
-    [BitAutoData(PlanType.Free, 1, 2, false)]
-    [BitAutoData(PlanType.Free, 2, 2, true)]
-    [BitAutoData(PlanType.Free, 3, 2, true)]
-    [BitAutoData(PlanType.Free, 4, 2, true)]
-    [BitAutoData(PlanType.Free, 40, 2, true)]
-    [BitAutoData(PlanType.Free, 0, 3, false)]
-    [BitAutoData(PlanType.Free, 1, 3, true)]
-    [BitAutoData(PlanType.Free, 2, 3, true)]
-    [BitAutoData(PlanType.Free, 3, 3, true)]
-    [BitAutoData(PlanType.Free, 4, 3, true)]
-    [BitAutoData(PlanType.Free, 40, 3, true)]
-    [BitAutoData(PlanType.Free, 0, 4, true)]
-    [BitAutoData(PlanType.Free, 1, 4, true)]
-    [BitAutoData(PlanType.Free, 2, 4, true)]
-    [BitAutoData(PlanType.Free, 3, 4, true)]
-    [BitAutoData(PlanType.Free, 4, 4, true)]
-    [BitAutoData(PlanType.Free, 40, 4, true)]
-    public async Task GetByOrgIdAsync_SelfHosted_SmFreePlan__Success(PlanType planType, int projects, int projectsToAdd, bool expectedOverMax,
-        SutProvider<MaxProjectsQuery> sutProvider, Organization organization)
-    {
-        organization.PlanType = planType;
-        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
-        sutProvider.GetDependency<IProjectRepository>().GetProjectCountByOrganizationIdAsync(organization.Id)
-            .Returns(projects);
-        sutProvider.GetDependency<IGlobalSettings>().SelfHosted.Returns(true);
-
-        var license = new OrganizationLicense();
-        var plan = StaticStore.GetPlan(planType);
-        var claims = new List<Claim>
-        {
-            new (nameof(OrganizationLicenseConstants.PlanType), organization.PlanType.ToString()),
-            new (nameof(OrganizationLicenseConstants.SmMaxProjects), plan.SecretsManager.MaxProjects.ToString())
-        };
-        var identity = new ClaimsIdentity(claims, "TestAuthenticationType");
-        var claimsPrincipal = new ClaimsPrincipal(identity);
-        sutProvider.GetDependency<ILicensingService>().ReadOrganizationLicenseAsync(organization).Returns(license);
-        sutProvider.GetDependency<ILicensingService>().GetClaimsPrincipalFromLicense(license).Returns(claimsPrincipal);
 
         var (max, overMax) = await sutProvider.Sut.GetByOrgIdAsync(organization.Id, projectsToAdd);
 

--- a/src/Core/Billing/Licenses/LicenseConstants.cs
+++ b/src/Core/Billing/Licenses/LicenseConstants.cs
@@ -34,7 +34,6 @@ public static class OrganizationLicenseConstants
     public const string UseSecretsManager = nameof(UseSecretsManager);
     public const string SmSeats = nameof(SmSeats);
     public const string SmServiceAccounts = nameof(SmServiceAccounts);
-    public const string SmMaxProjects = nameof(SmMaxProjects);
     public const string LimitCollectionCreationDeletion = nameof(LimitCollectionCreationDeletion);
     public const string AllowAdminAccessToAllCollectionItems = nameof(AllowAdminAccessToAllCollectionItems);
     public const string UseRiskInsights = nameof(UseRiskInsights);

--- a/src/Core/Billing/Licenses/Models/LicenseContext.cs
+++ b/src/Core/Billing/Licenses/Models/LicenseContext.cs
@@ -7,5 +7,4 @@ public class LicenseContext
 {
     public Guid? InstallationId { get; init; }
     public required SubscriptionInfo SubscriptionInfo { get; init; }
-    public int? SmMaxProjects { get; set; }
 }

--- a/src/Core/Billing/Licenses/Services/Implementations/OrganizationLicenseClaimsFactory.cs
+++ b/src/Core/Billing/Licenses/Services/Implementations/OrganizationLicenseClaimsFactory.cs
@@ -112,11 +112,6 @@ public class OrganizationLicenseClaimsFactory : ILicenseClaimsFactory<Organizati
         }
         claims.Add(new Claim(nameof(OrganizationLicenseConstants.UseAdminSponsoredFamilies), entity.UseAdminSponsoredFamilies.ToString()));
 
-        if (licenseContext.SmMaxProjects.HasValue)
-        {
-            claims.Add(new Claim(nameof(OrganizationLicenseConstants.SmMaxProjects), licenseContext.SmMaxProjects.ToString()));
-        }
-
         return Task.FromResult(claims);
     }
 

--- a/src/Core/OrganizationFeatures/OrganizationLicenses/Cloud/CloudGetOrganizationLicenseQuery.cs
+++ b/src/Core/OrganizationFeatures/OrganizationLicenses/Cloud/CloudGetOrganizationLicenseQuery.cs
@@ -1,6 +1,5 @@
 ﻿using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Repositories;
-using Bit.Core.Billing.Pricing;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Business;
@@ -17,22 +16,19 @@ public class CloudGetOrganizationLicenseQuery : ICloudGetOrganizationLicenseQuer
     private readonly ILicensingService _licensingService;
     private readonly IProviderRepository _providerRepository;
     private readonly IFeatureService _featureService;
-    private readonly IPricingClient _pricingClient;
 
     public CloudGetOrganizationLicenseQuery(
         IInstallationRepository installationRepository,
         IPaymentService paymentService,
         ILicensingService licensingService,
         IProviderRepository providerRepository,
-        IFeatureService featureService,
-        IPricingClient pricingClient)
+        IFeatureService featureService)
     {
         _installationRepository = installationRepository;
         _paymentService = paymentService;
         _licensingService = licensingService;
         _providerRepository = providerRepository;
         _featureService = featureService;
-        _pricingClient = pricingClient;
     }
 
     public async Task<OrganizationLicense> GetLicenseAsync(Organization organization, Guid installationId,
@@ -46,11 +42,7 @@ public class CloudGetOrganizationLicenseQuery : ICloudGetOrganizationLicenseQuer
 
         var subscriptionInfo = await GetSubscriptionAsync(organization);
         var license = new OrganizationLicense(organization, subscriptionInfo, installationId, _licensingService, version);
-        var plan = await _pricingClient.GetPlan(organization.PlanType);
-        int? smMaxProjects = plan?.SupportsSecretsManager ?? false
-            ? plan.SecretsManager.MaxProjects
-            : null;
-        license.Token = await _licensingService.CreateOrganizationTokenAsync(organization, installationId, subscriptionInfo, smMaxProjects);
+        license.Token = await _licensingService.CreateOrganizationTokenAsync(organization, installationId, subscriptionInfo);
 
         return license;
     }

--- a/src/Core/Services/ILicensingService.cs
+++ b/src/Core/Services/ILicensingService.cs
@@ -21,8 +21,7 @@ public interface ILicensingService
     Task<string?> CreateOrganizationTokenAsync(
         Organization organization,
         Guid installationId,
-        SubscriptionInfo subscriptionInfo,
-        int? smMaxProjects);
+        SubscriptionInfo subscriptionInfo);
 
     Task<string?> CreateUserTokenAsync(User user, SubscriptionInfo subscriptionInfo);
 }

--- a/src/Core/Services/Implementations/LicensingService.cs
+++ b/src/Core/Services/Implementations/LicensingService.cs
@@ -339,13 +339,12 @@ public class LicensingService : ILicensingService
         }
     }
 
-    public async Task<string> CreateOrganizationTokenAsync(Organization organization, Guid installationId, SubscriptionInfo subscriptionInfo, int? smMaxProjects)
+    public async Task<string> CreateOrganizationTokenAsync(Organization organization, Guid installationId, SubscriptionInfo subscriptionInfo)
     {
         var licenseContext = new LicenseContext
         {
             InstallationId = installationId,
             SubscriptionInfo = subscriptionInfo,
-            SmMaxProjects = smMaxProjects
         };
 
         var claims = await _organizationLicenseClaimsFactory.GenerateClaims(organization, licenseContext);

--- a/src/Core/Services/NoopImplementations/NoopLicensingService.cs
+++ b/src/Core/Services/NoopImplementations/NoopLicensingService.cs
@@ -62,7 +62,7 @@ public class NoopLicensingService : ILicensingService
         return null;
     }
 
-    public Task<string?> CreateOrganizationTokenAsync(Organization organization, Guid installationId, SubscriptionInfo subscriptionInfo, int? smMaxProjects)
+    public Task<string?> CreateOrganizationTokenAsync(Organization organization, Guid installationId, SubscriptionInfo subscriptionInfo)
     {
         return Task.FromResult<string?>(null);
     }

--- a/test/Core.Test/OrganizationFeatures/OrganizationLicenses/CloudGetOrganizationLicenseQueryTests.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationLicenses/CloudGetOrganizationLicenseQueryTests.cs
@@ -1,7 +1,6 @@
 ﻿using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Repositories;
-using Bit.Core.Billing.Pricing;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Business;
@@ -9,7 +8,6 @@ using Bit.Core.OrganizationFeatures.OrganizationLicenses;
 using Bit.Core.Platform.Installations;
 using Bit.Core.Services;
 using Bit.Core.Test.AutoFixture;
-using Bit.Core.Utilities;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
@@ -78,10 +76,8 @@ public class CloudGetOrganizationLicenseQueryTests
         sutProvider.GetDependency<IInstallationRepository>().GetByIdAsync(installationId).Returns(installation);
         sutProvider.GetDependency<IPaymentService>().GetSubscriptionAsync(organization).Returns(subInfo);
         sutProvider.GetDependency<ILicensingService>().SignLicense(Arg.Any<ILicense>()).Returns(licenseSignature);
-        var plan = StaticStore.GetPlan(organization.PlanType);
-        sutProvider.GetDependency<IPricingClient>().GetPlan(organization.PlanType).Returns(plan);
         sutProvider.GetDependency<ILicensingService>()
-            .CreateOrganizationTokenAsync(organization, installationId, subInfo, plan.SecretsManager.MaxProjects)
+            .CreateOrganizationTokenAsync(organization, installationId, subInfo)
             .Returns(token);
 
         var result = await sutProvider.Sut.GetLicenseAsync(organization, installationId);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-21257

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The license addition that was made as part of https://bitwarden.atlassian.net/browse/PM-17122 is not necessary because 2-person organizations cannot be self-hosted. Thus, querying for `MaxProjects` in a self-hosted environment should always return `(null, null)`. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/23a47f94-eed1-4180-854b-9d790bec064b



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
