### PR TITLE
Enable custom IDs for bindings

### DIFF
--- a/src/Api/Controllers/CollectionsController.cs
+++ b/src/Api/Controllers/CollectionsController.cs
@@ -199,7 +199,7 @@ public class CollectionsController : Controller
 
     [HttpPost("{id}")]
     [Obsolete("This endpoint is deprecated. Use PUT /{id} instead.")]
-    public async Task<CollectionResponseModel> Post(Guid orgId, Guid id, [FromBody] UpdateCollectionRequestModel model)
+    public async Task<CollectionResponseModel> PostPut(Guid orgId, Guid id, [FromBody] UpdateCollectionRequestModel model)
     {
         return await Put(orgId, id, model);
     }

--- a/src/Api/Controllers/DevicesController.cs
+++ b/src/Api/Controllers/DevicesController.cs
@@ -115,7 +115,7 @@ public class DevicesController : Controller
 
     [HttpPost("{id}")]
     [Obsolete("This endpoint is deprecated. Use PUT /{id} instead.")]
-    public async Task<DeviceResponseModel> Post(string id, [FromBody] DeviceRequestModel model)
+    public async Task<DeviceResponseModel> PostPut(string id, [FromBody] DeviceRequestModel model)
     {
         return await Put(id, model);
     }

--- a/src/SharedWeb/Swagger/SourceFileLineOperationFilter.cs
+++ b/src/SharedWeb/Swagger/SourceFileLineOperationFilter.cs
@@ -23,10 +23,6 @@ public class SourceFileLineOperationFilter : IOperationFilter
         var (fileName, lineNumber) = GetSourceFileLine(context.MethodInfo);
         if (fileName != null && lineNumber > 0)
         {
-            // Add the information with a link to the source file at the end of the operation description
-            operation.Description +=
-                $"\nThis operation is defined on: [`https://github.com/bitwarden/server/blob/main/{fileName}#L{lineNumber}`]";
-
             // Also add the information as extensions, so other tools can use it in the future
             operation.Extensions.Add("x-source-file", new OpenApiString(fileName));
             operation.Extensions.Add("x-source-line", new OpenApiInteger(lineNumber));

--- a/src/SharedWeb/Swagger/SwaggerGenOptionsExt.cs
+++ b/src/SharedWeb/Swagger/SwaggerGenOptionsExt.cs
@@ -19,9 +19,10 @@ public static class SwaggerGenOptionsExt
         // Set the operation ID to the name of the controller followed by the name of the function.
         // Note that the "Controller" suffix for the controllers, and the "Async" suffix for the actions
         // are removed already, so we don't need to do that ourselves.
-        // TODO(Dani): This is disabled until we remove all the duplicate operation IDs.
-        // config.CustomOperationIds(e => $"{e.ActionDescriptor.RouteValues["controller"]}_{e.ActionDescriptor.RouteValues["action"]}");
-        // config.DocumentFilter<CheckDuplicateOperationIdsDocumentFilter>();
+        config.CustomOperationIds(e => $"{e.ActionDescriptor.RouteValues["controller"]}_{e.ActionDescriptor.RouteValues["action"]}");
+        // Because we're setting custom operation IDs, we need to ensure that we don't accidentally
+        // introduce duplicate IDs, which is against the OpenAPI specification and could lead to issues.
+        config.DocumentFilter<CheckDuplicateOperationIdsDocumentFilter>();
 
         // These two filters require debug symbols/git, so only add them in development mode
         if (environment.IsDevelopment())


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23512

## 📔 Objective

Enable the custom ID generation for the OpenAPI bindings, now that all* the name conflicts have been resolved. I've also removed the description adding source origin, as the operation IDs now match controller name and function name, so it shouldn't be as hard to find.

\* And when I say all, I mean all but the two I've also included in this PR, oops.

The previous PRs as reference:
- https://github.com/bitwarden/server/pull/6229 
- https://github.com/bitwarden/server/pull/6236 
- https://github.com/bitwarden/server/pull/6238 
- https://github.com/bitwarden/server/pull/6239 
- https://github.com/bitwarden/server/pull/6240 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
