### PR TITLE
fix(events): re-add kerberos tools to container image

### DIFF
--- a/src/Events/Dockerfile
+++ b/src/Events/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     gosu \
     curl \
+    krb5-user \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy app from the build stage


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23079

## 📔 Objective

Follow-up to #6005. Kereberos tools were also [mistakenly removed](https://github.com/bitwarden/server/pull/5701/files#diff-ec2fcbc24a44a425bf4698de599f909829ce8ca1e61fd946f4b47162e4d6a684L9) from the Events image. This adds it back.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
