### PR TITLE
[SM-1548] Reducing processing time for retrieving a secret that is in a project…

### DIFF
--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/SecretRepository.cs
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/SecretsManager/Repositories/SecretRepository.cs
@@ -25,8 +25,8 @@ public class SecretRepository : Repository<Core.SecretsManager.Entities.Secret, 
         {
             var dbContext = GetDatabaseContext(scope);
             var secret = await dbContext.Secret
-                                    .Include("Projects")
                                     .Where(c => c.Id == id && c.DeletedDate == null)
+                                    .Include("Projects")
                                     .FirstOrDefaultAsync();
             return Mapper.Map<Core.SecretsManager.Entities.Secret>(secret);
         }
@@ -50,10 +50,8 @@ public class SecretRepository : Repository<Core.SecretsManager.Entities.Secret, 
     {
         await using var scope = ServiceScopeFactory.CreateAsyncScope();
         var dbContext = GetDatabaseContext(scope);
-        var query = dbContext.Secret
-            .Include(c => c.Projects)
-            .Where(c => c.OrganizationId == organizationId && c.DeletedDate == null);
-
+        var query = dbContext.Secret.Where(c => c.OrganizationId == organizationId && c.DeletedDate == null);
+        query.Include(c => c.Projects);
         query = accessType switch
         {
             AccessClientType.NoAccessCheck => query,
@@ -71,8 +69,8 @@ public class SecretRepository : Repository<Core.SecretsManager.Entities.Secret, 
         using var scope = ServiceScopeFactory.CreateScope();
         var dbContext = GetDatabaseContext(scope);
         var query = dbContext.Secret
-            .Include(c => c.Projects)
             .Where(c => c.OrganizationId == organizationId && c.DeletedDate == null)
+            .Include(c => c.Projects)
             .OrderBy(s => s.RevisionDate);
 
         var secrets = SecretToPermissionDetails(query, userId, accessType);
@@ -130,8 +128,8 @@ public class SecretRepository : Repository<Core.SecretsManager.Entities.Secret, 
     {
         using var scope = ServiceScopeFactory.CreateScope();
         var dbContext = GetDatabaseContext(scope);
-        var query = dbContext.Secret.Include(s => s.Projects)
-            .Where(s => s.Projects.Any(p => p.Id == projectId) && s.DeletedDate == null);
+        var query = dbContext.Secret.Where(s => s.Projects.Any(p => p.Id == projectId) && s.DeletedDate == null)
+            .Include(s => s.Projects);
 
         var secrets = SecretToPermissionDetails(query, userId, accessType);
 


### PR DESCRIPTION
… with multiple secrets

## 🎟️ Tracking

https://bitwarden.atlassian.net/jira/software/c/projects/SM/boards/74?assignee=625cb516fd06270069beaf5d&selectedIssue=SM-1548

## 📔 Objective

When accessing secret details for a secret that is a part of a project that has a lot of secrets (100s) it was too slow of a response from the endpoint.

## 📸 Screenshots

Left is before endpoint optimization, right is after.
<img width="1606" height="465" alt="image" src="https://github.com/user-attachments/assets/c871256d-9483-43c7-9efe-972adb2bf5df" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
