### PR TITLE
[PM-18476] Notifications service unit test coverage with small refactor

### DIFF
--- a/src/Notifications/Controllers/SendController.cs
+++ b/src/Notifications/Controllers/SendController.cs
@@ -1,36 +1,30 @@
-﻿using System.Text;
+﻿#nullable enable
+using System.Text;
 using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.SignalR;
 
-namespace Bit.Notifications;
+namespace Bit.Notifications.Controllers;
 
 [Authorize("Internal")]
 public class SendController : Controller
 {
-    private readonly IHubContext<NotificationsHub> _hubContext;
-    private readonly IHubContext<AnonymousNotificationsHub> _anonymousHubContext;
-    private readonly ILogger<SendController> _logger;
+    private readonly HubHelpers _hubHelpers;
 
-    public SendController(IHubContext<NotificationsHub> hubContext, IHubContext<AnonymousNotificationsHub> anonymousHubContext, ILogger<SendController> logger)
+    public SendController(HubHelpers hubHelpers)
     {
-        _hubContext = hubContext;
-        _anonymousHubContext = anonymousHubContext;
-        _logger = logger;
+        _hubHelpers = hubHelpers;
     }
 
     [HttpPost("~/send")]
     [SelfHosted(SelfHostedOnly = true)]
-    public async Task PostSend()
+    public async Task PostSendAsync()
     {
-        using (var reader = new StreamReader(Request.Body, Encoding.UTF8))
+        using var reader = new StreamReader(Request.Body, Encoding.UTF8);
+        var notificationJson = await reader.ReadToEndAsync();
+        if (!string.IsNullOrWhiteSpace(notificationJson))
         {
-            var notificationJson = await reader.ReadToEndAsync();
-            if (!string.IsNullOrWhiteSpace(notificationJson))
-            {
-                await HubHelpers.SendNotificationToHubAsync(notificationJson, _hubContext, _anonymousHubContext, _logger);
-            }
+            await _hubHelpers.SendNotificationToHubAsync(notificationJson);
         }
     }
 }

--- a/src/Notifications/Startup.cs
+++ b/src/Notifications/Startup.cs
@@ -61,6 +61,7 @@ public class Startup
         }
         services.AddSingleton<IUserIdProvider, SubjectUserIdProvider>();
         services.AddSingleton<ConnectionCounter>();
+        services.AddSingleton<HubHelpers>();
 
         // Mvc
         services.AddMvc();

--- a/test/Notifications.Test/HubHelpersTest.cs
+++ b/test/Notifications.Test/HubHelpersTest.cs
@@ -1,0 +1,250 @@
+﻿#nullable enable
+using System.Text.Json;
+using Bit.Core.Enums;
+using Bit.Core.Models;
+using Bit.Core.Test.NotificationCenter.AutoFixture;
+using Bit.Core.Utilities;
+using Bit.Notifications;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Microsoft.AspNetCore.SignalR;
+using NSubstitute;
+
+namespace Notifications.Test;
+
+[SutProviderCustomize]
+[NotificationCustomize(false)]
+public class HubHelpersTest
+{
+    [Theory]
+    [BitAutoData]
+    public async Task SendNotificationToHubAsync_NotificationPushNotificationGlobal_NothingSent(
+        SutProvider<HubHelpers> sutProvider,
+        NotificationPushNotification notification,
+        string contextId, CancellationToken cancellationToke)
+    {
+        notification.Global = true;
+        notification.InstallationId = null;
+        notification.UserId = null;
+        notification.OrganizationId = null;
+
+        var json = ToNotificationJson(notification, PushType.Notification, contextId);
+        await sutProvider.Sut.SendNotificationToHubAsync(json, cancellationToke);
+
+        sutProvider.GetDependency<IHubContext<NotificationsHub>>().Clients.Received(0).User(Arg.Any<string>());
+        sutProvider.GetDependency<IHubContext<NotificationsHub>>().Clients.Received(0).Group(Arg.Any<string>());
+        sutProvider.GetDependency<IHubContext<AnonymousNotificationsHub>>().Clients.Received(0).User(Arg.Any<string>());
+        sutProvider.GetDependency<IHubContext<AnonymousNotificationsHub>>().Clients.Received(0)
+            .Group(Arg.Any<string>());
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task
+        SendNotificationToHubAsync_NotificationPushNotificationInstallationIdProvidedClientTypeAll_SentToGroupInstallation(
+            SutProvider<HubHelpers> sutProvider,
+            NotificationPushNotification notification,
+            string contextId, CancellationToken cancellationToken)
+    {
+        notification.UserId = null;
+        notification.OrganizationId = null;
+        notification.ClientType = ClientType.All;
+
+        var json = ToNotificationJson(notification, PushType.Notification, contextId);
+        await sutProvider.Sut.SendNotificationToHubAsync(json, cancellationToken);
+
+        sutProvider.GetDependency<IHubContext<NotificationsHub>>().Clients.Received(0).User(Arg.Any<string>());
+        await sutProvider.GetDependency<IHubContext<NotificationsHub>>().Clients.Received(1)
+            .Group($"Installation_{notification.InstallationId!.Value.ToString()}")
+            .Received(1)
+            .SendCoreAsync("ReceiveMessage", Arg.Is<object?[]>(objects =>
+                    objects.Length == 1 && IsNotificationPushNotificationEqual(notification, objects[0],
+                        PushType.Notification, contextId)),
+                cancellationToken);
+        sutProvider.GetDependency<IHubContext<AnonymousNotificationsHub>>().Clients.Received(0).User(Arg.Any<string>());
+        sutProvider.GetDependency<IHubContext<AnonymousNotificationsHub>>().Clients.Received(0)
+            .Group(Arg.Any<string>());
+    }
+
+    [Theory]
+    [BitAutoData(ClientType.Browser)]
+    [BitAutoData(ClientType.Desktop)]
+    [BitAutoData(ClientType.Mobile)]
+    [BitAutoData(ClientType.Web)]
+    public async Task
+        SendNotificationToHubAsync_NotificationPushNotificationInstallationIdProvidedClientTypeNotAll_SentToGroupInstallationClientType(
+            ClientType clientType, SutProvider<HubHelpers> sutProvider,
+            NotificationPushNotification notification,
+            string contextId, CancellationToken cancellationToken)
+    {
+        notification.UserId = null;
+        notification.OrganizationId = null;
+        notification.ClientType = clientType;
+
+        var json = ToNotificationJson(notification, PushType.Notification, contextId);
+        await sutProvider.Sut.SendNotificationToHubAsync(json, cancellationToken);
+
+        sutProvider.GetDependency<IHubContext<NotificationsHub>>().Clients.Received(0).User(Arg.Any<string>());
+        await sutProvider.GetDependency<IHubContext<NotificationsHub>>().Clients.Received(1)
+            .Group($"Installation_ClientType_{notification.InstallationId!.Value}_{clientType}")
+            .Received(1)
+            .SendCoreAsync("ReceiveMessage", Arg.Is<object?[]>(objects =>
+                    objects.Length == 1 && IsNotificationPushNotificationEqual(notification, objects[0],
+                        PushType.Notification, contextId)),
+                cancellationToken);
+        sutProvider.GetDependency<IHubContext<AnonymousNotificationsHub>>().Clients.Received(0).User(Arg.Any<string>());
+        sutProvider.GetDependency<IHubContext<AnonymousNotificationsHub>>().Clients.Received(0)
+            .Group(Arg.Any<string>());
+    }
+
+    [Theory]
+    [BitAutoData(false)]
+    [BitAutoData(true)]
+    public async Task SendNotificationToHubAsync_NotificationPushNotificationUserIdProvidedClientTypeAll_SentToUser(
+        bool organizationIdProvided, SutProvider<HubHelpers> sutProvider,
+        NotificationPushNotification notification,
+        string contextId, CancellationToken cancellationToken)
+    {
+        notification.InstallationId = null;
+        notification.ClientType = ClientType.All;
+        if (!organizationIdProvided)
+        {
+            notification.OrganizationId = null;
+        }
+
+        var json = ToNotificationJson(notification, PushType.Notification, contextId);
+        await sutProvider.Sut.SendNotificationToHubAsync(json, cancellationToken);
+
+        await sutProvider.GetDependency<IHubContext<NotificationsHub>>().Clients.Received(1)
+            .User(notification.UserId!.Value.ToString())
+            .Received(1)
+            .SendCoreAsync("ReceiveMessage", Arg.Is<object?[]>(objects =>
+                    objects.Length == 1 && IsNotificationPushNotificationEqual(notification, objects[0],
+                        PushType.Notification, contextId)),
+                cancellationToken);
+        sutProvider.GetDependency<IHubContext<NotificationsHub>>().Clients.Received(0).Group(Arg.Any<string>());
+        sutProvider.GetDependency<IHubContext<AnonymousNotificationsHub>>().Clients.Received(0).User(Arg.Any<string>());
+        sutProvider.GetDependency<IHubContext<AnonymousNotificationsHub>>().Clients.Received(0)
+            .Group(Arg.Any<string>());
+    }
+
+    [Theory]
+    [BitAutoData(false, ClientType.Browser)]
+    [BitAutoData(false, ClientType.Desktop)]
+    [BitAutoData(false, ClientType.Mobile)]
+    [BitAutoData(false, ClientType.Web)]
+    [BitAutoData(true, ClientType.Browser)]
+    [BitAutoData(true, ClientType.Desktop)]
+    [BitAutoData(true, ClientType.Mobile)]
+    [BitAutoData(true, ClientType.Web)]
+    public async Task
+        SendNotificationToHubAsync_NotificationPushNotificationUserIdProvidedClientTypeNotAll_SentToGroupUserClientType(
+            bool organizationIdProvided, ClientType clientType, SutProvider<HubHelpers> sutProvider,
+            NotificationPushNotification notification,
+            string contextId, CancellationToken cancellationToken)
+    {
+        notification.InstallationId = null;
+        notification.ClientType = clientType;
+        if (!organizationIdProvided)
+        {
+            notification.OrganizationId = null;
+        }
+
+        var json = ToNotificationJson(notification, PushType.Notification, contextId);
+        await sutProvider.Sut.SendNotificationToHubAsync(json, cancellationToken);
+
+        sutProvider.GetDependency<IHubContext<NotificationsHub>>().Clients.Received(0).User(Arg.Any<string>());
+        await sutProvider.GetDependency<IHubContext<NotificationsHub>>().Clients.Received(1)
+            .Group($"UserClientType_{notification.UserId!.Value}_{clientType}")
+            .Received(1)
+            .SendCoreAsync("ReceiveMessage", Arg.Is<object?[]>(objects =>
+                    objects.Length == 1 && IsNotificationPushNotificationEqual(notification, objects[0],
+                        PushType.Notification, contextId)),
+                cancellationToken);
+        sutProvider.GetDependency<IHubContext<AnonymousNotificationsHub>>().Clients.Received(0).User(Arg.Any<string>());
+        sutProvider.GetDependency<IHubContext<AnonymousNotificationsHub>>().Clients.Received(0)
+            .Group(Arg.Any<string>());
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task
+        SendNotificationToHubAsync_NotificationPushNotificationOrganizationIdProvidedClientTypeAll_SentToGroupOrganization(
+            SutProvider<HubHelpers> sutProvider, string contextId,
+            NotificationPushNotification notification,
+            CancellationToken cancellationToken)
+    {
+        notification.UserId = null;
+        notification.InstallationId = null;
+        notification.ClientType = ClientType.All;
+
+        var json = ToNotificationJson(notification, PushType.Notification, contextId);
+        await sutProvider.Sut.SendNotificationToHubAsync(json, cancellationToken);
+
+        sutProvider.GetDependency<IHubContext<NotificationsHub>>().Clients.Received(0).User(Arg.Any<string>());
+        await sutProvider.GetDependency<IHubContext<NotificationsHub>>().Clients.Received(1)
+            .Group($"Organization_{notification.OrganizationId!.Value}")
+            .Received(1)
+            .SendCoreAsync("ReceiveMessage", Arg.Is<object?[]>(objects =>
+                    objects.Length == 1 && IsNotificationPushNotificationEqual(notification, objects[0],
+                        PushType.Notification, contextId)),
+                cancellationToken);
+        sutProvider.GetDependency<IHubContext<AnonymousNotificationsHub>>().Clients.Received(0).User(Arg.Any<string>());
+        sutProvider.GetDependency<IHubContext<AnonymousNotificationsHub>>().Clients.Received(0)
+            .Group(Arg.Any<string>());
+    }
+
+    [Theory]
+    [BitAutoData(ClientType.Browser)]
+    [BitAutoData(ClientType.Desktop)]
+    [BitAutoData(ClientType.Mobile)]
+    [BitAutoData(ClientType.Web)]
+    public async Task
+        SendNotificationToHubAsync_NotificationPushNotificationOrganizationIdProvidedClientTypeNotAll_SentToGroupOrganizationClientType(
+            ClientType clientType, SutProvider<HubHelpers> sutProvider, string contextId,
+            NotificationPushNotification notification,
+            CancellationToken cancellationToken)
+    {
+        notification.UserId = null;
+        notification.InstallationId = null;
+        notification.ClientType = clientType;
+
+        var json = ToNotificationJson(notification, PushType.Notification, contextId);
+        await sutProvider.Sut.SendNotificationToHubAsync(json, cancellationToken);
+
+        sutProvider.GetDependency<IHubContext<NotificationsHub>>().Clients.Received(0).User(Arg.Any<string>());
+        await sutProvider.GetDependency<IHubContext<NotificationsHub>>().Clients.Received(1)
+            .Group($"OrganizationClientType_{notification.OrganizationId!.Value}_{clientType}")
+            .Received(1)
+            .SendCoreAsync("ReceiveMessage", Arg.Is<object?[]>(objects =>
+                    objects.Length == 1 && IsNotificationPushNotificationEqual(notification, objects[0],
+                        PushType.Notification, contextId)),
+                cancellationToken);
+        sutProvider.GetDependency<IHubContext<AnonymousNotificationsHub>>().Clients.Received(0).User(Arg.Any<string>());
+        sutProvider.GetDependency<IHubContext<AnonymousNotificationsHub>>().Clients.Received(0)
+            .Group(Arg.Any<string>());
+    }
+
+    private static string ToNotificationJson(object payload, PushType type, string contextId)
+    {
+        var notification = new PushNotificationData<object>(type, payload, contextId);
+        return JsonSerializer.Serialize(notification, JsonHelpers.IgnoreWritingNull);
+    }
+
+    private static bool IsNotificationPushNotificationEqual(NotificationPushNotification expected, object? actual,
+        PushType type, string contextId)
+    {
+        if (actual is not PushNotificationData<NotificationPushNotification> pushNotificationData)
+        {
+            return false;
+        }
+
+        return pushNotificationData.Type == type &&
+               pushNotificationData.ContextId == contextId &&
+               expected.Id == pushNotificationData.Payload.Id &&
+               expected.UserId == pushNotificationData.Payload.UserId &&
+               expected.OrganizationId == pushNotificationData.Payload.OrganizationId &&
+               expected.ClientType == pushNotificationData.Payload.ClientType &&
+               expected.RevisionDate == pushNotificationData.Payload.RevisionDate;
+    }
+}

--- a/test/Notifications.Test/Notifications.Test.csproj
+++ b/test/Notifications.Test/Notifications.Test.csproj
@@ -18,5 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Notifications\Notifications.csproj" />
+    <ProjectReference Include="..\Common\Common.csproj" />
+    <ProjectReference Include="..\Core.Test\Core.Test.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18476

## 📔 Objective

Adds unit test coverage to Notification's service. Focused on `HubHelpers` class, which holds most of the business logic.
Also refactored the `HubHelpers` to dependency injectable class, which makes testing easier.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
