### PR TITLE
[PM-21383] Use Stripe to get provider pricing for display when feature flag is on

### DIFF
--- a/src/Api/Billing/Models/Responses/ProviderSubscriptionResponse.cs
+++ b/src/Api/Billing/Models/Responses/ProviderSubscriptionResponse.cs
@@ -35,7 +35,7 @@ public record ProviderSubscriptionResponse(
             .Select(providerPlan =>
             {
                 var plan = providerPlan.Plan;
-                var cost = (providerPlan.SeatMinimum + providerPlan.PurchasedSeats) * plan.PasswordManager.ProviderPortalSeatPrice;
+                var cost = (providerPlan.SeatMinimum + providerPlan.PurchasedSeats) * providerPlan.Price;
                 var cadence = plan.IsAnnual ? _annualCadence : _monthlyCadence;
                 return new ProviderPlanResponse(
                     plan.Name,

--- a/src/Core/Billing/Models/ConfiguredProviderPlan.cs
+++ b/src/Core/Billing/Models/ConfiguredProviderPlan.cs
@@ -6,6 +6,7 @@ public record ConfiguredProviderPlan(
     Guid Id,
     Guid ProviderId,
     Plan Plan,
+    decimal Price,
     int SeatMinimum,
     int PurchasedSeats,
     int AssignedSeats);

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -150,6 +150,7 @@ public static class FeatureFlagKeys
     public const string UseOrganizationWarningsService = "use-organization-warnings-service";
     public const string PM20322_AllowTrialLength0 = "pm-20322-allow-trial-length-0";
     public const string PM21092_SetNonUSBusinessUseToReverseCharge = "pm-21092-set-non-us-business-use-to-reverse-charge";
+    public const string PM21383_GetProviderPriceFromStripe = "pm-21383-get-provider-price-from-stripe";
 
     /* Data Insights and Reporting Team */
     public const string RiskInsightsCriticalApplication = "pm-14466-risk-insights-critical-application";

--- a/src/Core/Services/IStripeAdapter.cs
+++ b/src/Core/Services/IStripeAdapter.cs
@@ -57,4 +57,5 @@ public interface IStripeAdapter
     Task<SetupIntent> SetupIntentGet(string id, SetupIntentGetOptions options = null);
     Task SetupIntentVerifyMicroDeposit(string id, SetupIntentVerifyMicrodepositsOptions options);
     Task<List<Stripe.TestHelpers.TestClock>> TestClockListAsync();
+    Task<Price> PriceGetAsync(string id, PriceGetOptions options = null);
 }

--- a/src/Core/Services/Implementations/StripeAdapter.cs
+++ b/src/Core/Services/Implementations/StripeAdapter.cs
@@ -283,4 +283,7 @@ public class StripeAdapter : IStripeAdapter
         }
         return items;
     }
+
+    public Task<Price> PriceGetAsync(string id, PriceGetOptions options = null)
+        => _priceService.GetAsync(id, options);
 }

--- a/test/Api.Test/Billing/Controllers/ProviderBillingControllerTests.cs
+++ b/test/Api.Test/Billing/Controllers/ProviderBillingControllerTests.cs
@@ -2,6 +2,7 @@
 using Bit.Api.Billing.Models.Requests;
 using Bit.Api.Billing.Models.Responses;
 using Bit.Commercial.Core.Billing;
+using Bit.Core;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.AdminConsole.Repositories;
@@ -343,6 +344,9 @@ public class ProviderBillingControllerTests
                 AllocatedSeats = 90
             }
         };
+
+        sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.PM21383_GetProviderPriceFromStripe)
+            .Returns(true);
 
         sutProvider.GetDependency<IProviderPlanRepository>().GetByProviderId(provider.Id).Returns(providerPlans);
 

--- a/test/Api.Test/Billing/Controllers/ProviderBillingControllerTests.cs
+++ b/test/Api.Test/Billing/Controllers/ProviderBillingControllerTests.cs
@@ -1,6 +1,7 @@
 ﻿using Bit.Api.Billing.Controllers;
 using Bit.Api.Billing.Models.Requests;
 using Bit.Api.Billing.Models.Responses;
+using Bit.Commercial.Core.Billing;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.AdminConsole.Repositories;
@@ -285,6 +286,19 @@ public class ProviderBillingControllerTests
                 Discount = new Discount { Coupon = new Coupon { PercentOff = 10 } },
                 TaxIds = new StripeList<TaxId> { Data = [new TaxId { Value = "123456789" }] }
             },
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data = [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = ProviderPriceAdapter.MSP.Active.Enterprise }
+                    },
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = ProviderPriceAdapter.MSP.Active.Teams }
+                    }
+                ]
+            },
             Status = "unpaid",
         };
 
@@ -334,7 +348,14 @@ public class ProviderBillingControllerTests
 
         foreach (var providerPlan in providerPlans)
         {
-            sutProvider.GetDependency<IPricingClient>().GetPlanOrThrow(providerPlan.PlanType).Returns(StaticStore.GetPlan(providerPlan.PlanType));
+            var plan = StaticStore.GetPlan(providerPlan.PlanType);
+            sutProvider.GetDependency<IPricingClient>().GetPlanOrThrow(providerPlan.PlanType).Returns(plan);
+            var priceId = ProviderPriceAdapter.GetPriceId(provider, subscription, providerPlan.PlanType);
+            sutProvider.GetDependency<IStripeAdapter>().PriceGetAsync(priceId)
+                .Returns(new Price
+                {
+                    UnitAmountDecimal = plan.PasswordManager.ProviderPortalSeatPrice * 100
+                });
         }
 
         var result = await sutProvider.Sut.GetSubscriptionAsync(provider.Id);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-21383

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When `pm-21383-get-provider-price-from-stripe` is enabled, this PR causes the endpoint that retrieves a Provider's subscription to get the unit cost of the provider's seats from Stripe rather than from the defunct `ProviderPortalSeatPrice` on the plan object. 

A feature flag is necessary here even though this is a bug because it's not testable in QA. The price in the Stripe test environment is incorrect, which will result in this PR appearing to have a defect in QA when it does not. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
