### PR TITLE
[BRE-1058] fix alpine race condition

### DIFF
--- a/src/EventsProcessor/AzureQueueHostedService.cs
+++ b/src/EventsProcessor/AzureQueueHostedService.cs
@@ -101,6 +101,8 @@ public class AzureQueueHostedService : IHostedService, IDisposable
                 }
                 catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
+                    // comment for build difference
+                    // remove after testing
                     _logger.LogDebug("Task.Delay cancelled during Alpine container shutdown");
                     break;
                 }

--- a/src/EventsProcessor/AzureQueueHostedService.cs
+++ b/src/EventsProcessor/AzureQueueHostedService.cs
@@ -101,8 +101,6 @@ public class AzureQueueHostedService : IHostedService, IDisposable
                 }
                 catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    // comment for build difference
-                    // remove after testing
                     _logger.LogDebug("Task.Delay cancelled during Alpine container shutdown");
                     break;
                 }

--- a/src/EventsProcessor/AzureQueueHostedService.cs
+++ b/src/EventsProcessor/AzureQueueHostedService.cs
@@ -86,10 +86,9 @@ public class AzureQueueHostedService : IHostedService, IDisposable
                     await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
                 }
             }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                // Normal cancellation during Alpine container shutdown
-                _logger.LogDebug("Azure Queue processing cancelled during shutdown");
+                _logger.LogDebug("Task.Delay cancelled during Alpine container shutdown");
                 break;
             }
             catch (Exception ex)
@@ -100,9 +99,9 @@ public class AzureQueueHostedService : IHostedService, IDisposable
                 {
                     await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
                 }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    // Shutdown during error retry delay - exit gracefully
+                    _logger.LogDebug("Task.Delay cancelled during Alpine container shutdown");
                     break;
                 }
             }

--- a/src/Notifications/AzureQueueHostedService.cs
+++ b/src/Notifications/AzureQueueHostedService.cs
@@ -87,6 +87,12 @@ public class AzureQueueHostedService : IHostedService, IDisposable
                     await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
                 }
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Normal cancellation during Alpine container shutdown
+                _logger.LogDebug("Azure Queue processing cancelled during shutdown");
+                break;
+            }
             catch (Exception e)
             {
                 _logger.LogError(e, "Error processing messages.");

--- a/src/Notifications/AzureQueueHostedService.cs
+++ b/src/Notifications/AzureQueueHostedService.cs
@@ -87,10 +87,9 @@ public class AzureQueueHostedService : IHostedService, IDisposable
                     await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
                 }
             }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                // Normal cancellation during Alpine container shutdown
-                _logger.LogDebug("Azure Queue processing cancelled during shutdown");
+                _logger.LogDebug("Task.Delay cancelled during Alpine container shutdown");
                 break;
             }
             catch (Exception e)


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-1058](https://bitwarden.atlassian.net/browse/BRE-1058)
## 📔 Objective

detailed at length in the ticket, but I was seeing bursts of errors on shutdown after the switch to alpine containers. After debugging arrived at these to resolve the issues
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes

[BRE-1058]: https://bitwarden.atlassian.net/browse/BRE-1058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ