### PR TITLE
[PM-24624] Add more comments to AutoProvisionUserAsync

### DIFF
--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -456,7 +456,7 @@ public class AccountController : Controller
         }
         else
         {
-            existingUser = await GetUserFromManualLinkingToken(userIdentifier);
+            existingUser = await GetUserFromManualLinkingData(userIdentifier);
         }
 
         // Try to find the OrganizationUser if it exists.
@@ -592,7 +592,7 @@ public class AccountController : Controller
         return user;
     }
 
-    private async Task<User> GetUserFromManualLinkingToken(string userIdentifier)
+    private async Task<User> GetUserFromManualLinkingData(string userIdentifier)
     {
         User user = null;
         var split = userIdentifier.Split(",");

--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -427,8 +427,8 @@ public class AccountController : Controller
     /// <param name="claims">The claims from the external IdP.</param>
     /// <param name="userIdentifier">The user identifier used for manual SSO linking.</param>
     /// <param name="config">The SSO configuration for the organization.</param>
-    /// <returns></returns>
-    /// <exception cref="Exception"></exception>
+    /// <returns>The User to sign in.</returns>
+    /// <exception cref="Exception">An exception if the user cannot be authenticated.</exception>
     private async Task<User> AutoProvisionUserAsync(string provider, string providerUserId,
         IEnumerable<Claim> claims, string userIdentifier, SsoConfigurationData config)
     {

--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -428,7 +428,7 @@ public class AccountController : Controller
     /// <param name="userIdentifier">The user identifier used for manual SSO linking.</param>
     /// <param name="config">The SSO configuration for the organization.</param>
     /// <returns>The User to sign in.</returns>
-    /// <exception cref="Exception">An exception if the user cannot be authenticated.</exception>
+    /// <exception cref="Exception">An exception if the user cannot be provisioned as requested.</exception>
     private async Task<User> AutoProvisionUserAsync(string provider, string providerUserId,
         IEnumerable<Claim> claims, string userIdentifier, SsoConfigurationData config)
     {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-24624

## 📔 Objective

- Adds more comments to the `AutoProvisionUserAsync()` method, to try to get us closer to understanding how best to deconstruct this method in the future.
- Pulls out two small methods to make the code a bit clearer to follow:
  - Checking the `user_identifier`, which is used in manual linking of SSO: https://github.com/bitwarden/clients/blob/ce2416d45994337ecc6b4edf8bb4e755a1a925bd/apps/web/src/app/auth/core/services/link-sso.service.ts#L87.
  - Finding the `Organization` and `OrganizationUser`

## 📸 Screenshots

### Demonstrating that SSO works as expected

https://github.com/user-attachments/assets/088cd749-a19d-4376-b575-79850abbc66b

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
