### PR TITLE
[PM-26194] Fix: Provider Portal not automatically disabled, when subscription is cancelled

### DIFF
--- a/src/Billing/Jobs/ProviderOrganizationDisableJob.cs
+++ b/src/Billing/Jobs/ProviderOrganizationDisableJob.cs
@@ -1,0 +1,88 @@
+﻿// FIXME: Update this file to be null safe and then delete the line below
+#nullable disable
+
+using Bit.Core.AdminConsole.OrganizationFeatures.Organizations.Interfaces;
+using Bit.Core.AdminConsole.Repositories;
+using Quartz;
+
+namespace Bit.Billing.Jobs;
+
+public class ProviderOrganizationDisableJob(
+    IProviderOrganizationRepository providerOrganizationRepository,
+    IOrganizationDisableCommand organizationDisableCommand,
+    ILogger<ProviderOrganizationDisableJob> logger)
+    : IJob
+{
+    private const int MaxConcurrency = 5;
+    private const int MaxTimeoutMinutes = 10;
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        var providerId = new Guid(context.MergedJobDataMap.GetString("providerId") ?? string.Empty);
+        var expirationDateString = context.MergedJobDataMap.GetString("expirationDate");
+        DateTime? expirationDate = string.IsNullOrEmpty(expirationDateString)
+            ? null
+            : DateTime.Parse(expirationDateString);
+
+        logger.LogInformation("Starting to disable organizations for provider {ProviderId}", providerId);
+
+        var startTime = DateTime.UtcNow;
+        var totalProcessed = 0;
+        var totalErrors = 0;
+
+        try
+        {
+            var providerOrganizations = await providerOrganizationRepository
+                .GetManyDetailsByProviderAsync(providerId);
+
+            if (providerOrganizations == null || !providerOrganizations.Any())
+            {
+                logger.LogInformation("No organizations found for provider {ProviderId}", providerId);
+                return;
+            }
+
+            logger.LogInformation("Disabling {OrganizationCount} organizations for provider {ProviderId}",
+                providerOrganizations.Count, providerId);
+
+            var semaphore = new SemaphoreSlim(MaxConcurrency, MaxConcurrency);
+            var tasks = providerOrganizations.Select(async po =>
+            {
+                if (DateTime.UtcNow.Subtract(startTime).TotalMinutes > MaxTimeoutMinutes)
+                {
+                    logger.LogWarning("Timeout reached while disabling organizations for provider {ProviderId}", providerId);
+                    return false;
+                }
+
+                await semaphore.WaitAsync();
+                try
+                {
+                    await organizationDisableCommand.DisableAsync(po.OrganizationId, expirationDate);
+                    Interlocked.Increment(ref totalProcessed);
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to disable organization {OrganizationId} for provider {ProviderId}",
+                        po.OrganizationId, providerId);
+                    Interlocked.Increment(ref totalErrors);
+                    return false;
+                }
+                finally
+                {
+                    semaphore.Release();
+                }
+            });
+
+            await Task.WhenAll(tasks);
+
+            logger.LogInformation("Completed disabling organizations for provider {ProviderId}. Processed: {TotalProcessed}, Errors: {TotalErrors}",
+                providerId, totalProcessed, totalErrors);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error disabling organizations for provider {ProviderId}. Processed: {TotalProcessed}, Errors: {TotalErrors}",
+                providerId, totalProcessed, totalErrors);
+            throw;
+        }
+    }
+}

--- a/test/Billing.Test/Jobs/ProviderOrganizationDisableJobTests.cs
+++ b/test/Billing.Test/Jobs/ProviderOrganizationDisableJobTests.cs
@@ -1,0 +1,234 @@
+﻿using Bit.Billing.Jobs;
+using Bit.Core.AdminConsole.Models.Data.Provider;
+using Bit.Core.AdminConsole.OrganizationFeatures.Organizations.Interfaces;
+using Bit.Core.AdminConsole.Repositories;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Quartz;
+using Xunit;
+
+namespace Bit.Billing.Test.Jobs;
+
+public class ProviderOrganizationDisableJobTests
+{
+    private readonly IProviderOrganizationRepository _providerOrganizationRepository;
+    private readonly IOrganizationDisableCommand _organizationDisableCommand;
+    private readonly ILogger<ProviderOrganizationDisableJob> _logger;
+    private readonly ProviderOrganizationDisableJob _sut;
+
+    public ProviderOrganizationDisableJobTests()
+    {
+        _providerOrganizationRepository = Substitute.For<IProviderOrganizationRepository>();
+        _organizationDisableCommand = Substitute.For<IOrganizationDisableCommand>();
+        _logger = Substitute.For<ILogger<ProviderOrganizationDisableJob>>();
+        _sut = new ProviderOrganizationDisableJob(
+            _providerOrganizationRepository,
+            _organizationDisableCommand,
+            _logger);
+    }
+
+    [Fact]
+    public async Task Execute_NoOrganizations_LogsAndReturns()
+    {
+        // Arrange
+        var providerId = Guid.NewGuid();
+        var context = CreateJobExecutionContext(providerId, DateTime.UtcNow);
+        _providerOrganizationRepository.GetManyDetailsByProviderAsync(providerId)
+            .Returns((ICollection<ProviderOrganizationOrganizationDetails>)null);
+
+        // Act
+        await _sut.Execute(context);
+
+        // Assert
+        await _organizationDisableCommand.DidNotReceiveWithAnyArgs().DisableAsync(default, default);
+    }
+
+    [Fact]
+    public async Task Execute_WithOrganizations_DisablesAllOrganizations()
+    {
+        // Arrange
+        var providerId = Guid.NewGuid();
+        var expirationDate = DateTime.UtcNow.AddDays(30);
+        var org1Id = Guid.NewGuid();
+        var org2Id = Guid.NewGuid();
+        var org3Id = Guid.NewGuid();
+
+        var organizations = new List<ProviderOrganizationOrganizationDetails>
+        {
+            new() { OrganizationId = org1Id },
+            new() { OrganizationId = org2Id },
+            new() { OrganizationId = org3Id }
+        };
+
+        var context = CreateJobExecutionContext(providerId, expirationDate);
+        _providerOrganizationRepository.GetManyDetailsByProviderAsync(providerId)
+            .Returns(organizations);
+
+        // Act
+        await _sut.Execute(context);
+
+        // Assert
+        await _organizationDisableCommand.Received(1).DisableAsync(org1Id, Arg.Any<DateTime?>());
+        await _organizationDisableCommand.Received(1).DisableAsync(org2Id, Arg.Any<DateTime?>());
+        await _organizationDisableCommand.Received(1).DisableAsync(org3Id, Arg.Any<DateTime?>());
+    }
+
+    [Fact]
+    public async Task Execute_WithExpirationDate_PassesDateToDisableCommand()
+    {
+        // Arrange
+        var providerId = Guid.NewGuid();
+        var expirationDate = new DateTime(2025, 12, 31, 23, 59, 59);
+        var orgId = Guid.NewGuid();
+
+        var organizations = new List<ProviderOrganizationOrganizationDetails>
+        {
+            new() { OrganizationId = orgId }
+        };
+
+        var context = CreateJobExecutionContext(providerId, expirationDate);
+        _providerOrganizationRepository.GetManyDetailsByProviderAsync(providerId)
+            .Returns(organizations);
+
+        // Act
+        await _sut.Execute(context);
+
+        // Assert
+        await _organizationDisableCommand.Received(1).DisableAsync(orgId, expirationDate);
+    }
+
+    [Fact]
+    public async Task Execute_WithNullExpirationDate_PassesNullToDisableCommand()
+    {
+        // Arrange
+        var providerId = Guid.NewGuid();
+        var orgId = Guid.NewGuid();
+
+        var organizations = new List<ProviderOrganizationOrganizationDetails>
+        {
+            new() { OrganizationId = orgId }
+        };
+
+        var context = CreateJobExecutionContext(providerId, null);
+        _providerOrganizationRepository.GetManyDetailsByProviderAsync(providerId)
+            .Returns(organizations);
+
+        // Act
+        await _sut.Execute(context);
+
+        // Assert
+        await _organizationDisableCommand.Received(1).DisableAsync(orgId, null);
+    }
+
+    [Fact]
+    public async Task Execute_OneOrganizationFails_ContinuesProcessingOthers()
+    {
+        // Arrange
+        var providerId = Guid.NewGuid();
+        var expirationDate = DateTime.UtcNow.AddDays(30);
+        var org1Id = Guid.NewGuid();
+        var org2Id = Guid.NewGuid();
+        var org3Id = Guid.NewGuid();
+
+        var organizations = new List<ProviderOrganizationOrganizationDetails>
+        {
+            new() { OrganizationId = org1Id },
+            new() { OrganizationId = org2Id },
+            new() { OrganizationId = org3Id }
+        };
+
+        var context = CreateJobExecutionContext(providerId, expirationDate);
+        _providerOrganizationRepository.GetManyDetailsByProviderAsync(providerId)
+            .Returns(organizations);
+
+        // Make org2 fail
+        _organizationDisableCommand.DisableAsync(org2Id, Arg.Any<DateTime?>())
+            .Throws(new Exception("Database error"));
+
+        // Act
+        await _sut.Execute(context);
+
+        // Assert - all three should be attempted
+        await _organizationDisableCommand.Received(1).DisableAsync(org1Id, Arg.Any<DateTime?>());
+        await _organizationDisableCommand.Received(1).DisableAsync(org2Id, Arg.Any<DateTime?>());
+        await _organizationDisableCommand.Received(1).DisableAsync(org3Id, Arg.Any<DateTime?>());
+    }
+
+    [Fact]
+    public async Task Execute_ManyOrganizations_ProcessesWithLimitedConcurrency()
+    {
+        // Arrange
+        var providerId = Guid.NewGuid();
+        var expirationDate = DateTime.UtcNow.AddDays(30);
+
+        // Create 20 organizations
+        var organizations = Enumerable.Range(1, 20)
+            .Select(_ => new ProviderOrganizationOrganizationDetails { OrganizationId = Guid.NewGuid() })
+            .ToList();
+
+        var context = CreateJobExecutionContext(providerId, expirationDate);
+        _providerOrganizationRepository.GetManyDetailsByProviderAsync(providerId)
+            .Returns(organizations);
+
+        var concurrentCalls = 0;
+        var maxConcurrentCalls = 0;
+        var lockObj = new object();
+
+        _organizationDisableCommand.DisableAsync(Arg.Any<Guid>(), Arg.Any<DateTime?>())
+            .Returns(callInfo =>
+            {
+                lock (lockObj)
+                {
+                    concurrentCalls++;
+                    if (concurrentCalls > maxConcurrentCalls)
+                    {
+                        maxConcurrentCalls = concurrentCalls;
+                    }
+                }
+
+                return Task.Delay(50).ContinueWith(_ =>
+                {
+                    lock (lockObj)
+                    {
+                        concurrentCalls--;
+                    }
+                });
+            });
+
+        // Act
+        await _sut.Execute(context);
+
+        // Assert
+        Assert.True(maxConcurrentCalls <= 5, $"Expected max concurrency of 5, but got {maxConcurrentCalls}");
+        await _organizationDisableCommand.Received(20).DisableAsync(Arg.Any<Guid>(), Arg.Any<DateTime?>());
+    }
+
+    [Fact]
+    public async Task Execute_EmptyOrganizationsList_DoesNotCallDisableCommand()
+    {
+        // Arrange
+        var providerId = Guid.NewGuid();
+        var context = CreateJobExecutionContext(providerId, DateTime.UtcNow);
+        _providerOrganizationRepository.GetManyDetailsByProviderAsync(providerId)
+            .Returns(new List<ProviderOrganizationOrganizationDetails>());
+
+        // Act
+        await _sut.Execute(context);
+
+        // Assert
+        await _organizationDisableCommand.DidNotReceiveWithAnyArgs().DisableAsync(default, default);
+    }
+
+    private static IJobExecutionContext CreateJobExecutionContext(Guid providerId, DateTime? expirationDate)
+    {
+        var context = Substitute.For<IJobExecutionContext>();
+        var jobDataMap = new JobDataMap
+        {
+            { "providerId", providerId.ToString() },
+            { "expirationDate", expirationDate?.ToString("O") }
+        };
+        context.MergedJobDataMap.Returns(jobDataMap);
+        return context;
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-26194

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix the bug where Provider Portals and their associated client organizations are not automatically disabled when a Provider subscription is cancelled in Stripe.

 **Problem Statement**

  When a support agent cancels an MSP Provider subscription via the Stripe dashboard:
  - ❌ Provider Portal remains enabled (expected: disabled)
  - ❌ All client organizations remain enabled (expected: disabled)

**Root Cause**
 The SubscriptionDeletedHandler (which processes the customer.subscription.deleted Stripe webhook) only implemented logic for Organizations and Users, but completely ignored Providers.

🛠️ **Solution**
  Added provider handling logic to SubscriptionDeletedHandler to:
  1. ✅ Disable the Provider Portal (provider.Enabled = false)
  2. ✅ Disable all client organizations associated with that provider
  3. ✅ Set appropriate expiration dates (subscription.CurrentPeriodEnd)
  
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/9ad10cbc-d073-42ef-ad9b-8d28539e7194


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
