### PR TITLE
Add globalSettings.knownNetworks so that entire IP ranges can be used for trusting X-Forwarded-* headers

### DIFF
--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -19,6 +19,7 @@ public class GlobalSettings : IGlobalSettings
     public bool SelfHosted { get; set; }
     public bool UnifiedDeployment { get; set; }
     public virtual string KnownProxies { get; set; }
+    public virtual string KnownNetworks { get; set; }
     public virtual string SiteName { get; set; }
     public virtual string ProjectName { get; set; }
     public virtual string LogDirectory

--- a/src/Core/Settings/IGlobalSettings.cs
+++ b/src/Core/Settings/IGlobalSettings.cs
@@ -8,6 +8,7 @@ public interface IGlobalSettings
     bool SelfHosted { get; set; }
     bool UnifiedDeployment { get; set; }
     string KnownProxies { get; set; }
+    string KnownNetworks { get; set; }
     string ProjectName { get; set; }
     bool EnableCloudCommunication { get; set; }
     string LicenseDirectory { get; set; }

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -819,10 +819,24 @@ public static class ServiceCollectionExtensions
                 }
             }
         }
-        if (options.KnownProxies.Count > 1)
+
+        if (!string.IsNullOrWhiteSpace(globalSettings.KnownNetworks))
+        {
+            var proxyNetworks = globalSettings.KnownNetworks.Split(',');
+            foreach (var proxyNetwork in proxyNetworks)
+            {
+                if (Microsoft.AspNetCore.HttpOverrides.IPNetwork.TryParse(proxyNetwork.Trim(), out var ipn))
+                {
+                    options.KnownNetworks.Add(ipn);
+                }
+            }
+        }
+
+        if (options.KnownProxies.Count > 1 || options.KnownNetworks.Count > 1)
         {
             options.ForwardLimit = null;
         }
+
         app.UseForwardedHeaders(options);
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/server/issues/3116

## 📔 Objective

This change adds the globalSettings.knownNetworks as a partner to globalSettings.knownProxies and allows the trusting of an entire known network (IP range) instead of individual IP addresses so that X-Forwarded-* headers can be used in Kubernetes deployments where the proxy's IP address is subject to change.

My environment is running Kubernetes (talos) with traefik as the ingress controller, so I have been running into issues where redirects are not behaving as expected (incorrect hostname, incorrect protocol) because the X-Forwarded-* headers are not trusted. This results in the user being redirected to a http endpoint when accessing https://bitwarden.host/admin and then redirected back to https by traefik.

As far as I can tell, this change resolves the issue. However, C# is not a language I am deeply familiar with so I am open to feedback.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
