### PR TITLE
[PM-21975] Add Security Stamp claim to persisted grant

### DIFF
--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -712,6 +712,7 @@ public static class CoreHelpers
             new(Claims.Premium, isPremium ? "true" : "false"),
             new(JwtClaimTypes.Email, user.Email),
             new(JwtClaimTypes.EmailVerified, user.EmailVerified ? "true" : "false"),
+            // TODO: [https://bitwarden.atlassian.net/browse/PM-22171] Remove this since it is already added from the persisted grant
             new(Claims.SecurityStamp, user.SecurityStamp),
         };
 

--- a/src/Identity/IdentityServer/ProfileService.cs
+++ b/src/Identity/IdentityServer/ProfileService.cs
@@ -72,6 +72,10 @@ public class ProfileService : IProfileService
 
     public async Task IsActiveAsync(IsActiveContext context)
     {
+        // We add the security stamp claim to the persisted grant when we issue the refresh token.
+        // IdentityServer will add this claim to the subject, and here we evaluate whether the security stamp that
+        // was persisted matches the current security stamp of the user. If it does not match, then the user has performed
+        // an operation that we want to invalidate the refresh token.
         var securityTokenClaim = context.Subject?.Claims.FirstOrDefault(c => c.Type == Claims.SecurityStamp);
         var user = await _userService.GetUserByPrincipalAsync(context.Subject);
 

--- a/src/Identity/IdentityServer/RequestValidators/BaseRequestValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/BaseRequestValidator.cs
@@ -373,7 +373,7 @@ public abstract class BaseRequestValidator<T> where T : class
     }
 
     /// <summary>
-    /// Builds the claims that will be added to the Subject (also called the Principal) and available for interrogating during token validation.
+    /// Builds the claims that will be stored on the persisted grant.
     /// These claims are supplemented by the claims in the ProfileService when the access token is returned to the client.
     /// </summary>
     /// <param name="user">The authenticated user.</param>
@@ -381,6 +381,10 @@ public abstract class BaseRequestValidator<T> where T : class
     /// <param name="device">The device used for authentication.</param>
     private List<Claim> BuildSubjectClaims(User user, T context, Device device)
     {
+        // We are adding the security stamp claim to the list of claims that will be stored in the persisted grant.
+        // We need this because we check for changes in the stamp to determine if we need to invalidate token refresh requests,
+        // in the `ProfileService.IsActiveAsync` method.
+        // If we don't store the security stamp in the persistend grant, we won't have the previous value to compare against.
         var claims = new List<Claim>
         {
             new Claim(Claims.SecurityStamp, user.SecurityStamp)

--- a/src/Identity/IdentityServer/RequestValidators/BaseRequestValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/BaseRequestValidator.cs
@@ -211,7 +211,7 @@ public abstract class BaseRequestValidator<T> where T : class
     {
         await _eventService.LogUserEventAsync(user.Id, EventType.User_LoggedIn);
 
-        var claims = this.BuildRefreshTokenClaims(user, context, device);
+        var claims = this.BuildSubjectClaims(user, context, device);
 
         var customResponse = await BuildCustomResponse(user, context, device, sendRememberToken);
 
@@ -373,15 +373,13 @@ public abstract class BaseRequestValidator<T> where T : class
     }
 
     /// <summary>
-    /// Builds the claims that will be added to the refresh token that will be issued to the user.
-    /// This includes the security stamp and device information if available.
-    /// The claims for the access token are added in the ProfileService, so this method is only responsible
-    /// for the refresh token claims.
+    /// Builds the claims that will be added to the Subject (also called the Principal) and available for interrogating during token validation.
+    /// This is distinct from adding claims to the access token - these claims are the responsibility of the ProfileService.
     /// </summary>
     /// <param name="user">The authenticated user.</param>
     /// <param name="context">The current request context.</param>
     /// <param name="device">The device used for authentication.</param>
-    private List<Claim> BuildRefreshTokenClaims(User user, T context, Device device)
+    private List<Claim> BuildSubjectClaims(User user, T context, Device device)
     {
         var claims = new List<Claim>
         {

--- a/src/Identity/IdentityServer/RequestValidators/BaseRequestValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/BaseRequestValidator.cs
@@ -375,13 +375,13 @@ public abstract class BaseRequestValidator<T> where T : class
         return new MasterPasswordPolicyResponseModel(await PolicyService.GetMasterPasswordPolicyForUserAsync(user));
     }
 
-        private List<Claim> BuildRefreshTokenClaims(User user, T context, Device device)
+    private List<Claim> BuildRefreshTokenClaims(User user, T context, Device device)
     {
-          var claims = new List<Claim>
+        var claims = new List<Claim>
         {
             new Claim(Claims.SecurityStamp, user.SecurityStamp)
         };
-        
+
         if (device != null)
         {
             claims.Add(new Claim(Claims.Device, device.Identifier));
@@ -390,7 +390,7 @@ public abstract class BaseRequestValidator<T> where T : class
         return claims;
     }
 
-    private async Task<Dictionary<string, object>> BuildCustomResponse(User user,T context, Device device, bool sendRememberToken)
+    private async Task<Dictionary<string, object>> BuildCustomResponse(User user, T context, Device device, bool sendRememberToken)
     {
         var customResponse = new Dictionary<string, object>();
         if (!string.IsNullOrWhiteSpace(user.PrivateKey))

--- a/src/Identity/IdentityServer/RequestValidators/BaseRequestValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/BaseRequestValidator.cs
@@ -374,7 +374,7 @@ public abstract class BaseRequestValidator<T> where T : class
 
     /// <summary>
     /// Builds the claims that will be added to the Subject (also called the Principal) and available for interrogating during token validation.
-    /// This is distinct from adding claims to the access token - these claims are the responsibility of the ProfileService.
+    /// These claims are supplemented by the claims in the ProfileService when the access token is returned to the client.
     /// </summary>
     /// <param name="user">The authenticated user.</param>
     /// <param name="context">The current request context.</param>

--- a/src/Identity/IdentityServer/RequestValidators/BaseRequestValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/BaseRequestValidator.cs
@@ -384,7 +384,7 @@ public abstract class BaseRequestValidator<T> where T : class
         // We are adding the security stamp claim to the list of claims that will be stored in the persisted grant.
         // We need this because we check for changes in the stamp to determine if we need to invalidate token refresh requests,
         // in the `ProfileService.IsActiveAsync` method.
-        // If we don't store the security stamp in the persistend grant, we won't have the previous value to compare against.
+        // If we don't store the security stamp in the persisted grant, we won't have the previous value to compare against.
         var claims = new List<Claim>
         {
             new Claim(Claims.SecurityStamp, user.SecurityStamp)

--- a/src/Identity/IdentityServer/RequestValidators/BaseRequestValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/BaseRequestValidator.cs
@@ -202,9 +202,6 @@ public abstract class BaseRequestValidator<T> where T : class
 
     /// <summary>
     /// Responsible for building the response to the client when the user has successfully authenticated.
-    /// At a high level, the building the response currently includes the following:
-    /// - Claims we'll add to the refresh token (e.g. security stamp, device identifier). Claims for the access token are built in the ProfileService.
-    /// - Custom response data, which the client will receive and use to build the account.
     /// </summary>
     /// <param name="user">The authenticated user.</param>
     /// <param name="context">The current request context.</param>
@@ -375,6 +372,15 @@ public abstract class BaseRequestValidator<T> where T : class
         return new MasterPasswordPolicyResponseModel(await PolicyService.GetMasterPasswordPolicyForUserAsync(user));
     }
 
+    /// <summary>
+    /// Builds the claims that will be added to the refresh token that will be issued to the user.
+    /// This includes the security stamp and device information if available.
+    /// The claims for the access token are added in the ProfileService, so this method is only responsible
+    /// for the refresh token claims.
+    /// </summary>
+    /// <param name="user">The authenticated user.</param>
+    /// <param name="context">The current request context.</param>
+    /// <param name="device">The device used for authentication.</param>
     private List<Claim> BuildRefreshTokenClaims(User user, T context, Device device)
     {
         var claims = new List<Claim>
@@ -390,6 +396,14 @@ public abstract class BaseRequestValidator<T> where T : class
         return claims;
     }
 
+    /// <summary>
+    /// Builds the custom response that will be sent to the client upon successful authentication, which
+    /// includes the information needed for the client to initialize the user's account in state.
+    /// </summary> 
+    /// <param name="user">The authenticated user.</param> 
+    /// <param name="context">The current request context.</param>
+    /// <param name="device">The device used for authentication.</param>
+    /// <param name="sendRememberToken">Whether to send a 2FA remember token.</param>
     private async Task<Dictionary<string, object>> BuildCustomResponse(User user, T context, Device device, bool sendRememberToken)
     {
         var customResponse = new Dictionary<string, object>();


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21975

## 📔 Objective

When a user deauthorizes all sessions (or performs other account actions that invalidate the authentication guarantees of their account), we update the user's SecurityStamp.

In order to enforce this, we rely on the code [here](https://github.com/bitwarden/server/blob/main/src/Identity/IdentityServer/ProfileService.cs#L75-L76) that is intended to ensure that a refresh token is not valid if the security stamp does not match.  IdentityServer will call `IsActiveAsync()` to determine whether an access token should be issued.

However, this has never worked, because we were not adding the `Claims.SecurityStamp` claim to the refresh token.  This meant that it was never available for comparison and therefore never enforced.

In order to add the claim to the refresh token, we should be adding it to the `GrantValidationResult` that we're building in the `BaseRequestValidator`.  This ensures that when IdentityServer builds the response to the `/connect/token` request (including the `refresh_token`), the security stamp claim will be included.

**This will be enforced whenever the client requests a new access token with their refresh token.**. This occurs:
- When the client determines that the access token is within 5 minutes of expiration (~every 60 minutes)
- When we explicitly call `refreshIdentityToken()` on the client.  Most likely, for most users, this will occur on sync.

## 📸 Screenshots

https://github.com/user-attachments/assets/ed073563-552e-4c30-86cb-b2e017cf6126

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
