### PR TITLE
[PM-17562] Add support for retires on event integrations

### DIFF
--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -28,10 +28,8 @@ using Bit.Core.Tools.Entities;
 using Bit.Core.Vault.Entities;
 using Bit.Api.Auth.Models.Request.WebAuthn;
 using Bit.Api.Billing;
-using Bit.Core.AdminConsole.Services.NoopImplementations;
 using Bit.Core.Auth.Models.Data;
 using Bit.Core.Auth.Identity.TokenProviders;
-using Bit.Core.Services;
 using Bit.Core.Tools.ImportFeatures;
 using Bit.Core.Tools.ReportFeatures;
 using Bit.Core.Auth.Models.Api.Request;
@@ -222,18 +220,7 @@ public class Startup
             services.AddHostedService<Core.HostedServices.ApplicationCacheHostedService>();
         }
 
-        // Slack
-        if (CoreHelpers.SettingHasValue(globalSettings.Slack.ClientId) &&
-            CoreHelpers.SettingHasValue(globalSettings.Slack.ClientSecret) &&
-            CoreHelpers.SettingHasValue(globalSettings.Slack.Scopes))
-        {
-            services.AddHttpClient(SlackService.HttpClientName);
-            services.AddSingleton<ISlackService, SlackService>();
-        }
-        else
-        {
-            services.AddSingleton<ISlackService, NoopSlackService>();
-        }
+        services.AddSlackService(globalSettings);
     }
 
     public void Configure(

--- a/src/Core/AdminConsole/Enums/IntegrationType.cs
+++ b/src/Core/AdminConsole/Enums/IntegrationType.cs
@@ -7,3 +7,19 @@ public enum IntegrationType : int
     Slack = 3,
     Webhook = 4,
 }
+
+public static class IntegrationTypeExtensions
+{
+    public static string ToRoutingKey(this IntegrationType type)
+    {
+        switch (type)
+        {
+            case IntegrationType.Slack:
+                return "slack";
+            case IntegrationType.Webhook:
+                return "webhook";
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type), $"Unsupported integration type: {type}");
+        }
+    }
+}

--- a/src/Core/AdminConsole/Models/Data/Integrations/IntegrationHandlerResult.cs
+++ b/src/Core/AdminConsole/Models/Data/Integrations/IntegrationHandlerResult.cs
@@ -1,0 +1,16 @@
+﻿namespace Bit.Core.Models.Data.Integrations;
+
+public class IntegrationHandlerResult
+{
+    public IntegrationHandlerResult(bool success, IIntegrationMessage message)
+    {
+        Success = success;
+        Message = message;
+    }
+
+    public bool Success { get; set; } = false;
+    public bool Retryable { get; set; } = false;
+    public IIntegrationMessage Message { get; set; }
+    public DateTime? NotBeforeUtc { get; set; }
+    public string FailureReason { get; set; } = string.Empty;
+}

--- a/src/Core/AdminConsole/Models/Data/Integrations/IntegrationMessage.cs
+++ b/src/Core/AdminConsole/Models/Data/Integrations/IntegrationMessage.cs
@@ -1,0 +1,44 @@
+﻿using System.Text.Json;
+using Bit.Core.Enums;
+
+namespace Bit.Core.Models.Data.Integrations;
+
+public interface IIntegrationMessage
+{
+    IntegrationType IntegrationType { get; }
+    int RetryCount { get; set; }
+    DateTime? NotBeforeUtc { get; set; }
+    void ApplyRetry(DateTime? handlerNotBeforeUtc);
+    string ToJson();
+}
+
+public class IntegrationMessage<T> : IIntegrationMessage
+{
+    public IntegrationType IntegrationType { get; set; }
+    public T Configuration { get; set; }
+    public string RenderedTemplate { get; set; }
+    public int RetryCount { get; set; } = 0;
+    public DateTime? NotBeforeUtc { get; set; }
+
+    public void ApplyRetry(DateTime? handlerNotBeforeUtc)
+    {
+        RetryCount++;
+
+        var baseTime = handlerNotBeforeUtc ?? DateTime.UtcNow;
+        var backoffSeconds = Math.Pow(2, RetryCount);
+        var jitterSeconds = Random.Shared.Next(0, 3);
+
+        NotBeforeUtc = baseTime.AddSeconds(backoffSeconds + jitterSeconds);
+    }
+
+    public string ToJson()
+    {
+        return JsonSerializer.Serialize(this);
+    }
+
+    public static IntegrationMessage<T> FromJson(string json)
+    {
+        return JsonSerializer.Deserialize<IntegrationMessage<T>>(json)
+               ?? throw new InvalidOperationException("Invalid JSON payload.");
+    }
+}

--- a/src/Core/AdminConsole/Models/Data/Integrations/WebhookIntegrationConfigurationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Integrations/WebhookIntegrationConfigurationDetails.cs
@@ -1,0 +1,3 @@
+﻿namespace Bit.Core.Models.Data.Integrations;
+
+public record WebhookIntegrationConfigurationDetails(string url);

--- a/src/Core/AdminConsole/Models/Data/Integrations/WebhookIntegrationConfigurationDetils.cs
+++ b/src/Core/AdminConsole/Models/Data/Integrations/WebhookIntegrationConfigurationDetils.cs
@@ -1,3 +1,0 @@
-﻿namespace Bit.Core.Models.Data.Integrations;
-
-public record WebhookIntegrationConfigurationDetils(string url);

--- a/src/Core/AdminConsole/Services/IIntegrationHandler.cs
+++ b/src/Core/AdminConsole/Services/IIntegrationHandler.cs
@@ -1,0 +1,24 @@
+﻿using Bit.Core.Models.Data.Integrations;
+
+namespace Bit.Core.Services;
+
+public interface IIntegrationHandler
+{
+    Task<IntegrationHandlerResult> HandleAsync(string json);
+}
+
+public interface IIntegrationHandler<T> : IIntegrationHandler
+{
+    Task<IntegrationHandlerResult> HandleAsync(IntegrationMessage<T> message);
+}
+
+public abstract class IntegrationHandlerBase<T> : IIntegrationHandler<T>
+{
+    public async Task<IntegrationHandlerResult> HandleAsync(string json)
+    {
+        var message = IntegrationMessage<T>.FromJson(json);
+        return await HandleAsync(message);
+    }
+
+    public abstract Task<IntegrationHandlerResult> HandleAsync(IntegrationMessage<T> message);
+}

--- a/src/Core/AdminConsole/Services/IIntegrationPublisher.cs
+++ b/src/Core/AdminConsole/Services/IIntegrationPublisher.cs
@@ -1,0 +1,8 @@
+﻿using Bit.Core.Models.Data.Integrations;
+
+namespace Bit.Core.Services;
+
+public interface IIntegrationPublisher
+{
+    Task PublishAsync(IIntegrationMessage message);
+}

--- a/src/Core/AdminConsole/Services/Implementations/EventIntegrationHandler.cs
+++ b/src/Core/AdminConsole/Services/Implementations/EventIntegrationHandler.cs
@@ -1,0 +1,76 @@
+﻿using System.Text.Json;
+using Bit.Core.AdminConsole.Utilities;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data;
+using Bit.Core.Models.Data.Integrations;
+using Bit.Core.Repositories;
+
+namespace Bit.Core.Services;
+
+public class EventIntegrationHandler<T>(
+    IntegrationType integrationType,
+    IIntegrationPublisher integrationPublisher,
+    IOrganizationIntegrationConfigurationRepository configurationRepository,
+    IUserRepository userRepository,
+    IOrganizationRepository organizationRepository)
+    : IEventMessageHandler
+{
+    public async Task HandleEventAsync(EventMessage eventMessage)
+    {
+        var organizationId = eventMessage.OrganizationId ?? Guid.Parse("f431e04c-f2c3-473c-8cd1-b291014b0236");
+        var configurations = await configurationRepository.GetConfigurationDetailsAsync(
+            organizationId,
+            integrationType,
+            eventMessage.Type);
+
+        foreach (var configuration in configurations)
+        {
+            var context = await BuildContextAsync(eventMessage, configuration.Template);
+            var renderedTemplate = IntegrationTemplateProcessor.ReplaceTokens(configuration.Template, context);
+
+            var config = configuration.MergedConfiguration.Deserialize<T>()
+                         ?? throw new InvalidOperationException($"Failed to deserialize to {typeof(T).Name}");
+
+            var message = new IntegrationMessage<T>
+            {
+                IntegrationType = integrationType,
+                Configuration = config,
+                RenderedTemplate = renderedTemplate,
+                RetryCount = 0,
+                NotBeforeUtc = null
+            };
+
+            await integrationPublisher.PublishAsync(message);
+        }
+    }
+
+    public async Task HandleManyEventsAsync(IEnumerable<EventMessage> eventMessages)
+    {
+        foreach (var eventMessage in eventMessages)
+        {
+            await HandleEventAsync(eventMessage);
+        }
+    }
+
+    private async Task<IntegrationTemplateContext> BuildContextAsync(EventMessage eventMessage, string template)
+    {
+        var context = new IntegrationTemplateContext(eventMessage);
+
+        if (IntegrationTemplateProcessor.TemplateRequiresUser(template) && eventMessage.UserId.HasValue)
+        {
+            context.User = await userRepository.GetByIdAsync(eventMessage.UserId.Value);
+        }
+
+        if (IntegrationTemplateProcessor.TemplateRequiresActingUser(template) && eventMessage.ActingUserId.HasValue)
+        {
+            context.ActingUser = await userRepository.GetByIdAsync(eventMessage.ActingUserId.Value);
+        }
+
+        if (IntegrationTemplateProcessor.TemplateRequiresOrganization(template) && eventMessage.OrganizationId.HasValue)
+        {
+            context.Organization = await organizationRepository.GetByIdAsync(eventMessage.OrganizationId.Value);
+        }
+
+        return context;
+    }
+}

--- a/src/Core/AdminConsole/Services/Implementations/RabbitMqEventListenerService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/RabbitMqEventListenerService.cs
@@ -29,7 +29,7 @@ public class RabbitMqEventListenerService : EventLoggingListenerService
             UserName = globalSettings.EventLogging.RabbitMq.Username,
             Password = globalSettings.EventLogging.RabbitMq.Password
         };
-        _exchangeName = globalSettings.EventLogging.RabbitMq.ExchangeName;
+        _exchangeName = globalSettings.EventLogging.RabbitMq.EventExchangeName;
         _logger = logger;
         _queueName = queueName;
     }

--- a/src/Core/AdminConsole/Services/Implementations/RabbitMqEventWriteService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/RabbitMqEventWriteService.cs
@@ -18,7 +18,7 @@ public class RabbitMqEventWriteService : IEventWriteService, IAsyncDisposable
             UserName = globalSettings.EventLogging.RabbitMq.Username,
             Password = globalSettings.EventLogging.RabbitMq.Password
         };
-        _exchangeName = globalSettings.EventLogging.RabbitMq.ExchangeName;
+        _exchangeName = globalSettings.EventLogging.RabbitMq.EventExchangeName;
 
         _lazyConnection = new Lazy<Task<IConnection>>(CreateConnectionAsync);
     }

--- a/src/Core/AdminConsole/Services/Implementations/RabbitMqIntegrationListenerService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/RabbitMqIntegrationListenerService.cs
@@ -1,0 +1,180 @@
+﻿using System.Text;
+using Bit.Core.Settings;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace Bit.Core.Services;
+
+public class RabbitMqIntegrationListenerService : BackgroundService
+{
+    private const string _deadLetterRoutingKey = "dead-letter";
+    private IChannel _channel;
+    private IConnection _connection;
+    private readonly string _exchangeName;
+    private readonly string _queueName;
+    private readonly string _retryQueueName;
+    private readonly string _deadLetterQueueName;
+    private readonly string _routingKey;
+    private readonly string _retryRoutingKey;
+    private readonly int _maxRetries;
+    private readonly IIntegrationHandler _handler;
+    private readonly ConnectionFactory _factory;
+    private readonly ILogger<RabbitMqIntegrationListenerService> _logger;
+
+    public RabbitMqIntegrationListenerService(IIntegrationHandler handler,
+        string routingKey,
+        string queueName,
+        string retryQueueName,
+        string deadLetterQueueName,
+        GlobalSettings globalSettings,
+        ILogger<RabbitMqIntegrationListenerService> logger)
+    {
+        _handler = handler;
+        _routingKey = routingKey;
+        _retryRoutingKey = $"{_routingKey}-retry";
+        _queueName = queueName;
+        _retryQueueName = retryQueueName;
+        _deadLetterQueueName = deadLetterQueueName;
+        _logger = logger;
+        _exchangeName = globalSettings.EventLogging.RabbitMq.IntegrationExchangeName;
+        _maxRetries = globalSettings.EventLogging.RabbitMq.MaxRetries;
+
+        _factory = new ConnectionFactory
+        {
+            HostName = globalSettings.EventLogging.RabbitMq.HostName,
+            UserName = globalSettings.EventLogging.RabbitMq.Username,
+            Password = globalSettings.EventLogging.RabbitMq.Password
+        };
+    }
+
+    public override async Task StartAsync(CancellationToken cancellationToken)
+    {
+        _connection = await _factory.CreateConnectionAsync(cancellationToken);
+        _channel = await _connection.CreateChannelAsync(cancellationToken: cancellationToken);
+
+        await _channel.ExchangeDeclareAsync(exchange: _exchangeName,
+                                            type: ExchangeType.Direct,
+                                            durable: true,
+                                            cancellationToken: cancellationToken);
+
+        // Declare main queue
+        await _channel.QueueDeclareAsync(queue: _queueName,
+                                         durable: true,
+                                         exclusive: false,
+                                         autoDelete: false,
+                                         arguments: null,
+                                         cancellationToken: cancellationToken);
+        await _channel.QueueBindAsync(queue: _queueName,
+                                      exchange: _exchangeName,
+                                      routingKey: _routingKey,
+                                      cancellationToken: cancellationToken);
+
+        // Declare retry queue (30s TTL, dead-letters back to main queue)
+        await _channel.QueueDeclareAsync(queue: _retryQueueName,
+                                         durable: true,
+                                         exclusive: false,
+                                         autoDelete: false,
+                                         arguments: new Dictionary<string, object>
+                                         {
+                                             { "x-dead-letter-exchange", _exchangeName },
+                                             { "x-dead-letter-routing-key", _routingKey },
+                                             { "x-message-ttl", 30000 } // 30s
+                                         },
+                                         cancellationToken: cancellationToken);
+        await _channel.QueueBindAsync(queue: _retryQueueName,
+                                      exchange: _exchangeName,
+                                      routingKey: _retryRoutingKey,
+                                      cancellationToken: cancellationToken);
+
+        // Declare dead letter queue
+        await _channel.QueueDeclareAsync(queue: _deadLetterQueueName,
+                                         durable: true,
+                                         exclusive: false,
+                                         autoDelete: false,
+                                         arguments: null,
+                                         cancellationToken: cancellationToken);
+        await _channel.QueueBindAsync(queue: _deadLetterQueueName,
+                                      exchange: _exchangeName,
+                                      routingKey: _deadLetterRoutingKey,
+                                      cancellationToken: cancellationToken);
+
+        await base.StartAsync(cancellationToken);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var consumer = new AsyncEventingBasicConsumer(_channel);
+        consumer.ReceivedAsync += async (_, ea) =>
+        {
+            var json = Encoding.UTF8.GetString(ea.Body.Span);
+
+            try
+            {
+                var result = await _handler.HandleAsync(json);
+                var message = result.Message;
+
+                if (result.Success)
+                {
+                    await _channel.BasicAckAsync(ea.DeliveryTag, false, cancellationToken);
+                    return;
+                }
+
+                if (result.Retryable)
+                {
+                    message.ApplyRetry(result.NotBeforeUtc);
+
+                    if (message.RetryCount < _maxRetries)
+                    {
+                        await _channel.BasicPublishAsync(
+                            exchange: _exchangeName,
+                            routingKey: _retryRoutingKey,
+                            body: Encoding.UTF8.GetBytes(message.ToJson()),
+                            cancellationToken: cancellationToken);
+                    }
+                    else
+                    {
+                        await PublishToDeadLetterAsync(message.ToJson());
+                        _logger.LogWarning("Max retry attempts reached. Sent to DLQ.");
+                    }
+                }
+                else
+                {
+                    await PublishToDeadLetterAsync(message.ToJson());
+                    _logger.LogWarning("Non-retryable failure. Sent to DLQ.");
+                }
+
+                await _channel.BasicAckAsync(ea.DeliveryTag, false, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unhandled error processing integration message");
+                await _channel.BasicAckAsync(ea.DeliveryTag, false, cancellationToken);
+            }
+        };
+
+        await _channel.BasicConsumeAsync(queue: _queueName, autoAck: false, consumer: consumer, cancellationToken: cancellationToken);
+    }
+    private async Task PublishToDeadLetterAsync(string json)
+    {
+        await _channel.BasicPublishAsync(
+            exchange: _exchangeName,
+            routingKey: _deadLetterRoutingKey,
+            body: Encoding.UTF8.GetBytes(json));
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await _channel.CloseAsync(cancellationToken);
+        await _connection.CloseAsync(cancellationToken);
+        await base.StopAsync(cancellationToken);
+    }
+
+    public override void Dispose()
+    {
+        _channel.Dispose();
+        _connection.Dispose();
+        base.Dispose();
+    }
+}

--- a/src/Core/AdminConsole/Services/Implementations/RabbitMqIntegrationPublisher.cs
+++ b/src/Core/AdminConsole/Services/Implementations/RabbitMqIntegrationPublisher.cs
@@ -1,0 +1,54 @@
+﻿using System.Text;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data.Integrations;
+using Bit.Core.Settings;
+using RabbitMQ.Client;
+
+namespace Bit.Core.Services;
+
+public class RabbitMqIntegrationPublisher : IIntegrationPublisher, IAsyncDisposable
+{
+    private readonly ConnectionFactory _factory;
+    private readonly Lazy<Task<IConnection>> _lazyConnection;
+    private readonly string _exchangeName;
+
+    public RabbitMqIntegrationPublisher(GlobalSettings globalSettings)
+    {
+        _factory = new ConnectionFactory
+        {
+            HostName = globalSettings.EventLogging.RabbitMq.HostName,
+            UserName = globalSettings.EventLogging.RabbitMq.Username,
+            Password = globalSettings.EventLogging.RabbitMq.Password
+        };
+        _exchangeName = globalSettings.EventLogging.RabbitMq.IntegrationExchangeName;
+
+        _lazyConnection = new Lazy<Task<IConnection>>(CreateConnectionAsync);
+    }
+
+    public async Task PublishAsync(IIntegrationMessage message)
+    {
+        var routingKey = message.IntegrationType.ToRoutingKey();
+        var connection = await _lazyConnection.Value;
+        await using var channel = await connection.CreateChannelAsync();
+
+        await channel.ExchangeDeclareAsync(exchange: _exchangeName, type: ExchangeType.Direct, durable: true);
+
+        var body = Encoding.UTF8.GetBytes(message.ToJson());
+
+        await channel.BasicPublishAsync(exchange: _exchangeName, routingKey: routingKey, body: body);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_lazyConnection.IsValueCreated)
+        {
+            var connection = await _lazyConnection.Value;
+            await connection.DisposeAsync();
+        }
+    }
+
+    private async Task<IConnection> CreateConnectionAsync()
+    {
+        return await _factory.CreateConnectionAsync();
+    }
+}

--- a/src/Core/AdminConsole/Services/Implementations/SlackIntegrationHandler.cs
+++ b/src/Core/AdminConsole/Services/Implementations/SlackIntegrationHandler.cs
@@ -1,0 +1,19 @@
+﻿using Bit.Core.Models.Data.Integrations;
+
+namespace Bit.Core.Services;
+
+public class SlackIntegrationHandler(
+    ISlackService slackService)
+    : IntegrationHandlerBase<SlackIntegrationConfigurationDetails>
+{
+    public override async Task<IntegrationHandlerResult> HandleAsync(IntegrationMessage<SlackIntegrationConfigurationDetails> message)
+    {
+        await slackService.SendSlackMessageByChannelIdAsync(
+            message.Configuration.token,
+            message.RenderedTemplate,
+            message.Configuration.channelId
+        );
+
+        return new IntegrationHandlerResult(success: true, message: message);
+    }
+}

--- a/src/Core/AdminConsole/Services/Implementations/WebhookEventHandler.cs
+++ b/src/Core/AdminConsole/Services/Implementations/WebhookEventHandler.cs
@@ -25,7 +25,7 @@ public class WebhookEventHandler(
     protected override async Task ProcessEventIntegrationAsync(JsonObject mergedConfiguration,
         string renderedTemplate)
     {
-        var config = mergedConfiguration.Deserialize<WebhookIntegrationConfigurationDetils>();
+        var config = mergedConfiguration.Deserialize<WebhookIntegrationConfigurationDetails>();
         if (config is null || string.IsNullOrEmpty(config.url))
         {
             return;

--- a/src/Core/AdminConsole/Services/Implementations/WebhookIntegrationHandler.cs
+++ b/src/Core/AdminConsole/Services/Implementations/WebhookIntegrationHandler.cs
@@ -1,0 +1,47 @@
+﻿using System.Net;
+using System.Text;
+using Bit.Core.Models.Data.Integrations;
+
+#nullable enable
+
+namespace Bit.Core.Services;
+
+public class WebhookIntegrationHandler(IHttpClientFactory httpClientFactory)
+    : IntegrationHandlerBase<WebhookIntegrationConfigurationDetails>
+{
+    private readonly HttpClient _httpClient = httpClientFactory.CreateClient(HttpClientName);
+
+    public const string HttpClientName = "WebhookIntegrationHandlerHttpClient";
+
+    public override async Task<IntegrationHandlerResult> HandleAsync(IntegrationMessage<WebhookIntegrationConfigurationDetails> message)
+    {
+        var content = new StringContent(message.RenderedTemplate, Encoding.UTF8, "application/json");
+        var response = await _httpClient.PostAsync(message.Configuration.url, content);
+        var result = new IntegrationHandlerResult(success: response.IsSuccessStatusCode, message);
+
+        switch (response.StatusCode)
+        {
+            case HttpStatusCode.TooManyRequests:
+            case HttpStatusCode.RequestTimeout:
+            case HttpStatusCode.InternalServerError:
+            case HttpStatusCode.BadGateway:
+            case HttpStatusCode.ServiceUnavailable:
+            case HttpStatusCode.GatewayTimeout:
+                result.Retryable = true;
+                result.FailureReason = response.ReasonPhrase;
+
+                if (response.Headers.TryGetValues("Retry-After", out var values) &&
+                    int.TryParse(values.FirstOrDefault(), out var seconds))
+                {
+                    result.NotBeforeUtc = DateTime.UtcNow.AddSeconds(seconds);
+                }
+                break;
+            default:
+                result.Retryable = false;
+                result.FailureReason = response.ReasonPhrase;
+                break;
+        }
+
+        return result;
+    }
+}

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -313,11 +313,18 @@ public class GlobalSettings : IGlobalSettings
             private string _hostName;
             private string _username;
             private string _password;
-            private string _exchangeName;
+            private string _eventExchangeName;
+            private string _integrationExchangeName;
 
+            public int MaxRetries { get; set; } = 3;
             public virtual string EventRepositoryQueueName { get; set; } = "events-write-queue";
-            public virtual string WebhookQueueName { get; set; } = "events-webhook-queue";
-            public virtual string SlackQueueName { get; set; } = "events-slack-queue";
+            public virtual string IntegrationDeadLetterQueueName { get; set; } = "integration-dead-letter-queue";
+            public virtual string SlackEventsQueueName { get; set; } = "events-slack-queue";
+            public virtual string SlackIntegrationQueueName { get; set; } = "integration-slack-queue";
+            public virtual string SlackIntegrationRetryQueueName { get; set; } = "integration-slack-retry-queue";
+            public virtual string WebhookEventsQueueName { get; set; } = "events-webhook-queue";
+            public virtual string WebhookIntegrationQueueName { get; set; } = "integration-webhook-queue";
+            public virtual string WebhookIntegrationRetryQueueName { get; set; } = "integration-webhook-retry-queue";
 
             public string HostName
             {
@@ -334,10 +341,15 @@ public class GlobalSettings : IGlobalSettings
                 get => _password;
                 set => _password = value.Trim('"');
             }
-            public string ExchangeName
+            public string EventExchangeName
             {
-                get => _exchangeName;
-                set => _exchangeName = value.Trim('"');
+                get => _eventExchangeName;
+                set => _eventExchangeName = value.Trim('"');
+            }
+            public string IntegrationExchangeName
+            {
+                get => _integrationExchangeName;
+                set => _integrationExchangeName = value.Trim('"');
             }
         }
     }

--- a/src/EventsProcessor/Startup.cs
+++ b/src/EventsProcessor/Startup.cs
@@ -1,12 +1,8 @@
 ﻿using System.Globalization;
-using Bit.Core.AdminConsole.Services.NoopImplementations;
-using Bit.Core.Repositories;
-using Bit.Core.Services;
 using Bit.Core.Settings;
 using Bit.Core.Utilities;
 using Bit.SharedWeb.Utilities;
 using Microsoft.IdentityModel.Logging;
-using TableStorageRepos = Bit.Core.Repositories.TableStorage;
 
 namespace Bit.EventsProcessor;
 
@@ -37,50 +33,7 @@ public class Startup
         services.AddDatabaseRepositories(globalSettings);
 
         // Hosted Services
-
-        // Optional Azure Service Bus Listeners
-        if (CoreHelpers.SettingHasValue(globalSettings.EventLogging.AzureServiceBus.ConnectionString) &&
-            CoreHelpers.SettingHasValue(globalSettings.EventLogging.AzureServiceBus.TopicName))
-        {
-            services.AddSingleton<IEventRepository, TableStorageRepos.EventRepository>();
-            services.AddSingleton<AzureTableStorageEventHandler>();
-            services.AddKeyedSingleton<IEventWriteService, RepositoryEventWriteService>("persistent");
-            services.AddSingleton<IHostedService>(provider =>
-                new AzureServiceBusEventListenerService(
-                    provider.GetRequiredService<AzureTableStorageEventHandler>(),
-                    provider.GetRequiredService<ILogger<AzureServiceBusEventListenerService>>(),
-                    globalSettings,
-                    globalSettings.EventLogging.AzureServiceBus.EventRepositorySubscriptionName));
-
-            if (CoreHelpers.SettingHasValue(globalSettings.Slack.ClientId) &&
-                CoreHelpers.SettingHasValue(globalSettings.Slack.ClientSecret) &&
-                CoreHelpers.SettingHasValue(globalSettings.Slack.Scopes))
-            {
-                services.AddHttpClient(SlackService.HttpClientName);
-                services.AddSingleton<ISlackService, SlackService>();
-            }
-            else
-            {
-                services.AddSingleton<ISlackService, NoopSlackService>();
-            }
-            services.AddSingleton<SlackEventHandler>();
-            services.AddSingleton<IHostedService>(provider =>
-                new AzureServiceBusEventListenerService(
-                    provider.GetRequiredService<SlackEventHandler>(),
-                    provider.GetRequiredService<ILogger<AzureServiceBusEventListenerService>>(),
-                    globalSettings,
-                    globalSettings.EventLogging.AzureServiceBus.SlackSubscriptionName));
-
-            services.AddSingleton<WebhookEventHandler>();
-            services.AddHttpClient(WebhookEventHandler.HttpClientName);
-
-            services.AddSingleton<IHostedService>(provider =>
-                new AzureServiceBusEventListenerService(
-                    provider.GetRequiredService<WebhookEventHandler>(),
-                    provider.GetRequiredService<ILogger<AzureServiceBusEventListenerService>>(),
-                    globalSettings,
-                    globalSettings.EventLogging.AzureServiceBus.WebhookSubscriptionName));
-        }
+        services.AddAzureServiceBusListeners(globalSettings);
         services.AddHostedService<AzureQueueHostedService>();
     }
 

--- a/test/Core.Test/AdminConsole/Models/Data/Integrations/IntegrationMessageTests.cs
+++ b/test/Core.Test/AdminConsole/Models/Data/Integrations/IntegrationMessageTests.cs
@@ -1,0 +1,53 @@
+﻿using System.Text.Json;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data.Integrations;
+using Xunit;
+
+namespace Bit.Core.Test.Models.Data.Integrations;
+
+public class IntegrationMessageTests
+{
+    [Fact]
+    public void ApplyRetry_IncrementsRetryCountAndSetsNotBeforeUtc()
+    {
+        var message = new IntegrationMessage<WebhookIntegrationConfigurationDetails>
+        {
+            RetryCount = 2,
+            NotBeforeUtc = null
+        };
+
+        var baseline = DateTime.UtcNow;
+        message.ApplyRetry(baseline);
+
+        Assert.Equal(3, message.RetryCount);
+        Assert.True(message.NotBeforeUtc > baseline);
+    }
+
+    [Fact]
+    public void FromToJson_SerializesCorrectly()
+    {
+        var message = new IntegrationMessage<WebhookIntegrationConfigurationDetails>
+        {
+            Configuration = new WebhookIntegrationConfigurationDetails("https://localhost"),
+            RenderedTemplate = "This is the message",
+            IntegrationType = IntegrationType.Webhook,
+            RetryCount = 2,
+            NotBeforeUtc = null
+        };
+
+        var json = message.ToJson();
+        var result = IntegrationMessage<WebhookIntegrationConfigurationDetails>.FromJson(json);
+
+        Assert.Equal(message.Configuration, result.Configuration);
+        Assert.Equal(message.RenderedTemplate, result.RenderedTemplate);
+        Assert.Equal(message.IntegrationType, result.IntegrationType);
+        Assert.Equal(message.RetryCount, result.RetryCount);
+    }
+
+    [Fact]
+    public void FromJson_InvalidJson_ThrowsJsonException()
+    {
+        var json = "{ Invalid JSON";
+        Assert.Throws<JsonException>(() => IntegrationMessage<WebhookIntegrationConfigurationDetails>.FromJson(json));
+    }
+}

--- a/test/Core.Test/AdminConsole/Services/EventIntegrationHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/Services/EventIntegrationHandlerTests.cs
@@ -1,0 +1,212 @@
+﻿using System.Text.Json;
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data;
+using Bit.Core.Models.Data.Integrations;
+using Bit.Core.Models.Data.Organizations;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Bit.Test.Common.Helpers;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services;
+
+[SutProviderCustomize]
+public class EventIntegrationHandlerTests
+{
+    private const string _templateBase = "Date: #Date#, Type: #Type#, UserId: #UserId#";
+    private const string _templateWithOrganization = "Org: #OrganizationName#";
+    private const string _templateWithUser = "#UserName#, #UserEmail#";
+    private const string _templateWithActingUser = "#ActingUserName#, #ActingUserEmail#";
+    private const string _url = "https://localhost";
+    private const string _url2 = "https://example.com";
+    private readonly IIntegrationPublisher _integrationPublisher = Substitute.For<IIntegrationPublisher>();
+
+    private SutProvider<EventIntegrationHandler<WebhookIntegrationConfigurationDetails>> GetSutProvider(
+        List<OrganizationIntegrationConfigurationDetails> configurations)
+    {
+        var configurationRepository = Substitute.For<IOrganizationIntegrationConfigurationRepository>();
+        configurationRepository.GetConfigurationDetailsAsync(Arg.Any<Guid>(),
+            IntegrationType.Webhook, Arg.Any<EventType>()).Returns(configurations);
+
+        return new SutProvider<EventIntegrationHandler<WebhookIntegrationConfigurationDetails>>()
+            .SetDependency(configurationRepository)
+            .SetDependency(_integrationPublisher)
+            .SetDependency(IntegrationType.Webhook)
+            .Create();
+    }
+
+    private static IntegrationMessage<WebhookIntegrationConfigurationDetails> expectedMessage(string template)
+    {
+        return new IntegrationMessage<WebhookIntegrationConfigurationDetails>()
+        {
+            IntegrationType = IntegrationType.Webhook,
+            Configuration = new WebhookIntegrationConfigurationDetails(_url),
+            RenderedTemplate = template,
+            RetryCount = 0,
+            NotBeforeUtc = null
+        };
+    }
+
+    private static List<OrganizationIntegrationConfigurationDetails> NoConfigurations()
+    {
+        return [];
+    }
+
+    private static List<OrganizationIntegrationConfigurationDetails> OneConfiguration(string template)
+    {
+        var config = Substitute.For<OrganizationIntegrationConfigurationDetails>();
+        config.Configuration = null;
+        config.IntegrationConfiguration = JsonSerializer.Serialize(new { url = _url });
+        config.Template = template;
+
+        return [config];
+    }
+
+    private static List<OrganizationIntegrationConfigurationDetails> TwoConfigurations(string template)
+    {
+        var config = Substitute.For<OrganizationIntegrationConfigurationDetails>();
+        config.Configuration = null;
+        config.IntegrationConfiguration = JsonSerializer.Serialize(new { url = _url });
+        config.Template = template;
+        var config2 = Substitute.For<OrganizationIntegrationConfigurationDetails>();
+        config2.Configuration = null;
+        config2.IntegrationConfiguration = JsonSerializer.Serialize(new { url = _url2 });
+        config2.Template = template;
+
+        return [config, config2];
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleEventAsync_BaseTemplateNoConfigurations_DoesNothing(EventMessage eventMessage)
+    {
+        var sutProvider = GetSutProvider(NoConfigurations());
+
+        await sutProvider.Sut.HandleEventAsync(eventMessage);
+        Assert.Empty(_integrationPublisher.ReceivedCalls());
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleEventAsync_BaseTemplateOneConfiguration_CallsProcessEventIntegrationAsync(EventMessage eventMessage)
+    {
+        var sutProvider = GetSutProvider(OneConfiguration(_templateBase));
+
+        await sutProvider.Sut.HandleEventAsync(eventMessage);
+
+        var expectedMessage = EventIntegrationHandlerTests.expectedMessage(
+            $"Date: {eventMessage.Date}, Type: {eventMessage.Type}, UserId: {eventMessage.UserId}"
+        );
+
+        Assert.Single(_integrationPublisher.ReceivedCalls());
+        await _integrationPublisher.Received(1).PublishAsync(Arg.Is(AssertHelper.AssertPropertyEqual(expectedMessage)));
+        await sutProvider.GetDependency<IOrganizationRepository>().DidNotReceiveWithAnyArgs().GetByIdAsync(Arg.Any<Guid>());
+        await sutProvider.GetDependency<IUserRepository>().DidNotReceiveWithAnyArgs().GetByIdAsync(Arg.Any<Guid>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleEventAsync_ActingUserTemplate_LoadsUserFromRepository(EventMessage eventMessage)
+    {
+        var sutProvider = GetSutProvider(OneConfiguration(_templateWithActingUser));
+        var user = Substitute.For<User>();
+        user.Email = "test@example.com";
+        user.Name = "Test";
+
+        sutProvider.GetDependency<IUserRepository>().GetByIdAsync(Arg.Any<Guid>()).Returns(user);
+        await sutProvider.Sut.HandleEventAsync(eventMessage);
+
+        var expectedMessage = EventIntegrationHandlerTests.expectedMessage($"{user.Name}, {user.Email}");
+
+        Assert.Single(_integrationPublisher.ReceivedCalls());
+        await _integrationPublisher.Received(1).PublishAsync(Arg.Is(AssertHelper.AssertPropertyEqual(expectedMessage)));
+        await sutProvider.GetDependency<IOrganizationRepository>().DidNotReceiveWithAnyArgs().GetByIdAsync(Arg.Any<Guid>());
+        await sutProvider.GetDependency<IUserRepository>().Received(1).GetByIdAsync(eventMessage.ActingUserId ?? Guid.Empty);
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleEventAsync_OrganizationTemplate_LoadsOrganizationFromRepository(EventMessage eventMessage)
+    {
+        var sutProvider = GetSutProvider(OneConfiguration(_templateWithOrganization));
+        var organization = Substitute.For<Organization>();
+        organization.Name = "Test";
+
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(Arg.Any<Guid>()).Returns(organization);
+        await sutProvider.Sut.HandleEventAsync(eventMessage);
+
+        Assert.Single(_integrationPublisher.ReceivedCalls());
+
+        var expectedMessage = EventIntegrationHandlerTests.expectedMessage($"Org: {organization.Name}");
+
+        Assert.Single(_integrationPublisher.ReceivedCalls());
+        await _integrationPublisher.Received(1).PublishAsync(Arg.Is(AssertHelper.AssertPropertyEqual(expectedMessage)));
+        await sutProvider.GetDependency<IOrganizationRepository>().Received(1).GetByIdAsync(eventMessage.OrganizationId ?? Guid.Empty);
+        await sutProvider.GetDependency<IUserRepository>().DidNotReceiveWithAnyArgs().GetByIdAsync(Arg.Any<Guid>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleEventAsync_UserTemplate_LoadsUserFromRepository(EventMessage eventMessage)
+    {
+        var sutProvider = GetSutProvider(OneConfiguration(_templateWithUser));
+        var user = Substitute.For<User>();
+        user.Email = "test@example.com";
+        user.Name = "Test";
+
+        sutProvider.GetDependency<IUserRepository>().GetByIdAsync(Arg.Any<Guid>()).Returns(user);
+        await sutProvider.Sut.HandleEventAsync(eventMessage);
+
+        var expectedMessage = EventIntegrationHandlerTests.expectedMessage($"{user.Name}, {user.Email}");
+
+        Assert.Single(_integrationPublisher.ReceivedCalls());
+        await _integrationPublisher.Received(1).PublishAsync(Arg.Is(AssertHelper.AssertPropertyEqual(expectedMessage)));
+        await sutProvider.GetDependency<IOrganizationRepository>().DidNotReceiveWithAnyArgs().GetByIdAsync(Arg.Any<Guid>());
+        await sutProvider.GetDependency<IUserRepository>().Received(1).GetByIdAsync(eventMessage.UserId ?? Guid.Empty);
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleManyEventsAsync_BaseTemplateNoConfigurations_DoesNothing(List<EventMessage> eventMessages)
+    {
+        var sutProvider = GetSutProvider(NoConfigurations());
+
+        await sutProvider.Sut.HandleManyEventsAsync(eventMessages);
+        Assert.Empty(_integrationPublisher.ReceivedCalls());
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleManyEventsAsync_BaseTemplateOneConfiguration_CallsProcessEventIntegrationAsync(List<EventMessage> eventMessages)
+    {
+        var sutProvider = GetSutProvider(OneConfiguration(_templateBase));
+
+        await sutProvider.Sut.HandleManyEventsAsync(eventMessages);
+
+        foreach (var eventMessage in eventMessages)
+        {
+            var expectedMessage = EventIntegrationHandlerTests.expectedMessage(
+                $"Date: {eventMessage.Date}, Type: {eventMessage.Type}, UserId: {eventMessage.UserId}"
+            );
+            await _integrationPublisher.Received(1).PublishAsync(Arg.Is(AssertHelper.AssertPropertyEqual(expectedMessage)));
+        }
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleManyEventsAsync_BaseTemplateTwoConfigurations_CallsProcessEventIntegrationAsyncMultipleTimes(
+        List<EventMessage> eventMessages)
+    {
+        var sutProvider = GetSutProvider(TwoConfigurations(_templateBase));
+
+        await sutProvider.Sut.HandleManyEventsAsync(eventMessages);
+
+        foreach (var eventMessage in eventMessages)
+        {
+            var expectedMessage = EventIntegrationHandlerTests.expectedMessage(
+                $"Date: {eventMessage.Date}, Type: {eventMessage.Type}, UserId: {eventMessage.UserId}"
+            );
+            await _integrationPublisher.Received(1).PublishAsync(Arg.Is(AssertHelper.AssertPropertyEqual(expectedMessage)));
+
+            expectedMessage.Configuration = new WebhookIntegrationConfigurationDetails(_url2);
+            await _integrationPublisher.Received(1).PublishAsync(Arg.Is(AssertHelper.AssertPropertyEqual(expectedMessage)));
+        }
+    }
+}

--- a/test/Core.Test/AdminConsole/Services/SlackIntegrationHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/Services/SlackIntegrationHandlerTests.cs
@@ -1,0 +1,42 @@
+﻿using Bit.Core.Models.Data.Integrations;
+using Bit.Core.Services;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Bit.Test.Common.Helpers;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services;
+
+[SutProviderCustomize]
+public class SlackIntegrationHandlerTests
+{
+    private readonly ISlackService _slackService = Substitute.For<ISlackService>();
+    private readonly string _channelId = "C12345";
+    private readonly string _token = "xoxb-test-token";
+
+    private SutProvider<SlackIntegrationHandler> GetSutProvider()
+    {
+        return new SutProvider<SlackIntegrationHandler>()
+            .SetDependency(_slackService)
+            .Create();
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleAsync_SuccessfulRequest_ReturnsSuccess(IntegrationMessage<SlackIntegrationConfigurationDetails> message)
+    {
+        var sutProvider = GetSutProvider();
+        message.Configuration = new SlackIntegrationConfigurationDetails(_channelId, _token);
+
+        var result = await sutProvider.Sut.HandleAsync(message);
+
+        Assert.True(result.Success);
+        Assert.Equal(result.Message, message);
+
+        sutProvider.GetDependency<ISlackService>().Received(1).SendSlackMessageByChannelIdAsync(
+            Arg.Is(AssertHelper.AssertPropertyEqual(_token)),
+            Arg.Is(AssertHelper.AssertPropertyEqual(message.RenderedTemplate)),
+            Arg.Is(AssertHelper.AssertPropertyEqual(_channelId))
+        );
+    }
+}

--- a/test/Core.Test/AdminConsole/Services/WebhookIntegrationHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/Services/WebhookIntegrationHandlerTests.cs
@@ -1,0 +1,119 @@
+﻿using System.Net;
+using Bit.Core.Models.Data.Integrations;
+using Bit.Core.Services;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Bit.Test.Common.Helpers;
+using Bit.Test.Common.MockedHttpClient;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services;
+
+[SutProviderCustomize]
+public class WebhookIntegrationHandlerTests
+{
+    private readonly MockedHttpMessageHandler _handler;
+    private readonly HttpClient _httpClient;
+    private const string _webhookUrl = "http://localhost/test/event";
+
+    public WebhookIntegrationHandlerTests()
+    {
+        _handler = new MockedHttpMessageHandler();
+        _handler.Fallback
+            .WithStatusCode(HttpStatusCode.OK)
+            .WithContent(new StringContent("<html><head><title>test</title></head><body>test</body></html>"));
+        _httpClient = _handler.ToHttpClient();
+    }
+
+    private SutProvider<WebhookIntegrationHandler> GetSutProvider()
+    {
+        var clientFactory = Substitute.For<IHttpClientFactory>();
+        clientFactory.CreateClient(WebhookIntegrationHandler.HttpClientName).Returns(_httpClient);
+
+        return new SutProvider<WebhookIntegrationHandler>()
+            .SetDependency(clientFactory)
+            .Create();
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleAsync_SuccessfulRequest_ReturnsSuccess(IntegrationMessage<WebhookIntegrationConfigurationDetails> message)
+    {
+        var sutProvider = GetSutProvider();
+        message.Configuration = new WebhookIntegrationConfigurationDetails(_webhookUrl);
+
+        var result = await sutProvider.Sut.HandleAsync(message);
+
+        Assert.True(result.Success);
+        Assert.Equal(result.Message, message);
+
+        sutProvider.GetDependency<IHttpClientFactory>().Received(1).CreateClient(
+            Arg.Is(AssertHelper.AssertPropertyEqual(WebhookIntegrationHandler.HttpClientName))
+        );
+
+        Assert.Single(_handler.CapturedRequests);
+        var request = _handler.CapturedRequests[0];
+        Assert.NotNull(request);
+        var returned = await request.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal(_webhookUrl, request.RequestUri.ToString());
+        AssertHelper.AssertPropertyEqual(message.RenderedTemplate, returned);
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleAsync_TooManyRequests_ReturnsFailureSetsNotBeforUtc(IntegrationMessage<WebhookIntegrationConfigurationDetails> message)
+    {
+        var sutProvider = GetSutProvider();
+        message.Configuration = new WebhookIntegrationConfigurationDetails(_webhookUrl);
+
+        _handler.Fallback
+            .WithStatusCode(HttpStatusCode.TooManyRequests)
+            .WithHeader("Retry-After", "60")
+            .WithContent(new StringContent("<html><head><title>test</title></head><body>test</body></html>"));
+
+        var result = await sutProvider.Sut.HandleAsync(message);
+
+        Assert.False(result.Success);
+        Assert.True(result.Retryable);
+        Assert.Equal(result.Message, message);
+        Assert.True(result.NotBeforeUtc.HasValue);
+        Assert.InRange(result.NotBeforeUtc.Value, DateTime.UtcNow.AddSeconds(59), DateTime.UtcNow.AddSeconds(61));
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleAsync_InternalServerError_ReturnsFailureSetsRetryable(IntegrationMessage<WebhookIntegrationConfigurationDetails> message)
+    {
+        var sutProvider = GetSutProvider();
+        message.Configuration = new WebhookIntegrationConfigurationDetails(_webhookUrl);
+
+        _handler.Fallback
+            .WithStatusCode(HttpStatusCode.InternalServerError)
+            .WithContent(new StringContent("<html><head><title>test</title></head><body>test</body></html>"));
+
+        var result = await sutProvider.Sut.HandleAsync(message);
+
+        Assert.False(result.Success);
+        Assert.True(result.Retryable);
+        Assert.Equal(result.Message, message);
+        Assert.False(result.NotBeforeUtc.HasValue);
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleAsync_UnexpectedRedirect_ReturnsFailureNotRetryable(IntegrationMessage<WebhookIntegrationConfigurationDetails> message)
+    {
+        var sutProvider = GetSutProvider();
+        message.Configuration = new WebhookIntegrationConfigurationDetails(_webhookUrl);
+
+        _handler.Fallback
+            .WithStatusCode(HttpStatusCode.TemporaryRedirect)
+            .WithContent(new StringContent("<html><head><title>test</title></head><body>test</body></html>"));
+
+        var result = await sutProvider.Sut.HandleAsync(message);
+
+        Assert.False(result.Success);
+        Assert.False(result.Retryable);
+        Assert.Equal(result.Message, message);
+        Assert.Null(result.NotBeforeUtc);
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17562](https://bitwarden.atlassian.net/browse/PM-17562)

## 📔 Objective

This PR adds a new layer of AMQP messaging (for RabbitMQ now, but ASB will be added in another PR). This allows us to queue each individual integration message to allow for retries and dead-lettering.

The flow of events with this new change (assuming the feature flag is On and Rabbit is configured):
1. Event comes into the system
2. Event gets published to the main exchange, which is a fanout exchange. This means it is immediately published to the event-integration queues (1 per integration, currently webhook and slack), and the event repository queue
3. Listener/Handler pairs on each queue receive the message and run
   - For the event repository handler, it writes the event to the `EventRepository`.
4. For the event-integration queues, the EventIntegrationHandler pulls the current configurations for this Organization, Event Type, and `IntegrationType`. For each configuration: 
   - It parses the configuration into a typed configuration object
   - It processes the Template string and fills in tokens with the contents of EventMessage or any other fetched properties
   - It bundles all of this up into an `IntegrationMessage`
   - And it publishes that message to another exchange - the Integration Exchange - with the routing key of the `IntegrationType`.
5. The Integration Exchange is not fanout. It publishes direct to exactly one queue depending on the routing key. The queues are one per integration (i.e. slack, webhook).
6. The specific queue receives the message and another Listener/Handler pair runs. These are directly tied to the integration and take the IntegrationMessage (which has the necessary configuration and message) and publish it to the integration.
7. The handlers return a result that indicates a success/failure and (if failure) if the message can be retried. The listener checks the result. If it's a success, it's simply acknowledged and the process ends. If it's retryable, it is published to the retry queue for this integration. If it is not retryable, or it has exceeded the configurable number of retries, it is sent to the dead letter queue.

In the RabbitMQ implementation, we are using a very simple retry queue. It has a TTL of 30 seconds with a dead-letter pointing back to its original queue. This means that messages are put in the retry queue and no handlers ever pick them up. When the TTL expires, Rabbit dead-letters them back to the main integration queue, where they are picked up and reprocessed. Integration messages contain the number of retries, so we don't do this endlessly. 

Although this implementation adds things like `NotBeforeUtc` to support scheduling messages and obeying `Retry-After` headers, we ignore that for the RabbitMQ implementation. Azure Service Bus will use these directly since it supports scheduling out of the box. RabbitMQ needs a special package to add delay scheduling which adds complexity that self-hosted instances probably do not need.

We are also using one dead-letter-queue for all integrations. We could make this per-integration if we wanted to, it just adds more complexity in the configuration / global settings. Since messages in the DLQ are really just for information purposes (i.e. we're not planning on programmatically re-queueing them), it seemed cleaner to put them all in one place where they could be viewed.

Lastly, this PR also cleans up some of the Startup.cs files with some methods in our ServiceCollectionExtensions.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
