### PR TITLE
[PM-25259] Change swagger docs to refer to main

### DIFF
--- a/src/SharedWeb/Swagger/SourceFileLineOperationFilter.cs
+++ b/src/SharedWeb/Swagger/SourceFileLineOperationFilter.cs
@@ -17,8 +17,6 @@ namespace Bit.SharedWeb.Swagger;
 /// </summary>
 public class SourceFileLineOperationFilter : IOperationFilter
 {
-    private static readonly string _gitCommit = GitCommitDocumentFilter.GitCommit ?? "main";
-
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
 
@@ -27,7 +25,7 @@ public class SourceFileLineOperationFilter : IOperationFilter
         {
             // Add the information with a link to the source file at the end of the operation description
             operation.Description +=
-                $"\nThis operation is defined on: [`https://github.com/bitwarden/server/blob/{_gitCommit}/{fileName}#L{lineNumber}`]";
+                $"\nThis operation is defined on: [`https://github.com/bitwarden/server/blob/main/{fileName}#L{lineNumber}`]";
 
             // Also add the information as extensions, so other tools can use it in the future
             operation.Extensions.Add("x-source-file", new OpenApiString(fileName));


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-25259

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Since we're automating the updating of api bindings we would like to minimize the changes introduced by each update. Currently we use the git commit when generating bindings which unfortunately results in many comments being updated for each build. This uses the `main` branch instead which unfortunately means the links might not always be up to date but cuts down on the amount of changes.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
