### PR TITLE
[PM-25535] BEEEP update policies to be static strings

### DIFF
--- a/src/Api/Auth/Controllers/AccountsController.cs
+++ b/src/Api/Auth/Controllers/AccountsController.cs
@@ -9,6 +9,7 @@ using Bit.Core;
 using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.AdminConsole.Services;
+using Bit.Core.Auth.Identity;
 using Bit.Core.Auth.Models.Api.Request.Accounts;
 using Bit.Core.Auth.Services;
 using Bit.Core.Auth.UserFeatures.TdeOffboardingPassword.Interfaces;
@@ -26,7 +27,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Bit.Api.Auth.Controllers;
 
 [Route("accounts")]
-[Authorize("Application")]
+[Authorize(Policies.Application)]
 public class AccountsController : Controller
 {
     private readonly IOrganizationService _organizationService;

--- a/src/Api/Auth/Controllers/AuthRequestsController.cs
+++ b/src/Api/Auth/Controllers/AuthRequestsController.cs
@@ -5,6 +5,7 @@ using Bit.Api.Auth.Models.Response;
 using Bit.Api.Models.Response;
 using Bit.Core;
 using Bit.Core.Auth.Enums;
+using Bit.Core.Auth.Identity;
 using Bit.Core.Auth.Models.Api.Request.AuthRequest;
 using Bit.Core.Auth.Services;
 using Bit.Core.Exceptions;
@@ -18,7 +19,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Bit.Api.Auth.Controllers;
 
 [Route("auth-requests")]
-[Authorize("Application")]
+[Authorize(Policies.Application)]
 public class AuthRequestsController(
     IUserService userService,
     IAuthRequestRepository authRequestRepository,

--- a/src/Api/Auth/Controllers/EmergencyAccessController.cs
+++ b/src/Api/Auth/Controllers/EmergencyAccessController.cs
@@ -18,7 +18,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Bit.Api.Auth.Controllers;
 
 [Route("emergency-access")]
-[Authorize("Application")]
+[Authorize(Core.Auth.Identity.Policies.Application)]
 public class EmergencyAccessController : Controller
 {
     private readonly IUserService _userService;

--- a/src/Api/Auth/Controllers/TwoFactorController.cs
+++ b/src/Api/Auth/Controllers/TwoFactorController.cs
@@ -7,6 +7,7 @@ using Bit.Api.Auth.Models.Response.TwoFactor;
 using Bit.Api.Models.Request;
 using Bit.Api.Models.Response;
 using Bit.Core.Auth.Enums;
+using Bit.Core.Auth.Identity;
 using Bit.Core.Auth.Identity.TokenProviders;
 using Bit.Core.Auth.LoginFeatures.PasswordlessLogin.Interfaces;
 using Bit.Core.Auth.Models.Business.Tokenables;
@@ -26,7 +27,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Bit.Api.Auth.Controllers;
 
 [Route("two-factor")]
-[Authorize("Web")]
+[Authorize(Policies.Web)]
 public class TwoFactorController : Controller
 {
     private readonly IUserService _userService;

--- a/src/Api/Auth/Controllers/WebAuthnController.cs
+++ b/src/Api/Auth/Controllers/WebAuthnController.cs
@@ -7,6 +7,7 @@ using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
 using Bit.Core.AdminConsole.Services;
 using Bit.Core.Auth.Enums;
+using Bit.Core.Auth.Identity;
 using Bit.Core.Auth.Models.Api.Response.Accounts;
 using Bit.Core.Auth.Models.Business.Tokenables;
 using Bit.Core.Auth.Repositories;
@@ -20,7 +21,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Bit.Api.Auth.Controllers;
 
 [Route("webauthn")]
-[Authorize("Web")]
+[Authorize(Policies.Web)]
 public class WebAuthnController : Controller
 {
     private readonly IUserService _userService;

--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -34,6 +34,7 @@ using Bit.Core.Dirt.Reports.ReportFeatures;
 using Bit.Core.Tools.SendFeatures;
 using Bit.Core.Auth.IdentityServer;
 using Bit.Core.Auth.Identity;
+using Bit.Core.Enums;
 
 
 #if !OSS
@@ -105,40 +106,40 @@ public class Startup
         services.AddCustomIdentityServices(globalSettings);
         services.AddIdentityAuthenticationServices(globalSettings, Environment, config =>
         {
-            config.AddPolicy("Application", policy =>
+            config.AddPolicy(Policies.Application, policy =>
             {
                 policy.RequireAuthenticatedUser();
                 policy.RequireClaim(JwtClaimTypes.AuthenticationMethod, "Application", "external");
                 policy.RequireClaim(JwtClaimTypes.Scope, ApiScopes.Api);
             });
-            config.AddPolicy("Web", policy =>
+            config.AddPolicy(Policies.Web, policy =>
             {
                 policy.RequireAuthenticatedUser();
                 policy.RequireClaim(JwtClaimTypes.AuthenticationMethod, "Application", "external");
                 policy.RequireClaim(JwtClaimTypes.Scope, ApiScopes.Api);
-                policy.RequireClaim(JwtClaimTypes.ClientId, "web");
+                policy.RequireClaim(JwtClaimTypes.ClientId, BitwardenClient.Web);
             });
-            config.AddPolicy("Push", policy =>
+            config.AddPolicy(Policies.Push, policy =>
             {
                 policy.RequireAuthenticatedUser();
                 policy.RequireClaim(JwtClaimTypes.Scope, ApiScopes.ApiPush);
             });
-            config.AddPolicy("Licensing", policy =>
+            config.AddPolicy(Policies.Licensing, policy =>
             {
                 policy.RequireAuthenticatedUser();
                 policy.RequireClaim(JwtClaimTypes.Scope, ApiScopes.ApiLicensing);
             });
-            config.AddPolicy("Organization", policy =>
+            config.AddPolicy(Policies.Organization, policy =>
             {
                 policy.RequireAuthenticatedUser();
                 policy.RequireClaim(JwtClaimTypes.Scope, ApiScopes.ApiOrganization);
             });
-            config.AddPolicy("Installation", policy =>
+            config.AddPolicy(Policies.Installation, policy =>
             {
                 policy.RequireAuthenticatedUser();
                 policy.RequireClaim(JwtClaimTypes.Scope, ApiScopes.ApiInstallation);
             });
-            config.AddPolicy("Secrets", policy =>
+            config.AddPolicy(Policies.Secrets, policy =>
             {
                 policy.RequireAuthenticatedUser();
                 policy.RequireAssertion(ctx => ctx.User.HasClaim(c =>

--- a/src/Core/Auth/Identity/Policies.cs
+++ b/src/Core/Auth/Identity/Policies.cs
@@ -6,5 +6,11 @@ public static class Policies
     /// Policy for managing access to the Send feature.
     /// </summary>
     public const string Send = "Send";  // [Authorize(Policy = Policies.Send)]
-    // TODO: migrate other existing policies to use this class
+    public const string Application = "Application"; // [Authorize(Policy = Policies.Application)]
+    public const string Web = "Web"; // [Authorize(Policy = Policies.Web)]
+    public const string Push = "Push"; // [Authorize(Policy = Policies.Push)]
+    public const string Licensing = "Licensing"; // [Authorize(Policy = Policies.Licensing)]
+    public const string Organization = "Organization"; // [Authorize(Policy = Policies.Organization)]
+    public const string Installation = "Installation"; // [Authorize(Policy = Policies.Installation)]
+    public const string Secrets = "Secrets"; // [Authorize(Policy = Policies.Secrets)]
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-25535](https://bitwarden.atlassian.net/browse/PM-25535)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We were using magic strings to manage policies this introduces static strings in a `Policies.cs` class that can now be referenced.

Only auth owned endpoints have been updated to reduce review scope.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25535]: https://bitwarden.atlassian.net/browse/PM-25535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ