### PR TITLE
Feature/billing controller tests

### DIFF
--- a/test/Billing.Test/Controllers/AppleControllerTests.cs
+++ b/test/Billing.Test/Controllers/AppleControllerTests.cs
@@ -1,0 +1,72 @@
+using System.Text;
+using Bit.Billing.Controllers;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Billing.Test.Controllers;
+
+[ControllerCustomize(typeof(AppleController))]
+[SutProviderCustomize]
+public class AppleControllerTests
+{
+    [Theory]
+    [BitAutoData]
+    public async Task PostIap_NullHttpContext_BadRequest(SutProvider<AppleController> sutProvider)
+    {
+        sutProvider.Sut.ControllerContext = new ControllerContext
+        {
+            HttpContext = null
+        };
+
+        var response = await sutProvider.Sut.PostIap();
+
+        Assert.IsType<BadRequestResult>(response);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task PostIap_EmptyBody_BadRequest(SutProvider<AppleController> sutProvider)
+    {
+        var billingSettings = new BillingSettings { AppleWebhookKey = "test-key" };
+        sutProvider.GetDependency<IOptions<BillingSettings>>().Value.Returns(billingSettings);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.QueryString = new QueryString("?key=test-key");
+        httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(""));
+
+        sutProvider.Sut.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        var response = await sutProvider.Sut.PostIap();
+
+        Assert.IsType<BadRequestResult>(response);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task PostIap_InvalidJson_BadRequest(SutProvider<AppleController> sutProvider)
+    {
+        var billingSettings = new BillingSettings { AppleWebhookKey = "test-key" };
+        sutProvider.GetDependency<IOptions<BillingSettings>>().Value.Returns(billingSettings);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.QueryString = new QueryString("?key=test-key");
+        httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes("invalid json"));
+
+        sutProvider.Sut.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        var response = await sutProvider.Sut.PostIap();
+
+        Assert.IsType<BadRequestResult>(response);
+    }
+}

--- a/test/Billing.Test/Controllers/AppleControllerTests.cs
+++ b/test/Billing.Test/Controllers/AppleControllerTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using Bit.Billing.Controllers;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;

--- a/test/Billing.Test/Controllers/StripeControllerTests.cs
+++ b/test/Billing.Test/Controllers/StripeControllerTests.cs
@@ -1,0 +1,36 @@
+﻿using System.Text;
+using Bit.Billing.Controllers;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Billing.Test.Controllers;
+
+[ControllerCustomize(typeof(StripeController))]
+[SutProviderCustomize]
+public class StripeControllerTests
+{
+    [Theory]
+    [BitAutoData]
+    public async Task PostWebhook_InvalidWebhookKey_BadRequest(SutProvider<StripeController> sutProvider)
+    {
+        var billingSettings = new BillingSettings { StripeWebhookKey = "correct-key" };
+        sutProvider.GetDependency<IOptions<BillingSettings>>().Value.Returns(billingSettings);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes("{}"));
+
+        sutProvider.Sut.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        var response = await sutProvider.Sut.PostWebhook("definitely-wrong-key");
+
+        Assert.IsType<BadRequestResult>(response);
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

Additional unit testing for the AppleController and StripeController in the Billing modules.

## 📔 Objective

Adding additional unit testing for the Billing Controller module, specifically for Apple IAP and Stripe. These are net new testing suites that are additive and focused on testing invalid inputs to ensure they are handled properly within their respective controllers.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
