### PR TITLE
[BRE-917] alpine race condition

### DIFF
--- a/src/Api/entrypoint.sh
+++ b/src/Api/entrypoint.sh
@@ -51,4 +51,7 @@ if [ -f "/etc/bitwarden/kerberos/bitwarden.keytab" ] && [ -f "/etc/bitwarden/ker
     $gosu_cmd kinit $globalSettings__kerberosUser -k -t /etc/bitwarden/kerberos/bitwarden.keytab
 fi
 
+# Sleep to account for Alpine faster start times, allowing container to initialize before .NET runtime
+sleep 3
+
 exec $gosu_cmd /app/Api

--- a/src/Events/entrypoint.sh
+++ b/src/Events/entrypoint.sh
@@ -51,4 +51,7 @@ if [ -f "/etc/bitwarden/kerberos/bitwarden.keytab" ] && [ -f "/etc/bitwarden/ker
     $gosu_cmd kinit $globalSettings__kerberosUser -k -t /etc/bitwarden/kerberos/bitwarden.keytab
 fi
 
+# Sleep to account for Alpine faster start times, allowing container to initialize before .NET runtime
+sleep 3
+
 exec $gosu_cmd /app/Events

--- a/src/Identity/entrypoint.sh
+++ b/src/Identity/entrypoint.sh
@@ -57,4 +57,7 @@ if [ "$globalSettings__selfHosted" = "true" ]; then
     fi
 fi
 
+# Sleep to account for Alpine faster start times, allowing container to initialize before .NET runtime
+sleep 3
+
 exec $gosu_cmd /app/Identity


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-917](https://bitwarden.atlassian.net/browse/BRE-917)
## 📔 Objective

I was observing what appears to be an alpine race condition during deployments. Events, API and Identity would throw service bus errors, the container restarts and then the second container continues without issue. This was the least invasive fix I found to account for the faster alpine start times compared to our previous debian based images
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes