### PR TITLE
Added SendGridApiHost to Globals

### DIFF
--- a/src/Core/Services/Implementations/SendGridMailDeliveryService.cs
+++ b/src/Core/Services/Implementations/SendGridMailDeliveryService.cs
@@ -21,7 +21,7 @@ public class SendGridMailDeliveryService : IMailDeliveryService, IDisposable
         GlobalSettings globalSettings,
         IWebHostEnvironment hostingEnvironment,
         ILogger<SendGridMailDeliveryService> logger)
-        : this(new SendGridClient(globalSettings.Mail.SendGridApiKey),
+        : this(new SendGridClient(globalSettings.Mail.SendGridApiKey, globalSettings.Mail.SendGridApiHost),
              globalSettings, hostingEnvironment, logger)
     {
     }

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -431,6 +431,7 @@ public class GlobalSettings : IGlobalSettings
         public SmtpSettings Smtp { get; set; } = new SmtpSettings();
         public string SendGridApiKey { get; set; }
         public int? SendGridPercentage { get; set; }
+        public string SendGridApiHost { get; set; } = "https://api.sendgrid.com";
 
         public class SmtpSettings
         {

--- a/test/Core.Test/Services/SendGridMailDeliveryServiceTests.cs
+++ b/test/Core.Test/Services/SendGridMailDeliveryServiceTests.cs
@@ -25,7 +25,8 @@ public class SendGridMailDeliveryServiceTests : IDisposable
         {
             Mail =
             {
-                SendGridApiKey = "SendGridApiKey"
+                SendGridApiKey = "SendGridApiKey",
+                SendGridApiHost = "https://api.sendgrid.com"
             }
         };
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/SRE-2452
https://bitwarden.atlassian.net/browse/SRE-2451
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
To break out the API Host for SendGrid into it's own *globalSettings__mail__sendGridApiHost* environment variable with a default for the Global/US API endpoint.  This will allow us to swap to the EU endpoint or other endpoints for testing.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
