### PR TITLE
Fix HubHelpers field references causing build error

### DIFF
--- a/src/Notifications/HubHelpers.cs
+++ b/src/Notifications/HubHelpers.cs
@@ -162,14 +162,24 @@ public class HubHelpers
                 var organizationBankAccountVerifiedNotification =
                     JsonSerializer.Deserialize<PushNotificationData<OrganizationBankAccountVerifiedPushNotification>>(
                         notificationJson, _deserializerOptions);
-                await hubContext.Clients.Group(NotificationsHub.GetOrganizationGroup(organizationBankAccountVerifiedNotification.Payload.OrganizationId))
+                if (organizationBankAccountVerifiedNotification is null)
+                {
+                    break;
+                }
+
+                await _hubContext.Clients.Group(NotificationsHub.GetOrganizationGroup(organizationBankAccountVerifiedNotification.Payload.OrganizationId))
                     .SendAsync(_receiveMessageMethod, organizationBankAccountVerifiedNotification, cancellationToken);
                 break;
             case PushType.ProviderBankAccountVerified:
                 var providerBankAccountVerifiedNotification =
                     JsonSerializer.Deserialize<PushNotificationData<ProviderBankAccountVerifiedPushNotification>>(
                         notificationJson, _deserializerOptions);
-                await hubContext.Clients.User(providerBankAccountVerifiedNotification.Payload.AdminId.ToString())
+                if (providerBankAccountVerifiedNotification is null)
+                {
+                    break;
+                }
+
+                await _hubContext.Clients.User(providerBankAccountVerifiedNotification.Payload.AdminId.ToString())
                     .SendAsync(_receiveMessageMethod, providerBankAccountVerifiedNotification, cancellationToken);
                 break;
             case PushType.Notification:
@@ -222,7 +232,7 @@ public class HubHelpers
                     .SendAsync(_receiveMessageMethod, pendingTasksData, cancellationToken);
                 break;
             default:
-                logger.LogWarning("Notification type '{NotificationType}' has not been registered in HubHelpers and will not be pushed as as result", notification.Type);
+                _logger.LogWarning("Notification type '{NotificationType}' has not been registered in HubHelpers and will not be pushed as as result", notification.Type);
                 break;
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix compilation errors in `HubHelpers.cs` caused by a semantic merge conflict between PR #6126 (which refactored HubHelpers to use instance fields) and PR #6263 (which added BankAccount notification cases using the old static method parameter names).

The merge resulted in three variable naming errors:
- Lines 165 & 172: `hubContext` should be `_hubContext`
- Line 225: `logger` should be `_logger`

This PR corrects the field references and adds null checks following the pattern used throughout the rest of the file.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
