### PR TITLE
Improve Swagger OperationIDs for AC

### DIFF
--- a/src/Api/AdminConsole/Controllers/GroupsController.cs
+++ b/src/Api/AdminConsole/Controllers/GroupsController.cs
@@ -14,6 +14,7 @@ using Bit.Core.Context;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
+using Bit.SharedWeb.Swagger;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -164,6 +165,7 @@ public class GroupsController : Controller
 
     [HttpPut("{id}")]
     [HttpPost("{id}")]
+    [SwaggerExclude("POST")]
     public async Task<GroupResponseModel> Put(Guid orgId, Guid id, [FromBody] GroupRequestModel model)
     {
         if (!await _currentContext.ManageGroups(orgId))
@@ -239,6 +241,7 @@ public class GroupsController : Controller
 
     [HttpDelete("{id}")]
     [HttpPost("{id}/delete")]
+    [SwaggerExclude("POST")]
     public async Task Delete(string orgId, string id)
     {
         var group = await _groupRepository.GetByIdAsync(new Guid(id));
@@ -252,6 +255,7 @@ public class GroupsController : Controller
 
     [HttpDelete("")]
     [HttpPost("delete")]
+    [SwaggerExclude("POST")]
     public async Task BulkDelete([FromBody] GroupBulkRequestModel model)
     {
         var groups = await _groupRepository.GetManyByManyIds(model.Ids);
@@ -269,7 +273,8 @@ public class GroupsController : Controller
 
     [HttpDelete("{id}/user/{orgUserId}")]
     [HttpPost("{id}/delete-user/{orgUserId}")]
-    public async Task Delete(string orgId, string id, string orgUserId)
+    [SwaggerExclude("POST")]
+    public async Task DeleteUser(string orgId, string id, string orgUserId)
     {
         var group = await _groupRepository.GetByIdAsync(new Guid(id));
         if (group == null || !await _currentContext.ManageGroups(group.OrganizationId))

--- a/src/Api/AdminConsole/Controllers/OrganizationConnectionsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationConnectionsController.cs
@@ -13,6 +13,7 @@ using Bit.Core.Exceptions;
 using Bit.Core.Models.OrganizationConnectionConfigs;
 using Bit.Core.Repositories;
 using Bit.Core.Settings;
+using Bit.SharedWeb.Swagger;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -141,6 +142,7 @@ public class OrganizationConnectionsController : Controller
 
     [HttpDelete("{organizationConnectionId}")]
     [HttpPost("{organizationConnectionId}/delete")]
+    [SwaggerExclude("POST")]
     public async Task DeleteConnection(Guid organizationConnectionId)
     {
         var connection = await _organizationConnectionRepository.GetByIdAsync(organizationConnectionId);

--- a/src/Api/AdminConsole/Controllers/OrganizationDomainController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationDomainController.cs
@@ -7,6 +7,7 @@ using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
+using Bit.SharedWeb.Swagger;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -46,7 +47,7 @@ public class OrganizationDomainController : Controller
     }
 
     [HttpGet("{orgId}/domain")]
-    public async Task<ListResponseModel<OrganizationDomainResponseModel>> Get(Guid orgId)
+    public async Task<ListResponseModel<OrganizationDomainResponseModel>> GetAll(Guid orgId)
     {
         await ValidateOrganizationAccessAsync(orgId);
 
@@ -106,6 +107,7 @@ public class OrganizationDomainController : Controller
 
     [HttpDelete("{orgId}/domain/{id}")]
     [HttpPost("{orgId}/domain/{id}/remove")]
+    [SwaggerExclude("POST")]
     public async Task RemoveDomain(Guid orgId, Guid id)
     {
         await ValidateOrganizationAccessAsync(orgId);

--- a/src/Api/AdminConsole/Controllers/OrganizationIntegrationConfigurationController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationIntegrationConfigurationController.cs
@@ -5,6 +5,7 @@ using Bit.Core.Context;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.Utilities;
+using Bit.SharedWeb.Swagger;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -99,6 +100,7 @@ public class OrganizationIntegrationConfigurationController(
 
     [HttpDelete("{configurationId:guid}")]
     [HttpPost("{configurationId:guid}/delete")]
+    [SwaggerExclude("POST")]
     public async Task DeleteAsync(Guid organizationId, Guid integrationId, Guid configurationId)
     {
         if (!await HasPermission(organizationId))

--- a/src/Api/AdminConsole/Controllers/OrganizationIntegrationController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationIntegrationController.cs
@@ -5,6 +5,7 @@ using Bit.Core.Context;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.Utilities;
+using Bit.SharedWeb.Swagger;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -65,6 +66,7 @@ public class OrganizationIntegrationController(
 
     [HttpDelete("{integrationId:guid}")]
     [HttpPost("{integrationId:guid}/delete")]
+    [SwaggerExclude("POST")]
     public async Task DeleteAsync(Guid organizationId, Guid integrationId)
     {
         if (!await HasPermission(organizationId))

--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -30,6 +30,7 @@ using Bit.Core.OrganizationFeatures.OrganizationUsers.Interfaces;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Utilities;
+using Bit.SharedWeb.Swagger;
 using Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interfaces;
 using Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Requests;
 using Microsoft.AspNetCore.Authorization;
@@ -167,7 +168,7 @@ public class OrganizationUsersController : Controller
     }
 
     [HttpGet("")]
-    public async Task<ListResponseModel<OrganizationUserUserDetailsResponseModel>> Get(Guid orgId, bool includeGroups = false, bool includeCollections = false)
+    public async Task<ListResponseModel<OrganizationUserUserDetailsResponseModel>> GetAll(Guid orgId, bool includeGroups = false, bool includeCollections = false)
     {
         var request = new OrganizationUserUserDetailsQueryRequest
         {
@@ -361,6 +362,7 @@ public class OrganizationUsersController : Controller
 
     [HttpPut("{id}")]
     [HttpPost("{id}")]
+    [SwaggerExclude("POST")]
     [Authorize<ManageUsersRequirement>]
     public async Task Put(Guid orgId, Guid id, [FromBody] OrganizationUserUpdateRequestModel model)
     {
@@ -493,6 +495,7 @@ public class OrganizationUsersController : Controller
 
     [HttpDelete("{id}")]
     [HttpPost("{id}/remove")]
+    [SwaggerExclude("POST")]
     [Authorize<ManageUsersRequirement>]
     public async Task Remove(Guid orgId, Guid id)
     {
@@ -502,6 +505,7 @@ public class OrganizationUsersController : Controller
 
     [HttpDelete("")]
     [HttpPost("remove")]
+    [SwaggerExclude("POST")]
     [Authorize<ManageUsersRequirement>]
     public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkRemove(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
     {
@@ -513,6 +517,7 @@ public class OrganizationUsersController : Controller
 
     [HttpDelete("{id}/delete-account")]
     [HttpPost("{id}/delete-account")]
+    [SwaggerExclude("POST")]
     [Authorize<ManageUsersRequirement>]
     public async Task DeleteAccount(Guid orgId, Guid id)
     {
@@ -527,6 +532,7 @@ public class OrganizationUsersController : Controller
 
     [HttpDelete("delete-account")]
     [HttpPost("delete-account")]
+    [SwaggerExclude("POST")]
     [Authorize<ManageUsersRequirement>]
     public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkDeleteAccount(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
     {
@@ -542,40 +548,45 @@ public class OrganizationUsersController : Controller
             new OrganizationUserBulkResponseModel(r.OrganizationUserId, r.ErrorMessage)));
     }
 
-    [HttpPatch("{id}/revoke")]
     [HttpPut("{id}/revoke")]
+    [HttpPatch("{id}/revoke")]
+    [SwaggerExclude("PATCH")]
     [Authorize<ManageUsersRequirement>]
     public async Task RevokeAsync(Guid orgId, Guid id)
     {
         await RestoreOrRevokeUserAsync(orgId, id, _revokeOrganizationUserCommand.RevokeUserAsync);
     }
 
-    [HttpPatch("revoke")]
     [HttpPut("revoke")]
+    [HttpPatch("revoke")]
+    [SwaggerExclude("PATCH")]
     [Authorize<ManageUsersRequirement>]
     public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkRevokeAsync(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
     {
         return await RestoreOrRevokeUsersAsync(orgId, model, _revokeOrganizationUserCommand.RevokeUsersAsync);
     }
 
-    [HttpPatch("{id}/restore")]
     [HttpPut("{id}/restore")]
+    [HttpPatch("{id}/restore")]
+    [SwaggerExclude("PATCH")]
     [Authorize<ManageUsersRequirement>]
     public async Task RestoreAsync(Guid orgId, Guid id)
     {
         await RestoreOrRevokeUserAsync(orgId, id, (orgUser, userId) => _restoreOrganizationUserCommand.RestoreUserAsync(orgUser, userId));
     }
 
-    [HttpPatch("restore")]
     [HttpPut("restore")]
+    [HttpPatch("restore")]
+    [SwaggerExclude("PATCH")]
     [Authorize<ManageUsersRequirement>]
     public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkRestoreAsync(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
     {
         return await RestoreOrRevokeUsersAsync(orgId, model, (orgId, orgUserIds, restoringUserId) => _restoreOrganizationUserCommand.RestoreUsersAsync(orgId, orgUserIds, restoringUserId, _userService));
     }
 
-    [HttpPatch("enable-secrets-manager")]
     [HttpPut("enable-secrets-manager")]
+    [HttpPatch("enable-secrets-manager")]
+    [SwaggerExclude("PATCH")]
     [Authorize<ManageUsersRequirement>]
     public async Task BulkEnableSecretsManagerAsync(Guid orgId,
         [FromBody] OrganizationUserBulkRequestModel model)

--- a/src/Api/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationsController.cs
@@ -38,6 +38,7 @@ using Bit.Core.Services;
 using Bit.Core.Settings;
 using Bit.Core.Tokens;
 using Bit.Core.Utilities;
+using Bit.SharedWeb.Swagger;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -226,6 +227,7 @@ public class OrganizationsController : Controller
 
     [HttpPut("{id}")]
     [HttpPost("{id}")]
+    [SwaggerExclude("POST")]
     public async Task<OrganizationResponseModel> Put(string id, [FromBody] OrganizationUpdateRequestModel model)
     {
         var orgIdGuid = new Guid(id);
@@ -292,6 +294,7 @@ public class OrganizationsController : Controller
 
     [HttpDelete("{id}")]
     [HttpPost("{id}/delete")]
+    [SwaggerExclude("POST")]
     public async Task Delete(string id, [FromBody] SecretVerificationRequestModel model)
     {
         var orgIdGuid = new Guid(id);

--- a/src/Api/AdminConsole/Controllers/PoliciesController.cs
+++ b/src/Api/AdminConsole/Controllers/PoliciesController.cs
@@ -90,7 +90,7 @@ public class PoliciesController : Controller
     }
 
     [HttpGet("")]
-    public async Task<ListResponseModel<PolicyResponseModel>> Get(string orgId)
+    public async Task<ListResponseModel<PolicyResponseModel>> GetAll(string orgId)
     {
         var orgIdGuid = new Guid(orgId);
         if (!await _currentContext.ManagePolicies(orgIdGuid))

--- a/src/Api/AdminConsole/Controllers/ProviderOrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/ProviderOrganizationsController.cs
@@ -12,6 +12,7 @@ using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Utilities;
+using Bit.SharedWeb.Swagger;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -94,6 +95,7 @@ public class ProviderOrganizationsController : Controller
 
     [HttpDelete("{id:guid}")]
     [HttpPost("{id:guid}/delete")]
+    [SwaggerExclude("POST")]
     public async Task Delete(Guid providerId, Guid id)
     {
         if (!_currentContext.ManageProviderOrganizations(providerId))

--- a/src/Api/AdminConsole/Controllers/ProviderUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/ProviderUsersController.cs
@@ -10,6 +10,7 @@ using Bit.Core.AdminConsole.Services;
 using Bit.Core.Context;
 using Bit.Core.Exceptions;
 using Bit.Core.Services;
+using Bit.SharedWeb.Swagger;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -49,7 +50,7 @@ public class ProviderUsersController : Controller
     }
 
     [HttpGet("")]
-    public async Task<ListResponseModel<ProviderUserUserDetailsResponseModel>> Get(Guid providerId)
+    public async Task<ListResponseModel<ProviderUserUserDetailsResponseModel>> GetAll(Guid providerId)
     {
         if (!_currentContext.ProviderManageUsers(providerId))
         {
@@ -156,6 +157,7 @@ public class ProviderUsersController : Controller
 
     [HttpPut("{id:guid}")]
     [HttpPost("{id:guid}")]
+    [SwaggerExclude("POST")]
     public async Task Put(Guid providerId, Guid id, [FromBody] ProviderUserUpdateRequestModel model)
     {
         if (!_currentContext.ProviderManageUsers(providerId))
@@ -175,6 +177,7 @@ public class ProviderUsersController : Controller
 
     [HttpDelete("{id:guid}")]
     [HttpPost("{id:guid}/delete")]
+    [SwaggerExclude("POST")]
     public async Task Delete(Guid providerId, Guid id)
     {
         if (!_currentContext.ProviderManageUsers(providerId))
@@ -188,6 +191,7 @@ public class ProviderUsersController : Controller
 
     [HttpDelete("")]
     [HttpPost("delete")]
+    [SwaggerExclude("POST")]
     public async Task<ListResponseModel<ProviderUserBulkResponseModel>> BulkDelete(Guid providerId, [FromBody] ProviderUserBulkRequestModel model)
     {
         if (!_currentContext.ProviderManageUsers(providerId))

--- a/src/Api/AdminConsole/Controllers/ProvidersController.cs
+++ b/src/Api/AdminConsole/Controllers/ProvidersController.cs
@@ -10,6 +10,7 @@ using Bit.Core.Exceptions;
 using Bit.Core.Models.Business;
 using Bit.Core.Services;
 using Bit.Core.Settings;
+using Bit.SharedWeb.Swagger;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -54,6 +55,7 @@ public class ProvidersController : Controller
 
     [HttpPut("{id:guid}")]
     [HttpPost("{id:guid}")]
+    [SwaggerExclude("POST")]
     public async Task<ProviderResponseModel> Put(Guid id, [FromBody] ProviderUpdateRequestModel model)
     {
         if (!_currentContext.ProviderProviderAdmin(id))
@@ -121,6 +123,7 @@ public class ProvidersController : Controller
 
     [HttpDelete("{id}")]
     [HttpPost("{id}/delete")]
+    [SwaggerExclude("POST")]
     public async Task Delete(Guid id)
     {
         if (!_currentContext.ProviderProviderAdmin(id))

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationDomainControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationDomainControllerTests.cs
@@ -28,7 +28,7 @@ public class OrganizationDomainControllerTests
     {
         sutProvider.GetDependency<ICurrentContext>().ManageSso(orgId).Returns(false);
 
-        var requestAction = async () => await sutProvider.Sut.Get(orgId);
+        var requestAction = async () => await sutProvider.Sut.GetAll(orgId);
 
         await Assert.ThrowsAsync<UnauthorizedAccessException>(requestAction);
     }
@@ -40,7 +40,7 @@ public class OrganizationDomainControllerTests
         sutProvider.GetDependency<ICurrentContext>().ManageSso(orgId).Returns(true);
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(orgId).ReturnsNull();
 
-        var requestAction = async () => await sutProvider.Sut.Get(orgId);
+        var requestAction = async () => await sutProvider.Sut.GetAll(orgId);
 
         await Assert.ThrowsAsync<NotFoundException>(requestAction);
     }
@@ -64,7 +64,7 @@ public class OrganizationDomainControllerTests
                 }
             });
 
-        var result = await sutProvider.Sut.Get(orgId);
+        var result = await sutProvider.Sut.GetAll(orgId);
 
         Assert.IsType<ListResponseModel<OrganizationDomainResponseModel>>(result);
         Assert.Equal(orgId, result.Data.Select(x => x.OrganizationId).FirstOrDefault());

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
@@ -271,7 +271,7 @@ public class OrganizationUsersControllerTests
         SutProvider<OrganizationUsersController> sutProvider)
     {
         GetMany_Setup(organizationAbility, organizationUsers, sutProvider);
-        var response = await sutProvider.Sut.Get(organizationAbility.Id, false, false);
+        var response = await sutProvider.Sut.GetAll(organizationAbility.Id, false, false);
 
         Assert.True(response.Data.All(r => organizationUsers.Any(ou => ou.Id == r.Id)));
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This PR is a continuation of the work started in https://github.com/bitwarden/server/pull/6229, with some of the team specific changes split out for easier review/merge. You can read that PR for a more complete explanation of the purpose, but in short:
- The SDK generates bindings from the Swagger specification, which creates function names in the format `HTTP path + HTTP method`. This leads to very unwieldy names.
- Our goal is to instead generate function names that match the functions in the controller, which means we can't have duplicate function names, and we can have more than one route per function exposed in the schema.

To fullfill those two goals, this PR does two things:
- If there are two functions with the same name in a controller, I've renamed one of them to be more descriptive.
- If a function has two route attributes, I've used the new `[SwaggerExclude("")]` to exclude one of them. In general I tried to exclude the less precise HTTP method.

The final result in the SDK looks like this:
```rust
// The current function for GET {}/organizations/{id}/access-policies/people/potential-grantees
pub async fn organizations_id_access_policies_people_potential_grantees_get(...) {}

// Once all these PRs are merged, the name will be
pub async fn get_people_potential_grantees() {}
```

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
