### PR TITLE
Adding concurrency rate limiter to scim endpoint.

### DIFF
--- a/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
+++ b/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
@@ -11,6 +11,7 @@ using Bit.Scim.Users.Interfaces;
 using Bit.Scim.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 
 namespace Bit.Scim.Controllers.v2;
 
@@ -73,6 +74,7 @@ public class UsersController : Controller
     }
 
     [HttpPost("")]
+    [EnableRateLimiting(ScimConcurrencyRateLimiter.PolicyName)]
     public async Task<IActionResult> Post(Guid organizationId, [FromBody] ScimUserRequestModel model)
     {
         var orgUser = await _postUserCommand.PostUserAsync(organizationId, model);

--- a/bitwarden_license/src/Scim/Utilities/ScimConcurrencyRateLimiter.cs
+++ b/bitwarden_license/src/Scim/Utilities/ScimConcurrencyRateLimiter.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.RateLimiting;
+using Bit.Core.AdminConsole.Authorization;
+
+namespace Bit.Scim.Utilities;
+
+public static class ScimConcurrencyRateLimiter
+{
+    public const string PolicyName = "ScimConcurrencyLimiter";
+
+    public static IServiceCollection AddScimConcurrencyRateLimiter(this IServiceCollection services) =>
+        services.AddRateLimiter(options => options.AddPolicy(PolicyName, context =>
+            RateLimitPartition.GetConcurrencyLimiter(context.GetOrganizationId(),
+                factory: _ => new ConcurrencyLimiterOptions
+                {
+                    PermitLimit = int.MaxValue, // How much do we want in memory
+                    QueueLimit = 1,
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst
+                })
+        ));
+}

--- a/bitwarden_license/src/Scim/Utilities/ScimConcurrencyRateLimiter.cs
+++ b/bitwarden_license/src/Scim/Utilities/ScimConcurrencyRateLimiter.cs
@@ -12,8 +12,8 @@ public static class ScimConcurrencyRateLimiter
             RateLimitPartition.GetConcurrencyLimiter(context.GetOrganizationId(),
                 factory: _ => new ConcurrencyLimiterOptions
                 {
-                    PermitLimit = int.MaxValue, // How much do we want in memory
-                    QueueLimit = 1,
+                    PermitLimit = 1,
+                    QueueLimit = int.MaxValue,
                     QueueProcessingOrder = QueueProcessingOrder.OldestFirst
                 })
         ));

--- a/bitwarden_license/test/Scim.IntegrationTest/Factories/ScimApplicationFactory.cs
+++ b/bitwarden_license/test/Scim.IntegrationTest/Factories/ScimApplicationFactory.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using Bit.Core.Billing.Enums;
 using Bit.Core.Services;
 using Bit.Infrastructure.EntityFramework.AdminConsole.Models;
 using Bit.Infrastructure.EntityFramework.Repositories;
@@ -27,6 +28,7 @@ public class ScimApplicationFactory : WebApplicationFactoryBase<Startup>
     public static readonly Guid TestGroupId2 = Guid.Parse("562e5371-7020-40b6-b092-099ac66dbdf9");
     public static readonly Guid TestGroupId3 = Guid.Parse("362c2782-0f1f-4c86-95dd-edbdf7d6040b");
     public static readonly Guid TestOrganizationId1 = Guid.Parse("fb98e04f-0303-4914-9b37-a983943bf1ca");
+    public static readonly Guid TestOrganizationId2 = Guid.Parse("f47ac10b-58cc-4372-a567-0e02b2c3d479");
     public static readonly Guid TestOrganizationUserId1 = Guid.Parse("5d421196-8c59-485b-8926-2d6d0101e05f");
     public static readonly Guid TestOrganizationUserId2 = Guid.Parse("3a63d520-0d84-4679-b887-13fe2058d53b");
     public static readonly Guid TestOrganizationUserId3 = Guid.Parse("be2f9045-e2b6-4173-ad44-4c69c3ea8140");
@@ -203,7 +205,11 @@ public class ScimApplicationFactory : WebApplicationFactoryBase<Startup>
                 Name = "Test Organization 1",
                 BillingEmail = $"billing-email+{TestOrganizationId1}@example.com",
                 UseGroups = true,
+                PlanType = PlanType.EnterpriseAnnually2023,
                 Plan = "Enterprise",
+                Seats = 2,
+                GatewaySubscriptionId = "Not Null",
+                GatewayCustomerId = "Not null"
             },
         };
     }

--- a/src/Api/AdminConsole/Authorization/HttpContextExtensions.cs
+++ b/src/Api/AdminConsole/Authorization/HttpContextExtensions.cs
@@ -58,30 +58,4 @@ public static class HttpContextExtensions
         Guid userId)
         => await httpContext.WithFeaturesCacheAsync(() =>
             providerUserRepository.GetManyOrganizationDetailsByUserAsync(userId, ProviderUserStatusType.Confirmed));
-
-
-    /// <summary>
-    /// Parses the {orgId} or {organizationId} route parameter into a Guid, or throws if neither are present or are not valid guids.
-    /// </summary>
-    /// <param name="httpContext"></param>
-    /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
-    public static Guid GetOrganizationId(this HttpContext httpContext)
-    {
-        var routeValues = httpContext.GetRouteData().Values;
-
-        routeValues.TryGetValue("orgId", out var orgIdParam);
-        if (orgIdParam != null && Guid.TryParse(orgIdParam.ToString(), out var orgId))
-        {
-            return orgId;
-        }
-
-        routeValues.TryGetValue("organizationId", out var organizationIdParam);
-        if (organizationIdParam != null && Guid.TryParse(organizationIdParam.ToString(), out var organizationId))
-        {
-            return organizationId;
-        }
-
-        throw new InvalidOperationException(NoOrgIdError);
-    }
 }

--- a/src/Api/AdminConsole/Authorization/OrganizationRequirementHandler.cs
+++ b/src/Api/AdminConsole/Authorization/OrganizationRequirementHandler.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using Bit.Core.AdminConsole.Authorization;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Services;
 using Microsoft.AspNetCore.Authorization;

--- a/src/Core/AdminConsole/Authorization/HttpContextExtensions.cs
+++ b/src/Core/AdminConsole/Authorization/HttpContextExtensions.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Bit.Core.AdminConsole.Authorization;
+
+public static class HttpContextExtensions
+{
+    public const string NoOrgIdError =
+        "A route decorated with with '[Authorize<Requirement>]' must include a route value named 'orgId' or " +
+        "'organizationId' either through the [Controller] attribute or through a '[Http*]' attribute.";
+
+    private static readonly string[] _organizationIdKeys = ["orgId", "organizationId"];
+
+    /// <summary>
+    /// Parses the {orgId} or {organizationId} route parameter into a Guid, or throws if neither parameter is present
+    /// or the parameter is not a valid guid.
+    /// </summary>
+    /// <param name="httpContext"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public static Guid GetOrganizationId(this HttpContext httpContext)
+    {
+        var routeValues = httpContext.GetRouteData().Values;
+
+        var orgId = _organizationIdKeys
+            .Select(key => routeValues.TryGetValue(key, out var value) ? value?.ToString() : null)
+            .Where(value => value != null)
+            .Select(value => Guid.TryParse(value, out var guid) ? guid : Guid.Empty)
+            .FirstOrDefault();
+
+        if (orgId == Guid.Empty)
+        {
+            throw new InvalidOperationException(NoOrgIdError);
+        }
+
+        return orgId;
+    }
+}

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -1,6 +1,7 @@
 ﻿// FIXME: Update this file to be null safe and then delete the line below
 #nullable disable
 
+using System.Security.Cryptography.X509Certificates;
 using Bit.Core.Auth.Settings;
 using Bit.Core.Settings.LoggingSettings;
 
@@ -521,7 +522,7 @@ public class GlobalSettings : IGlobalSettings
         /// The absolute path to a Certificate (DER or Base64 encoded with private key).
         /// </summary>
         /// <remarks>
-        /// The certificate path and <see cref="CertificatePassword"/> are passed into the <see cref="System.Security.Cryptography.X509Certificates.X509Certificate2.X509Certificate2(string, string)" />.
+        /// The certificate path and <see cref="CertificatePassword"/> are passed into the <see cref="X509Certificate2" />.
         /// The file format of the certificate may be binary encoded (DER) or base64. If the private key is encrypted, provide the password in <see cref="CertificatePassword"/>,
         /// </remarks>
         public string CertificatePath { get; set; }

--- a/test/Api.Test/AdminConsole/Authorization/HttpContextExtensionsTests.cs
+++ b/test/Api.Test/AdminConsole/Authorization/HttpContextExtensionsTests.cs
@@ -1,7 +1,5 @@
-﻿using AutoFixture.Xunit2;
-using Bit.Api.AdminConsole.Authorization;
+﻿using Bit.Api.AdminConsole.Authorization;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Routing;
 using NSubstitute;
 using Xunit;
 
@@ -25,44 +23,5 @@ public class HttpContextExtensionsTests
         var result2 = await httpContext.WithFeaturesCacheAsync(callback);
         Assert.Equal("hello world", result2);
         await callback.ReceivedWithAnyArgs(1).Invoke();
-    }
-
-    [Theory]
-    [InlineAutoData("orgId")]
-    [InlineAutoData("organizationId")]
-    public void GetOrganizationId_GivenValidParameter_ReturnsOrganizationId(string paramName, Guid orgId)
-    {
-        var httpContext = new DefaultHttpContext
-        {
-            Request = { RouteValues = new RouteValueDictionary
-            {
-                { "userId", "someGuid" },
-                { paramName, orgId.ToString() }
-            }
-        }
-        };
-
-        var result = httpContext.GetOrganizationId();
-        Assert.Equal(orgId, result);
-    }
-
-    [Theory]
-    [InlineAutoData("orgId")]
-    [InlineAutoData("organizationId")]
-    [InlineAutoData("missingParameter")]
-    public void GetOrganizationId_GivenMissingOrInvalidGuid_Throws(string paramName)
-    {
-        var httpContext = new DefaultHttpContext
-        {
-            Request = { RouteValues = new RouteValueDictionary
-            {
-                { "userId", "someGuid" },
-                { paramName, "invalidGuid" }
-            }
-        }
-        };
-
-        var exception = Assert.Throws<InvalidOperationException>(() => httpContext.GetOrganizationId());
-        Assert.Equal(HttpContextExtensions.NoOrgIdError, exception.Message);
     }
 }

--- a/test/Core.Test/AdminConsole/Authorization/HttpContextExtensionsTests.cs
+++ b/test/Core.Test/AdminConsole/Authorization/HttpContextExtensionsTests.cs
@@ -1,0 +1,48 @@
+﻿using AutoFixture.Xunit2;
+using Bit.Core.AdminConsole.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Xunit;
+
+namespace Bit.Core.Test.AdminConsole.Authorization;
+
+public class HttpContextExtensionsTests
+{
+
+    [Theory]
+    [InlineAutoData("orgId")]
+    [InlineAutoData("organizationId")]
+    public void GetOrganizationId_GivenValidParameter_ReturnsOrganizationId(string paramName, Guid orgId)
+    {
+        var httpContext = new DefaultHttpContext
+        {
+            Request =
+            {
+                RouteValues =
+                    new RouteValueDictionary { { "userId", "someGuid" }, { paramName, orgId.ToString() } }
+            }
+        };
+
+        var result = httpContext.GetOrganizationId();
+        Assert.Equal(orgId, result);
+    }
+
+    [Theory]
+    [InlineAutoData("orgId")]
+    [InlineAutoData("organizationId")]
+    [InlineAutoData("missingParameter")]
+    public void GetOrganizationId_GivenMissingOrInvalidGuid_Throws(string paramName)
+    {
+        var httpContext = new DefaultHttpContext
+        {
+            Request =
+            {
+                RouteValues =
+                    new RouteValueDictionary { { "userId", "someGuid" }, { paramName, "invalidGuid" } }
+            }
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => httpContext.GetOrganizationId());
+        Assert.Equal(HttpContextExtensions.NoOrgIdError, exception.Message);
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking
[PM-24462](https://bitwarden.atlassian.net/browse/PM-24462)

## 📔 Objective
Since inviting users needs to be transactional and we need to return an error to the IdP for SCIM, this adds the `ConcurrencyRateLimiter` to the PostUsers SCIM endpoint.

This acts as a queue that only allows 1 request per organization to be processed. This should solve any concurrency issues we have while ensuring organizations can add users independently.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24462]: https://bitwarden.atlassian.net/browse/PM-24462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ