### PR TITLE
[PM-23385] consolidate superfluous feature flags

### DIFF
--- a/src/Api/Billing/Controllers/VNext/AccountBillingVNextController.cs
+++ b/src/Api/Billing/Controllers/VNext/AccountBillingVNextController.cs
@@ -66,7 +66,7 @@ public class AccountBillingVNextController(
     }
 
     [HttpPost("subscription")]
-    [RequireFeature(FeatureFlagKeys.PM23385_UseNewPremiumFlow)]
+    [RequireFeature(FeatureFlagKeys.PM24996ImplementUpgradeFromFreeDialog)]
     [InjectUser]
     public async Task<IResult> CreateSubscriptionAsync(
         [BindNever] User user,

--- a/src/Api/Billing/Controllers/VNext/SelfHostedAccountBillingController.cs
+++ b/src/Api/Billing/Controllers/VNext/SelfHostedAccountBillingController.cs
@@ -21,7 +21,7 @@ public class SelfHostedAccountBillingController(
     ICreatePremiumSelfHostedSubscriptionCommand createPremiumSelfHostedSubscriptionCommand) : BaseBillingController
 {
     [HttpPost("license")]
-    [RequireFeature(FeatureFlagKeys.PM23385_UseNewPremiumFlow)]
+    [RequireFeature(FeatureFlagKeys.PM24996ImplementUpgradeFromFreeDialog)]
     [InjectUser]
     public async Task<IResult> UploadLicenseAsync(
         [BindNever] User user,

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -182,7 +182,6 @@ public static class FeatureFlagKeys
     public const string PM19422_AllowAutomaticTaxUpdates = "pm-19422-allow-automatic-tax-updates";
     public const string PM21821_ProviderPortalTakeover = "pm-21821-provider-portal-takeover";
     public const string PM22415_TaxIDWarnings = "pm-22415-tax-id-warnings";
-    public const string PM23385_UseNewPremiumFlow = "pm-23385-use-new-premium-flow";
     public const string PM24996ImplementUpgradeFromFreeDialog = "pm-24996-implement-upgrade-from-free-dialog";
     public const string PM24032_NewNavigationPremiumUpgradeButton = "pm-24032-new-navigation-premium-upgrade-button";
     public const string PM23713_PremiumBadgeOpensNewPremiumUpgradeDialog = "pm-23713-premium-badge-opens-new-premium-upgrade-dialog";


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23385

## 📔 Objective

We decided that the server-side refactor for the new premium flow should use the same feature flag that the client-side is using instead of having its own. This PR removes the old feature flag and replaces it with the one that clients uses.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
