### PR TITLE
[PM-22838] Add hyperlink to provider name in Admin Panel organization details

### DIFF
--- a/src/Admin/AdminConsole/Views/Organizations/_ProviderInformation.cshtml
+++ b/src/Admin/AdminConsole/Views/Organizations/_ProviderInformation.cshtml
@@ -2,7 +2,9 @@
 @model Bit.Core.AdminConsole.Entities.Provider.Provider
 <dl class="row">
     <dt class="col-sm-4 col-lg-3">Provider Name</dt>
-    <dd class="col-sm-8 col-lg-9">@Model.DisplayName()</dd>
+    <dd class="col-sm-8 col-lg-9">
+        <a asp-controller="Providers" asp-action="Edit" asp-route-id="@Model.Id">@Model.DisplayName()</a>
+    </dd>
 
     <dt class="col-sm-4 col-lg-3">Provider Type</dt>
     <dd class="col-sm-8 col-lg-9">@(Model.Type.GetDisplayAttribute()?.GetName())</dd>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-22838

## 📔 Objective

> For all provider types (reseller, MSP, BUP), make the provider name value in the organization page hyperlinked. When the provider name is selected, it should direct the user to the provider page.

## 📸 Screenshots

<img width="724" height="247" alt="image" src="https://github.com/user-attachments/assets/e7fe6e37-3c9f-4ff6-8560-21436c8726de" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
