### PR TITLE
Fix MariaDB support for development

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       - ./.data/postgres/log:/var/log/postgresql
     profiles:
       - postgres
+      - ef
 
   mysql:
     image: mysql:8.0
@@ -69,6 +70,7 @@ services:
       - mysql_dev_data:/var/lib/mysql
     profiles:
       - mysql
+      - ef
 
   mariadb:
     image: mariadb:10
@@ -76,13 +78,13 @@ services:
       - 4306:3306
     environment:
       MARIADB_USER: maria
-      MARIADB_PASSWORD: ${MARIADB_ROOT_PASSWORD}
       MARIADB_DATABASE: vault_dev
       MARIADB_RANDOM_ROOT_PASSWORD: "true"
     volumes:
       - mariadb_dev_data:/var/lib/mysql
     profiles:
       - mariadb
+      - ef
 
   idp:
     image: kenchan0130/simplesamlphp:1.19.8
@@ -153,5 +155,6 @@ volumes:
   mssql_dev_data:
   postgres_dev_data:
   mysql_dev_data:
+  mariadb_dev_data:
   rabbitmq_data:
   redis_data:

--- a/dev/migrate.ps1
+++ b/dev/migrate.ps1
@@ -70,7 +70,7 @@ Foreach ($item in @(
     @($mysql, "MySQL", "MySqlMigrations", "mySql", 2),
     # MariaDB shares the MySQL connection string in the server config so they are mutually exclusive in that context.
     # However they can still be run independently for integration tests.
-    @($mariadb, "MariaDB", "MySqlMigrations", "mySql", 3) 
+    @($mariadb, "MariaDB", "MySqlMigrations", "mySql", 4) 
 )) {
   if (!$item[0] -and !$all) {
     continue


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
See https://github.com/bitwarden/contributing-docs/pull/687.

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Minor tweaks to assist https://github.com/bitwarden/contributing-docs/pull/687.

- MariaDB was sharing the same index number as MSSQL in `migrate.ps1`. Updated so it doesn't clash.
- Docker was complaining about a missing folder when starting the MariaDB database, fixed by listing it as a volume at the end
- MariaDB was specifying a root password but also using a random root password. Update to just use a random one given that the connection string doesn't need it.
- Add an EF profile so you can start all EF containers at once.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
