### PR TITLE
[PM-25413] Do not throw BadRequest from Freshdesk Webhook

### DIFF
--- a/src/Billing/Controllers/FreshdeskController.cs
+++ b/src/Billing/Controllers/FreshdeskController.cs
@@ -152,6 +152,12 @@ public class FreshdeskController : Controller
             return new BadRequestResult();
         }
 
+        // if there is no description, then we don't send anything to onyx
+        if (string.IsNullOrEmpty(model.TicketDescriptionText.Trim()))
+        {
+            return Ok();
+        }
+
         // create the onyx `answer-with-citation` request
         var onyxRequestModel = new OnyxAnswerWithCitationRequestModel(model.TicketDescriptionText, _billingSettings.Onyx.PersonaId);
         var onyxRequest = new HttpRequestMessage(HttpMethod.Post,
@@ -164,9 +170,12 @@ public class FreshdeskController : Controller
         // the CallOnyxApi will return a null if we have an error response
         if (onyxJsonResponse?.Answer == null || !string.IsNullOrEmpty(onyxJsonResponse?.ErrorMsg))
         {
-            return BadRequest(
-                string.Format("Failed to get a valid response from Onyx API. Response: {0}",
-                            JsonSerializer.Serialize(onyxJsonResponse ?? new OnyxAnswerWithCitationResponseModel())));
+            _logger.LogWarning("Error getting answer from Onyx AI. Freshdesk model: {model}\r\n Onyx query {query}\r\nresponse: {response}. ",
+                    JsonSerializer.Serialize(model),
+                    JsonSerializer.Serialize(onyxRequestModel),
+                    JsonSerializer.Serialize(onyxJsonResponse));
+
+            return Ok(); // return ok so we don't retry
         }
 
         // add the answer as a note to the ticket


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-25413

## 📔 Objective

When the webhook runs into an error, it throws a BadRequest exception.
We don't need to do this, instead, we log the error and return Ok.

## 📸 Screenshots

<img width="1527" height="889" alt="image" src="https://github.com/user-attachments/assets/6f7d3939-a6de-45da-9483-a53718bc24da" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
