### PR TITLE
Add change to enable organization after unlink

### DIFF
--- a/bitwarden_license/src/Commercial.Core/AdminConsole/Providers/RemoveOrganizationFromProviderCommand.cs
+++ b/bitwarden_license/src/Commercial.Core/AdminConsole/Providers/RemoveOrganizationFromProviderCommand.cs
@@ -156,6 +156,7 @@ public class RemoveOrganizationFromProviderCommand : IRemoveOrganizationFromProv
 
             organization.GatewaySubscriptionId = subscription.Id;
             organization.Status = OrganizationStatusType.Created;
+            organization.Enabled = true; // Enable organization when unlinked from provider and new subscription is created
 
             await _providerBillingService.ScaleSeats(provider, organization.PlanType, -organization.Seats ?? 0);
         }

--- a/bitwarden_license/test/Commercial.Core.Test/AdminConsole/ProviderFeatures/RemoveOrganizationFromProviderCommandTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/AdminConsole/ProviderFeatures/RemoveOrganizationFromProviderCommandTests.cs
@@ -263,7 +263,8 @@ public class RemoveOrganizationFromProviderCommandTests
             org =>
                 org.BillingEmail == "a@example.com" &&
                 org.GatewaySubscriptionId == "subscription_id" &&
-                org.Status == OrganizationStatusType.Created));
+                org.Status == OrganizationStatusType.Created &&
+                org.Enabled == true)); // Verify organization is enabled when new subscription is created
 
         await sutProvider.GetDependency<IProviderOrganizationRepository>().Received(1)
             .DeleteAsync(providerOrganization);
@@ -354,7 +355,8 @@ public class RemoveOrganizationFromProviderCommandTests
             org =>
                 org.BillingEmail == "a@example.com" &&
                 org.GatewaySubscriptionId == "subscription_id" &&
-                org.Status == OrganizationStatusType.Created));
+                org.Status == OrganizationStatusType.Created &&
+                org.Enabled == true)); // Verify organization is enabled when new subscription is created
 
         await sutProvider.GetDependency<IProviderOrganizationRepository>().Received(1)
             .DeleteAsync(providerOrganization);
@@ -390,4 +392,62 @@ public class RemoveOrganizationFromProviderCommandTests
                 }
             }
         };
+
+    [Theory, BitAutoData]
+    public async Task RemoveOrganizationFromProvider_DisabledOrganization_ConsolidatedBilling_EnablesOrganization(
+        Provider provider,
+        ProviderOrganization providerOrganization,
+        Organization organization,
+        SutProvider<RemoveOrganizationFromProviderCommand> sutProvider)
+    {
+        // Arrange: Set up a disabled organization that meets the criteria for consolidated billing
+        provider.Status = ProviderStatusType.Billable;
+        providerOrganization.ProviderId = provider.Id;
+        organization.Status = OrganizationStatusType.Managed;
+        organization.PlanType = PlanType.TeamsMonthly;
+        organization.Enabled = false; // Start with a disabled organization
+
+        var teamsMonthlyPlan = StaticStore.GetPlan(PlanType.TeamsMonthly);
+
+        sutProvider.GetDependency<IPricingClient>().GetPlanOrThrow(PlanType.TeamsMonthly).Returns(teamsMonthlyPlan);
+
+        sutProvider.GetDependency<IHasConfirmedOwnersExceptQuery>().HasConfirmedOwnersExceptAsync(
+                providerOrganization.OrganizationId,
+                [],
+                includeProvider: false)
+            .Returns(true);
+
+        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
+
+        organizationRepository.GetOwnerEmailAddressesById(organization.Id).Returns([
+            "owner@example.com"
+        ]);
+
+        var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
+
+        stripeAdapter.CustomerUpdateAsync(organization.GatewayCustomerId, Arg.Any<CustomerUpdateOptions>())
+            .Returns(new Customer
+            {
+                Id = "customer_id",
+                Address = new Address
+                {
+                    Country = "US"
+                }
+            });
+
+        stripeAdapter.SubscriptionCreateAsync(Arg.Any<SubscriptionCreateOptions>()).Returns(new Subscription
+        {
+            Id = "new_subscription_id"
+        });
+
+        // Act
+        await sutProvider.Sut.RemoveOrganizationFromProvider(provider, providerOrganization, organization);
+
+        // Assert: Verify the disabled organization is now enabled
+        await organizationRepository.Received(1).ReplaceAsync(Arg.Is<Organization>(
+            org =>
+                org.Enabled == true && // The previously disabled organization should now be enabled
+                org.Status == OrganizationStatusType.Created &&
+                org.GatewaySubscriptionId == "new_subscription_id"));
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-22967

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

**Enable disabled client organizations when unlinked from provider with new subscription**

**Purpose**
When a client organization is disabled and gets unlinked from their provider with a new subscription created, the organization should be automatically enabled to allow normal operations.

**Problem**
Previously, when unlinking a disabled client organization from a provider and creating a new subscription for them, the organization would remain disabled even though it now had an active subscription and should be operational.

**Solution**

- **Code Change:** Added `organization.Enabled = true` in `RemoveOrganizationFromProviderCommand.ResetOrganizationBillingAsync()` when a new subscription is created during the unlinking process
- **Location:** The change only applies to the consolidated billing path where `provider.IsBillable()` and `organization.IsValidClient()` are true, ensuring precise targeting

**Implementation Details**

- **Minimal Impact:** Single line addition with clear comment explaining the purpose
- **Safe Placement:** Organization changes are persisted via existing `ReplaceAsync` call
- **Preserves Logic:** All existing unlinking functionality remains unchanged

**Testing**

- **Updated existing tests:** Enhanced 2 existing test methods to verify `Enabled = true` in their assertions
- **Added comprehensive test:** New test `RemoveOrganizationFromProvider_DisabledOrganization_ConsolidatedBilling_EnablesOrganization` specifically validates the disabled→enabled transition
- **Coverage:** Tests cover both regular and feature-flag scenarios

**Validation**
    ✅ Disabled organizations are enabled when unlinked with new subscription
    ✅ Normal unlinking functionality preserved
    ✅ Only applies to valid client organizations with billable providers
    ✅ Comprehensive unit test coverage added

**Files Changed**

- `bitwarden_license/src/Commercial.Core/AdminConsole/Providers/RemoveOrganizationFromProviderCommand.cs - Implementation`
- `bitwarden_license/test/Commercial.Core.Test/AdminConsole/ProviderFeatures/RemoveOrganizationFromProviderCommandTests.cs` - Unit tests

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
