### PR TITLE
[PM-22146] Remove JSON_PATH_EXISTS from old migration script

### DIFF
--- a/util/Migrator/DbScripts/2025-04-16_00_AttachmentJsonValidation.sql
+++ b/util/Migrator/DbScripts/2025-04-16_00_AttachmentJsonValidation.sql
@@ -129,7 +129,7 @@ BEGIN
     END
 
     -- Check if the attachment exists before trying to remove it
-    IF JSON_PATH_EXISTS(@CurrentAttachments, @AttachmentIdPath) = 0
+    IF JSON_QUERY(@CurrentAttachments, @AttachmentIdPath) IS NULL
     BEGIN
         -- Attachment doesn't exist, nothing to do
         RETURN;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22146](https://bitwarden.atlassian.net/browse/PM-22146)

## 📔 Objective

https://github.com/bitwarden/server/pull/5891 removed the reference to `JSON_PATH_EXISTS` so that SH and Cloud will be in sync going forward. But, we still need to update the [2025-04-16_00_AttachmentJsonValidation.sql](https://github.com/bitwarden/server/compare/vault/pm-22146/fix-old-migration-script?expand=1#diff-8adc477fb26f271fa5c1c681454d370619cbe3f75c234e806a409ddd97190929) script so that SH instances with older SQL server versions can successfully run it.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22146]: https://bitwarden.atlassian.net/browse/PM-22146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ