### PR TITLE
Add Renovate ownership of MessagePack pinned transitive dependency

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -136,6 +136,7 @@
         "Azure.Storage.Blobs",
         "Azure.Storage.Queues",
         "LaunchDarkly.ServerSdk",
+        "MessagePack",
         "Microsoft.AspNetCore.Http",
         "Microsoft.AspNetCore.SignalR.Protocols.MessagePack",
         "Microsoft.AspNetCore.SignalR.StackExchangeRedis",


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/server/pull/5745

## 📔 Objective

We [pin](https://github.com/bitwarden/server/blob/89f4eea0f20f3b221468a889f366c91ef533c453/src/Notifications/Notifications.csproj#L15) the `MessagePack` transitive dependency.

This PR assigns ownership of those updates to Platform.  As you can see in #5745, they currently do not have an owner.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
