### PR TITLE
[PM-26925] Complete security tasks when deleting

### DIFF
--- a/src/Core/Vault/Repositories/ISecurityTaskRepository.cs
+++ b/src/Core/Vault/Repositories/ISecurityTaskRepository.cs
@@ -35,4 +35,10 @@ public interface ISecurityTaskRepository : IRepository<SecurityTask, Guid>
     /// <param name="organizationId">The id of the organization</param>
     /// <returns>A collection of security task metrics</returns>
     Task<SecurityTaskMetrics> GetTaskMetricsAsync(Guid organizationId);
+
+    /// <summary>
+    /// Marks all tasks associated with the respective ciphers as complete.
+    /// </summary>
+    /// <param name="cipherIds">Collection of cipher IDs</param>
+    Task MarkAsCompleteByCipherIds(IEnumerable<Guid> cipherIds);
 }

--- a/src/Infrastructure.Dapper/Vault/Repositories/SecurityTaskRepository.cs
+++ b/src/Infrastructure.Dapper/Vault/Repositories/SecurityTaskRepository.cs
@@ -85,4 +85,19 @@ public class SecurityTaskRepository : Repository<SecurityTask, Guid>, ISecurityT
 
         return tasksList;
     }
+
+    /// <inheritdoc />
+    public async Task MarkAsCompleteByCipherIds(IEnumerable<Guid> cipherIds)
+    {
+        if (!cipherIds.Any())
+        {
+            return;
+        }
+
+        await using var connection = new SqlConnection(ConnectionString);
+        await connection.ExecuteAsync(
+            $"[{Schema}].[SecurityTask_MarkCompleteByCipherIds]",
+            new { CipherIds = cipherIds.ToGuidIdArrayTVP() },
+            commandType: CommandType.StoredProcedure);
+    }
 }

--- a/src/Sql/dbo/Vault/Stored Procedures/SecurityTask/SecurityTask_MarkCompleteByCipherIds.sql
+++ b/src/Sql/dbo/Vault/Stored Procedures/SecurityTask/SecurityTask_MarkCompleteByCipherIds.sql
@@ -1,0 +1,15 @@
+CREATE PROCEDURE [dbo].[SecurityTask_MarkCompleteByCipherIds]
+    @CipherIds AS [dbo].[GuidIdArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    UPDATE
+        [dbo].[SecurityTask]
+    SET
+        [Status] = 1, -- completed
+        [RevisionDate] = SYSUTCDATETIME()
+    WHERE
+        [CipherId] IN (SELECT [Id] FROM @CipherIds)
+        AND [Status] <> 1 -- Not already completed
+END

--- a/test/Infrastructure.IntegrationTest/Vault/Repositories/SecurityTaskRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/Vault/Repositories/SecurityTaskRepositoryTests.cs
@@ -345,4 +345,110 @@ public class SecurityTaskRepositoryTests
         Assert.Equal(0, metrics.CompletedTasks);
         Assert.Equal(0, metrics.TotalTasks);
     }
+
+    [DatabaseTheory, DatabaseData]
+    public async Task MarkAsCompleteByCipherIds_MarksPendingTasksAsCompleted(
+        IOrganizationRepository organizationRepository,
+        ICipherRepository cipherRepository,
+        ISecurityTaskRepository securityTaskRepository)
+    {
+        var organization = await organizationRepository.CreateAsync(new Organization
+        {
+            Name = "Test Org",
+            PlanType = PlanType.EnterpriseAnnually,
+            Plan = "Test Plan",
+            BillingEmail = "billing@email.com"
+        });
+
+        var cipher1 = await cipherRepository.CreateAsync(new Cipher
+        {
+            Type = CipherType.Login,
+            OrganizationId = organization.Id,
+            Data = "",
+        });
+
+        var cipher2 = await cipherRepository.CreateAsync(new Cipher
+        {
+            Type = CipherType.Login,
+            OrganizationId = organization.Id,
+            Data = "",
+        });
+
+        var task1 = await securityTaskRepository.CreateAsync(new SecurityTask
+        {
+            OrganizationId = organization.Id,
+            CipherId = cipher1.Id,
+            Status = SecurityTaskStatus.Pending,
+            Type = SecurityTaskType.UpdateAtRiskCredential,
+        });
+
+        var task2 = await securityTaskRepository.CreateAsync(new SecurityTask
+        {
+            OrganizationId = organization.Id,
+            CipherId = cipher2.Id,
+            Status = SecurityTaskStatus.Pending,
+            Type = SecurityTaskType.UpdateAtRiskCredential,
+        });
+
+        await securityTaskRepository.MarkAsCompleteByCipherIds([cipher1.Id, cipher2.Id]);
+
+        var updatedTask1 = await securityTaskRepository.GetByIdAsync(task1.Id);
+        var updatedTask2 = await securityTaskRepository.GetByIdAsync(task2.Id);
+
+        Assert.Equal(SecurityTaskStatus.Completed, updatedTask1.Status);
+        Assert.Equal(SecurityTaskStatus.Completed, updatedTask2.Status);
+    }
+
+    [DatabaseTheory, DatabaseData]
+    public async Task MarkAsCompleteByCipherIds_OnlyUpdatesSpecifiedCiphers(
+        IOrganizationRepository organizationRepository,
+        ICipherRepository cipherRepository,
+        ISecurityTaskRepository securityTaskRepository)
+    {
+        var organization = await organizationRepository.CreateAsync(new Organization
+        {
+            Name = "Test Org",
+            PlanType = PlanType.EnterpriseAnnually,
+            Plan = "Test Plan",
+            BillingEmail = "billing@email.com"
+        });
+
+        var cipher1 = await cipherRepository.CreateAsync(new Cipher
+        {
+            Type = CipherType.Login,
+            OrganizationId = organization.Id,
+            Data = "",
+        });
+
+        var cipher2 = await cipherRepository.CreateAsync(new Cipher
+        {
+            Type = CipherType.Login,
+            OrganizationId = organization.Id,
+            Data = "",
+        });
+
+        var taskToUpdate = await securityTaskRepository.CreateAsync(new SecurityTask
+        {
+            OrganizationId = organization.Id,
+            CipherId = cipher1.Id,
+            Status = SecurityTaskStatus.Pending,
+            Type = SecurityTaskType.UpdateAtRiskCredential,
+        });
+
+        var taskToKeep = await securityTaskRepository.CreateAsync(new SecurityTask
+        {
+            OrganizationId = organization.Id,
+            CipherId = cipher2.Id,
+            Status = SecurityTaskStatus.Pending,
+            Type = SecurityTaskType.UpdateAtRiskCredential,
+        });
+
+        await securityTaskRepository.MarkAsCompleteByCipherIds([cipher1.Id]);
+
+        var updatedTask = await securityTaskRepository.GetByIdAsync(taskToUpdate.Id);
+        var unchangedTask = await securityTaskRepository.GetByIdAsync(taskToKeep.Id);
+
+        Assert.Equal(SecurityTaskStatus.Completed, updatedTask.Status);
+        Assert.Equal(SecurityTaskStatus.Pending, unchangedTask.Status);
+    }
 }

--- a/util/Migrator/DbScripts/2025-10-23_00_CompleteSecurityTaskByCipherIds.sql
+++ b/util/Migrator/DbScripts/2025-10-23_00_CompleteSecurityTaskByCipherIds.sql
@@ -1,0 +1,15 @@
+CREATE OR ALTER PROCEDURE [dbo].[SecurityTask_MarkCompleteByCipherIds]
+    @CipherIds AS [dbo].[GuidIdArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    UPDATE
+        [dbo].[SecurityTask]
+    SET
+        [Status] = 1, -- Completed
+        [RevisionDate] = SYSUTCDATETIME()
+    WHERE
+        [CipherId] IN (SELECT [Id] FROM @CipherIds)
+        AND [Status] <> 1 -- Not already completed
+END


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26925](https://bitwarden.atlassian.net/browse/PM-26925)

## 📔 Objective

When a cipher is soft deleted and has associated security tasks, they should be marked as completed. 

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/9bb7d2a5-bf34-4776-94f7-ce07d9a0edb7" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26925]: https://bitwarden.atlassian.net/browse/PM-26925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ