### PR TITLE
[PM-24414] Remove CollectionType property from the public CollectionResponseModel

### DIFF
--- a/src/Api/Models/Public/Response/CollectionResponseModel.cs
+++ b/src/Api/Models/Public/Response/CollectionResponseModel.cs
@@ -4,7 +4,6 @@
 using System.ComponentModel.DataAnnotations;
 using Bit.Api.AdminConsole.Public.Models.Response;
 using Bit.Core.Entities;
-using Bit.Core.Enums;
 using Bit.Core.Models.Data;
 
 namespace Bit.Api.Models.Public.Response;
@@ -24,7 +23,6 @@ public class CollectionResponseModel : CollectionBaseModel, IResponseModel
         Id = collection.Id;
         ExternalId = collection.ExternalId;
         Groups = groups?.Select(c => new AssociationWithPermissionsResponseModel(c));
-        Type = collection.Type;
     }
 
     /// <summary>
@@ -43,8 +41,4 @@ public class CollectionResponseModel : CollectionBaseModel, IResponseModel
     /// The associated groups that this collection is assigned to.
     /// </summary>
     public IEnumerable<AssociationWithPermissionsResponseModel> Groups { get; set; }
-    /// <summary>
-    /// The type of this collection
-    /// </summary>
-    public CollectionType Type { get; set; }
 }

--- a/test/Api.Test/Public/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.Test/Public/Controllers/CollectionsControllerTests.cs
@@ -67,7 +67,6 @@ public class CollectionsControllerTests
         var jsonResult = Assert.IsType<JsonResult>(result);
         var response = Assert.IsType<CollectionResponseModel>(jsonResult.Value);
         Assert.Equal(collection.Id, response.Id);
-        Assert.Equal(collection.Type, response.Type);
     }
 
     [Theory, BitAutoData]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-24414

## 📔 Objective

Remove `CollectionType` property from the public `CollectionResponseModel` and update related tests accordingly.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
