### PR TITLE
[PM 21415] Fix: Use organization expiration date for license generation when no subscription exists

### DIFF
--- a/src/Core/Billing/Licenses/Extensions/LicenseExtensions.cs
+++ b/src/Core/Billing/Licenses/Extensions/LicenseExtensions.cs
@@ -3,7 +3,6 @@
 
 using System.Security.Claims;
 using Bit.Core.AdminConsole.Entities;
-using Bit.Core.Billing.Enums;
 using Bit.Core.Models.Business;
 
 namespace Bit.Core.Billing.Licenses.Extensions;
@@ -14,7 +13,7 @@ public static class LicenseExtensions
     {
         if (subscriptionInfo?.Subscription == null)
         {
-            if (org.PlanType == PlanType.Custom && org.ExpirationDate.HasValue)
+            if (org.ExpirationDate.HasValue)
             {
                 return org.ExpirationDate.Value;
             }

--- a/src/Core/Billing/Licenses/Services/Implementations/OrganizationLicenseClaimsFactory.cs
+++ b/src/Core/Billing/Licenses/Services/Implementations/OrganizationLicenseClaimsFactory.cs
@@ -4,7 +4,6 @@
 using System.Globalization;
 using System.Security.Claims;
 using Bit.Core.AdminConsole.Entities;
-using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Licenses.Extensions;
 using Bit.Core.Billing.Licenses.Models;
 using Bit.Core.Enums;
@@ -121,6 +120,6 @@ public class OrganizationLicenseClaimsFactory : ILicenseClaimsFactory<Organizati
 
     private static bool IsTrialing(Organization org, SubscriptionInfo subscriptionInfo) =>
         subscriptionInfo?.Subscription is null
-            ? org.PlanType != PlanType.Custom || !org.ExpirationDate.HasValue
+            ? !org.ExpirationDate.HasValue
             : subscriptionInfo.Subscription.TrialEndDate > DateTime.UtcNow;
 }

--- a/src/Core/Billing/Organizations/Models/OrganizationLicense.cs
+++ b/src/Core/Billing/Organizations/Models/OrganizationLicense.cs
@@ -98,7 +98,7 @@ public class OrganizationLicense : ILicense
 
         if (subscriptionInfo?.Subscription == null)
         {
-            if (org.PlanType == PlanType.Custom && org.ExpirationDate.HasValue)
+            if (org.ExpirationDate.HasValue)
             {
                 Expires = Refresh = org.ExpirationDate.Value;
                 Trial = false;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21415

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When generating license files for organizations without subscriptions, the license expiration now correctly uses the organization's expiration date (if set) instead of defaulting to 7 days from the current date.

**Problem**
Previously, license generation logic only respected organization expiration dates for PlanType.Custom organizations. For all other organizations without subscriptions, licenses would expire after 7 days regardless of the organization's configured expiration date in the admin portal.

**Solution**
Modified the license generation logic to prioritize the organization's expiration date for all organizations without subscriptions, not just those with PlanType.Custom.

**Changes Made**
**Core Changes**
`LicenseExtensions.cs:` Updated `CalculateFreshExpirationDate()` to check for `org.ExpirationDate.HasValue` regardless of plan type
`OrganizationLicense.cs`: Updated legacy license constructor with same logic for consistency
`OrganizationLicenseClaimsFactory.cs`: Updated `IsTrialing()` method to reflect that organizations with expiration dates are not trialing

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="1728" height="1117" alt="Screenshot 2025-08-14 at 13 33 58" src="https://github.com/user-attachments/assets/4f29e953-3b31-4bce-9ac4-f28da20d1a79" />
<img width="1728" height="1117" alt="Screenshot 2025-08-14 at 13 34 17" src="https://github.com/user-attachments/assets/9a943bf6-133c-4d47-8479-48cd71b87cec" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
