### PR TITLE
Refactor `PendingSecurityTasks` to `RefreshSecurityTasks`

### DIFF
--- a/src/Core/Enums/PushType.cs
+++ b/src/Core/Enums/PushType.cs
@@ -31,5 +31,5 @@ public enum PushType : byte
     Notification = 20,
     NotificationStatus = 21,
 
-    PendingSecurityTasks = 22
+    RefreshSecurityTasks = 22
 }

--- a/src/Core/Platform/Push/Services/IPushNotificationService.cs
+++ b/src/Core/Platform/Push/Services/IPushNotificationService.cs
@@ -389,10 +389,10 @@ public interface IPushNotificationService
             ExcludeCurrentContext = false,
         });
 
-    Task PushPendingSecurityTasksAsync(Guid userId)
+    Task PushRefreshSecurityTasksAsync(Guid userId)
         => PushAsync(new PushNotification<UserPushNotification>
         {
-            Type = PushType.PendingSecurityTasks,
+            Type = PushType.RefreshSecurityTasks,
             Target = NotificationTarget.User,
             TargetId = userId,
             Payload = new UserPushNotification

--- a/src/Core/Vault/Commands/CreateManyTaskNotificationsCommand.cs
+++ b/src/Core/Vault/Commands/CreateManyTaskNotificationsCommand.cs
@@ -89,7 +89,7 @@ public class CreateManyTaskNotificationsCommand : ICreateManyTaskNotificationsCo
             }
 
             // Notify the user that they have pending security tasks
-            await _pushNotificationService.PushPendingSecurityTasksAsync(userId);
+            await _pushNotificationService.PushRefreshSecurityTasksAsync(userId);
         }
     }
 }

--- a/src/Core/Vault/Commands/MarkNotificationsForTaskAsDeletedCommand.cs
+++ b/src/Core/Vault/Commands/MarkNotificationsForTaskAsDeletedCommand.cs
@@ -26,7 +26,7 @@ public class MarkNotificationsForTaskAsDeletedCommand : IMarkNotificationsForTas
         var uniqueUserIds = userIds.Distinct();
         foreach (var id in uniqueUserIds)
         {
-            await _pushNotificationService.PushPendingSecurityTasksAsync(id);
+            await _pushNotificationService.PushRefreshSecurityTasksAsync(id);
         }
     }
 }

--- a/src/Notifications/HubHelpers.cs
+++ b/src/Notifications/HubHelpers.cs
@@ -135,7 +135,7 @@ public static class HubHelpers
                 }
 
                 break;
-            case PushType.PendingSecurityTasks:
+            case PushType.RefreshSecurityTasks:
                 var pendingTasksData = JsonSerializer.Deserialize<PushNotificationData<UserPushNotification>>(notificationJson, _deserializerOptions);
                 await hubContext.Clients.User(pendingTasksData.Payload.UserId.ToString())
                     .SendAsync(_receiveMessageMethod, pendingTasksData, cancellationToken);

--- a/test/Api.IntegrationTest/Platform/Controllers/PushControllerTests.cs
+++ b/test/Api.IntegrationTest/Platform/Controllers/PushControllerTests.cs
@@ -166,7 +166,7 @@ public class PushControllerTests
         yield return UserTyped(PushType.SyncOrgKeys);
         yield return UserTyped(PushType.SyncSettings);
         yield return UserTyped(PushType.LogOut);
-        yield return UserTyped(PushType.PendingSecurityTasks);
+        yield return UserTyped(PushType.RefreshSecurityTasks);
 
         yield return Typed(new PushSendRequestModel<AuthRequestPushNotification>
         {

--- a/test/Core.Test/Platform/Push/Services/AzureQueuePushNotificationServiceTests.cs
+++ b/test/Core.Test/Platform/Push/Services/AzureQueuePushNotificationServiceTests.cs
@@ -707,7 +707,7 @@ public class AzureQueuePushNotificationServiceTests
     }
 
     [Fact]
-    public async Task PushPendingSecurityTasksAsync_SendsExpectedResponse()
+    public async Task PushRefreshSecurityTasksAsync_SendsExpectedResponse()
     {
         var userId = Guid.NewGuid();
 
@@ -722,7 +722,7 @@ public class AzureQueuePushNotificationServiceTests
         };
 
         await VerifyNotificationAsync(
-            async sut => await sut.PushPendingSecurityTasksAsync(userId),
+            async sut => await sut.PushRefreshSecurityTasksAsync(userId),
             expectedPayload
         );
     }

--- a/test/Core.Test/Platform/Push/Services/NotificationsApiPushNotificationServiceTests.cs
+++ b/test/Core.Test/Platform/Push/Services/NotificationsApiPushNotificationServiceTests.cs
@@ -368,7 +368,7 @@ public class NotificationsApiPushNotificationServiceTests : PushTestBase
         };
     }
 
-    protected override JsonNode GetPushPendingSecurityTasksResponsePayload(Guid userId)
+    protected override JsonNode GetPushRefreshSecurityTasksResponsePayload(Guid userId)
     {
         return new JsonObject
         {

--- a/test/Core.Test/Platform/Push/Services/PushTestBase.cs
+++ b/test/Core.Test/Platform/Push/Services/PushTestBase.cs
@@ -93,7 +93,7 @@ public abstract class PushTestBase
     protected abstract JsonNode GetPushNotificationStatusResponsePayload(Notification notification, NotificationStatus notificationStatus, Guid? userId, Guid? organizationId);
     protected abstract JsonNode GetPushSyncOrganizationStatusResponsePayload(Organization organization);
     protected abstract JsonNode GetPushSyncOrganizationCollectionManagementSettingsResponsePayload(Organization organization);
-    protected abstract JsonNode GetPushPendingSecurityTasksResponsePayload(Guid userId);
+    protected abstract JsonNode GetPushRefreshSecurityTasksResponsePayload(Guid userId);
 
     [Fact]
     public async Task PushSyncCipherCreateAsync_SendsExpectedResponse()
@@ -444,13 +444,13 @@ public abstract class PushTestBase
     }
 
     [Fact]
-    public async Task PushPendingSecurityTasksAsync_SendsExpectedResponse()
+    public async Task PushRefreshSecurityTasksAsync_SendsExpectedResponse()
     {
         var userId = Guid.NewGuid();
 
         await VerifyNotificationAsync(
-            async sut => await sut.PushPendingSecurityTasksAsync(userId),
-            GetPushPendingSecurityTasksResponsePayload(userId)
+            async sut => await sut.PushRefreshSecurityTasksAsync(userId),
+            GetPushRefreshSecurityTasksResponsePayload(userId)
         );
     }
 

--- a/test/Core.Test/Platform/Push/Services/RelayPushNotificationServiceTests.cs
+++ b/test/Core.Test/Platform/Push/Services/RelayPushNotificationServiceTests.cs
@@ -491,7 +491,7 @@ public class RelayPushNotificationServiceTests : PushTestBase
         };
     }
 
-    protected override JsonNode GetPushPendingSecurityTasksResponsePayload(Guid userId)
+    protected override JsonNode GetPushRefreshSecurityTasksResponsePayload(Guid userId)
     {
         return new JsonObject
         {


### PR DESCRIPTION
✅ Stacked on top of https://github.com/bitwarden/server/pull/5896, I'll leave this as a draft to rebase once that merges. 

## 🎟️ Tracking

N/A

## 📔 Objective

Client PR: https://github.com/bitwarden/clients/pull/15021

As a part of https://github.com/bitwarden/server/pull/5896, I utilized the `PendingSecurityTasks` push type to trigger a refresh of the security tasks on the clients. This is currently on the clients are utilizing the notification but now the name `PendingSecurityTasks` doesn't match the all of the use cases.
- This renames `PendingSecurityTasks` to `RefreshSecurityTasks` to align for more general use cases of security task notifications.

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
