### PR TITLE
Alter integration template processing to remove keys when encountering null values

### DIFF
--- a/src/Core/AdminConsole/Models/Data/EventIntegrations/IntegrationTemplateContext.cs
+++ b/src/Core/AdminConsole/Models/Data/EventIntegrations/IntegrationTemplateContext.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.AdminConsole.Entities;
+﻿using System.Text.Json;
+using Bit.Core.AdminConsole.Entities;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Models.Data;
@@ -22,6 +23,8 @@ public class IntegrationTemplateContext(EventMessage eventMessage)
     public Guid? CollectionId => Event.CollectionId;
     public Guid? GroupId => Event.GroupId;
     public Guid? PolicyId => Event.PolicyId;
+
+    public string EventMessage => JsonSerializer.Serialize(Event);
 
     public User? User { get; set; }
     public string? UserName => User?.Name;

--- a/src/Core/AdminConsole/Utilities/IntegrationTemplateProcessor.cs
+++ b/src/Core/AdminConsole/Utilities/IntegrationTemplateProcessor.cs
@@ -1,6 +1,5 @@
 ﻿#nullable enable
 
-using System.Text.Json;
 using System.Text.RegularExpressions;
 
 namespace Bit.Core.AdminConsole.Utilities;
@@ -20,15 +19,14 @@ public static partial class IntegrationTemplateProcessor
         return TokenRegex().Replace(template, match =>
         {
             var propertyName = match.Groups[1].Value;
-            if (propertyName == "EventMessage")
+            var property = type.GetProperty(propertyName);
+
+            if (property == null)
             {
-                return JsonSerializer.Serialize(values);
+                return match.Value;  // Return unknown keys as keys - i.e. #Key#
             }
-            else
-            {
-                var property = type.GetProperty(propertyName);
-                return property?.GetValue(values)?.ToString() ?? match.Value;
-            }
+
+            return property?.GetValue(values)?.ToString() ?? "";
         });
     }
 

--- a/test/Core.Test/AdminConsole/Models/Data/EventIntegrations/IntegrationTemplateContextTests.cs
+++ b/test/Core.Test/AdminConsole/Models/Data/EventIntegrations/IntegrationTemplateContextTests.cs
@@ -1,0 +1,102 @@
+﻿#nullable enable
+using System.Text.Json;
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Models.Data.EventIntegrations;
+using Bit.Core.Entities;
+using Bit.Core.Models.Data;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Xunit;
+
+namespace Bit.Core.Test.AdminConsole.Models.Data.EventIntegrations;
+
+public class IntegrationTemplateContextTests
+{
+    [Theory, BitAutoData]
+    public void EventMessage_ReturnsSerializedJsonOfEvent(EventMessage eventMessage)
+    {
+        var sut = new IntegrationTemplateContext(eventMessage: eventMessage);
+        var expected = JsonSerializer.Serialize(eventMessage);
+
+        Assert.Equal(expected, sut.EventMessage);
+    }
+
+    [Theory, BitAutoData]
+    public void UserName_WhenUserIsSet_ReturnsName(EventMessage eventMessage, User user)
+    {
+        var sut = new IntegrationTemplateContext(eventMessage) { User = user };
+
+        Assert.Equal(user.Name, sut.UserName);
+    }
+
+    [Theory, BitAutoData]
+    public void UserName_WhenUserIsNull_ReturnsNull(EventMessage eventMessage)
+    {
+        var sut = new IntegrationTemplateContext(eventMessage) { User = null };
+
+        Assert.Null(sut.UserName);
+    }
+
+    [Theory, BitAutoData]
+    public void UserEmail_WhenUserIsSet_ReturnsEmail(EventMessage eventMessage, User user)
+    {
+        var sut = new IntegrationTemplateContext(eventMessage) { User = user };
+
+        Assert.Equal(user.Email, sut.UserEmail);
+    }
+
+    [Theory, BitAutoData]
+    public void UserEmail_WhenUserIsNull_ReturnsNull(EventMessage eventMessage)
+    {
+        var sut = new IntegrationTemplateContext(eventMessage) { User = null };
+
+        Assert.Null(sut.UserEmail);
+    }
+
+    [Theory, BitAutoData]
+    public void ActingUserName_WhenActingUserIsSet_ReturnsName(EventMessage eventMessage, User actingUser)
+    {
+        var sut = new IntegrationTemplateContext(eventMessage) { ActingUser = actingUser };
+
+        Assert.Equal(actingUser.Name, sut.ActingUserName);
+    }
+
+    [Theory, BitAutoData]
+    public void ActingUserName_WhenActingUserIsNull_ReturnsNull(EventMessage eventMessage)
+    {
+        var sut = new IntegrationTemplateContext(eventMessage) { ActingUser = null };
+
+        Assert.Null(sut.ActingUserName);
+    }
+
+    [Theory, BitAutoData]
+    public void ActingUserEmail_WhenActingUserIsSet_ReturnsEmail(EventMessage eventMessage, User actingUser)
+    {
+        var sut = new IntegrationTemplateContext(eventMessage) { ActingUser = actingUser };
+
+        Assert.Equal(actingUser.Email, sut.ActingUserEmail);
+    }
+
+    [Theory, BitAutoData]
+    public void ActingUserEmail_WhenActingUserIsNull_ReturnsNull(EventMessage eventMessage)
+    {
+        var sut = new IntegrationTemplateContext(eventMessage) { ActingUser = null };
+
+        Assert.Null(sut.ActingUserEmail);
+    }
+
+    [Theory, BitAutoData]
+    public void OrganizationName_WhenOrganizationIsSet_ReturnsDisplayName(EventMessage eventMessage, Organization organization)
+    {
+        var sut = new IntegrationTemplateContext(eventMessage) { Organization = organization };
+
+        Assert.Equal(organization.DisplayName(), sut.OrganizationName);
+    }
+
+    [Theory, BitAutoData]
+    public void OrganizationName_WhenOrganizationIsNull_ReturnsNull(EventMessage eventMessage)
+    {
+        var sut = new IntegrationTemplateContext(eventMessage) { Organization = null };
+
+        Assert.Null(sut.OrganizationName);
+    }
+}

--- a/test/Core.Test/AdminConsole/Utilities/IntegrationTemplateProcessorTests.cs
+++ b/test/Core.Test/AdminConsole/Utilities/IntegrationTemplateProcessorTests.cs
@@ -1,6 +1,5 @@
 ﻿#nullable enable
 
-using System.Text.Json;
 using Bit.Core.AdminConsole.Utilities;
 using Bit.Core.Models.Data;
 using Bit.Test.Common.AutoFixture.Attributes;
@@ -41,22 +40,12 @@ public class IntegrationTemplateProcessorTests
     }
 
     [Theory, BitAutoData]
-    public void ReplaceTokens_WithEventMessageToken_ReplacesWithSerializedJson(EventMessage eventMessage)
-    {
-        var template = "#EventMessage#";
-        var expected = $"{JsonSerializer.Serialize(eventMessage)}";
-        var result = IntegrationTemplateProcessor.ReplaceTokens(template, eventMessage);
-
-        Assert.Equal(expected, result);
-    }
-
-    [Theory, BitAutoData]
-    public void ReplaceTokens_WithNullProperty_LeavesTokenUnchanged(EventMessage eventMessage)
+    public void ReplaceTokens_WithNullProperty_InsertsEmptyString(EventMessage eventMessage)
     {
         eventMessage.UserId = null;
 
         var template = "Event #Type#, User (id: #UserId#).";
-        var expected = $"Event {eventMessage.Type}, User (id: #UserId#).";
+        var expected = $"Event {eventMessage.Type}, User (id: ).";
         var result = IntegrationTemplateProcessor.ReplaceTokens(template, eventMessage);
 
         Assert.Equal(expected, result);


### PR DESCRIPTION
## 📔 Objective

As we began experimenting with `Template` in real world scenarios, it started to seem awkward to have keys appear in the output string if the property was null.

For example, a JSON template with `#UserId#` returned the literal key when `UserId` was `null`:

```json
{
  "ActingUser": "acting-user-12345",
  "User": "#Userld#",
  "Event": "Cipher_ClientViewed"
}
```

This PR changes the behavior to return `""` for null values when the key is recognized. If the Template contains a key that is not found on the object, it will still return the key literal (in order to help when debugging custom templates). 

Our above example would then return:
```json
{
  "ActingUser": "acting-user-12345",
  "User": "",
  "Event": "Cipher_ClientViewed"
}
```

Additionally, I moved the JSON serialization property (`EventMessage`) into the `IntegrationTemplateContext` instead of special-casing it inside the `IntegrationTemplateProcessor`. It cleans up the processing function to not have to worry about a special case in the middle of everything. I've also added tests for `IntegrationTemplateContext` to make sure it's working as expected (and removed the special case test from `IntegrationTemplateProcessor`)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
