### PR TITLE
[PM-24192] Move account recovery logic to command

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -464,7 +464,7 @@ public class OrganizationUsersController : Controller
     }
 
     [HttpPut("{id}/reset-password")]
-    [Authorize<ManageAccountRecoveryRequirement>]
+    [Authorize<ManageAccountRecoveryRequirement>]   // note: the command has additional permissions checks
     public async Task PutResetPassword(Guid orgId, Guid id, [FromBody] OrganizationUserResetPasswordRequestModel model)
     {
         // Get the users role, since provider users aren't a member of the organization we use the owner check

--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -476,7 +476,7 @@ public class OrganizationUsersController : Controller
             throw new NotFoundException();
         }
 
-        var result = await _adminRecoverAccountCommand.AdminResetPasswordAsync(orgUserType.Value, orgId, id, model.NewMasterPasswordHash, model.Key);
+        var result = await _adminRecoverAccountCommand.RecoverAccountAsync(orgUserType.Value, orgId, id, model.NewMasterPasswordHash, model.Key);
         if (result.Succeeded)
         {
             return;

--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -11,6 +11,7 @@ using Bit.Api.Vault.AuthorizationHandlers.Collections;
 using Bit.Core;
 using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
+using Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interfaces;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.RestoreUser.v1;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
@@ -66,6 +67,7 @@ public class OrganizationUsersController : Controller
     private readonly IRestoreOrganizationUserCommand _restoreOrganizationUserCommand;
     private readonly IInitPendingOrganizationCommand _initPendingOrganizationCommand;
     private readonly IRevokeOrganizationUserCommand _revokeOrganizationUserCommand;
+    private readonly IAdminRecoverAccountCommand _adminRecoverAccountCommand;
 
     public OrganizationUsersController(IOrganizationRepository organizationRepository,
         IOrganizationUserRepository organizationUserRepository,
@@ -92,7 +94,8 @@ public class OrganizationUsersController : Controller
         IConfirmOrganizationUserCommand confirmOrganizationUserCommand,
         IRestoreOrganizationUserCommand restoreOrganizationUserCommand,
         IInitPendingOrganizationCommand initPendingOrganizationCommand,
-        IRevokeOrganizationUserCommand revokeOrganizationUserCommand)
+        IRevokeOrganizationUserCommand revokeOrganizationUserCommand,
+        IAdminRecoverAccountCommand adminRecoverAccountCommand)
     {
         _organizationRepository = organizationRepository;
         _organizationUserRepository = organizationUserRepository;
@@ -120,6 +123,7 @@ public class OrganizationUsersController : Controller
         _restoreOrganizationUserCommand = restoreOrganizationUserCommand;
         _initPendingOrganizationCommand = initPendingOrganizationCommand;
         _revokeOrganizationUserCommand = revokeOrganizationUserCommand;
+        _adminRecoverAccountCommand = adminRecoverAccountCommand;
     }
 
     [HttpGet("{id}")]
@@ -472,7 +476,7 @@ public class OrganizationUsersController : Controller
             throw new NotFoundException();
         }
 
-        var result = await _userService.AdminResetPasswordAsync(orgUserType.Value, orgId, id, model.NewMasterPasswordHash, model.Key);
+        var result = await _adminRecoverAccountCommand.AdminResetPasswordAsync(orgUserType.Value, orgId, id, model.NewMasterPasswordHash, model.Key);
         if (result.Succeeded)
         {
             return;

--- a/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommand.cs
@@ -24,7 +24,7 @@ public class AdminRecoverAccountCommand(IOrganizationRepository organizationRepo
     IProviderOrganizationRepository providerOrganizationRepository,
     ICurrentContext currentContext) : IAdminRecoverAccountCommand
 {
-    public async Task<IdentityResult> AdminResetPasswordAsync(OrganizationUserType callingUserType, Guid orgId,
+    public async Task<IdentityResult> RecoverAccountAsync(OrganizationUserType callingUserType, Guid orgId,
         Guid organizationUserId, string newMasterPassword, string key)
     {
         // Org must be able to use reset password

--- a/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommand.cs
@@ -23,6 +23,8 @@ public class AdminRecoverAccountCommand(IOrganizationRepository organizationRepo
     IProviderUserRepository providerUserRepository,
     ICurrentContext currentContext) : IAdminRecoverAccountCommand
 {
+    public const string InsufficientPermissionsForProvider = "You are not permitted to recover a Provider's account.";
+
     public async Task<IdentityResult> RecoverAccountAsync(OrganizationUserType callingUserType, Guid orgId,
         Guid organizationUserId, string newMasterPassword, string key)
     {
@@ -124,7 +126,7 @@ public class AdminRecoverAccountCommand(IOrganizationRepository organizationRepo
 
             if (!callingUserIsProvider)
             {
-                throw new BadRequestException("Calling user does not have permission to reset this user's master password");
+                throw new BadRequestException(InsufficientPermissionsForProvider);
             }
         }
     }

--- a/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommand.cs
@@ -18,7 +18,8 @@ public class AdminRecoverAccountCommand(IOrganizationRepository organizationRepo
     IPushNotificationService pushNotificationService,
     IUserService userService) : IAdminRecoverAccountCommand
 {
-    public async Task<IdentityResult> AdminResetPasswordAsync(OrganizationUserType callingUserType, Guid orgId, Guid id, string newMasterPassword, string key)
+    public async Task<IdentityResult> AdminResetPasswordAsync(OrganizationUserType callingUserType, Guid orgId,
+        Guid organizationUserId, string newMasterPassword, string key)
     {
         // Org must be able to use reset password
         var org = await organizationRepository.GetByIdAsync(orgId);
@@ -36,7 +37,7 @@ public class AdminRecoverAccountCommand(IOrganizationRepository organizationRepo
         }
 
         // Org User must be confirmed and have a ResetPasswordKey
-        var orgUser = await organizationUserRepository.GetByIdAsync(id);
+        var orgUser = await organizationUserRepository.GetByIdAsync(organizationUserId);
         if (orgUser == null || orgUser.Status != OrganizationUserStatusType.Confirmed ||
             orgUser.OrganizationId != orgId || string.IsNullOrEmpty(orgUser.ResetPasswordKey) ||
             !orgUser.UserId.HasValue)

--- a/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommand.cs
@@ -1,0 +1,97 @@
+﻿using Bit.Core.AdminConsole.Enums;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Enums;
+using Bit.Core.Exceptions;
+using Bit.Core.Platform.Push;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Microsoft.AspNetCore.Identity;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
+
+public class AdminRecoverAccountCommand(IOrganizationRepository organizationRepository,
+    IPolicyRepository policyRepository,
+    IOrganizationUserRepository organizationUserRepository,
+    IUserRepository userRepository,
+    IMailService mailService,
+    IEventService eventService,
+    IPushNotificationService pushNotificationService,
+    IUserService userService) : IAdminRecoverAccountCommand
+{
+    public async Task<IdentityResult> AdminResetPasswordAsync(OrganizationUserType callingUserType, Guid orgId, Guid id, string newMasterPassword, string key)
+    {
+        // Org must be able to use reset password
+        var org = await organizationRepository.GetByIdAsync(orgId);
+        if (org == null || !org.UseResetPassword)
+        {
+            throw new BadRequestException("Organization does not allow password reset.");
+        }
+
+        // Enterprise policy must be enabled
+        var resetPasswordPolicy =
+            await policyRepository.GetByOrganizationIdTypeAsync(orgId, PolicyType.ResetPassword);
+        if (resetPasswordPolicy == null || !resetPasswordPolicy.Enabled)
+        {
+            throw new BadRequestException("Organization does not have the password reset policy enabled.");
+        }
+
+        // Org User must be confirmed and have a ResetPasswordKey
+        var orgUser = await organizationUserRepository.GetByIdAsync(id);
+        if (orgUser == null || orgUser.Status != OrganizationUserStatusType.Confirmed ||
+            orgUser.OrganizationId != orgId || string.IsNullOrEmpty(orgUser.ResetPasswordKey) ||
+            !orgUser.UserId.HasValue)
+        {
+            throw new BadRequestException("Organization User not valid");
+        }
+
+        // Calling User must be of higher/equal user type to reset user's password
+        var canAdjustPassword = false;
+        switch (callingUserType)
+        {
+            case OrganizationUserType.Owner:
+                canAdjustPassword = true;
+                break;
+            case OrganizationUserType.Admin:
+                canAdjustPassword = orgUser.Type != OrganizationUserType.Owner;
+                break;
+            case OrganizationUserType.Custom:
+                canAdjustPassword = orgUser.Type != OrganizationUserType.Owner &&
+                    orgUser.Type != OrganizationUserType.Admin;
+                break;
+        }
+
+        if (!canAdjustPassword)
+        {
+            throw new BadRequestException("Calling user does not have permission to reset this user's master password");
+        }
+
+        var user = await userService.GetUserByIdAsync(orgUser.UserId.Value);
+        if (user == null)
+        {
+            throw new NotFoundException();
+        }
+
+        if (user.UsesKeyConnector)
+        {
+            throw new BadRequestException("Cannot reset password of a user with Key Connector.");
+        }
+
+        var result = await userService.UpdatePasswordHash(user, newMasterPassword);
+        if (!result.Succeeded)
+        {
+            return result;
+        }
+
+        user.RevisionDate = user.AccountRevisionDate = DateTime.UtcNow;
+        user.LastPasswordChangeDate = user.RevisionDate;
+        user.ForcePasswordReset = true;
+        user.Key = key;
+
+        await userRepository.ReplaceAsync(user);
+        await mailService.SendAdminResetPasswordEmailAsync(user.Email, user.Name, org.DisplayName());
+        await eventService.LogOrganizationUserEventAsync(orgUser, EventType.OrganizationUser_AdminResetPassword);
+        await pushNotificationService.PushLogOutAsync(user.Id);
+
+        return IdentityResult.Success;
+    }
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/IAdminRecoverAccountCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/IAdminRecoverAccountCommand.cs
@@ -5,6 +5,6 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
 
 public interface IAdminRecoverAccountCommand
 {
-    Task<IdentityResult> AdminResetPasswordAsync(OrganizationUserType callingUserType, Guid orgId, Guid id,
+    Task<IdentityResult> AdminResetPasswordAsync(OrganizationUserType callingUserType, Guid orgId, Guid organizationUserId,
         string newMasterPassword, string key);
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/IAdminRecoverAccountCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/IAdminRecoverAccountCommand.cs
@@ -1,0 +1,10 @@
+﻿using Bit.Core.Enums;
+using Microsoft.AspNetCore.Identity;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
+
+public interface IAdminRecoverAccountCommand
+{
+    Task<IdentityResult> AdminResetPasswordAsync(OrganizationUserType callingUserType, Guid orgId, Guid id,
+        string newMasterPassword, string key);
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/IAdminRecoverAccountCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/IAdminRecoverAccountCommand.cs
@@ -5,6 +5,6 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
 
 public interface IAdminRecoverAccountCommand
 {
-    Task<IdentityResult> AdminResetPasswordAsync(OrganizationUserType callingUserType, Guid orgId, Guid organizationUserId,
+    Task<IdentityResult> RecoverAccountAsync(OrganizationUserType callingUserType, Guid orgId, Guid organizationUserId,
         string newMasterPassword, string key);
 }

--- a/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
+++ b/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Core.AdminConsole.OrganizationAuth;
 using Bit.Core.AdminConsole.OrganizationAuth.Interfaces;
+using Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
 using Bit.Core.AdminConsole.OrganizationFeatures.Groups;
 using Bit.Core.AdminConsole.OrganizationFeatures.Groups.Interfaces;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationApiKeys;
@@ -132,6 +133,7 @@ public static class OrganizationServiceCollectionExtensions
         services.AddScoped<IUpdateOrganizationUserGroupsCommand, UpdateOrganizationUserGroupsCommand>();
         services.AddScoped<IDeleteClaimedOrganizationUserAccountCommand, DeleteClaimedOrganizationUserAccountCommand>();
         services.AddScoped<IConfirmOrganizationUserCommand, ConfirmOrganizationUserCommand>();
+        services.AddScoped<IAdminRecoverAccountCommand, AdminRecoverAccountCommand>();
     }
 
     private static void AddOrganizationApiKeyCommandsQueries(this IServiceCollection services)

--- a/src/Core/Services/IMailService.cs
+++ b/src/Core/Services/IMailService.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Bit.Core.AdminConsole.Entities;
+﻿using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.Auth.Entities;
 using Bit.Core.Billing.Enums;
@@ -70,7 +68,7 @@ public interface IMailService
     Task SendEmergencyAccessRecoveryReminder(EmergencyAccess emergencyAccess, string initiatingName, string email);
     Task SendEmergencyAccessRecoveryTimedOut(EmergencyAccess ea, string initiatingName, string email);
     Task SendEnqueuedMailMessageAsync(IMailQueueMessage queueMessage);
-    Task SendAdminResetPasswordEmailAsync(string email, string userName, string orgName);
+    Task SendAdminResetPasswordEmailAsync(string email, string? userName, string orgName);
     Task SendProviderSetupInviteEmailAsync(Provider provider, string token, string email);
     Task SendBusinessUnitConversionInviteAsync(Organization organization, string token, string email);
     Task SendProviderInviteEmailAsync(string providerName, ProviderUser providerUser, string token, string email);

--- a/src/Core/Services/IUserService.cs
+++ b/src/Core/Services/IUserService.cs
@@ -36,7 +36,6 @@ public interface IUserService
     Task<IdentityResult> ChangePasswordAsync(User user, string masterPassword, string newMasterPassword, string passwordHint, string key);
     Task<IdentityResult> SetKeyConnectorKeyAsync(User user, string key, string orgIdentifier);
     Task<IdentityResult> ConvertToKeyConnectorAsync(User user);
-    Task<IdentityResult> AdminResetPasswordAsync(OrganizationUserType type, Guid orgId, Guid id, string newMasterPassword, string key);
     Task<IdentityResult> UpdateTempPasswordAsync(User user, string newMasterPassword, string key, string hint);
     Task<IdentityResult> ChangeKdfAsync(User user, string masterPassword, string newMasterPassword, string key,
         KdfType kdf, int kdfIterations, int? kdfMemory, int? kdfParallelism);

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -545,7 +545,7 @@ public class HandlebarsMailService : IMailService
         await _mailDeliveryService.SendEmailAsync(message);
     }
 
-    public async Task SendAdminResetPasswordEmailAsync(string email, string userName, string orgName)
+    public async Task SendAdminResetPasswordEmailAsync(string email, string? userName, string orgName)
     {
         var message = CreateDefaultMessage("Your admin has initiated account recovery", email);
         var model = new AdminResetPasswordViewModel()

--- a/src/Core/Services/NoopImplementations/NoopMailService.cs
+++ b/src/Core/Services/NoopImplementations/NoopMailService.cs
@@ -196,7 +196,7 @@ public class NoopMailService : IMailService
         return Task.FromResult(0);
     }
 
-    public Task SendAdminResetPasswordEmailAsync(string email, string userName, string orgName)
+    public Task SendAdminResetPasswordEmailAsync(string email, string? userName, string orgName)
     {
         return Task.FromResult(0);
     }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommandTests.cs
@@ -42,7 +42,7 @@ public class AdminRecoverAccountCommandTests
         SetupSuccessfulPasswordUpdate(sutProvider, user, newMasterPassword);
 
         // Act
-        var result = await sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id,
+        var result = await sutProvider.Sut.RecoverAccountAsync(callingUserType, organization.Id,
             organizationUser.Id, newMasterPassword, key);
 
         // Assert
@@ -69,7 +69,7 @@ public class AdminRecoverAccountCommandTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
-            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, orgId, Guid.NewGuid(),
+            sutProvider.Sut.RecoverAccountAsync(callingUserType, orgId, Guid.NewGuid(),
                 newMasterPassword, key));
         Assert.Equal("Organization does not allow password reset.", exception.Message);
     }
@@ -91,7 +91,7 @@ public class AdminRecoverAccountCommandTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
-            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, Guid.NewGuid(),
+            sutProvider.Sut.RecoverAccountAsync(callingUserType, organization.Id, Guid.NewGuid(),
                 newMasterPassword, key));
         Assert.Equal("Organization does not allow password reset.", exception.Message);
     }
@@ -113,7 +113,7 @@ public class AdminRecoverAccountCommandTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
-            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, Guid.NewGuid(),
+            sutProvider.Sut.RecoverAccountAsync(callingUserType, organization.Id, Guid.NewGuid(),
                 newMasterPassword, key));
         Assert.Equal("Organization does not have the password reset policy enabled.", exception.Message);
     }
@@ -137,7 +137,7 @@ public class AdminRecoverAccountCommandTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
-            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, Guid.NewGuid(),
+            sutProvider.Sut.RecoverAccountAsync(callingUserType, organization.Id, Guid.NewGuid(),
                 newMasterPassword, key));
         Assert.Equal("Organization does not have the password reset policy enabled.", exception.Message);
     }
@@ -162,7 +162,7 @@ public class AdminRecoverAccountCommandTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
-            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, orgUserId, newMasterPassword, key));
+            sutProvider.Sut.RecoverAccountAsync(callingUserType, organization.Id, orgUserId, newMasterPassword, key));
         Assert.Equal("Organization User not valid", exception.Message);
     }
 
@@ -190,7 +190,7 @@ public class AdminRecoverAccountCommandTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
-            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
+            sutProvider.Sut.RecoverAccountAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
         Assert.Equal("Organization User not valid", exception.Message);
     }
 
@@ -218,7 +218,7 @@ public class AdminRecoverAccountCommandTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
-            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
+            sutProvider.Sut.RecoverAccountAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
         Assert.Equal("Organization User not valid", exception.Message);
     }
 
@@ -246,7 +246,7 @@ public class AdminRecoverAccountCommandTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
-            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
+            sutProvider.Sut.RecoverAccountAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
         Assert.Equal("Organization User not valid", exception.Message);
     }
 
@@ -274,7 +274,7 @@ public class AdminRecoverAccountCommandTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
-            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
+            sutProvider.Sut.RecoverAccountAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
         Assert.Equal("Organization User not valid", exception.Message);
     }
 
@@ -306,7 +306,7 @@ public class AdminRecoverAccountCommandTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
-            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
+            sutProvider.Sut.RecoverAccountAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
         Assert.Equal("Calling user does not have permission to reset this user's master password", exception.Message);
     }
 
@@ -331,7 +331,7 @@ public class AdminRecoverAccountCommandTests
 
         // Act & Assert
         await Assert.ThrowsAsync<NotFoundException>(() =>
-            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
+            sutProvider.Sut.RecoverAccountAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
     }
 
     [Theory]
@@ -357,7 +357,7 @@ public class AdminRecoverAccountCommandTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
-            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
+            sutProvider.Sut.RecoverAccountAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
         Assert.Equal("Cannot reset password of a user with Key Connector.", exception.Message);
     }
 
@@ -385,7 +385,7 @@ public class AdminRecoverAccountCommandTests
             .Returns(failedResult);
 
         // Act
-        var result = await sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key);
+        var result = await sutProvider.Sut.RecoverAccountAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key);
 
         // Assert
         Assert.False(result.Succeeded);
@@ -428,7 +428,7 @@ public class AdminRecoverAccountCommandTests
         SetupSuccessfulPasswordUpdate(sutProvider, user, newMasterPassword);
 
         // Act
-        var result = await sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key);
+        var result = await sutProvider.Sut.RecoverAccountAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key);
 
         // Assert
         Assert.True(result.Succeeded);
@@ -481,7 +481,7 @@ public class AdminRecoverAccountCommandTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
-            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
+            sutProvider.Sut.RecoverAccountAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
         Assert.Equal("Calling user does not have permission to reset this user's master password", exception.Message);
     }
 

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommandTests.cs
@@ -24,7 +24,7 @@ public class AdminRecoverAccountCommandTests
 {
     [Theory]
     [BitAutoData]
-    public async Task AdminResetPasswordAsync_ValidRequest_Success(
+    public async Task RecoverAccountAsync_ValidRequest_Success(
         OrganizationUserType callingUserType,
         string newMasterPassword,
         string key,
@@ -55,7 +55,7 @@ public class AdminRecoverAccountCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task AdminResetPasswordAsync_OrganizationDoesNotExist_ThrowsBadRequest(
+    public async Task RecoverAccountAsync_OrganizationDoesNotExist_ThrowsBadRequest(
         OrganizationUserType callingUserType,
         string newMasterPassword,
         string key,
@@ -76,7 +76,7 @@ public class AdminRecoverAccountCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task AdminResetPasswordAsync_OrganizationDoesNotAllowResetPassword_ThrowsBadRequest(
+    public async Task RecoverAccountAsync_OrganizationDoesNotAllowResetPassword_ThrowsBadRequest(
         OrganizationUserType callingUserType,
         string newMasterPassword,
         string key,
@@ -98,7 +98,7 @@ public class AdminRecoverAccountCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task AdminResetPasswordAsync_PolicyDoesNotExist_ThrowsBadRequest(
+    public async Task RecoverAccountAsync_PolicyDoesNotExist_ThrowsBadRequest(
         OrganizationUserType callingUserType,
         string newMasterPassword,
         string key,
@@ -120,7 +120,7 @@ public class AdminRecoverAccountCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task AdminResetPasswordAsync_PolicyNotEnabled_ThrowsBadRequest(
+    public async Task RecoverAccountAsync_PolicyNotEnabled_ThrowsBadRequest(
         OrganizationUserType callingUserType,
         string newMasterPassword,
         string key,
@@ -144,7 +144,7 @@ public class AdminRecoverAccountCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task AdminResetPasswordAsync_OrganizationUserDoesNotExist_ThrowsBadRequest(
+    public async Task RecoverAccountAsync_OrganizationUserDoesNotExist_ThrowsBadRequest(
         OrganizationUserType callingUserType,
         string newMasterPassword,
         string key,
@@ -168,7 +168,7 @@ public class AdminRecoverAccountCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task AdminResetPasswordAsync_OrganizationUserNotConfirmed_ThrowsBadRequest(
+    public async Task RecoverAccountAsync_OrganizationUserNotConfirmed_ThrowsBadRequest(
         OrganizationUserType callingUserType,
         string newMasterPassword,
         string key,
@@ -196,7 +196,7 @@ public class AdminRecoverAccountCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task AdminResetPasswordAsync_OrganizationUserWrongOrganization_ThrowsBadRequest(
+    public async Task RecoverAccountAsync_OrganizationUserWrongOrganization_ThrowsBadRequest(
         OrganizationUserType callingUserType,
         string newMasterPassword,
         string key,
@@ -224,7 +224,7 @@ public class AdminRecoverAccountCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task AdminResetPasswordAsync_OrganizationUserNoResetPasswordKey_ThrowsBadRequest(
+    public async Task RecoverAccountAsync_OrganizationUserNoResetPasswordKey_ThrowsBadRequest(
         OrganizationUserType callingUserType,
         string newMasterPassword,
         string key,
@@ -252,7 +252,7 @@ public class AdminRecoverAccountCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task AdminResetPasswordAsync_OrganizationUserNoUserId_ThrowsBadRequest(
+    public async Task RecoverAccountAsync_OrganizationUserNoUserId_ThrowsBadRequest(
         OrganizationUserType callingUserType,
         string newMasterPassword,
         string key,
@@ -282,7 +282,7 @@ public class AdminRecoverAccountCommandTests
     [BitAutoData(OrganizationUserType.Admin, OrganizationUserType.Owner)]
     [BitAutoData(OrganizationUserType.Custom, OrganizationUserType.Owner)]
     [BitAutoData(OrganizationUserType.Custom, OrganizationUserType.Admin)]
-    public async Task AdminResetPasswordAsync_InsufficientPermissions_ThrowsBadRequest(
+    public async Task RecoverAccountAsync_InsufficientPermissions_ThrowsBadRequest(
         OrganizationUserType callingUserType,
         OrganizationUserType targetUserType,
         string newMasterPassword,
@@ -312,7 +312,7 @@ public class AdminRecoverAccountCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task AdminResetPasswordAsync_UserDoesNotExist_ThrowsNotFoundException(
+    public async Task RecoverAccountAsync_UserDoesNotExist_ThrowsNotFoundException(
         OrganizationUserType callingUserType,
         string newMasterPassword,
         string key,
@@ -336,7 +336,7 @@ public class AdminRecoverAccountCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task AdminResetPasswordAsync_UserUsesKeyConnector_ThrowsBadRequest(
+    public async Task RecoverAccountAsync_UserUsesKeyConnector_ThrowsBadRequest(
         OrganizationUserType callingUserType,
         string newMasterPassword,
         string key,
@@ -363,7 +363,7 @@ public class AdminRecoverAccountCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task AdminResetPasswordAsync_PasswordUpdateFails_ReturnsFailure(
+    public async Task RecoverAccountAsync_PasswordUpdateFails_ReturnsFailure(
         OrganizationUserType callingUserType,
         string newMasterPassword,
         string key,
@@ -402,7 +402,7 @@ public class AdminRecoverAccountCommandTests
     [BitAutoData(OrganizationUserType.Admin, OrganizationUserType.User)]
     [BitAutoData(OrganizationUserType.Custom, OrganizationUserType.Custom)]
     [BitAutoData(OrganizationUserType.Custom, OrganizationUserType.User)]
-    public async Task AdminResetPasswordAsync_ValidPermissionCombinations_Success(
+    public async Task RecoverAccountAsync_ValidPermissionCombinations_Success(
         OrganizationUserType callingUserType,
         OrganizationUserType targetUserType,
         string newMasterPassword,
@@ -436,7 +436,7 @@ public class AdminRecoverAccountCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task AdminResetPasswordAsync_CallingUserNotProviderForTargetUser_ThrowsBadRequest(
+    public async Task RecoverAccountAsync_CallingUserNotProviderForTargetUser_ThrowsBadRequest(
         OrganizationUserType callingUserType,
         string newMasterPassword,
         string key,

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommandTests.cs
@@ -474,7 +474,7 @@ public class AdminRecoverAccountCommandTests
         // Act & Assert
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
             sutProvider.Sut.RecoverAccountAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
-        Assert.Equal("Calling user does not have permission to reset this user's master password", exception.Message);
+        Assert.Equal(AdminRecoverAccountCommand.InsufficientPermissionsForProvider, exception.Message);
     }
 
     private void SetupValidOrganization(SutProvider<AdminRecoverAccountCommand> sutProvider, Organization organization)

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommandTests.cs
@@ -1,0 +1,507 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Enums;
+using Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Exceptions;
+using Bit.Core.Platform.Push;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Microsoft.AspNetCore.Identity;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.AccountRecovery;
+
+[SutProviderCustomize]
+public class AdminRecoverAccountCommandTests
+{
+    [Theory]
+    [BitAutoData]
+    public async Task AdminResetPasswordAsync_ValidRequest_Success(
+        OrganizationUserType callingUserType,
+        string newMasterPassword,
+        string key,
+        Organization organization,
+        Policy resetPasswordPolicy,
+        OrganizationUser organizationUser,
+        User user,
+        SutProvider<AdminRecoverAccountCommand> sutProvider)
+    {
+        // Arrange
+        SetupValidOrganization(sutProvider, organization);
+        SetupValidPolicy(sutProvider, resetPasswordPolicy, organization.Id);
+        SetupValidOrganizationUser(sutProvider, organizationUser, organization.Id, callingUserType);
+        SetupValidUser(sutProvider, user, organizationUser.UserId.Value);
+        SetupSuccessfulPasswordUpdate(sutProvider, user, newMasterPassword);
+
+        // Act
+        var result = await sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id,
+            organizationUser.Id, newMasterPassword, key);
+
+        // Assert
+        Assert.True(result.Succeeded);
+        await VerifyUserUpdated(sutProvider, user, key);
+        await VerifyEmailSent(sutProvider, user, organization);
+        await VerifyEventLogged(sutProvider, organizationUser);
+        await VerifyPushNotificationSent(sutProvider, user.Id);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task AdminResetPasswordAsync_OrganizationDoesNotExist_ThrowsBadRequest(
+        OrganizationUserType callingUserType,
+        string newMasterPassword,
+        string key,
+        SutProvider<AdminRecoverAccountCommand> sutProvider)
+    {
+        // Arrange
+        var orgId = Guid.NewGuid();
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetByIdAsync(orgId)
+            .Returns((Organization)null);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
+            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, orgId, Guid.NewGuid(),
+                newMasterPassword, key));
+        Assert.Equal("Organization does not allow password reset.", exception.Message);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task AdminResetPasswordAsync_OrganizationDoesNotAllowResetPassword_ThrowsBadRequest(
+        OrganizationUserType callingUserType,
+        string newMasterPassword,
+        string key,
+        Organization organization,
+        SutProvider<AdminRecoverAccountCommand> sutProvider)
+    {
+        // Arrange
+        organization.UseResetPassword = false;
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetByIdAsync(organization.Id)
+            .Returns(organization);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
+            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, Guid.NewGuid(), newMasterPassword, key));
+        Assert.Equal("Organization does not allow password reset.", exception.Message);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task AdminResetPasswordAsync_PolicyDoesNotExist_ThrowsBadRequest(
+        OrganizationUserType callingUserType,
+        string newMasterPassword,
+        string key,
+        Organization organization,
+        SutProvider<AdminRecoverAccountCommand> sutProvider)
+    {
+        // Arrange
+        SetupValidOrganization(sutProvider, organization);
+        sutProvider.GetDependency<IPolicyRepository>()
+            .GetByOrganizationIdTypeAsync(organization.Id, PolicyType.ResetPassword)
+            .Returns((Policy)null);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
+            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, Guid.NewGuid(),
+                newMasterPassword, key));
+        Assert.Equal("Organization does not have the password reset policy enabled.", exception.Message);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task AdminResetPasswordAsync_PolicyNotEnabled_ThrowsBadRequest(
+        OrganizationUserType callingUserType,
+        string newMasterPassword,
+        string key,
+        Organization organization,
+        Policy resetPasswordPolicy,
+        SutProvider<AdminRecoverAccountCommand> sutProvider)
+    {
+        // Arrange
+        SetupValidOrganization(sutProvider, organization);
+        resetPasswordPolicy.Enabled = false;
+        sutProvider.GetDependency<IPolicyRepository>()
+            .GetByOrganizationIdTypeAsync(organization.Id, PolicyType.ResetPassword)
+            .Returns(resetPasswordPolicy);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
+            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, Guid.NewGuid(),
+                newMasterPassword, key));
+        Assert.Equal("Organization does not have the password reset policy enabled.", exception.Message);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task AdminResetPasswordAsync_OrganizationUserDoesNotExist_ThrowsBadRequest(
+        OrganizationUserType callingUserType,
+        string newMasterPassword,
+        string key,
+        Organization organization,
+        Policy resetPasswordPolicy,
+        SutProvider<AdminRecoverAccountCommand> sutProvider)
+    {
+        // Arrange
+        SetupValidOrganization(sutProvider, organization);
+        SetupValidPolicy(sutProvider, resetPasswordPolicy, organization.Id);
+        var orgUserId = Guid.NewGuid();
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByIdAsync(orgUserId)
+            .Returns((OrganizationUser)null);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
+            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, orgUserId, newMasterPassword, key));
+        Assert.Equal("Organization User not valid", exception.Message);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task AdminResetPasswordAsync_OrganizationUserNotConfirmed_ThrowsBadRequest(
+        OrganizationUserType callingUserType,
+        string newMasterPassword,
+        string key,
+        Organization organization,
+        Policy resetPasswordPolicy,
+        OrganizationUser organizationUser,
+        SutProvider<AdminRecoverAccountCommand> sutProvider)
+    {
+        // Arrange
+        SetupValidOrganization(sutProvider, organization);
+        SetupValidPolicy(sutProvider, resetPasswordPolicy, organization.Id);
+        organizationUser.Status = OrganizationUserStatusType.Invited;
+        organizationUser.OrganizationId = organization.Id;
+        organizationUser.ResetPasswordKey = "test-key";
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByIdAsync(organizationUser.Id)
+            .Returns(organizationUser);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
+            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
+        Assert.Equal("Organization User not valid", exception.Message);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task AdminResetPasswordAsync_OrganizationUserWrongOrganization_ThrowsBadRequest(
+        OrganizationUserType callingUserType,
+        string newMasterPassword,
+        string key,
+        Organization organization,
+        Policy resetPasswordPolicy,
+        OrganizationUser organizationUser,
+        SutProvider<AdminRecoverAccountCommand> sutProvider)
+    {
+        // Arrange
+        SetupValidOrganization(sutProvider, organization);
+        SetupValidPolicy(sutProvider, resetPasswordPolicy, organization.Id);
+        organizationUser.Status = OrganizationUserStatusType.Confirmed;
+        organizationUser.OrganizationId = Guid.NewGuid(); // Different org
+        organizationUser.ResetPasswordKey = "test-key";
+        organizationUser.UserId = Guid.NewGuid();
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByIdAsync(organizationUser.Id)
+            .Returns(organizationUser);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
+            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
+        Assert.Equal("Organization User not valid", exception.Message);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task AdminResetPasswordAsync_OrganizationUserNoResetPasswordKey_ThrowsBadRequest(
+        OrganizationUserType callingUserType,
+        string newMasterPassword,
+        string key,
+        Organization organization,
+        Policy resetPasswordPolicy,
+        OrganizationUser organizationUser,
+        SutProvider<AdminRecoverAccountCommand> sutProvider)
+    {
+        // Arrange
+        SetupValidOrganization(sutProvider, organization);
+        SetupValidPolicy(sutProvider, resetPasswordPolicy, organization.Id);
+        organizationUser.Status = OrganizationUserStatusType.Confirmed;
+        organizationUser.OrganizationId = organization.Id;
+        organizationUser.ResetPasswordKey = null;
+        organizationUser.UserId = Guid.NewGuid();
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByIdAsync(organizationUser.Id)
+            .Returns(organizationUser);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
+            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
+        Assert.Equal("Organization User not valid", exception.Message);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task AdminResetPasswordAsync_OrganizationUserNoUserId_ThrowsBadRequest(
+        OrganizationUserType callingUserType,
+        string newMasterPassword,
+        string key,
+        Organization organization,
+        Policy resetPasswordPolicy,
+        OrganizationUser organizationUser,
+        SutProvider<AdminRecoverAccountCommand> sutProvider)
+    {
+        // Arrange
+        SetupValidOrganization(sutProvider, organization);
+        SetupValidPolicy(sutProvider, resetPasswordPolicy, organization.Id);
+        organizationUser.Status = OrganizationUserStatusType.Confirmed;
+        organizationUser.OrganizationId = organization.Id;
+        organizationUser.ResetPasswordKey = "test-key";
+        organizationUser.UserId = null;
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByIdAsync(organizationUser.Id)
+            .Returns(organizationUser);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
+            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
+        Assert.Equal("Organization User not valid", exception.Message);
+    }
+
+    [Theory]
+    [BitAutoData(OrganizationUserType.Admin, OrganizationUserType.Owner)]
+    [BitAutoData(OrganizationUserType.Custom, OrganizationUserType.Owner)]
+    [BitAutoData(OrganizationUserType.Custom, OrganizationUserType.Admin)]
+    public async Task AdminResetPasswordAsync_InsufficientPermissions_ThrowsBadRequest(
+        OrganizationUserType callingUserType,
+        OrganizationUserType targetUserType,
+        string newMasterPassword,
+        string key,
+        Organization organization,
+        Policy resetPasswordPolicy,
+        OrganizationUser organizationUser,
+        SutProvider<AdminRecoverAccountCommand> sutProvider)
+    {
+        // Arrange
+        SetupValidOrganization(sutProvider, organization);
+        SetupValidPolicy(sutProvider, resetPasswordPolicy, organization.Id);
+        organizationUser.Status = OrganizationUserStatusType.Confirmed;
+        organizationUser.OrganizationId = organization.Id;
+        organizationUser.ResetPasswordKey = "test-key";
+        organizationUser.UserId = Guid.NewGuid();
+        organizationUser.Type = targetUserType;
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByIdAsync(organizationUser.Id)
+            .Returns(organizationUser);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
+            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
+        Assert.Equal("Calling user does not have permission to reset this user's master password", exception.Message);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task AdminResetPasswordAsync_UserDoesNotExist_ThrowsNotFoundException(
+        OrganizationUserType callingUserType,
+        string newMasterPassword,
+        string key,
+        Organization organization,
+        Policy resetPasswordPolicy,
+        OrganizationUser organizationUser,
+        SutProvider<AdminRecoverAccountCommand> sutProvider)
+    {
+        // Arrange
+        SetupValidOrganization(sutProvider, organization);
+        SetupValidPolicy(sutProvider, resetPasswordPolicy, organization.Id);
+        SetupValidOrganizationUser(sutProvider, organizationUser, organization.Id, callingUserType);
+        sutProvider.GetDependency<IUserService>()
+            .GetUserByIdAsync(organizationUser.UserId.Value)
+            .Returns((User)null);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task AdminResetPasswordAsync_UserUsesKeyConnector_ThrowsBadRequest(
+        OrganizationUserType callingUserType,
+        string newMasterPassword,
+        string key,
+        Organization organization,
+        Policy resetPasswordPolicy,
+        OrganizationUser organizationUser,
+        User user,
+        SutProvider<AdminRecoverAccountCommand> sutProvider)
+    {
+        // Arrange
+        SetupValidOrganization(sutProvider, organization);
+        SetupValidPolicy(sutProvider, resetPasswordPolicy, organization.Id);
+        SetupValidOrganizationUser(sutProvider, organizationUser, organization.Id, callingUserType);
+        user.UsesKeyConnector = true;
+        sutProvider.GetDependency<IUserService>()
+            .GetUserByIdAsync(organizationUser.UserId.Value)
+            .Returns(user);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
+            sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key));
+        Assert.Equal("Cannot reset password of a user with Key Connector.", exception.Message);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task AdminResetPasswordAsync_PasswordUpdateFails_ReturnsFailure(
+        OrganizationUserType callingUserType,
+        string newMasterPassword,
+        string key,
+        Organization organization,
+        Policy resetPasswordPolicy,
+        OrganizationUser organizationUser,
+        User user,
+        SutProvider<AdminRecoverAccountCommand> sutProvider)
+    {
+        // Arrange
+        SetupValidOrganization(sutProvider, organization);
+        SetupValidPolicy(sutProvider, resetPasswordPolicy, organization.Id);
+        SetupValidOrganizationUser(sutProvider, organizationUser, organization.Id, callingUserType);
+        SetupValidUser(sutProvider, user, organizationUser.UserId.Value);
+
+        var failedResult = IdentityResult.Failed(new IdentityError { Description = "Password update failed" });
+        sutProvider.GetDependency<IUserService>()
+            .UpdatePasswordHash(user, newMasterPassword)
+            .Returns(failedResult);
+
+        // Act
+        var result = await sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Errors, e => e.Description == "Password update failed");
+    }
+
+    [Theory]
+    [BitAutoData(OrganizationUserType.Owner, OrganizationUserType.Owner)]
+    [BitAutoData(OrganizationUserType.Owner, OrganizationUserType.Admin)]
+    [BitAutoData(OrganizationUserType.Owner, OrganizationUserType.Custom)]
+    [BitAutoData(OrganizationUserType.Owner, OrganizationUserType.User)]
+    [BitAutoData(OrganizationUserType.Admin, OrganizationUserType.Admin)]
+    [BitAutoData(OrganizationUserType.Admin, OrganizationUserType.Custom)]
+    [BitAutoData(OrganizationUserType.Admin, OrganizationUserType.User)]
+    [BitAutoData(OrganizationUserType.Custom, OrganizationUserType.Custom)]
+    [BitAutoData(OrganizationUserType.Custom, OrganizationUserType.User)]
+    public async Task AdminResetPasswordAsync_ValidPermissionCombinations_Success(
+        OrganizationUserType callingUserType,
+        OrganizationUserType targetUserType,
+        string newMasterPassword,
+        string key,
+        Organization organization,
+        Policy resetPasswordPolicy,
+        OrganizationUser organizationUser,
+        User user,
+        SutProvider<AdminRecoverAccountCommand> sutProvider)
+    {
+        // Arrange
+        SetupValidOrganization(sutProvider, organization);
+        SetupValidPolicy(sutProvider, resetPasswordPolicy, organization.Id);
+        organizationUser.Status = OrganizationUserStatusType.Confirmed;
+        organizationUser.OrganizationId = organization.Id;
+        organizationUser.ResetPasswordKey = "test-key";
+        organizationUser.UserId = Guid.NewGuid();
+        organizationUser.Type = targetUserType;
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByIdAsync(organizationUser.Id)
+            .Returns(organizationUser);
+        SetupValidUser(sutProvider, user, organizationUser.UserId.Value);
+        SetupSuccessfulPasswordUpdate(sutProvider, user, newMasterPassword);
+
+        // Act
+        var result = await sutProvider.Sut.AdminResetPasswordAsync(callingUserType, organization.Id, organizationUser.Id, newMasterPassword, key);
+
+        // Assert
+        Assert.True(result.Succeeded);
+    }
+
+    private void SetupValidOrganization(SutProvider<AdminRecoverAccountCommand> sutProvider, Organization organization)
+    {
+        organization.UseResetPassword = true;
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetByIdAsync(organization.Id)
+            .Returns(organization);
+    }
+
+    private void SetupValidPolicy(SutProvider<AdminRecoverAccountCommand> sutProvider, Policy resetPasswordPolicy, Guid orgId)
+    {
+        resetPasswordPolicy.Enabled = true;
+        sutProvider.GetDependency<IPolicyRepository>()
+            .GetByOrganizationIdTypeAsync(orgId, PolicyType.ResetPassword)
+            .Returns(resetPasswordPolicy);
+    }
+
+    private void SetupValidOrganizationUser(SutProvider<AdminRecoverAccountCommand> sutProvider, OrganizationUser organizationUser, Guid orgId, OrganizationUserType callingUserType)
+    {
+        organizationUser.Status = OrganizationUserStatusType.Confirmed;
+        organizationUser.OrganizationId = orgId;
+        organizationUser.ResetPasswordKey = "test-key";
+        organizationUser.UserId = Guid.NewGuid();
+        // Set a user type that the calling user can reset
+        organizationUser.Type = callingUserType == OrganizationUserType.Owner ? OrganizationUserType.Admin : OrganizationUserType.User;
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByIdAsync(organizationUser.Id)
+            .Returns(organizationUser);
+    }
+
+    private void SetupValidUser(SutProvider<AdminRecoverAccountCommand> sutProvider, User user, Guid userId)
+    {
+        user.UsesKeyConnector = false;
+        sutProvider.GetDependency<IUserService>()
+            .GetUserByIdAsync(userId)
+            .Returns(user);
+    }
+
+    private void SetupSuccessfulPasswordUpdate(SutProvider<AdminRecoverAccountCommand> sutProvider, User user, string newMasterPassword)
+    {
+        sutProvider.GetDependency<IUserService>()
+            .UpdatePasswordHash(user, newMasterPassword)
+            .Returns(IdentityResult.Success);
+    }
+
+    private async Task VerifyUserUpdated(SutProvider<AdminRecoverAccountCommand> sutProvider, User user, string key)
+    {
+        await sutProvider.GetDependency<IUserRepository>().Received(1).ReplaceAsync(
+            Arg.Is<User>(u =>
+                u.Id == user.Id &&
+                u.Key == key &&
+                u.ForcePasswordReset == true &&
+                u.RevisionDate == u.AccountRevisionDate &&
+                u.LastPasswordChangeDate == u.RevisionDate));
+    }
+
+    private async Task VerifyEmailSent(SutProvider<AdminRecoverAccountCommand> sutProvider, User user, Organization organization)
+    {
+        await sutProvider.GetDependency<IMailService>().Received(1).SendAdminResetPasswordEmailAsync(
+            Arg.Is(user.Email),
+            Arg.Is(user.Name),
+            Arg.Is(organization.DisplayName()));
+    }
+
+    private async Task VerifyEventLogged(SutProvider<AdminRecoverAccountCommand> sutProvider, OrganizationUser organizationUser)
+    {
+        await sutProvider.GetDependency<IEventService>().Received(1).LogOrganizationUserEventAsync(
+            Arg.Is(organizationUser),
+            Arg.Is(EventType.OrganizationUser_AdminResetPassword));
+    }
+
+    private async Task VerifyPushNotificationSent(SutProvider<AdminRecoverAccountCommand> sutProvider, Guid userId)
+    {
+        await sutProvider.GetDependency<IPushNotificationService>().Received(1).PushLogOutAsync(
+            Arg.Is(userId));
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-24192

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Move the recover account logic out of `UserService` and into its own command. See ticket for more information.

This is generally a lift & shift, except for the new `CheckProviderPermissionsAsync` private method, and tests (which are all new).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
