### PR TITLE
[PM-25923] Simplify and align ProfileOrganizationResponseModel and ProfileProviderOrganizationResponseModel

### DIFF
--- a/src/Api/AdminConsole/Models/Response/BaseProfileOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/BaseProfileOrganizationResponseModel.cs
@@ -1,0 +1,139 @@
+﻿// FIXME: Update this file to be null safe and then delete the line below
+#nullable disable
+
+using System.Text.Json.Serialization;
+using Bit.Core.AdminConsole.Enums.Provider;
+using Bit.Core.AdminConsole.Models.Data;
+using Bit.Core.Auth.Enums;
+using Bit.Core.Auth.Models.Data;
+using Bit.Core.Billing.Enums;
+using Bit.Core.Billing.Extensions;
+using Bit.Core.Enums;
+using Bit.Core.Models.Api;
+using Bit.Core.Models.Data;
+using Bit.Core.Utilities;
+
+namespace Bit.Api.AdminConsole.Models.Response;
+
+/// <summary>
+/// Base class for profile organization response models that ensures all properties are fully populated.
+/// This class cannot be instantiated with an empty constructor to prevent incomplete hydration.
+/// </summary>
+public abstract class BaseProfileOrganizationResponseModel : ResponseModel
+{
+    protected BaseProfileOrganizationResponseModel(string type, BaseUserOrganizationDetails organization) : base(type)
+    {
+        Id = organization.OrganizationId;
+        Name = organization.Name;
+        Enabled = organization.Enabled;
+        Identifier = organization.Identifier;
+        ProductTierType = organization.PlanType.GetProductTier();
+        UsePolicies = organization.UsePolicies;
+        UseSso = organization.UseSso;
+        UseKeyConnector = organization.UseKeyConnector;
+        UseScim = organization.UseScim;
+        UseGroups = organization.UseGroups;
+        UseDirectory = organization.UseDirectory;
+        UseEvents = organization.UseEvents;
+        UseTotp = organization.UseTotp;
+        Use2fa = organization.Use2fa;
+        UseApi = organization.UseApi;
+        UseResetPassword = organization.UseResetPassword;
+        UsersGetPremium = organization.UsersGetPremium;
+        UseCustomPermissions = organization.UseCustomPermissions;
+        UseActivateAutofillPolicy = organization.PlanType.GetProductTier() == ProductTierType.Enterprise;
+        UseRiskInsights = organization.UseRiskInsights;
+        UseOrganizationDomains = organization.UseOrganizationDomains;
+        UseAdminSponsoredFamilies = organization.UseAdminSponsoredFamilies;
+        SelfHost = organization.SelfHost;
+        Seats = organization.Seats;
+        MaxCollections = organization.MaxCollections;
+        MaxStorageGb = organization.MaxStorageGb;
+        Key = organization.Key;
+        HasPublicAndPrivateKeys = organization.PublicKey != null && organization.PrivateKey != null;
+        ProviderId = organization.ProviderId;
+        ProviderName = organization.ProviderName;
+        ProviderType = organization.ProviderType;
+        LimitCollectionCreation = organization.LimitCollectionCreation;
+        LimitCollectionDeletion = organization.LimitCollectionDeletion;
+        LimitItemDeletion = organization.LimitItemDeletion;
+        AllowAdminAccessToAllCollectionItems = organization.AllowAdminAccessToAllCollectionItems;
+        SsoEnabled = organization.SsoEnabled ?? false;
+        if (organization.SsoConfig != null)
+        {
+            var ssoConfigData = SsoConfigurationData.Deserialize(organization.SsoConfig);
+            KeyConnectorEnabled = ssoConfigData.MemberDecryptionType == MemberDecryptionType.KeyConnector && !string.IsNullOrEmpty(ssoConfigData.KeyConnectorUrl);
+            KeyConnectorUrl = ssoConfigData.KeyConnectorUrl;
+            SsoMemberDecryptionType = ssoConfigData.MemberDecryptionType;
+        }
+    }
+
+    public Guid Id { get; set; }
+    [JsonConverter(typeof(HtmlEncodingStringConverter))]
+    public string Name { get; set; }
+    public bool Enabled { get; set; }
+    public string Identifier { get; set; }
+    public ProductTierType ProductTierType { get; set; }
+    public bool UsePolicies { get; set; }
+    public bool UseSso { get; set; }
+    public bool UseKeyConnector { get; set; }
+    public bool UseScim { get; set; }
+    public bool UseGroups { get; set; }
+    public bool UseDirectory { get; set; }
+    public bool UseEvents { get; set; }
+    public bool UseTotp { get; set; }
+    public bool Use2fa { get; set; }
+    public bool UseApi { get; set; }
+    public bool UseResetPassword { get; set; }
+    public bool UseSecretsManager { get; set; }
+    public bool UsePasswordManager { get; set; }
+    public bool UsersGetPremium { get; set; }
+    public bool UseCustomPermissions { get; set; }
+    public bool UseActivateAutofillPolicy { get; set; }
+    public bool UseRiskInsights { get; set; }
+    public bool UseOrganizationDomains { get; set; }
+    public bool UseAdminSponsoredFamilies { get; set; }
+    public bool SelfHost { get; set; }
+    public int? Seats { get; set; }
+    public short? MaxCollections { get; set; }
+    public short? MaxStorageGb { get; set; }
+    public string Key { get; set; }
+    public bool HasPublicAndPrivateKeys { get; set; }
+    public bool SsoBound { get; set; }
+    public bool ResetPasswordEnrolled { get; set; }
+    public bool LimitCollectionCreation { get; set; }
+    public bool LimitCollectionDeletion { get; set; }
+    public bool LimitItemDeletion { get; set; }
+    public bool AllowAdminAccessToAllCollectionItems { get; set; }
+    public Guid? ProviderId { get; set; }
+    [JsonConverter(typeof(HtmlEncodingStringConverter))]
+    public string ProviderName { get; set; }
+    public ProviderType? ProviderType { get; set; }
+    public bool SsoEnabled { get; set; }
+    public bool KeyConnectorEnabled { get; set; }
+    public string KeyConnectorUrl { get; set; }
+    public MemberDecryptionType? SsoMemberDecryptionType { get; set; }
+    public string FamilySponsorshipFriendlyName { get; set; }
+    public bool FamilySponsorshipAvailable { get; set; }
+    public DateTime? FamilySponsorshipLastSyncDate { get; set; }
+    public DateTime? FamilySponsorshipValidUntil { get; set; }
+    public bool? FamilySponsorshipToDelete { get; set; }
+    public bool IsAdminInitiated { get; set; }
+    public bool AccessSecretsManager { get; set; }
+    public Guid? UserId { get; set; }
+    public Guid? OrganizationUserId { get; set; }
+    public OrganizationUserStatusType Status { get; set; }
+    public OrganizationUserType Type { get; set; }
+    public Permissions Permissions { get; set; }
+    public bool UserIsClaimedByOrganization { get; set; }
+
+    /// <summary>
+    /// Obsolete property for backward compatibility
+    /// </summary>
+    [Obsolete("Please use UserIsClaimedByOrganization instead. This property will be removed in a future version.")]
+    public bool UserIsManagedByOrganization
+    {
+        get => UserIsClaimedByOrganization;
+        set => UserIsClaimedByOrganization = value;
+    }
+}

--- a/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
@@ -1,167 +1,37 @@
 ﻿// FIXME: Update this file to be null safe and then delete the line below
 #nullable disable
 
-using System.Text.Json.Serialization;
-using Bit.Core.AdminConsole.Enums.Provider;
-using Bit.Core.Auth.Enums;
-using Bit.Core.Auth.Models.Data;
-using Bit.Core.Billing.Enums;
-using Bit.Core.Billing.Extensions;
 using Bit.Core.Enums;
-using Bit.Core.Models.Api;
 using Bit.Core.Models.Data;
 using Bit.Core.Models.Data.Organizations.OrganizationUsers;
 using Bit.Core.Utilities;
 
 namespace Bit.Api.AdminConsole.Models.Response;
 
-public class ProfileOrganizationResponseModel : ResponseModel
+public class ProfileOrganizationResponseModel : BaseProfileOrganizationResponseModel
 {
-    public ProfileOrganizationResponseModel(string str) : base(str) { }
-
     public ProfileOrganizationResponseModel(
         OrganizationUserOrganizationDetails organization,
         IEnumerable<Guid> organizationIdsClaimingUser)
-        : this("profileOrganization")
+        : base("profileOrganization", organization)
     {
-        Id = organization.OrganizationId;
-        Name = organization.Name;
-        UsePolicies = organization.UsePolicies;
-        UseSso = organization.UseSso;
-        UseKeyConnector = organization.UseKeyConnector;
-        UseScim = organization.UseScim;
-        UseGroups = organization.UseGroups;
-        UseDirectory = organization.UseDirectory;
-        UseEvents = organization.UseEvents;
-        UseTotp = organization.UseTotp;
-        Use2fa = organization.Use2fa;
-        UseApi = organization.UseApi;
-        UseResetPassword = organization.UseResetPassword;
         UseSecretsManager = organization.UseSecretsManager;
         UsePasswordManager = organization.UsePasswordManager;
-        UsersGetPremium = organization.UsersGetPremium;
-        UseCustomPermissions = organization.UseCustomPermissions;
-        UseActivateAutofillPolicy = organization.PlanType.GetProductTier() == ProductTierType.Enterprise;
-        SelfHost = organization.SelfHost;
-        Seats = organization.Seats;
-        MaxCollections = organization.MaxCollections;
-        MaxStorageGb = organization.MaxStorageGb;
-        Key = organization.Key;
-        HasPublicAndPrivateKeys = organization.PublicKey != null && organization.PrivateKey != null;
         Status = organization.Status;
         Type = organization.Type;
-        Enabled = organization.Enabled;
         SsoBound = !string.IsNullOrWhiteSpace(organization.SsoExternalId);
-        Identifier = organization.Identifier;
         Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(organization.Permissions);
         ResetPasswordEnrolled = !string.IsNullOrWhiteSpace(organization.ResetPasswordKey);
-        UserId = organization.UserId;
         OrganizationUserId = organization.OrganizationUserId;
-        ProviderId = organization.ProviderId;
-        ProviderName = organization.ProviderName;
-        ProviderType = organization.ProviderType;
         FamilySponsorshipFriendlyName = organization.FamilySponsorshipFriendlyName;
         IsAdminInitiated = organization.IsAdminInitiated ?? false;
         FamilySponsorshipAvailable = (FamilySponsorshipFriendlyName == null || IsAdminInitiated) &&
             StaticStore.GetSponsoredPlan(PlanSponsorshipType.FamiliesForEnterprise)
             .UsersCanSponsor(organization);
-        ProductTierType = organization.PlanType.GetProductTier();
         FamilySponsorshipLastSyncDate = organization.FamilySponsorshipLastSyncDate;
         FamilySponsorshipToDelete = organization.FamilySponsorshipToDelete;
         FamilySponsorshipValidUntil = organization.FamilySponsorshipValidUntil;
         AccessSecretsManager = organization.AccessSecretsManager;
-        LimitCollectionCreation = organization.LimitCollectionCreation;
-        LimitCollectionDeletion = organization.LimitCollectionDeletion;
-        LimitItemDeletion = organization.LimitItemDeletion;
-        AllowAdminAccessToAllCollectionItems = organization.AllowAdminAccessToAllCollectionItems;
         UserIsClaimedByOrganization = organizationIdsClaimingUser.Contains(organization.OrganizationId);
-        UseRiskInsights = organization.UseRiskInsights;
-        UseOrganizationDomains = organization.UseOrganizationDomains;
-        UseAdminSponsoredFamilies = organization.UseAdminSponsoredFamilies;
-        SsoEnabled = organization.SsoEnabled ?? false;
-
-        if (organization.SsoConfig != null)
-        {
-            var ssoConfigData = SsoConfigurationData.Deserialize(organization.SsoConfig);
-            KeyConnectorEnabled = ssoConfigData.MemberDecryptionType == MemberDecryptionType.KeyConnector && !string.IsNullOrEmpty(ssoConfigData.KeyConnectorUrl);
-            KeyConnectorUrl = ssoConfigData.KeyConnectorUrl;
-            SsoMemberDecryptionType = ssoConfigData.MemberDecryptionType;
-        }
     }
-
-    public Guid Id { get; set; }
-    [JsonConverter(typeof(HtmlEncodingStringConverter))]
-    public string Name { get; set; }
-    public bool UsePolicies { get; set; }
-    public bool UseSso { get; set; }
-    public bool UseKeyConnector { get; set; }
-    public bool UseScim { get; set; }
-    public bool UseGroups { get; set; }
-    public bool UseDirectory { get; set; }
-    public bool UseEvents { get; set; }
-    public bool UseTotp { get; set; }
-    public bool Use2fa { get; set; }
-    public bool UseApi { get; set; }
-    public bool UseResetPassword { get; set; }
-    public bool UseSecretsManager { get; set; }
-    public bool UsePasswordManager { get; set; }
-    public bool UsersGetPremium { get; set; }
-    public bool UseCustomPermissions { get; set; }
-    public bool UseActivateAutofillPolicy { get; set; }
-    public bool SelfHost { get; set; }
-    public int? Seats { get; set; }
-    public short? MaxCollections { get; set; }
-    public short? MaxStorageGb { get; set; }
-    public string Key { get; set; }
-    public OrganizationUserStatusType Status { get; set; }
-    public OrganizationUserType Type { get; set; }
-    public bool Enabled { get; set; }
-    public bool SsoBound { get; set; }
-    public string Identifier { get; set; }
-    public Permissions Permissions { get; set; }
-    public bool ResetPasswordEnrolled { get; set; }
-    public Guid? UserId { get; set; }
-    public Guid OrganizationUserId { get; set; }
-    public bool HasPublicAndPrivateKeys { get; set; }
-    public Guid? ProviderId { get; set; }
-    [JsonConverter(typeof(HtmlEncodingStringConverter))]
-    public string ProviderName { get; set; }
-    public ProviderType? ProviderType { get; set; }
-    public string FamilySponsorshipFriendlyName { get; set; }
-    public bool FamilySponsorshipAvailable { get; set; }
-    public ProductTierType ProductTierType { get; set; }
-    public bool KeyConnectorEnabled { get; set; }
-    public string KeyConnectorUrl { get; set; }
-    public DateTime? FamilySponsorshipLastSyncDate { get; set; }
-    public DateTime? FamilySponsorshipValidUntil { get; set; }
-    public bool? FamilySponsorshipToDelete { get; set; }
-    public bool AccessSecretsManager { get; set; }
-    public bool LimitCollectionCreation { get; set; }
-    public bool LimitCollectionDeletion { get; set; }
-    public bool LimitItemDeletion { get; set; }
-    public bool AllowAdminAccessToAllCollectionItems { get; set; }
-    /// <summary>
-    /// Obsolete.
-    /// See <see cref="UserIsClaimedByOrganization"/>
-    /// </summary>
-    [Obsolete("Please use UserIsClaimedByOrganization instead. This property will be removed in a future version.")]
-    public bool UserIsManagedByOrganization
-    {
-        get => UserIsClaimedByOrganization;
-        set => UserIsClaimedByOrganization = value;
-    }
-    /// <summary>
-    /// Indicates if the user is claimed by the organization.
-    /// </summary>
-    /// <remarks>
-    /// A user is claimed by an organization if the user's email domain is verified by the organization and the user is a member.
-    /// The organization must be enabled and able to have verified domains.
-    /// </remarks>
-    public bool UserIsClaimedByOrganization { get; set; }
-    public bool UseRiskInsights { get; set; }
-    public bool UseOrganizationDomains { get; set; }
-    public bool UseAdminSponsoredFamilies { get; set; }
-    public bool IsAdminInitiated { get; set; }
-    public bool SsoEnabled { get; set; }
-    public MemberDecryptionType? SsoMemberDecryptionType { get; set; }
 }

--- a/src/Api/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModel.cs
@@ -1,4 +1,6 @@
 ﻿using Bit.Core.AdminConsole.Models.Data.Provider;
+using Bit.Core.Auth.Enums;
+using Bit.Core.Auth.Models.Data;
 using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Extensions;
 using Bit.Core.Enums;
@@ -52,5 +54,14 @@ public class ProfileProviderOrganizationResponseModel : ProfileOrganizationRespo
         UseRiskInsights = organization.UseRiskInsights;
         UseOrganizationDomains = organization.UseOrganizationDomains;
         UseAdminSponsoredFamilies = organization.UseAdminSponsoredFamilies;
+        SsoEnabled = organization.SsoEnabled ?? false;
+
+        if (organization.SsoConfig != null)
+        {
+            var ssoConfigData = SsoConfigurationData.Deserialize(organization.SsoConfig);
+            KeyConnectorEnabled = ssoConfigData.MemberDecryptionType == MemberDecryptionType.KeyConnector && !string.IsNullOrEmpty(ssoConfigData.KeyConnectorUrl);
+            KeyConnectorUrl = ssoConfigData.KeyConnectorUrl;
+            SsoMemberDecryptionType = ssoConfigData.MemberDecryptionType;
+        }
     }
 }

--- a/src/Api/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModel.cs
@@ -1,67 +1,19 @@
 ﻿using Bit.Core.AdminConsole.Models.Data.Provider;
-using Bit.Core.Auth.Enums;
-using Bit.Core.Auth.Models.Data;
-using Bit.Core.Billing.Enums;
-using Bit.Core.Billing.Extensions;
 using Bit.Core.Enums;
 using Bit.Core.Models.Data;
 
 namespace Bit.Api.AdminConsole.Models.Response;
 
-public class ProfileProviderOrganizationResponseModel : ProfileOrganizationResponseModel
+public class ProfileProviderOrganizationResponseModel : BaseProfileOrganizationResponseModel
 {
     public ProfileProviderOrganizationResponseModel(ProviderUserOrganizationDetails organization)
-        : base("profileProviderOrganization")
+        : base("profileProviderOrganization", organization)
     {
-        Id = organization.OrganizationId;
-        Name = organization.Name;
-        UsePolicies = organization.UsePolicies;
-        UseSso = organization.UseSso;
-        UseKeyConnector = organization.UseKeyConnector;
-        UseScim = organization.UseScim;
-        UseGroups = organization.UseGroups;
-        UseDirectory = organization.UseDirectory;
-        UseEvents = organization.UseEvents;
-        UseTotp = organization.UseTotp;
-        Use2fa = organization.Use2fa;
-        UseApi = organization.UseApi;
-        UseResetPassword = organization.UseResetPassword;
-        UsersGetPremium = organization.UsersGetPremium;
-        UseCustomPermissions = organization.UseCustomPermissions;
-        UseActivateAutofillPolicy = organization.PlanType.GetProductTier() == ProductTierType.Enterprise;
-        SelfHost = organization.SelfHost;
-        Seats = organization.Seats;
-        MaxCollections = organization.MaxCollections;
-        MaxStorageGb = organization.MaxStorageGb;
-        Key = organization.Key;
-        HasPublicAndPrivateKeys = organization.PublicKey != null && organization.PrivateKey != null;
         Status = OrganizationUserStatusType.Confirmed; // Provider users are always confirmed
         Type = OrganizationUserType.Owner; // Provider users behave like Owners
-        Enabled = organization.Enabled;
-        SsoBound = false;
-        Identifier = organization.Identifier;
-        Permissions = new Permissions();
-        ResetPasswordEnrolled = false;
-        UserId = organization.UserId;
         ProviderId = organization.ProviderId;
         ProviderName = organization.ProviderName;
         ProviderType = organization.ProviderType;
-        ProductTierType = organization.PlanType.GetProductTier();
-        LimitCollectionCreation = organization.LimitCollectionCreation;
-        LimitCollectionDeletion = organization.LimitCollectionDeletion;
-        LimitItemDeletion = organization.LimitItemDeletion;
-        AllowAdminAccessToAllCollectionItems = organization.AllowAdminAccessToAllCollectionItems;
-        UseRiskInsights = organization.UseRiskInsights;
-        UseOrganizationDomains = organization.UseOrganizationDomains;
-        UseAdminSponsoredFamilies = organization.UseAdminSponsoredFamilies;
-        SsoEnabled = organization.SsoEnabled ?? false;
-
-        if (organization.SsoConfig != null)
-        {
-            var ssoConfigData = SsoConfigurationData.Deserialize(organization.SsoConfig);
-            KeyConnectorEnabled = ssoConfigData.MemberDecryptionType == MemberDecryptionType.KeyConnector && !string.IsNullOrEmpty(ssoConfigData.KeyConnectorUrl);
-            KeyConnectorUrl = ssoConfigData.KeyConnectorUrl;
-            SsoMemberDecryptionType = ssoConfigData.MemberDecryptionType;
-        }
+        Permissions = new Permissions();
     }
 }

--- a/src/Core/AdminConsole/Models/Data/BaseUserOrganizationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/BaseUserOrganizationDetails.cs
@@ -1,0 +1,57 @@
+﻿// FIXME: Update this file to be null safe and then delete the line below
+#nullable disable
+
+using System.Text.Json.Serialization;
+using Bit.Core.AdminConsole.Enums.Provider;
+using Bit.Core.Billing.Enums;
+using Bit.Core.Utilities;
+
+namespace Bit.Core.AdminConsole.Models.Data;
+
+/// <summary>
+/// Base class containing all common organization details properties shared between
+/// regular organization users and provider organization users.
+/// </summary>
+public abstract class BaseUserOrganizationDetails
+{
+    public Guid OrganizationId { get; set; }
+    public Guid? UserId { get; set; }
+    [JsonConverter(typeof(HtmlEncodingStringConverter))]
+    public string Name { get; set; }
+    public bool Enabled { get; set; }
+    public string Identifier { get; set; }
+    public PlanType PlanType { get; set; }
+    public bool UsePolicies { get; set; }
+    public bool UseSso { get; set; }
+    public bool UseKeyConnector { get; set; }
+    public bool UseScim { get; set; }
+    public bool UseGroups { get; set; }
+    public bool UseDirectory { get; set; }
+    public bool UseEvents { get; set; }
+    public bool UseTotp { get; set; }
+    public bool Use2fa { get; set; }
+    public bool UseApi { get; set; }
+    public bool UseResetPassword { get; set; }
+    public bool UsersGetPremium { get; set; }
+    public bool UseCustomPermissions { get; set; }
+    public bool UseRiskInsights { get; set; }
+    public bool UseOrganizationDomains { get; set; }
+    public bool UseAdminSponsoredFamilies { get; set; }
+    public bool SelfHost { get; set; }
+    public int? Seats { get; set; }
+    public short? MaxCollections { get; set; }
+    public short? MaxStorageGb { get; set; }
+    public string Key { get; set; }
+    public string PublicKey { get; set; }
+    public string PrivateKey { get; set; }
+    public Guid? ProviderId { get; set; }
+    [JsonConverter(typeof(HtmlEncodingStringConverter))]
+    public string ProviderName { get; set; }
+    public ProviderType? ProviderType { get; set; }
+    public bool LimitCollectionCreation { get; set; }
+    public bool LimitCollectionDeletion { get; set; }
+    public bool LimitItemDeletion { get; set; }
+    public bool AllowAdminAccessToAllCollectionItems { get; set; }
+    public bool? SsoEnabled { get; set; }
+    public string SsoConfig { get; set; }
+}

--- a/src/Core/AdminConsole/Models/Data/Organizations/OrganizationUsers/OrganizationUserOrganizationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Organizations/OrganizationUsers/OrganizationUserOrganizationDetails.cs
@@ -1,56 +1,20 @@
 ﻿// FIXME: Update this file to be null safe and then delete the line below
 #nullable disable
 
-using System.Text.Json.Serialization;
-using Bit.Core.AdminConsole.Enums.Provider;
-using Bit.Core.Billing.Enums;
-using Bit.Core.Utilities;
+using Bit.Core.AdminConsole.Models.Data;
 
 namespace Bit.Core.Models.Data.Organizations.OrganizationUsers;
 
-public class OrganizationUserOrganizationDetails
+public class OrganizationUserOrganizationDetails : BaseUserOrganizationDetails
 {
-    public Guid OrganizationId { get; set; }
-    public Guid? UserId { get; set; }
     public Guid OrganizationUserId { get; set; }
-    [JsonConverter(typeof(HtmlEncodingStringConverter))]
-    public string Name { get; set; }
-    public bool UsePolicies { get; set; }
-    public bool UseSso { get; set; }
-    public bool UseKeyConnector { get; set; }
-    public bool UseScim { get; set; }
-    public bool UseGroups { get; set; }
-    public bool UseDirectory { get; set; }
-    public bool UseEvents { get; set; }
-    public bool UseTotp { get; set; }
-    public bool Use2fa { get; set; }
-    public bool UseApi { get; set; }
-    public bool UseResetPassword { get; set; }
     public bool UseSecretsManager { get; set; }
-    public bool SelfHost { get; set; }
-    public bool UsersGetPremium { get; set; }
-    public bool UseCustomPermissions { get; set; }
-    public int? Seats { get; set; }
-    public short? MaxCollections { get; set; }
-    public short? MaxStorageGb { get; set; }
-    public string Key { get; set; }
     public Enums.OrganizationUserStatusType Status { get; set; }
     public Enums.OrganizationUserType Type { get; set; }
-    public bool Enabled { get; set; }
-    public PlanType PlanType { get; set; }
     public string SsoExternalId { get; set; }
-    public string Identifier { get; set; }
     public string Permissions { get; set; }
     public string ResetPasswordKey { get; set; }
-    public string PublicKey { get; set; }
-    public string PrivateKey { get; set; }
-    public Guid? ProviderId { get; set; }
-    [JsonConverter(typeof(HtmlEncodingStringConverter))]
-    public string ProviderName { get; set; }
-    public ProviderType? ProviderType { get; set; }
     public string FamilySponsorshipFriendlyName { get; set; }
-    public bool? SsoEnabled { get; set; }
-    public string SsoConfig { get; set; }
     public DateTime? FamilySponsorshipLastSyncDate { get; set; }
     public DateTime? FamilySponsorshipValidUntil { get; set; }
     public bool? FamilySponsorshipToDelete { get; set; }
@@ -58,12 +22,5 @@ public class OrganizationUserOrganizationDetails
     public bool UsePasswordManager { get; set; }
     public int? SmSeats { get; set; }
     public int? SmServiceAccounts { get; set; }
-    public bool LimitCollectionCreation { get; set; }
-    public bool LimitCollectionDeletion { get; set; }
-    public bool LimitItemDeletion { get; set; }
-    public bool AllowAdminAccessToAllCollectionItems { get; set; }
-    public bool UseRiskInsights { get; set; }
-    public bool UseOrganizationDomains { get; set; }
-    public bool UseAdminSponsoredFamilies { get; set; }
     public bool? IsAdminInitiated { get; set; }
 }

--- a/src/Core/AdminConsole/Models/Data/Provider/ProviderUserOrganizationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Provider/ProviderUserOrganizationDetails.cs
@@ -1,56 +1,12 @@
-﻿// FIXME: Update this file to be null safe and then delete the line below
-#nullable disable
-
-using System.Text.Json.Serialization;
-using Bit.Core.AdminConsole.Enums.Provider;
-using Bit.Core.Billing.Enums;
-using Bit.Core.Utilities;
+﻿using Bit.Core.AdminConsole.Enums.Provider;
 
 namespace Bit.Core.AdminConsole.Models.Data.Provider;
 
-public class ProviderUserOrganizationDetails
+public class ProviderUserOrganizationDetails : BaseUserOrganizationDetails
 {
-    public Guid OrganizationId { get; set; }
-    public Guid? UserId { get; set; }
-    [JsonConverter(typeof(HtmlEncodingStringConverter))]
-    public string Name { get; set; }
-    public bool UsePolicies { get; set; }
-    public bool UseSso { get; set; }
-    public bool UseKeyConnector { get; set; }
-    public bool UseScim { get; set; }
-    public bool UseGroups { get; set; }
-    public bool UseDirectory { get; set; }
-    public bool UseEvents { get; set; }
-    public bool UseTotp { get; set; }
-    public bool Use2fa { get; set; }
-    public bool UseApi { get; set; }
-    public bool UseResetPassword { get; set; }
-    public bool SelfHost { get; set; }
-    public bool UsersGetPremium { get; set; }
-    public bool UseCustomPermissions { get; set; }
-    public int? Seats { get; set; }
-    public short? MaxCollections { get; set; }
-    public short? MaxStorageGb { get; set; }
-    public string Key { get; set; }
+    public new Guid ProviderId { get; set; }
+    public new ProviderType ProviderType { get; set; }
+    public Guid ProviderUserId { get; set; }
     public ProviderUserStatusType Status { get; set; }
     public ProviderUserType Type { get; set; }
-    public bool Enabled { get; set; }
-    public string Identifier { get; set; }
-    public string PublicKey { get; set; }
-    public string PrivateKey { get; set; }
-    public Guid? ProviderId { get; set; }
-    public Guid? ProviderUserId { get; set; }
-    [JsonConverter(typeof(HtmlEncodingStringConverter))]
-    public string ProviderName { get; set; }
-    public PlanType PlanType { get; set; }
-    public bool LimitCollectionCreation { get; set; }
-    public bool LimitCollectionDeletion { get; set; }
-    public bool LimitItemDeletion { get; set; }
-    public bool AllowAdminAccessToAllCollectionItems { get; set; }
-    public bool UseRiskInsights { get; set; }
-    public bool UseOrganizationDomains { get; set; }
-    public bool UseAdminSponsoredFamilies { get; set; }
-    public ProviderType ProviderType { get; set; }
-    public bool? SsoEnabled { get; set; }
-    public string SsoConfig { get; set; }
 }

--- a/src/Core/AdminConsole/Models/Data/Provider/ProviderUserOrganizationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Provider/ProviderUserOrganizationDetails.cs
@@ -51,4 +51,6 @@ public class ProviderUserOrganizationDetails
     public bool UseOrganizationDomains { get; set; }
     public bool UseAdminSponsoredFamilies { get; set; }
     public ProviderType ProviderType { get; set; }
+    public bool? SsoEnabled { get; set; }
+    public string SsoConfig { get; set; }
 }

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/ProviderUserOrganizationDetailsViewQuery.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/ProviderUserOrganizationDetailsViewQuery.cs
@@ -12,7 +12,9 @@ public class ProviderUserOrganizationDetailsViewQuery : IQuery<ProviderUserOrgan
                     join po in dbContext.ProviderOrganizations on pu.ProviderId equals po.ProviderId
                     join o in dbContext.Organizations on po.OrganizationId equals o.Id
                     join p in dbContext.Providers on pu.ProviderId equals p.Id
-                    select new { pu, po, o, p };
+                    join ss in dbContext.SsoConfigs on o.Id equals ss.OrganizationId into ss_g
+                    from ss in ss_g.DefaultIfEmpty()
+                    select new { pu, po, o, p, ss };
         return query.Select(x => new ProviderUserOrganizationDetails
         {
             OrganizationId = x.po.OrganizationId,
@@ -52,6 +54,8 @@ public class ProviderUserOrganizationDetailsViewQuery : IQuery<ProviderUserOrgan
             ProviderType = x.p.Type,
             UseOrganizationDomains = x.o.UseOrganizationDomains,
             UseAdminSponsoredFamilies = x.o.UseAdminSponsoredFamilies,
+            SsoEnabled = x.ss.Enabled,
+            SsoConfig = x.ss.Data,
         });
     }
 }

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/ProviderUserOrganizationDetailsViewQuery.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/ProviderUserOrganizationDetailsViewQuery.cs
@@ -41,6 +41,7 @@ public class ProviderUserOrganizationDetailsViewQuery : IQuery<ProviderUserOrgan
             Key = x.po.Key,
             Status = x.pu.Status,
             Type = x.pu.Type,
+            ProviderUserId = x.pu.Id,
             PublicKey = x.o.PublicKey,
             PrivateKey = x.o.PrivateKey,
             ProviderId = x.p.Id,

--- a/test/Api.Test/AdminConsole/Models/Response/ProfileOrganizationResponseModelTests.cs
+++ b/test/Api.Test/AdminConsole/Models/Response/ProfileOrganizationResponseModelTests.cs
@@ -1,0 +1,68 @@
+﻿using Bit.Api.AdminConsole.Models.Response;
+using Bit.Core.Auth.Enums;
+using Bit.Core.Auth.Models.Data;
+using Bit.Core.Billing.Enums;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data.Organizations.OrganizationUsers;
+using Bit.Core.Utilities;
+using Xunit;
+
+namespace Bit.Api.Test.AdminConsole.Models.Response;
+
+public class ProfileOrganizationResponseModelTests
+{
+    [Fact]
+    public void Constructor_ShouldPopulatePropertiesCorrectly()
+    {
+        var organizationId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var organizationUserId = Guid.NewGuid();
+        var organizationIdsClaimingUser = new[] { organizationId };
+
+        var organization = new OrganizationUserOrganizationDetails
+        {
+            OrganizationId = organizationId,
+            UserId = userId,
+            OrganizationUserId = organizationUserId,
+            Name = "Test Organization",
+            Enabled = true,
+            PlanType = PlanType.EnterpriseAnnually,
+            SsoEnabled = true,
+            SsoConfig = new SsoConfigurationData
+            {
+                MemberDecryptionType = MemberDecryptionType.KeyConnector,
+                KeyConnectorUrl = "https://keyconnector.example.com"
+            }.Serialize(),
+            Status = OrganizationUserStatusType.Confirmed,
+            Type = OrganizationUserType.Owner,
+            SsoExternalId = "external-sso-id",
+            Permissions = CoreHelpers.ClassToJsonData(new Core.Models.Data.Permissions { ManageUsers = true }),
+            ResetPasswordKey = "reset-password-key",
+            UseSecretsManager = true,
+            UsePasswordManager = true,
+            AccessSecretsManager = true
+        };
+
+        var result = new ProfileOrganizationResponseModel(organization, organizationIdsClaimingUser);
+
+        Assert.Equal("profileOrganization", result.Object);
+        Assert.Equal(organizationId, result.Id);
+        Assert.Equal("Test Organization", result.Name);
+        Assert.True(result.Enabled);
+        Assert.Equal(ProductTierType.Enterprise, result.ProductTierType);
+        Assert.True(result.SsoEnabled);
+        Assert.True(result.KeyConnectorEnabled);
+        Assert.Equal("https://keyconnector.example.com", result.KeyConnectorUrl);
+        Assert.Equal(MemberDecryptionType.KeyConnector, result.SsoMemberDecryptionType);
+        Assert.Equal(OrganizationUserStatusType.Confirmed, result.Status);
+        Assert.Equal(OrganizationUserType.Owner, result.Type);
+        Assert.True(result.SsoBound);
+        Assert.NotNull(result.Permissions);
+        Assert.True(result.ResetPasswordEnrolled);
+        Assert.Equal(organizationUserId, result.OrganizationUserId);
+        Assert.True(result.UserIsClaimedByOrganization);
+        Assert.True(result.UseSecretsManager);
+        Assert.True(result.UsePasswordManager);
+        Assert.True(result.AccessSecretsManager);
+    }
+}

--- a/test/Api.Test/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModelTests.cs
+++ b/test/Api.Test/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModelTests.cs
@@ -1,0 +1,70 @@
+﻿using Bit.Api.AdminConsole.Models.Response;
+using Bit.Core.AdminConsole.Enums.Provider;
+using Bit.Core.AdminConsole.Models.Data.Provider;
+using Bit.Core.Auth.Enums;
+using Bit.Core.Auth.Models.Data;
+using Bit.Core.Billing.Enums;
+using Bit.Core.Enums;
+using Xunit;
+
+namespace Bit.Api.Test.AdminConsole.Models.Response;
+
+public class ProfileProviderOrganizationResponseModelTests
+{
+    [Fact]
+    public void Constructor_ShouldPopulatePropertiesCorrectly()
+    {
+        var organizationId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var providerId = Guid.NewGuid();
+        var providerUserId = Guid.NewGuid();
+
+        var organization = new ProviderUserOrganizationDetails
+        {
+            OrganizationId = organizationId,
+            UserId = userId,
+            Name = "Test Provider Organization",
+            Enabled = true,
+            PlanType = PlanType.EnterpriseAnnually,
+            ProviderId = providerId,
+            ProviderName = "Test MSP Provider",
+            ProviderType = ProviderType.Msp,
+            SsoEnabled = true,
+            SsoConfig = new SsoConfigurationData
+            {
+                MemberDecryptionType = MemberDecryptionType.TrustedDeviceEncryption
+            }.Serialize(),
+            Status = ProviderUserStatusType.Confirmed,
+            Type = ProviderUserType.ProviderAdmin,
+            ProviderUserId = providerUserId
+        };
+
+        var result = new ProfileProviderOrganizationResponseModel(organization);
+
+        Assert.Equal("profileProviderOrganization", result.Object);
+        Assert.Equal(organizationId, result.Id);
+        Assert.Equal("Test Provider Organization", result.Name);
+        Assert.True(result.Enabled);
+        Assert.Equal(ProductTierType.Enterprise, result.ProductTierType);
+        Assert.Equal(providerId, result.ProviderId);
+        Assert.Equal("Test MSP Provider", result.ProviderName);
+        Assert.Equal(ProviderType.Msp, result.ProviderType);
+        Assert.True(result.SsoEnabled);
+        Assert.False(result.KeyConnectorEnabled);
+        Assert.Null(result.KeyConnectorUrl);
+        Assert.Equal(MemberDecryptionType.TrustedDeviceEncryption, result.SsoMemberDecryptionType);
+        Assert.Equal(OrganizationUserStatusType.Confirmed, result.Status);
+        Assert.Equal(OrganizationUserType.Owner, result.Type);
+        Assert.False(result.SsoBound);
+        Assert.NotNull(result.Permissions);
+        Assert.False(result.ResetPasswordEnrolled);
+        Assert.Null(result.OrganizationUserId);
+        Assert.False(result.UserIsClaimedByOrganization);
+        Assert.False(result.UseSecretsManager);
+        Assert.False(result.UsePasswordManager); // Provider model doesn't have this data
+        Assert.False(result.AccessSecretsManager); // Provider model doesn't have this data
+        Assert.Null(result.FamilySponsorshipFriendlyName);
+        Assert.False(result.FamilySponsorshipAvailable);
+        Assert.False(result.IsAdminInitiated);
+    }
+}

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/ProviderUserRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/ProviderUserRepositoryTests.cs
@@ -1,0 +1,105 @@
+﻿using Bit.Core.AdminConsole.Entities.Provider;
+using Bit.Core.AdminConsole.Enums.Provider;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Auth.Entities;
+using Bit.Core.Auth.Enums;
+using Bit.Core.Auth.Models.Data;
+using Bit.Core.Auth.Repositories;
+using Bit.Core.Repositories;
+using Xunit;
+
+namespace Bit.Infrastructure.IntegrationTest.AdminConsole.Repositories;
+
+public class ProviderUserRepositoryTests
+{
+    [Theory, DatabaseData]
+    public async Task GetManyOrganizationDetailsByUserAsync_ShouldPopulateSsoPropertiesCorrectly(
+        IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IProviderRepository providerRepository,
+        IProviderUserRepository providerUserRepository,
+        IProviderOrganizationRepository providerOrganizationRepository,
+        ISsoConfigRepository ssoConfigRepository)
+    {
+        var user = await userRepository.CreateTestUserAsync();
+        var organizationWithSso = await organizationRepository.CreateTestOrganizationAsync();
+        var organizationWithoutSso = await organizationRepository.CreateTestOrganizationAsync();
+
+        var provider = await providerRepository.CreateAsync(new Provider
+        {
+            Name = "Test Provider",
+            Enabled = true,
+            Type = ProviderType.Msp
+        });
+
+        var providerUser = await providerUserRepository.CreateAsync(new ProviderUser
+        {
+            ProviderId = provider.Id,
+            UserId = user.Id,
+            Status = ProviderUserStatusType.Confirmed,
+            Type = ProviderUserType.ProviderAdmin
+        });
+
+        var providerOrganizationWithSso = await providerOrganizationRepository.CreateAsync(new ProviderOrganization
+        {
+            ProviderId = provider.Id,
+            OrganizationId = organizationWithSso.Id
+        });
+
+        var providerOrganizationWithoutSso = await providerOrganizationRepository.CreateAsync(new ProviderOrganization
+        {
+            ProviderId = provider.Id,
+            OrganizationId = organizationWithoutSso.Id
+        });
+
+        // Create SSO configuration for first organization only
+        var serializedSsoConfigData = new SsoConfigurationData
+        {
+            MemberDecryptionType = MemberDecryptionType.KeyConnector,
+            KeyConnectorUrl = "https://keyconnector.example.com"
+        }.Serialize();
+
+        var ssoConfig = await ssoConfigRepository.CreateAsync(new SsoConfig
+        {
+            OrganizationId = organizationWithSso.Id,
+            Enabled = true,
+            Data = serializedSsoConfigData
+        });
+        var results = (await providerUserRepository.GetManyOrganizationDetailsByUserAsync(user.Id, ProviderUserStatusType.Confirmed)).ToList();
+
+        Assert.Equal(2, results.Count);
+
+        var orgWithSsoDetails = results.Single(r => r.OrganizationId == organizationWithSso.Id);
+        var orgWithoutSsoDetails = results.Single(r => r.OrganizationId == organizationWithoutSso.Id);
+
+        // Verify common properties for both organizations
+        Assert.Equal(user.Id, orgWithSsoDetails.UserId);
+        Assert.Equal(provider.Id, orgWithSsoDetails.ProviderId);
+        Assert.Equal(provider.Name, orgWithSsoDetails.ProviderName);
+        Assert.Equal(provider.Type, orgWithSsoDetails.ProviderType);
+
+        Assert.Equal(user.Id, orgWithoutSsoDetails.UserId);
+        Assert.Equal(provider.Id, orgWithoutSsoDetails.ProviderId);
+        Assert.Equal(provider.Name, orgWithoutSsoDetails.ProviderName);
+        Assert.Equal(provider.Type, orgWithoutSsoDetails.ProviderType);
+
+        // Organization with SSO should have SSO properties populated
+        Assert.True(orgWithSsoDetails.SsoEnabled);
+        Assert.NotNull(orgWithSsoDetails.SsoConfig);
+        Assert.Equal(serializedSsoConfigData, orgWithSsoDetails.SsoConfig);
+
+        // Organization without SSO should have null SSO properties
+        Assert.Null(orgWithoutSsoDetails.SsoEnabled);
+        Assert.Null(orgWithoutSsoDetails.SsoConfig);
+
+        // Cleanup
+        await ssoConfigRepository.DeleteAsync(ssoConfig);
+        await providerOrganizationRepository.DeleteAsync(providerOrganizationWithSso);
+        await providerOrganizationRepository.DeleteAsync(providerOrganizationWithoutSso);
+        await providerUserRepository.DeleteAsync(providerUser);
+        await providerRepository.DeleteAsync(provider);
+        await organizationRepository.DeleteAsync(organizationWithSso);
+        await organizationRepository.DeleteAsync(organizationWithoutSso);
+        await userRepository.DeleteAsync(user);
+    }
+}

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/ProviderUserRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/ProviderUserRepositoryTests.cs
@@ -1,10 +1,13 @@
-﻿using Bit.Core.AdminConsole.Entities.Provider;
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
+using Bit.Core.AdminConsole.Models.Data.Provider;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Auth.Entities;
 using Bit.Core.Auth.Enums;
 using Bit.Core.Auth.Models.Data;
 using Bit.Core.Auth.Repositories;
+using Bit.Core.Entities;
 using Bit.Core.Repositories;
 using Xunit;
 
@@ -72,25 +75,18 @@ public class ProviderUserRepositoryTests
         var orgWithSsoDetails = results.Single(r => r.OrganizationId == organizationWithSso.Id);
         var orgWithoutSsoDetails = results.Single(r => r.OrganizationId == organizationWithoutSso.Id);
 
-        // Verify common properties for both organizations
-        Assert.Equal(user.Id, orgWithSsoDetails.UserId);
-        Assert.Equal(provider.Id, orgWithSsoDetails.ProviderId);
-        Assert.Equal(provider.Name, orgWithSsoDetails.ProviderName);
-        Assert.Equal(provider.Type, orgWithSsoDetails.ProviderType);
+        // Verify all properties for both organizations
+        AssertProviderOrganizationDetails(orgWithSsoDetails, organizationWithSso, user, provider, providerUser);
+        AssertProviderOrganizationDetails(orgWithoutSsoDetails, organizationWithoutSso, user, provider, providerUser);
 
-        Assert.Equal(user.Id, orgWithoutSsoDetails.UserId);
-        Assert.Equal(provider.Id, orgWithoutSsoDetails.ProviderId);
-        Assert.Equal(provider.Name, orgWithoutSsoDetails.ProviderName);
-        Assert.Equal(provider.Type, orgWithoutSsoDetails.ProviderType);
+        // Organization without SSO should have null SSO properties
+        Assert.Null(orgWithoutSsoDetails.SsoEnabled);
+        Assert.Null(orgWithoutSsoDetails.SsoConfig);
 
         // Organization with SSO should have SSO properties populated
         Assert.True(orgWithSsoDetails.SsoEnabled);
         Assert.NotNull(orgWithSsoDetails.SsoConfig);
         Assert.Equal(serializedSsoConfigData, orgWithSsoDetails.SsoConfig);
-
-        // Organization without SSO should have null SSO properties
-        Assert.Null(orgWithoutSsoDetails.SsoEnabled);
-        Assert.Null(orgWithoutSsoDetails.SsoConfig);
 
         // Cleanup
         await ssoConfigRepository.DeleteAsync(ssoConfig);
@@ -101,5 +97,55 @@ public class ProviderUserRepositoryTests
         await organizationRepository.DeleteAsync(organizationWithSso);
         await organizationRepository.DeleteAsync(organizationWithoutSso);
         await userRepository.DeleteAsync(user);
+    }
+
+    private static void AssertProviderOrganizationDetails(
+        ProviderUserOrganizationDetails actual,
+        Organization expectedOrganization,
+        User expectedUser,
+        Provider expectedProvider,
+        ProviderUser expectedProviderUser)
+    {
+        // Organization properties
+        Assert.Equal(expectedOrganization.Id, actual.OrganizationId);
+        Assert.Equal(expectedUser.Id, actual.UserId);
+        Assert.Equal(expectedOrganization.Name, actual.Name);
+        Assert.Equal(expectedOrganization.UsePolicies, actual.UsePolicies);
+        Assert.Equal(expectedOrganization.UseSso, actual.UseSso);
+        Assert.Equal(expectedOrganization.UseKeyConnector, actual.UseKeyConnector);
+        Assert.Equal(expectedOrganization.UseScim, actual.UseScim);
+        Assert.Equal(expectedOrganization.UseGroups, actual.UseGroups);
+        Assert.Equal(expectedOrganization.UseDirectory, actual.UseDirectory);
+        Assert.Equal(expectedOrganization.UseEvents, actual.UseEvents);
+        Assert.Equal(expectedOrganization.UseTotp, actual.UseTotp);
+        Assert.Equal(expectedOrganization.Use2fa, actual.Use2fa);
+        Assert.Equal(expectedOrganization.UseApi, actual.UseApi);
+        Assert.Equal(expectedOrganization.UseResetPassword, actual.UseResetPassword);
+        Assert.Equal(expectedOrganization.UsersGetPremium, actual.UsersGetPremium);
+        Assert.Equal(expectedOrganization.UseCustomPermissions, actual.UseCustomPermissions);
+        Assert.Equal(expectedOrganization.SelfHost, actual.SelfHost);
+        Assert.Equal(expectedOrganization.Seats, actual.Seats);
+        Assert.Equal(expectedOrganization.MaxCollections, actual.MaxCollections);
+        Assert.Equal(expectedOrganization.MaxStorageGb, actual.MaxStorageGb);
+        Assert.Equal(expectedOrganization.Identifier, actual.Identifier);
+        Assert.Equal(expectedOrganization.PublicKey, actual.PublicKey);
+        Assert.Equal(expectedOrganization.PrivateKey, actual.PrivateKey);
+        Assert.Equal(expectedOrganization.Enabled, actual.Enabled);
+        Assert.Equal(expectedOrganization.PlanType, actual.PlanType);
+        Assert.Equal(expectedOrganization.LimitCollectionCreation, actual.LimitCollectionCreation);
+        Assert.Equal(expectedOrganization.LimitCollectionDeletion, actual.LimitCollectionDeletion);
+        Assert.Equal(expectedOrganization.LimitItemDeletion, actual.LimitItemDeletion);
+        Assert.Equal(expectedOrganization.AllowAdminAccessToAllCollectionItems, actual.AllowAdminAccessToAllCollectionItems);
+        Assert.Equal(expectedOrganization.UseRiskInsights, actual.UseRiskInsights);
+        Assert.Equal(expectedOrganization.UseOrganizationDomains, actual.UseOrganizationDomains);
+        Assert.Equal(expectedOrganization.UseAdminSponsoredFamilies, actual.UseAdminSponsoredFamilies);
+
+        // Provider-specific properties
+        Assert.Equal(expectedProvider.Id, actual.ProviderId);
+        Assert.Equal(expectedProvider.Name, actual.ProviderName);
+        Assert.Equal(expectedProvider.Type, actual.ProviderType);
+        Assert.Equal(expectedProviderUser.Id, actual.ProviderUserId);
+        Assert.Equal(expectedProviderUser.Status, actual.Status);
+        Assert.Equal(expectedProviderUser.Type, actual.Type);
     }
 }

--- a/util/Migrator/DbScripts/2025-09-25_00_ProviderUserOrganizationSsoData.sql
+++ b/util/Migrator/DbScripts/2025-09-25_00_ProviderUserOrganizationSsoData.sql
@@ -1,4 +1,4 @@
-CREATE VIEW [dbo].[ProviderUserProviderOrganizationDetailsView]
+CREATE OR ALTER VIEW [dbo].[ProviderUserProviderOrganizationDetailsView]
 AS
 SELECT
     PU.[UserId],
@@ -52,3 +52,4 @@ INNER JOIN
     [dbo].[Provider] P ON P.[Id] = PU.[ProviderId]
 LEFT JOIN
     [dbo].[SsoConfig] SS ON SS.[OrganizationId] = O.[Id]
+GO


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-25923

## 📔 Objective

Ensure `ProfileOrganizationResponseModel` and `ProfileProviderOrganizationResponseModel` have consistent properties and simplify their implementation.

Enforced consistency on both models through shared `BaseProfileOrganizationResponseModel` inheritance.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
