### PR TITLE
[PM-23242] Added MasterPasswordUnlock to UserDecryptionOptions as part of identity response

### DIFF
--- a/src/Core/Auth/Models/Api/Response/UserDecryptionOptions.cs
+++ b/src/Core/Auth/Models/Api/Response/UserDecryptionOptions.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text.Json.Serialization;
+using Bit.Core.KeyManagement.Models.Response;
 using Bit.Core.Models.Api;
-
-#nullable enable
 
 namespace Bit.Core.Auth.Models.Api.Response;
 
@@ -14,7 +13,14 @@ public class UserDecryptionOptions : ResponseModel
     /// <summary>
     /// Gets or sets whether the current user has a master password that can be used to decrypt their vault.
     /// </summary>
+    [Obsolete("Use MasterPasswordUnlock instead. This will be removed in a future version.")]
     public bool HasMasterPassword { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the current user has master password unlock data available.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public MasterPasswordUnlockResponseModel? MasterPasswordUnlock { get; set; }
 
     /// <summary>
     /// Gets or sets the WebAuthn PRF decryption keys.

--- a/src/Core/KeyManagement/Models/Response/MasterPasswordUnlockResponseModel.cs
+++ b/src/Core/KeyManagement/Models/Response/MasterPasswordUnlockResponseModel.cs
@@ -1,0 +1,20 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.Enums;
+using Bit.Core.Utilities;
+
+namespace Bit.Core.KeyManagement.Models.Response;
+
+public class MasterPasswordUnlockResponseModel
+{
+    public required MasterPasswordUnlockKdfResponseModel Kdf { get; init; }
+    [EncryptedString] public required string MasterKeyEncryptedUserKey { get; init; }
+    [StringLength(256)] public required string Salt { get; init; }
+}
+
+public class MasterPasswordUnlockKdfResponseModel
+{
+    public required KdfType KdfType { get; init; }
+    public required int Iterations { get; init; }
+    public int? Memory { get; init; }
+    public int? Parallelism { get; init; }
+}

--- a/src/Identity/IdentityServer/UserDecryptionOptionsBuilder.cs
+++ b/src/Identity/IdentityServer/UserDecryptionOptionsBuilder.cs
@@ -5,6 +5,7 @@ using Bit.Core.Auth.Utilities;
 using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
+using Bit.Core.KeyManagement.Models.Response;
 using Bit.Core.Repositories;
 using Bit.Core.Utilities;
 using Bit.Identity.Utilities;
@@ -25,7 +26,7 @@ public class UserDecryptionOptionsBuilder : IUserDecryptionOptionsBuilder
     private readonly ILoginApprovingClientTypes _loginApprovingClientTypes;
 
     private UserDecryptionOptions _options = new UserDecryptionOptions();
-    private User? _user;
+    private User _user = null!;
     private SsoConfig? _ssoConfig;
     private Device? _device;
 
@@ -44,7 +45,6 @@ public class UserDecryptionOptionsBuilder : IUserDecryptionOptionsBuilder
 
     public IUserDecryptionOptionsBuilder ForUser(User user)
     {
-        _options.HasMasterPassword = user.HasMasterPassword();
         _user = user;
         return this;
     }
@@ -72,6 +72,7 @@ public class UserDecryptionOptionsBuilder : IUserDecryptionOptionsBuilder
 
     public async Task<UserDecryptionOptions> BuildAsync()
     {
+        BuildMasterPasswordUnlock();
         BuildKeyConnectorOptions();
         await BuildTrustedDeviceOptions();
 
@@ -101,7 +102,7 @@ public class UserDecryptionOptionsBuilder : IUserDecryptionOptionsBuilder
         }
 
         var isTdeActive = _ssoConfig.GetData() is { MemberDecryptionType: MemberDecryptionType.TrustedDeviceEncryption };
-        var isTdeOffboarding = _user != null && !_user.HasMasterPassword() && _device != null && _device.IsTrusted() && !isTdeActive;
+        var isTdeOffboarding = !_user.HasMasterPassword() && _device != null && _device.IsTrusted() && !isTdeActive;
         if (!isTdeActive && !isTdeOffboarding)
         {
             return;
@@ -116,7 +117,7 @@ public class UserDecryptionOptionsBuilder : IUserDecryptionOptionsBuilder
         }
 
         var hasLoginApprovingDevice = false;
-        if (_device != null && _user != null)
+        if (_device != null)
         {
             var allDevices = await _deviceRepository.GetManyByUserIdAsync(_user.Id);
             // Checks if the current user has any devices that are capable of approving login with device requests except for
@@ -134,16 +135,12 @@ public class UserDecryptionOptionsBuilder : IUserDecryptionOptionsBuilder
             hasManageResetPasswordPermission = await _currentContext.ManageResetPassword(_ssoConfig!.OrganizationId);
         }
 
-        var hasAdminApproval = false;
-        if (_user != null)
-        {
-            // If sso configuration data is not null then I know for sure that ssoConfiguration isn't null
-            var organizationUser = await _organizationUserRepository.GetByOrganizationAsync(_ssoConfig.OrganizationId, _user.Id);
+        // If sso configuration data is not null then I know for sure that ssoConfiguration isn't null
+        var organizationUser = await _organizationUserRepository.GetByOrganizationAsync(_ssoConfig.OrganizationId, _user.Id);
 
-            hasManageResetPasswordPermission |= organizationUser != null && (organizationUser.Type == OrganizationUserType.Owner || organizationUser.Type == OrganizationUserType.Admin);
-            // They are only able to be approved by an admin if they have enrolled is reset password
-            hasAdminApproval = organizationUser != null && !string.IsNullOrEmpty(organizationUser.ResetPasswordKey);
-        }
+        hasManageResetPasswordPermission |= organizationUser != null && (organizationUser.Type == OrganizationUserType.Owner || organizationUser.Type == OrganizationUserType.Admin);
+        // They are only able to be approved by an admin if they have enrolled is reset password
+        var hasAdminApproval = organizationUser != null && !string.IsNullOrEmpty(organizationUser.ResetPasswordKey);
 
         _options.TrustedDeviceOption = new TrustedDeviceUserDecryptionOption(
             hasAdminApproval,
@@ -152,5 +149,29 @@ public class UserDecryptionOptionsBuilder : IUserDecryptionOptionsBuilder
             isTdeOffboarding,
             encryptedPrivateKey,
             encryptedUserKey);
+    }
+
+    private void BuildMasterPasswordUnlock()
+    {
+        if (_user.HasMasterPassword())
+        {
+            _options.HasMasterPassword = true;
+            _options.MasterPasswordUnlock = new MasterPasswordUnlockResponseModel
+            {
+                Kdf = new MasterPasswordUnlockKdfResponseModel
+                {
+                    KdfType = _user.Kdf,
+                    Iterations = _user.KdfIterations,
+                    Memory = _user.KdfMemory,
+                    Parallelism = _user.KdfParallelism
+                },
+                MasterKeyEncryptedUserKey = _user.Key!,
+                Salt = _user.Email.ToLowerInvariant()
+            };
+        }
+        else
+        {
+            _options.HasMasterPassword = false;
+        }
     }
 }

--- a/test/Identity.IntegrationTest/Endpoints/IdentityServerSsoTests.cs
+++ b/test/Identity.IntegrationTest/Endpoints/IdentityServerSsoTests.cs
@@ -36,7 +36,15 @@ public class IdentityServerSsoTests
     public async Task Test_MasterPassword_DecryptionType()
     {
         // Arrange
-        using var responseBody = await RunSuccessTestAsync(MemberDecryptionType.MasterPassword);
+        User? expectedUser = null;
+        using var responseBody = await RunSuccessTestAsync(async factory =>
+        {
+            var database = factory.GetDatabaseContext();
+
+            expectedUser = await database.Users.SingleAsync(u => u.Email == TestEmail);
+            Assert.NotNull(expectedUser);
+        }, MemberDecryptionType.MasterPassword);
+        Assert.NotNull(expectedUser);
 
         // Assert
         // If the organization has a member decryption type of MasterPassword that should be the only option in the reply
@@ -47,13 +55,33 @@ public class IdentityServerSsoTests
         // Expected to look like:
         // "UserDecryptionOptions": {
         //   "Object": "userDecryptionOptions"
-        //   "HasMasterPassword": true
+        //   "HasMasterPassword": true,
+        //   "MasterPasswordUnlock": {
+        //     "Kdf": {
+        //       "KdfType": 0,
+        //       "Iterations": 600000
+        //     },
+        //     "MasterKeyEncryptedUserKey": "2.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA==",
+        //     "Salt": "sso_user@email.com"
+        //   }
         // }
 
         AssertHelper.AssertJsonProperty(userDecryptionOptions, "HasMasterPassword", JsonValueKind.True);
-
-        // One property for the Object and one for master password
-        Assert.Equal(2, userDecryptionOptions.EnumerateObject().Count());
+        var objectString = AssertHelper.AssertJsonProperty(userDecryptionOptions, "Object", JsonValueKind.String).ToString();
+        Assert.Equal("userDecryptionOptions", objectString);
+        var masterPasswordUnlock = AssertHelper.AssertJsonProperty(userDecryptionOptions, "MasterPasswordUnlock", JsonValueKind.Object);
+        // MasterPasswordUnlock.Kdf
+        var kdf = AssertHelper.AssertJsonProperty(masterPasswordUnlock, "Kdf", JsonValueKind.Object);
+        var kdfType = AssertHelper.AssertJsonProperty(kdf, "KdfType", JsonValueKind.Number).GetInt32();
+        Assert.Equal((int)expectedUser.Kdf, kdfType);
+        var kdfIterations = AssertHelper.AssertJsonProperty(kdf, "Iterations", JsonValueKind.Number).GetInt32();
+        Assert.Equal(expectedUser.KdfIterations, kdfIterations);
+        // MasterPasswordUnlock.MasterKeyEncryptedUserKey
+        var masterKeyEncryptedUserKey = AssertHelper.AssertJsonProperty(masterPasswordUnlock, "MasterKeyEncryptedUserKey", JsonValueKind.String).ToString();
+        Assert.Equal(expectedUser.Key, masterKeyEncryptedUserKey);
+        // MasterPasswordUnlock.Salt
+        var salt = AssertHelper.AssertJsonProperty(masterPasswordUnlock, "Salt", JsonValueKind.String).ToString();
+        Assert.Equal(TestEmail, salt);
     }
 
     [Fact]

--- a/test/Identity.IntegrationTest/Endpoints/IdentityServerTests.cs
+++ b/test/Identity.IntegrationTest/Endpoints/IdentityServerTests.cs
@@ -67,7 +67,7 @@ public class IdentityServerTests : IClassFixture<IdentityApplicationFactory>
         Assert.Equal(0, kdf);
         var kdfIterations = AssertHelper.AssertJsonProperty(root, "KdfIterations", JsonValueKind.Number).GetInt32();
         Assert.Equal(AuthConstants.PBKDF2_ITERATIONS.Default, kdfIterations);
-        AssertUserDecryptionOptions(root);
+        AssertUserDecryptionOptions(root, user);
     }
 
     [Theory, RegisterFinishRequestModelCustomize]
@@ -601,14 +601,27 @@ public class IdentityServerTests : IClassFixture<IdentityApplicationFactory>
         Assert.StartsWith("sso authentication", errorDescription.ToLowerInvariant());
     }
 
-    private static void AssertUserDecryptionOptions(JsonElement tokenResponse)
+    private static void AssertUserDecryptionOptions(JsonElement tokenResponse, User expectedUser)
     {
-        var userDecryptionOptions = AssertHelper.AssertJsonProperty(tokenResponse, "UserDecryptionOptions", JsonValueKind.Object)
-            .EnumerateObject();
+        var userDecryptionOptions =
+            AssertHelper.AssertJsonProperty(tokenResponse, "UserDecryptionOptions", JsonValueKind.Object);
 
-        Assert.Collection(userDecryptionOptions,
-            (prop) => { Assert.Equal("HasMasterPassword", prop.Name); Assert.Equal(JsonValueKind.True, prop.Value.ValueKind); },
-            (prop) => { Assert.Equal("Object", prop.Name); Assert.Equal("userDecryptionOptions", prop.Value.GetString()); });
+        AssertHelper.AssertJsonProperty(userDecryptionOptions, "HasMasterPassword", JsonValueKind.True);
+        var objectString = AssertHelper.AssertJsonProperty(userDecryptionOptions, "Object", JsonValueKind.String).ToString();
+        Assert.Equal("userDecryptionOptions", objectString);
+        var masterPasswordUnlock = AssertHelper.AssertJsonProperty(userDecryptionOptions, "MasterPasswordUnlock", JsonValueKind.Object);
+        // MasterPasswordUnlock.Kdf
+        var kdf = AssertHelper.AssertJsonProperty(masterPasswordUnlock, "Kdf", JsonValueKind.Object);
+        var kdfType = AssertHelper.AssertJsonProperty(kdf, "KdfType", JsonValueKind.Number).GetInt32();
+        Assert.Equal((int)expectedUser.Kdf, kdfType);
+        var kdfIterations = AssertHelper.AssertJsonProperty(kdf, "Iterations", JsonValueKind.Number).GetInt32();
+        Assert.Equal(expectedUser.KdfIterations, kdfIterations);
+        // MasterPasswordUnlock.MasterKeyEncryptedUserKey
+        var masterKeyEncryptedUserKey = AssertHelper.AssertJsonProperty(masterPasswordUnlock, "MasterKeyEncryptedUserKey", JsonValueKind.String).ToString();
+        Assert.Equal(expectedUser.Key, masterKeyEncryptedUserKey);
+        // MasterPasswordUnlock.Salt
+        var salt = AssertHelper.AssertJsonProperty(masterPasswordUnlock, "Salt", JsonValueKind.String).ToString();
+        Assert.Equal(expectedUser.Email.ToLower(), salt);
     }
 
     private void ReinitializeDbForTests(IdentityApplicationFactory factory)


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23242

## 📔 Objective

Establishes clear ownership (model owned by KM team) and abstraction of Master Password unlock parameters required for decryption of User Key via master password.

Adds `MasterPasswordUnlock` field into the `UserDecryptionOptions` of the Identity's`/connect/token` successful response.
Note, this is only the case for `password` grant_type identity request.

The content of the new field include all Kdf, Salt and MasterKeyEncryptedUserKey fields. Those allows us to decrypt UserKey with master password.
This consolidates all decryption options into the "UserDecryptionOptions" field, where one of: MP, KC, TDE or WebAuthn decryption options are provided.
Longer term, we might want to clean up the identity response and only rely on `UserDecryptionOptions` for decryption and remove the "Kdf*" and "Key" fields.

Note, we already have`MasterPasswordUnlockData` and `MasterPasswordUnlockDataModel`, but they are used explicitly for Key Rotation (one for request, one for carrying out data for the key rotation service), with fields that are not required for decryption and that are not needed for either identity token or sync responses.

Changes to /sync (Vault owned) PR #6102

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
