### PR TITLE
[PM-24278] Fix sproc to return UserId

### DIFF
--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetPolicyDetailsByOrganizationIdAsyncTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetPolicyDetailsByOrganizationIdAsyncTests.cs
@@ -40,6 +40,10 @@ public class GetPolicyDetailsByOrganizationIdAsyncTests
 
         Assert.True(results.Single().IsProvider);
 
+        // Annul
+        await organizationRepository.DeleteAsync(new Organization { Id = userOrgConnectedDirectly.OrganizationId });
+        await userRepository.DeleteAsync(user);
+
         async Task ArrangeProvider()
         {
             var provider = await providerRepository.CreateAsync(new Provider
@@ -86,6 +90,11 @@ public class GetPolicyDetailsByOrganizationIdAsyncTests
         Assert.Contains(results, result => result.OrganizationUserId == userOrgConnectedDirectly.Id
                                            && result.OrganizationId == userOrgConnectedDirectly.OrganizationId);
         Assert.DoesNotContain(results, result => result.OrganizationId == notConnectedOrg.Id);
+
+        // Annul
+        await organizationRepository.DeleteAsync(new Organization { Id = userOrgConnectedDirectly.OrganizationId });
+        await organizationRepository.DeleteAsync(notConnectedOrg);
+        await userRepository.DeleteAsync(user);
     }
 
     [DatabaseTheory, DatabaseData]
@@ -115,6 +124,10 @@ public class GetPolicyDetailsByOrganizationIdAsyncTests
                                            && result.PolicyType == inputPolicyType);
 
         Assert.DoesNotContain(results, result => result.PolicyType == notInputPolicyType);
+
+        // Annul
+        await organizationRepository.DeleteAsync(new Organization { Id = orgUser.OrganizationId });
+        await userRepository.DeleteAsync(user);
     }
 
 
@@ -143,6 +156,12 @@ public class GetPolicyDetailsByOrganizationIdAsyncTests
         Assert.Equal(expectedCount, results.Count);
 
         AssertPolicyDetailUserConnections(results, userOrgConnectedDirectly, userOrgConnectedByEmail, userOrgConnectedByUserId);
+
+        // Annul
+        await organizationRepository.DeleteAsync(new Organization() { Id = userOrgConnectedDirectly.OrganizationId });
+        await organizationRepository.DeleteAsync(new Organization() { Id = userOrgConnectedByEmail.OrganizationId });
+        await organizationRepository.DeleteAsync(new Organization() { Id = userOrgConnectedByUserId.OrganizationId });
+        await userRepository.DeleteAsync(user);
     }
 
     [DatabaseTheory, DatabaseData]
@@ -167,6 +186,12 @@ public class GetPolicyDetailsByOrganizationIdAsyncTests
 
         // Assert
         AssertPolicyDetailUserConnections(results, userOrgConnectedDirectly, userOrgConnectedByEmail, userOrgConnectedByUserId);
+
+        // Annul
+        await organizationRepository.DeleteAsync(new Organization() { Id = userOrgConnectedDirectly.OrganizationId });
+        await organizationRepository.DeleteAsync(new Organization() { Id = userOrgConnectedByEmail.OrganizationId });
+        await organizationRepository.DeleteAsync(new Organization() { Id = userOrgConnectedByUserId.OrganizationId });
+        await userRepository.DeleteAsync(user);
     }
 
     [DatabaseTheory, DatabaseData]
@@ -200,6 +225,10 @@ public class GetPolicyDetailsByOrganizationIdAsyncTests
         Assert.Contains(results, result => result.OrganizationUserId == orgUser2.Id
                                            && result.UserId == orgUser2.UserId
                                            && result.OrganizationId == orgUser2.OrganizationId);
+
+        // Annul
+        await organizationRepository.DeleteAsync(organization);
+        await userRepository.DeleteManyAsync([user1, user2]);
     }
 
 

--- a/util/Migrator/DbScripts/2025-08-15_00_PolicyDetails_ReadByOrganizationId_AddUserId.sql
+++ b/util/Migrator/DbScripts/2025-08-15_00_PolicyDetails_ReadByOrganizationId_AddUserId.sql
@@ -1,4 +1,4 @@
-CREATE PROCEDURE [dbo].[PolicyDetails_ReadByOrganizationId]
+CREATE OR ALTER PROCEDURE [dbo].[PolicyDetails_ReadByOrganizationId]
     @OrganizationId UNIQUEIDENTIFIER,
     @PolicyType  TINYINT
 AS


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-24278


## 📔 Objective

Found a bug while working on this ticket. The sproc isn’t returning the UserId. The rest of the sproc is already set up to return it; we’re just not returning it in the final SELECT. The EF query is already returning it.

Note: This sproc is currently not being used anywhere, so no worries about backward compatibility.

1. Update sprocs to return UserId 
2. Add a database integration test to cover this case.
3. Migration script

## 📸 Screenshots

Migration was successfully run on local.

<img width="1254" height="159" alt="image" src="https://github.com/user-attachments/assets/1b452c38-cd07-4a24-b146-60fc7d9df57c" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
