### PR TITLE
[PM-21821] Enable disabled provider on successful update payment method invocation

### DIFF
--- a/src/Api/Billing/Controllers/VNext/ProviderBillingVNextController.cs
+++ b/src/Api/Billing/Controllers/VNext/ProviderBillingVNextController.cs
@@ -1,8 +1,8 @@
-﻿#nullable enable
-using Bit.Api.Billing.Attributes;
+﻿using Bit.Api.Billing.Attributes;
 using Bit.Api.Billing.Models.Requests.Payment;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
+using Bit.Core.AdminConsole.Services;
 using Bit.Core.Billing.Payment.Commands;
 using Bit.Core.Billing.Payment.Queries;
 using Bit.Core.Utilities;
@@ -19,6 +19,7 @@ public class ProviderBillingVNextController(
     IGetBillingAddressQuery getBillingAddressQuery,
     IGetCreditQuery getCreditQuery,
     IGetPaymentMethodQuery getPaymentMethodQuery,
+    IProviderService providerService,
     IUpdateBillingAddressCommand updateBillingAddressCommand,
     IUpdatePaymentMethodCommand updatePaymentMethodCommand,
     IVerifyBankAccountCommand verifyBankAccountCommand) : BaseBillingController
@@ -82,6 +83,15 @@ public class ProviderBillingVNextController(
     {
         var (paymentMethod, billingAddress) = request.ToDomain();
         var result = await updatePaymentMethodCommand.Run(provider, paymentMethod, billingAddress);
+        // TODO: Temporary until we can send Provider notifications from the Billing API
+        if (!provider.Enabled)
+        {
+            await result.TapAsync(async _ =>
+            {
+                provider.Enabled = true;
+                await providerService.UpdateAsync(provider);
+            });
+        }
         return Handle(result);
     }
 

--- a/src/Core/Billing/Commands/BillingCommandResult.cs
+++ b/src/Core/Billing/Commands/BillingCommandResult.cs
@@ -28,4 +28,10 @@ public class BillingCommandResult<T> : OneOfBase<T, BadRequest, Conflict, Unhand
     public static implicit operator BillingCommandResult<T>(BadRequest badRequest) => new(badRequest);
     public static implicit operator BillingCommandResult<T>(Conflict conflict) => new(conflict);
     public static implicit operator BillingCommandResult<T>(Unhandled unhandled) => new(unhandled);
+
+    public Task TapAsync(Func<T, Task> f) => Match(
+        f,
+        _ => Task.CompletedTask,
+        _ => Task.CompletedTask,
+        _ => Task.CompletedTask);
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-21821

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The technically correct thing to do here and what we'll want to do in the future is manage this using notifications sent from the Billing API to the web client.

But for the sake of expediency, we're going to enable the provider on the trust that the updated payment method made the subscription go active.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
