### PR TITLE
[PM-24641] Remove `prompt_id` from Onyx Queries

### DIFF
--- a/src/Billing/Models/OnyxAnswerWithCitationRequestModel.cs
+++ b/src/Billing/Models/OnyxAnswerWithCitationRequestModel.cs
@@ -14,9 +14,6 @@ public class OnyxAnswerWithCitationRequestModel
     [JsonPropertyName("persona_id")]
     public int PersonaId { get; set; } = 1;
 
-    [JsonPropertyName("prompt_id")]
-    public int PromptId { get; set; } = 1;
-
     [JsonPropertyName("retrieval_options")]
     public RetrievalOptions RetrievalOptions { get; set; }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-24641

## 📔 Objective

The prompt_is was always defaulted to 1 in the onyx queries. This causes quality issues in the responses from Onyx.

## 📸 Screenshots

None at this time

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
