### PR TITLE
Turn of casing validation for identifiers

### DIFF
--- a/src/Sql/Sql.sqlproj
+++ b/src/Sql/Sql.sqlproj
@@ -9,6 +9,7 @@
     <TargetDatabaseSet>True</TargetDatabaseSet>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <TargetFrameworkProfile />
+    <ValidateCasingOnIdentifiers>false</ValidateCasingOnIdentifiers>
   </PropertyGroup>
   <ItemGroup>
     <Build Remove="dbo_future/**/*" />


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We currently have 7 warnings from SQL project, since we have a collation that doesn't actually need the identifiers to match casing-wise we don't need these particular warnings. 

```
src/Sql/dbo/Stored Procedures/OrganizationDomainSsoDetails_ReadByEmail.sql(1,1,1,1): Build warning SQL71558: The object reference [dbo].[Ssoconfig].[Enabled] differs only by case from the object definition [dbo].[SsoConfig].[Enabled]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/OrganizationDomainSsoDetails_ReadByEmail.sql(1,1,1,1): Build warning SQL71558: The object reference [dbo].[Ssoconfig].[OrganizationId] differs only by case from the object definition [dbo].[SsoConfig].[OrganizationId]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/OrganizationDomainSsoDetails_ReadByEmail.sql(1,1,1,1): Build warning SQL71558: The object reference [dbo].[Ssoconfig] differs only by case from the object definition [dbo].[SsoConfig]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/VerfiedOrganaizationDomainSsoDetails_ReadByEmail.sql(1,1,1,1): Build warning SQL71558: The object reference [dbo].[Ssoconfig] differs only by case from the object definition [dbo].[SsoConfig]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/VerfiedOrganaizationDomainSsoDetails_ReadByEmail.sql(1,1,1,1): Build warning SQL71558: The object reference [dbo].[Ssoconfig].[OrganizationId] differs only by case from the object definition [dbo].[SsoConfig].[OrganizationId]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/VerfiedOrganaizationDomainSsoDetails_ReadByEmail.sql(1,1,1,1): Build warning SQL71558: The object reference [dbo].[Ssoconfig].[Enabled] differs only by case from the object definition [dbo].[SsoConfig].[Enabled]. [src/Sql/Sql.sqlproj]
src/Sql/dbo/Stored Procedures/OrganizationSponsorship_ReadBySponsoringOrganiationUserId.sql(1,1,1,1): Build warning SQL71558: The object reference [dbo].[OrganizationSponsorshipView].[SponsoringOrganizationUserId] differs only by case from the object definition [dbo].[OrganizationSponsorshipView].[SponsoringOrganizationUserID]. [src/Sql/Sql.sqlproj]
```

This means our codebase has 0 warnings!

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
