### PR TITLE
Temporarily hold SARIF uploads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,12 +275,12 @@ jobs:
           fail-build: false
           output-format: sarif
 
-      - name: Upload Grype results to GitHub
-        uses: github/codeql-action/upload-sarif@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
-        with:
-          sarif_file: ${{ steps.container-scan.outputs.sarif }}
-          sha: ${{ contains(github.event_name, 'pull_request') && github.event.pull_request.head.sha || github.sha }}
-          ref: ${{ contains(github.event_name, 'pull_request') && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
+#      - name: Upload Grype results to GitHub
+#        uses: github/codeql-action/upload-sarif@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
+#        with:
+#          sarif_file: ${{ steps.container-scan.outputs.sarif }}
+#          sha: ${{ contains(github.event_name, 'pull_request') && github.event.pull_request.head.sha || github.sha }}
+#          ref: ${{ contains(github.event_name, 'pull_request') && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -38,6 +38,8 @@ jobs:
       pull-requests: write
       security-events: write
       id-token: write
+    with:
+      upload-sarif: false
 
   quality:
     name: Sonar


### PR DESCRIPTION
## 🎟️ Tracking

Working through appsec issues

## 📔 Objective

Temporarily hold SARIF uploads for:
* Grype
* Checkmarx

This should temporarily stop these tools from uploading to Github Advanced Security, so that we can manage existing entries. This commit will then be reverted after GHAS is in a proper state.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
