### PR TITLE
[PM-18562] Remove installation-last-activity-date from server

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -189,7 +189,6 @@ public static class FeatureFlagKeys
     public const string PersistPopupView = "persist-popup-view";
     public const string StorageReseedRefactor = "storage-reseed-refactor";
     public const string WebPush = "web-push";
-    public const string RecordInstallationLastActivityDate = "installation-last-activity-date";
     public const string IpcChannelFramework = "ipc-channel-framework";
 
     /* Tools Team */

--- a/src/Identity/IdentityServer/RequestValidators/CustomTokenRequestValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/CustomTokenRequestValidator.cs
@@ -95,11 +95,10 @@ public class CustomTokenRequestValidator : BaseRequestValidator<CustomTokenReque
                 context.Result.CustomResponse = new Dictionary<string, object> { { "encrypted_payload", payload } };
 
             }
-            if (FeatureService.IsEnabled(FeatureFlagKeys.RecordInstallationLastActivityDate)
-                && context.Result.ValidatedRequest.ClientId.StartsWith("installation"))
+            if (context.Result.ValidatedRequest.ClientId.StartsWith("installation"))
             {
                 var installationIdPart = clientId.Split(".")[1];
-                await RecordActivityForInstallation(clientId.Split(".")[1]);
+                await RecordActivityForInstallation(installationIdPart);
             }
             return;
         }

--- a/src/Identity/IdentityServer/RequestValidators/CustomTokenRequestValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/CustomTokenRequestValidator.cs
@@ -97,8 +97,7 @@ public class CustomTokenRequestValidator : BaseRequestValidator<CustomTokenReque
             }
             if (context.Result.ValidatedRequest.ClientId.StartsWith("installation"))
             {
-                var installationIdPart = clientId.Split(".")[1];
-                await RecordActivityForInstallation(installationIdPart);
+                await RecordActivityForInstallation(clientId.Split(".")[1]);
             }
             return;
         }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18562

## 📔 Objective

Remove the `installation-last-activity-date` feature flag from the server.  It has been enabled in Production since February 19, and it is not used on the client.

I also removed the `installationPart` variable since it was not used.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
