### PR TITLE
[PM-20485] [PM-20486] Add missing mappings to PlanAdapter

### DIFF
--- a/src/Core/Billing/Pricing/PlanAdapter.cs
+++ b/src/Core/Billing/Pricing/PlanAdapter.cs
@@ -30,6 +30,7 @@ public record PlanAdapter : Plan
         HasScim = HasFeature("scim");
         HasResetPassword = HasFeature("resetPassword");
         UsersGetPremium = HasFeature("usersGetPremium");
+        HasCustomPermissions = HasFeature("customPermissions");
         UpgradeSortOrder = plan.AdditionalData.TryGetValue("upgradeSortOrder", out var upgradeSortOrder)
             ? int.Parse(upgradeSortOrder)
             : 0;
@@ -168,7 +169,10 @@ public record PlanAdapter : Plan
         => purchasable.FromPackaged(x => x.Price);
 
     private static int GetBaseSeats(PurchasableDTO purchasable)
-        => purchasable.FromPackaged(x => x.Quantity);
+        => purchasable.Match(
+            free => free.Quantity,
+            packaged => packaged.Quantity,
+            scalable => scalable.Provided);
 
     private static short GetBaseServiceAccount(FreeOrScalableDTO freeOrScalable)
         => freeOrScalable.Match(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-20485
https://bitwarden.atlassian.net/browse/PM-20486

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This PR resolves two missing mappings in the `PlanAdapter` for the Pricing Service. 

1. `BaseSeats` was not being mapped for Free Organizations
2. `CustomPermissions` were not being mapped as feature access

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/c07d73c4-7e76-411d-b146-e3fd336d9fea


https://github.com/user-attachments/assets/56447e2e-8d5e-45d5-949d-bcabbfc8af0d




## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
