### PR TITLE
[PM-24554] Remove code for pm-20322-allow-trial-length-0

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -156,7 +156,6 @@ public static class FeatureFlagKeys
     public const string PM199566_UpdateMSPToChargeAutomatically = "pm-199566-update-msp-to-charge-automatically";
     public const string PM19956_RequireProviderPaymentMethodDuringSetup = "pm-19956-require-provider-payment-method-during-setup";
     public const string UseOrganizationWarningsService = "use-organization-warnings-service";
-    public const string PM20322_AllowTrialLength0 = "pm-20322-allow-trial-length-0";
     public const string PM21092_SetNonUSBusinessUseToReverseCharge = "pm-21092-set-non-us-business-use-to-reverse-charge";
     public const string PM21881_ManagePaymentDetailsOutsideCheckout = "pm-21881-manage-payment-details-outside-checkout";
     public const string PM21821_ProviderPortalTakeover = "pm-21821-provider-portal-takeover";

--- a/src/Identity/Billing/Controller/AccountsController.cs
+++ b/src/Identity/Billing/Controller/AccountsController.cs
@@ -1,7 +1,6 @@
 ﻿using Bit.Core;
 using Bit.Core.Billing.Models.Api.Requests.Accounts;
 using Bit.Core.Billing.TrialInitiation.Registration;
-using Bit.Core.Services;
 using Bit.Core.Utilities;
 using Bit.SharedWeb.Utilities;
 using Microsoft.AspNetCore.Mvc;
@@ -11,16 +10,13 @@ namespace Bit.Identity.Billing.Controller;
 [Route("accounts")]
 [ExceptionHandlerFilter]
 public class AccountsController(
-    ISendTrialInitiationEmailForRegistrationCommand sendTrialInitiationEmailForRegistrationCommand,
-    IFeatureService featureService) : Microsoft.AspNetCore.Mvc.Controller
+    ISendTrialInitiationEmailForRegistrationCommand sendTrialInitiationEmailForRegistrationCommand) : Microsoft.AspNetCore.Mvc.Controller
 {
     [HttpPost("trial/send-verification-email")]
     [SelfHosted(NotSelfHostedOnly = true)]
     public async Task<IActionResult> PostTrialInitiationSendVerificationEmailAsync([FromBody] TrialSendVerificationEmailRequestModel model)
     {
-        var allowTrialLength0 = featureService.IsEnabled(FeatureFlagKeys.PM20322_AllowTrialLength0);
-
-        var trialLength = allowTrialLength0 ? model.TrialLength ?? 7 : 7;
+        var trialLength = model.TrialLength ?? 7;
 
         var token = await sendTrialInitiationEmailForRegistrationCommand.Handle(
             model.Email,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-24554

## 📔 Objective

This PR removes code associated with the `pm-20322-allow-trial-length-0` feature flag.

## 📸 Screenshots

(Billing step is required during signup when trial length is zero)
<img width="955" height="913" alt="image" src="https://github.com/user-attachments/assets/9a111042-5bd9-4c5e-b270-c9e80e0e4d39" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
