### PR TITLE
[PM-25947] Add folders and favorites when sharing a cipher

### DIFF
--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -757,7 +757,7 @@ public class CiphersController : Controller
         ValidateClientVersionForFido2CredentialSupport(cipher);
 
         var original = cipher.Clone();
-        await _cipherService.ShareAsync(original, model.Cipher.ToCipher(cipher), new Guid(model.Cipher.OrganizationId),
+        await _cipherService.ShareAsync(original, model.Cipher.ToCipher(cipher, user.Id), new Guid(model.Cipher.OrganizationId),
             model.CollectionIds.Select(c => new Guid(c)), user.Id, model.Cipher.LastKnownRevisionDate);
 
         var sharedCipher = await GetByIdAsync(id, user.Id);

--- a/src/Api/Vault/Models/Request/CipherRequestModel.cs
+++ b/src/Api/Vault/Models/Request/CipherRequestModel.cs
@@ -84,7 +84,7 @@ public class CipherRequestModel
         return existingCipher;
     }
 
-    public Cipher ToCipher(Cipher existingCipher)
+    public Cipher ToCipher(Cipher existingCipher, Guid? userId = null)
     {
         // If Data field is provided, use it directly
         if (!string.IsNullOrWhiteSpace(Data))
@@ -124,9 +124,16 @@ public class CipherRequestModel
             }
         }
 
+        var userIdKey = userId.HasValue ? $"\"{userId.ToString().ToUpperInvariant()}\"" : null;
         existingCipher.Reprompt = Reprompt;
         existingCipher.Key = Key;
         existingCipher.ArchivedDate = ArchivedDate;
+        existingCipher.Folders = userIdKey != null && FolderId != null ?
+            $"{{{userIdKey}:\"{FolderId.ToUpperInvariant()}\"}}" :
+            null;
+        existingCipher.Favorites = userIdKey != null && Favorite ?
+               $"{{{userIdKey}:true}}" :
+               null;
 
         var hasAttachments2 = (Attachments2?.Count ?? 0) > 0;
         var hasAttachments = (Attachments?.Count ?? 0) > 0;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25947](https://bitwarden.atlassian.net/browse/PM-25947)

## 📔 Objective

When sharing a cipher from a personal vault to an organization the folder and favorite attributes were being lost in the `toCipher` method.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/297b699c-cb65-4410-b0ad-c86e074e67da" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
