### PR TITLE
BRE-857/collect-code-references-fails-against-tags

### DIFF
--- a/.github/workflows/code-references.yml
+++ b/.github/workflows/code-references.yml
@@ -29,7 +29,7 @@ jobs:
     name: Code reference collection
     runs-on: ubuntu-22.04
     needs: check-ld-secret
-    if: ${{ needs.check-ld-secret.outputs.available == 'true' }}
+    if: ${{ needs.check-ld-secret.outputs.available == 'true' && startsWith(github.ref, 'refs/heads/') }}
     permissions:
       contents: read
       pull-requests: write
@@ -44,6 +44,7 @@ jobs:
         with:
           accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
           projKey: default
+          allowTags: true
 
       - name: Add label
         if: steps.collect.outputs.any-changed == 'true'

--- a/.github/workflows/code-references.yml
+++ b/.github/workflows/code-references.yml
@@ -29,7 +29,7 @@ jobs:
     name: Code reference collection
     runs-on: ubuntu-22.04
     needs: check-ld-secret
-    if: ${{ needs.check-ld-secret.outputs.available == 'true' && startsWith(github.ref, 'refs/heads/') }}
+    if: ${{ needs.check-ld-secret.outputs.available == 'true' }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## 🎟️ Tracking
[BRE-857](https://bitwarden.atlassian.net/browse/BRE-857)

## 📔 Objective
when running release workflows, this fails since it is checking against a tag not a branch. the library has an `--allowTags` flag we can add. alternative would be to not check tags at all, more details in the linked ticket

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-857]: https://bitwarden.atlassian.net/browse/BRE-857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ