### PR TITLE
[PM-21345] Re-add existing customer coupon after subscription update

### DIFF
--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.AdminConsole.Entities;
+﻿using Amazon.SimpleEmail.Model;
+using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Models.Business;
 using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Extensions;
@@ -112,6 +113,8 @@ public class StripePaymentService : IPaymentService
             throw new BadRequestException("You do not have an active subscription. Reinstate your subscription to make changes.");
         }
 
+        var existingCoupon = sub.Customer.Discount?.Coupon?.Id;
+
         var collectionMethod = sub.CollectionMethod;
         var daysUntilDue = sub.DaysUntilDue;
         var chargeNow = collectionMethod == "charge_automatically";
@@ -214,6 +217,19 @@ public class StripePaymentService : IPaymentService
                 {
                     CollectionMethod = collectionMethod,
                     DaysUntilDue = daysUntilDue,
+                });
+            }
+
+            var customer = await _stripeAdapter.CustomerGetAsync(sub.CustomerId);
+
+            var newCoupon = customer.Discount?.Coupon?.Id;
+
+            if (!string.IsNullOrEmpty(existingCoupon) && string.IsNullOrEmpty(newCoupon))
+            {
+                // Re-add the lost coupon due to the update.
+                await _stripeAdapter.CustomerUpdateAsync(sub.CustomerId, new CustomerUpdateOptions
+                {
+                    Coupon = existingCoupon
                 });
             }
         }

--- a/src/Core/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Services/Implementations/StripePaymentService.cs
@@ -1,5 +1,4 @@
-﻿using Amazon.SimpleEmail.Model;
-using Bit.Core.AdminConsole.Entities;
+﻿using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Models.Business;
 using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Extensions;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-21345

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The `sm-standalone` coupon applied to a Stripe customer is lost after their subscription is updated via the Upgrade Plan Dialog. This could be for any number of reasons since we're updating a good amount of the subscription. 

This PR checks if the customer had a coupon prior to the update and, if it doesn't have it after the update, re-applies the coupon to the customer.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/b4ad1fdc-47ae-460b-9758-d9a0122f5b19



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
