### PR TITLE
[PM-21612] [Unified] Bump account revision date more consistently

### DIFF
--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationUserRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationUserRepository.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using AutoMapper;
+﻿using AutoMapper;
 using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.InviteUsers.Models;
 using Bit.Core.Enums;
@@ -446,14 +445,11 @@ public class OrganizationUserRepository : Repository<Core.Entities.OrganizationU
     {
         await base.ReplaceAsync(organizationUser);
 
-        // Only bump account revision dates for confirmed OrgUsers,
-        // as this is the only status that receives sync data from the organization
-        if (organizationUser.Status is not OrganizationUserStatusType.Confirmed)
+        // Only bump the account revision date if linked to a user account
+        if (!organizationUser.UserId.HasValue)
         {
             return;
         }
-
-        Debug.Assert(organizationUser.UserId is not null, "OrganizationUser is confirmed but does not have a UserId.");
 
         using var scope = ServiceScopeFactory.CreateScope();
         var dbContext = GetDatabaseContext(scope);

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/OrganizationUserReplaceTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/OrganizationUserReplaceTests.cs
@@ -45,9 +45,6 @@ public class OrganizationUserReplaceTests
     /// Tests OrganizationUsers in the Confirmed status, which is a stand-in for all other
     /// non-Invited statuses (which are all linked to a UserId).
     /// </summary>
-    /// <param name="organizationRepository"></param>
-    /// <param name="organizationUserRepository"></param>
-    /// <param name="collectionRepository"></param>
     [DatabaseTheory, DatabaseData]
     public async Task ReplaceAsync_WithCollectionAccess_WhenUserIsConfirmed_Success(
         IUserRepository userRepository,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21612

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Per QA feedback on #5817, a user's account revision date is being updated in MSSQL but not in EF when they are edited as a member.

This is because the EF implementation only bumps their account revision date if the user is in the confirmed status, whereas the MSSQL sproc will bump it if it's linked to a `UserId` (which in effect also includes the invited, accepted, and some revoked statuses).

I previously thought this was unnecessary - the account revision date indicates whether the user needs to re-sync, and only users in the Confirmed status receive sync data from an organization (per my code comment). However, I think it's more important that our EF implementation is consistent with our canonical MSSQL implementation. There are also some other cases here I didn't consider, such as moving the user into a Revoked status, which would also affect their sync data (by removing org items).

Therefore, this PR brings the EF implementation into line with MSSQL.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
