### PR TITLE
Auth/PM-21428 - Registration via Org Invite should send welcome email even if reference data is missing

### DIFF
--- a/test/Core.Test/Auth/UserFeatures/Registration/RegisterUserCommandTests.cs
+++ b/test/Core.Test/Auth/UserFeatures/Registration/RegisterUserCommandTests.cs
@@ -226,6 +226,11 @@ public class RegisterUserCommandTests
             await sutProvider.GetDependency<IReferenceEventService>()
                 .Received(1)
                 .RaiseEventAsync(Arg.Is<ReferenceEvent>(refEvent => refEvent.Type == ReferenceEventType.Signup && refEvent.SignupInitiationPath == default));
+
+            // Even if user doesn't have reference data, we should send them welcome email
+            await sutProvider.GetDependency<IMailService>()
+                .Received(1)
+                .SendWelcomeEmailAsync(user);
         }
 
         Assert.True(result.Succeeded);


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21428

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To resolve the fact that we weren't sending the normal welcome emails to users who created an account via an organization invite. 

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
