### PR TITLE
[PM-17562] Add support for Auth on Webhook integration requests

### DIFF
--- a/src/Core/AdminConsole/Models/Data/EventIntegrations/SlackIntegration.cs
+++ b/src/Core/AdminConsole/Models/Data/EventIntegrations/SlackIntegration.cs
@@ -2,4 +2,4 @@
 
 namespace Bit.Core.AdminConsole.Models.Data.EventIntegrations;
 
-public record SlackIntegration(string token);
+public record SlackIntegration(string Token);

--- a/src/Core/AdminConsole/Models/Data/EventIntegrations/SlackIntegrationConfiguration.cs
+++ b/src/Core/AdminConsole/Models/Data/EventIntegrations/SlackIntegrationConfiguration.cs
@@ -2,4 +2,4 @@
 
 namespace Bit.Core.AdminConsole.Models.Data.EventIntegrations;
 
-public record SlackIntegrationConfiguration(string channelId);
+public record SlackIntegrationConfiguration(string ChannelId);

--- a/src/Core/AdminConsole/Models/Data/EventIntegrations/SlackIntegrationConfigurationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/EventIntegrations/SlackIntegrationConfigurationDetails.cs
@@ -2,4 +2,4 @@
 
 namespace Bit.Core.AdminConsole.Models.Data.EventIntegrations;
 
-public record SlackIntegrationConfigurationDetails(string channelId, string token);
+public record SlackIntegrationConfigurationDetails(string ChannelId, string Token);

--- a/src/Core/AdminConsole/Models/Data/EventIntegrations/WebhookIntegrationConfiguration.cs
+++ b/src/Core/AdminConsole/Models/Data/EventIntegrations/WebhookIntegrationConfiguration.cs
@@ -2,4 +2,4 @@
 
 namespace Bit.Core.AdminConsole.Models.Data.EventIntegrations;
 
-public record WebhookIntegrationConfiguration(string url);
+public record WebhookIntegrationConfiguration(string? Scheme, string? Token, string Url);

--- a/src/Core/AdminConsole/Models/Data/EventIntegrations/WebhookIntegrationConfigurationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/EventIntegrations/WebhookIntegrationConfigurationDetails.cs
@@ -2,4 +2,4 @@
 
 namespace Bit.Core.AdminConsole.Models.Data.EventIntegrations;
 
-public record WebhookIntegrationConfigurationDetails(string url);
+public record WebhookIntegrationConfigurationDetails(string? Scheme, string? Token, string Url);

--- a/src/Core/AdminConsole/Services/Implementations/EventIntegrations/SlackIntegrationHandler.cs
+++ b/src/Core/AdminConsole/Services/Implementations/EventIntegrations/SlackIntegrationHandler.cs
@@ -11,9 +11,9 @@ public class SlackIntegrationHandler(
     public override async Task<IntegrationHandlerResult> HandleAsync(IntegrationMessage<SlackIntegrationConfigurationDetails> message)
     {
         await slackService.SendSlackMessageByChannelIdAsync(
-            message.Configuration.token,
+            message.Configuration.Token,
             message.RenderedTemplate,
-            message.Configuration.channelId
+            message.Configuration.ChannelId
         );
 
         return new IntegrationHandlerResult(success: true, message: message);

--- a/src/Core/AdminConsole/Services/Implementations/EventIntegrations/WebhookIntegrationHandler.cs
+++ b/src/Core/AdminConsole/Services/Implementations/EventIntegrations/WebhookIntegrationHandler.cs
@@ -2,6 +2,7 @@
 
 using System.Globalization;
 using System.Net;
+using System.Net.Http.Headers;
 using System.Text;
 using Bit.Core.AdminConsole.Models.Data.EventIntegrations;
 
@@ -18,8 +19,16 @@ public class WebhookIntegrationHandler(IHttpClientFactory httpClientFactory)
 
     public override async Task<IntegrationHandlerResult> HandleAsync(IntegrationMessage<WebhookIntegrationConfigurationDetails> message)
     {
-        var content = new StringContent(message.RenderedTemplate, Encoding.UTF8, "application/json");
-        var response = await _httpClient.PostAsync(message.Configuration.url, content);
+        var request = new HttpRequestMessage(HttpMethod.Post, message.Configuration.Url);
+        request.Content = new StringContent(message.RenderedTemplate, Encoding.UTF8, "application/json");
+        if (!string.IsNullOrEmpty(message.Configuration.Scheme))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue(
+                scheme: message.Configuration.Scheme,
+                parameter: message.Configuration.Token
+            );
+        }
+        var response = await _httpClient.SendAsync(request);
         var result = new IntegrationHandlerResult(success: response.IsSuccessStatusCode, message);
 
         switch (response.StatusCode)

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationIntegrationsConfigurationControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationIntegrationsConfigurationControllerTests.cs
@@ -151,7 +151,7 @@ public class OrganizationIntegrationsConfigurationControllerTests
     {
         organizationIntegration.OrganizationId = organizationId;
         organizationIntegration.Type = IntegrationType.Slack;
-        var slackConfig = new SlackIntegrationConfiguration(channelId: "C123456");
+        var slackConfig = new SlackIntegrationConfiguration(ChannelId: "C123456");
         model.Configuration = JsonSerializer.Serialize(slackConfig);
         model.Template = "Template String";
 
@@ -188,7 +188,7 @@ public class OrganizationIntegrationsConfigurationControllerTests
     {
         organizationIntegration.OrganizationId = organizationId;
         organizationIntegration.Type = IntegrationType.Webhook;
-        var webhookConfig = new WebhookIntegrationConfiguration(url: "https://localhost");
+        var webhookConfig = new WebhookIntegrationConfiguration("Bearer", "AUTH-TOKEN", Url: "https://localhost");
         model.Configuration = JsonSerializer.Serialize(webhookConfig);
         model.Template = "Template String";
 
@@ -350,7 +350,7 @@ public class OrganizationIntegrationsConfigurationControllerTests
     {
         organizationIntegration.OrganizationId = organizationId;
         organizationIntegration.Type = IntegrationType.Webhook;
-        var webhookConfig = new WebhookIntegrationConfiguration(url: "https://localhost");
+        var webhookConfig = new WebhookIntegrationConfiguration("Bearer", "AUTH-TOKEN", Url: "https://localhost");
         model.Configuration = JsonSerializer.Serialize(webhookConfig);
         model.Template = null;
 
@@ -393,7 +393,7 @@ public class OrganizationIntegrationsConfigurationControllerTests
         organizationIntegration.OrganizationId = organizationId;
         organizationIntegrationConfiguration.OrganizationIntegrationId = organizationIntegration.Id;
         organizationIntegration.Type = IntegrationType.Slack;
-        var slackConfig = new SlackIntegrationConfiguration(channelId: "C123456");
+        var slackConfig = new SlackIntegrationConfiguration(ChannelId: "C123456");
         model.Configuration = JsonSerializer.Serialize(slackConfig);
         model.Template = "Template String";
 
@@ -436,7 +436,7 @@ public class OrganizationIntegrationsConfigurationControllerTests
         organizationIntegration.OrganizationId = organizationId;
         organizationIntegrationConfiguration.OrganizationIntegrationId = organizationIntegration.Id;
         organizationIntegration.Type = IntegrationType.Webhook;
-        var webhookConfig = new WebhookIntegrationConfiguration(url: "https://localhost");
+        var webhookConfig = new WebhookIntegrationConfiguration("Bearer", "AUTH-TOKEN", Url: "https://localhost");
         model.Configuration = JsonSerializer.Serialize(webhookConfig);
         model.Template = "Template String";
 
@@ -476,7 +476,7 @@ public class OrganizationIntegrationsConfigurationControllerTests
     {
         organizationIntegration.OrganizationId = organizationId;
         organizationIntegration.Type = IntegrationType.Webhook;
-        var webhookConfig = new WebhookIntegrationConfiguration(url: "https://localhost");
+        var webhookConfig = new WebhookIntegrationConfiguration("Bearer", "AUTH-TOKEN", Url: "https://localhost");
         model.Configuration = JsonSerializer.Serialize(webhookConfig);
         model.Template = "Template String";
 
@@ -582,7 +582,7 @@ public class OrganizationIntegrationsConfigurationControllerTests
         organizationIntegration.OrganizationId = organizationId;
         organizationIntegrationConfiguration.OrganizationIntegrationId = organizationIntegration.Id;
         organizationIntegration.Type = IntegrationType.Slack;
-        var slackConfig = new SlackIntegrationConfiguration(channelId: "C123456");
+        var slackConfig = new SlackIntegrationConfiguration(ChannelId: "C123456");
         model.Configuration = JsonSerializer.Serialize(slackConfig);
         model.Template = null;
 

--- a/test/Api.Test/AdminConsole/Models/Request/Organizations/OrganizationIntegrationConfigurationRequestModelTests.cs
+++ b/test/Api.Test/AdminConsole/Models/Request/Organizations/OrganizationIntegrationConfigurationRequestModelTests.cs
@@ -43,7 +43,7 @@ public class OrganizationIntegrationConfigurationRequestModelTests
     [InlineData("    ")]
     public void IsValidForType_EmptyTemplate_ReturnsFalse(string? template)
     {
-        var config = JsonSerializer.Serialize(new WebhookIntegrationConfiguration("https://example.com"));
+        var config = JsonSerializer.Serialize(new WebhookIntegrationConfiguration("Bearer", "AUTH-TOKEN", "https://example.com"));
         var model = new OrganizationIntegrationConfigurationRequestModel
         {
             Configuration = config,
@@ -92,9 +92,22 @@ public class OrganizationIntegrationConfigurationRequestModelTests
     }
 
     [Fact]
+    public void IsValidForType_ValidNoAuthWebhookConfiguration_ReturnsTrue()
+    {
+        var config = JsonSerializer.Serialize(new WebhookIntegrationConfiguration(null, null, "https://example.com"));
+        var model = new OrganizationIntegrationConfigurationRequestModel
+        {
+            Configuration = config,
+            Template = "template"
+        };
+
+        Assert.True(model.IsValidForType(IntegrationType.Webhook));
+    }
+
+    [Fact]
     public void IsValidForType_ValidWebhookConfiguration_ReturnsTrue()
     {
-        var config = JsonSerializer.Serialize(new WebhookIntegrationConfiguration("https://example.com"));
+        var config = JsonSerializer.Serialize(new WebhookIntegrationConfiguration("Bearer", "AUTH-TOKEN", "https://example.com"));
         var model = new OrganizationIntegrationConfigurationRequestModel
         {
             Configuration = config,

--- a/test/Core.Test/AdminConsole/Models/Data/EventIntegrations/IntegrationMessageTests.cs
+++ b/test/Core.Test/AdminConsole/Models/Data/EventIntegrations/IntegrationMessageTests.cs
@@ -14,7 +14,7 @@ public class IntegrationMessageTests
     {
         var message = new IntegrationMessage<WebhookIntegrationConfigurationDetails>
         {
-            Configuration = new WebhookIntegrationConfigurationDetails("https://localhost"),
+            Configuration = new WebhookIntegrationConfigurationDetails("Bearer", "AUTH-TOKEN", "https://localhost"),
             MessageId = _messageId,
             RetryCount = 2,
             RenderedTemplate = string.Empty,
@@ -34,7 +34,7 @@ public class IntegrationMessageTests
     {
         var message = new IntegrationMessage<WebhookIntegrationConfigurationDetails>
         {
-            Configuration = new WebhookIntegrationConfigurationDetails("https://localhost"),
+            Configuration = new WebhookIntegrationConfigurationDetails("Bearer", "AUTH-TOKEN", "https://localhost"),
             MessageId = _messageId,
             RenderedTemplate = "This is the message",
             IntegrationType = IntegrationType.Webhook,

--- a/test/Core.Test/AdminConsole/Services/EventIntegrationHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/Services/EventIntegrationHandlerTests.cs
@@ -46,7 +46,7 @@ public class EventIntegrationHandlerTests
         {
             IntegrationType = IntegrationType.Webhook,
             MessageId = "TestMessageId",
-            Configuration = new WebhookIntegrationConfigurationDetails(_url),
+            Configuration = new WebhookIntegrationConfigurationDetails(null, null, _url),
             RenderedTemplate = template,
             RetryCount = 0,
             DelayUntilDate = null
@@ -62,7 +62,7 @@ public class EventIntegrationHandlerTests
     {
         var config = Substitute.For<OrganizationIntegrationConfigurationDetails>();
         config.Configuration = null;
-        config.IntegrationConfiguration = JsonSerializer.Serialize(new { url = _url });
+        config.IntegrationConfiguration = JsonSerializer.Serialize(new { Url = _url });
         config.Template = template;
 
         return [config];
@@ -72,11 +72,11 @@ public class EventIntegrationHandlerTests
     {
         var config = Substitute.For<OrganizationIntegrationConfigurationDetails>();
         config.Configuration = null;
-        config.IntegrationConfiguration = JsonSerializer.Serialize(new { url = _url });
+        config.IntegrationConfiguration = JsonSerializer.Serialize(new { Url = _url });
         config.Template = template;
         var config2 = Substitute.For<OrganizationIntegrationConfigurationDetails>();
         config2.Configuration = null;
-        config2.IntegrationConfiguration = JsonSerializer.Serialize(new { url = _url2 });
+        config2.IntegrationConfiguration = JsonSerializer.Serialize(new { Url = _url2 });
         config2.Template = template;
 
         return [config, config2];
@@ -212,7 +212,7 @@ public class EventIntegrationHandlerTests
             await _eventIntegrationPublisher.Received(1).PublishAsync(Arg.Is(
                 AssertHelper.AssertPropertyEqual(expectedMessage, new[] { "MessageId" })));
 
-            expectedMessage.Configuration = new WebhookIntegrationConfigurationDetails(_url2);
+            expectedMessage.Configuration = new WebhookIntegrationConfigurationDetails(null, null, _url2);
             await _eventIntegrationPublisher.Received(1).PublishAsync(Arg.Is(
                 AssertHelper.AssertPropertyEqual(expectedMessage, new[] { "MessageId" })));
         }

--- a/test/Core.Test/AdminConsole/Services/IntegrationHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/Services/IntegrationHandlerTests.cs
@@ -14,7 +14,7 @@ public class IntegrationHandlerTests
         var sut = new TestIntegrationHandler();
         var expected = new IntegrationMessage<WebhookIntegrationConfigurationDetails>()
         {
-            Configuration = new WebhookIntegrationConfigurationDetails("https://localhost"),
+            Configuration = new WebhookIntegrationConfigurationDetails("Bearer", "AUTH-TOKEN", "https://localhost"),
             MessageId = "TestMessageId",
             IntegrationType = IntegrationType.Webhook,
             RenderedTemplate = "Template",


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17562](https://bitwarden.atlassian.net/browse/PM-17562)

## 📔 Objective

This PR adds optional support for auth (scheme and token) to our current webhook integration. The WebhookIntegrationHandler checks the configuration for a `Scheme` and, if present, will use the `Scheme` and `Token` to build an authentication header as part of the request. For webhooks without auth requirements, everything stays the same (both scheme and token are nullable and no Auth header is added if `Scheme` is `null`).

### Architectural Question

I've built this one to follow along our current path of configuring the `Url` at the `WebhookIntegrationConfiguration` level. This allows for the most flexibility (and multiple webhooks), but it also requires a lot of duplication and now requires token and scheme to be duplicated as well. We could alternatively move `Scheme`, `Token`, and `Url` to the `WebhookIntegration` level, which would require far less duplication on each configuration, but would also mean that Organizations could only really have one webhook (unless we relax the restriction on the `OrganizationIntegration` table that only allows for one instance of an integration type).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
