### PR TITLE
[PM-22812] [PM-22985] Attachments get corrupted when downgrading from cipherkeys

### DIFF
--- a/src/Sql/dbo/Vault/Stored Procedures/Cipher/Cipher_Update.sql
+++ b/src/Sql/dbo/Vault/Stored Procedures/Cipher/Cipher_Update.sql
@@ -6,7 +6,7 @@
     @Data NVARCHAR(MAX),
     @Favorites NVARCHAR(MAX),
     @Folders NVARCHAR(MAX),
-    @Attachments NVARCHAR(MAX), -- not used
+    @Attachments NVARCHAR(MAX),
     @CreationDate DATETIME2(7),
     @RevisionDate DATETIME2(7),
     @DeletedDate DATETIME2(7),
@@ -25,6 +25,7 @@ BEGIN
         [Data] = @Data,
         [Favorites] = @Favorites,
         [Folders] = @Folders,
+        [Attachments] = @Attachments,
         [CreationDate] = @CreationDate,
         [RevisionDate] = @RevisionDate,
         [DeletedDate] = @DeletedDate,

--- a/util/Migrator/DbScripts/2025-06-24_00_AttachmentCipherUpdateDetails.sql
+++ b/util/Migrator/DbScripts/2025-06-24_00_AttachmentCipherUpdateDetails.sql
@@ -1,4 +1,4 @@
-﻿CREATE PROCEDURE [dbo].[CipherDetails_Update]
+CREATE OR ALTER PROCEDURE [dbo].[CipherDetails_Update]
     @Id UNIQUEIDENTIFIER,
     @UserId UNIQUEIDENTIFIER,
     @OrganizationId UNIQUEIDENTIFIER,

--- a/util/Migrator/DbScripts/2025-06-24_00_AttachmentCipherUpdateDetails.sql
+++ b/util/Migrator/DbScripts/2025-06-24_00_AttachmentCipherUpdateDetails.sql
@@ -68,3 +68,51 @@ BEGIN
         EXEC [dbo].[User_BumpAccountRevisionDate] @UserId
     END
 END
+GO
+
+CREATE OR ALTER PROCEDURE [dbo].[Cipher_Update]
+    @Id UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @Type TINYINT,
+    @Data NVARCHAR(MAX),
+    @Favorites NVARCHAR(MAX),
+    @Folders NVARCHAR(MAX),
+    @Attachments NVARCHAR(MAX),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @DeletedDate DATETIME2(7),
+    @Reprompt TINYINT,
+    @Key VARCHAR(MAX) = NULL
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    UPDATE
+        [dbo].[Cipher]
+    SET
+        [UserId] = CASE WHEN @OrganizationId IS NULL THEN @UserId ELSE NULL END,
+        [OrganizationId] = @OrganizationId,
+        [Type] = @Type,
+        [Data] = @Data,
+        [Favorites] = @Favorites,
+        [Folders] = @Folders,
+        [Attachments] = @Attachments,
+        [CreationDate] = @CreationDate,
+        [RevisionDate] = @RevisionDate,
+        [DeletedDate] = @DeletedDate,
+        [Reprompt] = @Reprompt,
+        [Key] = @Key
+    WHERE
+        [Id] = @Id
+
+    IF @OrganizationId IS NOT NULL
+    BEGIN
+        EXEC [dbo].[User_BumpAccountRevisionDateByCipherId] @Id, @OrganizationId
+    END
+    ELSE IF @UserId IS NOT NULL
+    BEGIN
+        EXEC [dbo].[User_BumpAccountRevisionDate] @UserId
+    END
+END
+GO


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-22985
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
With a cipher that has a cipherkey, and an attachment, with the domain sdk decryption feature flag on, editing the item causes the attachment to disappear (be corrupted and the decryption error is hidden) after saving and syncing.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
