### PR TITLE
fix-false-build-fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -598,7 +598,7 @@ jobs:
     uses: bitwarden/gh-actions/.github/workflows/_ephemeral_environment_manager.yml@main
     with:
       project: server
-      pull_request_number: ${{ github.event.number }}
+      pull_request_number: ${{ github.event.number || 0 }}
     secrets: inherit
     permissions: read-all
 


### PR DESCRIPTION
## 📔 Objective
https://github.com/bitwarden/server/actions/runs/15422959191 as an example
all the containers build successfully, but it is marked as failed due to the follow error noted in the annotations section `.github/workflows/build.yml (Line: 601, Col: 28): Unexpected value ''`
 
this has been this way for months but just started failing. must be because of a change GitHub made to how this would be evaluated, so when the if statement doesn't trigger this, we will simply pass `0`

Vince tested here and it passed https://github.com/bitwarden/server/actions/runs/15420437019

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
