### PR TITLE
[PM-21079] Add support to integration tests for using sqlserver

### DIFF
--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerPerformanceTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerPerformanceTests.cs
@@ -9,7 +9,7 @@ namespace Bit.Api.IntegrationTest.AdminConsole.Controllers;
 
 public class OrganizationUsersControllerPerformanceTest(ITestOutputHelper testOutputHelper)
 {
-    [Theory]
+    [Theory(Skip = "Performance test")]
     [InlineData(100)]
     [InlineData(60000)]
     public async Task GetAsync(int seats)

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerPerformanceTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerPerformanceTests.cs
@@ -9,12 +9,12 @@ namespace Bit.Api.IntegrationTest.AdminConsole.Controllers;
 
 public class OrganizationUsersControllerPerformanceTest(ITestOutputHelper testOutputHelper)
 {
-    [Theory(Skip = "Performance test")]
+    [Theory]
     [InlineData(100)]
     [InlineData(60000)]
     public async Task GetAsync(int seats)
     {
-        await using var factory = new ApiApplicationFactory();
+        await using var factory = new SqlServerApiApplicationFactory();
         var client = factory.CreateClient();
 
         var db = factory.GetDatabaseContext();

--- a/test/Api.IntegrationTest/Factories/ApiApplicationFactory.cs
+++ b/test/Api.IntegrationTest/Factories/ApiApplicationFactory.cs
@@ -22,10 +22,10 @@ public class ApiApplicationFactory : WebApplicationFactoryBase<Startup>
     protected ApiApplicationFactory(ITestDatabase db)
     {
         TestDatabase = db;
-        HandleDbDisposal = true;
 
         _identityApplicationFactory = new IdentityApplicationFactory();
         _identityApplicationFactory.TestDatabase = TestDatabase;
+        _identityApplicationFactory.ManagesDatabase = false;
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)

--- a/test/Api.IntegrationTest/Factories/ApiApplicationFactory.cs
+++ b/test/Api.IntegrationTest/Factories/ApiApplicationFactory.cs
@@ -18,7 +18,7 @@ public class ApiApplicationFactory : WebApplicationFactoryBase<Startup>
     {
     }
 
-    public ApiApplicationFactory(ITestDatabase db)
+    protected ApiApplicationFactory(ITestDatabase db)
     {
         TestDatabase = db;
         HandleDbDisposal = true;

--- a/test/Api.IntegrationTest/Factories/ApiApplicationFactory.cs
+++ b/test/Api.IntegrationTest/Factories/ApiApplicationFactory.cs
@@ -14,7 +14,7 @@ public class ApiApplicationFactory : WebApplicationFactoryBase<Startup>
 {
     protected IdentityApplicationFactory _identityApplicationFactory;
 
-    public ApiApplicationFactory() : this(new SqlServerTestDatabase())
+    public ApiApplicationFactory() : this(new SqliteTestDatabase())
     {
     }
 

--- a/test/Api.IntegrationTest/Factories/ApiApplicationFactory.cs
+++ b/test/Api.IntegrationTest/Factories/ApiApplicationFactory.cs
@@ -5,6 +5,7 @@ using Bit.IntegrationTestCommon;
 using Bit.IntegrationTestCommon.Factories;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.TestHost;
+using Xunit;
 
 #nullable enable
 
@@ -50,6 +51,10 @@ public class ApiApplicationFactory : WebApplicationFactoryBase<Startup>
     public async Task<(string Token, string RefreshToken)> LoginWithNewAccount(
         string email = "integration-test@bitwarden.com", string masterPasswordHash = "master_password_hash")
     {
+        // This might be the first action in a test and since it forwards to the Identity server, we need to ensure that
+        // this server is initialized since it's responsible for seeding the database.
+        Assert.NotNull(Services);
+
         await _identityApplicationFactory.RegisterNewIdentityFactoryUserAsync(
             new RegisterFinishRequestModel
             {

--- a/test/Api.IntegrationTest/Factories/ApiApplicationFactory.cs
+++ b/test/Api.IntegrationTest/Factories/ApiApplicationFactory.cs
@@ -21,7 +21,7 @@ public class ApiApplicationFactory : WebApplicationFactoryBase<Startup>
     public ApiApplicationFactory(ITestDatabase db)
     {
         TestDatabase = db;
-        _handleDbDisposal = true;
+        HandleDbDisposal = true;
 
         _identityApplicationFactory = new IdentityApplicationFactory();
         _identityApplicationFactory.TestDatabase = TestDatabase;

--- a/test/Api.IntegrationTest/Factories/SqlServerApiApplicationFactory.cs
+++ b/test/Api.IntegrationTest/Factories/SqlServerApiApplicationFactory.cs
@@ -1,0 +1,7 @@
+﻿using Bit.IntegrationTestCommon;
+
+#nullable enable
+
+namespace Bit.Api.IntegrationTest.Factories;
+
+public class SqlServerApiApplicationFactory() : ApiApplicationFactory(new SqlServerTestDatabase());

--- a/test/Events.IntegrationTest/EventsApplicationFactory.cs
+++ b/test/Events.IntegrationTest/EventsApplicationFactory.cs
@@ -1,6 +1,7 @@
 ﻿using Bit.Core;
 using Bit.Core.Auth.Models.Api.Request.Accounts;
 using Bit.Core.Enums;
+using Bit.IntegrationTestCommon;
 using Bit.IntegrationTestCommon.Factories;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
@@ -13,15 +14,18 @@ namespace Bit.Events.IntegrationTest;
 public class EventsApplicationFactory : WebApplicationFactoryBase<Startup>
 {
     private readonly IdentityApplicationFactory _identityApplicationFactory;
-    private const string _connectionString = "DataSource=:memory:";
 
-    public EventsApplicationFactory()
+    public EventsApplicationFactory() : this(new SqlServerTestDatabase())
     {
-        SqliteConnection = new SqliteConnection(_connectionString);
-        SqliteConnection.Open();
+    }
+
+    public EventsApplicationFactory(ITestDatabase db)
+    {
+        TestDatabase = db;
+        HandleDbDisposal = true;
 
         _identityApplicationFactory = new IdentityApplicationFactory();
-        _identityApplicationFactory.SqliteConnection = SqliteConnection;
+        _identityApplicationFactory.TestDatabase = TestDatabase;
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)

--- a/test/Events.IntegrationTest/EventsApplicationFactory.cs
+++ b/test/Events.IntegrationTest/EventsApplicationFactory.cs
@@ -6,7 +6,6 @@ using Bit.IntegrationTestCommon.Factories;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Bit.Events.IntegrationTest;
@@ -62,11 +61,5 @@ public class EventsApplicationFactory : WebApplicationFactoryBase<Startup>
             });
 
         return await _identityApplicationFactory.TokenFromPasswordAsync(email, masterPasswordHash);
-    }
-
-    protected override void Dispose(bool disposing)
-    {
-        base.Dispose(disposing);
-        SqliteConnection!.Dispose();
     }
 }

--- a/test/Events.IntegrationTest/EventsApplicationFactory.cs
+++ b/test/Events.IntegrationTest/EventsApplicationFactory.cs
@@ -14,7 +14,7 @@ public class EventsApplicationFactory : WebApplicationFactoryBase<Startup>
 {
     private readonly IdentityApplicationFactory _identityApplicationFactory;
 
-    public EventsApplicationFactory() : this(new SqlServerTestDatabase())
+    public EventsApplicationFactory() : this(new SqliteTestDatabase())
     {
     }
 

--- a/test/Events.IntegrationTest/EventsApplicationFactory.cs
+++ b/test/Events.IntegrationTest/EventsApplicationFactory.cs
@@ -45,6 +45,10 @@ public class EventsApplicationFactory : WebApplicationFactoryBase<Startup>
     /// </summary>
     public async Task<(string Token, string RefreshToken)> LoginWithNewAccount(string email = "integration-test@bitwarden.com", string masterPasswordHash = "master_password_hash")
     {
+        // This might be the first action in a test and since it forwards to the Identity server, we need to ensure that
+        // this server is initialized since it's responsible for seeding the database.
+        Assert.NotNull(Services);
+
         await _identityApplicationFactory.RegisterNewIdentityFactoryUserAsync(
             new RegisterFinishRequestModel
             {

--- a/test/Events.IntegrationTest/EventsApplicationFactory.cs
+++ b/test/Events.IntegrationTest/EventsApplicationFactory.cs
@@ -21,10 +21,10 @@ public class EventsApplicationFactory : WebApplicationFactoryBase<Startup>
     protected EventsApplicationFactory(ITestDatabase db)
     {
         TestDatabase = db;
-        HandleDbDisposal = true;
 
         _identityApplicationFactory = new IdentityApplicationFactory();
         _identityApplicationFactory.TestDatabase = TestDatabase;
+        _identityApplicationFactory.ManagesDatabase = false;
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)

--- a/test/Events.IntegrationTest/EventsApplicationFactory.cs
+++ b/test/Events.IntegrationTest/EventsApplicationFactory.cs
@@ -18,7 +18,7 @@ public class EventsApplicationFactory : WebApplicationFactoryBase<Startup>
     {
     }
 
-    public EventsApplicationFactory(ITestDatabase db)
+    protected EventsApplicationFactory(ITestDatabase db)
     {
         TestDatabase = db;
         HandleDbDisposal = true;

--- a/test/IntegrationTestCommon/Factories/WebApplicationFactoryBase.cs
+++ b/test/IntegrationTestCommon/Factories/WebApplicationFactoryBase.cs
@@ -41,7 +41,7 @@ public abstract class WebApplicationFactoryBase<T> : WebApplicationFactory<T>
     private readonly List<Action<IServiceCollection>> _configureTestServices = new();
     private readonly List<Action<IConfigurationBuilder>> _configureAppConfiguration = new();
 
-    private bool _handleDbDisposal { get; set; }
+    public bool HandleDbDisposal { get; set; }
 
 
     public void SubstituteService<TService>(Action<TService> mockService)
@@ -121,7 +121,7 @@ public abstract class WebApplicationFactoryBase<T> : WebApplicationFactory<T>
         if (TestDatabase == null)
         {
             TestDatabase = new SqliteTestDatabase();
-            _handleDbDisposal = true;
+            HandleDbDisposal = true;
         }
 
         var config = new Dictionary<string, string?>
@@ -185,7 +185,7 @@ public abstract class WebApplicationFactoryBase<T> : WebApplicationFactory<T>
 
             // Add database to the service collection
             TestDatabase.AddDatabase(services);
-            if (_handleDbDisposal)
+            if (HandleDbDisposal)
             {
                 TestDatabase.Migrate(services);
             }
@@ -287,9 +287,9 @@ public abstract class WebApplicationFactoryBase<T> : WebApplicationFactory<T>
     protected override void Dispose(bool disposing)
     {
         base.Dispose(disposing);
-        if (_handleDbDisposal)
+        if (HandleDbDisposal)
         {
-            _handleDbDisposal = false;
+            HandleDbDisposal = false;
 
             if (TestDatabase != null)
             {

--- a/test/IntegrationTestCommon/ITestDatabase.cs
+++ b/test/IntegrationTestCommon/ITestDatabase.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Bit.IntegrationTestCommon;
+
+#nullable enable
+
+public interface ITestDatabase
+{
+    public void AddDatabase(IServiceCollection serviceCollection);
+
+    public void Migrate(IServiceCollection serviceCollection);
+
+    public void Dispose();
+
+    public void ModifyGlobalSettings(Dictionary<string, string?> config)
+    {
+        // Default implementation does nothing
+    }
+}

--- a/test/IntegrationTestCommon/IntegrationTestCommon.csproj
+++ b/test/IntegrationTestCommon/IntegrationTestCommon.csproj
@@ -11,6 +11,7 @@
     
   <ItemGroup>
     <ProjectReference Include="..\..\src\Identity\Identity.csproj" />
+    <ProjectReference Include="..\..\util\Migrator\Migrator.csproj" />
     <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>
 </Project>

--- a/test/IntegrationTestCommon/SqlServerTestDatabase.cs
+++ b/test/IntegrationTestCommon/SqlServerTestDatabase.cs
@@ -1,0 +1,70 @@
+﻿using Bit.Core.Settings;
+using Bit.Infrastructure.EntityFramework.Repositories;
+using Bit.Migrator;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Bit.IntegrationTestCommon;
+
+public class SqlServerTestDatabase : ITestDatabase
+{
+    public string SqlServerConnection { get; set; }
+
+    public SqlServerTestDatabase()
+    {
+        SqlServerConnection = "Server=localhost;Database=vault_test;User Id=SA;Password=SET_A_PASSWORD_HERE_123;Encrypt=True;TrustServerCertificate=True;";
+    }
+
+    public void ModifyGlobalSettings(Dictionary<string, string> config)
+    {
+        config["globalSettings:databaseProvider"] = "sqlserver";
+        config["globalSettings:sqlServer:connectionString"] = SqlServerConnection;
+    }
+
+    public void AddDatabase(IServiceCollection serviceCollection)
+    {
+        serviceCollection.AddScoped(s => new DbContextOptionsBuilder<DatabaseContext>()
+            .UseSqlServer(SqlServerConnection)
+            .UseApplicationServiceProvider(s)
+            .Options);
+    }
+
+    public void Migrate(IServiceCollection serviceCollection)
+    {
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        using var scope = serviceProvider.CreateScope();
+        var services = scope.ServiceProvider;
+        var globalSettings = services.GetRequiredService<GlobalSettings>();
+        var logger = services.GetRequiredService<ILogger<DbMigrator>>();
+
+        var migrator = new SqlServerDbMigrator(globalSettings, logger);
+        migrator.MigrateDatabase();
+    }
+
+    public void Dispose()
+    {
+        var masterConnectionString = new SqlConnectionStringBuilder(SqlServerConnection)
+        {
+            InitialCatalog = "master"
+        }.ConnectionString;
+
+        using var connection = new SqlConnection(masterConnectionString);
+        var databaseName = new SqlConnectionStringBuilder(SqlServerConnection).InitialCatalog;
+
+        connection.Open();
+
+        var databaseNameQuoted = new SqlCommandBuilder().QuoteIdentifier(databaseName);
+
+        using (var cmd = new SqlCommand($"ALTER DATABASE {databaseNameQuoted} SET single_user WITH rollback IMMEDIATE", connection))
+        {
+            cmd.ExecuteNonQuery();
+        }
+
+        using (var cmd = new SqlCommand($"DROP DATABASE {databaseNameQuoted}", connection))
+        {
+            cmd.ExecuteNonQuery();
+        }
+    }
+}

--- a/test/IntegrationTestCommon/SqliteTestDatabase.cs
+++ b/test/IntegrationTestCommon/SqliteTestDatabase.cs
@@ -1,0 +1,41 @@
+﻿using Bit.Infrastructure.EntityFramework.Repositories;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bit.IntegrationTestCommon;
+
+public class SqliteTestDatabase : ITestDatabase
+{
+    private SqliteConnection SqliteConnection { get; set; }
+
+    public SqliteTestDatabase()
+    {
+        SqliteConnection = new SqliteConnection("DataSource=:memory:");
+        SqliteConnection.Open();
+    }
+
+    public void AddDatabase(IServiceCollection serviceCollection)
+    {
+        serviceCollection.AddScoped(s => new DbContextOptionsBuilder<DatabaseContext>()
+            .UseSqlite(SqliteConnection)
+            .UseApplicationServiceProvider(s)
+            .Options);
+    }
+
+    public void Migrate(IServiceCollection serviceCollection)
+    {
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        using var scope = serviceProvider.CreateScope();
+        var services = scope.ServiceProvider;
+        var context = services.GetRequiredService<DatabaseContext>();
+
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.Dispose();
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-21079

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds a `SqlServerApiApplicationFactory` which allows you to run api tests using SqlServer. Currently a new database is create and destroyed for each test. In the future we'd like a more optimized way to do this.

The database logic is abstracted away in a `ITestDatabase` interface which handles the configuration, migration and teardown.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
