### PR TITLE
[PM 21647]Update Billing application to utilize new webhook secrets

### DIFF
--- a/src/Billing/BillingSettings.cs
+++ b/src/Billing/BillingSettings.cs
@@ -7,9 +7,7 @@ public class BillingSettings
 {
     public virtual string JobsKey { get; set; }
     public virtual string StripeWebhookKey { get; set; }
-    public virtual string StripeWebhookSecret { get; set; }
-    public virtual string StripeWebhookSecret20231016 { get; set; }
-    public virtual string StripeWebhookSecret20240620 { get; set; }
+    public virtual string StripeWebhookSecret20250730Basil { get; set; }
     public virtual string BitPayWebhookKey { get; set; }
     public virtual string AppleWebhookKey { get; set; }
     public virtual FreshDeskSettings FreshDesk { get; set; } = new FreshDeskSettings();

--- a/src/Billing/Controllers/StripeController.cs
+++ b/src/Billing/Controllers/StripeController.cs
@@ -120,9 +120,7 @@ public class StripeController : Controller
 
         return deliveryContainer.ApiVersion switch
         {
-            "2024-06-20" => HandleVersionWith(_billingSettings.StripeWebhookSecret20240620),
-            "2023-10-16" => HandleVersionWith(_billingSettings.StripeWebhookSecret20231016),
-            "2022-08-01" => HandleVersionWith(_billingSettings.StripeWebhookSecret),
+            "2025-07-30.basil" => HandleVersionWith(_billingSettings.StripeWebhookSecret20250730Basil),
             _ => HandleDefault(deliveryContainer.ApiVersion)
         };
 

--- a/src/Billing/appsettings.json
+++ b/src/Billing/appsettings.json
@@ -57,9 +57,7 @@
   "billingSettings": {
     "jobsKey": "SECRET",
     "stripeWebhookKey": "SECRET",
-    "stripeWebhookSecret": "SECRET",
-    "stripeWebhookSecret20231016": "SECRET",
-    "stripeWebhookSecret20240620": "SECRET",
+    "stripeWebhookSecret20250730Basil": "SECRET",
     "bitPayWebhookKey": "SECRET",
     "appleWebhookKey": "SECRET",
     "payPal": {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21647

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add support for Stripe API Version 2025-07-30.basil webhook secrets in Billing application
This PR implements backend configuration changes to support new Stripe webhook endpoints created for API Version 2025-07-30.basil across lower environments (US DEV, US QA, EU QA).
**🐛 Problem Solved**
- The Billing application was unable to process webhook events from Stripe's new API version 2025-07-30.basil

**Technical Changes**
**Files Modified:**

1. `src/Billing/BillingSettings.cs`
  - Added `StripeWebhookSecret20250430Basil` property
  -  Remove stripeWebhookSecret20240620
  - Remove stripeWebhookSecret20231016
  - Remove stripeWebhookSecret

2. `src/Billing/Controllers/StripeController.cs`
  - Updated PickStripeWebhookSecret method to include case for "2025-07-30.basil" API version
  - Maintains existing webhook parsing logic without special-case handling

3. `src/Billing/appsettings.json`
  - Added placeholder configuration for new webhook secret
  - Remove stripeWebhookSecret20240620
  - Remove stripeWebhookSecret20231016
  - Remove stripeWebhookSecret
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
