### PR TITLE
[PM-21878] update gateway/stripe fields for business units

### DIFF
--- a/src/Admin/AdminConsole/Models/ProviderEditModel.cs
+++ b/src/Admin/AdminConsole/Models/ProviderEditModel.cs
@@ -90,6 +90,7 @@ public class ProviderEditModel : ProviderViewModel, IValidatableObject
         switch (Type)
         {
             case ProviderType.Msp:
+            case ProviderType.BusinessUnit:
                 existingProvider.Gateway = Gateway;
                 existingProvider.GatewayCustomerId = GatewayCustomerId;
                 existingProvider.GatewaySubscriptionId = GatewaySubscriptionId;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21878

## 📔 Objective

When editing a business unit in the Bitwarden portal, a bug exists that prevents the billing "Gateway Customer ID" and "Gateway Subscription ID" fields from saving. This change fixes the bug by making sure the fields get copied to the save model for business units, not only for MSPs.

## 📸 Screenshots


https://github.com/user-attachments/assets/39238237-9b4c-46cb-b866-8f5825025986


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
