### PR TITLE
[PM 21729] Fix UseKeyConnector is set to true when upgrading to Enterprise  from Free/Teams

### DIFF
--- a/src/Api/Billing/Controllers/OrganizationBillingController.cs
+++ b/src/Api/Billing/Controllers/OrganizationBillingController.cs
@@ -304,7 +304,7 @@ public class OrganizationBillingController(
             sale.Organization.UsePolicies = plan.HasPolicies;
             sale.Organization.UseSso = plan.HasSso;
             sale.Organization.UseResetPassword = plan.HasResetPassword;
-            sale.Organization.UseKeyConnector = plan.HasKeyConnector;
+            sale.Organization.UseKeyConnector = plan.HasKeyConnector ? organization.UseKeyConnector : false;
             sale.Organization.UseScim = plan.HasScim;
             sale.Organization.UseCustomPermissions = plan.HasCustomPermissions;
             sale.Organization.UseOrganizationDomains = plan.HasOrganizationDomains;

--- a/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs
@@ -265,7 +265,7 @@ public class UpgradeOrganizationPlanCommand : IUpgradeOrganizationPlanCommand
         organization.UseApi = newPlan.HasApi;
         organization.UseSso = newPlan.HasSso;
         organization.UseOrganizationDomains = newPlan.HasOrganizationDomains;
-        organization.UseKeyConnector = newPlan.HasKeyConnector;
+        organization.UseKeyConnector = newPlan.HasKeyConnector ? organization.UseKeyConnector : false;
         organization.UseScim = newPlan.HasScim;
         organization.UseResetPassword = newPlan.HasResetPassword;
         organization.SelfHost = newPlan.HasSelfHost;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21729

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR fixes a bug where upgrading from Free/Teams to Enterprise organizations incorrectly sets `UseKeyConnector` to true, when it should remain false to match the behavior of creating new Enterprise organizations.

**Problem Description**
Issue: When end users upgrade a Free or Teams organization to Enterprise through the billing upgrade flow, the system automatically enables the Key Connector feature (`UseKeyConnector = true`). This contradicts the expected behavior where Key Connector should only be enabled manually by Bitwarden employees in the Admin Portal.
Expected Behavior: `UseKeyConnector` should remain false after upgrade, matching how new Enterprise organizations are created.
Actual Behavior: `UseKeyConnector` is set to true during the upgrade process.

**Solution**
Modified the upgrade logic to preserve the existing UseKeyConnector setting while still respecting plan capabilities:

`organization.UseKeyConnector = newPlan.HasKeyConnector ? organization.UseKeyConnector : false;`

**Files Modified**
`src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs`

- Line 268-270: Fixed the main organization upgrade flow
- Impact: Affects all user-initiated plan upgrades via /organizations/{id}/upgrade endpoint

`src/Api/Billing/Controllers/OrganizationBillingController.cs`

- Line 307-308: Fixed the restart subscription flow
- Impact: Affects subscription restarts for Free organizations with existing gateway subscriptions

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="1728" height="1117" alt="Screenshot 2025-09-04 at 09 58 59" src="https://github.com/user-attachments/assets/96c64956-64c3-4027-be20-adaacd491dfe" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
