### PR TITLE
[PM-17562] Add HEC integration support

### DIFF
--- a/dev/servicebusemulator_config.json
+++ b/dev/servicebusemulator_config.json
@@ -31,6 +31,9 @@
               },
               {
                 "Name": "events-webhook-subscription"
+              },
+              {
+                "Name": "events-hec-subscription"
               }
             ]
           },
@@ -60,6 +63,20 @@
                       "FilterType": "Correlation",
                       "CorrelationFilter": {
                         "Label": "webhook"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "Name": "integration-hec-subscription",
+                "Rules": [
+                  {
+                    "Name": "hec-integration-filter",
+                    "Properties": {
+                      "FilterType": "Correlation",
+                      "CorrelationFilter": {
+                        "Label": "hec"
                       }
                     }
                   }

--- a/src/Api/AdminConsole/Models/Request/Organizations/OrganizationIntegrationConfigurationRequestModel.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/OrganizationIntegrationConfigurationRequestModel.cs
@@ -27,6 +27,8 @@ public class OrganizationIntegrationConfigurationRequestModel
                 return !string.IsNullOrWhiteSpace(Template) && IsConfigurationValid<SlackIntegrationConfiguration>();
             case IntegrationType.Webhook:
                 return !string.IsNullOrWhiteSpace(Template) && IsConfigurationValid<WebhookIntegrationConfiguration>();
+            case IntegrationType.Hec:
+                return !string.IsNullOrWhiteSpace(Template) && Configuration is null;
             default:
                 return false;
 

--- a/src/Api/AdminConsole/Models/Request/Organizations/OrgnizationIntegrationRequestModel.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/OrgnizationIntegrationRequestModel.cs
@@ -41,7 +41,11 @@ public class OrganizationIntegrationRequestModel : IValidatableObject
                 yield return new ValidationResult($"{nameof(Type)} integrations cannot be created directly.", new[] { nameof(Type) });
                 break;
             case IntegrationType.Webhook:
-                if (!string.IsNullOrWhiteSpace(Configuration) && !IsIntegrationValid<WebhookIntegration>())
+                if (string.IsNullOrWhiteSpace(Configuration))
+                {
+                    break;
+                }
+                if (!IsIntegrationValid<WebhookIntegration>())
                 {
                     yield return new ValidationResult(
                         "Webhook integrations must include valid configuration.",

--- a/src/Api/AdminConsole/Models/Request/Organizations/OrgnizationIntegrationRequestModel.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/OrgnizationIntegrationRequestModel.cs
@@ -1,5 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Models.Data.EventIntegrations;
 using Bit.Core.Enums;
 
 #nullable enable
@@ -39,10 +41,18 @@ public class OrganizationIntegrationRequestModel : IValidatableObject
                 yield return new ValidationResult($"{nameof(Type)} integrations cannot be created directly.", new[] { nameof(Type) });
                 break;
             case IntegrationType.Webhook:
-                if (Configuration is not null)
+                if (!string.IsNullOrWhiteSpace(Configuration) && !IsIntegrationValid<WebhookIntegration>())
                 {
                     yield return new ValidationResult(
-                        "Webhook integrations must not include configuration.",
+                        "Webhook integrations must include valid configuration.",
+                        new[] { nameof(Configuration) });
+                }
+                break;
+            case IntegrationType.Hec:
+                if (!IsIntegrationValid<HecIntegration>())
+                {
+                    yield return new ValidationResult(
+                        "HEC integrations must include valid configuration.",
                         new[] { nameof(Configuration) });
                 }
                 break;
@@ -51,6 +61,24 @@ public class OrganizationIntegrationRequestModel : IValidatableObject
                     $"Integration type '{Type}' is not recognized.",
                     new[] { nameof(Type) });
                 break;
+        }
+    }
+
+    private bool IsIntegrationValid<T>()
+    {
+        if (string.IsNullOrWhiteSpace(Configuration))
+        {
+            return false;
+        }
+
+        try
+        {
+            var config = JsonSerializer.Deserialize<T>(Configuration);
+            return config is not null;
+        }
+        catch
+        {
+            return false;
         }
     }
 }

--- a/src/Core/AdminConsole/Enums/IntegrationType.cs
+++ b/src/Core/AdminConsole/Enums/IntegrationType.cs
@@ -6,6 +6,7 @@ public enum IntegrationType : int
     Scim = 2,
     Slack = 3,
     Webhook = 4,
+    Hec = 5
 }
 
 public static class IntegrationTypeExtensions
@@ -18,6 +19,8 @@ public static class IntegrationTypeExtensions
                 return "slack";
             case IntegrationType.Webhook:
                 return "webhook";
+            case IntegrationType.Hec:
+                return "hec";
             default:
                 throw new ArgumentOutOfRangeException(nameof(type), $"Unsupported integration type: {type}");
         }

--- a/src/Core/AdminConsole/Models/Data/EventIntegrations/HecIntegration.cs
+++ b/src/Core/AdminConsole/Models/Data/EventIntegrations/HecIntegration.cs
@@ -1,0 +1,5 @@
+﻿#nullable enable
+
+namespace Bit.Core.AdminConsole.Models.Data.EventIntegrations;
+
+public record HecIntegration(string Scheme, string Token, Uri Uri);

--- a/src/Core/AdminConsole/Models/Data/EventIntegrations/HecIntegration.cs
+++ b/src/Core/AdminConsole/Models/Data/EventIntegrations/HecIntegration.cs
@@ -2,4 +2,4 @@
 
 namespace Bit.Core.AdminConsole.Models.Data.EventIntegrations;
 
-public record HecIntegration(string Scheme, string Token, Uri Uri);
+public record HecIntegration(Uri Uri, string Scheme, string Token);

--- a/src/Core/AdminConsole/Models/Data/EventIntegrations/WebhookIntegration.cs
+++ b/src/Core/AdminConsole/Models/Data/EventIntegrations/WebhookIntegration.cs
@@ -1,0 +1,5 @@
+﻿#nullable enable
+
+namespace Bit.Core.AdminConsole.Models.Data.EventIntegrations;
+
+public record WebhookIntegration(Uri Uri, string? Scheme = null, string? Token = null);

--- a/src/Core/AdminConsole/Models/Data/EventIntegrations/WebhookIntegrationConfiguration.cs
+++ b/src/Core/AdminConsole/Models/Data/EventIntegrations/WebhookIntegrationConfiguration.cs
@@ -2,4 +2,4 @@
 
 namespace Bit.Core.AdminConsole.Models.Data.EventIntegrations;
 
-public record WebhookIntegrationConfiguration(string Url, string? Scheme = null, string? Token = null);
+public record WebhookIntegrationConfiguration(Uri Uri, string? Scheme = null, string? Token = null);

--- a/src/Core/AdminConsole/Models/Data/EventIntegrations/WebhookIntegrationConfigurationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/EventIntegrations/WebhookIntegrationConfigurationDetails.cs
@@ -2,4 +2,4 @@
 
 namespace Bit.Core.AdminConsole.Models.Data.EventIntegrations;
 
-public record WebhookIntegrationConfigurationDetails(string Url, string? Scheme = null, string? Token = null);
+public record WebhookIntegrationConfigurationDetails(Uri Uri, string? Scheme = null, string? Token = null);

--- a/src/Core/AdminConsole/Services/Implementations/EventIntegrations/README.md
+++ b/src/Core/AdminConsole/Services/Implementations/EventIntegrations/README.md
@@ -227,7 +227,7 @@ Currently, there are integrations / handlers for Slack, webhooks, and HTTP Event
       - Optionally this also can include a `Scheme` and `Token` if this webhook needs Authentication.
       - As stated above, all of this information can be specified here or at the `OrganizationIntegration`
         level, but any properties declared here will take precedence over the ones above.
-    - for HEC, this must be null. HEC is configured only at the `OrganizationIntegration` level.
+    - For HEC, this must be null. HEC is configured only at the `OrganizationIntegration` level.
 - `Template` contains a template string that is expected to be filled in with the contents of the actual event.
     - The tokens in the string are wrapped in `#` characters. For instance, the UserId would be `#UserId#`.
     - The `IntegrationTemplateProcessor` does the actual work of replacing these tokens with introspected values from

--- a/src/Core/AdminConsole/Services/Implementations/EventIntegrations/WebhookIntegrationHandler.cs
+++ b/src/Core/AdminConsole/Services/Implementations/EventIntegrations/WebhookIntegrationHandler.cs
@@ -6,8 +6,6 @@ using System.Net.Http.Headers;
 using System.Text;
 using Bit.Core.AdminConsole.Models.Data.EventIntegrations;
 
-#nullable enable
-
 namespace Bit.Core.Services;
 
 public class WebhookIntegrationHandler(
@@ -21,7 +19,7 @@ public class WebhookIntegrationHandler(
 
     public override async Task<IntegrationHandlerResult> HandleAsync(IntegrationMessage<WebhookIntegrationConfigurationDetails> message)
     {
-        var request = new HttpRequestMessage(HttpMethod.Post, message.Configuration.Url);
+        var request = new HttpRequestMessage(HttpMethod.Post, message.Configuration.Uri);
         request.Content = new StringContent(message.RenderedTemplate, Encoding.UTF8, "application/json");
         if (!string.IsNullOrEmpty(message.Configuration.Scheme))
         {

--- a/src/Core/AdminConsole/Utilities/IntegrationTemplateProcessor.cs
+++ b/src/Core/AdminConsole/Utilities/IntegrationTemplateProcessor.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using System.Text.Json;
 using System.Text.RegularExpressions;
 
 namespace Bit.Core.AdminConsole.Utilities;
@@ -19,8 +20,15 @@ public static partial class IntegrationTemplateProcessor
         return TokenRegex().Replace(template, match =>
         {
             var propertyName = match.Groups[1].Value;
-            var property = type.GetProperty(propertyName);
-            return property?.GetValue(values)?.ToString() ?? match.Value;
+            if (propertyName == "EventMessage")
+            {
+                return JsonSerializer.Serialize(values);
+            }
+            else
+            {
+                var property = type.GetProperty(propertyName);
+                return property?.GetValue(values)?.ToString() ?? match.Value;
+            }
         });
     }
 

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -297,6 +297,8 @@ public class GlobalSettings : IGlobalSettings
             public virtual string SlackIntegrationSubscriptionName { get; set; } = "integration-slack-subscription";
             public virtual string WebhookEventSubscriptionName { get; set; } = "events-webhook-subscription";
             public virtual string WebhookIntegrationSubscriptionName { get; set; } = "integration-webhook-subscription";
+            public virtual string HecEventSubscriptionName { get; set; } = "events-hec-subscription";
+            public virtual string HecIntegrationSubscriptionName { get; set; } = "integration-hec-subscription";
 
             public string ConnectionString
             {
@@ -336,6 +338,9 @@ public class GlobalSettings : IGlobalSettings
             public virtual string WebhookEventsQueueName { get; set; } = "events-webhook-queue";
             public virtual string WebhookIntegrationQueueName { get; set; } = "integration-webhook-queue";
             public virtual string WebhookIntegrationRetryQueueName { get; set; } = "integration-webhook-retry-queue";
+            public virtual string HecEventsQueueName { get; set; } = "events-hec-queue";
+            public virtual string HecIntegrationQueueName { get; set; } = "integration-hec-queue";
+            public virtual string HecIntegrationRetryQueueName { get; set; } = "integration-hec-retry-queue";
 
             public string HostName
             {

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -664,6 +664,13 @@ public static class ServiceCollectionExtensions
             integrationSubscriptionName: globalSettings.EventLogging.AzureServiceBus.WebhookIntegrationSubscriptionName,
             integrationType: IntegrationType.Webhook,
             globalSettings: globalSettings);
+
+        services.AddAzureServiceBusIntegration<WebhookIntegrationConfigurationDetails, WebhookIntegrationHandler>(
+            eventSubscriptionName: globalSettings.EventLogging.AzureServiceBus.HecEventSubscriptionName,
+            integrationSubscriptionName: globalSettings.EventLogging.AzureServiceBus.HecIntegrationSubscriptionName,
+            integrationType: IntegrationType.Hec,
+            globalSettings: globalSettings);
+
         return services;
     }
 
@@ -749,6 +756,13 @@ public static class ServiceCollectionExtensions
             globalSettings.EventLogging.RabbitMq.WebhookIntegrationRetryQueueName,
             globalSettings.EventLogging.RabbitMq.MaxRetries,
             IntegrationType.Webhook);
+
+        services.AddRabbitMqIntegration<WebhookIntegrationConfigurationDetails, WebhookIntegrationHandler>(
+            globalSettings.EventLogging.RabbitMq.HecEventsQueueName,
+            globalSettings.EventLogging.RabbitMq.HecIntegrationQueueName,
+            globalSettings.EventLogging.RabbitMq.HecIntegrationRetryQueueName,
+            globalSettings.EventLogging.RabbitMq.MaxRetries,
+            IntegrationType.Hec);
 
         return services;
     }

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationIntegrationsConfigurationControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationIntegrationsConfigurationControllerTests.cs
@@ -188,7 +188,7 @@ public class OrganizationIntegrationsConfigurationControllerTests
     {
         organizationIntegration.OrganizationId = organizationId;
         organizationIntegration.Type = IntegrationType.Webhook;
-        var webhookConfig = new WebhookIntegrationConfiguration(Url: "https://localhost", Scheme: "Bearer", Token: "AUTH-TOKEN");
+        var webhookConfig = new WebhookIntegrationConfiguration(Uri: new Uri("https://localhost"), Scheme: "Bearer", Token: "AUTH-TOKEN");
         model.Configuration = JsonSerializer.Serialize(webhookConfig);
         model.Template = "Template String";
 
@@ -225,7 +225,7 @@ public class OrganizationIntegrationsConfigurationControllerTests
     {
         organizationIntegration.OrganizationId = organizationId;
         organizationIntegration.Type = IntegrationType.Webhook;
-        var webhookConfig = new WebhookIntegrationConfiguration(Url: "https://localhost");
+        var webhookConfig = new WebhookIntegrationConfiguration(Uri: new Uri("https://localhost"));
         model.Configuration = JsonSerializer.Serialize(webhookConfig);
         model.Template = "Template String";
 
@@ -387,7 +387,7 @@ public class OrganizationIntegrationsConfigurationControllerTests
     {
         organizationIntegration.OrganizationId = organizationId;
         organizationIntegration.Type = IntegrationType.Webhook;
-        var webhookConfig = new WebhookIntegrationConfiguration(Url: "https://localhost", Scheme: "Bearer", Token: "AUTH-TOKEN");
+        var webhookConfig = new WebhookIntegrationConfiguration(Uri: new Uri("https://localhost"), Scheme: "Bearer", Token: "AUTH-TOKEN");
         model.Configuration = JsonSerializer.Serialize(webhookConfig);
         model.Template = null;
 
@@ -473,7 +473,7 @@ public class OrganizationIntegrationsConfigurationControllerTests
         organizationIntegration.OrganizationId = organizationId;
         organizationIntegrationConfiguration.OrganizationIntegrationId = organizationIntegration.Id;
         organizationIntegration.Type = IntegrationType.Webhook;
-        var webhookConfig = new WebhookIntegrationConfiguration(Url: "https://localhost", Scheme: "Bearer", Token: "AUTH-TOKEN");
+        var webhookConfig = new WebhookIntegrationConfiguration(Uri: new Uri("https://localhost"), Scheme: "Bearer", Token: "AUTH-TOKEN");
         model.Configuration = JsonSerializer.Serialize(webhookConfig);
         model.Template = "Template String";
 
@@ -515,7 +515,7 @@ public class OrganizationIntegrationsConfigurationControllerTests
         organizationIntegration.OrganizationId = organizationId;
         organizationIntegrationConfiguration.OrganizationIntegrationId = organizationIntegration.Id;
         organizationIntegration.Type = IntegrationType.Webhook;
-        var webhookConfig = new WebhookIntegrationConfiguration(Url: "https://localhost");
+        var webhookConfig = new WebhookIntegrationConfiguration(Uri: new Uri("https://localhost"));
         model.Configuration = JsonSerializer.Serialize(webhookConfig);
         model.Template = "Template String";
 
@@ -555,7 +555,7 @@ public class OrganizationIntegrationsConfigurationControllerTests
     {
         organizationIntegration.OrganizationId = organizationId;
         organizationIntegration.Type = IntegrationType.Webhook;
-        var webhookConfig = new WebhookIntegrationConfiguration(Url: "https://localhost", Scheme: "Bearer", Token: "AUTH-TOKEN");
+        var webhookConfig = new WebhookIntegrationConfiguration(Uri: new Uri("https://localhost"), Scheme: "Bearer", Token: "AUTH-TOKEN");
         model.Configuration = JsonSerializer.Serialize(webhookConfig);
         model.Template = "Template String";
 

--- a/test/Api.Test/AdminConsole/Models/Request/Organizations/OrganizationIntegrationConfigurationRequestModelTests.cs
+++ b/test/Api.Test/AdminConsole/Models/Request/Organizations/OrganizationIntegrationConfigurationRequestModelTests.cs
@@ -17,13 +17,13 @@ public class OrganizationIntegrationConfigurationRequestModelTests
             Template = "template"
         };
 
-        Assert.False(model.IsValidForType(IntegrationType.CloudBillingSync));
+        Assert.False(condition: model.IsValidForType(IntegrationType.CloudBillingSync));
     }
 
     [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("    ")]
+    [InlineData(data: null)]
+    [InlineData(data: "")]
+    [InlineData(data: "    ")]
     public void IsValidForType_EmptyConfiguration_ReturnsFalse(string? config)
     {
         var model = new OrganizationIntegrationConfigurationRequestModel
@@ -32,25 +32,55 @@ public class OrganizationIntegrationConfigurationRequestModelTests
             Template = "template"
         };
 
-        var result = model.IsValidForType(IntegrationType.Slack);
-
-        Assert.False(result);
+        Assert.False(condition: model.IsValidForType(IntegrationType.Slack));
+        Assert.False(condition: model.IsValidForType(IntegrationType.Webhook));
     }
 
     [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("    ")]
+    [InlineData(data: "")]
+    [InlineData(data: "    ")]
+    public void IsValidForType_EmptyNonNullHecConfiguration_ReturnsFalse(string? config)
+    {
+        var model = new OrganizationIntegrationConfigurationRequestModel
+        {
+            Configuration = config,
+            Template = "template"
+        };
+
+        Assert.False(condition: model.IsValidForType(IntegrationType.Hec));
+    }
+
+    [Fact]
+    public void IsValidForType_NullHecConfiguration_ReturnsTrue()
+    {
+        var model = new OrganizationIntegrationConfigurationRequestModel
+        {
+            Configuration = null,
+            Template = "template"
+        };
+
+        Assert.True(condition: model.IsValidForType(IntegrationType.Hec));
+    }
+
+    [Theory]
+    [InlineData(data: null)]
+    [InlineData(data: "")]
+    [InlineData(data: "    ")]
     public void IsValidForType_EmptyTemplate_ReturnsFalse(string? template)
     {
-        var config = JsonSerializer.Serialize(new WebhookIntegrationConfiguration("https://example.com", "Bearer", "AUTH-TOKEN"));
+        var config = JsonSerializer.Serialize(value: new WebhookIntegrationConfiguration(
+            Uri: new Uri("https://localhost"),
+            Scheme: "Bearer",
+            Token: "AUTH-TOKEN"));
         var model = new OrganizationIntegrationConfigurationRequestModel
         {
             Configuration = config,
             Template = template
         };
 
-        Assert.False(model.IsValidForType(IntegrationType.Webhook));
+        Assert.False(condition: model.IsValidForType(IntegrationType.Slack));
+        Assert.False(condition: model.IsValidForType(IntegrationType.Webhook));
+        Assert.False(condition: model.IsValidForType(IntegrationType.Hec));
     }
 
     [Fact]
@@ -62,7 +92,9 @@ public class OrganizationIntegrationConfigurationRequestModelTests
             Template = "template"
         };
 
-        Assert.False(model.IsValidForType(IntegrationType.Webhook));
+        Assert.False(condition: model.IsValidForType(IntegrationType.Slack));
+        Assert.False(condition: model.IsValidForType(IntegrationType.Webhook));
+        Assert.False(condition: model.IsValidForType(IntegrationType.Hec));
     }
 
     [Fact]
@@ -74,13 +106,13 @@ public class OrganizationIntegrationConfigurationRequestModelTests
             Template = "template"
         };
 
-        Assert.False(model.IsValidForType(IntegrationType.Scim));
+        Assert.False(condition: model.IsValidForType(IntegrationType.Scim));
     }
 
     [Fact]
     public void IsValidForType_ValidSlackConfiguration_ReturnsTrue()
     {
-        var config = JsonSerializer.Serialize(new SlackIntegrationConfiguration("C12345"));
+        var config = JsonSerializer.Serialize(value: new SlackIntegrationConfiguration(ChannelId: "C12345"));
 
         var model = new OrganizationIntegrationConfigurationRequestModel
         {
@@ -88,33 +120,36 @@ public class OrganizationIntegrationConfigurationRequestModelTests
             Template = "template"
         };
 
-        Assert.True(model.IsValidForType(IntegrationType.Slack));
+        Assert.True(condition: model.IsValidForType(IntegrationType.Slack));
     }
 
     [Fact]
     public void IsValidForType_ValidNoAuthWebhookConfiguration_ReturnsTrue()
     {
-        var config = JsonSerializer.Serialize(new WebhookIntegrationConfiguration("https://example.com"));
+        var config = JsonSerializer.Serialize(value: new WebhookIntegrationConfiguration(Uri: new Uri("https://localhost")));
         var model = new OrganizationIntegrationConfigurationRequestModel
         {
             Configuration = config,
             Template = "template"
         };
 
-        Assert.True(model.IsValidForType(IntegrationType.Webhook));
+        Assert.True(condition: model.IsValidForType(IntegrationType.Webhook));
     }
 
     [Fact]
     public void IsValidForType_ValidWebhookConfiguration_ReturnsTrue()
     {
-        var config = JsonSerializer.Serialize(new WebhookIntegrationConfiguration("https://example.com", "Bearer", "AUTH-TOKEN"));
+        var config = JsonSerializer.Serialize(value: new WebhookIntegrationConfiguration(
+            Uri: new Uri("https://localhost"),
+            Scheme: "Bearer",
+            Token: "AUTH-TOKEN"));
         var model = new OrganizationIntegrationConfigurationRequestModel
         {
             Configuration = config,
             Template = "template"
         };
 
-        Assert.True(model.IsValidForType(IntegrationType.Webhook));
+        Assert.True(condition: model.IsValidForType(IntegrationType.Webhook));
     }
 
     [Fact]
@@ -128,6 +163,6 @@ public class OrganizationIntegrationConfigurationRequestModelTests
 
         var unknownType = (IntegrationType)999;
 
-        Assert.False(model.IsValidForType(unknownType));
+        Assert.False(condition: model.IsValidForType(unknownType));
     }
 }

--- a/test/Api.Test/AdminConsole/Models/Request/Organizations/OrganizationIntegrationRequestModelTests.cs
+++ b/test/Api.Test/AdminConsole/Models/Request/Organizations/OrganizationIntegrationRequestModelTests.cs
@@ -139,7 +139,7 @@ public class OrganizationIntegrationRequestModelTests
         var model = new OrganizationIntegrationRequestModel
         {
             Type = IntegrationType.Hec,
-            Configuration = JsonSerializer.Serialize(new HecIntegration("Bearer", Token: "Token", Uri: new Uri("http://localhost")))
+            Configuration = JsonSerializer.Serialize(new HecIntegration(Uri: new Uri("http://localhost"), Scheme: "Bearer", Token: "Token"))
         };
 
         var results = model.Validate(new ValidationContext(model)).ToList();

--- a/test/Api.Test/AdminConsole/Models/Request/Organizations/OrganizationIntegrationRequestModelTests.cs
+++ b/test/Api.Test/AdminConsole/Models/Request/Organizations/OrganizationIntegrationRequestModelTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 using Bit.Api.AdminConsole.Models.Request.Organizations;
+using Bit.Core.AdminConsole.Models.Data.EventIntegrations;
 using Bit.Core.Enums;
 using Xunit;
 
@@ -70,7 +72,7 @@ public class OrganizationIntegrationRequestModelTests
     }
 
     [Fact]
-    public void Validate_Webhook_WithConfiguration_ReturnsConfigurationError()
+    public void Validate_Webhook_WithInvalidConfiguration_ReturnsConfigurationError()
     {
         var model = new OrganizationIntegrationRequestModel
         {
@@ -82,7 +84,67 @@ public class OrganizationIntegrationRequestModelTests
 
         Assert.Single(results);
         Assert.Contains(nameof(model.Configuration), results[0].MemberNames);
-        Assert.Contains("must not include configuration", results[0].ErrorMessage);
+        Assert.Contains("must include valid configuration", results[0].ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_Webhook_WithValidConfiguration_ReturnsNoErrors()
+    {
+        var model = new OrganizationIntegrationRequestModel
+        {
+            Type = IntegrationType.Webhook,
+            Configuration = JsonSerializer.Serialize(new WebhookIntegration(new Uri("https://example.com")))
+        };
+
+        var results = model.Validate(new ValidationContext(model)).ToList();
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Validate_Hec_WithNullConfiguration_ReturnsError()
+    {
+        var model = new OrganizationIntegrationRequestModel
+        {
+            Type = IntegrationType.Hec,
+            Configuration = null
+        };
+
+        var results = model.Validate(new ValidationContext(model)).ToList();
+
+        Assert.Single(results);
+        Assert.Contains(nameof(model.Configuration), results[0].MemberNames);
+        Assert.Contains("must include valid configuration", results[0].ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_Hec_WithInvalidConfiguration_ReturnsError()
+    {
+        var model = new OrganizationIntegrationRequestModel
+        {
+            Type = IntegrationType.Hec,
+            Configuration = "Not valid"
+        };
+
+        var results = model.Validate(new ValidationContext(model)).ToList();
+
+        Assert.Single(results);
+        Assert.Contains(nameof(model.Configuration), results[0].MemberNames);
+        Assert.Contains("must include valid configuration", results[0].ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_Hec_WithValidConfiguration_ReturnsNoErrors()
+    {
+        var model = new OrganizationIntegrationRequestModel
+        {
+            Type = IntegrationType.Hec,
+            Configuration = JsonSerializer.Serialize(new HecIntegration("Bearer", Token: "Token", Uri: new Uri("http://localhost")))
+        };
+
+        var results = model.Validate(new ValidationContext(model)).ToList();
+
+        Assert.Empty(results);
     }
 
     [Fact]

--- a/test/Core.Test/AdminConsole/Models/Data/EventIntegrations/IntegrationMessageTests.cs
+++ b/test/Core.Test/AdminConsole/Models/Data/EventIntegrations/IntegrationMessageTests.cs
@@ -14,7 +14,7 @@ public class IntegrationMessageTests
     {
         var message = new IntegrationMessage<WebhookIntegrationConfigurationDetails>
         {
-            Configuration = new WebhookIntegrationConfigurationDetails("https://localhost", "Bearer", "AUTH-TOKEN"),
+            Configuration = new WebhookIntegrationConfigurationDetails(new Uri("https://localhost"), "Bearer", "AUTH-TOKEN"),
             MessageId = _messageId,
             RetryCount = 2,
             RenderedTemplate = string.Empty,
@@ -34,7 +34,7 @@ public class IntegrationMessageTests
     {
         var message = new IntegrationMessage<WebhookIntegrationConfigurationDetails>
         {
-            Configuration = new WebhookIntegrationConfigurationDetails("https://localhost", "Bearer", "AUTH-TOKEN"),
+            Configuration = new WebhookIntegrationConfigurationDetails(new Uri("https://localhost"), "Bearer", "AUTH-TOKEN"),
             MessageId = _messageId,
             RenderedTemplate = "This is the message",
             IntegrationType = IntegrationType.Webhook,

--- a/test/Core.Test/AdminConsole/Models/Data/Organizations/OrganizationIntegrationConfigurationDetailsTests.cs
+++ b/test/Core.Test/AdminConsole/Models/Data/Organizations/OrganizationIntegrationConfigurationDetailsTests.cs
@@ -23,6 +23,22 @@ public class OrganizationIntegrationConfigurationDetailsTests
     }
 
     [Fact]
+    public void MergedConfiguration_WithSameKeyIndConfigAndIntegration_GivesPrecedenceToConfiguration()
+    {
+        var config = new { config = "A new config value" };
+        var integration = new { config = "An integration value" };
+        var expectedObj = new { config = "A new config value" };
+        var expected = JsonSerializer.Serialize(expectedObj);
+
+        var sut = new OrganizationIntegrationConfigurationDetails();
+        sut.Configuration = JsonSerializer.Serialize(config);
+        sut.IntegrationConfiguration = JsonSerializer.Serialize(integration);
+
+        var result = sut.MergedConfiguration;
+        Assert.Equal(expected, result.ToJsonString());
+    }
+
+    [Fact]
     public void MergedConfiguration_WithInvalidJsonConfigAndIntegration_ReturnsEmptyJson()
     {
         var expectedObj = new { };

--- a/test/Core.Test/AdminConsole/Services/EventIntegrationHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/Services/EventIntegrationHandlerTests.cs
@@ -22,8 +22,8 @@ public class EventIntegrationHandlerTests
     private const string _templateWithOrganization = "Org: #OrganizationName#";
     private const string _templateWithUser = "#UserName#, #UserEmail#";
     private const string _templateWithActingUser = "#ActingUserName#, #ActingUserEmail#";
-    private const string _url = "https://localhost";
-    private const string _url2 = "https://example.com";
+    private static readonly Uri _uri = new Uri("https://localhost");
+    private static readonly Uri _uri2 = new Uri("https://example.com");
     private readonly IEventIntegrationPublisher _eventIntegrationPublisher = Substitute.For<IEventIntegrationPublisher>();
 
     private SutProvider<EventIntegrationHandler<WebhookIntegrationConfigurationDetails>> GetSutProvider(
@@ -46,7 +46,7 @@ public class EventIntegrationHandlerTests
         {
             IntegrationType = IntegrationType.Webhook,
             MessageId = "TestMessageId",
-            Configuration = new WebhookIntegrationConfigurationDetails(_url),
+            Configuration = new WebhookIntegrationConfigurationDetails(_uri),
             RenderedTemplate = template,
             RetryCount = 0,
             DelayUntilDate = null
@@ -62,7 +62,7 @@ public class EventIntegrationHandlerTests
     {
         var config = Substitute.For<OrganizationIntegrationConfigurationDetails>();
         config.Configuration = null;
-        config.IntegrationConfiguration = JsonSerializer.Serialize(new { Url = _url });
+        config.IntegrationConfiguration = JsonSerializer.Serialize(new { Uri = _uri });
         config.Template = template;
 
         return [config];
@@ -72,11 +72,11 @@ public class EventIntegrationHandlerTests
     {
         var config = Substitute.For<OrganizationIntegrationConfigurationDetails>();
         config.Configuration = null;
-        config.IntegrationConfiguration = JsonSerializer.Serialize(new { Url = _url });
+        config.IntegrationConfiguration = JsonSerializer.Serialize(new { Uri = _uri });
         config.Template = template;
         var config2 = Substitute.For<OrganizationIntegrationConfigurationDetails>();
         config2.Configuration = null;
-        config2.IntegrationConfiguration = JsonSerializer.Serialize(new { Url = _url2 });
+        config2.IntegrationConfiguration = JsonSerializer.Serialize(new { Uri = _uri2 });
         config2.Template = template;
 
         return [config, config2];
@@ -212,7 +212,7 @@ public class EventIntegrationHandlerTests
             await _eventIntegrationPublisher.Received(1).PublishAsync(Arg.Is(
                 AssertHelper.AssertPropertyEqual(expectedMessage, new[] { "MessageId" })));
 
-            expectedMessage.Configuration = new WebhookIntegrationConfigurationDetails(_url2);
+            expectedMessage.Configuration = new WebhookIntegrationConfigurationDetails(_uri2);
             await _eventIntegrationPublisher.Received(1).PublishAsync(Arg.Is(
                 AssertHelper.AssertPropertyEqual(expectedMessage, new[] { "MessageId" })));
         }

--- a/test/Core.Test/AdminConsole/Services/IntegrationHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/Services/IntegrationHandlerTests.cs
@@ -14,7 +14,7 @@ public class IntegrationHandlerTests
         var sut = new TestIntegrationHandler();
         var expected = new IntegrationMessage<WebhookIntegrationConfigurationDetails>()
         {
-            Configuration = new WebhookIntegrationConfigurationDetails("https://localhost", "Bearer", "AUTH-TOKEN"),
+            Configuration = new WebhookIntegrationConfigurationDetails(new Uri("https://localhost"), "Bearer", "AUTH-TOKEN"),
             MessageId = "TestMessageId",
             IntegrationType = IntegrationType.Webhook,
             RenderedTemplate = "Template",

--- a/test/Core.Test/AdminConsole/Utilities/IntegrationTemplateProcessorTests.cs
+++ b/test/Core.Test/AdminConsole/Utilities/IntegrationTemplateProcessorTests.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using System.Text.Json;
 using Bit.Core.AdminConsole.Utilities;
 using Bit.Core.Models.Data;
 using Bit.Test.Common.AutoFixture.Attributes;
@@ -34,6 +35,16 @@ public class IntegrationTemplateProcessorTests
     {
         var template = "Event #Type#, User (id: #UserId#), Details: #UnknownKey#.";
         var expected = $"Event {eventMessage.Type}, User (id: {eventMessage.UserId}), Details: #UnknownKey#.";
+        var result = IntegrationTemplateProcessor.ReplaceTokens(template, eventMessage);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory, BitAutoData]
+    public void ReplaceTokens_WithEventMessageToken_ReplacesWithSerializedJson(EventMessage eventMessage)
+    {
+        var template = "#EventMessage#";
+        var expected = $"{JsonSerializer.Serialize(eventMessage)}";
         var result = IntegrationTemplateProcessor.ReplaceTokens(template, eventMessage);
 
         Assert.Equal(expected, result);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17562](https://bitwarden.atlassian.net/browse/PM-17562)

## 📔 Objective

The main focus of this PR is to add support for a new HTTP Event Collector (HEC) integration. This is an event format supported by a couple of SIEM vendors (Splunk, Crowdstrike, etc) for ingesting events over HTTP. It is almost identical to our existing webhook, so this PR re-uses a lot of the existing webhook classes to support the new type.

Notable changes:

1. In the previous PR that added auth support for Webhooks (#5970), Matt noted that we might be better served by an explicit `Uri` instead of a `string` for Url. This PR adjusts Webhooks to use that and picks that support up for HEC as well.
2. In addition, I altered Webhook so that it can support configuration at the `OrganizationIntegration` level _or_ at the `OrganizationIntegrationConfiguration` level. Previously, we only allowed configuring it at the configuration level, which meant that URL, scheme and token would all have to be specified on each event.
   -  Now we allow it on either level and anything specified on `OrganizationIntegrationConfiguration` takes precedence over the `OrganizationIntegration` level.
3. There is a new `HecIntegration` for configuring the top level (`OrganizationIntegration`). This requires HEC integrations to only be configured at that level. When we build an admin UI for this, this will make it easier to simply turn on support for a SIEM vendor by providing your token (instead of managing the token, url, and scheme across all events in `OrganizationIntegrationConfiguration`).
4. This configuration will be deserialized into `WebhookIntegrationConfigurationDetails` from the database and given to the `WebhookIntegrationHandler` to perform the request. This allows us to have a new set of queues/subscriptions for HEC as a new integration, but reuses all of the code from webhooks (including support for timed delays, failures, etc).
5. This PR also adds a new key to the template processor (`#EventMessage#`) which dumps the entire `EventMessage` as JSON into the template. This can be used to support easily handing the entire event to SIEM via HEC.
6. Lastly, I also updated the README to bring it in line with these changes as well.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17562]: https://bitwarden.atlassian.net/browse/PM-17562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ