### PR TITLE
[PM-21281] Email TOTP sent twice when user only has Email MFA enabled

### DIFF
--- a/src/Core/Auth/Models/Business/Tokenables/SsoEmail2faSessionTokenable.cs
+++ b/src/Core/Auth/Models/Business/Tokenables/SsoEmail2faSessionTokenable.cs
@@ -4,9 +4,10 @@ using Bit.Core.Tokens;
 
 namespace Bit.Core.Auth.Models.Business.Tokenables;
 
-// This token just provides a verifiable authN mechanism for the API service
-// TwoFactorController.cs SendEmailLogin anonymous endpoint so it cannot be
-// used maliciously.
+/// <summary>
+/// This token provides a verifiable authN mechanism for the TwoFactorController.SendEmailLoginAsync
+/// anonymous endpoint so it cannot used maliciously.
+/// </summary>
 public class SsoEmail2faSessionTokenable : ExpiringTokenable
 {
     // Just over 2 min expiration (client expires session after 2 min)

--- a/src/Identity/IdentityServer/RequestValidators/TwoFactorAuthenticationValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/TwoFactorAuthenticationValidator.cs
@@ -130,12 +130,6 @@ public class TwoFactorAuthenticationValidator(
             twoFactorResultDict.Add("Email", user.Email);
         }
 
-        if (enabledProviders.Count == 1 && enabledProviders.First().Key == TwoFactorProviderType.Email)
-        {
-            // Send email now if this is their only 2FA method
-            await _userService.SendTwoFactorEmailAsync(user);
-        }
-
         return twoFactorResultDict;
     }
 

--- a/src/Identity/IdentityServer/RequestValidators/TwoFactorAuthenticationValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/TwoFactorAuthenticationValidator.cs
@@ -121,7 +121,10 @@ public class TwoFactorAuthenticationValidator(
             { "TwoFactorProviders2", providers },
         };
 
-        // If we have email as a 2FA provider, we might need an SsoEmail2fa Session Token
+        // If we have an Email 2FA provider we need this session token so SSO users
+        // can re-request an email TOTP. The TwoFactorController.SendEmailLoginAsync
+        // endpoint requires a way to authenticate the user before sending another email with
+        // a TOTP, this token acts as the authentication mechanism.
         if (enabledProviders.Any(p => p.Key == TwoFactorProviderType.Email))
         {
             twoFactorResultDict.Add("SsoEmail2faSessionToken",

--- a/test/Identity.Test/IdentityServer/TwoFactorAuthenticationValidatorTests.cs
+++ b/test/Identity.Test/IdentityServer/TwoFactorAuthenticationValidatorTests.cs
@@ -250,39 +250,6 @@ public class TwoFactorAuthenticationValidatorTests
     }
 
     [Theory]
-    [BitAutoData(TwoFactorProviderType.Email)]
-    public async void BuildTwoFactorResultAsync_IndividualEmailProvider_SendsEmail_SetsSsoToken_ReturnsNotNull(
-        TwoFactorProviderType providerType,
-        User user)
-    {
-        // Arrange
-        var providerTypeInt = (int)providerType;
-        user.TwoFactorProviders = GetTwoFactorIndividualProviderJson(providerType);
-
-        _userManager.TWO_FACTOR_ENABLED = true;
-        _userManager.SUPPORTS_TWO_FACTOR = true;
-        _userManager.TWO_FACTOR_PROVIDERS = [providerType.ToString()];
-
-        _userService.TwoFactorProviderIsEnabledAsync(Arg.Any<TwoFactorProviderType>(), user)
-            .Returns(true);
-
-        // Act
-        var result = await _sut.BuildTwoFactorResultAsync(user, null);
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.IsType<Dictionary<string, object>>(result);
-        Assert.NotEmpty(result);
-        Assert.True(result.ContainsKey("TwoFactorProviders2"));
-        var providers = (Dictionary<string, Dictionary<string, object>>)result["TwoFactorProviders2"];
-        Assert.True(providers.ContainsKey(providerTypeInt.ToString()));
-        Assert.True(result.ContainsKey("SsoEmail2faSessionToken"));
-        Assert.True(result.ContainsKey("Email"));
-
-        await _userService.Received(1).SendTwoFactorEmailAsync(Arg.Any<User>());
-    }
-
-    [Theory]
     [BitAutoData(TwoFactorProviderType.Duo)]
     [BitAutoData(TwoFactorProviderType.WebAuthn)]
     [BitAutoData(TwoFactorProviderType.Email)]

--- a/test/Identity.Test/IdentityServer/TwoFactorAuthenticationValidatorTests.cs
+++ b/test/Identity.Test/IdentityServer/TwoFactorAuthenticationValidatorTests.cs
@@ -250,6 +250,37 @@ public class TwoFactorAuthenticationValidatorTests
     }
 
     [Theory]
+    [BitAutoData(TwoFactorProviderType.Email)]
+    public async void BuildTwoFactorResultAsync_SetsSsoToken_ReturnsNotNull(
+    TwoFactorProviderType providerType,
+    User user)
+    {
+        // Arrange
+        var providerTypeInt = (int)providerType;
+        user.TwoFactorProviders = GetTwoFactorIndividualProviderJson(providerType);
+
+        _userManager.TWO_FACTOR_ENABLED = true;
+        _userManager.SUPPORTS_TWO_FACTOR = true;
+        _userManager.TWO_FACTOR_PROVIDERS = [providerType.ToString()];
+
+        _userService.TwoFactorProviderIsEnabledAsync(Arg.Any<TwoFactorProviderType>(), user)
+            .Returns(true);
+
+        // Act
+        var result = await _sut.BuildTwoFactorResultAsync(user, null);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<Dictionary<string, object>>(result);
+        Assert.NotEmpty(result);
+        Assert.True(result.ContainsKey("TwoFactorProviders2"));
+        var providers = (Dictionary<string, Dictionary<string, object>>)result["TwoFactorProviders2"];
+        Assert.True(providers.ContainsKey(providerTypeInt.ToString()));
+        Assert.True(result.ContainsKey("SsoEmail2faSessionToken"));
+        Assert.True(result.ContainsKey("Email"));
+    }
+
+    [Theory]
     [BitAutoData(TwoFactorProviderType.Duo)]
     [BitAutoData(TwoFactorProviderType.WebAuthn)]
     [BitAutoData(TwoFactorProviderType.Email)]


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-21281](https://bitwarden.atlassian.net/browse/PM-21281)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

With the new two factor component refactors on the client we now send an email automatically when a user selects the email 2 factor option. Historically the server would assume and send an email automatically if email two factor was the only available option to the user. The team opted to not have the server make assumptions about what the client wishes to do and instead wait for instruction from the client.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21281]: https://bitwarden.atlassian.net/browse/PM-21281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ