### PR TITLE
Switch to using built in source link feature

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,6 @@
 
     <RootNamespace>Bit.$(MSBuildProjectName)</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
-    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
-    
     <IsTestProject Condition="'$(IsTestProject)' == '' and ($(MSBuildProjectName.EndsWith('.Test')) or $(MSBuildProjectName.EndsWith('.IntegrationTest')))">true</IsTestProject>
     <Nullable Condition="'$(Nullable)' == '' and '$(IsTestProject)' == 'true'">annotations</Nullable>
     <Nullable Condition="'$(Nullable)' == '' and '$(IsTestProject)' != 'true'">enable</Nullable>
@@ -32,19 +30,4 @@
     
     <AutoFixtureAutoNSubstituteVersion>4.18.1</AutoFixtureAutoNSubstituteVersion>
   </PropertyGroup>
-
-  
-  <Target Name="SetSourceRevisionId" BeforeTargets="CoreGenerateAssemblyInfo">
-    <Exec Command="git describe --long --always --dirty --exclude=* --abbrev=8" ConsoleToMSBuild="True" IgnoreExitCode="False">
-      <Output PropertyName="SourceRevisionId" TaskParameter="ConsoleOutput" />
-    </Exec>
-  </Target>
-  <Target Name="WriteRevision" AfterTargets="SetSourceRevisionId">
-    <ItemGroup>
-      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
-        <_Parameter1>GitHash</_Parameter1>
-        <_Parameter2>$(SourceRevisionId)</_Parameter2>
-      </AssemblyAttribute>
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/Core/Utilities/AssemblyHelpers.cs
+++ b/src/Core/Utilities/AssemblyHelpers.cs
@@ -1,46 +1,34 @@
-﻿// FIXME: Update this file to be null safe and then delete the line below
-#nullable disable
-
+﻿using System.Diagnostics;
 using System.Reflection;
 
 namespace Bit.Core.Utilities;
 
 public static class AssemblyHelpers
 {
-    private static readonly IEnumerable<AssemblyMetadataAttribute> _assemblyMetadataAttributes;
-    private static readonly AssemblyInformationalVersionAttribute _assemblyInformationalVersionAttributes;
-    private const string GIT_HASH_ASSEMBLY_KEY = "GitHash";
     private static string _version;
     private static string _gitHash;
 
     static AssemblyHelpers()
     {
-        _assemblyMetadataAttributes = Assembly.GetEntryAssembly().GetCustomAttributes<AssemblyMetadataAttribute>();
-        _assemblyInformationalVersionAttributes = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+        var entryAssembly = Assembly.GetEntryAssembly();
+        Debug.Assert(entryAssembly is not null);
+        var assemblyInformationalVersionAttribute = entryAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+        Debug.Assert(assemblyInformationalVersionAttribute is not null);
+
+        var success = assemblyInformationalVersionAttribute.InformationalVersion.AsSpan().TrySplitBy('+', out var version, out var gitHash);
+        Debug.Assert(success);
+
+        _version = version.ToString();
+        _gitHash = gitHash[..8].ToString();
     }
 
     public static string GetVersion()
     {
-        if (string.IsNullOrWhiteSpace(_version))
-        {
-            _version = _assemblyInformationalVersionAttributes.InformationalVersion;
-        }
-
         return _version;
     }
 
     public static string GetGitHash()
     {
-        if (string.IsNullOrWhiteSpace(_gitHash))
-        {
-            try
-            {
-                _gitHash = _assemblyMetadataAttributes.Where(i => i.Key == GIT_HASH_ASSEMBLY_KEY).First().Value;
-            }
-            catch (Exception)
-            { }
-        }
-
         return _gitHash;
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We introduced including the git hash in our config endpoint before .NET 8 but in .NET 8 this became built in, albeit with a different format than we had used. This removes out opt out and deletes our home grown solution. This has the awesome side effect of cleaning up the built output a good amount. 

https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/source-link

Before:
![Uploading Screenshot 2025-09-05 at 4.20.22 PM.png…]()


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
