### PR TITLE
[PM-25390] Update global settings for icons service

### DIFF
--- a/src/Icons/appsettings.Development.json
+++ b/src/Icons/appsettings.Development.json
@@ -1,4 +1,21 @@
 ﻿{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://localhost:8080",
+      "api": "http://localhost:4000",
+      "identity": "http://localhost:33656",
+      "admin": "http://localhost:62911",
+      "notifications": "http://localhost:61840",
+      "sso": "http://localhost:51822",
+      "internalNotifications": "http://localhost:61840",
+      "internalAdmin": "http://localhost:62911",
+      "internalIdentity": "http://localhost:33656",
+      "internalApi": "http://localhost:4000",
+      "internalVault": "https://localhost:8080",
+      "internalSso": "http://localhost:51822",
+      "internalScim": "http://localhost:44559"
+    }
+  },
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {

--- a/src/Icons/appsettings.Production.json
+++ b/src/Icons/appsettings.Production.json
@@ -1,4 +1,21 @@
 {
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://vault.bitwarden.com",
+      "api": "https://api.bitwarden.com",
+      "identity": "https://identity.bitwarden.com",
+      "admin": "https://admin.bitwarden.com",
+      "notifications": "https://notifications.bitwarden.com",
+      "sso": "https://sso.bitwarden.com",
+      "internalNotifications": "https://notifications.bitwarden.com",
+      "internalAdmin": "https://admin.bitwarden.com",
+      "internalIdentity": "https://identity.bitwarden.com",
+      "internalApi": "https://api.bitwarden.com",
+      "internalVault": "https://vault.bitwarden.com",
+      "internalSso": "https://sso.bitwarden.com",
+      "internalScim": "https://scim.bitwarden.com"
+    }
+  },
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {

--- a/src/Icons/appsettings.QA.json
+++ b/src/Icons/appsettings.QA.json
@@ -1,4 +1,21 @@
 {
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": "https://vault.qa.bitwarden.pw",
+      "api": "https://api.qa.bitwarden.pw",
+      "identity": "https://identity.qa.bitwarden.pw",
+      "admin": "https://admin.qa.bitwarden.pw",
+      "notifications": "https://notifications.qa.bitwarden.pw",
+      "sso": "https://sso.qa.bitwarden.pw",
+      "internalNotifications": "https://notifications.qa.bitwarden.pw",
+      "internalAdmin": "https://admin.qa.bitwarden.pw",
+      "internalIdentity": "https://identity.qa.bitwarden.pw",
+      "internalApi": "https://api.qa.bitwarden.pw",
+      "internalVault": "https://vault.qa.bitwarden.pw",
+      "internalSso": "https://sso.qa.bitwarden.pw",
+      "internalScim": "https://scim.qa.bitwarden.pw"
+    }
+  },
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {

--- a/src/Icons/appsettings.SelfHosted.json
+++ b/src/Icons/appsettings.SelfHosted.json
@@ -1,0 +1,19 @@
+﻿{
+  "globalSettings": {
+    "baseServiceUri": {
+      "vault": null,
+      "api": null,
+      "identity": null,
+      "admin": null,
+      "notifications": null,
+      "sso": null,
+      "internalNotifications": null,
+      "internalAdmin": null,
+      "internalIdentity": null,
+      "internalApi": null,
+      "internalVault": null,
+      "internalSso": null,
+      "internalScim": null
+    }
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25390](https://bitwarden.atlassian.net/browse/PM-25390)
Initial Server PR: https://github.com/bitwarden/server/pull/5845

## 📔 Objective

As a part of https://github.com/bitwarden/server/pull/6287 I added a CORS check to the Icons service. The service is now being hit with an API request from the client. 
- The CORS check includes a [IsCorsOriginAllowed](https://github.com/bitwarden/server/blob/747e212b1ba374e4c1be9cfe255bb40c002d0ceb/src/Core/Utilities/CoreHelpers.cs#L648-L656) check that checks if the origin of the request is the Vault URI. The IconService did not populate these values before as they were not needed. 
- I copied the same values from the `Api` appsettings.json files.

### Open Question

@bitwarden/team-platform-dev  - When the clients are deployed to USDev the web vault URI will be `vault.usdev.bitwarden.pw` but there are not region specific `appsetting.json` files in the server repo. When the server is deployed to `usdev` are these variables overridden/populated through another means?

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25390]: https://bitwarden.atlassian.net/browse/PM-25390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ