### PR TITLE
[PM-21563] Replace owner/admins list with table

### DIFF
--- a/src/Admin/AdminConsole/Models/OrganizationViewModel.cs
+++ b/src/Admin/AdminConsole/Models/OrganizationViewModel.cs
@@ -44,6 +44,8 @@ public class OrganizationViewModel
             orgUsers
                 .Where(u => u.Type == OrganizationUserType.Admin && u.Status == organizationUserStatus)
                 .Select(u => u.Email));
+        OwnersDetails = orgUsers.Where(u => u.Type == OrganizationUserType.Owner && u.Status == organizationUserStatus);
+        AdminsDetails = orgUsers.Where(u => u.Type == OrganizationUserType.Admin && u.Status == organizationUserStatus);
         SecretsCount = secretsCount;
         ProjectsCount = projectCount;
         ServiceAccountsCount = serviceAccountsCount;
@@ -70,4 +72,6 @@ public class OrganizationViewModel
     public int OccupiedSmSeatsCount { get; set; }
     public bool UseSecretsManager => Organization.UseSecretsManager;
     public bool UseRiskInsights => Organization.UseRiskInsights;
+    public IEnumerable<OrganizationUserUserDetails> OwnersDetails { get; set; }
+    public IEnumerable<OrganizationUserUserDetails> AdminsDetails { get; set; }
 }

--- a/src/Admin/AdminConsole/Views/Organizations/_ViewInformation.cshtml
+++ b/src/Admin/AdminConsole/Views/Organizations/_ViewInformation.cshtml
@@ -19,12 +19,6 @@
         <span id="org-confirmed-users" title="Confirmed">@Model.UserConfirmedCount</span>)
     </dd>
 
-    <dt class="col-sm-4 col-lg-3">Owners</dt>
-    <dd id="org-owner" class="col-sm-8 col-lg-9">@(string.IsNullOrWhiteSpace(Model.Owners) ? "None" : Model.Owners)</dd>
-
-    <dt class="col-sm-4 col-lg-3">Admins</dt>
-    <dd id="org-admins" class="col-sm-8 col-lg-9">@(string.IsNullOrWhiteSpace(Model.Admins) ? "None" : Model.Admins)</dd>
-
     <dt class="col-sm-4 col-lg-3">Using 2FA</dt>
     <dd id="org-2fa" class="col-sm-8 col-lg-9">@(Model.Organization.TwoFactorIsEnabled() ? "Yes" : "No")</dd>
 
@@ -75,4 +69,50 @@
 
     <dt class="col-sm-4 col-lg-3">Secrets Manager Seats</dt>
     <dd id="sm-seat-count" class="col-sm-8 col-lg-9">@(Model.UseSecretsManager ? Model.OccupiedSmSeatsCount: "N/A" )</dd>
+</dl>
+
+<h2>Administrators</h2>
+<dl class="row">
+    <div class="table-responsive">
+        <div class="col-8">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th style="width: 190px;">Email</th>
+                        <th style="width: 60px;">Role</th>
+                        <th style="width: 40px;">Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @if(!Model.Admins.Any() && !Model.Owners.Any())
+                    {
+                        <tr>
+                            <td colspan="6">No results to list.</td>
+                        </tr>
+                    }
+                    else
+                    {
+                        @foreach(var owner in Model.OwnersDetails)
+                        {
+                            <tr>
+                                <td class="align-middle">@owner.Email</td>
+                                <td class="align-middle">Owner</td>
+                                <td class="align-middle">@owner.Status</td>
+                            </tr>
+                        }
+
+                        @foreach(var admin in Model.AdminsDetails)
+                        {
+                            <tr>
+                                <td class="align-middle">@admin.Email</td>
+                                <td class="align-middle">Admin</td>
+                                <td class="align-middle">@admin.Status</td>
+                            </tr>
+
+                        }
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
 </dl>


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-21563
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Replaces the owners and admins list with a table similar to what is displayed in the provider portal.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
![Screenshot 2025-05-28 at 11 55 32 AM](https://github.com/user-attachments/assets/94402407-53f2-4d51-9218-b6a0f7a23147)

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
