### PR TITLE
[PM-25390] CORS - Password Change URI

### DIFF
--- a/src/Icons/Controllers/ChangePasswordUriController.cs
+++ b/src/Icons/Controllers/ChangePasswordUriController.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Caching.Memory;
 
 namespace Bit.Icons.Controllers;
 
-[Route("change-password-uri")]
+[Route("~/change-password-uri")]
 public class ChangePasswordUriController : Controller
 {
     private readonly IMemoryCache _memoryCache;

--- a/src/Icons/Startup.cs
+++ b/src/Icons/Startup.cs
@@ -92,6 +92,9 @@ public class Startup
             await next();
         });
 
+        app.UseCors(policy => policy.SetIsOriginAllowed(o => CoreHelpers.IsCorsOriginAllowed(o, globalSettings))
+            .AllowAnyMethod().AllowAnyHeader().AllowCredentials());
+
         app.UseRouting();
         app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25390](https://bitwarden.atlassian.net/browse/PM-25390)

## 📔 Objective

There were two things that I missed/didn't catch in https://github.com/bitwarden/server/pull/5845
- Testing locally I was proxying the icons service through my local web vault, which avoided CORS. That isn't how production or the lower environments operate. These requests are currently being blocked by CORS in lower environments. I copied over the CORS definition from other services.
- Testing locally now - it appears as if the root `IconsController` was catching requests because it has the `[Route("")]` - I add to add `~/` to `[Route("~/change-password-uri")]` in order to hit this directly.

## 📸 Screenshots

To test I added my local server as the `icon` url resulting in the request not being proxied through the web dev server.
<video src="https://github.com/user-attachments/assets/8aab3df5-d835-4162-a7de-456d9a06a7c4" /> 

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
