### PR TITLE
[PM-22503] Fix manage cipher permission

### DIFF
--- a/src/Infrastructure.Dapper/Vault/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.Dapper/Vault/Repositories/CipherRepository.cs
@@ -99,9 +99,9 @@ public class CipherRepository : Repository<Cipher, Guid>, ICipherRepository
             return results
                 .GroupBy(c => c.Id)
                 .Select(g =>
-                    g.OrderByDescending(og => og.Edit)
-                        .ThenByDescending(og => og.ViewPassword)
-                        .ThenByDescending(og => og.Manage).First())
+                    g.OrderByDescending(og => og.Manage)
+                        .ThenByDescending(og => og.Edit)
+                        .ThenByDescending(og => og.ViewPassword).First())
                 .ToList();
         }
     }

--- a/src/Infrastructure.Dapper/Vault/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.Dapper/Vault/Repositories/CipherRepository.cs
@@ -98,7 +98,10 @@ public class CipherRepository : Repository<Cipher, Guid>, ICipherRepository
 
             return results
                 .GroupBy(c => c.Id)
-                .Select(g => g.OrderByDescending(og => og.Edit).ThenByDescending(og => og.ViewPassword).First())
+                .Select(g =>
+                    g.OrderByDescending(og => og.Edit)
+                        .ThenByDescending(og => og.ViewPassword)
+                        .ThenByDescending(og => og.Manage).First())
                 .ToList();
         }
     }

--- a/src/Infrastructure.EntityFramework/Vault/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.EntityFramework/Vault/Repositories/CipherRepository.cs
@@ -489,9 +489,9 @@ public class CipherRepository : Repository<Core.Vault.Entities.Cipher, Cipher, G
             var ciphers = await cipherDetailsView.ToListAsync();
 
             return ciphers.GroupBy(c => c.Id)
-                .Select(g => g.OrderByDescending(c => c.Edit)
+                .Select(g => g.OrderByDescending(c => c.Manage)
+                    .ThenByDescending(c => c.Edit)
                     .ThenByDescending(c => c.ViewPassword)
-                    .ThenByDescending(c => c.Manage)
                     .First())
                 .ToList();
         }


### PR DESCRIPTION
## 🎟️ Tracking
[PM-22503](https://bitwarden.atlassian.net/browse/PM-22503)

## 📔 Objective
This fixes what manage gets set to on a cipher when a cipher is shared between two collections a user has access to.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22503]: https://bitwarden.atlassian.net/browse/PM-22503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ