### PR TITLE
[PM-24509] Remove the citation limit from Onyx calls

### DIFF
--- a/src/Billing/Models/OnyxAnswerWithCitationRequestModel.cs
+++ b/src/Billing/Models/OnyxAnswerWithCitationRequestModel.cs
@@ -45,9 +45,6 @@ public class RetrievalOptions
 
     [JsonPropertyName("real_time")]
     public bool RealTime { get; set; } = true;
-
-    [JsonPropertyName("limit")]
-    public int? Limit { get; set; } = 3;
 }
 
 public class RetrievalOptionsRunSearch


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-24509

## 📔 Objective

The `limit` parameter to Onyx needs to be removed.
It seems like limiting the number of documents to search from degrades the quality of the result

## 📸 Screenshots

None at this time

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
