### PR TITLE
auth/pm-17719/make-sso-identifier-errors-consistent

### DIFF
--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -108,6 +108,7 @@ public class AccountController : Controller
             // Validate domain_hint provided
             if (string.IsNullOrWhiteSpace(domainHint))
             {
+                _logger.LogError(new ArgumentException("domainHint is required."), "domainHint not specified.");
                 return InvalidJson("SsoInvalidIdentifierError");
             }
 
@@ -115,6 +116,7 @@ public class AccountController : Controller
             var organization = await _organizationRepository.GetByIdentifierAsync(domainHint);
             if (organization is not { UseSso: true })
             {
+                _logger.LogError("Organization not configured to use SSO.");
                 return InvalidJson("SsoInvalidIdentifierError");
             }
 
@@ -122,6 +124,7 @@ public class AccountController : Controller
             var ssoConfig = await _ssoConfigRepository.GetByIdentifierAsync(domainHint);
             if (ssoConfig is not { Enabled: true })
             {
+                _logger.LogError("SsoConfig not enabled.");
                 return InvalidJson("SsoInvalidIdentifierError");
             }
 
@@ -129,6 +132,7 @@ public class AccountController : Controller
             var scheme = await _schemeProvider.GetSchemeAsync(organization.Id.ToString());
             if (scheme is not IDynamicAuthenticationScheme dynamicScheme)
             {
+                _logger.LogError("Invalid authentication scheme for organization.");
                 return InvalidJson("SsoInvalidIdentifierError");
             }
 

--- a/src/Core/Resources/SharedResources.en.resx
+++ b/src/Core/Resources/SharedResources.en.resx
@@ -394,23 +394,8 @@
   <data name="InvalidSchemeConfigurationError" xml:space="preserve">
     <value>The configured authentication scheme is not valid: "{0}"</value>
   </data>
-  <data name="NoSchemeOrHandlerForSsoConfigurationFoundError" xml:space="preserve">
-    <value>No scheme or handler for this SSO configuration found.</value>
-  </data>
-  <data name="SsoNotEnabledForOrganizationError" xml:space="preserve">
-    <value>SSO is not yet enabled for this organization.</value>
-  </data>
-  <data name="SsoConfigurationNotFoundForOrganizationError" xml:space="preserve">
-    <value>No SSO configuration exists for this organization.</value>
-  </data>
-  <data name="SsoNotAllowedForOrganizationError" xml:space="preserve">
-    <value>SSO is not allowed for this organization.</value>
-  </data>
   <data name="OrganizationNotFoundByIdentifierError" xml:space="preserve">
     <value>Organization not found from identifier.</value>
-  </data>
-  <data name="NoOrganizationIdentifierProvidedError" xml:space="preserve">
-    <value>No organization identifier provided.</value>
   </data>
   <data name="InvalidAuthenticationOptionsForSaml2SchemeError" xml:space="preserve">
     <value>Invalid authentication options provided to SAML2 scheme.</value>
@@ -690,5 +675,8 @@
   </data>
   <data name="InvalidSsoRedirectToken" xml:space="preserve">
     <value>Single sign on redirect token is invalid or expired.</value>
+  </data>
+  <data name="SsoInvalidIdentifierError" xml:space="preserve">
+    <value>Invalid SSO identifier</value>
   </data>
 </root>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17719](https://bitwarden.atlassian.net/browse/PM-17719)

## 📔 Objective

Error messages returned from SSO validation should be consistent. This update makes the error message consistent across error cases, hardening the surface of SSO authentication.

## 📸 Screenshots

SSO authenticating to an organization with SSO disabled

https://github.com/user-attachments/assets/52b2f439-41c2-417e-aa1d-f8715d3ded58

SSO authentication to an organization that does not exist

https://github.com/user-attachments/assets/b01e8291-cd17-4372-9760-4326b7808298

SSO authentication to an organization which exists and has SSO enabled

https://github.com/user-attachments/assets/6bc1cd68-6197-49af-af4f-8d0a6b47edb4

Additionally, some logging was updated for SSO. No runtime exceptions should leak outside the SSO Account Controller (and no redirections to `/Error` should occur). Exceptions will be caught and logged at the SSO layer, returning the standard error notification to the user.

<img width="1224" height="591" alt="PM-17719__sso-exception" src="https://github.com/user-attachments/assets/86e3ab13-4917-4b78-bccd-d3155c17d9b4" />
<img width="844" height="174" alt="PM-17719__sso-exception-log" src="https://github.com/user-attachments/assets/c058bbd6-ac6f-40ba-a167-7e0dfdc64af4" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17719]: https://bitwarden.atlassian.net/browse/PM-17719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ