### PR TITLE
[PM-21680] Set BU trial length to 4 days

### DIFF
--- a/bitwarden_license/src/Commercial.Core/Billing/ProviderBillingService.cs
+++ b/bitwarden_license/src/Commercial.Core/Billing/ProviderBillingService.cs
@@ -694,6 +694,13 @@ public class ProviderBillingService(
              customer.Metadata.ContainsKey(BraintreeCustomerIdKey) ||
              setupIntent.IsUnverifiedBankAccount());
 
+        int? trialPeriodDays = provider.Type switch
+        {
+            ProviderType.Msp when usePaymentMethod => 14,
+            ProviderType.BusinessUnit when usePaymentMethod => 4,
+            _ => null
+        };
+
         var subscriptionCreateOptions = new SubscriptionCreateOptions
         {
             CollectionMethod = usePaymentMethod ?
@@ -707,7 +714,7 @@ public class ProviderBillingService(
             },
             OffSession = true,
             ProrationBehavior = StripeConstants.ProrationBehavior.CreateProrations,
-            TrialPeriodDays = usePaymentMethod ? 14 : null
+            TrialPeriodDays = trialPeriodDays
         };
 
         if (featureService.IsEnabled(FeatureFlagKeys.PM19147_AutomaticTaxImprovements))


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-21680

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

I forgot to pivot the trial length for a provider subscription based on the type. 

This PR ensures MSPs get 14 days and BUs get 4. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/6d0bdec3-01f7-41ed-8469-447e1b1c4e79


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
