### PR TITLE
[PM-20439] Remove flagging logic (BrowserExtensionLoginApproval)

### DIFF
--- a/src/Api/Auth/Controllers/AuthRequestsController.cs
+++ b/src/Api/Auth/Controllers/AuthRequestsController.cs
@@ -3,7 +3,6 @@
 
 using Bit.Api.Auth.Models.Response;
 using Bit.Api.Models.Response;
-using Bit.Core;
 using Bit.Core.Auth.Enums;
 using Bit.Core.Auth.Models.Api.Request.AuthRequest;
 using Bit.Core.Auth.Services;
@@ -11,7 +10,6 @@ using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Settings;
-using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -54,7 +52,6 @@ public class AuthRequestsController(
     }
 
     [HttpGet("pending")]
-    [RequireFeature(FeatureFlagKeys.BrowserExtensionLoginApproval)]
     public async Task<ListResponseModel<PendingAuthRequestResponseModel>> GetPendingAuthRequestsAsync()
     {
         var userId = _userService.GetProperUserId(User).Value;

--- a/src/Identity/Utilities/LoginApprovingClientTypes.cs
+++ b/src/Identity/Utilities/LoginApprovingClientTypes.cs
@@ -1,6 +1,4 @@
-﻿using Bit.Core;
-using Bit.Core.Enums;
-using Bit.Core.Services;
+﻿using Bit.Core.Enums;
 
 namespace Bit.Identity.Utilities;
 
@@ -11,28 +9,15 @@ public interface ILoginApprovingClientTypes
 
 public class LoginApprovingClientTypes : ILoginApprovingClientTypes
 {
-    public LoginApprovingClientTypes(
-        IFeatureService featureService)
+    public LoginApprovingClientTypes()
     {
-        if (featureService.IsEnabled(FeatureFlagKeys.BrowserExtensionLoginApproval))
+        TypesThatCanApprove = new List<ClientType>
         {
-            TypesThatCanApprove = new List<ClientType>
-            {
-                ClientType.Desktop,
-                ClientType.Mobile,
-                ClientType.Web,
-                ClientType.Browser,
-            };
-        }
-        else
-        {
-            TypesThatCanApprove = new List<ClientType>
-            {
-                ClientType.Desktop,
-                ClientType.Mobile,
-                ClientType.Web,
-            };
-        }
+            ClientType.Desktop,
+            ClientType.Mobile,
+            ClientType.Web,
+            ClientType.Browser,
+        };
     }
 
     public IReadOnlyCollection<ClientType> TypesThatCanApprove { get; }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20439](https://bitwarden.atlassian.net/browse/PM-20439)

Client PR: https://github.com/bitwarden/clients/pull/16568

## 📔 Objective

- Removes flagging logic for the `BrowserExtensionLoginApproval` feature flag.
- Does NOT remove the flag itself from `FeatureFlagKeys` in `Contants.cs`

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20439]: https://bitwarden.atlassian.net/browse/PM-20439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ