### PR TITLE
Migrate dirt code to have `#nullable disable`

### DIFF
--- a/src/Core/Dirt/Models/Data/MemberAccessCipherDetails.cs
+++ b/src/Core/Dirt/Models/Data/MemberAccessCipherDetails.cs
@@ -1,4 +1,7 @@
-﻿namespace Bit.Core.Dirt.Models.Data;
+﻿// FIXME: Update this file to be null safe and then delete the line below
+#nullable disable
+
+namespace Bit.Core.Dirt.Models.Data;
 
 public class MemberAccessDetails
 {

--- a/src/Core/Dirt/Models/Data/MemberAccessReportDetail.cs
+++ b/src/Core/Dirt/Models/Data/MemberAccessReportDetail.cs
@@ -1,4 +1,7 @@
-﻿namespace Bit.Core.Dirt.Reports.Models.Data;
+﻿// FIXME: Update this file to be null safe and then delete the line below
+#nullable disable
+
+namespace Bit.Core.Dirt.Reports.Models.Data;
 
 public class MemberAccessReportDetail
 {

--- a/src/Core/Dirt/Models/Data/OrganizationMemberBaseDetail.cs
+++ b/src/Core/Dirt/Models/Data/OrganizationMemberBaseDetail.cs
@@ -1,4 +1,7 @@
-﻿namespace Bit.Core.Dirt.Reports.Models.Data;
+﻿// FIXME: Update this file to be null safe and then delete the line below
+#nullable disable
+
+namespace Bit.Core.Dirt.Reports.Models.Data;
 
 public class OrganizationMemberBaseDetail
 {

--- a/src/Core/Dirt/Models/Data/RiskInsightsReportDetail.cs
+++ b/src/Core/Dirt/Models/Data/RiskInsightsReportDetail.cs
@@ -1,4 +1,7 @@
-﻿namespace Bit.Core.Dirt.Reports.Models.Data;
+﻿// FIXME: Update this file to be null safe and then delete the line below
+#nullable disable
+
+namespace Bit.Core.Dirt.Reports.Models.Data;
 
 public class RiskInsightsReportDetail
 {

--- a/src/Core/Dirt/Reports/ReportFeatures/MemberAccessReportQuery.cs
+++ b/src/Core/Dirt/Reports/ReportFeatures/MemberAccessReportQuery.cs
@@ -1,4 +1,7 @@
-﻿using Bit.Core.Auth.UserFeatures.TwoFactorAuth.Interfaces;
+﻿// FIXME: Update this file to be null safe and then delete the line below
+#nullable disable
+
+using Bit.Core.Auth.UserFeatures.TwoFactorAuth.Interfaces;
 using Bit.Core.Dirt.Reports.Models.Data;
 using Bit.Core.Dirt.Reports.ReportFeatures.OrganizationReportMembers.Interfaces;
 using Bit.Core.Dirt.Reports.ReportFeatures.Requests;

--- a/src/Core/Dirt/Reports/ReportFeatures/Requests/AddOrganizationReportRequest.cs
+++ b/src/Core/Dirt/Reports/ReportFeatures/Requests/AddOrganizationReportRequest.cs
@@ -1,4 +1,7 @@
-﻿namespace Bit.Core.Dirt.Reports.ReportFeatures.Requests;
+﻿// FIXME: Update this file to be null safe and then delete the line below
+#nullable disable
+
+namespace Bit.Core.Dirt.Reports.ReportFeatures.Requests;
 
 public class AddOrganizationReportRequest
 {

--- a/src/Core/Dirt/Reports/ReportFeatures/Requests/AddPasswordHealthReportApplicationRequest.cs
+++ b/src/Core/Dirt/Reports/ReportFeatures/Requests/AddPasswordHealthReportApplicationRequest.cs
@@ -1,4 +1,7 @@
-﻿namespace Bit.Core.Dirt.Reports.ReportFeatures.Requests;
+﻿// FIXME: Update this file to be null safe and then delete the line below
+#nullable disable
+
+namespace Bit.Core.Dirt.Reports.ReportFeatures.Requests;
 
 public class AddPasswordHealthReportApplicationRequest
 {

--- a/src/Core/Dirt/Reports/ReportFeatures/Requests/DropOrganizationReportRequest.cs
+++ b/src/Core/Dirt/Reports/ReportFeatures/Requests/DropOrganizationReportRequest.cs
@@ -1,4 +1,7 @@
-﻿namespace Bit.Core.Dirt.Reports.ReportFeatures.Requests;
+﻿// FIXME: Update this file to be null safe and then delete the line below
+#nullable disable
+
+namespace Bit.Core.Dirt.Reports.ReportFeatures.Requests;
 
 public class DropOrganizationReportRequest
 {

--- a/src/Core/Dirt/Reports/ReportFeatures/Requests/DropPasswordHealthReportApplicationRequest.cs
+++ b/src/Core/Dirt/Reports/ReportFeatures/Requests/DropPasswordHealthReportApplicationRequest.cs
@@ -1,4 +1,7 @@
-﻿namespace Bit.Core.Dirt.Reports.ReportFeatures.Requests;
+﻿// FIXME: Update this file to be null safe and then delete the line below
+#nullable disable
+
+namespace Bit.Core.Dirt.Reports.ReportFeatures.Requests;
 
 public class DropPasswordHealthReportApplicationRequest
 {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://contributing.bitwarden.com/architecture/adr/csharp-nullable-reference-types

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Migrate dirt code to have `#nullable disable` so that nullable reference types can be enabled globally.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
