### PR TITLE
[PM-23287] Enable Provider When Subscription Is Paid

### DIFF
--- a/src/Billing/Services/Implementations/SubscriptionUpdatedHandler.cs
+++ b/src/Billing/Services/Implementations/SubscriptionUpdatedHandler.cs
@@ -21,13 +21,11 @@ public class SubscriptionUpdatedHandler : ISubscriptionUpdatedHandler
     private readonly IStripeEventService _stripeEventService;
     private readonly IStripeEventUtilityService _stripeEventUtilityService;
     private readonly IOrganizationService _organizationService;
-    private readonly IProviderService _providerService;
     private readonly IStripeFacade _stripeFacade;
     private readonly IOrganizationSponsorshipRenewCommand _organizationSponsorshipRenewCommand;
     private readonly IUserService _userService;
     private readonly IPushNotificationService _pushNotificationService;
     private readonly IOrganizationRepository _organizationRepository;
-    private readonly IProviderRepository _providerRepository;
     private readonly ISchedulerFactory _schedulerFactory;
     private readonly IOrganizationEnableCommand _organizationEnableCommand;
     private readonly IOrganizationDisableCommand _organizationDisableCommand;
@@ -41,13 +39,11 @@ public class SubscriptionUpdatedHandler : ISubscriptionUpdatedHandler
         IStripeEventService stripeEventService,
         IStripeEventUtilityService stripeEventUtilityService,
         IOrganizationService organizationService,
-        IProviderService providerService,
         IStripeFacade stripeFacade,
         IOrganizationSponsorshipRenewCommand organizationSponsorshipRenewCommand,
         IUserService userService,
         IPushNotificationService pushNotificationService,
         IOrganizationRepository organizationRepository,
-        IProviderRepository providerRepository,
         ISchedulerFactory schedulerFactory,
         IOrganizationEnableCommand organizationEnableCommand,
         IOrganizationDisableCommand organizationDisableCommand,

--- a/src/Billing/Services/Implementations/SubscriptionUpdatedHandler.cs
+++ b/src/Billing/Services/Implementations/SubscriptionUpdatedHandler.cs
@@ -190,7 +190,7 @@ public class SubscriptionUpdatedHandler : ISubscriptionUpdatedHandler
 
     /// <summary>
     /// Checks if the provider subscription status has changed from a non-active to an active status type
-    /// If the previous status is already active(active,past-due,trialing) or cancelled, then this will return false.
+    /// If the previous status is already active(active,past-due,trialing),canceled,or null, then this will return false.
     /// </summary>
     /// <param name="parsedEvent">The event containing the previous subscription status</param>
     /// <param name="subscription">The current subscription status</param>
@@ -209,21 +209,12 @@ public class SubscriptionUpdatedHandler : ISubscriptionUpdatedHandler
 
         return previousSubscription?.Status switch
         {
-            null
-                or StripeSubscriptionStatus.Canceled
-                or StripeSubscriptionStatus.Active
-                or StripeSubscriptionStatus.PastDue
-                or StripeSubscriptionStatus.Trialing => false,
-
-            _ => previousSubscription is
-            {
-                Status:
-                     StripeSubscriptionStatus.IncompleteExpired or
-                     StripeSubscriptionStatus.Paused or
-                     StripeSubscriptionStatus.Incomplete or
-                     StripeSubscriptionStatus.Unpaid
-            } &&
-                 subscription.Status == StripeSubscriptionStatus.Active
+            StripeSubscriptionStatus.IncompleteExpired
+                or StripeSubscriptionStatus.Paused
+                or StripeSubscriptionStatus.Incomplete
+                or StripeSubscriptionStatus.Unpaid
+                when subscription.Status == StripeSubscriptionStatus.Active => true,
+            _ => false
         };
     }
 

--- a/src/Billing/Services/Implementations/SubscriptionUpdatedHandler.cs
+++ b/src/Billing/Services/Implementations/SubscriptionUpdatedHandler.cs
@@ -130,6 +130,11 @@ public class SubscriptionUpdatedHandler : ISubscriptionUpdatedHandler
                 }
             case StripeSubscriptionStatus.Active when providerId.HasValue:
                 {
+                    var providerPortalTakeover = _featureService.IsEnabled(FeatureFlagKeys.PM21821_ProviderPortalTakeover);
+                    if (!providerPortalTakeover)
+                    {
+                        break;
+                    }
                     var provider = await _providerRepository.GetByIdAsync(providerId.Value);
                     if (provider != null)
                     {

--- a/test/Billing.Test/Services/SubscriptionUpdatedHandlerTests.cs
+++ b/test/Billing.Test/Services/SubscriptionUpdatedHandlerTests.cs
@@ -34,10 +34,8 @@ public class SubscriptionUpdatedHandlerTests
     private readonly IStripeFacade _stripeFacade;
     private readonly IOrganizationSponsorshipRenewCommand _organizationSponsorshipRenewCommand;
     private readonly IUserService _userService;
-    private readonly IProviderService _providerService;
     private readonly IPushNotificationService _pushNotificationService;
     private readonly IOrganizationRepository _organizationRepository;
-    private readonly IProviderRepository _providerRepository;
     private readonly ISchedulerFactory _schedulerFactory;
     private readonly IOrganizationEnableCommand _organizationEnableCommand;
     private readonly IOrganizationDisableCommand _organizationDisableCommand;
@@ -77,13 +75,11 @@ public class SubscriptionUpdatedHandlerTests
             _stripeEventService,
             _stripeEventUtilityService,
             _organizationService,
-            _providerService,
             _stripeFacade,
             _organizationSponsorshipRenewCommand,
             _userService,
             _pushNotificationService,
             _organizationRepository,
-            _providerRepository,
             _schedulerFactory,
             _organizationEnableCommand,
             _organizationDisableCommand,

--- a/test/Billing.Test/Services/SubscriptionUpdatedHandlerTests.cs
+++ b/test/Billing.Test/Services/SubscriptionUpdatedHandlerTests.cs
@@ -17,6 +17,7 @@ using Bit.Core.Services;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using Quartz;
 using Stripe;
 using Stripe.TestHelpers;
@@ -33,8 +34,10 @@ public class SubscriptionUpdatedHandlerTests
     private readonly IStripeFacade _stripeFacade;
     private readonly IOrganizationSponsorshipRenewCommand _organizationSponsorshipRenewCommand;
     private readonly IUserService _userService;
+    private readonly IProviderService _providerService;
     private readonly IPushNotificationService _pushNotificationService;
     private readonly IOrganizationRepository _organizationRepository;
+    private readonly IProviderRepository _providerRepository;
     private readonly ISchedulerFactory _schedulerFactory;
     private readonly IOrganizationEnableCommand _organizationEnableCommand;
     private readonly IOrganizationDisableCommand _organizationDisableCommand;
@@ -54,8 +57,10 @@ public class SubscriptionUpdatedHandlerTests
         _stripeFacade = Substitute.For<IStripeFacade>();
         _organizationSponsorshipRenewCommand = Substitute.For<IOrganizationSponsorshipRenewCommand>();
         _userService = Substitute.For<IUserService>();
+        _providerService = Substitute.For<IProviderService>();
         _pushNotificationService = Substitute.For<IPushNotificationService>();
         _organizationRepository = Substitute.For<IOrganizationRepository>();
+        _providerRepository = Substitute.For<IProviderRepository>();
         _schedulerFactory = Substitute.For<ISchedulerFactory>();
         _organizationEnableCommand = Substitute.For<IOrganizationEnableCommand>();
         _organizationDisableCommand = Substitute.For<IOrganizationDisableCommand>();
@@ -72,11 +77,13 @@ public class SubscriptionUpdatedHandlerTests
             _stripeEventService,
             _stripeEventUtilityService,
             _organizationService,
+            _providerService,
             _stripeFacade,
             _organizationSponsorshipRenewCommand,
             _userService,
             _pushNotificationService,
             _organizationRepository,
+            _providerRepository,
             _schedulerFactory,
             _organizationEnableCommand,
             _organizationDisableCommand,
@@ -662,5 +669,323 @@ public class SubscriptionUpdatedHandlerTests
         // Assert
         await _stripeFacade.Received(1).DeleteCustomerDiscount(subscription.CustomerId);
         await _stripeFacade.Received(1).DeleteSubscriptionDiscount(subscription.Id);
+    }
+
+    [Theory]
+    [MemberData(nameof(GetNonActiveSubscriptions))]
+    public async Task
+        HandleAsync_ActiveProviderSubscriptionEvent_AndPreviousSubscriptionStatusWasNonActive_EnableProviderAndUpdateSubscription(
+            Subscription previousSubscription)
+    {
+        // Arrange
+        var (providerId, newSubscription, provider, parsedEvent) =
+            CreateProviderTestInputsForUpdatedActiveSubscriptionStatus(previousSubscription);
+
+        _stripeEventService
+            .GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(newSubscription);
+
+        _stripeEventUtilityService
+            .GetIdsFromMetadata(Arg.Any<Dictionary<string, string>>())
+            .Returns(Tuple.Create<Guid?, Guid?, Guid?>(null, null, providerId));
+
+        _providerRepository
+            .GetByIdAsync(Arg.Any<Guid>())
+            .Returns(provider);
+
+        _stripeFacade
+            .UpdateSubscription(Arg.Any<string>(), Arg.Any<SubscriptionUpdateOptions>())
+            .Returns(newSubscription);
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert
+        await _stripeEventService
+            .Received(1)
+            .GetSubscription(parsedEvent, true, Arg.Any<List<string>>());
+        _stripeEventUtilityService
+            .Received(1)
+            .GetIdsFromMetadata(newSubscription.Metadata);
+        await _providerRepository
+            .Received(1)
+            .GetByIdAsync(providerId);
+        await _providerService
+            .Received(1)
+            .UpdateAsync(Arg.Is<Provider>(p => p.Id == providerId && p.Enabled == true));
+        await _stripeFacade
+            .Received(1)
+            .UpdateSubscription(newSubscription.Id,
+                Arg.Is<SubscriptionUpdateOptions>(options => options.CancelAtPeriodEnd == false));
+    }
+
+
+    [Fact]
+    public async Task
+        HandleAsync_ActiveProviderSubscriptionEvent_AndPreviousSubscriptionStatusWasCanceled_EnableProvider()
+    {
+        // Arrange
+        var previousSubscription = new Subscription { Id = "sub_123", Status = StripeSubscriptionStatus.Canceled };
+        var (providerId, newSubscription, provider, parsedEvent) =
+            CreateProviderTestInputsForUpdatedActiveSubscriptionStatus(previousSubscription);
+
+        _stripeEventService
+            .GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(newSubscription);
+        _stripeEventUtilityService
+            .GetIdsFromMetadata(Arg.Any<Dictionary<string, string>>())
+            .Returns(Tuple.Create<Guid?, Guid?, Guid?>(null, null, providerId));
+        _providerRepository
+            .GetByIdAsync(Arg.Any<Guid>())
+            .Returns(provider);
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert
+        await _stripeEventService
+            .Received(1)
+            .GetSubscription(parsedEvent, true, Arg.Any<List<string>>());
+        _stripeEventUtilityService
+            .Received(1)
+            .GetIdsFromMetadata(newSubscription.Metadata);
+        await _providerRepository.Received(1).GetByIdAsync(providerId);
+        await _providerService
+            .Received(1)
+            .UpdateAsync(Arg.Is<Provider>(p => p.Id == providerId && p.Enabled == true));
+        await _stripeFacade
+            .DidNotReceiveWithAnyArgs()
+            .UpdateSubscription(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task
+        HandleAsync_ActiveProviderSubscriptionEvent_AndPreviousSubscriptionStatusWasAlreadyActive_EnableProvider()
+    {
+        // Arrange
+        var previousSubscription = new Subscription { Id = "sub_123", Status = StripeSubscriptionStatus.Active };
+        var (providerId, newSubscription, provider, parsedEvent) =
+            CreateProviderTestInputsForUpdatedActiveSubscriptionStatus(previousSubscription);
+
+        _stripeEventService
+            .GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(newSubscription);
+        _stripeEventUtilityService
+            .GetIdsFromMetadata(Arg.Any<Dictionary<string, string>>())
+            .Returns(Tuple.Create<Guid?, Guid?, Guid?>(null, null, providerId));
+        _providerRepository
+            .GetByIdAsync(Arg.Any<Guid>())
+            .Returns(provider);
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert
+        await _stripeEventService
+            .Received(1)
+            .GetSubscription(parsedEvent, true, Arg.Any<List<string>>());
+        _stripeEventUtilityService
+            .Received(1)
+            .GetIdsFromMetadata(newSubscription.Metadata);
+        await _providerRepository.Received(1).GetByIdAsync(providerId);
+        await _providerService
+            .Received(1)
+            .UpdateAsync(Arg.Is<Provider>(p => p.Id == providerId && p.Enabled == true));
+        await _stripeFacade
+            .DidNotReceiveWithAnyArgs()
+            .UpdateSubscription(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task
+        HandleAsync_ActiveProviderSubscriptionEvent_AndPreviousSubscriptionStatusWasTrailing_EnableProvider()
+    {
+        // Arrange
+        var previousSubscription = new Subscription { Id = "sub_123", Status = StripeSubscriptionStatus.Trialing };
+        var (providerId, newSubscription, provider, parsedEvent) =
+            CreateProviderTestInputsForUpdatedActiveSubscriptionStatus(previousSubscription);
+
+        _stripeEventService
+            .GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(newSubscription);
+        _stripeEventUtilityService
+            .GetIdsFromMetadata(Arg.Any<Dictionary<string, string>>())
+            .Returns(Tuple.Create<Guid?, Guid?, Guid?>(null, null, providerId));
+        _providerRepository
+            .GetByIdAsync(Arg.Any<Guid>())
+            .Returns(provider);
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert
+        await _stripeEventService
+            .Received(1)
+            .GetSubscription(parsedEvent, true, Arg.Any<List<string>>());
+        _stripeEventUtilityService
+            .Received(1)
+            .GetIdsFromMetadata(newSubscription.Metadata);
+        await _providerRepository.Received(1).GetByIdAsync(providerId);
+        await _providerService
+            .Received(1)
+            .UpdateAsync(Arg.Is<Provider>(p => p.Id == providerId && p.Enabled == true));
+        await _stripeFacade
+            .DidNotReceiveWithAnyArgs()
+            .UpdateSubscription(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task
+        HandleAsync_ActiveProviderSubscriptionEvent_AndPreviousSubscriptionStatusWasPastDue_EnableProvider()
+    {
+        // Arrange
+        var previousSubscription = new Subscription { Id = "sub_123", Status = StripeSubscriptionStatus.PastDue };
+        var (providerId, newSubscription, provider, parsedEvent) =
+            CreateProviderTestInputsForUpdatedActiveSubscriptionStatus(previousSubscription);
+
+
+        _stripeEventService
+            .GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(newSubscription);
+        _stripeEventUtilityService
+            .GetIdsFromMetadata(Arg.Any<Dictionary<string, string>>())
+            .Returns(Tuple.Create<Guid?, Guid?, Guid?>(null, null, providerId));
+        _providerRepository
+            .GetByIdAsync(Arg.Any<Guid>())
+            .Returns(provider);
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert
+        await _stripeEventService
+            .Received(1)
+            .GetSubscription(parsedEvent, true, Arg.Any<List<string>>());
+        _stripeEventUtilityService
+            .Received(1)
+            .GetIdsFromMetadata(newSubscription.Metadata);
+        await _providerRepository
+            .Received(1)
+            .GetByIdAsync(Arg.Any<Guid>());
+        await _providerService
+            .Received(1)
+            .UpdateAsync(Arg.Is<Provider>(p => p.Id == providerId && p.Enabled == true));
+        await _stripeFacade
+            .DidNotReceiveWithAnyArgs()
+            .UpdateSubscription(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_ActiveProviderSubscriptionEvent_AndProviderDoesNotExist_NoChanges()
+    {
+        // Arrange
+        var previousSubscription = new Subscription { Id = "sub_123", Status = StripeSubscriptionStatus.Unpaid };
+        var (providerId, newSubscription, _, parsedEvent) =
+            CreateProviderTestInputsForUpdatedActiveSubscriptionStatus(previousSubscription);
+
+        _stripeEventService
+            .GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(newSubscription);
+
+        _stripeEventUtilityService
+            .GetIdsFromMetadata(Arg.Any<Dictionary<string, string>>())
+            .Returns(Tuple.Create<Guid?, Guid?, Guid?>(null, null, providerId));
+
+        _providerRepository
+            .GetByIdAsync(Arg.Any<Guid>())
+            .ReturnsNull();
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert
+        await _stripeEventService
+            .Received(1)
+            .GetSubscription(parsedEvent, true, Arg.Any<List<string>>());
+        _stripeEventUtilityService
+            .Received(1)
+            .GetIdsFromMetadata(newSubscription.Metadata);
+        await _providerRepository
+            .Received(1)
+            .GetByIdAsync(providerId);
+        await _providerService
+            .DidNotReceive()
+            .UpdateAsync(Arg.Any<Provider>());
+        await _stripeFacade
+            .DidNotReceive()
+            .UpdateSubscription(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_ActiveProviderSubscriptionEvent_WithNoPreviousAttributes_EnableProvider()
+    {
+        // Arrange
+        var (providerId, newSubscription, provider, parsedEvent) =
+            CreateProviderTestInputsForUpdatedActiveSubscriptionStatus(null);
+
+        _stripeEventService
+            .GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(newSubscription);
+        _stripeEventUtilityService
+            .GetIdsFromMetadata(Arg.Any<Dictionary<string, string>>())
+            .Returns(Tuple.Create<Guid?, Guid?, Guid?>(null, null, providerId));
+        _providerRepository
+            .GetByIdAsync(Arg.Any<Guid>())
+            .Returns(provider);
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert
+        await _stripeEventService
+            .Received(1)
+            .GetSubscription(parsedEvent, true, Arg.Any<List<string>>());
+        _stripeEventUtilityService
+            .Received(1)
+            .GetIdsFromMetadata(newSubscription.Metadata);
+        await _providerRepository
+            .Received(1)
+            .GetByIdAsync(Arg.Any<Guid>());
+        await _providerService
+            .Received(1)
+            .UpdateAsync(Arg.Is<Provider>(p => p.Id == providerId && p.Enabled == true));
+        await _stripeFacade
+            .DidNotReceive()
+            .UpdateSubscription(Arg.Any<string>());
+    }
+
+    private static (Guid providerId, Subscription newSubscription, Provider provider, Event parsedEvent)
+        CreateProviderTestInputsForUpdatedActiveSubscriptionStatus(Subscription? previousSubscription)
+    {
+        var providerId = Guid.NewGuid();
+        var newSubscription = new Subscription
+        {
+            Id = previousSubscription?.Id ?? "sub_123",
+            Status = StripeSubscriptionStatus.Active,
+            Metadata = new Dictionary<string, string> { { "providerId", providerId.ToString() } },
+        };
+
+        var provider = new Provider { Id = providerId, Enabled = false };
+        var parsedEvent = new Event
+        {
+            Data = new EventData
+            {
+                Object = newSubscription,
+                PreviousAttributes =
+                    previousSubscription == null ? null : JObject.FromObject(previousSubscription)
+            }
+        };
+        return (providerId, newSubscription, provider, parsedEvent);
+    }
+
+    public static IEnumerable<object[]> GetNonActiveSubscriptions()
+    {
+        return new List<object[]>
+        {
+            new object[] { new Subscription { Id = "sub_123", Status = StripeSubscriptionStatus.Unpaid }, },
+            new object[] { new Subscription { Id = "sub_123", Status = StripeSubscriptionStatus.Incomplete }, },
+            new object[] { new Subscription { Id = "sub_123", Status = StripeSubscriptionStatus.IncompleteExpired }, },
+            new object[] { new Subscription { Id = "sub_123", Status = StripeSubscriptionStatus.Paused }, },
+        };
     }
 }

--- a/test/Billing.Test/Services/SubscriptionUpdatedHandlerTests.cs
+++ b/test/Billing.Test/Services/SubscriptionUpdatedHandlerTests.cs
@@ -688,10 +688,11 @@ public class SubscriptionUpdatedHandlerTests
         _providerRepository
             .GetByIdAsync(Arg.Any<Guid>())
             .Returns(provider);
-
         _stripeFacade
             .UpdateSubscription(Arg.Any<string>(), Arg.Any<SubscriptionUpdateOptions>())
             .Returns(newSubscription);
+        _featureService.IsEnabled(FeatureFlagKeys.PM21821_ProviderPortalTakeover)
+            .Returns(true);
 
         // Act
         await _sut.HandleAsync(parsedEvent);
@@ -713,6 +714,9 @@ public class SubscriptionUpdatedHandlerTests
             .Received(1)
             .UpdateSubscription(newSubscription.Id,
                 Arg.Is<SubscriptionUpdateOptions>(options => options.CancelAtPeriodEnd == false));
+        _featureService
+            .Received(1)
+            .IsEnabled(FeatureFlagKeys.PM21821_ProviderPortalTakeover);
     }
 
 
@@ -734,6 +738,8 @@ public class SubscriptionUpdatedHandlerTests
         _providerRepository
             .GetByIdAsync(Arg.Any<Guid>())
             .Returns(provider);
+        _featureService.IsEnabled(FeatureFlagKeys.PM21821_ProviderPortalTakeover)
+            .Returns(true);
 
         // Act
         await _sut.HandleAsync(parsedEvent);
@@ -752,6 +758,9 @@ public class SubscriptionUpdatedHandlerTests
         await _stripeFacade
             .DidNotReceiveWithAnyArgs()
             .UpdateSubscription(Arg.Any<string>());
+        _featureService
+            .Received(1)
+            .IsEnabled(FeatureFlagKeys.PM21821_ProviderPortalTakeover);
     }
 
     [Fact]
@@ -772,6 +781,8 @@ public class SubscriptionUpdatedHandlerTests
         _providerRepository
             .GetByIdAsync(Arg.Any<Guid>())
             .Returns(provider);
+        _featureService.IsEnabled(FeatureFlagKeys.PM21821_ProviderPortalTakeover)
+            .Returns(true);
 
         // Act
         await _sut.HandleAsync(parsedEvent);
@@ -790,6 +801,9 @@ public class SubscriptionUpdatedHandlerTests
         await _stripeFacade
             .DidNotReceiveWithAnyArgs()
             .UpdateSubscription(Arg.Any<string>());
+        _featureService
+            .Received(1)
+            .IsEnabled(FeatureFlagKeys.PM21821_ProviderPortalTakeover);
     }
 
     [Fact]
@@ -810,6 +824,8 @@ public class SubscriptionUpdatedHandlerTests
         _providerRepository
             .GetByIdAsync(Arg.Any<Guid>())
             .Returns(provider);
+        _featureService.IsEnabled(FeatureFlagKeys.PM21821_ProviderPortalTakeover)
+            .Returns(true);
 
         // Act
         await _sut.HandleAsync(parsedEvent);
@@ -828,6 +844,9 @@ public class SubscriptionUpdatedHandlerTests
         await _stripeFacade
             .DidNotReceiveWithAnyArgs()
             .UpdateSubscription(Arg.Any<string>());
+        _featureService
+            .Received(1)
+            .IsEnabled(FeatureFlagKeys.PM21821_ProviderPortalTakeover);
     }
 
     [Fact]
@@ -849,6 +868,8 @@ public class SubscriptionUpdatedHandlerTests
         _providerRepository
             .GetByIdAsync(Arg.Any<Guid>())
             .Returns(provider);
+        _featureService.IsEnabled(FeatureFlagKeys.PM21821_ProviderPortalTakeover)
+            .Returns(true);
 
         // Act
         await _sut.HandleAsync(parsedEvent);
@@ -869,6 +890,9 @@ public class SubscriptionUpdatedHandlerTests
         await _stripeFacade
             .DidNotReceiveWithAnyArgs()
             .UpdateSubscription(Arg.Any<string>());
+        _featureService
+            .Received(1)
+            .IsEnabled(FeatureFlagKeys.PM21821_ProviderPortalTakeover);
     }
 
     [Fact]
@@ -882,14 +906,14 @@ public class SubscriptionUpdatedHandlerTests
         _stripeEventService
             .GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
             .Returns(newSubscription);
-
         _stripeEventUtilityService
             .GetIdsFromMetadata(Arg.Any<Dictionary<string, string>>())
             .Returns(Tuple.Create<Guid?, Guid?, Guid?>(null, null, providerId));
-
         _providerRepository
             .GetByIdAsync(Arg.Any<Guid>())
             .ReturnsNull();
+        _featureService.IsEnabled(FeatureFlagKeys.PM21821_ProviderPortalTakeover)
+            .Returns(true);
 
         // Act
         await _sut.HandleAsync(parsedEvent);
@@ -910,6 +934,9 @@ public class SubscriptionUpdatedHandlerTests
         await _stripeFacade
             .DidNotReceive()
             .UpdateSubscription(Arg.Any<string>());
+        _featureService
+            .Received(1)
+            .IsEnabled(FeatureFlagKeys.PM21821_ProviderPortalTakeover);
     }
 
     [Fact]
@@ -928,6 +955,8 @@ public class SubscriptionUpdatedHandlerTests
         _providerRepository
             .GetByIdAsync(Arg.Any<Guid>())
             .Returns(provider);
+        _featureService.IsEnabled(FeatureFlagKeys.PM21821_ProviderPortalTakeover)
+            .Returns(true);
 
         // Act
         await _sut.HandleAsync(parsedEvent);
@@ -948,6 +977,9 @@ public class SubscriptionUpdatedHandlerTests
         await _stripeFacade
             .DidNotReceive()
             .UpdateSubscription(Arg.Any<string>());
+        _featureService
+            .Received(1)
+            .IsEnabled(FeatureFlagKeys.PM21821_ProviderPortalTakeover);
     }
 
     private static (Guid providerId, Subscription newSubscription, Provider provider, Event parsedEvent)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-23287
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Updates the `SubscriptionUpdateHandler` to re-enable Providers when an update subscription event comes in. This also re-activates the subscription if the subscription status was previously in a non-active state(incomplete, incomplete_expired, unpaid, paused) to an active status by overwriting the `cancel_at_period_end` property.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
