### PR TITLE
Improve generated OpenAPI files

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "swashbuckle.aspnetcore.cli": {
-      "version": "7.3.2",
+      "version": "9.0.2",
       "commands": ["swagger"]
     },
     "dotnet-ef": {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
     types: [opened, synchronize]
   workflow_call:
     inputs: {}
-  
+
 permissions:
   contents: read
 
@@ -370,56 +370,17 @@ jobs:
           path: docker-stub-EU.zip
           if-no-files-found: error
 
-      - name: Build Public API Swagger
+      - name: Build Swagger files
         run: |
-          cd ./src/Api
-          echo "Restore tools"
-          dotnet tool restore
-          echo "Publish"
-          dotnet publish -c "Release" -o obj/build-output/publish
-
-          dotnet swagger tofile --output ../../swagger.json --host https://api.bitwarden.com \
-            ./obj/build-output/publish/Api.dll public
-          cd ../..
-        env:
-          ASPNETCORE_ENVIRONMENT: Production
-          swaggerGen: "True"
-          DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX: 2
-          GLOBALSETTINGS__SQLSERVER__CONNECTIONSTRING: "placeholder"
+          cd ./dev
+          powershell ./generate_openapi_files.ps1
 
       - name: Upload Public API Swagger artifact
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: swagger.json
-          path: swagger.json
+          path: api.public.json
           if-no-files-found: error
-
-      - name: Build Internal API Swagger
-        run: |
-          cd ./src/Api
-          echo "Restore API tools"
-          dotnet tool restore
-          echo "Publish API"
-          dotnet publish -c "Release" -o obj/build-output/publish
-
-          dotnet swagger tofile --output ../../internal.json --host https://api.bitwarden.com \
-            ./obj/build-output/publish/Api.dll internal
-
-          cd ../Identity
-
-          echo "Restore Identity tools"
-          dotnet tool restore
-          echo "Publish Identity"
-          dotnet publish -c "Release" -o obj/build-output/publish
-
-          dotnet swagger tofile --output ../../identity.json --host https://identity.bitwarden.com \
-            ./obj/build-output/publish/Identity.dll v1
-          cd ../..
-        env:
-          ASPNETCORE_ENVIRONMENT: Development
-          swaggerGen: "True"
-          DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX: 2
-          GLOBALSETTINGS__SQLSERVER__CONNECTIONSTRING: "placeholder"
 
       - name: Upload Internal API Swagger artifact
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0

--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,7 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# TODO: Comment the next line if you want to checkin your web deploy settings 
+# TODO: Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
 *.publishproj
@@ -225,3 +225,8 @@ src/Notifications/Notifications.zip
 bitwarden_license/src/Portal/Portal.zip
 bitwarden_license/src/Sso/Sso.zip
 **/src/**/flags.json
+
+# Generated swagger specs
+/identity.json
+/api.json
+/api.public.json

--- a/dev/generate_openapi_files.ps1
+++ b/dev/generate_openapi_files.ps1
@@ -1,0 +1,19 @@
+Set-Location "$PSScriptRoot/.."
+
+$env:ASPNETCORE_ENVIRONMENT = "Development"
+$env:swaggerGen = "True"
+$env:DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX = "2"
+$env:GLOBALSETTINGS__SQLSERVER__CONNECTIONSTRING = "placeholder"
+
+dotnet tool restore
+
+# Identity
+Set-Location "./src/Identity"
+dotnet build
+dotnet swagger tofile --output "../../identity.json" --host "https://identity.bitwarden.com" "./bin/Debug/net8.0/Identity.dll" "v1"
+
+# Api internal & public
+Set-Location "../../src/Api"
+dotnet build
+dotnet swagger tofile --output "../../api.json" --host "https://api.bitwarden.com" "./bin/Debug/net8.0/Api.dll" "internal"
+dotnet swagger tofile --output "../../api.public.json" --host "https://api.bitwarden.com" "./bin/Debug/net8.0/Api.dll" "public"

--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="8.0.1" />
     <PackageReference Include="Azure.Messaging.EventGrid" Version="4.25.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -212,7 +212,7 @@ public class Startup
             config.Conventions.Add(new PublicApiControllersModelConvention());
         });
 
-        services.AddSwagger(globalSettings);
+        services.AddSwagger(globalSettings, Environment);
         Jobs.JobsHostedService.AddJobsServices(services, globalSettings.SelfHosted);
         services.AddHostedService<Jobs.JobsHostedService>();
 

--- a/src/Api/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Api/Utilities/ServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ namespace Bit.Api.Utilities;
 
 public static class ServiceCollectionExtensions
 {
-    public static void AddSwagger(this IServiceCollection services, GlobalSettings globalSettings)
+    public static void AddSwagger(this IServiceCollection services, GlobalSettings globalSettings, IWebHostEnvironment environment)
     {
         services.AddSwaggerGen(config =>
         {
@@ -78,6 +78,14 @@ public static class ServiceCollectionExtensions
             // config.UseReferencedDefinitionsForEnums();
 
             config.SchemaFilter<EnumSchemaFilter>();
+            config.SchemaFilter<EncryptedStringSchemaFilter>();
+
+            // These two filters require debug symbols/git, so only add them in development mode
+            if (environment.IsDevelopment())
+            {
+                config.DocumentFilter<GitCommitDocumentFilter>();
+                config.OperationFilter<SourceFileLineOperationFilter>();
+            }
 
             var apiFilePath = Path.Combine(AppContext.BaseDirectory, "Api.xml");
             config.IncludeXmlComments(apiFilePath, true);

--- a/src/Billing/Billing.csproj
+++ b/src/Billing/Billing.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\Core\Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Identity/Startup.cs
+++ b/src/Identity/Startup.cs
@@ -64,10 +64,19 @@ public class Startup
             config.Filters.Add(new ModelStateValidationFilterAttribute());
         });
 
-        services.AddSwaggerGen(c =>
+        services.AddSwaggerGen(config =>
         {
-            c.SchemaFilter<EnumSchemaFilter>();
-            c.SwaggerDoc("v1", new OpenApiInfo { Title = "Bitwarden Identity", Version = "v1" });
+            config.SchemaFilter<EnumSchemaFilter>();
+            config.SchemaFilter<EncryptedStringSchemaFilter>();
+
+            // These two filters require debug symbols/git, so only add them in development mode
+            if (Environment.IsDevelopment())
+            {
+                config.DocumentFilter<GitCommitDocumentFilter>();
+                config.OperationFilter<SourceFileLineOperationFilter>();
+            }
+
+            config.SwaggerDoc("v1", new OpenApiInfo { Title = "Bitwarden Identity", Version = "v1" });
         });
 
         if (!globalSettings.SelfHosted)

--- a/src/SharedWeb/SharedWeb.csproj
+++ b/src/SharedWeb/SharedWeb.csproj
@@ -7,7 +7,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.3.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/SharedWeb/Swagger/EncryptedStringSchemaFilter.cs
+++ b/src/SharedWeb/Swagger/EncryptedStringSchemaFilter.cs
@@ -1,0 +1,37 @@
+using Bit.Core.Utilities;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Bit.SharedWeb.Swagger;
+
+/// <summary>
+///  Set the format of any strings that are decorated with the <see cref="EncryptedStringAttribute"/> to "x-enc-string".
+///  This will allow the generated bindings to use a more appropriate type for encrypted strings.
+/// </summary>
+public class EncryptedStringSchemaFilter : ISchemaFilter
+{
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (context.Type == null || schema.Properties == null)
+            return;
+
+        foreach (var prop in context.Type.GetProperties())
+        {
+            // Only apply to string properties
+            if (prop.PropertyType != typeof(string))
+                continue;
+
+            // Check if the property has the EncryptedString attribute
+            if (prop.GetCustomAttributes(typeof(EncryptedStringAttribute), true).FirstOrDefault() != null)
+            {
+                // Convert prop.Name to camelCase for JSON schema property lookup
+                var jsonPropName = char.ToLowerInvariant(prop.Name[0]) + prop.Name[1..];
+
+                if (schema.Properties.TryGetValue(jsonPropName, out var value))
+                {
+                    value.Format = "x-enc-string";
+                }
+            }
+        }
+    }
+}

--- a/src/SharedWeb/Swagger/GitCommitDocumentFilter.cs
+++ b/src/SharedWeb/Swagger/GitCommitDocumentFilter.cs
@@ -1,0 +1,50 @@
+#nullable enable
+
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Diagnostics;
+
+namespace Bit.SharedWeb.Swagger;
+
+/// <summary>
+/// Add the Git commit that was used to generate the Swagger document, to help with debugging and reproducibility.
+/// </summary>
+public class GitCommitDocumentFilter : IDocumentFilter
+{
+
+    public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+    {
+        if (!string.IsNullOrEmpty(GitCommit))
+        {
+            swaggerDoc.Extensions.Add("x-git-commit", new Microsoft.OpenApi.Any.OpenApiString(GitCommit));
+        }
+    }
+
+    public static string? GitCommit => _gitCommit.Value;
+
+    private static readonly Lazy<string?> _gitCommit = new(() =>
+    {
+        try
+        {
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "git",
+                    Arguments = "rev-parse HEAD",
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+            process.Start();
+            var result = process.StandardOutput.ReadLine()?.Trim();
+            process.WaitForExit();
+            return result ?? string.Empty;
+        }
+        catch
+        {
+            return null;
+        }
+    });
+}

--- a/src/SharedWeb/Swagger/SourceFileLineOperationFilter.cs
+++ b/src/SharedWeb/Swagger/SourceFileLineOperationFilter.cs
@@ -1,0 +1,87 @@
+#nullable enable
+
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Runtime.CompilerServices;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Bit.SharedWeb.Swagger;
+
+/// <summary>
+/// Adds source file and line number information to the Swagger operation description.
+/// This can be useful for locating the source code of the operation in the repository,
+/// as the generated names are based on the HTTP path, and are hard to search for.
+/// </summary>
+public class SourceFileLineOperationFilter : IOperationFilter
+{
+    private static readonly string _gitCommit = GitCommitDocumentFilter.GitCommit ?? "main";
+
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+
+        var (fileName, lineNumber) = GetSourceFileLine(context.MethodInfo);
+        if (fileName != null && lineNumber > 0)
+        {
+            // Add the information with a link to the source file at the end of the operation description
+            operation.Description +=
+                $"\nThis operation is defined on: [`https://github.com/bitwarden/server/blob/{_gitCommit}/{fileName}#L{lineNumber}`]";
+
+            // Also add the information as extensions, so other tools can use it in the future
+            operation.Extensions.Add("x-source-file", new OpenApiString(fileName));
+            operation.Extensions.Add("x-source-line", new OpenApiInteger(lineNumber));
+        }
+    }
+
+    private static (string? fileName, int lineNumber) GetSourceFileLine(MethodInfo methodInfo)
+    {
+        // Get the location of the PDB file associated with the module of the method
+        var pdbPath = Path.ChangeExtension(methodInfo.Module.FullyQualifiedName, ".pdb");
+        if (!File.Exists(pdbPath)) return (null, 0);
+
+        // Open the PDB file and read the metadata
+        using var pdbStream = File.OpenRead(pdbPath);
+        using var metadataReaderProvider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+        var metadataReader = metadataReaderProvider.GetMetadataReader();
+
+        // If the method is async, the compiler will generate a state machine,
+        // so we can't look for the original method, but we instead need to look
+        // for the MoveNext method of the state machine.
+        var attr = methodInfo.GetCustomAttribute<AsyncStateMachineAttribute>();
+        if (attr?.StateMachineType != null)
+        {
+            var moveNext = attr.StateMachineType.GetMethod("MoveNext", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            if (moveNext != null) methodInfo = moveNext;
+        }
+
+        // Once we have the  method, we can get its sequence points
+        var handle = (MethodDefinitionHandle)MetadataTokens.Handle(methodInfo.MetadataToken);
+        if (handle.IsNil) return (null, 0);
+        var sequencePoints = metadataReader.GetMethodDebugInformation(handle).GetSequencePoints();
+
+        // Iterate through the sequence points and pick the first one that has a valid line number
+        foreach (var sp in sequencePoints)
+        {
+            var docName = metadataReader.GetDocument(sp.Document).Name;
+            if (sp.StartLine != 0 && sp.StartLine != SequencePoint.HiddenLine && !docName.IsNil)
+            {
+                var fileName = metadataReader.GetString(docName);
+                var repoRoot = FindRepoRoot(AppContext.BaseDirectory);
+                var relativeFileName = repoRoot != null ? Path.GetRelativePath(repoRoot, fileName) : fileName;
+                return (relativeFileName, sp.StartLine);
+            }
+        }
+
+        return (null, 0);
+    }
+
+    private static string? FindRepoRoot(string startPath)
+    {
+        var dir = new DirectoryInfo(startPath);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, ".git")))
+            dir = dir.Parent;
+        return dir?.FullName;
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Improve the OpenAPI generation experience in a couple of ways:
- Added a new script in the `dev` folder to generate the OpenAPI files in the same way that CI does and the way that the SDK requires. Previously this was documented on [the SDK readme](https://github.com/bitwarden/sdk-internal#api-bindings), but I had to go and look up the commands every single time. This also simplifies the CI workflow.
- Updated swashbuckle to the latest version, technically not needed, but might as well do it while i was playing with the other things.
- Added a couple of filters to modify how the OpenAPI file gets generated:
    - 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
