### PR TITLE
[PM-24051] UserDecryption response model tagged with sdk-wasm in OpenApi generated schema

### DIFF
--- a/src/Api/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Api/Utilities/ServiceCollectionExtensions.cs
@@ -83,6 +83,7 @@ public static class ServiceCollectionExtensions
             // config.UseReferencedDefinitionsForEnums();
 
             config.SchemaFilter<EnumSchemaFilter>();
+            config.SchemaFilter<SdkWasmSchemaFilter>();
 
             var apiFilePath = Path.Combine(AppContext.BaseDirectory, "Api.xml");
             config.IncludeXmlComments(apiFilePath, true);

--- a/src/Core/KeyManagement/Models/Response/MasterPasswordUnlockResponseModel.cs
+++ b/src/Core/KeyManagement/Models/Response/MasterPasswordUnlockResponseModel.cs
@@ -6,15 +6,15 @@ namespace Bit.Core.KeyManagement.Models.Response;
 
 public class MasterPasswordUnlockResponseModel
 {
-    public required MasterPasswordUnlockKdfResponseModel Kdf { get; init; }
-    [EncryptedString] public required string MasterKeyEncryptedUserKey { get; init; }
-    [StringLength(256)] public required string Salt { get; init; }
+    [Required] public required MasterPasswordUnlockKdfResponseModel Kdf { get; init; }
+    [Required][EncryptedString] public required string MasterKeyEncryptedUserKey { get; init; }
+    [Required][StringLength(256)] public required string Salt { get; init; }
 }
 
 public class MasterPasswordUnlockKdfResponseModel
 {
-    public required KdfType KdfType { get; init; }
-    public required int Iterations { get; init; }
+    [Required] public required KdfType KdfType { get; init; }
+    [Required] public required int Iterations { get; init; }
     public int? Memory { get; init; }
     public int? Parallelism { get; init; }
 }

--- a/src/Identity/Startup.cs
+++ b/src/Identity/Startup.cs
@@ -67,6 +67,7 @@ public class Startup
         services.AddSwaggerGen(c =>
         {
             c.SchemaFilter<EnumSchemaFilter>();
+            c.SchemaFilter<SdkWasmSchemaFilter>();
             c.SwaggerDoc("v1", new OpenApiInfo { Title = "Bitwarden Identity", Version = "v1" });
         });
 

--- a/src/SharedWeb/Swagger/EnumSchemaFilter.cs
+++ b/src/SharedWeb/Swagger/EnumSchemaFilter.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.OpenApi.Any;
+﻿using Bit.Core.KeyManagement.Models.Response;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -21,6 +22,26 @@ public class EnumSchemaFilter : ISchemaFilter
             var array = new OpenApiArray();
             array.AddRange(Enum.GetNames(context.Type).Select(n => new OpenApiString(n)));
             schema.Extensions.Add("x-enum-varnames", array);
+        }
+    }
+}
+
+/// <summary>
+/// Adds x-sdk-wasm extension into the models that are used in the Bitwarden WASM SDK.
+/// </summary>
+public class SdkWasmSchemaFilter : ISchemaFilter
+{
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        var sdkWasmTypes = new[]
+        {
+            typeof(UserDecryptionResponseModel), typeof(MasterPasswordUnlockResponseModel),
+            typeof(MasterPasswordUnlockKdfResponseModel)
+        };
+
+        if (sdkWasmTypes.Contains(context.Type))
+        {
+            schema.Extensions.Add("x-sdk-wasm", new OpenApiBoolean(true));
         }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-24051

## 📔 Objective

UserDecryption response model tagged with sdk-wasm in OpenApi generated schema.
This is easier than manually post-processing the generated json schema before generating Rust models.
See https://github.com/bitwarden/sdk-internal/pull/376 for example usage.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
