### PR TITLE
[PM-23756] Report summary endpoints- mocked

### DIFF
--- a/src/Api/Dirt/Controllers/ReportsController.cs
+++ b/src/Api/Dirt/Controllers/ReportsController.cs
@@ -288,16 +288,25 @@ public class ReportsController : Controller
     /// This is a mock implementation and should be replaced with actual data retrieval logic.
     /// </summary>
     /// <param name="orgId"></param>
+    /// <param name="from">Min date (example: 2023-01-01)</param>
+    /// <param name="to">Max date (example: 2023-12-31)</param>
     /// <returns></returns>
     /// <exception cref="NotFoundException"></exception>
-    [HttpGet("organization-report-summary/latest/{orgId}")]
-    public async Task<IEnumerable<OrganizationReportSummaryModel>> GetOrganizationReportSummary([FromRoute] Guid orgId)
+    [HttpGet("organization-report-summary/{orgId}")]
+    public async Task<IEnumerable<OrganizationReportSummaryModel>> GetOrganizationReportSummary(
+        [FromRoute] Guid orgId,
+        [FromQuery] DateOnly from,
+        [FromQuery] DateOnly to)
     {
         if (!await _currentContext.AccessReports(orgId))
         {
             throw new NotFoundException();
         }
-        return MockOrganizationReportSummary.GetMockData();
+
+        return MockOrganizationReportSummary.GetMockData()
+            .Where(_ => _.OrganizationId == orgId
+                && _.Date >= from.ToDateTime(TimeOnly.MinValue)
+                && _.Date <= to.ToDateTime(TimeOnly.MaxValue));
     }
 
     /// <summary>
@@ -338,28 +347,28 @@ public class ReportsController : Controller
                     OrganizationId = Guid.Parse("cf6cb873-4916-4b2b-aef0-b20d00e7f3e2"),
                     EncryptedData = "2.HvY4fAvbzYV1hqa3255m5Q==|WcKga2Wka5i8fVso8MgjzfBAwxaqdhZDL3bnvhDsisZ0r9lNKQcG3YUQSFpJxr74cgg5QRQaFieCUe2YppciHDT6bsaE2VzFce3cNNB821uTFqnlJClkGJpG1nGvPupdErrg4Ik57WenEzYesmR4pw==|F0aJfF+1MlPm+eAlQnDgFnwfv198N9VtPqFJa4+UFqk=",
                     EncryptionKey = "2.ctMgLN4ycPusbQArG/uiag==|NtqiQsAoUxMSTBQsxAMyVLWdt5lVEUGZQNxZSBU4l76ywH2f6dx5FWFrcF3t3GBqy5yDoc5eBg0VlJDW9coqzp8j9n8h1iMrtmXPyBMAhbc=|pbH+w68BUdUKYCfNRpjd8NENw2lZ0vfxgMuTrsrRCTQ=",
-                    Date = DateTime.UtcNow.AddDays(-1),
+                    Date = DateTime.UtcNow.AddMonths(-1)
                 },
                 new OrganizationReportSummaryModel
                 {
                     OrganizationId = Guid.Parse("cf6cb873-4916-4b2b-aef0-b20d00e7f3e2"),
                     EncryptedData = "2.NH4qLZYUkz/+qpB/mRsLTA==|LEFt05jJz0ngh+Hl5lqk6kebj7lZMefA3eFdL1kLJSGdD3uTOngRwH7GXLQNFeQOxutnLX9YUILbUEPwaM8gCwNQ1KWYdB1Z+Ky4nzKRb60N7L5aTA2za6zXTIdjv7Zwhg0jPZ6sPevTuvSyqjMCuA==|Uuu6gZaF0wvB2mHFwtvHegMxfe8DgsYWTRfGiVn4lkM=",
                     EncryptionKey = "2.3YwG78ykSxAn44NcymdG4w==|4jfn0nLoFielicAFbmq27DNUUjV4SwGePnjYRmOa7hk4pEPnQRS3MsTJFbutVyXOgKFY9Yn2yGFZownY9EmXOMM+gHPD0t6TfzUKqQcRyuI=|wasP9zZEL9mFH5HzJYrMxnKUr/XlFKXCxG9uW66uaPU=",
-                    Date = DateTime.UtcNow.AddDays(-1)
+                    Date = DateTime.UtcNow.AddMonths(-1)
                 },
                 new OrganizationReportSummaryModel
                 {
                     OrganizationId = Guid.Parse("cf6cb873-4916-4b2b-aef0-b20d00e7f3e2"),
                     EncryptedData = "2.YmKWj/707wDPONh+JXPBOw==|Fx4jcUHmnUnSMCU8vdThMSYpDyKPnC09TxpSbNxia0M6MFbd5WHElcVribrYgTENyU0HlqPW43hThJ6xXCM0EjEWP7/jb/0l07vMNkA7sDYq+czf0XnYZgZSGKh06wFVz8xkhaPTdsiO4CXuMsoH+w==|DDVwVFHzdfbPQe3ycCx82eYVHDW97V/eWTPsNpHX/+U=",
                     EncryptionKey = "2.f/U45I7KF+JKfnvOArUyaw==|zNhhS2q2WwBl6SqLWMkxrXC8EX91Ra9LJExywkJhsRbxubRLt7fK+YWc8T1LUaDmMwJ3G8buSPGzyacKX0lnUR33dW6DIaLNgRZ/ekb/zkg=|qFoIZWwS0foiiIOyikFRwQKmmmI2HeyHcOVklJnIILI=",
-                    Date = DateTime.UtcNow.AddDays(-1)
+                    Date = DateTime.UtcNow.AddMonths(-1)
                 },
                 new OrganizationReportSummaryModel
                 {
                     OrganizationId = Guid.Parse("cf6cb873-4916-4b2b-aef0-b20d00e7f3e2"),
                     EncryptedData = "2.WYauwooJUEY3kZsDPphmrA==|oguYW6h10A4GxK4KkRS0X32qSTekU2CkGqNDNGfisUgvJzsyoVTafO9sVcdPdg4BUM7YNkPMjYiKEc5jMHkIgLzbnM27jcGvMJrrccSrLHiWL6/mEiqQkV3TlfiZF9i3wqj1ITsYRzM454uNle6Wrg==|uR67aFYb1i5LSidWib0iTf8091l8GY5olHkVXse3CAw=",
                     EncryptionKey = "2.ZyV9+9A2cxNaf8dfzfbnlA==|hhorBpVkcrrhTtNmd6SNHYI8gPNokGLOC22Vx8Qa/AotDAcyuYWw56zsawMnzpAdJGEJFtszKM2+VUVOcroCTMWHpy8yNf/kZA6uPk3Lz3s=|ASzVeJf+K1ZB8NXuypamRBGRuRq0GUHZBEy5r/O7ORY=",
-                    Date = DateTime.UtcNow.AddDays(-1)
+                    Date = DateTime.UtcNow.AddMonths(-1)
                 },
             };
         }

--- a/src/Api/Dirt/Controllers/ReportsController.cs
+++ b/src/Api/Dirt/Controllers/ReportsController.cs
@@ -334,6 +334,22 @@ public class ReportsController : Controller
         return NoContent();
     }
 
+    [HttpPut("organization-report-summary")]
+    public IActionResult UpdateOrganizationReportSummary([FromBody] OrganizationReportSummaryModel model)
+    {
+        if (!ModelState.IsValid)
+        {
+            throw new BadRequestException(ModelState);
+        }
+
+        GuardOrganizationAccess(model.OrganizationId);
+
+        // TODO: Implement actual update logic
+
+        // Returns 204 No Content as a placeholder
+        return NoContent();
+    }
+
     private void GuardOrganizationAccess(Guid organizationId)
     {
         if (!_currentContext.AccessReports(organizationId).Result)
@@ -342,6 +358,7 @@ public class ReportsController : Controller
         }
     }
 
+    // FIXME: remove this mock class when actual data retrieval is implemented
     private class MockOrganizationReportSummary
     {
         public static List<OrganizationReportSummaryModel> GetMockData()

--- a/src/Api/Dirt/Controllers/ReportsController.cs
+++ b/src/Api/Dirt/Controllers/ReportsController.cs
@@ -10,7 +10,6 @@ using Bit.Core.Dirt.Reports.ReportFeatures.Requests;
 using Bit.Core.Exceptions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Bit.Api.Dirt.Controllers;
 
@@ -299,7 +298,10 @@ public class ReportsController : Controller
         [FromQuery] DateOnly from,
         [FromQuery] DateOnly to)
     {
-        GuardAgainstInvalidModelState(ModelState);
+        if (!ModelState.IsValid)
+        {
+            throw new BadRequestException(ModelState);
+        }
 
         GuardOrganizationAccess(orgId);
 
@@ -319,7 +321,10 @@ public class ReportsController : Controller
     [HttpPost("organization-report-summary")]
     public IActionResult CreateOrganizationReportSummary([FromBody] OrganizationReportSummaryModel model)
     {
-        GuardAgainstInvalidModelState(ModelState);
+        if (!ModelState.IsValid)
+        {
+            throw new BadRequestException(ModelState);
+        }
 
         GuardOrganizationAccess(model.OrganizationId);
 
@@ -327,14 +332,6 @@ public class ReportsController : Controller
 
         // Returns 204 No Content as a placeholder
         return NoContent();
-    }
-
-    private void GuardAgainstInvalidModelState(ModelStateDictionary modelState)
-    {
-        if (!modelState.IsValid)
-        {
-            throw new BadRequestException(modelState);
-        }
     }
 
     private void GuardOrganizationAccess(Guid organizationId)

--- a/src/Api/Dirt/Controllers/ReportsController.cs
+++ b/src/Api/Dirt/Controllers/ReportsController.cs
@@ -305,6 +305,7 @@ public class ReportsController : Controller
 
         GuardOrganizationAccess(orgId);
 
+        // FIXME: remove this mock class when actual data retrieval is implemented
         return MockOrganizationReportSummary.GetMockData()
             .Where(_ => _.OrganizationId == orgId
                 && _.Date >= from.ToDateTime(TimeOnly.MinValue)

--- a/src/Api/Dirt/Controllers/ReportsController.cs
+++ b/src/Api/Dirt/Controllers/ReportsController.cs
@@ -281,4 +281,87 @@ public class ReportsController : Controller
         }
         return await _getOrganizationReportQuery.GetLatestOrganizationReportAsync(orgId);
     }
+
+    /// <summary>
+    /// Gets the Organization Report Summary for an organization.
+    /// This includes the latest report's encrypted data, encryption key, and date.
+    /// This is a mock implementation and should be replaced with actual data retrieval logic.
+    /// </summary>
+    /// <param name="orgId"></param>
+    /// <returns></returns>
+    /// <exception cref="NotFoundException"></exception>
+    [HttpGet("organization-report-summary/latest/{orgId}")]
+    public async Task<IEnumerable<OrganizationReportSummaryModel>> GetOrganizationReportSummary([FromRoute] Guid orgId)
+    {
+        if (!await _currentContext.AccessReports(orgId))
+        {
+            throw new NotFoundException();
+        }
+        return MockOrganizationReportSummary.GetMockData();
+    }
+
+    /// <summary>
+    /// Creates a new Organization Report Summary for an organization.
+    /// This is a mock implementation and should be replaced with actual creation logic.
+    /// </summary>
+    /// <param name="model"></param>
+    /// <returns>Returns 204 Created with the created OrganizationReportSummaryModel</returns>
+    /// <exception cref="NotFoundException"></exception>
+    [HttpPost("organization-report-summary")]
+    public async Task<IActionResult> CreateOrganizationReportSummary([FromBody] OrganizationReportSummaryModel model)
+    {
+        if (!await _currentContext.AccessReports(model.OrganizationId))
+        {
+            throw new NotFoundException();
+        }
+        // TODO: Implement actual creation logic
+
+        // Returns 204 No Content as a placeholder
+        return NoContent();
+    }
+
+    private class MockOrganizationReportSummary
+    {
+        public static List<OrganizationReportSummaryModel> GetMockData()
+        {
+            return new List<OrganizationReportSummaryModel>
+            {
+                new OrganizationReportSummaryModel
+                {
+                    OrganizationId = Guid.Parse("cf6cb873-4916-4b2b-aef0-b20d00e7f3e2"),
+                    EncryptedData = "2.EtCcxDEBoF1MYChYHC4Q1w==|RyZ07R7qEFBbc/ICLFpEMockL9K+PD6rOod6DGHHrkaRLHUDqDwmxbu3jnD0cg8s7GIYmp0jApHXC+82QdApk87pA0Kr8fN2Rj0+8bDQCjhKfoRTipAB25S/n2E+ttjvlFfag92S66XqUH9S/eZw/Q==|0bPfykHk3SqS/biLNcNoYtH6YTstBEKu3AhvdZZLxhU=",
+                    EncryptionKey = "2.Dd/TtdNwxWdYg9+fRkxh6w==|8KAiK9SoadgFRmyVOchd4tNh2vErD1Rv9x1gqtsE5tzxKE/V/5kkr1WuVG+QpEj//YaQt221UEMESRSXicZ7a9cB6xXLBkbbFwmecQRJVBs=|902em44n9cwciZzYrYuX6MRzRa+4hh1HHfNAxyJx/IM=",
+                    Date = DateTime.UtcNow
+                },
+                new OrganizationReportSummaryModel
+                {
+                    OrganizationId = Guid.Parse("cf6cb873-4916-4b2b-aef0-b20d00e7f3e2"),
+                    EncryptedData = "2.HvY4fAvbzYV1hqa3255m5Q==|WcKga2Wka5i8fVso8MgjzfBAwxaqdhZDL3bnvhDsisZ0r9lNKQcG3YUQSFpJxr74cgg5QRQaFieCUe2YppciHDT6bsaE2VzFce3cNNB821uTFqnlJClkGJpG1nGvPupdErrg4Ik57WenEzYesmR4pw==|F0aJfF+1MlPm+eAlQnDgFnwfv198N9VtPqFJa4+UFqk=",
+                    EncryptionKey = "2.ctMgLN4ycPusbQArG/uiag==|NtqiQsAoUxMSTBQsxAMyVLWdt5lVEUGZQNxZSBU4l76ywH2f6dx5FWFrcF3t3GBqy5yDoc5eBg0VlJDW9coqzp8j9n8h1iMrtmXPyBMAhbc=|pbH+w68BUdUKYCfNRpjd8NENw2lZ0vfxgMuTrsrRCTQ=",
+                    Date = DateTime.UtcNow.AddDays(-1),
+                },
+                new OrganizationReportSummaryModel
+                {
+                    OrganizationId = Guid.Parse("cf6cb873-4916-4b2b-aef0-b20d00e7f3e2"),
+                    EncryptedData = "2.NH4qLZYUkz/+qpB/mRsLTA==|LEFt05jJz0ngh+Hl5lqk6kebj7lZMefA3eFdL1kLJSGdD3uTOngRwH7GXLQNFeQOxutnLX9YUILbUEPwaM8gCwNQ1KWYdB1Z+Ky4nzKRb60N7L5aTA2za6zXTIdjv7Zwhg0jPZ6sPevTuvSyqjMCuA==|Uuu6gZaF0wvB2mHFwtvHegMxfe8DgsYWTRfGiVn4lkM=",
+                    EncryptionKey = "2.3YwG78ykSxAn44NcymdG4w==|4jfn0nLoFielicAFbmq27DNUUjV4SwGePnjYRmOa7hk4pEPnQRS3MsTJFbutVyXOgKFY9Yn2yGFZownY9EmXOMM+gHPD0t6TfzUKqQcRyuI=|wasP9zZEL9mFH5HzJYrMxnKUr/XlFKXCxG9uW66uaPU=",
+                    Date = DateTime.UtcNow.AddDays(-1)
+                },
+                new OrganizationReportSummaryModel
+                {
+                    OrganizationId = Guid.Parse("cf6cb873-4916-4b2b-aef0-b20d00e7f3e2"),
+                    EncryptedData = "2.YmKWj/707wDPONh+JXPBOw==|Fx4jcUHmnUnSMCU8vdThMSYpDyKPnC09TxpSbNxia0M6MFbd5WHElcVribrYgTENyU0HlqPW43hThJ6xXCM0EjEWP7/jb/0l07vMNkA7sDYq+czf0XnYZgZSGKh06wFVz8xkhaPTdsiO4CXuMsoH+w==|DDVwVFHzdfbPQe3ycCx82eYVHDW97V/eWTPsNpHX/+U=",
+                    EncryptionKey = "2.f/U45I7KF+JKfnvOArUyaw==|zNhhS2q2WwBl6SqLWMkxrXC8EX91Ra9LJExywkJhsRbxubRLt7fK+YWc8T1LUaDmMwJ3G8buSPGzyacKX0lnUR33dW6DIaLNgRZ/ekb/zkg=|qFoIZWwS0foiiIOyikFRwQKmmmI2HeyHcOVklJnIILI=",
+                    Date = DateTime.UtcNow.AddDays(-1)
+                },
+                new OrganizationReportSummaryModel
+                {
+                    OrganizationId = Guid.Parse("cf6cb873-4916-4b2b-aef0-b20d00e7f3e2"),
+                    EncryptedData = "2.WYauwooJUEY3kZsDPphmrA==|oguYW6h10A4GxK4KkRS0X32qSTekU2CkGqNDNGfisUgvJzsyoVTafO9sVcdPdg4BUM7YNkPMjYiKEc5jMHkIgLzbnM27jcGvMJrrccSrLHiWL6/mEiqQkV3TlfiZF9i3wqj1ITsYRzM454uNle6Wrg==|uR67aFYb1i5LSidWib0iTf8091l8GY5olHkVXse3CAw=",
+                    EncryptionKey = "2.ZyV9+9A2cxNaf8dfzfbnlA==|hhorBpVkcrrhTtNmd6SNHYI8gPNokGLOC22Vx8Qa/AotDAcyuYWw56zsawMnzpAdJGEJFtszKM2+VUVOcroCTMWHpy8yNf/kZA6uPk3Lz3s=|ASzVeJf+K1ZB8NXuypamRBGRuRq0GUHZBEy5r/O7ORY=",
+                    Date = DateTime.UtcNow.AddDays(-1)
+                },
+            };
+        }
+    }
 }

--- a/src/Api/Dirt/Models/Response/OrganizationReportSummaryModel.cs
+++ b/src/Api/Dirt/Models/Response/OrganizationReportSummaryModel.cs
@@ -1,0 +1,9 @@
+﻿namespace Bit.Api.Dirt.Models.Response;
+
+public class OrganizationReportSummaryModel
+{
+    public Guid OrganizationId { get; set; }
+    public required string EncryptedData { get; set; }
+    public required string EncryptionKey { get; set; }
+    public DateTime Date { get; set; }
+}

--- a/test/Api.Test/Dirt/ReportsControllerTests.cs
+++ b/test/Api.Test/Dirt/ReportsControllerTests.cs
@@ -284,7 +284,7 @@ public class ReportsControllerTests
     }
 
     [Theory, BitAutoData]
-    public async Task CreateOrganizationReportSummary_ReturnsNoContent_WhenAccessGranted(SutProvider<ReportsController> sutProvider)
+    public void CreateOrganizationReportSummary_ReturnsNoContent_WhenAccessGranted(SutProvider<ReportsController> sutProvider)
     {
         // Arrange
         var orgId = Guid.NewGuid();
@@ -298,14 +298,14 @@ public class ReportsControllerTests
         sutProvider.GetDependency<ICurrentContext>().AccessReports(orgId).Returns(true);
 
         // Act
-        var result = await sutProvider.Sut.CreateOrganizationReportSummary(model);
+        var result = sutProvider.Sut.CreateOrganizationReportSummary(model);
 
         // Assert
         Assert.IsType<NoContentResult>(result);
     }
 
     [Theory, BitAutoData]
-    public async Task CreateOrganizationReportSummary_ThrowsNotFoundException_WhenAccessDenied(SutProvider<ReportsController> sutProvider)
+    public void CreateOrganizationReportSummary_ThrowsNotFoundException_WhenAccessDenied(SutProvider<ReportsController> sutProvider)
     {
         // Arrange
         var orgId = Guid.NewGuid();
@@ -319,12 +319,12 @@ public class ReportsControllerTests
         sutProvider.GetDependency<ICurrentContext>().AccessReports(orgId).Returns(false);
 
         // Act & Assert
-        await Assert.ThrowsAsync<Bit.Core.Exceptions.NotFoundException>(
+        Assert.Throws<Bit.Core.Exceptions.NotFoundException>(
             () => sutProvider.Sut.CreateOrganizationReportSummary(model));
     }
 
     [Theory, BitAutoData]
-    public async Task GetOrganizationReportSummary_ThrowsNotFoundException_WhenAccessDenied(
+    public void GetOrganizationReportSummary_ThrowsNotFoundException_WhenAccessDenied(
         SutProvider<ReportsController> sutProvider
     )
     {
@@ -334,12 +334,12 @@ public class ReportsControllerTests
         sutProvider.GetDependency<ICurrentContext>().AccessReports(orgId).Returns(false);
 
         // Act & Assert
-        await Assert.ThrowsAsync<Bit.Core.Exceptions.NotFoundException>(
+        Assert.Throws<Bit.Core.Exceptions.NotFoundException>(
             () => sutProvider.Sut.GetOrganizationReportSummary(orgId, DateOnly.FromDateTime(DateTime.UtcNow), DateOnly.FromDateTime(DateTime.UtcNow)));
     }
 
     [Theory, BitAutoData]
-    public async Task GetOrganizationReportSummary_returnsExpectedResult(
+    public void GetOrganizationReportSummary_returnsExpectedResult(
         SutProvider<ReportsController> sutProvider
     )
     {
@@ -354,7 +354,7 @@ public class ReportsControllerTests
         sutProvider.GetDependency<ICurrentContext>().AccessReports(orgId).Returns(true);
 
         // Act
-        var result = await sutProvider.Sut.GetOrganizationReportSummary(orgId, dates[0], dates[1]);
+        var result = sutProvider.Sut.GetOrganizationReportSummary(orgId, dates[0], dates[1]);
 
         // Assert
         Assert.NotNull(result);

--- a/test/Api.Test/Dirt/ReportsControllerTests.cs
+++ b/test/Api.Test/Dirt/ReportsControllerTests.cs
@@ -335,6 +335,28 @@ public class ReportsControllerTests
 
         // Act & Assert
         await Assert.ThrowsAsync<Bit.Core.Exceptions.NotFoundException>(
-            () => sutProvider.Sut.GetOrganizationReportSummary(orgId));
+            () => sutProvider.Sut.GetOrganizationReportSummary(orgId, DateOnly.FromDateTime(DateTime.UtcNow), DateOnly.FromDateTime(DateTime.UtcNow)));
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetOrganizationReportSummary_returnsExpectedResult(
+        SutProvider<ReportsController> sutProvider
+    )
+    {
+        // Arrange
+        var orgId = Guid.NewGuid();
+        var dates = new[]
+        {
+            DateOnly.FromDateTime(DateTime.UtcNow),
+            DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-1))
+        };
+
+        sutProvider.GetDependency<ICurrentContext>().AccessReports(orgId).Returns(true);
+
+        // Act
+        var result = await sutProvider.Sut.GetOrganizationReportSummary(orgId, dates[0], dates[1]);
+
+        // Assert
+        Assert.NotNull(result);
     }
 }

--- a/test/Api.Test/Dirt/ReportsControllerTests.cs
+++ b/test/Api.Test/Dirt/ReportsControllerTests.cs
@@ -359,4 +359,108 @@ public class ReportsControllerTests
         // Assert
         Assert.NotNull(result);
     }
+
+    [Theory, BitAutoData]
+    public void CreateOrganizationReportSummary_ReturnsNoContent_WhenModelIsValidAndAccessGranted(
+            SutProvider<ReportsController> sutProvider
+        )
+    {
+        // Arrange
+        var orgId = Guid.NewGuid();
+        var model = new OrganizationReportSummaryModel
+        {
+            OrganizationId = orgId,
+            EncryptedData = "mock-data",
+            EncryptionKey = "mock-key"
+        };
+        sutProvider.Sut.ModelState.Clear();
+        sutProvider.GetDependency<ICurrentContext>().AccessReports(orgId).Returns(true);
+
+        // Act
+        var result = sutProvider.Sut.CreateOrganizationReportSummary(model);
+
+        // Assert
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Theory, BitAutoData]
+    public void CreateOrganizationReportSummary_ThrowsBadRequestException_WhenModelStateIsInvalid(
+        SutProvider<ReportsController> sutProvider
+    )
+    {
+        // Arrange
+        var orgId = Guid.NewGuid();
+        var model = new OrganizationReportSummaryModel
+        {
+            OrganizationId = orgId,
+            EncryptedData = "mock-data",
+            EncryptionKey = "mock-key"
+        };
+        sutProvider.Sut.ModelState.AddModelError("key", "error");
+
+        // Act & Assert
+        Assert.Throws<BadRequestException>(() => sutProvider.Sut.CreateOrganizationReportSummary(model));
+    }
+
+    [Theory, BitAutoData]
+    public void UpdateOrganizationReportSummary_ReturnsNoContent_WhenModelIsValidAndAccessGranted(
+        SutProvider<ReportsController> sutProvider
+    )
+    {
+        // Arrange
+        var orgId = Guid.NewGuid();
+        var model = new OrganizationReportSummaryModel
+        {
+            OrganizationId = orgId,
+            EncryptedData = "mock-data",
+            EncryptionKey = "mock-key"
+        };
+        sutProvider.Sut.ModelState.Clear();
+        sutProvider.GetDependency<ICurrentContext>().AccessReports(orgId).Returns(true);
+
+        // Act
+        var result = sutProvider.Sut.UpdateOrganizationReportSummary(model);
+
+        // Assert
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Theory, BitAutoData]
+    public void UpdateOrganizationReportSummary_ThrowsBadRequestException_WhenModelStateIsInvalid(
+        SutProvider<ReportsController> sutProvider
+    )
+    {
+        // Arrange
+        var orgId = Guid.NewGuid();
+        var model = new OrganizationReportSummaryModel
+        {
+            OrganizationId = orgId,
+            EncryptedData = "mock-data",
+            EncryptionKey = "mock-key"
+        };
+        sutProvider.Sut.ModelState.AddModelError("key", "error");
+
+        // Act & Assert
+        Assert.Throws<BadRequestException>(() => sutProvider.Sut.UpdateOrganizationReportSummary(model));
+    }
+
+    [Theory, BitAutoData]
+    public void UpdateOrganizationReportSummary_ThrowsNotFoundException_WhenAccessDenied(
+        SutProvider<ReportsController> sutProvider
+    )
+    {
+        // Arrange
+        var orgId = Guid.NewGuid();
+        var model = new OrganizationReportSummaryModel
+        {
+            OrganizationId = orgId,
+            EncryptedData = "mock-data",
+            EncryptionKey = "mock-key"
+        };
+        sutProvider.Sut.ModelState.Clear();
+        sutProvider.GetDependency<ICurrentContext>().AccessReports(orgId).Returns(false);
+
+        // Act & Assert
+        Assert.Throws<NotFoundException>(() => sutProvider.Sut.UpdateOrganizationReportSummary(model));
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23756

## 📔 Objective

To mock up the report controller endpoints for Organization report summary.
The endpoints are required to progress on the client side work.

## 📸 Screenshots

Get Organization Reports
<img width="1498" height="974" alt="image" src="https://github.com/user-attachments/assets/9e3d80cd-7ccc-445e-8d22-d42db25e191f" />


Create Organization Report
<img width="1498" height="974" alt="image" src="https://github.com/user-attachments/assets/707c13ee-87f5-4860-8972-763072aee9c6" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
