### PR TITLE
Improve Swagger OperationIDs for Auth

### DIFF
--- a/src/Api/Auth/Controllers/AccountsController.cs
+++ b/src/Api/Auth/Controllers/AccountsController.cs
@@ -20,6 +20,7 @@ using Bit.Core.Models.Api.Response;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Utilities;
+using Bit.SharedWeb.Swagger;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -345,6 +346,7 @@ public class AccountsController : Controller
 
     [HttpPut("profile")]
     [HttpPost("profile")]
+    [SwaggerExclude("POST")]
     public async Task<ProfileResponseModel> PutProfile([FromBody] UpdateProfileRequestModel model)
     {
         var user = await _userService.GetUserByPrincipalAsync(User);
@@ -365,6 +367,7 @@ public class AccountsController : Controller
 
     [HttpPut("avatar")]
     [HttpPost("avatar")]
+    [SwaggerExclude("POST")]
     public async Task<ProfileResponseModel> PutAvatar([FromBody] UpdateAvatarRequestModel model)
     {
         var user = await _userService.GetUserByPrincipalAsync(User);
@@ -431,6 +434,7 @@ public class AccountsController : Controller
 
     [HttpDelete]
     [HttpPost("delete")]
+    [SwaggerExclude("POST")]
     public async Task Delete([FromBody] SecretVerificationRequestModel model)
     {
         var user = await _userService.GetUserByPrincipalAsync(User);
@@ -638,8 +642,9 @@ public class AccountsController : Controller
         await _twoFactorEmailService.SendNewDeviceVerificationEmailAsync(user);
     }
 
-    [HttpPost("verify-devices")]
     [HttpPut("verify-devices")]
+    [HttpPost("verify-devices")]
+    [SwaggerExclude("POST")]
     public async Task SetUserVerifyDevicesAsync([FromBody] SetVerifyDevicesRequestModel request)
     {
         var user = await _userService.GetUserByPrincipalAsync(User) ?? throw new UnauthorizedAccessException();

--- a/src/Api/Auth/Controllers/AuthRequestsController.cs
+++ b/src/Api/Auth/Controllers/AuthRequestsController.cs
@@ -31,7 +31,7 @@ public class AuthRequestsController(
     private readonly IAuthRequestService _authRequestService = authRequestService;
 
     [HttpGet("")]
-    public async Task<ListResponseModel<AuthRequestResponseModel>> Get()
+    public async Task<ListResponseModel<AuthRequestResponseModel>> GetAll()
     {
         var userId = _userService.GetProperUserId(User).Value;
         var authRequests = await _authRequestRepository.GetManyByUserIdAsync(userId);

--- a/src/Api/Auth/Controllers/EmergencyAccessController.cs
+++ b/src/Api/Auth/Controllers/EmergencyAccessController.cs
@@ -12,6 +12,7 @@ using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Settings;
+using Bit.SharedWeb.Swagger;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -80,6 +81,7 @@ public class EmergencyAccessController : Controller
 
     [HttpPut("{id}")]
     [HttpPost("{id}")]
+    [SwaggerExclude("POST")]
     public async Task Put(Guid id, [FromBody] EmergencyAccessUpdateRequestModel model)
     {
         var emergencyAccess = await _emergencyAccessRepository.GetByIdAsync(id);
@@ -94,6 +96,7 @@ public class EmergencyAccessController : Controller
 
     [HttpDelete("{id}")]
     [HttpPost("{id}/delete")]
+    [SwaggerExclude("POST")]
     public async Task Delete(Guid id)
     {
         var userId = _userService.GetProperUserId(User);
@@ -136,7 +139,7 @@ public class EmergencyAccessController : Controller
     }
 
     [HttpPost("{id}/approve")]
-    public async Task Accept(Guid id)
+    public async Task Approve(Guid id)
     {
         var user = await _userService.GetUserByPrincipalAsync(User);
         await _emergencyAccessService.ApproveAsync(id, user);

--- a/src/Api/Auth/Controllers/TwoFactorController.cs
+++ b/src/Api/Auth/Controllers/TwoFactorController.cs
@@ -18,6 +18,7 @@ using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Tokens;
 using Bit.Core.Utilities;
+using Bit.SharedWeb.Swagger;
 using Fido2NetLib;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
@@ -111,6 +112,7 @@ public class TwoFactorController : Controller
 
     [HttpPut("authenticator")]
     [HttpPost("authenticator")]
+    [SwaggerExclude("POST")]
     public async Task<TwoFactorAuthenticatorResponseModel> PutAuthenticator(
         [FromBody] UpdateTwoFactorAuthenticatorRequestModel model)
     {
@@ -158,6 +160,7 @@ public class TwoFactorController : Controller
 
     [HttpPut("yubikey")]
     [HttpPost("yubikey")]
+    [SwaggerExclude("POST")]
     public async Task<TwoFactorYubiKeyResponseModel> PutYubiKey([FromBody] UpdateTwoFactorYubicoOtpRequestModel model)
     {
         var user = await CheckAsync(model, true);
@@ -184,6 +187,7 @@ public class TwoFactorController : Controller
 
     [HttpPut("duo")]
     [HttpPost("duo")]
+    [SwaggerExclude("POST")]
     public async Task<TwoFactorDuoResponseModel> PutDuo([FromBody] UpdateTwoFactorDuoRequestModel model)
     {
         var user = await CheckAsync(model, true);
@@ -218,6 +222,7 @@ public class TwoFactorController : Controller
 
     [HttpPut("~/organizations/{id}/two-factor/duo")]
     [HttpPost("~/organizations/{id}/two-factor/duo")]
+    [SwaggerExclude("POST")]
     public async Task<TwoFactorDuoResponseModel> PutOrganizationDuo(string id,
         [FromBody] UpdateTwoFactorDuoRequestModel model)
     {
@@ -262,6 +267,7 @@ public class TwoFactorController : Controller
 
     [HttpPut("webauthn")]
     [HttpPost("webauthn")]
+    [SwaggerExclude("POST")]
     public async Task<TwoFactorWebAuthnResponseModel> PutWebAuthn([FromBody] TwoFactorWebAuthnRequestModel model)
     {
         var user = await CheckAsync(model, false);
@@ -350,6 +356,7 @@ public class TwoFactorController : Controller
 
     [HttpPut("email")]
     [HttpPost("email")]
+    [SwaggerExclude("POST")]
     public async Task<TwoFactorEmailResponseModel> PutEmail([FromBody] UpdateTwoFactorEmailRequestModel model)
     {
         var user = await CheckAsync(model, false);
@@ -369,6 +376,7 @@ public class TwoFactorController : Controller
 
     [HttpPut("disable")]
     [HttpPost("disable")]
+    [SwaggerExclude("POST")]
     public async Task<TwoFactorProviderResponseModel> PutDisable([FromBody] TwoFactorProviderRequestModel model)
     {
         var user = await CheckAsync(model, false);
@@ -379,6 +387,7 @@ public class TwoFactorController : Controller
 
     [HttpPut("~/organizations/{id}/two-factor/disable")]
     [HttpPost("~/organizations/{id}/two-factor/disable")]
+    [SwaggerExclude("POST")]
     public async Task<TwoFactorProviderResponseModel> PutOrganizationDisable(string id,
         [FromBody] TwoFactorProviderRequestModel model)
     {

--- a/test/Api.Test/Auth/Controllers/AuthRequestsControllerTests.cs
+++ b/test/Api.Test/Auth/Controllers/AuthRequestsControllerTests.cs
@@ -43,7 +43,7 @@ public class AuthRequestsControllerTests
             .Returns([authRequest]);
 
         // Act
-        var result = await sutProvider.Sut.Get();
+        var result = await sutProvider.Sut.GetAll();
 
         // Assert
         Assert.NotNull(result);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-25182

## 📔 Objective

This PR is a continuation of the work started in https://github.com/bitwarden/server/pull/6229, with some of the team specific changes split out for easier review/merge. You can read that PR for a more complete explanation of the purpose, but in short:
- The SDK generates bindings from the Swagger specification, which creates function names in the format `HTTP path + HTTP method`. This leads to very unwieldy names.
- Our goal is to instead generate function names that match the functions in the controller, which means we can't have duplicate function names, and we can have more than one route per function exposed in the schema.

To fullfill those two goals, this PR does two things:
- If there are two functions with the same name in a controller, I've renamed one of them to be more descriptive.
- If a function has two route attributes, I've used the new `[SwaggerExclude("")]` to exclude one of them. In general I tried to exclude the less precise HTTP method.

The final result in the SDK looks like this:
```rust
// The current function for GET {}/organizations/{id}/access-policies/people/potential-grantees
pub async fn organizations_id_access_policies_people_potential_grantees_get(...) {}

// Once all these PRs are merged, the name will be
pub async fn get_people_potential_grantees() {}
```

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
