### PR TITLE
BRE-888 - Remove logic for generating and uploading checksum artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -350,14 +350,6 @@ jobs:
           cd docker-stub/US; zip -r ../../docker-stub-US.zip *; cd ../..
           cd docker-stub/EU; zip -r ../../docker-stub-EU.zip *; cd ../..
 
-      - name: Make Docker stub checksums
-        if: |
-          github.event_name != 'pull_request'
-          && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix-rc')
-        run: |
-          sha256sum docker-stub-US.zip > docker-stub-US-sha256.txt
-          sha256sum docker-stub-EU.zip > docker-stub-EU-sha256.txt
-
       - name: Upload Docker stub US artifact
         if: |
           github.event_name != 'pull_request'
@@ -376,26 +368,6 @@ jobs:
         with:
           name: docker-stub-EU.zip
           path: docker-stub-EU.zip
-          if-no-files-found: error
-
-      - name: Upload Docker stub US checksum artifact
-        if: |
-          github.event_name != 'pull_request'
-          && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix-rc')
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
-        with:
-          name: docker-stub-US-sha256.txt
-          path: docker-stub-US-sha256.txt
-          if-no-files-found: error
-
-      - name: Upload Docker stub EU checksum artifact
-        if: |
-          github.event_name != 'pull_request'
-          && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/hotfix-rc')
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
-        with:
-          name: docker-stub-EU-sha256.txt
-          path: docker-stub-EU-sha256.txt
           if-no-files-found: error
 
       - name: Build Public API Swagger

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,9 +65,7 @@ jobs:
           workflow_conclusion: success
           branch: ${{ needs.setup.outputs.branch-name }}
           artifacts: "docker-stub-US.zip,
-            docker-stub-US-sha256.txt,
             docker-stub-EU.zip,
-            docker-stub-EU-sha256.txt,
             swagger.json"
 
       - name: Dry Run - Download latest release Docker stubs
@@ -78,9 +76,7 @@ jobs:
           workflow_conclusion: success
           branch: main
           artifacts: "docker-stub-US.zip,
-            docker-stub-US-sha256.txt,
             docker-stub-EU.zip,
-            docker-stub-EU-sha256.txt,
             swagger.json"
 
       - name: Create release
@@ -88,9 +84,7 @@ jobs:
         uses: ncipollo/release-action@cdcc88a9acf3ca41c16c37bb7d21b9ad48560d87 # v1.15.0
         with:
           artifacts: "docker-stub-US.zip,
-            docker-stub-US-sha256.txt,
             docker-stub-EU.zip,
-            docker-stub-EU-sha256.txt,
             swagger.json"
           commit: ${{ github.sha }}
           tag: "v${{ needs.setup.outputs.release_version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ on:
 env:
   _AZ_REGISTRY: "bitwardenprod.azurecr.io"
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     name: Setup


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
- [BRE-888](https://bitwarden.atlassian.net/browse/BRE-888?atlOrigin=eyJpIjoiM2Y4OWNlOThjMTc5NDFmZjkzZmFiNWNmMDMxYjU0MDIiLCJwIjoiaiJ9)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR removes the logic for generating and uploading checksum artifacts to the GitHub release. GitHub has started generating checksums automatically for each asset uploaded to a release.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-888]: https://bitwarden.atlassian.net/browse/BRE-888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ