### PR TITLE
[PM-25473] Non-encryption passkeys prevent key rotation

### DIFF
--- a/src/Api/KeyManagement/Validators/WebAuthnLoginKeyRotationValidator.cs
+++ b/src/Api/KeyManagement/Validators/WebAuthnLoginKeyRotationValidator.cs
@@ -6,7 +6,13 @@ using Bit.Core.Exceptions;
 
 namespace Bit.Api.KeyManagement.Validators;
 
-public class WebAuthnLoginKeyRotationValidator : IRotationValidator<IEnumerable<WebAuthnLoginRotateKeyRequestModel>, IEnumerable<WebAuthnLoginRotateKeyData>>
+/// <summary>
+/// Validates WebAuthn credentials during key rotation. Only processes credentials that support PRF
+/// and have encrypted user, public, and private keys. Ensures all such credentials are included
+/// in the rotation request with the required encrypted keys.
+/// </summary>
+public class WebAuthnLoginKeyRotationValidator : IRotationValidator<IEnumerable<WebAuthnLoginRotateKeyRequestModel>,
+    IEnumerable<WebAuthnLoginRotateKeyData>>
 {
     private readonly IWebAuthnCredentialRepository _webAuthnCredentialRepository;
 
@@ -15,24 +21,26 @@ public class WebAuthnLoginKeyRotationValidator : IRotationValidator<IEnumerable<
         _webAuthnCredentialRepository = webAuthnCredentialRepository;
     }
 
-    public async Task<IEnumerable<WebAuthnLoginRotateKeyData>> ValidateAsync(User user, IEnumerable<WebAuthnLoginRotateKeyRequestModel> keysToRotate)
+    public async Task<IEnumerable<WebAuthnLoginRotateKeyData>> ValidateAsync(User user,
+        IEnumerable<WebAuthnLoginRotateKeyRequestModel> keysToRotate)
     {
         var result = new List<WebAuthnLoginRotateKeyData>();
-        var existing = await _webAuthnCredentialRepository.GetManyByUserIdAsync(user.Id);
-        if (existing == null)
+        var validCredentials = (await _webAuthnCredentialRepository.GetManyByUserIdAsync(user.Id))
+            .Where(credential => credential is
+            {
+                SupportsPrf: true,
+                EncryptedUserKey: not null,
+                EncryptedPublicKey: not null,
+                EncryptedPrivateKey: not null
+            }).ToList();
+        if (validCredentials.Count == 0)
         {
             return result;
         }
 
-        var validCredentials = existing.Where(credential => credential.SupportsPrf);
-        if (!validCredentials.Any())
+        foreach (var webAuthnCredential in validCredentials)
         {
-            return result;
-        }
-
-        foreach (var ea in validCredentials)
-        {
-            var keyToRotate = keysToRotate.FirstOrDefault(c => c.Id == ea.Id);
+            var keyToRotate = keysToRotate.FirstOrDefault(c => c.Id == webAuthnCredential.Id);
             if (keyToRotate == null)
             {
                 throw new BadRequestException("All existing webauthn prf keys must be included in the rotation.");

--- a/src/Core/Auth/Entities/WebAuthnCredential.cs
+++ b/src/Core/Auth/Entities/WebAuthnCredential.cs
@@ -22,13 +22,30 @@ public class WebAuthnCredential : ITableObject<Guid>
     [MaxLength(20)]
     public string Type { get; set; }
     public Guid AaGuid { get; set; }
+
+    /// <summary>
+    /// User key encrypted with this WebAuthn credential's public key (EncryptedPublicKey field).
+    /// </summary>
     [MaxLength(2000)]
     public string EncryptedUserKey { get; set; }
+
+    /// <summary>
+    /// Private key encrypted with an external key for secure storage.
+    /// </summary>
     [MaxLength(2000)]
     public string EncryptedPrivateKey { get; set; }
+
+    /// <summary>
+    /// Public key encrypted with the user key for key rotation.
+    /// </summary>
     [MaxLength(2000)]
     public string EncryptedPublicKey { get; set; }
+
+    /// <summary>
+    /// Indicates whether this credential supports PRF (Pseudo-Random Function) extension.
+    /// </summary>
     public bool SupportsPrf { get; set; }
+
     public DateTime CreationDate { get; internal set; } = DateTime.UtcNow;
     public DateTime RevisionDate { get; internal set; } = DateTime.UtcNow;
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-25473

## 📔 Objective

Fix key-rotation not working when one of the WebAuthn credentials supports PRF but is not used for encryption.
The server and clients have inconsitent filter on what WebAuthn credentials are picked for re-encryption (clients) and validation before saving to db (server).

For user key rotation, we should only pick and validate WebAuthn credentials that have PRF enabled and have all encrypted keys (user key, public key, private key) - which in practise can be checked by the `prfStatus` field https://github.com/bitwarden/server/blob/7708e80ac44463ff4219a39ff911e538a16c941e/src/Core/Auth/Entities/WebAuthnCredential.cs#L57-L70

Client change https://github.com/bitwarden/clients/pull/16514

## 📸 Screenshots

https://github.com/user-attachments/assets/64a525e3-9eb5-401c-a248-ff21467d6423

1. Three passkeys setup: with encryption, without encryption and encryption not supported
2. Rotate keys
3. Login with passkey for encryption, vault unlocked - no secondary unlock needed (like master password)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
