### PR TITLE
[PM-18612] Consolidate all email OTP to use 6 digits

### DIFF
--- a/src/Core/Auth/Identity/TokenProviders/EmailTokenProvider.cs
+++ b/src/Core/Auth/Identity/TokenProviders/EmailTokenProvider.cs
@@ -25,7 +25,7 @@ public class EmailTokenProvider : IUserTwoFactorTokenProvider<User>
         };
     }
 
-    public int TokenLength { get; protected set; } = 8;
+    public int TokenLength { get; protected set; } = 6;
     public bool TokenAlpha { get; protected set; } = false;
     public bool TokenNumeric { get; protected set; } = true;
 

--- a/src/Core/Auth/Identity/TokenProviders/EmailTwoFactorTokenProvider.cs
+++ b/src/Core/Auth/Identity/TokenProviders/EmailTwoFactorTokenProvider.cs
@@ -7,17 +7,18 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Bit.Core.Auth.Identity.TokenProviders;
 
+/// <summary>
+/// Generates tokens for email two-factor authentication.
+/// It inherits from the EmailTokenProvider class, which manages the persistence and validation of tokens, 
+/// and adds additional validation to ensure that 2FA is enabled for the user.
+/// </summary>
 public class EmailTwoFactorTokenProvider : EmailTokenProvider
 {
     public EmailTwoFactorTokenProvider(
         [FromKeyedServices("persistent")]
         IDistributedCache distributedCache) :
         base(distributedCache)
-    {
-        TokenAlpha = false;
-        TokenNumeric = true;
-        TokenLength = 6;
-    }
+    { }
 
     public override Task<bool> CanGenerateTwoFactorTokenAsync(UserManager<User> manager, User user)
     {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18612

## 📔 Objective

Currently the base `EmailTokenProvider` uses 8 digits for the OTP, and the `EmalTwoFactorTokenProvider` overrides this with 6.  

As we have more users using the `EmailTokenProvider` for New Device Verification, we have been asked to change this to 6 digits as well.  This allows us to consolidate the implementation and not override any of the token parameters on the child class.

The `EmailTokenProvider` is used:
- On New Device Verification
- When an OTP is required for User Verification (user does not have a master password)

To improve clarity on why we are inheriting in the `EmailTwoFactorTokenProvider`, I added a comment to explain what it does relative to its base class.  I did not elect to refactor this inheritance at this point.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
