### PR TITLE
Add default values for MaxConcurrentCalls and PrefetchCount across event and integration ASB listeners

### DIFF
--- a/src/Core/AdminConsole/Models/Data/EventIntegrations/IEventListenerConfiguration.cs
+++ b/src/Core/AdminConsole/Models/Data/EventIntegrations/IEventListenerConfiguration.cs
@@ -5,4 +5,6 @@ public interface IEventListenerConfiguration
     public string EventQueueName { get; }
     public string EventSubscriptionName { get; }
     public string EventTopicName { get; }
+    public int EventPrefetchCount { get; }
+    public int EventMaxConcurrentCalls { get; }
 }

--- a/src/Core/AdminConsole/Models/Data/EventIntegrations/IIntegrationListenerConfiguration.cs
+++ b/src/Core/AdminConsole/Models/Data/EventIntegrations/IIntegrationListenerConfiguration.cs
@@ -10,6 +10,8 @@ public interface IIntegrationListenerConfiguration : IEventListenerConfiguration
     public string IntegrationSubscriptionName { get; }
     public string IntegrationTopicName { get; }
     public int MaxRetries { get; }
+    public int IntegrationPrefetchCount { get; }
+    public int IntegrationMaxConcurrentCalls { get; }
 
     public string RoutingKey
     {

--- a/src/Core/AdminConsole/Models/Data/EventIntegrations/ListenerConfiguration.cs
+++ b/src/Core/AdminConsole/Models/Data/EventIntegrations/ListenerConfiguration.cs
@@ -25,4 +25,24 @@ public abstract class ListenerConfiguration
     {
         get => _globalSettings.EventLogging.AzureServiceBus.IntegrationTopicName;
     }
+
+    public int EventPrefetchCount
+    {
+        get => _globalSettings.EventLogging.AzureServiceBus.DefaultPrefetchCount;
+    }
+
+    public int EventMaxConcurrentCalls
+    {
+        get => _globalSettings.EventLogging.AzureServiceBus.DefaultMaxConcurrentCalls;
+    }
+
+    public int IntegrationPrefetchCount
+    {
+        get => _globalSettings.EventLogging.AzureServiceBus.DefaultPrefetchCount;
+    }
+
+    public int IntegrationMaxConcurrentCalls
+    {
+        get => _globalSettings.EventLogging.AzureServiceBus.DefaultMaxConcurrentCalls;
+    }
 }

--- a/src/Core/AdminConsole/Services/Implementations/EventIntegrations/AzureServiceBusEventListenerService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/EventIntegrations/AzureServiceBusEventListenerService.cs
@@ -14,13 +14,14 @@ public class AzureServiceBusEventListenerService<TConfiguration> : EventLoggingL
         TConfiguration configuration,
         IEventMessageHandler handler,
         IAzureServiceBusService serviceBusService,
+        ServiceBusProcessorOptions serviceBusOptions,
         ILoggerFactory loggerFactory)
         : base(handler, CreateLogger(loggerFactory, configuration))
     {
         _processor = serviceBusService.CreateProcessor(
             topicName: configuration.EventTopicName,
             subscriptionName: configuration.EventSubscriptionName,
-            new ServiceBusProcessorOptions());
+            options: serviceBusOptions);
     }
 
     protected override async Task ExecuteAsync(CancellationToken cancellationToken)

--- a/src/Core/AdminConsole/Services/Implementations/EventIntegrations/AzureServiceBusIntegrationListenerService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/EventIntegrations/AzureServiceBusIntegrationListenerService.cs
@@ -18,6 +18,7 @@ public class AzureServiceBusIntegrationListenerService<TConfiguration> : Backgro
         TConfiguration configuration,
         IIntegrationHandler handler,
         IAzureServiceBusService serviceBusService,
+        ServiceBusProcessorOptions serviceBusOptions,
         ILoggerFactory loggerFactory)
     {
         _handler = handler;
@@ -29,7 +30,7 @@ public class AzureServiceBusIntegrationListenerService<TConfiguration> : Backgro
         _processor = _serviceBusService.CreateProcessor(
             topicName: configuration.IntegrationTopicName,
             subscriptionName: configuration.IntegrationSubscriptionName,
-            options: new ServiceBusProcessorOptions());
+            options: serviceBusOptions);
     }
 
     protected override async Task ExecuteAsync(CancellationToken cancellationToken)

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -301,6 +301,9 @@ public class GlobalSettings : IGlobalSettings
             private string _eventTopicName;
             private string _integrationTopicName;
 
+            public virtual int DefaultMaxConcurrentCalls { get; set; } = 1;
+            public virtual int DefaultPrefetchCount { get; set; } = 0;
+
             public virtual string EventRepositorySubscriptionName { get; set; } = "events-write-subscription";
             public virtual string SlackEventSubscriptionName { get; set; } = "events-slack-subscription";
             public virtual string SlackIntegrationSubscriptionName { get; set; } = "integration-slack-subscription";

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
 using AspNetCoreRateLimit;
+using Azure.Messaging.ServiceBus;
 using Bit.Core.AdminConsole.AbilitiesCache;
 using Bit.Core.AdminConsole.Models.Business.Tokenables;
 using Bit.Core.AdminConsole.Models.Data.EventIntegrations;
@@ -855,6 +856,11 @@ public static class ServiceCollectionExtensions
                     configuration: listenerConfiguration,
                     handler: provider.GetRequiredKeyedService<IEventMessageHandler>(serviceKey: listenerConfiguration.RoutingKey),
                     serviceBusService: provider.GetRequiredService<IAzureServiceBusService>(),
+                    serviceBusOptions: new ServiceBusProcessorOptions()
+                    {
+                        PrefetchCount = listenerConfiguration.EventPrefetchCount,
+                        MaxConcurrentCalls = listenerConfiguration.EventMaxConcurrentCalls
+                    },
                     loggerFactory: provider.GetRequiredService<ILoggerFactory>()
                 )
             )
@@ -865,6 +871,11 @@ public static class ServiceCollectionExtensions
                     configuration: listenerConfiguration,
                     handler: provider.GetRequiredService<IIntegrationHandler<TConfig>>(),
                     serviceBusService: provider.GetRequiredService<IAzureServiceBusService>(),
+                    serviceBusOptions: new ServiceBusProcessorOptions()
+                    {
+                        PrefetchCount = listenerConfiguration.IntegrationPrefetchCount,
+                        MaxConcurrentCalls = listenerConfiguration.IntegrationMaxConcurrentCalls
+                    },
                     loggerFactory: provider.GetRequiredService<ILoggerFactory>()
                 )
             )
@@ -927,6 +938,11 @@ public static class ServiceCollectionExtensions
                         configuration: repositoryConfiguration,
                         handler: provider.GetRequiredService<AzureTableStorageEventHandler>(),
                         serviceBusService: provider.GetRequiredService<IAzureServiceBusService>(),
+                        serviceBusOptions: new ServiceBusProcessorOptions()
+                        {
+                            PrefetchCount = repositoryConfiguration.EventPrefetchCount,
+                            MaxConcurrentCalls = repositoryConfiguration.EventMaxConcurrentCalls
+                        },
                         loggerFactory: provider.GetRequiredService<ILoggerFactory>()
                     )
                 )

--- a/test/Core.Test/AdminConsole/Models/Data/EventIntegrations/TestListenerConfiguration.cs
+++ b/test/Core.Test/AdminConsole/Models/Data/EventIntegrations/TestListenerConfiguration.cs
@@ -13,4 +13,8 @@ public class TestListenerConfiguration : IIntegrationListenerConfiguration
     public string IntegrationSubscriptionName => "integration_subscription";
     public string IntegrationTopicName => "integration_topic";
     public int MaxRetries => 3;
+    public int EventMaxConcurrentCalls => 1;
+    public int EventPrefetchCount => 0;
+    public int IntegrationMaxConcurrentCalls => 1;
+    public int IntegrationPrefetchCount => 0;
 }


### PR DESCRIPTION
## 📔 Objective

When looking at the performance on prod of the new event integrations, it became clear that we had some sort of bottleneck in getting messages out of ASB fast enough. Most of the message processing code and the code that does the table storage piece are identical across the new version and the Azure queue hosted service. In digging into ASB performance, we found two possible settings that could be causing problems:

- **MaxConcurrentCalls**
  - Determines the number of asynchronously operating concurrent processors of messages
  - Default is 1, so everything was processed serially (i.e. one listener could handle 1 message at a time)
- **PrefetchCount**
  - Determines how many rows an instance should fetch ahead of processing
  - Instances fetch their prefetch count, cache locally, work through their cache until they've exhausted it, and then prefetch another batch
  - This lowers the amount of network latency per instance, so they can process their queue faster without needing to fetch records as often
  - Default is 0, meaning _no_ prefetch at all - each message required a fetch from ASB

This PR adds some code to allow for us to configure these at the ListenerConfiguration level. That mans we could later introduce individual global settings properties and tune to the level of each event or integration listener (if we need that granularity). As a starting point, however, it simply introduces global settings properties for default values. The `ListenerConfiguration` base class then applies those defaults to everything. This gives us a quick way to get started, but a path forward for more precise tuning later.

Also note: I initialized global settings with the same defaults as ASB has (i.e. 1 for MaxConcurrentCalls, 0 for PrefetchCount). My thinking was this gives us a way to safely deploy this code without having to worry about changing anything by accident. The expectation is that we'd override these with precise values as we deploy.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
