### PR TITLE
null coalesce collections to an empty array

### DIFF
--- a/src/Api/AdminConsole/Public/Models/Request/MemberCreateRequestModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Request/MemberCreateRequestModel.cs
@@ -31,7 +31,7 @@ public class MemberCreateRequestModel : MemberUpdateRequestModel
         {
             Emails = new[] { Email },
             Type = Type.Value,
-            Collections = Collections?.Select(c => c.ToCollectionAccessSelection()).ToList(),
+            Collections = Collections?.Select(c => c.ToCollectionAccessSelection())?.ToList() ?? [],
             Groups = Groups
         };
 


### PR DESCRIPTION
## 🎟️ Tracking

TBD

## 📔 Objective

When creating a member via the org public API, collections property is not required and may be null. This fixes a bug where it was assumed to be not null.