### PR TITLE
[PM-22736] Send password hasher

### DIFF
--- a/src/Core/Auth/UserFeatures/PasswordValidation/PasswordValidationConstants.cs
+++ b/src/Core/Auth/UserFeatures/PasswordValidation/PasswordValidationConstants.cs
@@ -1,0 +1,6 @@
+﻿namespace Bit.Core.Auth.PasswordValidation;
+
+public static class PasswordValidationConstants
+{
+    public const int PasswordHasherKdfIterations = 100000;
+}

--- a/src/Core/KeyManagement/Sends/ISendPasswordHasher.cs
+++ b/src/Core/KeyManagement/Sends/ISendPasswordHasher.cs
@@ -1,0 +1,7 @@
+﻿namespace Bit.Core.KeyManagement.Sends;
+
+public interface ISendPasswordHasher
+{
+    bool VerifyPasswordHash(string sendPasswordHash, string inputPasswordHash);
+    string HashPasswordHash(string clientHashedPassword);
+}

--- a/src/Core/KeyManagement/Sends/SendPasswordHasher.cs
+++ b/src/Core/KeyManagement/Sends/SendPasswordHasher.cs
@@ -1,0 +1,29 @@
+﻿using Bit.Core.Entities;
+using Microsoft.AspNetCore.Identity;
+
+namespace Bit.Core.KeyManagement.Sends;
+
+public class SendPasswordHasher(IPasswordHasher<User> passwordHasher) : ISendPasswordHasher
+{
+    /// <summary>
+    /// Verifies an existing send password hash against a new input password hash.
+    /// </summary>
+    public bool VerifyPasswordHash(string sendPasswordHash, string inputPasswordHash)
+    {
+        if (string.IsNullOrWhiteSpace(sendPasswordHash) || string.IsNullOrWhiteSpace(inputPasswordHash))
+        {
+            return false;
+        }
+        var passwordResult = passwordHasher.VerifyHashedPassword(new User(), sendPasswordHash, inputPasswordHash);
+
+        return passwordResult is PasswordVerificationResult.Success or PasswordVerificationResult.SuccessRehashNeeded;
+    }
+
+    /// <summary>
+    /// Accepts a client hashed send password and returns a server hashed password.
+    /// </summary>
+    public string HashPasswordHash(string clientHashedPassword)
+    {
+        return passwordHasher.HashPassword(new User(), clientHashedPassword);
+    }
+}

--- a/src/Core/KeyManagement/Sends/SendPasswordServiceCollectionExtensions.cs
+++ b/src/Core/KeyManagement/Sends/SendPasswordServiceCollectionExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Bit.Core.Auth.PasswordValidation;
+using Bit.Core.Entities;
+using Bit.Core.KeyManagement.Sends;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class SendPasswordServiceCollectionExtensions
+{
+    public static void AddSendPasswordServices(this IServiceCollection services)
+    {
+        services.TryAddScoped<IPasswordHasher<User>, PasswordHasher<User>>();
+        services.Configure<PasswordHasherOptions>(options => options.IterationCount = PasswordValidationConstants.PasswordHasherKdfIterations);
+        services.TryAddScoped<ISendPasswordHasher, SendPasswordHasher>();
+    }
+}

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ using Bit.Core.Auth.Identity.TokenProviders;
 using Bit.Core.Auth.IdentityServer;
 using Bit.Core.Auth.LoginFeatures;
 using Bit.Core.Auth.Models.Business.Tokenables;
+using Bit.Core.Auth.PasswordValidation;
 using Bit.Core.Auth.Repositories;
 using Bit.Core.Auth.Services;
 using Bit.Core.Auth.Services.Implementations;
@@ -381,7 +382,7 @@ public static class ServiceCollectionExtensions
         services.TryAddTransient(typeof(IOtpTokenProvider<>), typeof(OtpTokenProvider<>));
 
         services.AddScoped<IOrganizationDuoUniversalTokenProvider, OrganizationDuoUniversalTokenProvider>();
-        services.Configure<PasswordHasherOptions>(options => options.IterationCount = 100000);
+        services.Configure<PasswordHasherOptions>(options => options.IterationCount = PasswordValidationConstants.PasswordHasherKdfIterations);
         services.Configure<TwoFactorRememberTokenProviderOptions>(options =>
         {
             options.TokenLifespan = TimeSpan.FromDays(30);

--- a/test/Core.Test/KeyManagement/SendPasswordHasherTests.cs
+++ b/test/Core.Test/KeyManagement/SendPasswordHasherTests.cs
@@ -1,0 +1,188 @@
+﻿using Bit.Core.Entities;
+using Bit.Core.KeyManagement.Sends;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Microsoft.AspNetCore.Identity;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.KeyManagement.Sends;
+
+[SutProviderCustomize]
+public class SendPasswordHasherTests
+{
+    [Theory]
+    [BitAutoData(PasswordVerificationResult.Success)]
+    [BitAutoData(PasswordVerificationResult.SuccessRehashNeeded)]
+    public void VerifyPasswordHash_WithValidMatching_ReturnsTrue(
+        PasswordVerificationResult passwordVerificationResult,
+        SutProvider<SendPasswordHasher> sutProvider,
+        string sendPasswordHash,
+        string inputPasswordHash)
+    {
+        // Arrange
+        sutProvider.GetDependency<IPasswordHasher<User>>()
+            .VerifyHashedPassword(Arg.Any<User>(), sendPasswordHash, inputPasswordHash)
+            .Returns(passwordVerificationResult);
+
+        // Act
+        var result = sutProvider.Sut.VerifyPasswordHash(sendPasswordHash, inputPasswordHash);
+
+        // Assert
+        Assert.True(result);
+        sutProvider.GetDependency<IPasswordHasher<User>>()
+            .Received(1)
+            .VerifyHashedPassword(Arg.Any<User>(), sendPasswordHash, inputPasswordHash);
+    }
+
+    [Theory, BitAutoData]
+    public void VerifyPasswordHash_WithNonMatchingPasswords_ReturnsFalse(
+        SutProvider<SendPasswordHasher> sutProvider,
+        string sendPasswordHash,
+        string inputPasswordHash)
+    {
+        // Arrange
+        sutProvider.GetDependency<IPasswordHasher<User>>()
+            .VerifyHashedPassword(Arg.Any<User>(), sendPasswordHash, inputPasswordHash)
+            .Returns(PasswordVerificationResult.Failed);
+
+        // Act
+        var result = sutProvider.Sut.VerifyPasswordHash(sendPasswordHash, inputPasswordHash);
+
+        // Assert
+        Assert.False(result);
+        sutProvider.GetDependency<IPasswordHasher<User>>()
+            .Received(1)
+            .VerifyHashedPassword(Arg.Any<User>(), sendPasswordHash, inputPasswordHash);
+    }
+
+    [Theory]
+    [InlineData(null, "inputPassword")]
+    [InlineData("", "inputPassword")]
+    [InlineData("   ", "inputPassword")]
+    [InlineData("sendPassword", null)]
+    [InlineData("sendPassword", "")]
+    [InlineData("sendPassword", "   ")]
+    [InlineData(null, null)]
+    [InlineData("", "")]
+    public void VerifyPasswordHash_WithNullOrEmptyParameters_ReturnsFalse(
+        string? sendPasswordHash,
+        string? inputPasswordHash)
+    {
+        // Arrange
+        var passwordHasher = Substitute.For<IPasswordHasher<User>>();
+        var sut = new SendPasswordHasher(passwordHasher);
+
+        // Act
+        var result = sut.VerifyPasswordHash(sendPasswordHash, inputPasswordHash);
+
+        // Assert
+        Assert.False(result);
+        passwordHasher.DidNotReceive().VerifyHashedPassword(Arg.Any<User>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Theory, BitAutoData]
+    public void HashPasswordHash_WithValidInput_ReturnsHashedPassword(
+        SutProvider<SendPasswordHasher> sutProvider,
+        string clientHashedPassword,
+        string expectedHashedResult)
+    {
+        // Arrange
+        sutProvider.GetDependency<IPasswordHasher<User>>()
+            .HashPassword(Arg.Any<User>(), clientHashedPassword)
+            .Returns(expectedHashedResult);
+
+        // Act
+        var result = sutProvider.Sut.HashPasswordHash(clientHashedPassword);
+
+        // Assert
+        Assert.Equal(expectedHashedResult, result);
+        sutProvider.GetDependency<IPasswordHasher<User>>()
+            .Received(1)
+            .HashPassword(Arg.Any<User>(), clientHashedPassword);
+    }
+
+    [Theory, BitAutoData]
+    public void HashPasswordHash_CreatesNewUserInstance_ForPasswordHashing(
+        SutProvider<SendPasswordHasher> sutProvider,
+        string clientHashedPassword)
+    {
+        // Arrange
+        User capturedUser = null;
+        sutProvider.GetDependency<IPasswordHasher<User>>()
+            .HashPassword(Arg.Do<User>(u => capturedUser = u), clientHashedPassword)
+            .Returns("hashed_result");
+
+        // Act
+        sutProvider.Sut.HashPasswordHash(clientHashedPassword);
+
+        // Assert
+        Assert.NotNull(capturedUser);
+        Assert.IsType<User>(capturedUser);
+    }
+
+    [Theory, BitAutoData]
+    public void VerifyPasswordHash_CreatesNewUserInstance_ForPasswordVerification(
+        SutProvider<SendPasswordHasher> sutProvider,
+        string sendPasswordHash,
+        string inputPasswordHash)
+    {
+        // Arrange
+        User capturedUser = null;
+        sutProvider.GetDependency<IPasswordHasher<User>>()
+            .VerifyHashedPassword(Arg.Do<User>(u => capturedUser = u), sendPasswordHash, inputPasswordHash)
+            .Returns(PasswordVerificationResult.Success);
+
+        // Act
+        sutProvider.Sut.VerifyPasswordHash(sendPasswordHash, inputPasswordHash);
+
+        // Assert
+        Assert.NotNull(capturedUser);
+        Assert.IsType<User>(capturedUser);
+    }
+
+    [Theory, BitAutoData]
+    public void VerifyPasswordHash_WithMultipleCalls_CreatesNewUserInstanceEachTime(
+        SutProvider<SendPasswordHasher> sutProvider,
+        string sendPasswordHash1,
+        string inputPasswordHash1,
+        string sendPasswordHash2,
+        string inputPasswordHash2)
+    {
+        // Arrange
+        var capturedUsers = new List<User>();
+        sutProvider.GetDependency<IPasswordHasher<User>>()
+            .VerifyHashedPassword(Arg.Do<User>(u => capturedUsers.Add(u)), Arg.Any<string>(), Arg.Any<string>())
+            .Returns(PasswordVerificationResult.Success);
+
+        // Act
+        sutProvider.Sut.VerifyPasswordHash(sendPasswordHash1, inputPasswordHash1);
+        sutProvider.Sut.VerifyPasswordHash(sendPasswordHash2, inputPasswordHash2);
+
+        // Assert
+        Assert.Equal(2, capturedUsers.Count);
+        Assert.NotSame(capturedUsers[0], capturedUsers[1]);
+    }
+
+    [Theory, BitAutoData]
+    // Even when the input is the same, a new User instance should be created each time
+    public void HashPasswordHash_WithMultipleCalls_CreatesNewUserInstanceEachTime(
+        SutProvider<SendPasswordHasher> sutProvider,
+        string clientHashedPassword1,
+        string clientHashedPassword2)
+    {
+        // Arrange
+        var capturedUsers = new List<User>();
+        sutProvider.GetDependency<IPasswordHasher<User>>()
+            .HashPassword(Arg.Do<User>(u => capturedUsers.Add(u)), Arg.Any<string>())
+            .Returns("hashed_result");
+
+        // Act
+        sutProvider.Sut.HashPasswordHash(clientHashedPassword1);
+        sutProvider.Sut.HashPasswordHash(clientHashedPassword2);
+
+        // Assert
+        Assert.Equal(2, capturedUsers.Count);
+        Assert.NotSame(capturedUsers[0], capturedUsers[1]);
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22736](https://bitwarden.atlassian.net/browse/PM-22736)

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This accomplishes enablement work needed to implement the send authorization features. We are using the password hasher that key management has built to help standardize how we manage send password hashing for authorization.

Services are not currently injected anywhere in the code base. They are also not injected into the dependency pipeline but are set up to be injected in the future.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
