### PR TITLE
[PM-25419] Move `ProviderPriceAdapter` to Core project

### DIFF
--- a/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Services/BusinessUnitConverterTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Services/BusinessUnitConverterTests.cs
@@ -11,6 +11,7 @@ using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Pricing;
 using Bit.Core.Billing.Providers.Entities;
 using Bit.Core.Billing.Providers.Repositories;
+using Bit.Core.Billing.Providers.Services;
 using Bit.Core.Billing.Services;
 using Bit.Core.Entities;
 using Bit.Core.Enums;

--- a/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Services/ProviderBillingServiceTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Services/ProviderBillingServiceTests.cs
@@ -15,6 +15,7 @@ using Bit.Core.Billing.Pricing;
 using Bit.Core.Billing.Providers.Entities;
 using Bit.Core.Billing.Providers.Models;
 using Bit.Core.Billing.Providers.Repositories;
+using Bit.Core.Billing.Providers.Services;
 using Bit.Core.Billing.Services;
 using Bit.Core.Billing.Tax.Services;
 using Bit.Core.Entities;

--- a/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Services/ProviderPriceAdapterTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Services/ProviderPriceAdapterTests.cs
@@ -2,6 +2,7 @@
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.Billing.Enums;
+using Bit.Core.Billing.Providers.Services;
 using Stripe;
 using Xunit;
 

--- a/src/Api/Billing/Controllers/ProviderBillingController.cs
+++ b/src/Api/Billing/Controllers/ProviderBillingController.cs
@@ -3,7 +3,6 @@
 
 using Bit.Api.Billing.Models.Requests;
 using Bit.Api.Billing.Models.Responses;
-using Bit.Commercial.Core.Billing.Providers.Services;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Billing.Pricing;
 using Bit.Core.Billing.Providers.Models;

--- a/src/Core/Billing/Providers/Services/ProviderPriceAdapter.cs
+++ b/src/Core/Billing/Providers/Services/ProviderPriceAdapter.cs
@@ -1,12 +1,10 @@
 ﻿// ReSharper disable SwitchExpressionHandlesSomeKnownEnumValuesWithExceptionInDefault
-#nullable enable
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
-using Bit.Core.Billing;
 using Bit.Core.Billing.Enums;
 using Stripe;
 
-namespace Bit.Commercial.Core.Billing.Providers.Services;
+namespace Bit.Core.Billing.Providers.Services;
 
 public static class ProviderPriceAdapter
 {
@@ -52,7 +50,7 @@ public static class ProviderPriceAdapter
     /// <param name="planType">The plan type correlating to the desired Stripe price ID.</param>
     /// <returns>A Stripe <see cref="Stripe.Price"/> ID.</returns>
     /// <exception cref="BillingException">Thrown when the provider's type is not <see cref="ProviderType.Msp"/> or <see cref="ProviderType.BusinessUnit"/>.</exception>
-    /// <exception cref="BillingException">Thrown when the provided <see cref="planType"/> does not relate to a Stripe price ID.</exception>
+    /// <exception cref="BillingException">Thrown when the provided <paramref name="planType"/> does not relate to a Stripe price ID.</exception>
     public static string GetPriceId(
         Provider provider,
         Subscription subscription,
@@ -104,7 +102,7 @@ public static class ProviderPriceAdapter
     /// <param name="planType">The plan type correlating to the desired Stripe price ID.</param>
     /// <returns>A Stripe <see cref="Stripe.Price"/> ID.</returns>
     /// <exception cref="BillingException">Thrown when the provider's type is not <see cref="ProviderType.Msp"/> or <see cref="ProviderType.BusinessUnit"/>.</exception>
-    /// <exception cref="BillingException">Thrown when the provided <see cref="planType"/> does not relate to a Stripe price ID.</exception>
+    /// <exception cref="BillingException">Thrown when the provided <paramref name="planType"/> does not relate to a Stripe price ID.</exception>
     public static string GetActivePriceId(
         Provider provider,
         PlanType planType)

--- a/test/Api.Test/Billing/Controllers/ProviderBillingControllerTests.cs
+++ b/test/Api.Test/Billing/Controllers/ProviderBillingControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿using Bit.Api.Billing.Controllers;
 using Bit.Api.Billing.Models.Requests;
 using Bit.Api.Billing.Models.Responses;
-using Bit.Commercial.Core.Billing.Providers.Services;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.AdminConsole.Repositories;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-25419

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The `ProviderPriceAdapter` (a collection of static methods) was moved to the Commercial project, but referenced directly in the API, which broke the OSS build.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
