### PR TITLE
[PM-21044] - optimize security task ReadByUserIdStatus

### DIFF
--- a/src/Sql/Vault/dbo/Stored Procedures/SecurityTask/SecurityTask_ReadByUserIdStatus.sql
+++ b/src/Sql/Vault/dbo/Stored Procedures/SecurityTask/SecurityTask_ReadByUserIdStatus.sql
@@ -3,8 +3,61 @@ CREATE PROCEDURE [dbo].[SecurityTask_ReadByUserIdStatus]
     @Status TINYINT = NULL
 AS
 BEGIN
-    SET NOCOUNT ON
+    SET NOCOUNT ON;
 
+    WITH OrganizationAccess AS (
+        SELECT
+            OU.OrganizationId
+        FROM
+            dbo.OrganizationUser OU
+        WHERE
+            OU.UserId = @UserId
+            AND OU.Status = 2
+    ),
+    UserCollectionAccess AS (
+        SELECT
+            CC.CipherId
+        FROM
+            dbo.OrganizationUser OU
+            JOIN dbo.CollectionUser CU
+                ON CU.OrganizationUserId = OU.Id
+            JOIN dbo.CollectionCipher CC
+                ON CC.CollectionId = CU.CollectionId
+        WHERE
+            OU.UserId = @UserId
+            AND OU.Status = 2
+            AND CU.ReadOnly = 0
+    ),
+    GroupCollectionAccess AS (
+        SELECT
+            CC.CipherId
+        FROM
+            dbo.OrganizationUser OU
+            JOIN dbo.GroupUser GU
+                ON GU.OrganizationUserId = OU.Id
+            JOIN dbo.CollectionGroup CG
+                ON CG.GroupId = GU.GroupId
+            JOIN dbo.CollectionCipher CC
+                ON CC.CollectionId = CG.CollectionId
+        WHERE
+            OU.UserId = @UserId
+            AND OU.Status = 2
+            AND CG.ReadOnly = 0
+    ),
+    AccessibleCiphers AS (
+        SELECT CipherId FROM UserCollectionAccess
+        UNION ALL
+        SELECT CipherId FROM GroupCollectionAccess
+    ),
+    SecurityTasks AS (
+        SELECT
+            ST.*
+        FROM
+            dbo.SecurityTask ST
+        WHERE
+            @Status IS NULL
+            OR ST.Status = @Status
+    )
     SELECT
         ST.Id,
         ST.OrganizationId,
@@ -14,43 +67,14 @@ BEGIN
         ST.CreationDate,
         ST.RevisionDate
     FROM
-        [dbo].[SecurityTaskView] ST
-    INNER JOIN
-        [dbo].[OrganizationUserView] OU ON OU.[OrganizationId] = ST.[OrganizationId]
-    INNER JOIN
-        [dbo].[Organization] O ON O.[Id] = ST.[OrganizationId]
-    LEFT JOIN
-        [dbo].[CipherView] C ON C.[Id] = ST.[CipherId]
-    LEFT JOIN
-        [dbo].[CollectionCipher] CC ON CC.[CipherId] = C.[Id] AND C.[Id] IS NOT NULL
-    LEFT JOIN
-        [dbo].[CollectionUser] CU ON CU.[CollectionId] = CC.[CollectionId] AND CU.[OrganizationUserId] = OU.[Id] AND C.[Id] IS NOT NULL
-    LEFT JOIN
-        [dbo].[GroupUser] GU ON GU.[OrganizationUserId] = OU.[Id] AND CU.[CollectionId] IS NULL AND C.[Id] IS NOT NULL
-    LEFT JOIN
-        [dbo].[CollectionGroup] CG ON CG.[GroupId] = GU.[GroupId] AND CG.[CollectionId] = CC.[CollectionId]
+        SecurityTasks ST
+        JOIN OrganizationAccess OA
+            ON ST.OrganizationId = OA.OrganizationId
+        LEFT JOIN AccessibleCiphers AC
+            ON ST.CipherId = AC.CipherId
     WHERE
-        OU.[UserId] = @UserId
-        AND OU.[Status] = 2 -- Ensure user is confirmed
-        AND O.[Enabled] = 1
-        AND (
-            ST.[CipherId] IS NULL
-            OR (
-                C.[Id] IS NOT NULL
-                AND (
-                    CU.[ReadOnly] = 0
-                    OR CG.[ReadOnly] = 0
-                )
-            )
-        )
-        AND ST.[Status] = COALESCE(@Status, ST.[Status])
-    GROUP BY
-        ST.Id,
-        ST.OrganizationId,
-        ST.CipherId,
-        ST.Type,
-        ST.Status,
-        ST.CreationDate,
-        ST.RevisionDate
-    ORDER BY ST.[CreationDate] DESC
+        ST.CipherId IS NULL
+        OR AC.CipherId IS NOT NULL
+    ORDER BY
+        ST.CreationDate DESC;
 END


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21044

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The original query What we had was a single flat query with numerous JOINs and a GROUP BY,. This forced the optimizer to consider large intermediate rowsets and perform hidden de‑duping and scans.

After taking @shane-melton's initial plan to use focused CTE's I added further refinements:


Aspect | First Draft | Final Version
-- | -- | --
Source tables | Used the *View tables (OrganizationUserView, SecurityTaskView, CipherView) plus a join to Organization | Switched to the base tables (OrganizationUser, SecurityTask, etc.), avoiding any hidden complexity or overhead that the views might introduce.
Status filter | WHERE ST.Status = COALESCE(@Status, ST.Status) → non‑sargable, forced scans/filters | Rewritten as `WHERE @Status IS NULL OR ST.Status = @Status` → fully sargable, pushes directly into an Index Seek on (Status, OrganizationId, CreationDate DESC) and eliminates scan + downstream SORT.
Deduplication | UNION in AccessibleCiphers + SELECT DISTINCT in final query (both introduce hidden sorts) | Changed to `UNION ALL` (no sort/dedupe) and dropped the `DISTINCT`—the combination of CTEs and `LEFT JOIN` … `IS NOT NULL` ensures no duplicates naturally.
EXISTS vs JOIN | … `OR EXISTS (SELECT 1 FROM AccessibleCiphers AC WHERE AC.CipherId = ST.CipherId)` (correlated subquery per row) | Replaced with a single `LEFT JOIN AccessibleCiphers AC ON ST.CipherId = AC.CipherId` and `WHERE ST.CipherId IS NULL OR AC.CipherId IS NOT NULL`.  This flattens the plan into one nested‑loops join over the small CTE, cutting I/O and simplifying the optimizer’s job.
Sorting | `ORDER BY ST.CreationDate DESC` always triggered a SORT operator | By including `CreationDate DESC` in the third key of our covering IX_SecurityTask_Status_OrgId_CreationDateDesc index, the engine can return rows in descending order directly—no separate SORT required.| 
| Overall cost | ~0.036 (estimated subtree cost) | ~0.005 (estimated), 5 ms cold run, 2 logical reads on SecurityTask, no SORT, and only tiny seeks on the CTEs. |


Added Four targeted non‑clustered indexes. Eliminated scans on CollectionGroup, SecurityTask, etc., and covered every lookup.

1. IX_CollectionGroup_GroupId_ReadOnly on (GroupId, ReadOnly)
```
CREATE NONCLUSTERED INDEX IX_CollectionGroup_GroupId_ReadOnly
  ON dbo.CollectionGroup (GroupId, ReadOnly)
  INCLUDE (CollectionId);
  ```
2. IX_CollectionUser_OrganizationUserId_ReadOnly on (OrganizationUserId, ReadOnly)
```
CREATE NONCLUSTERED INDEX IX_CollectionUser_OrganizationUserId_ReadOnly
  ON dbo.CollectionUser (OrganizationUserId, ReadOnly)
  INCLUDE (CollectionId);
```
3. IX_GroupUser_OrganizationUserId on (OrganizationUserId)
```
CREATE NONCLUSTERED INDEX IX_GroupUser_OrganizationUserId
  ON dbo.GroupUser (OrganizationUserId)
  INCLUDE (GroupId);
```
4. IX_SecurityTask_Status_OrgId_CreationDateDesc on (Status, OrganizationId, CreationDate DESC) including (CipherId, Type, RevisionDate)
```
CREATE NONCLUSTERED INDEX IX_SecurityTask_Status_OrgId_CreationDateDesc
  ON dbo.SecurityTask (Status, OrganizationId, CreationDate DESC)
  INCLUDE (CipherId, [Type], RevisionDate);
```



## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
