### PR TITLE
[PM-25339] Expand remove card policy to all multi-select of item types

### DIFF
--- a/src/Core/AdminConsole/Enums/PolicyType.cs
+++ b/src/Core/AdminConsole/Enums/PolicyType.cs
@@ -45,7 +45,7 @@ public static class PolicyTypeExtensions
             PolicyType.AutomaticAppLogIn => "Automatically log in users for allowed applications",
             PolicyType.FreeFamiliesSponsorshipPolicy => "Remove Free Bitwarden Families sponsorship",
             PolicyType.RemoveUnlockWithPin => "Remove unlock with PIN",
-            PolicyType.RestrictedItemTypesPolicy => "Restricted item types",
+            PolicyType.RestrictedItemTypesPolicy => "Remove certain item types",
         };
     }
 }

--- a/src/Core/AdminConsole/Models/Data/Organizations/Policies/RestrictedItemTypesPolicyData.cs
+++ b/src/Core/AdminConsole/Models/Data/Organizations/Policies/RestrictedItemTypesPolicyData.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.Vault.Enums;
+
+namespace Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
+
+public class RestrictedItemTypesPolicyData : IPolicyDataModel
+{
+    [Display(Name = "RestrictedItemTypes")]
+    public ICollection<CipherType> RestrictedItemTypes { get; set; } = new List<CipherType>();
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyServiceCollectionExtensions.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ public static class PolicyServiceCollectionExtensions
         services.AddScoped<IPolicyValidator, ResetPasswordPolicyValidator>();
         services.AddScoped<IPolicyValidator, MaximumVaultTimeoutPolicyValidator>();
         services.AddScoped<IPolicyValidator, FreeFamiliesForEnterprisePolicyValidator>();
+        services.AddScoped<IPolicyValidator, RestrictedItemTypesPolicyValidator>();
         // This validator will be hooked up in https://bitwarden.atlassian.net/browse/PM-24279.
         // services.AddScoped<IPolicyValidator, OrganizationDataOwnershipPolicyValidator>();
     }

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyValidators/RestrictedItemTypesPolicyValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyValidators/RestrictedItemTypesPolicyValidator.cs
@@ -1,0 +1,55 @@
+﻿using System.Text.Json;
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Enums;
+using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies.Models;
+using Bit.Core.Vault.Enums;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyValidators;
+
+public class RestrictedItemTypesPolicyValidator : IPolicyValidator
+{
+    public PolicyType Type => PolicyType.RestrictedItemTypesPolicy;
+    public IEnumerable<PolicyType> RequiredPolicies => Array.Empty<PolicyType>();
+
+    public Task OnSaveSideEffectsAsync(PolicyUpdate policyUpdate, Policy? currentPolicy)
+    {
+        // No side effects needed for RestrictedItemTypes policy
+        return Task.CompletedTask;
+    }
+
+    public Task<string> ValidateAsync(PolicyUpdate policyUpdate, Policy? currentPolicy)
+    {
+        if (policyUpdate.Enabled && !string.IsNullOrEmpty(policyUpdate.Data))
+        {
+            try
+            {
+                var data = JsonSerializer.Deserialize<RestrictedItemTypesPolicyData>(policyUpdate.Data);
+
+                if (data?.RestrictedItemTypes != null)
+                {
+                    // Validate that all cipher types are valid enum values
+                    var validCipherTypes = Enum.GetValues<CipherType>();
+                    var invalidTypes = data.RestrictedItemTypes.Where(type => !validCipherTypes.Contains(type)).ToList();
+
+                    if (invalidTypes.Any())
+                    {
+                        return Task.FromResult($"Invalid cipher types: {string.Join(", ", invalidTypes)}");
+                    }
+
+                    // Validate that Login cipher type is not restricted (business rule)
+                    if (data.RestrictedItemTypes.Contains(CipherType.Login))
+                    {
+                        return Task.FromResult("Login items cannot be restricted as they are essential for password management.");
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                return Task.FromResult("Invalid policy data format.");
+            }
+        }
+
+        return Task.FromResult("");
+    }
+}

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -208,6 +208,7 @@ public static class FeatureFlagKeys
     public const string EndUserNotifications = "pm-10609-end-user-notifications";
     public const string PhishingDetection = "phishing-detection";
     public const string RemoveCardItemTypePolicy = "pm-16442-remove-card-item-type-policy";
+    public const string ExpandRemoveItemTypesPolicy = "expand-remove-item-types-policy";
     public const string PM22134SdkCipherListView = "pm-22134-sdk-cipher-list-view";
     public const string PM19315EndUserActivationMvp = "pm-19315-end-user-activation-mvp";
     public const string PM22136_SdkCipherEncryption = "pm-22136-sdk-cipher-encryption";


### PR DESCRIPTION
## 🎟️ Tracking

None

## 📔 Objective

Recently released, the Remove card item type policy allows organization administrators to prevent users from storing and creating card items in the individual or org vault. This expansion allows for administrators to select any item type (except for login items)

## 📸 Screenshots

The only UI change is in the pollcy:

<img width="683" height="565" alt="image" src="https://github.com/user-attachments/assets/67ec52ee-f11a-404a-ac0c-38a15140c30a" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
