### PR TITLE
Add Datadog integration

### DIFF
--- a/dev/servicebusemulator_config.json
+++ b/dev/servicebusemulator_config.json
@@ -34,6 +34,9 @@
               },
               {
                 "Name": "events-hec-subscription"
+              },
+              {
+                "Name": "events-datadog-subscription"
               }
             ]
           },
@@ -77,6 +80,20 @@
                       "FilterType": "Correlation",
                       "CorrelationFilter": {
                         "Label": "hec"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "Name": "integration-datadog-subscription",
+                "Rules": [
+                  {
+                    "Name": "datadog-integration-filter",
+                    "Properties": {
+                      "FilterType": "Correlation",
+                      "CorrelationFilter": {
+                        "Label": "datadog"
                       }
                     }
                   }

--- a/src/Api/AdminConsole/Models/Request/Organizations/OrganizationIntegrationConfigurationRequestModel.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/OrganizationIntegrationConfigurationRequestModel.cs
@@ -36,6 +36,10 @@ public class OrganizationIntegrationConfigurationRequestModel
                 return !string.IsNullOrWhiteSpace(Template) &&
                        Configuration is null &&
                        IsFiltersValid();
+            case IntegrationType.Datadog:
+                return !string.IsNullOrWhiteSpace(Template) &&
+                       Configuration is null &&
+                       IsFiltersValid();
             default:
                 return false;
 

--- a/src/Api/AdminConsole/Models/Request/Organizations/OrgnizationIntegrationRequestModel.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/OrgnizationIntegrationRequestModel.cs
@@ -60,6 +60,14 @@ public class OrganizationIntegrationRequestModel : IValidatableObject
                         new[] { nameof(Configuration) });
                 }
                 break;
+            case IntegrationType.Datadog:
+                if (!IsIntegrationValid<DatadogIntegration>())
+                {
+                    yield return new ValidationResult(
+                        "Datadog integrations must include valid configuration.",
+                        new[] { nameof(Configuration) });
+                }
+                break;
             default:
                 yield return new ValidationResult(
                     $"Integration type '{Type}' is not recognized.",

--- a/src/Core/AdminConsole/Enums/IntegrationType.cs
+++ b/src/Core/AdminConsole/Enums/IntegrationType.cs
@@ -6,7 +6,8 @@ public enum IntegrationType : int
     Scim = 2,
     Slack = 3,
     Webhook = 4,
-    Hec = 5
+    Hec = 5,
+    Datadog = 6
 }
 
 public static class IntegrationTypeExtensions
@@ -21,6 +22,8 @@ public static class IntegrationTypeExtensions
                 return "webhook";
             case IntegrationType.Hec:
                 return "hec";
+            case IntegrationType.Datadog:
+                return "datadog";
             default:
                 throw new ArgumentOutOfRangeException(nameof(type), $"Unsupported integration type: {type}");
         }

--- a/src/Core/AdminConsole/Models/Data/EventIntegrations/DatadogIntegration.cs
+++ b/src/Core/AdminConsole/Models/Data/EventIntegrations/DatadogIntegration.cs
@@ -1,0 +1,5 @@
+﻿#nullable enable
+
+namespace Bit.Core.AdminConsole.Models.Data.EventIntegrations;
+
+public record DatadogIntegration(string ApiKey, Uri Uri);

--- a/src/Core/AdminConsole/Models/Data/EventIntegrations/DatadogIntegrationConfigurationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/EventIntegrations/DatadogIntegrationConfigurationDetails.cs
@@ -1,0 +1,5 @@
+﻿#nullable enable
+
+namespace Bit.Core.AdminConsole.Models.Data.EventIntegrations;
+
+public record DatadogIntegrationConfigurationDetails(string ApiKey, Uri Uri);

--- a/src/Core/AdminConsole/Models/Data/EventIntegrations/DatadogListenerConfiguration.cs
+++ b/src/Core/AdminConsole/Models/Data/EventIntegrations/DatadogListenerConfiguration.cs
@@ -1,0 +1,38 @@
+﻿using Bit.Core.Enums;
+using Bit.Core.Settings;
+
+namespace Bit.Core.AdminConsole.Models.Data.EventIntegrations;
+
+public class DatadogListenerConfiguration(GlobalSettings globalSettings)
+    : ListenerConfiguration(globalSettings), IIntegrationListenerConfiguration
+{
+    public IntegrationType IntegrationType
+    {
+        get => IntegrationType.Datadog;
+    }
+
+    public string EventQueueName
+    {
+        get => _globalSettings.EventLogging.RabbitMq.DatadogEventsQueueName;
+    }
+
+    public string IntegrationQueueName
+    {
+        get => _globalSettings.EventLogging.RabbitMq.DatadogIntegrationQueueName;
+    }
+
+    public string IntegrationRetryQueueName
+    {
+        get => _globalSettings.EventLogging.RabbitMq.DatadogIntegrationRetryQueueName;
+    }
+
+    public string EventSubscriptionName
+    {
+        get => _globalSettings.EventLogging.AzureServiceBus.DatadogEventSubscriptionName;
+    }
+
+    public string IntegrationSubscriptionName
+    {
+        get => _globalSettings.EventLogging.AzureServiceBus.DatadogIntegrationSubscriptionName;
+    }
+}

--- a/src/Core/AdminConsole/Services/Implementations/EventIntegrations/DatadogIntegrationHandler.cs
+++ b/src/Core/AdminConsole/Services/Implementations/EventIntegrations/DatadogIntegrationHandler.cs
@@ -1,0 +1,27 @@
+﻿#nullable enable
+
+using System.Text;
+using Bit.Core.AdminConsole.Models.Data.EventIntegrations;
+
+namespace Bit.Core.Services;
+
+public class DatadogIntegrationHandler(
+    IHttpClientFactory httpClientFactory,
+    TimeProvider timeProvider)
+    : IntegrationHandlerBase<DatadogIntegrationConfigurationDetails>
+{
+    private readonly HttpClient _httpClient = httpClientFactory.CreateClient(HttpClientName);
+
+    public const string HttpClientName = "DatadogIntegrationHandlerHttpClient";
+
+    public override async Task<IntegrationHandlerResult> HandleAsync(IntegrationMessage<DatadogIntegrationConfigurationDetails> message)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, message.Configuration.Uri);
+        request.Content = new StringContent(message.RenderedTemplate, Encoding.UTF8, "application/json");
+        request.Headers.Add("DD-API-KEY", message.Configuration.ApiKey);
+
+        var response = await _httpClient.SendAsync(request);
+
+        return ResultFromHttpResponse(response, message, timeProvider);
+    }
+}

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -304,6 +304,8 @@ public class GlobalSettings : IGlobalSettings
             public virtual string WebhookIntegrationSubscriptionName { get; set; } = "integration-webhook-subscription";
             public virtual string HecEventSubscriptionName { get; set; } = "events-hec-subscription";
             public virtual string HecIntegrationSubscriptionName { get; set; } = "integration-hec-subscription";
+            public virtual string DatadogEventSubscriptionName { get; set; } = "events-datadog-subscription";
+            public virtual string DatadogIntegrationSubscriptionName { get; set; } = "integration-datadog-subscription";
 
             public string ConnectionString
             {
@@ -345,6 +347,9 @@ public class GlobalSettings : IGlobalSettings
             public virtual string HecEventsQueueName { get; set; } = "events-hec-queue";
             public virtual string HecIntegrationQueueName { get; set; } = "integration-hec-queue";
             public virtual string HecIntegrationRetryQueueName { get; set; } = "integration-hec-retry-queue";
+            public virtual string DatadogEventsQueueName { get; set; } = "events-datadog-queue";
+            public virtual string DatadogIntegrationQueueName { get; set; } = "integration-datadog-queue";
+            public virtual string DatadogIntegrationRetryQueueName { get; set; } = "integration-datadog-retry-queue";
 
             public string HostName
             {

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -881,15 +881,18 @@ public static class ServiceCollectionExtensions
         services.AddSlackService(globalSettings);
         services.TryAddSingleton(TimeProvider.System);
         services.AddHttpClient(WebhookIntegrationHandler.HttpClientName);
+        services.AddHttpClient(DatadogIntegrationHandler.HttpClientName);
 
         // Add integration handlers
         services.TryAddSingleton<IIntegrationHandler<SlackIntegrationConfigurationDetails>, SlackIntegrationHandler>();
         services.TryAddSingleton<IIntegrationHandler<WebhookIntegrationConfigurationDetails>, WebhookIntegrationHandler>();
+        services.TryAddSingleton<IIntegrationHandler<DatadogIntegrationConfigurationDetails>, DatadogIntegrationHandler>();
 
         var repositoryConfiguration = new RepositoryListenerConfiguration(globalSettings);
         var slackConfiguration = new SlackListenerConfiguration(globalSettings);
         var webhookConfiguration = new WebhookListenerConfiguration(globalSettings);
         var hecConfiguration = new HecListenerConfiguration(globalSettings);
+        var datadogConfiguration = new DatadogListenerConfiguration(globalSettings);
 
         if (IsRabbitMqEnabled(globalSettings))
         {
@@ -906,6 +909,7 @@ public static class ServiceCollectionExtensions
             services.AddRabbitMqIntegration<SlackIntegrationConfigurationDetails, SlackListenerConfiguration>(slackConfiguration);
             services.AddRabbitMqIntegration<WebhookIntegrationConfigurationDetails, WebhookListenerConfiguration>(webhookConfiguration);
             services.AddRabbitMqIntegration<WebhookIntegrationConfigurationDetails, HecListenerConfiguration>(hecConfiguration);
+            services.AddRabbitMqIntegration<DatadogIntegrationConfigurationDetails, DatadogListenerConfiguration>(datadogConfiguration);
         }
 
         if (IsAzureServiceBusEnabled(globalSettings))
@@ -923,6 +927,7 @@ public static class ServiceCollectionExtensions
             services.AddAzureServiceBusIntegration<SlackIntegrationConfigurationDetails, SlackListenerConfiguration>(slackConfiguration);
             services.AddAzureServiceBusIntegration<WebhookIntegrationConfigurationDetails, WebhookListenerConfiguration>(webhookConfiguration);
             services.AddAzureServiceBusIntegration<WebhookIntegrationConfigurationDetails, HecListenerConfiguration>(hecConfiguration);
+            services.AddAzureServiceBusIntegration<DatadogIntegrationConfigurationDetails, DatadogListenerConfiguration>(datadogConfiguration);
         }
 
         return services;

--- a/test/Api.Test/AdminConsole/Models/Request/Organizations/OrganizationIntegrationConfigurationRequestModelTests.cs
+++ b/test/Api.Test/AdminConsole/Models/Request/Organizations/OrganizationIntegrationConfigurationRequestModelTests.cs
@@ -63,6 +63,32 @@ public class OrganizationIntegrationConfigurationRequestModelTests
     }
 
     [Theory]
+    [InlineData(data: "")]
+    [InlineData(data: "    ")]
+    public void IsValidForType_EmptyNonNullDatadogConfiguration_ReturnsFalse(string? config)
+    {
+        var model = new OrganizationIntegrationConfigurationRequestModel
+        {
+            Configuration = config,
+            Template = "template"
+        };
+
+        Assert.False(condition: model.IsValidForType(IntegrationType.Datadog));
+    }
+
+    [Fact]
+    public void IsValidForType_NullDatadogConfiguration_ReturnsTrue()
+    {
+        var model = new OrganizationIntegrationConfigurationRequestModel
+        {
+            Configuration = null,
+            Template = "template"
+        };
+
+        Assert.True(condition: model.IsValidForType(IntegrationType.Datadog));
+    }
+
+    [Theory]
     [InlineData(data: null)]
     [InlineData(data: "")]
     [InlineData(data: "    ")]

--- a/test/Api.Test/AdminConsole/Models/Request/Organizations/OrganizationIntegrationRequestModelTests.cs
+++ b/test/Api.Test/AdminConsole/Models/Request/Organizations/OrganizationIntegrationRequestModelTests.cs
@@ -148,6 +148,54 @@ public class OrganizationIntegrationRequestModelTests
     }
 
     [Fact]
+    public void Validate_Datadog_WithNullConfiguration_ReturnsError()
+    {
+        var model = new OrganizationIntegrationRequestModel
+        {
+            Type = IntegrationType.Datadog,
+            Configuration = null
+        };
+
+        var results = model.Validate(new ValidationContext(model)).ToList();
+
+        Assert.Single(results);
+        Assert.Contains(nameof(model.Configuration), results[0].MemberNames);
+        Assert.Contains("must include valid configuration", results[0].ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_Datadog_WithInvalidConfiguration_ReturnsError()
+    {
+        var model = new OrganizationIntegrationRequestModel
+        {
+            Type = IntegrationType.Datadog,
+            Configuration = "Not valid"
+        };
+
+        var results = model.Validate(new ValidationContext(model)).ToList();
+
+        Assert.Single(results);
+        Assert.Contains(nameof(model.Configuration), results[0].MemberNames);
+        Assert.Contains("must include valid configuration", results[0].ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_Datadog_WithValidConfiguration_ReturnsNoErrors()
+    {
+        var model = new OrganizationIntegrationRequestModel
+        {
+            Type = IntegrationType.Datadog,
+            Configuration = JsonSerializer.Serialize(
+                new DatadogIntegration(ApiKey: "API1234", Uri: new Uri("http://localhost"))
+            )
+        };
+
+        var results = model.Validate(new ValidationContext(model)).ToList();
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
     public void Validate_UnknownIntegrationType_ReturnsUnrecognizedError()
     {
         var model = new OrganizationIntegrationRequestModel

--- a/test/Core.Test/AdminConsole/Services/DatadogIntegrationHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/Services/DatadogIntegrationHandlerTests.cs
@@ -1,0 +1,157 @@
+﻿#nullable enable
+
+using System.Net;
+using Bit.Core.AdminConsole.Models.Data.EventIntegrations;
+using Bit.Core.Services;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Bit.Test.Common.Helpers;
+using Bit.Test.Common.MockedHttpClient;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Services;
+
+[SutProviderCustomize]
+public class DatadogIntegrationHandlerTests
+{
+    private readonly MockedHttpMessageHandler _handler;
+    private readonly HttpClient _httpClient;
+    private const string _apiKey = "AUTH_TOKEN";
+    private static readonly Uri _datadogUri = new Uri("https://localhost");
+
+    public DatadogIntegrationHandlerTests()
+    {
+        _handler = new MockedHttpMessageHandler();
+        _handler.Fallback
+            .WithStatusCode(HttpStatusCode.OK)
+            .WithContent(new StringContent("<html><head><title>test</title></head><body>test</body></html>"));
+        _httpClient = _handler.ToHttpClient();
+    }
+
+    private SutProvider<DatadogIntegrationHandler> GetSutProvider()
+    {
+        var clientFactory = Substitute.For<IHttpClientFactory>();
+        clientFactory.CreateClient(DatadogIntegrationHandler.HttpClientName).Returns(_httpClient);
+
+        return new SutProvider<DatadogIntegrationHandler>()
+            .SetDependency(clientFactory)
+            .WithFakeTimeProvider()
+            .Create();
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleAsync_SuccessfulRequest_ReturnsSuccess(IntegrationMessage<DatadogIntegrationConfigurationDetails> message)
+    {
+        var sutProvider = GetSutProvider();
+        message.Configuration = new DatadogIntegrationConfigurationDetails(ApiKey: _apiKey, Uri: _datadogUri);
+
+        var result = await sutProvider.Sut.HandleAsync(message);
+
+        Assert.True(result.Success);
+        Assert.Equal(result.Message, message);
+        Assert.Empty(result.FailureReason);
+
+        sutProvider.GetDependency<IHttpClientFactory>().Received(1).CreateClient(
+            Arg.Is(AssertHelper.AssertPropertyEqual(DatadogIntegrationHandler.HttpClientName))
+        );
+
+        Assert.Single(_handler.CapturedRequests);
+        var request = _handler.CapturedRequests[0];
+        Assert.NotNull(request);
+        Assert.NotNull(request.Content);
+        var returned = await request.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal(_apiKey, request.Headers.GetValues("DD-API-KEY").Single());
+        Assert.Equal(_datadogUri, request.RequestUri);
+        AssertHelper.AssertPropertyEqual(message.RenderedTemplate, returned);
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleAsync_TooManyRequests_ReturnsFailureSetsDelayUntilDate(IntegrationMessage<DatadogIntegrationConfigurationDetails> message)
+    {
+        var sutProvider = GetSutProvider();
+        var now = new DateTime(2014, 3, 2, 1, 0, 0, DateTimeKind.Utc);
+        var retryAfter = now.AddSeconds(60);
+
+        sutProvider.GetDependency<FakeTimeProvider>().SetUtcNow(now);
+        message.Configuration = new DatadogIntegrationConfigurationDetails(ApiKey: _apiKey, Uri: _datadogUri);
+
+        _handler.Fallback
+            .WithStatusCode(HttpStatusCode.TooManyRequests)
+            .WithHeader("Retry-After", "60")
+            .WithContent(new StringContent("<html><head><title>test</title></head><body>test</body></html>"));
+
+        var result = await sutProvider.Sut.HandleAsync(message);
+
+        Assert.False(result.Success);
+        Assert.True(result.Retryable);
+        Assert.Equal(result.Message, message);
+        Assert.True(result.DelayUntilDate.HasValue);
+        Assert.Equal(retryAfter, result.DelayUntilDate.Value);
+        Assert.Equal("Too Many Requests", result.FailureReason);
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleAsync_TooManyRequestsWithDate_ReturnsFailureSetsDelayUntilDate(IntegrationMessage<DatadogIntegrationConfigurationDetails> message)
+    {
+        var sutProvider = GetSutProvider();
+        var now = new DateTime(2014, 3, 2, 1, 0, 0, DateTimeKind.Utc);
+        var retryAfter = now.AddSeconds(60);
+        message.Configuration = new DatadogIntegrationConfigurationDetails(ApiKey: _apiKey, Uri: _datadogUri);
+
+        _handler.Fallback
+            .WithStatusCode(HttpStatusCode.TooManyRequests)
+            .WithHeader("Retry-After", retryAfter.ToString("r"))
+            .WithContent(new StringContent("<html><head><title>test</title></head><body>test</body></html>"));
+
+        var result = await sutProvider.Sut.HandleAsync(message);
+
+        Assert.False(result.Success);
+        Assert.True(result.Retryable);
+        Assert.Equal(result.Message, message);
+        Assert.True(result.DelayUntilDate.HasValue);
+        Assert.Equal(retryAfter, result.DelayUntilDate.Value);
+        Assert.Equal("Too Many Requests", result.FailureReason);
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleAsync_InternalServerError_ReturnsFailureSetsRetryable(IntegrationMessage<DatadogIntegrationConfigurationDetails> message)
+    {
+        var sutProvider = GetSutProvider();
+        message.Configuration = new DatadogIntegrationConfigurationDetails(ApiKey: _apiKey, Uri: _datadogUri);
+
+        _handler.Fallback
+            .WithStatusCode(HttpStatusCode.InternalServerError)
+            .WithContent(new StringContent("<html><head><title>test</title></head><body>test</body></html>"));
+
+        var result = await sutProvider.Sut.HandleAsync(message);
+
+        Assert.False(result.Success);
+        Assert.True(result.Retryable);
+        Assert.Equal(result.Message, message);
+        Assert.False(result.DelayUntilDate.HasValue);
+        Assert.Equal("Internal Server Error", result.FailureReason);
+    }
+
+    [Theory, BitAutoData]
+    public async Task HandleAsync_UnexpectedRedirect_ReturnsFailureNotRetryable(IntegrationMessage<DatadogIntegrationConfigurationDetails> message)
+    {
+        var sutProvider = GetSutProvider();
+        message.Configuration = new DatadogIntegrationConfigurationDetails(ApiKey: _apiKey, Uri: _datadogUri);
+
+        _handler.Fallback
+            .WithStatusCode(HttpStatusCode.TemporaryRedirect)
+            .WithContent(new StringContent("<html><head><title>test</title></head><body>test</body></html>"));
+
+        var result = await sutProvider.Sut.HandleAsync(message);
+
+        Assert.False(result.Success);
+        Assert.False(result.Retryable);
+        Assert.Equal(result.Message, message);
+        Assert.Null(result.DelayUntilDate);
+        Assert.Equal("Temporary Redirect", result.FailureReason);
+    }
+}


### PR DESCRIPTION
## 📔 Objective

This PR adds a new integration for Datadog

### Integration notes

Datadog has a base configuration with:
- API Key (user provided, from the Datadog settings)
- Uri (user provided because it varies based on region)

There is no event specific configuration. We can work out the exact template and provide it as a default when creating the UI, but the template I'm working with locally is:

``` json
{
  "source_type_name": "bitwarden",
  "title": "#Type#",
  "text": "ActingUser: #ActingUserId#\nUser: #UserId#\nEvent: #Type#\nOrganization: #OrganizationId#\nPolicyId: #PolicyId#\nIpAddress: #IpAddress#\nDomainName: #DomainName#\nCipherId: #CipherId#\n"
}
```

Datadog correctly interprets the source type to attribute these as coming from Bitwarden and adds the icon and branding. The title then shows the event type and the text provides the extended details.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
