### PR TITLE
Nrt/core part2

### DIFF
--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/AuthorizationHandlers/AccessPolicies/ProjectServiceAccountsAccessPoliciesAuthorizationHandlerTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/AuthorizationHandlers/AccessPolicies/ProjectServiceAccountsAccessPoliciesAuthorizationHandlerTests.cs
@@ -295,7 +295,7 @@ public class ProjectServiceAccountsAccessPoliciesAuthorizationHandlerTests
     {
         sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(resource.OrganizationId)
             .Returns(true);
-        sutProvider.GetDependency<IAccessClientQuery>().GetAccessClientAsync(default, resource.OrganizationId)
+        sutProvider.GetDependency<IAccessClientQuery>().GetAccessClientAsync(null!, resource.OrganizationId)
             .ReturnsForAnyArgs((accessClientType, userId));
     }
 

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/AuthorizationHandlers/AccessPolicies/ServiceAccountGrantedPoliciesAuthorizationHandlerTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/AuthorizationHandlers/AccessPolicies/ServiceAccountGrantedPoliciesAuthorizationHandlerTests.cs
@@ -247,7 +247,7 @@ public class ServiceAccountGrantedPoliciesAuthorizationHandlerTests
     {
         sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(resource.OrganizationId)
             .Returns(true);
-        sutProvider.GetDependency<IAccessClientQuery>().GetAccessClientAsync(default, resource.OrganizationId)
+        sutProvider.GetDependency<IAccessClientQuery>().GetAccessClientAsync(null!, resource.OrganizationId)
             .ReturnsForAnyArgs((accessClientType, userId));
     }
 

--- a/bitwarden_license/test/Commercial.Core.Test/SecretsManager/AuthorizationHandlers/Secrets/BulkSecretAuthorizationHandlerTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/SecretsManager/AuthorizationHandlers/Secrets/BulkSecretAuthorizationHandlerTests.cs
@@ -207,7 +207,7 @@ public class BulkSecretAuthorizationHandlerTests
     {
         sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(organizationId)
             .Returns(true);
-        sutProvider.GetDependency<IAccessClientQuery>().GetAccessClientAsync(default, organizationId)
+        sutProvider.GetDependency<IAccessClientQuery>().GetAccessClientAsync(null!, organizationId)
             .ReturnsForAnyArgs((accessClientType, userId));
     }
 

--- a/src/Core/SecretsManager/AuthorizationRequirements/BulkSecretOperationRequirement.cs
+++ b/src/Core/SecretsManager/AuthorizationRequirements/BulkSecretOperationRequirement.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.SecretsManager.AuthorizationRequirements;
 
+#nullable enable
+
 public class BulkSecretOperationRequirement : OperationAuthorizationRequirement
 {
 }

--- a/src/Core/SecretsManager/AuthorizationRequirements/ProjectOperationRequirement.cs
+++ b/src/Core/SecretsManager/AuthorizationRequirements/ProjectOperationRequirement.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.SecretsManager.AuthorizationRequirements;
 
+#nullable enable
+
 public class ProjectOperationRequirement : OperationAuthorizationRequirement
 {
 }

--- a/src/Core/SecretsManager/AuthorizationRequirements/ProjectPeopleAccessPoliciesOperationRequirement.cs
+++ b/src/Core/SecretsManager/AuthorizationRequirements/ProjectPeopleAccessPoliciesOperationRequirement.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.SecretsManager.AuthorizationRequirements;
 
+#nullable enable
+
 public class ProjectPeopleAccessPoliciesOperationRequirement : OperationAuthorizationRequirement
 {
 }

--- a/src/Core/SecretsManager/AuthorizationRequirements/SecretAccessPoliciesOperationRequirement.cs
+++ b/src/Core/SecretsManager/AuthorizationRequirements/SecretAccessPoliciesOperationRequirement.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.SecretsManager.AuthorizationRequirements;
 
+#nullable enable
+
 public class SecretAccessPoliciesOperationRequirement : OperationAuthorizationRequirement
 {
 }

--- a/src/Core/SecretsManager/AuthorizationRequirements/SecretOperationRequirement.cs
+++ b/src/Core/SecretsManager/AuthorizationRequirements/SecretOperationRequirement.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.SecretsManager.AuthorizationRequirements;
 
+#nullable enable
+
 public class SecretOperationRequirement : OperationAuthorizationRequirement
 {
 }

--- a/src/Core/SecretsManager/AuthorizationRequirements/ServiceAccountOperationRequirement.cs
+++ b/src/Core/SecretsManager/AuthorizationRequirements/ServiceAccountOperationRequirement.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.SecretsManager.AuthorizationRequirements;
 
+#nullable enable
+
 public class ServiceAccountOperationRequirement : OperationAuthorizationRequirement
 {
 }

--- a/src/Core/SecretsManager/AuthorizationRequirements/ServiceAccountPeopleAccessPoliciesOperationRequirement.cs
+++ b/src/Core/SecretsManager/AuthorizationRequirements/ServiceAccountPeopleAccessPoliciesOperationRequirement.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.SecretsManager.AuthorizationRequirements;
 
+#nullable enable
+
 public class ServiceAccountPeopleAccessPoliciesOperationRequirement : OperationAuthorizationRequirement
 {
 }

--- a/src/Core/SecretsManager/Commands/AccessTokens/Interfaces/ICreateAccessTokenCommand.cs
+++ b/src/Core/SecretsManager/Commands/AccessTokens/Interfaces/ICreateAccessTokenCommand.cs
@@ -3,6 +3,8 @@ using Bit.Core.SecretsManager.Models.Data;
 
 namespace Bit.Core.SecretsManager.Commands.AccessTokens.Interfaces;
 
+#nullable enable
+
 public interface ICreateAccessTokenCommand
 {
     Task<ApiKeyClientSecretDetails> CreateAsync(ApiKey apiKey);

--- a/src/Core/SecretsManager/Commands/Porting/Interfaces/IImportCommand.cs
+++ b/src/Core/SecretsManager/Commands/Porting/Interfaces/IImportCommand.cs
@@ -1,5 +1,7 @@
 ﻿namespace Bit.Core.SecretsManager.Commands.Porting.Interfaces;
 
+#nullable enable
+
 public interface IImportCommand
 {
     Task ImportAsync(Guid organizationId, SMImport import);

--- a/src/Core/SecretsManager/Commands/Porting/SMImport.cs
+++ b/src/Core/SecretsManager/Commands/Porting/SMImport.cs
@@ -1,9 +1,11 @@
 ﻿namespace Bit.Core.SecretsManager.Commands.Porting;
 
+#nullable enable
+
 public class SMImport
 {
-    public IEnumerable<InnerProject> Projects { get; set; }
-    public IEnumerable<InnerSecret> Secrets { get; set; }
+    public IEnumerable<InnerProject>? Projects { get; set; }
+    public IEnumerable<InnerSecret>? Secrets { get; set; }
 
     public class InnerProject
     {
@@ -16,7 +18,7 @@ public class SMImport
         }
 
         public Guid Id { get; set; }
-        public string Name { get; set; }
+        public string? Name { get; set; }
     }
 
     public class InnerSecret
@@ -33,9 +35,9 @@ public class SMImport
         }
 
         public Guid Id { get; set; }
-        public string Key { get; set; }
-        public string Value { get; set; }
-        public string Note { get; set; }
-        public IEnumerable<Guid> ProjectIds { get; set; }
+        public string? Key { get; set; }
+        public string? Value { get; set; }
+        public string? Note { get; set; }
+        public IEnumerable<Guid>? ProjectIds { get; set; }
     }
 }

--- a/src/Core/SecretsManager/Commands/Projects/Interfaces/ICreateProjectCommand.cs
+++ b/src/Core/SecretsManager/Commands/Projects/Interfaces/ICreateProjectCommand.cs
@@ -3,6 +3,8 @@ using Bit.Core.SecretsManager.Entities;
 
 namespace Bit.Core.SecretsManager.Commands.Projects.Interfaces;
 
+#nullable enable
+
 public interface ICreateProjectCommand
 {
     Task<Project> CreateAsync(Project project, Guid userId, IdentityClientType identityClientType);

--- a/src/Core/SecretsManager/Commands/Projects/Interfaces/IDeleteProjectCommand.cs
+++ b/src/Core/SecretsManager/Commands/Projects/Interfaces/IDeleteProjectCommand.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.SecretsManager.Commands.Projects.Interfaces;
 
+#nullable enable
+
 public interface IDeleteProjectCommand
 {
     Task DeleteProjects(IEnumerable<Project> projects);

--- a/src/Core/SecretsManager/Commands/Projects/Interfaces/IUpdateProjectCommand.cs
+++ b/src/Core/SecretsManager/Commands/Projects/Interfaces/IUpdateProjectCommand.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.SecretsManager.Commands.Projects.Interfaces;
 
+#nullable enable
+
 public interface IUpdateProjectCommand
 {
     Task<Project> UpdateAsync(Project updatedProject);

--- a/src/Core/SecretsManager/Commands/Requests/Interfaces/IRequestSMAccessCommand.cs
+++ b/src/Core/SecretsManager/Commands/Requests/Interfaces/IRequestSMAccessCommand.cs
@@ -4,6 +4,8 @@ using Bit.Core.Models.Data.Organizations.OrganizationUsers;
 
 namespace Bit.Core.SecretsManager.Commands.Requests.Interfaces;
 
+#nullable enable
+
 public interface IRequestSMAccessCommand
 {
     Task SendRequestAccessToSM(Organization organization, ICollection<OrganizationUserUserDetails> orgUsers, User user, string emailContent);

--- a/src/Core/SecretsManager/Commands/Secrets/Interfaces/IDeleteSecretCommand.cs
+++ b/src/Core/SecretsManager/Commands/Secrets/Interfaces/IDeleteSecretCommand.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.SecretsManager.Commands.Secrets.Interfaces;
 
+#nullable enable
+
 public interface IDeleteSecretCommand
 {
     Task DeleteSecrets(IEnumerable<Secret> secrets);

--- a/src/Core/SecretsManager/Commands/ServiceAccounts/Interfaces/ICreateServiceAccountCommand.cs
+++ b/src/Core/SecretsManager/Commands/ServiceAccounts/Interfaces/ICreateServiceAccountCommand.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.SecretsManager.Commands.ServiceAccounts.Interfaces;
 
+#nullable enable
+
 public interface ICreateServiceAccountCommand
 {
     Task<ServiceAccount> CreateAsync(ServiceAccount serviceAccount, Guid userId);

--- a/src/Core/SecretsManager/Commands/ServiceAccounts/Interfaces/IDeleteServiceAccountsCommand.cs
+++ b/src/Core/SecretsManager/Commands/ServiceAccounts/Interfaces/IDeleteServiceAccountsCommand.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.SecretsManager.Commands.ServiceAccounts.Interfaces;
 
+#nullable enable
+
 public interface IDeleteServiceAccountsCommand
 {
     Task DeleteServiceAccounts(IEnumerable<ServiceAccount> serviceAccounts);

--- a/src/Core/SecretsManager/Commands/ServiceAccounts/Interfaces/IRevokeAccessTokensCommand.cs
+++ b/src/Core/SecretsManager/Commands/ServiceAccounts/Interfaces/IRevokeAccessTokensCommand.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.SecretsManager.Commands.ServiceAccounts.Interfaces;
 
+#nullable enable
+
 public interface IRevokeAccessTokensCommand
 {
     Task RevokeAsync(ServiceAccount serviceAccount, IEnumerable<Guid> ids);

--- a/src/Core/SecretsManager/Commands/ServiceAccounts/Interfaces/IUpdateServiceAccountCommand.cs
+++ b/src/Core/SecretsManager/Commands/ServiceAccounts/Interfaces/IUpdateServiceAccountCommand.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.SecretsManager.Commands.ServiceAccounts.Interfaces;
 
+#nullable enable
+
 public interface IUpdateServiceAccountCommand
 {
     Task<ServiceAccount> UpdateAsync(ServiceAccount serviceAccount);

--- a/src/Core/SecretsManager/Commands/Trash/IEmptyTrashCommand.cs
+++ b/src/Core/SecretsManager/Commands/Trash/IEmptyTrashCommand.cs
@@ -1,5 +1,7 @@
 ﻿namespace Bit.Core.SecretsManager.Commands.Trash.Interfaces;
 
+#nullable enable
+
 public interface IEmptyTrashCommand
 {
     Task EmptyTrash(Guid organizationId, List<Guid> ids);

--- a/src/Core/SecretsManager/Commands/Trash/IRestoreTrashCommand.cs
+++ b/src/Core/SecretsManager/Commands/Trash/IRestoreTrashCommand.cs
@@ -1,5 +1,7 @@
 ﻿namespace Bit.Core.SecretsManager.Commands.Trash.Interfaces;
 
+#nullable enable
+
 public interface IRestoreTrashCommand
 {
     Task RestoreTrash(Guid organizationId, List<Guid> ids);

--- a/src/Core/SecretsManager/Models/Data/ApiKeyClientSecretDetails.cs
+++ b/src/Core/SecretsManager/Models/Data/ApiKeyClientSecretDetails.cs
@@ -2,8 +2,10 @@
 
 namespace Bit.Core.SecretsManager.Models.Data;
 
+#nullable enable
+
 public class ApiKeyClientSecretDetails
 {
-    public ApiKey ApiKey { get; set; }
-    public string ClientSecret { get; set; }
+    public required ApiKey ApiKey { get; set; }
+    public required string ClientSecret { get; set; }
 }

--- a/src/Core/SecretsManager/Models/Data/ApiKeyDetails.cs
+++ b/src/Core/SecretsManager/Models/Data/ApiKeyDetails.cs
@@ -3,10 +3,13 @@ using Bit.Core.SecretsManager.Entities;
 
 namespace Bit.Core.SecretsManager.Models.Data;
 
+#nullable enable
+
 public class ApiKeyDetails : ApiKey
 {
     protected ApiKeyDetails() { }
 
+    [SetsRequiredMembers]
     protected ApiKeyDetails(ApiKey apiKey)
     {
         Id = apiKey.Id;

--- a/src/Core/SecretsManager/Models/Data/PeopleGrantees.cs
+++ b/src/Core/SecretsManager/Models/Data/PeopleGrantees.cs
@@ -1,22 +1,24 @@
 ﻿namespace Bit.Core.SecretsManager.Models.Data;
 
+#nullable enable
+
 public class PeopleGrantees
 {
-    public IEnumerable<UserGrantee> UserGrantees { get; set; }
-    public IEnumerable<GroupGrantee> GroupGrantees { get; set; }
+    public required IEnumerable<UserGrantee> UserGrantees { get; set; }
+    public required IEnumerable<GroupGrantee> GroupGrantees { get; set; }
 }
 
 public class UserGrantee
 {
     public Guid OrganizationUserId { get; set; }
-    public string Name { get; set; }
-    public string Email { get; set; }
+    public string? Name { get; set; }
+    public required string Email { get; set; }
     public bool CurrentUser { get; set; }
 }
 
 public class GroupGrantee
 {
     public Guid GroupId { get; set; }
-    public string Name { get; set; }
+    public required string Name { get; set; }
     public bool CurrentUserInGroup { get; set; }
 }

--- a/src/Core/SecretsManager/Models/Data/ProjectPeopleAccessPolicies.cs
+++ b/src/Core/SecretsManager/Models/Data/ProjectPeopleAccessPolicies.cs
@@ -2,12 +2,14 @@
 
 namespace Bit.Core.SecretsManager.Models.Data;
 
+#nullable enable
+
 public class ProjectPeopleAccessPolicies
 {
     public Guid Id { get; set; }
     public Guid OrganizationId { get; set; }
-    public IEnumerable<UserProjectAccessPolicy> UserAccessPolicies { get; set; }
-    public IEnumerable<GroupProjectAccessPolicy> GroupAccessPolicies { get; set; }
+    public IEnumerable<UserProjectAccessPolicy>? UserAccessPolicies { get; set; }
+    public IEnumerable<GroupProjectAccessPolicy>? GroupAccessPolicies { get; set; }
 
     public IEnumerable<BaseAccessPolicy> ToBaseAccessPolicies()
     {

--- a/src/Core/SecretsManager/Models/Data/ProjectPermissionDetails.cs
+++ b/src/Core/SecretsManager/Models/Data/ProjectPermissionDetails.cs
@@ -2,9 +2,11 @@
 
 namespace Bit.Core.SecretsManager.Models.Data;
 
+#nullable enable
+
 public class ProjectPermissionDetails
 {
-    public Project Project { get; set; }
+    public required Project Project { get; set; }
     public bool Read { get; set; }
     public bool Write { get; set; }
 }

--- a/src/Core/SecretsManager/Models/Data/SecretPermissionDetails.cs
+++ b/src/Core/SecretsManager/Models/Data/SecretPermissionDetails.cs
@@ -2,9 +2,11 @@
 
 namespace Bit.Core.SecretsManager.Models.Data;
 
+#nullable enable
+
 public class SecretPermissionDetails
 {
-    public Secret Secret { get; set; }
+    public required Secret Secret { get; set; }
     public bool Read { get; set; }
     public bool Write { get; set; }
 }

--- a/src/Core/SecretsManager/Models/Data/ServiceAccountPeopleAccessPolicies.cs
+++ b/src/Core/SecretsManager/Models/Data/ServiceAccountPeopleAccessPolicies.cs
@@ -2,12 +2,14 @@
 
 namespace Bit.Core.SecretsManager.Models.Data;
 
+#nullable enable
+
 public class ServiceAccountPeopleAccessPolicies
 {
     public Guid Id { get; set; }
     public Guid OrganizationId { get; set; }
-    public IEnumerable<UserServiceAccountAccessPolicy> UserAccessPolicies { get; set; }
-    public IEnumerable<GroupServiceAccountAccessPolicy> GroupAccessPolicies { get; set; }
+    public IEnumerable<UserServiceAccountAccessPolicy>? UserAccessPolicies { get; set; }
+    public IEnumerable<GroupServiceAccountAccessPolicy>? GroupAccessPolicies { get; set; }
 
     public IEnumerable<BaseAccessPolicy> ToBaseAccessPolicies()
     {

--- a/src/Core/SecretsManager/Models/Data/ServiceAccountSecretsDetails.cs
+++ b/src/Core/SecretsManager/Models/Data/ServiceAccountSecretsDetails.cs
@@ -2,8 +2,10 @@
 
 namespace Bit.Core.SecretsManager.Models.Data;
 
+#nullable enable
+
 public class ServiceAccountSecretsDetails
 {
-    public ServiceAccount ServiceAccount { get; set; }
+    public required ServiceAccount ServiceAccount { get; set; }
     public int AccessToSecrets { get; set; }
 }

--- a/src/Core/SecretsManager/Queries/AccessPolicies/Interfaces/ISameOrganizationQuery.cs
+++ b/src/Core/SecretsManager/Queries/AccessPolicies/Interfaces/ISameOrganizationQuery.cs
@@ -1,5 +1,7 @@
 ﻿namespace Bit.Core.SecretsManager.Queries.AccessPolicies.Interfaces;
 
+#nullable enable
+
 public interface ISameOrganizationQuery
 {
     Task<bool> OrgUsersInTheSameOrgAsync(List<Guid> organizationUserIds, Guid organizationId);

--- a/src/Core/SecretsManager/Queries/Interfaces/IAccessClientQuery.cs
+++ b/src/Core/SecretsManager/Queries/Interfaces/IAccessClientQuery.cs
@@ -3,6 +3,8 @@ using Bit.Core.Enums;
 
 namespace Bit.Core.SecretsManager.Queries.Interfaces;
 
+#nullable enable
+
 public interface IAccessClientQuery
 {
     Task<(AccessClientType AccessClientType, Guid UserId)> GetAccessClientAsync(ClaimsPrincipal claimsPrincipal, Guid organizationId);

--- a/src/Core/SecretsManager/Queries/Projects/Interfaces/IMaxProjectsQuery.cs
+++ b/src/Core/SecretsManager/Queries/Projects/Interfaces/IMaxProjectsQuery.cs
@@ -1,5 +1,7 @@
 ﻿namespace Bit.Core.SecretsManager.Queries.Projects.Interfaces;
 
+#nullable enable
+
 public interface IMaxProjectsQuery
 {
     Task<(short? max, bool? overMax)> GetByOrgIdAsync(Guid organizationId, int projectsToAdd);

--- a/src/Core/SecretsManager/Queries/ServiceAccounts/Interfaces/ICountNewServiceAccountSlotsRequiredQuery.cs
+++ b/src/Core/SecretsManager/Queries/ServiceAccounts/Interfaces/ICountNewServiceAccountSlotsRequiredQuery.cs
@@ -1,5 +1,7 @@
 ﻿namespace Bit.Core.SecretsManager.Queries.ServiceAccounts.Interfaces;
 
+#nullable enable
+
 public interface ICountNewServiceAccountSlotsRequiredQuery
 {
     Task<int> CountNewServiceAccountSlotsRequiredAsync(Guid organizationId, int serviceAccountsToAdd);

--- a/src/Core/SecretsManager/Queries/ServiceAccounts/Interfaces/IServiceAccountSecretsDetailsQuery.cs
+++ b/src/Core/SecretsManager/Queries/ServiceAccounts/Interfaces/IServiceAccountSecretsDetailsQuery.cs
@@ -3,6 +3,8 @@ using Bit.Core.SecretsManager.Models.Data;
 
 namespace Bit.Core.SecretsManager.Queries.ServiceAccounts.Interfaces;
 
+#nullable enable
+
 public interface IServiceAccountSecretsDetailsQuery
 {
     public Task<IEnumerable<ServiceAccountSecretsDetails>> GetManyByOrganizationIdAsync(

--- a/src/Core/SecretsManager/Repositories/IApiKeyRepository.cs
+++ b/src/Core/SecretsManager/Repositories/IApiKeyRepository.cs
@@ -4,9 +4,11 @@ using Bit.Core.SecretsManager.Models.Data;
 
 namespace Bit.Core.SecretsManager.Repositories;
 
+#nullable enable
+
 public interface IApiKeyRepository : IRepository<ApiKey, Guid>
 {
-    Task<ApiKeyDetails> GetDetailsByIdAsync(Guid id);
+    Task<ApiKeyDetails?> GetDetailsByIdAsync(Guid id);
     Task<ICollection<ApiKey>> GetManyByServiceAccountIdAsync(Guid id);
     Task DeleteManyAsync(IEnumerable<ApiKey> objs);
 }

--- a/src/Core/SecretsManager/Repositories/IProjectRepository.cs
+++ b/src/Core/SecretsManager/Repositories/IProjectRepository.cs
@@ -4,12 +4,14 @@ using Bit.Core.SecretsManager.Models.Data;
 
 namespace Bit.Core.SecretsManager.Repositories;
 
+#nullable enable
+
 public interface IProjectRepository
 {
     Task<IEnumerable<ProjectPermissionDetails>> GetManyByOrganizationIdAsync(Guid organizationId, Guid userId, AccessClientType accessType);
     Task<IEnumerable<Project>> GetManyByOrganizationIdWriteAccessAsync(Guid organizationId, Guid userId, AccessClientType accessType);
     Task<IEnumerable<Project>> GetManyWithSecretsByIds(IEnumerable<Guid> ids);
-    Task<Project> GetByIdAsync(Guid id);
+    Task<Project?> GetByIdAsync(Guid id);
     Task<Project> CreateAsync(Project project);
     Task ReplaceAsync(Project project);
     Task DeleteManyByIdAsync(IEnumerable<Guid> ids);

--- a/src/Core/SecretsManager/Repositories/ISecretRepository.cs
+++ b/src/Core/SecretsManager/Repositories/ISecretRepository.cs
@@ -5,6 +5,8 @@ using Bit.Core.SecretsManager.Models.Data.AccessPolicyUpdates;
 
 namespace Bit.Core.SecretsManager.Repositories;
 
+#nullable enable
+
 public interface ISecretRepository
 {
     Task<IEnumerable<SecretPermissionDetails>> GetManyDetailsByOrganizationIdAsync(Guid organizationId, Guid userId, AccessClientType accessType);
@@ -13,9 +15,9 @@ public interface ISecretRepository
     Task<IEnumerable<Secret>> GetManyByOrganizationIdAsync(Guid organizationId, Guid userId, AccessClientType accessType);
     Task<IEnumerable<Secret>> GetManyByOrganizationIdInTrashByIdsAsync(Guid organizationId, IEnumerable<Guid> ids);
     Task<IEnumerable<Secret>> GetManyByIds(IEnumerable<Guid> ids);
-    Task<Secret> GetByIdAsync(Guid id);
-    Task<Secret> CreateAsync(Secret secret, SecretAccessPoliciesUpdates accessPoliciesUpdates = null);
-    Task<Secret> UpdateAsync(Secret secret, SecretAccessPoliciesUpdates accessPoliciesUpdates = null);
+    Task<Secret?> GetByIdAsync(Guid id);
+    Task<Secret> CreateAsync(Secret secret, SecretAccessPoliciesUpdates? accessPoliciesUpdates = null);
+    Task<Secret> UpdateAsync(Secret secret, SecretAccessPoliciesUpdates? accessPoliciesUpdates = null);
     Task SoftDeleteManyByIdAsync(IEnumerable<Guid> ids);
     Task HardDeleteManyByIdAsync(IEnumerable<Guid> ids);
     Task RestoreManyByIdAsync(IEnumerable<Guid> ids);

--- a/src/Core/SecretsManager/Repositories/IServiceAccountRepository.cs
+++ b/src/Core/SecretsManager/Repositories/IServiceAccountRepository.cs
@@ -4,10 +4,12 @@ using Bit.Core.SecretsManager.Models.Data;
 
 namespace Bit.Core.SecretsManager.Repositories;
 
+#nullable enable
+
 public interface IServiceAccountRepository
 {
     Task<IEnumerable<ServiceAccount>> GetManyByOrganizationIdAsync(Guid organizationId, Guid userId, AccessClientType accessType);
-    Task<ServiceAccount> GetByIdAsync(Guid id);
+    Task<ServiceAccount?> GetByIdAsync(Guid id);
     Task<IEnumerable<ServiceAccount>> GetManyByIds(IEnumerable<Guid> ids);
     Task<ServiceAccount> CreateAsync(ServiceAccount serviceAccount);
     Task ReplaceAsync(ServiceAccount serviceAccount);

--- a/src/Core/Utilities/AssemblyHelpers.cs
+++ b/src/Core/Utilities/AssemblyHelpers.cs
@@ -2,18 +2,20 @@
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public static class AssemblyHelpers
 {
-    private static readonly IEnumerable<AssemblyMetadataAttribute> _assemblyMetadataAttributes;
+    private static readonly IEnumerable<AssemblyMetadataAttribute>? _assemblyMetadataAttributes;
     private static readonly AssemblyInformationalVersionAttribute _assemblyInformationalVersionAttributes;
     private const string GIT_HASH_ASSEMBLY_KEY = "GitHash";
-    private static string _version;
-    private static string _gitHash;
+    private static string? _version;
+    private static string? _gitHash;
 
     static AssemblyHelpers()
     {
-        _assemblyMetadataAttributes = Assembly.GetEntryAssembly().GetCustomAttributes<AssemblyMetadataAttribute>();
-        _assemblyInformationalVersionAttributes = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+        _assemblyMetadataAttributes = Assembly.GetEntryAssembly()!.GetCustomAttributes<AssemblyMetadataAttribute>();
+        _assemblyInformationalVersionAttributes = Assembly.GetEntryAssembly()!.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!;
     }
 
     public static string GetVersion()
@@ -26,13 +28,13 @@ public static class AssemblyHelpers
         return _version;
     }
 
-    public static string GetGitHash()
+    public static string? GetGitHash()
     {
         if (string.IsNullOrWhiteSpace(_gitHash))
         {
             try
             {
-                _gitHash = _assemblyMetadataAttributes.Where(i => i.Key == GIT_HASH_ASSEMBLY_KEY).First().Value;
+                _gitHash = _assemblyMetadataAttributes?.Where(i => i.Key == GIT_HASH_ASSEMBLY_KEY).First().Value;
             }
             catch (Exception)
             { }

--- a/src/Core/Utilities/AuthorizationServiceExtensions.cs
+++ b/src/Core/Utilities/AuthorizationServiceExtensions.cs
@@ -4,6 +4,8 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public static class AuthorizationServiceExtensions
 {
     /// <summary>

--- a/src/Core/Utilities/BillingHelpers.cs
+++ b/src/Core/Utilities/BillingHelpers.cs
@@ -4,6 +4,8 @@ using Bit.Core.Services;
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public static class BillingHelpers
 {
     internal static async Task<string> AdjustStorageAsync(IPaymentService paymentService, IStorableSubscriber storableSubscriber,

--- a/src/Core/Utilities/BitPayClient.cs
+++ b/src/Core/Utilities/BitPayClient.cs
@@ -2,9 +2,11 @@
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public class BitPayClient
 {
-    private readonly BitPayLight.BitPay _bpClient;
+    private readonly BitPayLight.BitPay? _bpClient;
 
     public BitPayClient(GlobalSettings globalSettings)
     {
@@ -15,13 +17,21 @@ public class BitPayClient
         }
     }
 
-    public Task<BitPayLight.Models.Invoice.Invoice> GetInvoiceAsync(string id)
+    public async Task<BitPayLight.Models.Invoice.Invoice?> GetInvoiceAsync(string id)
     {
-        return _bpClient.GetInvoice(id);
+        if (_bpClient is null)
+        {
+            return null;
+        }
+        return await _bpClient.GetInvoice(id);
     }
 
-    public Task<BitPayLight.Models.Invoice.Invoice> CreateInvoiceAsync(BitPayLight.Models.Invoice.Invoice invoice)
+    public async Task<BitPayLight.Models.Invoice.Invoice?> CreateInvoiceAsync(BitPayLight.Models.Invoice.Invoice invoice)
     {
-        return _bpClient.CreateInvoice(invoice);
+        if (_bpClient is null)
+        {
+            return null;
+        }
+        return await _bpClient.CreateInvoice(invoice);
     }
 }

--- a/src/Core/Utilities/BulkAuthorizationHandler.cs
+++ b/src/Core/Utilities/BulkAuthorizationHandler.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 /// <summary>
 /// Allows a single authorization handler implementation to handle requirements for
 /// both singular or bulk operations on single or multiple resources.
@@ -25,7 +27,7 @@ public abstract class BulkAuthorizationHandler<TRequirement, TResource> : Author
         await HandleRequirementAsync(context, requirement, bulkResources);
     }
 
-    private static ICollection<TResource> GetBulkResourceFromContext(AuthorizationHandlerContext context)
+    private static ICollection<TResource>? GetBulkResourceFromContext(AuthorizationHandlerContext context)
     {
         return context.Resource switch
         {

--- a/src/Core/Utilities/ClaimsExtensions.cs
+++ b/src/Core/Utilities/ClaimsExtensions.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public static class ClaimsExtensions
 {
     public static bool HasSsoIdP(this IEnumerable<Claim> claims)

--- a/src/Core/Utilities/CurrentContextMiddleware.cs
+++ b/src/Core/Utilities/CurrentContextMiddleware.cs
@@ -4,6 +4,8 @@ using Microsoft.AspNetCore.Http;
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public class CurrentContextMiddleware
 {
     private readonly RequestDelegate _next;

--- a/src/Core/Utilities/CustomIpRateLimitMiddleware.cs
+++ b/src/Core/Utilities/CustomIpRateLimitMiddleware.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.Options;
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public class CustomIpRateLimitMiddleware : IpRateLimitMiddleware
 {
     private readonly IpRateLimitOptions _options;

--- a/src/Core/Utilities/CustomRedisProcessingStrategy.cs
+++ b/src/Core/Utilities/CustomRedisProcessingStrategy.cs
@@ -8,6 +8,8 @@ using StackExchange.Redis;
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 /// <summary>
 /// A modified version of <see cref="AspNetCoreRateLimit.Redis.RedisProcessingStrategy"/> that gracefully
 /// handles a disrupted Redis connection. If the connection is down or the number of failed requests within
@@ -56,7 +58,7 @@ public class CustomRedisProcessingStrategy : RedisProcessingStrategy
         if (_memoryCache.TryGetValue<TimeoutCounter>(_redisTimeoutCacheKey, out var timeoutCounter))
         {
             // We've exceeded threshold, backoff Redis and skip rate limiting for now
-            if (timeoutCounter.Count >= _distributedSettings.MaxRedisTimeoutsThreshold)
+            if (timeoutCounter?.Count >= _distributedSettings.MaxRedisTimeoutsThreshold)
             {
                 _logger.LogDebug(
                     "Redis timeout threshold has been exceeded, backing off and skipping IP rate limiting");

--- a/src/Core/Utilities/DeviceTypes.cs
+++ b/src/Core/Utilities/DeviceTypes.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public static class DeviceTypes
 {
     public static IReadOnlyCollection<DeviceType> MobileTypes { get; } =

--- a/src/Core/Utilities/DistributedCacheExtensions.cs
+++ b/src/Core/Utilities/DistributedCacheExtensions.cs
@@ -3,6 +3,8 @@ using Microsoft.Extensions.Caching.Distributed;
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public static class DistributedCacheExtensions
 {
     public static void Set<T>(this IDistributedCache cache, string key, T value)
@@ -29,7 +31,7 @@ public static class DistributedCacheExtensions
         return cache.SetAsync(key, bytes, options);
     }
 
-    public static bool TryGetValue<T>(this IDistributedCache cache, string key, out T value)
+    public static bool TryGetValue<T>(this IDistributedCache cache, string key, out T? value)
     {
         var val = cache.Get(key);
         value = default;

--- a/src/Core/Utilities/EmailValidation.cs
+++ b/src/Core/Utilities/EmailValidation.cs
@@ -3,6 +3,8 @@ using MimeKit;
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public static class EmailValidation
 {
     public static bool IsValidEmail(this string emailAddress)

--- a/src/Core/Utilities/EncryptedStringLengthAttribute.cs
+++ b/src/Core/Utilities/EncryptedStringLengthAttribute.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public class EncryptedStringLengthAttribute : StringLengthAttribute
 {
     public EncryptedStringLengthAttribute(int maximumLength)

--- a/src/Core/Utilities/EpochDateTimeJsonConverter.cs
+++ b/src/Core/Utilities/EpochDateTimeJsonConverter.cs
@@ -3,6 +3,8 @@ using System.Text.Json.Serialization;
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public class EpochDateTimeJsonConverter : JsonConverter<DateTime>
 {
     public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/src/Core/Utilities/HandlebarsObjectJsonConverter.cs
+++ b/src/Core/Utilities/HandlebarsObjectJsonConverter.cs
@@ -3,10 +3,12 @@ using System.Text.Json.Serialization;
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public class HandlebarsObjectJsonConverter : JsonConverter<object>
 {
     public override bool CanConvert(Type typeToConvert) => true;
-    public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         return JsonSerializer.Deserialize<Dictionary<string, object>>(ref reader, options);
     }

--- a/src/Core/Utilities/HostBuilderExtensions.cs
+++ b/src/Core/Utilities/HostBuilderExtensions.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.Hosting;
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public static class HostBuilderExtensions
 {
     public static IHostBuilder ConfigureCustomAppConfiguration(this IHostBuilder hostBuilder, string[] args)

--- a/src/Core/Utilities/IDbMigrator.cs
+++ b/src/Core/Utilities/IDbMigrator.cs
@@ -1,5 +1,7 @@
 ﻿namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public interface IDbMigrator
 {
     bool MigrateDatabase(bool enableLogging = true,

--- a/src/Core/Utilities/JsonHelpers.cs
+++ b/src/Core/Utilities/JsonHelpers.cs
@@ -6,6 +6,8 @@ using NS = Newtonsoft.Json;
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public static class JsonHelpers
 {
     public static JsonSerializerOptions Default { get; }
@@ -46,7 +48,7 @@ public static class JsonHelpers
         };
     }
 
-    public static T DeserializeOrNew<T>(string json, JsonSerializerOptions options = null)
+    public static T? DeserializeOrNew<T>(string json, JsonSerializerOptions? options = null)
         where T : new()
     {
         if (string.IsNullOrWhiteSpace(json))
@@ -67,13 +69,13 @@ public static class JsonHelpers
     };
 
     [Obsolete(LegacyMessage)]
-    public static string LegacySerialize(object value, NS.JsonSerializerSettings settings = null)
+    public static string LegacySerialize(object value, NS.JsonSerializerSettings? settings = null)
     {
         return NS.JsonConvert.SerializeObject(value, settings);
     }
 
     [Obsolete(LegacyMessage)]
-    public static T LegacyDeserialize<T>(string value, NS.JsonSerializerSettings settings = null)
+    public static T? LegacyDeserialize<T>(string value, NS.JsonSerializerSettings? settings = null)
     {
         return NS.JsonConvert.DeserializeObject<T>(value, settings);
     }
@@ -88,9 +90,9 @@ public class EnumKeyResolver<T> : NS.Serialization.DefaultContractResolver
         var contract = base.CreateDictionaryContract(objectType);
         var keyType = contract.DictionaryKeyType;
 
-        if (keyType.BaseType == typeof(Enum))
+        if (keyType?.BaseType == typeof(Enum))
         {
-            contract.DictionaryKeyResolver = propName => ((T)Enum.Parse(keyType, propName)).ToString();
+            contract.DictionaryKeyResolver = propName => ((T)Enum.Parse(keyType, propName)).ToString()!;
         }
 
         return contract;
@@ -120,8 +122,10 @@ public class MsEpochConverter : JsonConverter<DateTime?>
         {
             writer.WriteNullValue();
         }
-
-        writer.WriteStringValue(CoreHelpers.ToEpocMilliseconds(value.Value).ToString());
+        else
+        {
+            writer.WriteStringValue(CoreHelpers.ToEpocMilliseconds(value.Value).ToString());
+        }
     }
 }
 
@@ -137,7 +141,7 @@ public class PermissiveStringConverter : JsonConverter<string>
     {
         return reader.TokenType switch
         {
-            JsonTokenType.String => reader.GetString(),
+            JsonTokenType.String => reader.GetString()!,
             JsonTokenType.Number => reader.GetDecimal().ToString(_cultureInfo),
             JsonTokenType.True => bool.TrueString,
             JsonTokenType.False => bool.FalseString,
@@ -200,7 +204,7 @@ public class PermissiveStringEnumerableConverter : JsonConverter<IEnumerable<str
 /// </summary>
 public class HtmlEncodingStringConverter : JsonConverter<string>
 {
-    public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         if (reader.TokenType == JsonTokenType.String)
         {

--- a/src/Core/Utilities/KdfSettingsValidator.cs
+++ b/src/Core/Utilities/KdfSettingsValidator.cs
@@ -3,6 +3,8 @@ using Bit.Core.Enums;
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public static class KdfSettingsValidator
 {
     public static IEnumerable<ValidationResult> Validate(KdfType kdfType, int kdfIterations, int? kdfMemory, int? kdfParallelism)

--- a/src/Core/Utilities/LoggerFactoryExtensions.cs
+++ b/src/Core/Utilities/LoggerFactoryExtensions.cs
@@ -11,6 +11,8 @@ using Serilog.Sinks.Syslog;
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public static class LoggerFactoryExtensions
 {
     public static void UseSerilog(
@@ -30,7 +32,7 @@ public static class LoggerFactoryExtensions
     public static ILoggingBuilder AddSerilog(
         this ILoggingBuilder builder,
         WebHostBuilderContext context,
-        Func<LogEvent, IGlobalSettings, bool> filter = null)
+        Func<LogEvent, IGlobalSettings, bool>? filter = null)
     {
         var globalSettings = new GlobalSettings();
         ConfigurationBinder.Bind(context.Configuration.GetSection("GlobalSettings"), globalSettings);
@@ -59,13 +61,13 @@ public static class LoggerFactoryExtensions
             .Enrich.FromLogContext()
             .Filter.ByIncludingOnly(inclusionPredicate);
 
-        if (CoreHelpers.SettingHasValue(globalSettings?.Sentry.Dsn))
+        if (CoreHelpers.SettingHasValue(globalSettings.Sentry.Dsn))
         {
             config.WriteTo.Sentry(globalSettings.Sentry.Dsn)
                 .Enrich.FromLogContext()
                 .Enrich.WithProperty("Project", globalSettings.ProjectName);
         }
-        else if (CoreHelpers.SettingHasValue(globalSettings?.Syslog.Destination))
+        else if (CoreHelpers.SettingHasValue(globalSettings.Syslog.Destination))
         {
             // appending sitename to project name to allow easier identification in syslog.
             var appName = $"{globalSettings.SiteName}-{globalSettings.ProjectName}";

--- a/src/Core/Utilities/LoggingExceptionHandlerFilterAttribute.cs
+++ b/src/Core/Utilities/LoggingExceptionHandlerFilterAttribute.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public class LoggingExceptionHandlerFilterAttribute : ExceptionFilterAttribute
 {
     public override void OnException(ExceptionContext context)

--- a/src/Core/Utilities/ModelStateExtensions.cs
+++ b/src/Core/Utilities/ModelStateExtensions.cs
@@ -2,6 +2,8 @@
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public static class ModelStateExtensions
 {
     public static string GetErrorMessage(this ModelStateDictionary modelState)

--- a/src/Core/Utilities/RequireFeatureAttribute.cs
+++ b/src/Core/Utilities/RequireFeatureAttribute.cs
@@ -5,6 +5,8 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 /// <summary>
 /// Specifies that the class or method that this attribute is applied to requires the specified boolean feature flag
 /// to be enabled. If the feature flag is not enabled, a <see cref="FeatureUnavailableException"/> is thrown

--- a/src/Core/Utilities/SecurityHeadersMiddleware.cs
+++ b/src/Core/Utilities/SecurityHeadersMiddleware.cs
@@ -3,6 +3,8 @@ using Microsoft.Extensions.Primitives;
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public sealed class SecurityHeadersMiddleware
 {
     private readonly RequestDelegate _next;

--- a/src/Core/Utilities/SelfHostedAttribute.cs
+++ b/src/Core/Utilities/SelfHostedAttribute.cs
@@ -5,6 +5,8 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public class SelfHostedAttribute : ActionFilterAttribute
 {
     public bool SelfHostedOnly { get; set; }

--- a/src/Core/Utilities/SpanExtensions.cs
+++ b/src/Core/Utilities/SpanExtensions.cs
@@ -1,5 +1,7 @@
 ﻿namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public static class SpanExtensions
 {
     public static bool TrySplitBy(this ReadOnlySpan<char> input,

--- a/src/Core/Utilities/StrictEmailAddressAttribute.cs
+++ b/src/Core/Utilities/StrictEmailAddressAttribute.cs
@@ -2,13 +2,15 @@
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public class StrictEmailAddressAttribute : ValidationAttribute
 {
     public StrictEmailAddressAttribute()
         : base("The {0} field is not a supported e-mail address format.")
     { }
 
-    public override bool IsValid(object value)
+    public override bool IsValid(object? value)
     {
         var emailAddress = value?.ToString() ?? string.Empty;
 

--- a/src/Core/Utilities/StrictEmailAddressListAttribute.cs
+++ b/src/Core/Utilities/StrictEmailAddressListAttribute.cs
@@ -2,26 +2,27 @@
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 public class StrictEmailAddressListAttribute : ValidationAttribute
 {
-    protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
     {
         var strictEmailAttribute = new StrictEmailAddressAttribute();
-        var emails = value as IList<string>;
 
-        if (!emails?.Any() ?? true)
+        if (value is not IList<string> emails || emails.Count == 0)
         {
             return new ValidationResult("An email is required.");
         }
 
-        if (emails.Count() > 20)
+        if (emails.Count > 20)
         {
             return new ValidationResult("You can only submit up to 20 emails at a time.");
         }
 
-        for (var i = 0; i < emails.Count(); i++)
+        for (var i = 0; i < emails.Count; i++)
         {
-            var email = emails.ElementAt(i);
+            var email = emails[i];
             if (!strictEmailAttribute.IsValid(email))
             {
                 return new ValidationResult($"Email #{i + 1} is not valid.");

--- a/src/Core/Utilities/SystemTextJsonCosmosSerializer.cs
+++ b/src/Core/Utilities/SystemTextJsonCosmosSerializer.cs
@@ -4,6 +4,8 @@ using Microsoft.Azure.Cosmos;
 
 namespace Bit.Core.Utilities;
 
+#nullable enable
+
 // ref: https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/CosmosSystemTextJsonSerializer.cs
 public class SystemTextJsonCosmosSerializer : CosmosSerializer
 {
@@ -14,7 +16,7 @@ public class SystemTextJsonCosmosSerializer : CosmosSerializer
         _systemTextJsonSerializer = new JsonObjectSerializer(jsonSerializerOptions);
     }
 
-    public override T FromStream<T>(Stream stream)
+    public override T? FromStream<T>(Stream stream) where T : default
     {
         using (stream)
         {
@@ -26,7 +28,7 @@ public class SystemTextJsonCosmosSerializer : CosmosSerializer
             {
                 return (T)(object)stream;
             }
-            return (T)_systemTextJsonSerializer.Deserialize(stream, typeof(T), default);
+            return (T?)_systemTextJsonSerializer.Deserialize(stream, typeof(T), default);
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

Related to [this ADR](https://contributing.bitwarden.com/architecture/adr/csharp-nullable-reference-types/), but until that's accepted I'm working in the other direction and enabling per-file instead (as discussed [here](https://github.com/orgs/bitwarden/discussions/15033)).

## 📔 Objective

![nullabubblelubble](https://github.com/user-attachments/assets/73d64eab-6369-45eb-977a-1fca4784344c)

This PR enables NRT (nullable reference types) for almost all remaining files in Core/Utilities and Core/SecretsManager (all the files that didn't result in changes matching anyone in [CODEOWNERS](https://github.com/bitwarden/server/blob/6411cc63ca0af7a21386214eb9a8e31e8e219f44/.github/CODEOWNERS))

I've split the changes into commits based on the folders. The only changes that required more than just annotations were a few changes in Core/Utilities, so I broke those out into another commit and I'll dump some notes/explanations as another comment.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
