### PR TITLE
Add SSH key fields for lossless encrypted PEM storage and optional passphrase

### DIFF
--- a/src/Api/Vault/Models/CipherSSHKeyModel.cs
+++ b/src/Api/Vault/Models/CipherSSHKeyModel.cs
@@ -15,15 +15,37 @@ public class CipherSSHKeyModel
         PrivateKey = data.PrivateKey;
         PublicKey = data.PublicKey;
         KeyFingerprint = data.KeyFingerprint;
+
+        // Map new optional properties if present
+        OriginalPrivateKey = data.OriginalPrivateKey;
+        IsEncrypted = data.IsEncrypted;
+        SshKeyPassphrase = data.SshKeyPassphrase;
     }
 
     [EncryptedString]
     [EncryptedStringLength(5000)]
     public string PrivateKey { get; set; }
+
     [EncryptedString]
     [EncryptedStringLength(5000)]
     public string PublicKey { get; set; }
+
     [EncryptedString]
     [EncryptedStringLength(1000)]
     public string KeyFingerprint { get; set; }
+
+    // Preserve original encrypted PEM verbatim
+    [EncryptedString]
+    [EncryptedStringLength(5000)]
+    public string OriginalPrivateKey { get; set; }
+
+    // Transported as encrypted string ("true"/"false")
+    [EncryptedString]
+    [EncryptedStringLength(10)]
+    public string IsEncrypted { get; set; }
+
+    // Optional stored passphrase (encrypted)
+    [EncryptedString]
+    [EncryptedStringLength(5000)]
+    public string SshKeyPassphrase { get; set; }
 }

--- a/src/Api/Vault/Models/Request/CipherRequestModel.cs
+++ b/src/Api/Vault/Models/Request/CipherRequestModel.cs
@@ -261,6 +261,11 @@ public class CipherRequestModel
             PrivateKey = SSHKey.PrivateKey,
             PublicKey = SSHKey.PublicKey,
             KeyFingerprint = SSHKey.KeyFingerprint,
+
+            // Preserve original encrypted PEM and optional passphrase; track encryption flag
+            OriginalPrivateKey = SSHKey.OriginalPrivateKey,
+            IsEncrypted = SSHKey.IsEncrypted,
+            SshKeyPassphrase = SSHKey.SshKeyPassphrase,
         };
     }
 }

--- a/src/Core/Vault/Models/Data/CipherSSHKeyData.cs
+++ b/src/Core/Vault/Models/Data/CipherSSHKeyData.cs
@@ -10,4 +10,10 @@ public class CipherSSHKeyData : CipherData
     public string PrivateKey { get; set; }
     public string PublicKey { get; set; }
     public string KeyFingerprint { get; set; }
+
+    // New fields to preserve original encrypted key and optional passphrase
+    public string OriginalPrivateKey { get; set; }
+    // Booleans are typically transported as encrypted strings ("true"/"false") in Bitwarden models
+    public string IsEncrypted { get; set; }
+    public string SshKeyPassphrase { get; set; }
 }


### PR DESCRIPTION
Summary
Extends the server SSH key models and request mapping to persist original encrypted PEM and optional passphrase fields, enabling clients to preserve exact imports and decrypt on-demand for agent use.

Linked PRs needed to work for this changes:
- clients: https://github.com/bitwarden/clients/pull/16121
- server:
- sdk-internal: https://github.com/bitwarden/sdk-internal/pull/408

Linked Issue
- OpenSSH keys with passphrase not saving correctly (https://github.com/bitwarden/clients/issues/13878)
- SSH agent can't import RSA keys (PKCS#1 / PEM) (https://github.com/bitwarden/clients/issues/15088)
- unable to save SSH key with or without a passphrase from puttygen (https://github.com/bitwarden/clients/issues/13343)

Changes
- Core model
  - src/Core/Vault/Models/Data/CipherSSHKeyData.cs
    - Added OriginalPrivateKey, IsEncrypted, SshKeyPassphrase.
- API model
  - src/Api/Vault/Models/CipherSSHKeyModel.cs
    - Added [EncryptedString] OriginalPrivateKey, IsEncrypted, SshKeyPassphrase.
    - Constructor maps from CipherSSHKeyData.
- Request mapping
  - src/Api/Vault/Models/Request/CipherRequestModel.cs
    - ToCipherSSHKeyData() now assigns:
      - OriginalPrivateKey, IsEncrypted, SshKeyPassphrase from request model when provided.

Backwards Compatibility
- Optional fields; no service-level breaking change.
- Existing clients not sending these fields remain supported.

Security Considerations
- All new fields are encrypted strings at rest, consistent with existing cipher data protections.

Testing
- API: Create/Update SSH key cipher including OriginalPrivateKey and SshKeyPassphrase; verify round-trip persistence.
- Ensure existing create/update flows still pass with minimal payloads (backward compatibility).

Release Notes
- Add server support for preserving encrypted SSH private key PEM and optional passphrase on SSH key items.

General Notes

Why this fixes the bug
- Clients now retain the original encrypted PEM that was imported. Copy/export from the item reproduces the exact input (including encryption header), avoiding mismatches with SSH tooling.
- The agent decrypts in memory for use; the vault never stores plaintext.

Rollout
- Order: server → sdk-internal → clients.
- Mixed-version environments remain functional; new fields are optional.

Follow-ups (optional)
- Prompt passphrase on agent use when it isn’t stored, then decrypt transiently and proceed (without saving).
- Consider deriving IsEncrypted on the server from OriginalPrivateKey header, if desired, and removing reliance on client-provided IsEncrypted entirely.
- Expand automated tests for PKCS#8 encrypted flow; add end-to-end agent test.