### PR TITLE
[PM-21707] Add back stub CaptchaBypassToken

### DIFF
--- a/src/Identity/Models/Response/Accounts/RegisterFinishResponseModel.cs
+++ b/src/Identity/Models/Response/Accounts/RegisterFinishResponseModel.cs
@@ -6,5 +6,12 @@ public class RegisterFinishResponseModel : ResponseModel
 {
     public RegisterFinishResponseModel()
         : base("registerFinish")
-    { }
+    {
+        // We are setting this to an empty string so that old mobile clients don't break, as they reqiure a non-null value.
+        // This will be cleaned up in https://bitwarden.atlassian.net/browse/PM-21720.
+        CaptchaBypassToken = string.Empty;
+    }
+
+    public string CaptchaBypassToken { get; set; }
+
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21707

## 📔 Objective

The mobile apps require a non-null value in `captchaBypassToken` in the `RegisterFinishResponseModel`.  This field was not optional.

Even if it is changed to optional now, we must support 3 previous client releases, and so we must return a value in the interim.

Note that older mobile apps will still send up this empty `captchaBypassToken` on the subsequent `/connect/token` request, but since #5675 the endpoint will ignore that extra field. 

## 📸 Screenshots

### Server response

![image](https://github.com/user-attachments/assets/1c1a8da5-8008-4e2b-955a-e83e6efd3ab7)

### Successful mobile registration

https://github.com/user-attachments/assets/74868444-7362-41c1-9d34-e48a24518aef

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
