### PR TITLE
Improve Swagger OperationIDs for Tools

### DIFF
--- a/src/Api/Tools/Controllers/ImportCiphersController.cs
+++ b/src/Api/Tools/Controllers/ImportCiphersController.cs
@@ -63,7 +63,7 @@ public class ImportCiphersController : Controller
     }
 
     [HttpPost("import-organization")]
-    public async Task PostImport([FromQuery] string organizationId,
+    public async Task PostImportOrganization([FromQuery] string organizationId,
         [FromBody] ImportOrganizationCiphersRequestModel model)
     {
         if (!_globalSettings.SelfHosted &&

--- a/src/Api/Tools/Controllers/SendsController.cs
+++ b/src/Api/Tools/Controllers/SendsController.cs
@@ -192,7 +192,7 @@ public class SendsController : Controller
     }
 
     [HttpGet("")]
-    public async Task<ListResponseModel<SendResponseModel>> Get()
+    public async Task<ListResponseModel<SendResponseModel>> GetAll()
     {
         var userId = _userService.GetProperUserId(User).Value;
         var sends = await _sendRepository.GetManyByUserIdAsync(userId);

--- a/test/Api.Test/Tools/Controllers/ImportCiphersControllerTests.cs
+++ b/test/Api.Test/Tools/Controllers/ImportCiphersControllerTests.cs
@@ -126,7 +126,7 @@ public class ImportCiphersControllerTests
         };
 
         // Act
-        var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.PostImport(Arg.Any<string>(), model));
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.PostImportOrganization(Arg.Any<string>(), model));
 
         // Assert
         Assert.Equal("You cannot import this much data at once.", exception.Message);
@@ -186,7 +186,7 @@ public class ImportCiphersControllerTests
             .Returns(existingCollections.Select(c => new Collection { Id = orgIdGuid }).ToList());
 
         // Act
-        await sutProvider.Sut.PostImport(orgId, request);
+        await sutProvider.Sut.PostImportOrganization(orgId, request);
 
         // Assert
         await sutProvider.GetDependency<IImportCiphersCommand>()
@@ -257,7 +257,7 @@ public class ImportCiphersControllerTests
             .Returns(existingCollections.Select(c => new Collection { Id = orgIdGuid }).ToList());
 
         // Act
-        await sutProvider.Sut.PostImport(orgId, request);
+        await sutProvider.Sut.PostImportOrganization(orgId, request);
 
         // Assert
         await sutProvider.GetDependency<IImportCiphersCommand>()
@@ -324,7 +324,7 @@ public class ImportCiphersControllerTests
 
         // Act
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
-            sutProvider.Sut.PostImport(orgId, request));
+            sutProvider.Sut.PostImportOrganization(orgId, request));
 
         // Assert
         Assert.IsType<Bit.Core.Exceptions.BadRequestException>(exception);
@@ -387,7 +387,7 @@ public class ImportCiphersControllerTests
 
         // Act
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
-            sutProvider.Sut.PostImport(orgId, request));
+            sutProvider.Sut.PostImportOrganization(orgId, request));
 
         // Assert
         Assert.IsType<Bit.Core.Exceptions.BadRequestException>(exception);
@@ -457,7 +457,7 @@ public class ImportCiphersControllerTests
         // Act
         // User imports into collections and creates new collections
         // User has ImportCiphers and Create ciphers permission
-        await sutProvider.Sut.PostImport(orgId.ToString(), request);
+        await sutProvider.Sut.PostImportOrganization(orgId.ToString(), request);
 
         // Assert
         await sutProvider.GetDependency<IImportCiphersCommand>()
@@ -535,7 +535,7 @@ public class ImportCiphersControllerTests
         // User has ImportCiphers permission only and doesn't have Create permission
         var exception = await Assert.ThrowsAsync<BadRequestException>(async () =>
         {
-            await sutProvider.Sut.PostImport(orgId.ToString(), request);
+            await sutProvider.Sut.PostImportOrganization(orgId.ToString(), request);
         });
 
         // Assert
@@ -610,7 +610,7 @@ public class ImportCiphersControllerTests
         // Act
         // User imports/creates a new collection - existing collections not affected
         // User has create permissions and doesn't need import permissions
-        await sutProvider.Sut.PostImport(orgId.ToString(), request);
+        await sutProvider.Sut.PostImportOrganization(orgId.ToString(), request);
 
         // Assert
         await sutProvider.GetDependency<IImportCiphersCommand>()
@@ -685,7 +685,7 @@ public class ImportCiphersControllerTests
         // Act
         // User import into existing collection
         // User has ImportCiphers permission only and doesn't need create permission
-        await sutProvider.Sut.PostImport(orgId.ToString(), request);
+        await sutProvider.Sut.PostImportOrganization(orgId.ToString(), request);
 
         // Assert
         await sutProvider.GetDependency<IImportCiphersCommand>()
@@ -753,7 +753,7 @@ public class ImportCiphersControllerTests
         // import ciphers only and no collections
         // User has Create permissions
         // expected to be successful
-        await sutProvider.Sut.PostImport(orgId.ToString(), request);
+        await sutProvider.Sut.PostImportOrganization(orgId.ToString(), request);
 
         // Assert
         await sutProvider.GetDependency<IImportCiphersCommand>()


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This PR is a continuation of the work started in https://github.com/bitwarden/server/pull/6229, with some of the team specific changes split out for easier review/merge. You can read that PR for a more complete explanation of the purpose, but in short:
- The SDK generates bindings from the Swagger specification, which creates function names in the format `HTTP path + HTTP method`. This leads to very unwieldy names.
- Our goal is to instead generate function names that match the functions in the controller, which means we can't have duplicate function names, and we can have more than one route per function exposed in the schema.

To fullfill those two goals, this PR does two things:
- If there are two functions with the same name in a controller, I've renamed one of them to be more descriptive.
- If a function has two route attributes, I've used the new `[SwaggerExclude("")]` to exclude one of them. In general I tried to exclude the less precise HTTP method.

The final result in the SDK looks like this:
```rust
// The current function for GET {}/organizations/{id}/access-policies/people/potential-grantees
pub async fn organizations_id_access_policies_people_potential_grantees_get(...) {}

// Once all these PRs are merged, the name will be
pub async fn get_people_potential_grantees() {}
```

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
