### PR TITLE
[PM-25088] - refactor premium purchase endpoint

### DIFF
--- a/src/Api/Billing/Attributes/PaymentMethodTypeValidationAttribute.cs
+++ b/src/Api/Billing/Attributes/PaymentMethodTypeValidationAttribute.cs
@@ -1,0 +1,13 @@
+﻿using Bit.Api.Utilities;
+
+namespace Bit.Api.Billing.Attributes;
+
+public class PaymentMethodTypeValidationAttribute : StringMatchesAttribute
+{
+    private static readonly string[] _acceptedValues = ["bankAccount", "card", "payPal"];
+
+    public PaymentMethodTypeValidationAttribute() : base(_acceptedValues)
+    {
+        ErrorMessage = $"Payment method type must be one of: {string.Join(", ", _acceptedValues)}";
+    }
+}

--- a/src/Api/Billing/Controllers/VNext/AccountBillingVNextController.cs
+++ b/src/Api/Billing/Controllers/VNext/AccountBillingVNextController.cs
@@ -1,8 +1,11 @@
 ﻿#nullable enable
 using Bit.Api.Billing.Attributes;
 using Bit.Api.Billing.Models.Requests.Payment;
+using Bit.Api.Billing.Models.Requests.Premium;
+using Bit.Core;
 using Bit.Core.Billing.Payment.Commands;
 using Bit.Core.Billing.Payment.Queries;
+using Bit.Core.Billing.Premium.Commands;
 using Bit.Core.Entities;
 using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Authorization;
@@ -16,6 +19,7 @@ namespace Bit.Api.Billing.Controllers.VNext;
 [SelfHosted(NotSelfHostedOnly = true)]
 public class AccountBillingVNextController(
     ICreateBitPayInvoiceForCreditCommand createBitPayInvoiceForCreditCommand,
+    ICreatePremiumCloudHostedSubscriptionCommand createPremiumCloudHostedSubscriptionCommand,
     IGetCreditQuery getCreditQuery,
     IGetPaymentMethodQuery getPaymentMethodQuery,
     IUpdatePaymentMethodCommand updatePaymentMethodCommand) : BaseBillingController
@@ -59,6 +63,19 @@ public class AccountBillingVNextController(
     {
         var (paymentMethod, billingAddress) = request.ToDomain();
         var result = await updatePaymentMethodCommand.Run(user, paymentMethod, billingAddress);
+        return Handle(result);
+    }
+
+    [HttpPost("subscription")]
+    [RequireFeature(FeatureFlagKeys.PM23385_UseNewPremiumFlow)]
+    [InjectUser]
+    public async Task<IResult> CreateSubscriptionAsync(
+        [BindNever] User user,
+        [FromBody] PremiumCloudHostedSubscriptionRequest request)
+    {
+        var (paymentMethod, billingAddress, additionalStorageGb) = request.ToDomain();
+        var result = await createPremiumCloudHostedSubscriptionCommand.Run(
+            user, paymentMethod, billingAddress, additionalStorageGb);
         return Handle(result);
     }
 }

--- a/src/Api/Billing/Controllers/VNext/SelfHostedAccountBillingController.cs
+++ b/src/Api/Billing/Controllers/VNext/SelfHostedAccountBillingController.cs
@@ -1,0 +1,38 @@
+﻿#nullable enable
+using Bit.Api.Billing.Attributes;
+using Bit.Api.Billing.Models.Requests.Premium;
+using Bit.Api.Utilities;
+using Bit.Core;
+using Bit.Core.Billing.Models.Business;
+using Bit.Core.Billing.Premium.Commands;
+using Bit.Core.Entities;
+using Bit.Core.Exceptions;
+using Bit.Core.Utilities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Bit.Api.Billing.Controllers.VNext;
+
+[Authorize("Application")]
+[Route("account/billing/vnext/self-host")]
+[SelfHosted(SelfHostedOnly = true)]
+public class SelfHostedAccountBillingController(
+    ICreatePremiumSelfHostedSubscriptionCommand createPremiumSelfHostedSubscriptionCommand) : BaseBillingController
+{
+    [HttpPost("license")]
+    [RequireFeature(FeatureFlagKeys.PM23385_UseNewPremiumFlow)]
+    [InjectUser]
+    public async Task<IResult> UploadLicenseAsync(
+        [BindNever] User user,
+        PremiumSelfHostedSubscriptionRequest request)
+    {
+        var license = await ApiHelpers.ReadJsonFileFromBody<UserLicense>(HttpContext, request.License);
+        if (license == null)
+        {
+            throw new BadRequestException("Invalid license.");
+        }
+        var result = await createPremiumSelfHostedSubscriptionCommand.Run(user, license);
+        return Handle(result);
+    }
+}

--- a/src/Api/Billing/Models/Requests/Payment/TokenizedPaymentMethodRequest.cs
+++ b/src/Api/Billing/Models/Requests/Payment/TokenizedPaymentMethodRequest.cs
@@ -1,6 +1,6 @@
 ﻿#nullable enable
 using System.ComponentModel.DataAnnotations;
-using Bit.Api.Utilities;
+using Bit.Api.Billing.Attributes;
 using Bit.Core.Billing.Payment.Models;
 
 namespace Bit.Api.Billing.Models.Requests.Payment;
@@ -8,8 +8,7 @@ namespace Bit.Api.Billing.Models.Requests.Payment;
 public class TokenizedPaymentMethodRequest
 {
     [Required]
-    [StringMatches("bankAccount", "card", "payPal",
-        ErrorMessage = "Payment method type must be one of: bankAccount, card, payPal")]
+    [PaymentMethodTypeValidation]
     public required string Type { get; set; }
 
     [Required]
@@ -21,14 +20,7 @@ public class TokenizedPaymentMethodRequest
     {
         var paymentMethod = new TokenizedPaymentMethod
         {
-            Type = Type switch
-            {
-                "bankAccount" => TokenizablePaymentMethodType.BankAccount,
-                "card" => TokenizablePaymentMethodType.Card,
-                "payPal" => TokenizablePaymentMethodType.PayPal,
-                _ => throw new InvalidOperationException(
-                    $"Invalid value for {nameof(TokenizedPaymentMethod)}.{nameof(TokenizedPaymentMethod.Type)}")
-            },
+            Type = TokenizablePaymentMethodTypeExtensions.From(Type),
             Token = Token
         };
 

--- a/src/Api/Billing/Models/Requests/Premium/PremiumCloudHostedSubscriptionRequest.cs
+++ b/src/Api/Billing/Models/Requests/Premium/PremiumCloudHostedSubscriptionRequest.cs
@@ -1,0 +1,50 @@
+﻿#nullable enable
+using System.ComponentModel.DataAnnotations;
+using Bit.Api.Billing.Attributes;
+using Bit.Core.Billing.Payment.Models;
+
+namespace Bit.Api.Billing.Models.Requests.Premium;
+
+public class PremiumCloudHostedSubscriptionRequest : IValidatableObject
+{
+    [Required]
+    [PaymentMethodTypeValidation]
+    public required string PaymentMethodType { get; set; }
+
+    [Required]
+    public required string PaymentToken { get; set; }
+
+    [Range(0, 99)]
+    public short AdditionalStorageGb { get; set; } = 0;
+
+    [Required]
+    [StringLength(2, MinimumLength = 2, ErrorMessage = "Country code must be 2 characters long.")]
+    public required string Country { get; set; }
+
+    public string? PostalCode { get; set; }
+
+    public (TokenizedPaymentMethod, BillingAddress, short) ToDomain()
+    {
+        var paymentMethod = new TokenizedPaymentMethod
+        {
+            Type = TokenizablePaymentMethodTypeExtensions.From(PaymentMethodType),
+            Token = PaymentToken
+        };
+
+        var billingAddress = new BillingAddress
+        {
+            Country = Country,
+            PostalCode = PostalCode ?? string.Empty
+        };
+
+        return (paymentMethod, billingAddress, AdditionalStorageGb);
+    }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (Country == "US" && string.IsNullOrWhiteSpace(PostalCode))
+        {
+            yield return new ValidationResult("Zip / postal code is required.", [nameof(PostalCode)]);
+        }
+    }
+}

--- a/src/Api/Billing/Models/Requests/Premium/PremiumSelfHostedSubscriptionRequest.cs
+++ b/src/Api/Billing/Models/Requests/Premium/PremiumSelfHostedSubscriptionRequest.cs
@@ -1,0 +1,10 @@
+﻿#nullable enable
+using System.ComponentModel.DataAnnotations;
+
+namespace Bit.Api.Billing.Models.Requests.Premium;
+
+public class PremiumSelfHostedSubscriptionRequest
+{
+    [Required]
+    public required IFormFile License { get; set; }
+}

--- a/src/Core/Billing/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Core/Billing/Extensions/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Bit.Core.Billing.Organizations.Commands;
 using Bit.Core.Billing.Organizations.Queries;
 using Bit.Core.Billing.Organizations.Services;
 using Bit.Core.Billing.Payment;
+using Bit.Core.Billing.Premium.Commands;
 using Bit.Core.Billing.Pricing;
 using Bit.Core.Billing.Services;
 using Bit.Core.Billing.Services.Implementations;
@@ -33,6 +34,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IPreviewTaxAmountCommand, PreviewTaxAmountCommand>();
         services.AddPaymentOperations();
         services.AddOrganizationLicenseCommandsQueries();
+        services.AddPremiumCommands();
         services.AddTransient<IGetOrganizationWarningsQuery, GetOrganizationWarningsQuery>();
     }
 
@@ -41,5 +43,11 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IGetCloudOrganizationLicenseQuery, GetCloudOrganizationLicenseQuery>();
         services.AddScoped<IGetSelfHostedOrganizationLicenseQuery, GetSelfHostedOrganizationLicenseQuery>();
         services.AddScoped<IUpdateOrganizationLicenseCommand, UpdateOrganizationLicenseCommand>();
+    }
+
+    private static void AddPremiumCommands(this IServiceCollection services)
+    {
+        services.AddScoped<ICreatePremiumCloudHostedSubscriptionCommand, CreatePremiumCloudHostedSubscriptionCommand>();
+        services.AddScoped<ICreatePremiumSelfHostedSubscriptionCommand, CreatePremiumSelfHostedSubscriptionCommand>();
     }
 }

--- a/src/Core/Billing/Payment/Models/TokenizablePaymentMethodType.cs
+++ b/src/Core/Billing/Payment/Models/TokenizablePaymentMethodType.cs
@@ -6,3 +6,17 @@ public enum TokenizablePaymentMethodType
     Card,
     PayPal
 }
+
+public static class TokenizablePaymentMethodTypeExtensions
+{
+    public static TokenizablePaymentMethodType From(string type)
+    {
+        return type switch
+        {
+            "bankAccount" => TokenizablePaymentMethodType.BankAccount,
+            "card" => TokenizablePaymentMethodType.Card,
+            "payPal" => TokenizablePaymentMethodType.PayPal,
+            _ => throw new InvalidOperationException($"Invalid value for {nameof(TokenizedPaymentMethod)}.{nameof(TokenizedPaymentMethod.Type)}")
+        };
+    }
+}

--- a/src/Core/Billing/Premium/Commands/CreatePremiumCloudHostedSubscriptionCommand.cs
+++ b/src/Core/Billing/Premium/Commands/CreatePremiumCloudHostedSubscriptionCommand.cs
@@ -1,0 +1,84 @@
+﻿using Bit.Core.Billing.Commands;
+using Bit.Core.Billing.Models.Sales;
+using Bit.Core.Billing.Payment.Models;
+using Bit.Core.Billing.Services;
+using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Models.Business;
+using Bit.Core.Platform.Push;
+using Bit.Core.Services;
+using Bit.Core.Utilities;
+using Microsoft.Extensions.Logging;
+using OneOf.Types;
+
+namespace Bit.Core.Billing.Premium.Commands;
+
+public interface ICreatePremiumCloudHostedSubscriptionCommand
+{
+    Task<BillingCommandResult<None>> Run(
+        User user,
+        TokenizedPaymentMethod paymentMethod,
+        BillingAddress billingAddress,
+        short additionalStorageGb);
+}
+
+public class CreatePremiumCloudHostedSubscriptionCommand(
+    IPremiumUserBillingService premiumUserBillingService,
+    IUserService userService,
+    IPaymentService paymentService,
+    IPushNotificationService pushNotificationService,
+    ILogger<CreatePremiumCloudHostedSubscriptionCommand> logger)
+    : BaseBillingCommand<CreatePremiumCloudHostedSubscriptionCommand>(logger), ICreatePremiumCloudHostedSubscriptionCommand
+{
+    public Task<BillingCommandResult<None>> Run(
+        User user,
+        TokenizedPaymentMethod paymentMethod,
+        BillingAddress billingAddress,
+        short additionalStorageGb) => HandleAsync<None>(async () =>
+    {
+        if (user.Premium)
+        {
+            return new BadRequest("Already a premium user.");
+        }
+
+        if (additionalStorageGb < 0)
+        {
+            return new BadRequest("You can't subtract storage.");
+        }
+
+        var paymentMethodType = paymentMethod.Type switch
+        {
+            TokenizablePaymentMethodType.BankAccount => PaymentMethodType.BankAccount,
+            TokenizablePaymentMethodType.Card => PaymentMethodType.Card,
+            TokenizablePaymentMethodType.PayPal => PaymentMethodType.PayPal,
+            _ => throw new InvalidOperationException($"Unsupported payment method type: {paymentMethod.Type}")
+        };
+
+        var taxInfo = new TaxInfo
+        {
+            BillingAddressCountry = billingAddress.Country,
+            BillingAddressPostalCode = billingAddress.PostalCode
+        };
+
+        var sale = PremiumUserSale.From(user, paymentMethodType, paymentMethod.Token, taxInfo, additionalStorageGb);
+        await premiumUserBillingService.Finalize(sale);
+
+        user.Premium = true;
+        user.RevisionDate = DateTime.UtcNow;
+        user.MaxStorageGb = (short)(1 + additionalStorageGb);
+        user.LicenseKey = CoreHelpers.SecureRandomString(20);
+
+        try
+        {
+            await userService.SaveUserAsync(user);
+            await pushNotificationService.PushSyncVaultAsync(user.Id);
+        }
+        catch
+        {
+            await paymentService.CancelAndRecoverChargesAsync(user);
+            throw;
+        }
+
+        return new None();
+    });
+}

--- a/src/Core/Billing/Premium/Commands/CreatePremiumSelfHostedSubscriptionCommand.cs
+++ b/src/Core/Billing/Premium/Commands/CreatePremiumSelfHostedSubscriptionCommand.cs
@@ -1,0 +1,57 @@
+﻿using Bit.Core.Billing.Commands;
+using Bit.Core.Billing.Models.Business;
+using Bit.Core.Billing.Services;
+using Bit.Core.Entities;
+using Bit.Core.Platform.Push;
+using Bit.Core.Services;
+using Microsoft.Extensions.Logging;
+using OneOf.Types;
+
+namespace Bit.Core.Billing.Premium.Commands;
+
+public interface ICreatePremiumSelfHostedSubscriptionCommand
+{
+    Task<BillingCommandResult<None>> Run(User user, UserLicense license);
+}
+
+public class CreatePremiumSelfHostedSubscriptionCommand(
+    ILicensingService licensingService,
+    IUserService userService,
+    IPushNotificationService pushNotificationService,
+    ILogger<CreatePremiumSelfHostedSubscriptionCommand> logger)
+    : BaseBillingCommand<CreatePremiumSelfHostedSubscriptionCommand>(logger), ICreatePremiumSelfHostedSubscriptionCommand
+{
+    public Task<BillingCommandResult<None>> Run(
+        User user,
+        UserLicense license) => HandleAsync<None>(async () =>
+    {
+        if (user.Premium)
+        {
+            return new BadRequest("Already a premium user.");
+        }
+
+        if (!licensingService.VerifyLicense(license))
+        {
+            return new BadRequest("Invalid license.");
+        }
+
+        var claimsPrincipal = licensingService.GetClaimsPrincipalFromLicense(license);
+        if (!license.CanUse(user, claimsPrincipal, out var exceptionMessage))
+        {
+            return new BadRequest(exceptionMessage);
+        }
+
+        await licensingService.WriteUserLicenseAsync(user, license);
+
+        user.Premium = true;
+        user.RevisionDate = DateTime.UtcNow;
+        user.MaxStorageGb = 10240; // 10 TB
+        user.LicenseKey = license.LicenseKey;
+        user.PremiumExpirationDate = license.Expires;
+
+        await userService.SaveUserAsync(user);
+        await pushNotificationService.PushSyncVaultAsync(user.Id);
+
+        return new None();
+    });
+}

--- a/src/Core/Billing/Services/ILicensingService.cs
+++ b/src/Core/Billing/Services/ILicensingService.cs
@@ -26,4 +26,5 @@ public interface ILicensingService
         SubscriptionInfo subscriptionInfo);
 
     Task<string?> CreateUserTokenAsync(User user, SubscriptionInfo subscriptionInfo);
+    Task WriteUserLicenseAsync(User user, UserLicense license);
 }

--- a/src/Core/Billing/Services/Implementations/LicensingService.cs
+++ b/src/Core/Billing/Services/Implementations/LicensingService.cs
@@ -389,4 +389,12 @@ public class LicensingService : ILicensingService
         var token = tokenHandler.CreateToken(tokenDescriptor);
         return tokenHandler.WriteToken(token);
     }
+
+    public async Task WriteUserLicenseAsync(User user, UserLicense license)
+    {
+        var dir = $"{_globalSettings.LicenseDirectory}/user";
+        Directory.CreateDirectory(dir);
+        await using var fs = File.OpenWrite(Path.Combine(dir, $"{user.Id}.json"));
+        await JsonSerializer.SerializeAsync(fs, license, JsonHelpers.Indented);
+    }
 }

--- a/src/Core/Billing/Services/NoopImplementations/NoopLicensingService.cs
+++ b/src/Core/Billing/Services/NoopImplementations/NoopLicensingService.cs
@@ -73,4 +73,9 @@ public class NoopLicensingService : ILicensingService
     {
         return Task.FromResult<string?>(null);
     }
+
+    public Task WriteUserLicenseAsync(User user, UserLicense license)
+    {
+        return Task.CompletedTask;
+    }
 }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -155,6 +155,7 @@ public static class FeatureFlagKeys
     public const string PM21881_ManagePaymentDetailsOutsideCheckout = "pm-21881-manage-payment-details-outside-checkout";
     public const string PM21821_ProviderPortalTakeover = "pm-21821-provider-portal-takeover";
     public const string PM22415_TaxIDWarnings = "pm-22415-tax-id-warnings";
+    public const string PM23385_UseNewPremiumFlow = "pm-23385-use-new-premium-flow";
 
     /* Key Management Team */
     public const string ReturnErrorOnExistingKeypair = "return-error-on-existing-keypair";

--- a/test/Core.Test/Billing/Premium/Commands/CreatePremiumCloudHostedSubscriptionCommandTests.cs
+++ b/test/Core.Test/Billing/Premium/Commands/CreatePremiumCloudHostedSubscriptionCommandTests.cs
@@ -1,0 +1,240 @@
+﻿using Bit.Core.Billing.Payment.Models;
+using Bit.Core.Billing.Premium.Commands;
+using Bit.Core.Billing.Services;
+using Bit.Core.Entities;
+using Bit.Core.Platform.Push;
+using Bit.Core.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Billing.Premium.Commands;
+
+public class CreatePremiumCloudHostedSubscriptionCommandTests
+{
+    private readonly IPremiumUserBillingService _premiumUserBillingService = Substitute.For<IPremiumUserBillingService>();
+    private readonly IUserService _userService = Substitute.For<IUserService>();
+    private readonly IPaymentService _paymentService = Substitute.For<IPaymentService>();
+    private readonly IPushNotificationService _pushNotificationService = Substitute.For<IPushNotificationService>();
+    private readonly CreatePremiumCloudHostedSubscriptionCommand _command;
+
+    public CreatePremiumCloudHostedSubscriptionCommandTests()
+    {
+        _command = new CreatePremiumCloudHostedSubscriptionCommand(
+            _premiumUserBillingService,
+            _userService,
+            _paymentService,
+            _pushNotificationService,
+            Substitute.For<ILogger<CreatePremiumCloudHostedSubscriptionCommand>>());
+    }
+
+    [Fact]
+    public async Task Run_UserAlreadyPremium_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Premium = true
+        };
+
+        var paymentMethod = new TokenizedPaymentMethod
+        {
+            Type = TokenizablePaymentMethodType.Card,
+            Token = "token_123"
+        };
+
+        var billingAddress = new BillingAddress
+        {
+            Country = "US",
+            PostalCode = "12345"
+        };
+
+        // Act
+        var result = await _command.Run(user, paymentMethod, billingAddress, 0);
+
+        // Assert
+        Assert.True(result.IsT1);
+        var badRequest = result.AsT1;
+        Assert.Equal("Already a premium user.", badRequest.Response);
+    }
+
+    [Fact]
+    public async Task Run_NegativeStorageAmount_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Premium = false
+        };
+
+        var paymentMethod = new TokenizedPaymentMethod
+        {
+            Type = TokenizablePaymentMethodType.Card,
+            Token = "token_123"
+        };
+
+        var billingAddress = new BillingAddress
+        {
+            Country = "US",
+            PostalCode = "12345"
+        };
+
+        // Act
+        var result = await _command.Run(user, paymentMethod, billingAddress, -1);
+
+        // Assert
+        Assert.True(result.IsT1);
+        var badRequest = result.AsT1;
+        Assert.Equal("You can't subtract storage!", badRequest.Response);
+    }
+
+    [Theory]
+    [InlineData(TokenizablePaymentMethodType.BankAccount)]
+    [InlineData(TokenizablePaymentMethodType.Card)]
+    [InlineData(TokenizablePaymentMethodType.PayPal)]
+    public async Task Run_ValidPaymentMethodTypes_Success(TokenizablePaymentMethodType paymentMethodType)
+    {
+        // Arrange
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Premium = false,
+            Email = "test@example.com"
+        };
+
+        var paymentMethod = new TokenizedPaymentMethod
+        {
+            Type = paymentMethodType,
+            Token = "token_123"
+        };
+
+        var billingAddress = new BillingAddress
+        {
+            Country = "US",
+            PostalCode = "12345"
+        };
+
+        // Act
+        var result = await _command.Run(user, paymentMethod, billingAddress, 0);
+
+        // Assert
+        Assert.True(result.IsT0);
+        await _premiumUserBillingService.Received(1).Finalize(Arg.Any<Bit.Core.Billing.Models.Sales.PremiumUserSale>());
+    }
+
+    [Fact]
+    public async Task Run_ValidRequestWithAdditionalStorage_Success()
+    {
+        // Arrange
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Premium = false,
+            Email = "test@example.com"
+        };
+
+        var paymentMethod = new TokenizedPaymentMethod
+        {
+            Type = TokenizablePaymentMethodType.Card,
+            Token = "token_123"
+        };
+
+        var billingAddress = new BillingAddress
+        {
+            Country = "US",
+            PostalCode = "12345"
+        };
+
+        const short additionalStorage = 2;
+
+        // Act
+        var result = await _command.Run(user, paymentMethod, billingAddress, additionalStorage);
+
+        // Assert
+        Assert.True(result.IsT0);
+
+        // Verify user was updated correctly
+        Assert.True(user.Premium);
+        Assert.Equal((short)(1 + additionalStorage), user.MaxStorageGb);
+        Assert.NotNull(user.LicenseKey);
+        Assert.Equal(20, user.LicenseKey.Length);
+        Assert.NotEqual(default, user.RevisionDate);
+
+        // Verify services were called
+        await _premiumUserBillingService.Received(1).Finalize(Arg.Any<Bit.Core.Billing.Models.Sales.PremiumUserSale>());
+        await _userService.Received(1).SaveUserAsync(user);
+        await _pushNotificationService.Received(1).PushSyncVaultAsync(user.Id);
+    }
+
+    [Fact]
+    public async Task Run_UserServiceThrowsException_CancelsChargesAndRethrows()
+    {
+        // Arrange
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Premium = false,
+            Email = "test@example.com"
+        };
+
+        var paymentMethod = new TokenizedPaymentMethod
+        {
+            Type = TokenizablePaymentMethodType.Card,
+            Token = "token_123"
+        };
+
+        var billingAddress = new BillingAddress
+        {
+            Country = "US",
+            PostalCode = "12345"
+        };
+
+        var expectedException = new Exception("User service error");
+        _userService.When(x => x.SaveUserAsync(user)).Do(x => throw expectedException);
+
+        // Act
+        var result = await _command.Run(user, paymentMethod, billingAddress, 0);
+
+        // Assert
+        Assert.True(result.IsT3);
+        // Verify payment cancellation was attempted
+        await _paymentService.Received(1).CancelAndRecoverChargesAsync(user);
+    }
+
+    [Fact]
+    public async Task Run_PushServiceThrowsException_CancelsChargesAndRethrows()
+    {
+        // Arrange
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Premium = false,
+            Email = "test@example.com"
+        };
+
+        var paymentMethod = new TokenizedPaymentMethod
+        {
+            Type = TokenizablePaymentMethodType.Card,
+            Token = "token_123"
+        };
+
+        var billingAddress = new BillingAddress
+        {
+            Country = "US",
+            PostalCode = "12345"
+        };
+
+        var expectedException = new Exception("Push service error");
+        _pushNotificationService.When(x => x.PushSyncVaultAsync(user.Id)).Do(x => throw expectedException);
+
+        // Act
+        var result = await _command.Run(user, paymentMethod, billingAddress, 0);
+
+        // Assert
+        Assert.True(result.IsT3);
+        // Verify payment cancellation was attempted
+        await _paymentService.Received(1).CancelAndRecoverChargesAsync(user);
+    }
+}

--- a/test/Core.Test/Billing/Premium/Commands/CreatePremiumSelfHostedSubscriptionCommandTests.cs
+++ b/test/Core.Test/Billing/Premium/Commands/CreatePremiumSelfHostedSubscriptionCommandTests.cs
@@ -1,0 +1,199 @@
+﻿using System.Security.Claims;
+using Bit.Core.Billing.Models.Business;
+using Bit.Core.Billing.Premium.Commands;
+using Bit.Core.Billing.Services;
+using Bit.Core.Entities;
+using Bit.Core.Platform.Push;
+using Bit.Core.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Billing.Premium.Commands;
+
+public class CreatePremiumSelfHostedSubscriptionCommandTests
+{
+    private readonly ILicensingService _licensingService = Substitute.For<ILicensingService>();
+    private readonly IUserService _userService = Substitute.For<IUserService>();
+    private readonly IPushNotificationService _pushNotificationService = Substitute.For<IPushNotificationService>();
+    private readonly CreatePremiumSelfHostedSubscriptionCommand _command;
+
+    public CreatePremiumSelfHostedSubscriptionCommandTests()
+    {
+        _command = new CreatePremiumSelfHostedSubscriptionCommand(
+            _licensingService,
+            _userService,
+            _pushNotificationService,
+            Substitute.For<ILogger<CreatePremiumSelfHostedSubscriptionCommand>>());
+    }
+
+    [Fact]
+    public async Task Run_UserAlreadyPremium_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Premium = true
+        };
+
+        var license = new UserLicense
+        {
+            LicenseKey = "test_key",
+            Expires = DateTime.UtcNow.AddYears(1)
+        };
+
+        // Act
+        var result = await _command.Run(user, license);
+
+        // Assert
+        Assert.True(result.IsT1);
+        var badRequest = result.AsT1;
+        Assert.Equal("Already a premium user.", badRequest.Response);
+    }
+
+    [Fact]
+    public async Task Run_InvalidLicense_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Premium = false
+        };
+
+        var license = new UserLicense
+        {
+            LicenseKey = "invalid_key",
+            Expires = DateTime.UtcNow.AddYears(1)
+        };
+
+        _licensingService.VerifyLicense(license).Returns(false);
+
+        // Act
+        var result = await _command.Run(user, license);
+
+        // Assert
+        Assert.True(result.IsT1);
+        var badRequest = result.AsT1;
+        Assert.Equal("Invalid license.", badRequest.Response);
+    }
+
+    [Fact]
+    public async Task Run_LicenseCannotBeUsed_EmailNotVerified_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Premium = false,
+            Email = "test@example.com",
+            EmailVerified = false
+        };
+
+        var license = new UserLicense
+        {
+            LicenseKey = "test_key",
+            Expires = DateTime.UtcNow.AddYears(1),
+            Token = "valid_token"
+        };
+
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim("Email", "test@example.com")
+        }));
+
+        _licensingService.VerifyLicense(license).Returns(true);
+        _licensingService.GetClaimsPrincipalFromLicense(license).Returns(claimsPrincipal);
+
+        // Act
+        var result = await _command.Run(user, license);
+
+        // Assert
+        Assert.True(result.IsT1);
+        var badRequest = result.AsT1;
+        Assert.Contains("The user's email is not verified.", badRequest.Response);
+    }
+
+    [Fact]
+    public async Task Run_LicenseCannotBeUsed_EmailMismatch_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Premium = false,
+            Email = "user@example.com",
+            EmailVerified = true
+        };
+
+        var license = new UserLicense
+        {
+            LicenseKey = "test_key",
+            Expires = DateTime.UtcNow.AddYears(1),
+            Token = "valid_token"
+        };
+
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim("Email", "license@example.com")
+        }));
+
+        _licensingService.VerifyLicense(license).Returns(true);
+        _licensingService.GetClaimsPrincipalFromLicense(license).Returns(claimsPrincipal);
+
+        // Act
+        var result = await _command.Run(user, license);
+
+        // Assert
+        Assert.True(result.IsT1);
+        var badRequest = result.AsT1;
+        Assert.Contains("The user's email does not match the license email.", badRequest.Response);
+    }
+
+    [Fact]
+    public async Task Run_ValidRequest_Success()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var user = new User
+        {
+            Id = userId,
+            Premium = false,
+            Email = "test@example.com",
+            EmailVerified = true
+        };
+
+        var license = new UserLicense
+        {
+            LicenseKey = "test_key_12345",
+            Expires = DateTime.UtcNow.AddYears(1),
+            Token = "valid_token"
+        };
+
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim("Email", "test@example.com")
+        }));
+
+        _licensingService.VerifyLicense(license).Returns(true);
+        _licensingService.GetClaimsPrincipalFromLicense(license).Returns(claimsPrincipal);
+
+        // Act
+        var result = await _command.Run(user, license);
+
+        // Assert
+        Assert.True(result.IsT0);
+
+        // Verify user was updated correctly
+        Assert.True(user.Premium);
+        Assert.NotNull(user.LicenseKey);
+        Assert.Equal(license.LicenseKey, user.LicenseKey);
+        Assert.NotEqual(default, user.RevisionDate);
+
+        // Verify services were called
+        await _licensingService.Received(1).WriteUserLicenseAsync(user, license);
+        await _userService.Received(1).SaveUserAsync(user);
+        await _pushNotificationService.Received(1).PushSyncVaultAsync(user.Id);
+    }
+}

--- a/test/Core.Test/Billing/Services/LicensingServiceTests.cs
+++ b/test/Core.Test/Billing/Services/LicensingServiceTests.cs
@@ -1,8 +1,10 @@
 ﻿using System.Text.Json;
 using AutoFixture;
 using Bit.Core.AdminConsole.Entities;
+using Bit.Core.Billing.Models.Business;
 using Bit.Core.Billing.Organizations.Models;
 using Bit.Core.Billing.Services;
+using Bit.Core.Entities;
 using Bit.Core.Settings;
 using Bit.Core.Test.Billing.AutoFixture;
 using Bit.Test.Common.AutoFixture;
@@ -16,10 +18,21 @@ public class LicensingServiceTests
 {
     private static string licenseFilePath(Guid orgId) =>
         Path.Combine(OrganizationLicenseDirectory.Value, $"{orgId}.json");
+    private static string userLicenseFilePath(Guid userId) =>
+        Path.Combine(UserLicenseDirectory.Value, $"{userId}.json");
     private static string LicenseDirectory => Path.GetDirectoryName(OrganizationLicenseDirectory.Value);
     private static Lazy<string> OrganizationLicenseDirectory => new(() =>
     {
         var directory = Path.Combine(Path.GetTempPath(), "organization");
+        if (!Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+        return directory;
+    });
+    private static Lazy<string> UserLicenseDirectory => new(() =>
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "user");
         if (!Directory.Exists(directory))
         {
             Directory.CreateDirectory(directory);
@@ -55,6 +68,68 @@ public class LicensingServiceTests
         finally
         {
             Directory.Delete(OrganizationLicenseDirectory.Value, true);
+        }
+    }
+
+    [Theory, BitAutoData]
+    public async Task WriteUserLicense_CreatesFileWithCorrectContent(User user, UserLicense license)
+    {
+        // Arrange
+        var sutProvider = GetSutProvider();
+        var expectedFilePath = userLicenseFilePath(user.Id);
+
+        try
+        {
+            // Act
+            await sutProvider.Sut.WriteUserLicenseAsync(user, license);
+
+            // Assert
+            Assert.True(File.Exists(expectedFilePath));
+            var fileContent = await File.ReadAllTextAsync(expectedFilePath);
+            var actualLicense = JsonSerializer.Deserialize<UserLicense>(fileContent);
+
+            Assert.Equal(license.LicenseKey, actualLicense.LicenseKey);
+            Assert.Equal(license.Id, actualLicense.Id);
+            Assert.Equal(license.Expires, actualLicense.Expires);
+        }
+        finally
+        {
+            // Cleanup
+            if (Directory.Exists(UserLicenseDirectory.Value))
+            {
+                Directory.Delete(UserLicenseDirectory.Value, true);
+            }
+        }
+    }
+
+    [Theory, BitAutoData]
+    public async Task WriteUserLicense_CreatesDirectoryIfNotExists(User user, UserLicense license)
+    {
+        // Arrange
+        var sutProvider = GetSutProvider();
+
+        // Ensure directory doesn't exist
+        if (Directory.Exists(UserLicenseDirectory.Value))
+        {
+            Directory.Delete(UserLicenseDirectory.Value, true);
+        }
+
+        try
+        {
+            // Act
+            await sutProvider.Sut.WriteUserLicenseAsync(user, license);
+
+            // Assert
+            Assert.True(Directory.Exists(UserLicenseDirectory.Value));
+            Assert.True(File.Exists(userLicenseFilePath(user.Id)));
+        }
+        finally
+        {
+            // Cleanup
+            if (Directory.Exists(UserLicenseDirectory.Value))
+            {
+                Directory.Delete(UserLicenseDirectory.Value, true);
+            }
         }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-25088

## 📔 Objective

This PR adds 2 new endpoints for use in the new premium subscription flow coming soon. Both endpoints are logically equivalent to the existing POST `/accounts/premium` endpoint, except split into one for self-host, and one for cloud-hosted.

The endpoints were added to the vNext controllers in billing, and conform to the new command/query pattern. The old endpoint relied on `UserService` to complete some of the process but in an effort to continually decouple billing code from code owned by other teams, this new flow incorporates all of the logic previously in UserService inside the command itself instead.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
