### PR TITLE
Remove unused ctor dependencies from OrgExportController

### DIFF
--- a/src/Api/Tools/Controllers/OrganizationExportController.cs
+++ b/src/Api/Tools/Controllers/OrganizationExportController.cs
@@ -1,13 +1,11 @@
 ﻿using Bit.Api.Tools.Authorization;
 using Bit.Api.Tools.Models.Response;
 using Bit.Core.AdminConsole.OrganizationFeatures.Shared.Authorization;
-using Bit.Core.Context;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Settings;
 using Bit.Core.Vault.Queries;
-using Bit.Core.Vault.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -17,30 +15,21 @@ namespace Bit.Api.Tools.Controllers;
 [Authorize("Application")]
 public class OrganizationExportController : Controller
 {
-    private readonly ICurrentContext _currentContext;
     private readonly IUserService _userService;
-    private readonly ICipherService _cipherService;
     private readonly GlobalSettings _globalSettings;
-    private readonly IFeatureService _featureService;
     private readonly IAuthorizationService _authorizationService;
     private readonly IOrganizationCiphersQuery _organizationCiphersQuery;
     private readonly ICollectionRepository _collectionRepository;
 
     public OrganizationExportController(
-        ICurrentContext currentContext,
-        ICipherService cipherService,
         IUserService userService,
         GlobalSettings globalSettings,
-        IFeatureService featureService,
         IAuthorizationService authorizationService,
         IOrganizationCiphersQuery organizationCiphersQuery,
         ICollectionRepository collectionRepository)
     {
-        _currentContext = currentContext;
-        _cipherService = cipherService;
         _userService = userService;
         _globalSettings = globalSettings;
-        _featureService = featureService;
         _authorizationService = authorizationService;
         _organizationCiphersQuery = organizationCiphersQuery;
         _collectionRepository = collectionRepository;


### PR DESCRIPTION
## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
While reviewing https://github.com/bitwarden/server/pull/6015, I noticed there were other ctor dependencies that aren't used and can be removed.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
