### PR TITLE
[PM-23061] Remove `GetManyDetailsByUserAsync` & `ReplaceAsync` DB Calls

### DIFF
--- a/src/Api/Controllers/DevicesController.cs
+++ b/src/Api/Controllers/DevicesController.cs
@@ -206,7 +206,11 @@ public class DevicesController : Controller
             throw new NotFoundException();
         }
 
-        await _deviceService.SaveAsync(model.ToData(), device);
+        await _deviceService.SaveAsync(
+            model.ToData(),
+            device,
+            _currentContext.Organizations.Select(org => org.Id.ToString())
+        );
     }
 
     [AllowAnonymous]

--- a/src/Core/Services/IDeviceService.cs
+++ b/src/Core/Services/IDeviceService.cs
@@ -6,7 +6,7 @@ namespace Bit.Core.Services;
 
 public interface IDeviceService
 {
-    Task SaveAsync(WebPushRegistrationData webPush, Device device);
+    Task SaveAsync(WebPushRegistrationData webPush, Device device, IEnumerable<string> organizationIds);
     Task SaveAsync(Device device);
     Task ClearTokenAsync(Device device);
     Task DeactivateAsync(Device device);

--- a/src/Core/Services/Implementations/DeviceService.cs
+++ b/src/Core/Services/Implementations/DeviceService.cs
@@ -29,9 +29,17 @@ public class DeviceService : IDeviceService
         _globalSettings = globalSettings;
     }
 
-    public async Task SaveAsync(WebPushRegistrationData webPush, Device device)
+    public async Task SaveAsync(WebPushRegistrationData webPush, Device device, IEnumerable<string> organizationIds)
     {
-        await SaveAsync(new PushRegistrationData(webPush.Endpoint, webPush.P256dh, webPush.Auth), device);
+        await _pushRegistrationService.CreateOrUpdateRegistrationAsync(
+            new PushRegistrationData(webPush.Endpoint, webPush.P256dh, webPush.Auth),
+            device.Id.ToString(),
+            device.UserId.ToString(),
+            device.Identifier,
+            device.Type,
+            organizationIds,
+            _globalSettings.Installation.Id
+        );
     }
 
     public async Task SaveAsync(Device device)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-23061

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Instead of calling an inner `SaveAsync` that our mobile clients use to store the `PushToken` on the device table we can just short circuit and call the `PushRegistrationService` to register the web push details with our current device. We don't need to update the device in the table since all that was changing was the revision date and no other column. We can also avoid hitting the database to get the orgs the current user is a part of since those org ids already exist in the JWT token and can be retrieved through `ICurrentContext`. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
