### PR TITLE
Azure Service Bus Local Batching

### DIFF
--- a/src/Core/AdminConsole/Services/Implementations/EventIntegrations/AzureServiceBusEventBatchBackgroundService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/EventIntegrations/AzureServiceBusEventBatchBackgroundService.cs
@@ -1,0 +1,96 @@
+﻿using System.Collections.Concurrent;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Bit.Core.Services;
+
+public class AzureServiceBusEventBatchBackgroundService(ServiceBusSender sender, int batchSize, ILogger logger) : BackgroundService
+{
+    private readonly ConcurrentQueue<string> _queue = new();
+
+    public void Enqueue(string body)
+    {
+        _queue.Enqueue(body);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (_queue.IsEmpty)
+                {
+                    await Task.Delay(20, stoppingToken);
+                    continue;
+                }
+
+                using var batch = await sender.CreateMessageBatchAsync(stoppingToken);
+                var added = 0;
+
+                while (added < batchSize && _queue.TryDequeue(out var body))
+                {
+                    var message = new ServiceBusMessage(body)
+                    {
+                        ContentType = "application/json",
+                        MessageId = Guid.NewGuid().ToString()
+                    };
+
+                    if (!batch.TryAddMessage(message))
+                    {
+                        // Batch is full - return message to queue and break to send this batch
+                        _queue.Enqueue(body);
+                        break;
+                    }
+
+                    added++;
+                }
+
+                if (batch.Count > 0)
+                {
+                    await sender.SendMessagesAsync(batch, stoppingToken);
+                }
+
+                await Task.Yield();
+            }
+            catch (TaskCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "An exception occurred in the AzureServiceBusEventBatchBackgroundService");
+                await Task.Delay(1000, stoppingToken);
+            }
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        while (!_queue.IsEmpty)
+        {
+            using var batch = await sender.CreateMessageBatchAsync(cancellationToken);
+
+            while (_queue.TryDequeue(out var body))
+            {
+                var msg = new ServiceBusMessage(body)
+                {
+                    ContentType = "application/json",
+                    MessageId = Guid.NewGuid().ToString()
+                };
+
+                if (!batch.TryAddMessage(msg))
+                {
+                    _queue.Enqueue(body); // re-enqueue for next batch
+                    break;
+                }
+            }
+
+            if (batch.Count > 0)
+                await sender.SendMessagesAsync(batch, cancellationToken);
+        }
+
+        await base.StopAsync(cancellationToken);
+    }
+}

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -321,7 +321,6 @@ public class GlobalSettings : IGlobalSettings
             public virtual int DefaultMaxConcurrentCalls { get; set; } = 1;
             public virtual int DefaultPrefetchCount { get; set; } = 0;
             public virtual int SenderBatchSize { get; set; } = 100;
-            public virtual int SenderFlushInterval { get; set; } = 50;
 
             public virtual string EventRepositorySubscriptionName { get; set; } = "events-write-subscription";
             public virtual string SlackEventSubscriptionName { get; set; } = "events-slack-subscription";


### PR DESCRIPTION
## 📔 Objective

When turning on the new events integration in production, we were witnessing latency spikes on various services that need to make calls into EventWriteSerivce (mostly for single events via CreateAsync). The spikes seemed to be due to the fact that we couldn't write to ASB fast enough. Part of that may have been throttling on the standard tier ASB instance, but we also wanted to make sure we were handling writes as fast as possible.

This PR implements a local batching solution that will batch messages up before sending them as a batch in a single AMQP frame. ASB has slightly higher latency than the previous Azure Queues because it has to deal with AMQP overhead that is slightly more than the simpler REST calls for Azure Queue. However, there is support in ASB for batching multiple messages into a single frame, which should allow us to accept writes faster but still deliver everything quickly to ASB. It should also reduce network overhead since each individual message no longer requires a separate call. 

In essence, this is the same principle we used in #6403 to reduce network on the listener side, just applied to the sender. There is no built in support for building batches locally, however, so we have to use a concurrent queue and handle that ourselves.

**Note:** I actually implemented this first entirely inside of AzureServiceBusService using a Timer based flush. After having finished that version, I realized that the queue is likely to be constantly filled with new messages coming in and it would simplify things a bit to just have a separate, persistent worker batching and sending constantly (i.e. we don't have to worry about a semaphore or locking or timing, just keep sending batches as long as we have something to send). I pushed this up as the latest commit. But the first commit is still there if we think it's a better approach.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
