### PR TITLE
[PM-27382] [Offline Editing] Add core infrastructure for offline-safe edits and version history

### DIFF
--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -249,7 +249,7 @@ public class CiphersController : Controller
     }
 
     [HttpPut("{id}")]
-    public async Task<CipherResponseModel> Put(Guid id, [FromBody] CipherRequestModel model)
+    public async Task<ActionResult<CipherResponseModel>> Put(Guid id, [FromBody] CipherRequestModel model)
     {
         var user = await _userService.GetUserByPrincipalAsync(User);
         var cipher = await GetByIdAsync(id, user.Id);
@@ -279,25 +279,32 @@ public class CiphersController : Controller
                 "then try again.");
         }
 
-        await _cipherService.SaveDetailsAsync(model.ToCipherDetails(cipher), user.Id, model.LastKnownRevisionDate, collectionIds);
+        try
+        {
+            await _cipherService.SaveDetailsAsync(model.ToCipherDetails(cipher), user.Id, model.LastKnownRevisionDate, collectionIds);
 
-        var response = new CipherResponseModel(
-            cipher,
-            user,
-            await _applicationCacheService.GetOrganizationAbilitiesAsync(),
-            _globalSettings);
-        return response;
+            var response = new CipherResponseModel(
+                cipher,
+                user,
+                await _applicationCacheService.GetOrganizationAbilitiesAsync(),
+                _globalSettings);
+            return Ok(response);
+        }
+        catch (SyncConflictException ex)
+        {
+            return await BuildConflictResponseAsync(ex, user);
+        }
     }
 
     [HttpPost("{id}")]
     [Obsolete("This endpoint is deprecated. Use PUT method instead.")]
-    public async Task<CipherResponseModel> PostPut(Guid id, [FromBody] CipherRequestModel model)
+    public Task<ActionResult<CipherResponseModel>> PostPut(Guid id, [FromBody] CipherRequestModel model)
     {
-        return await Put(id, model);
+        return Put(id, model);
     }
 
     [HttpPut("{id}/admin")]
-    public async Task<CipherMiniResponseModel> PutAdmin(Guid id, [FromBody] CipherRequestModel model)
+    public async Task<ActionResult<CipherMiniResponseModel>> PutAdmin(Guid id, [FromBody] CipherRequestModel model)
     {
         var userId = _userService.GetProperUserId(User).Value;
         var cipher = await _cipherRepository.GetOrganizationDetailsByIdAsync(id);
@@ -323,17 +330,24 @@ public class CiphersController : Controller
         var collectionIds = (await _collectionCipherRepository.GetManyByUserIdCipherIdAsync(userId, id)).Select(c => c.CollectionId).ToList();
         // object cannot be a descendant of CipherDetails, so let's clone it.
         var cipherClone = model.ToCipher(cipher).Clone();
-        await _cipherService.SaveAsync(cipherClone, userId, model.LastKnownRevisionDate, collectionIds, true, false);
+        try
+        {
+            await _cipherService.SaveAsync(cipherClone, userId, model.LastKnownRevisionDate, collectionIds, true, false);
 
-        var response = new CipherMiniResponseModel(cipherClone, _globalSettings, cipher.OrganizationUseTotp);
-        return response;
+            var response = new CipherMiniResponseModel(cipherClone, _globalSettings, cipher.OrganizationUseTotp);
+            return Ok(response);
+        }
+        catch (SyncConflictException ex)
+        {
+            return await BuildAdminConflictResponseAsync(ex);
+        }
     }
 
     [HttpPost("{id}/admin")]
     [Obsolete("This endpoint is deprecated. Use PUT method instead.")]
-    public async Task<CipherMiniResponseModel> PostPutAdmin(Guid id, [FromBody] CipherRequestModel model)
+    public Task<ActionResult<CipherMiniResponseModel>> PostPutAdmin(Guid id, [FromBody] CipherRequestModel model)
     {
-        return await PutAdmin(id, model);
+        return PutAdmin(id, model);
     }
 
     [HttpGet("organization-details")]
@@ -712,30 +726,37 @@ public class CiphersController : Controller
     }
 
     [HttpPut("{id}/partial")]
-    public async Task<CipherResponseModel> PutPartial(Guid id, [FromBody] CipherPartialRequestModel model)
+    public async Task<ActionResult<CipherResponseModel>> PutPartial(Guid id, [FromBody] CipherPartialRequestModel model)
     {
         var user = await _userService.GetUserByPrincipalAsync(User);
         var folderId = string.IsNullOrWhiteSpace(model.FolderId) ? null : (Guid?)new Guid(model.FolderId);
-        await _cipherRepository.UpdatePartialAsync(id, user.Id, folderId, model.Favorite);
+        try
+        {
+            await _cipherRepository.UpdatePartialAsync(id, user.Id, folderId, model.Favorite);
 
-        var cipher = await GetByIdAsync(id, user.Id);
-        var response = new CipherResponseModel(
-            cipher,
-            user,
-            await _applicationCacheService.GetOrganizationAbilitiesAsync(),
-            _globalSettings);
-        return response;
+            var cipher = await GetByIdAsync(id, user.Id);
+            var response = new CipherResponseModel(
+                cipher,
+                user,
+                await _applicationCacheService.GetOrganizationAbilitiesAsync(),
+                _globalSettings);
+            return Ok(response);
+        }
+        catch (SyncConflictException ex)
+        {
+            return await BuildConflictResponseAsync(ex, user);
+        }
     }
 
     [HttpPost("{id}/partial")]
     [Obsolete("This endpoint is deprecated. Use PUT method instead.")]
-    public async Task<CipherResponseModel> PostPartial(Guid id, [FromBody] CipherPartialRequestModel model)
+    public Task<ActionResult<CipherResponseModel>> PostPartial(Guid id, [FromBody] CipherPartialRequestModel model)
     {
-        return await PutPartial(id, model);
+        return PutPartial(id, model);
     }
 
     [HttpPut("{id}/share")]
-    public async Task<CipherResponseModel> PutShare(Guid id, [FromBody] CipherShareRequestModel model)
+    public async Task<ActionResult<CipherResponseModel>> PutShare(Guid id, [FromBody] CipherShareRequestModel model)
     {
         var user = await _userService.GetUserByPrincipalAsync(User);
         var cipher = await _cipherRepository.GetByIdAsync(id);
@@ -763,23 +784,30 @@ public class CiphersController : Controller
         ValidateClientVersionForFido2CredentialSupport(cipher);
 
         var original = cipher.Clone();
-        await _cipherService.ShareAsync(original, model.Cipher.ToCipher(cipher), new Guid(model.Cipher.OrganizationId),
-            model.CollectionIds.Select(c => new Guid(c)), user.Id, model.Cipher.LastKnownRevisionDate);
+        try
+        {
+            await _cipherService.ShareAsync(original, model.Cipher.ToCipher(cipher), new Guid(model.Cipher.OrganizationId),
+                model.CollectionIds.Select(c => new Guid(c)), user.Id, model.Cipher.LastKnownRevisionDate);
 
-        var sharedCipher = await GetByIdAsync(id, user.Id);
-        var response = new CipherResponseModel(
-            sharedCipher,
-            user,
-            await _applicationCacheService.GetOrganizationAbilitiesAsync(),
-            _globalSettings);
-        return response;
+            var sharedCipher = await GetByIdAsync(id, user.Id);
+            var response = new CipherResponseModel(
+                sharedCipher,
+                user,
+                await _applicationCacheService.GetOrganizationAbilitiesAsync(),
+                _globalSettings);
+            return Ok(response);
+        }
+        catch (SyncConflictException ex)
+        {
+            return await BuildConflictResponseAsync(ex, user);
+        }
     }
 
     [HttpPost("{id}/share")]
     [Obsolete("This endpoint is deprecated. Use PUT method instead.")]
-    public async Task<CipherResponseModel> PostShare(Guid id, [FromBody] CipherShareRequestModel model)
+    public Task<ActionResult<CipherResponseModel>> PostShare(Guid id, [FromBody] CipherShareRequestModel model)
     {
-        return await PutShare(id, model);
+        return PutShare(id, model);
     }
 
     [HttpPut("{id}/collections")]
@@ -1640,6 +1668,37 @@ public class CiphersController : Controller
     private async Task<CipherDetails> GetByIdAsync(Guid cipherId, Guid userId)
     {
         return await _cipherRepository.GetByIdAsync(cipherId, userId);
+    }
+
+    private async Task<ActionResult<CipherResponseModel>> BuildConflictResponseAsync(SyncConflictException exception, User user)
+    {
+        var serverCipher = await _cipherRepository.GetByIdAsync(exception.ServerCipher.Id, user.Id);
+        if (serverCipher == null)
+        {
+            return Conflict();
+        }
+
+        var conflictResponse = new CipherResponseModel(
+            serverCipher,
+            user,
+            await _applicationCacheService.GetOrganizationAbilitiesAsync(),
+            _globalSettings);
+        return Conflict(conflictResponse);
+    }
+
+    private async Task<ActionResult<CipherMiniResponseModel>> BuildAdminConflictResponseAsync(SyncConflictException exception)
+    {
+        var serverCipher = await _cipherRepository.GetOrganizationDetailsByIdAsync(exception.ServerCipher.Id);
+        if (serverCipher == null)
+        {
+            return Conflict();
+        }
+
+        var response = new CipherMiniResponseModel(
+            serverCipher,
+            _globalSettings,
+            serverCipher.OrganizationUseTotp);
+        return Conflict(response);
     }
 
     private DateTime? GetLastKnownRevisionDateFromForm()

--- a/src/Api/Vault/Models/Response/CipherHistoryResponseModel.cs
+++ b/src/Api/Vault/Models/Response/CipherHistoryResponseModel.cs
@@ -1,0 +1,55 @@
+﻿// FIXME: Update this file to be null safe and then delete the line below
+#nullable disable
+
+using System;
+using Bit.Core.Models.Api;
+using Bit.Core.Vault.Entities;
+using Bit.Core.Vault.Enums;
+
+namespace Bit.Api.Vault.Models.Response;
+
+public class CipherHistoryResponseModel : ResponseModel
+{
+    public CipherHistoryResponseModel(CipherHistory history, string obj = "cipherHistory")
+        : base(obj)
+    {
+        if (history == null)
+        {
+            throw new ArgumentNullException(nameof(history));
+        }
+
+        Id = history.Id;
+        CipherId = history.CipherId;
+        UserId = history.UserId;
+        OrganizationId = history.OrganizationId;
+        Type = history.Type;
+        Data = history.Data;
+        Favorites = history.Favorites;
+        Folders = history.Folders;
+        Attachments = history.Attachments;
+        CreationDate = history.CreationDate;
+        RevisionDate = history.RevisionDate;
+        DeletedDate = history.DeletedDate;
+        Reprompt = history.Reprompt;
+        Key = history.Key;
+        ArchivedDate = history.ArchivedDate;
+        HistoryDate = history.HistoryDate;
+    }
+
+    public Guid Id { get; set; }
+    public Guid CipherId { get; set; }
+    public Guid? UserId { get; set; }
+    public Guid? OrganizationId { get; set; }
+    public CipherType Type { get; set; }
+    public string Data { get; set; }
+    public string Favorites { get; set; }
+    public string Folders { get; set; }
+    public string Attachments { get; set; }
+    public DateTime CreationDate { get; set; }
+    public DateTime RevisionDate { get; set; }
+    public DateTime? DeletedDate { get; set; }
+    public CipherRepromptType? Reprompt { get; set; }
+    public string Key { get; set; }
+    public DateTime? ArchivedDate { get; set; }
+    public DateTime HistoryDate { get; set; }
+}

--- a/src/Core/Exceptions/SyncConflictException.cs
+++ b/src/Core/Exceptions/SyncConflictException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Bit.Core.Vault.Entities;
+
+namespace Bit.Core.Exceptions;
+
+public class SyncConflictException : ConflictException
+{
+    public SyncConflictException(Cipher serverCipher)
+        : base("The cipher you are updating is out of date. Please save your work, sync your vault, and try again.")
+    {
+        ServerCipher = serverCipher ?? throw new ArgumentNullException(nameof(serverCipher));
+    }
+
+    public Cipher ServerCipher { get; }
+}

--- a/src/Core/Vault/Entities/CipherHistory.cs
+++ b/src/Core/Vault/Entities/CipherHistory.cs
@@ -1,0 +1,33 @@
+﻿// FIXME: Update this file to be null safe and then delete the line below
+#nullable disable
+
+using Bit.Core.Entities;
+using Bit.Core.Utilities;
+using Bit.Core.Vault.Enums;
+
+namespace Bit.Core.Vault.Entities;
+
+public class CipherHistory : ITableObject<Guid>
+{
+    public Guid Id { get; set; }
+    public Guid CipherId { get; set; }
+    public Guid? UserId { get; set; }
+    public Guid? OrganizationId { get; set; }
+    public CipherType Type { get; set; }
+    public string Data { get; set; }
+    public string Favorites { get; set; }
+    public string Folders { get; set; }
+    public string Attachments { get; set; }
+    public DateTime CreationDate { get; set; }
+    public DateTime RevisionDate { get; set; }
+    public DateTime? DeletedDate { get; set; }
+    public CipherRepromptType? Reprompt { get; set; }
+    public string Key { get; set; }
+    public DateTime? ArchivedDate { get; set; }
+    public DateTime HistoryDate { get; set; }
+
+    public void SetNewId()
+    {
+        Id = CoreHelpers.GenerateComb();
+    }
+}

--- a/src/Core/Vault/Repositories/ICipherHistoryRepository.cs
+++ b/src/Core/Vault/Repositories/ICipherHistoryRepository.cs
@@ -1,8 +1,10 @@
-﻿using Bit.Core.Repositories;
+﻿using System.Collections.Generic;
+using Bit.Core.Repositories;
 using Bit.Core.Vault.Entities;
 
 namespace Bit.Core.Vault.Repositories;
 
 public interface ICipherHistoryRepository : IRepository<CipherHistory, Guid>
 {
+    Task<ICollection<CipherHistory>> GetManyByCipherIdAsync(Guid cipherId);
 }

--- a/src/Core/Vault/Repositories/ICipherHistoryRepository.cs
+++ b/src/Core/Vault/Repositories/ICipherHistoryRepository.cs
@@ -1,0 +1,8 @@
+﻿using Bit.Core.Repositories;
+using Bit.Core.Vault.Entities;
+
+namespace Bit.Core.Vault.Repositories;
+
+public interface ICipherHistoryRepository : IRepository<CipherHistory, Guid>
+{
+}

--- a/src/Core/Vault/Services/ICipherService.cs
+++ b/src/Core/Vault/Services/ICipherService.cs
@@ -38,4 +38,5 @@ public interface ICipherService
     Task<AttachmentResponseData> GetAttachmentDownloadDataAsync(Cipher cipher, string attachmentId);
     Task<bool> ValidateCipherAttachmentFile(Cipher cipher, CipherAttachment.MetaData attachmentData);
     Task ValidateBulkCollectionAssignmentAsync(IEnumerable<Guid> collectionIds, IEnumerable<Guid> cipherIds, Guid userId);
+    Task<CipherDetails> RestoreFromHistoryAsync(CipherDetails cipher, CipherHistory history, Guid restoringUserId);
 }

--- a/src/Infrastructure.Dapper/DapperServiceCollectionExtensions.cs
+++ b/src/Infrastructure.Dapper/DapperServiceCollectionExtensions.cs
@@ -33,6 +33,7 @@ public static class DapperServiceCollectionExtensions
         services.AddSingleton<IApiKeyRepository, ApiKeyRepository>();
         services.AddSingleton<IAuthRequestRepository, AuthRequestRepository>();
         services.AddSingleton<ICipherRepository, CipherRepository>();
+        services.AddSingleton<ICipherHistoryRepository, CipherHistoryRepository>();
         services.AddSingleton<ICollectionCipherRepository, CollectionCipherRepository>();
         services.AddSingleton<ICollectionRepository, CollectionRepository>();
         services.AddSingleton<IDeviceRepository, DeviceRepository>();

--- a/src/Infrastructure.Dapper/Vault/Repositories/CipherHistoryRepository.cs
+++ b/src/Infrastructure.Dapper/Vault/Repositories/CipherHistoryRepository.cs
@@ -1,10 +1,15 @@
 ﻿// FIXME: Update this file to be null safe and then delete the line below
 #nullable disable
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Bit.Core.Settings;
 using Bit.Core.Vault.Entities;
 using Bit.Core.Vault.Repositories;
 using Bit.Infrastructure.Dapper.Repositories;
+using Dapper;
+using Microsoft.Data.SqlClient;
 
 namespace Bit.Infrastructure.Dapper.Vault.Repositories;
 
@@ -17,4 +22,26 @@ public class CipherHistoryRepository : Repository<CipherHistory, Guid>, ICipherH
     public CipherHistoryRepository(string connectionString, string readOnlyConnectionString)
         : base(connectionString, readOnlyConnectionString)
     { }
+
+    public override async Task<CipherHistory> GetByIdAsync(Guid id)
+    {
+        using (var connection = new SqlConnection(ReadOnlyConnectionString))
+        {
+            return await connection.QuerySingleOrDefaultAsync<CipherHistory>(
+                $"SELECT Id, CipherId, UserId, OrganizationId, Type, Data, Favorites, Folders, Attachments, CreationDate, RevisionDate, DeletedDate, Reprompt, [Key], ArchivedDate, HistoryDate FROM [{Schema}].[{Table}] WHERE Id = @Id",
+                new { Id = id });
+        }
+    }
+
+    public async Task<ICollection<CipherHistory>> GetManyByCipherIdAsync(Guid cipherId)
+    {
+        using (var connection = new SqlConnection(ReadOnlyConnectionString))
+        {
+            var results = await connection.QueryAsync<CipherHistory>(
+                $"SELECT Id, CipherId, UserId, OrganizationId, Type, Data, Favorites, Folders, Attachments, CreationDate, RevisionDate, DeletedDate, Reprompt, [Key], ArchivedDate, HistoryDate FROM [{Schema}].[{Table}] WHERE CipherId = @CipherId ORDER BY HistoryDate DESC",
+                new { CipherId = cipherId });
+
+            return results.ToList();
+        }
+    }
 }

--- a/src/Infrastructure.Dapper/Vault/Repositories/CipherHistoryRepository.cs
+++ b/src/Infrastructure.Dapper/Vault/Repositories/CipherHistoryRepository.cs
@@ -1,0 +1,20 @@
+﻿// FIXME: Update this file to be null safe and then delete the line below
+#nullable disable
+
+using Bit.Core.Settings;
+using Bit.Core.Vault.Entities;
+using Bit.Core.Vault.Repositories;
+using Bit.Infrastructure.Dapper.Repositories;
+
+namespace Bit.Infrastructure.Dapper.Vault.Repositories;
+
+public class CipherHistoryRepository : Repository<CipherHistory, Guid>, ICipherHistoryRepository
+{
+    public CipherHistoryRepository(GlobalSettings globalSettings)
+        : this(globalSettings.SqlServer.ConnectionString, globalSettings.SqlServer.ReadOnlyConnectionString)
+    { }
+
+    public CipherHistoryRepository(string connectionString, string readOnlyConnectionString)
+        : base(connectionString, readOnlyConnectionString)
+    { }
+}

--- a/src/Infrastructure.EntityFramework/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/Infrastructure.EntityFramework/EntityFrameworkServiceCollectionExtensions.cs
@@ -72,6 +72,7 @@ public static class EntityFrameworkServiceCollectionExtensions
         services.AddSingleton<IApiKeyRepository, ApiKeyRepository>();
         services.AddSingleton<IAuthRequestRepository, AuthRequestRepository>();
         services.AddSingleton<ICipherRepository, CipherRepository>();
+        services.AddSingleton<ICipherHistoryRepository, CipherHistoryRepository>();
         services.AddSingleton<ICollectionCipherRepository, CollectionCipherRepository>();
         services.AddSingleton<ICollectionRepository, CollectionRepository>();
         services.AddSingleton<IDeviceRepository, DeviceRepository>();

--- a/src/Infrastructure.EntityFramework/Repositories/DatabaseContext.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/DatabaseContext.cs
@@ -41,6 +41,7 @@ public class DatabaseContext : DbContext
     public DbSet<ApiKey> ApiKeys { get; set; }
     public DbSet<Cache> Cache { get; set; }
     public DbSet<Cipher> Ciphers { get; set; }
+    public DbSet<CipherHistory> CipherHistories { get; set; }
     public DbSet<Collection> Collections { get; set; }
     public DbSet<CollectionCipher> CollectionCiphers { get; set; }
     public DbSet<CollectionGroup> CollectionGroups { get; set; }
@@ -100,6 +101,7 @@ public class DatabaseContext : DbContext
         // Going forward use `IEntityTypeConfiguration` in the Configurations folder for managing
         // Entity Framework code first database configurations.
         var eCipher = builder.Entity<Cipher>();
+        var eCipherHistory = builder.Entity<CipherHistory>();
         var eCollection = builder.Entity<Collection>();
         var eCollectionCipher = builder.Entity<CollectionCipher>();
         var eCollectionUser = builder.Entity<CollectionUser>();
@@ -124,6 +126,7 @@ public class DatabaseContext : DbContext
         // Shadow property configurations go here
 
         eCipher.Property(c => c.Id).ValueGeneratedNever();
+        eCipherHistory.Property(c => c.Id).ValueGeneratedNever();
         eCollection.Property(c => c.Id).ValueGeneratedNever();
         eEmergencyAccess.Property(c => c.Id).ValueGeneratedNever();
         eFolder.Property(c => c.Id).ValueGeneratedNever();
@@ -162,6 +165,7 @@ public class DatabaseContext : DbContext
         }
 
         eCipher.ToTable(nameof(Cipher));
+        eCipherHistory.ToTable(nameof(CipherHistory));
         eCollection.ToTable(nameof(Collection));
         eCollectionCipher.ToTable(nameof(CollectionCipher));
         eEmergencyAccess.ToTable(nameof(EmergencyAccess));

--- a/src/Infrastructure.EntityFramework/Vault/Models/CipherHistory.cs
+++ b/src/Infrastructure.EntityFramework/Vault/Models/CipherHistory.cs
@@ -1,0 +1,19 @@
+﻿// FIXME: Update this file to be null safe and then delete the line below
+#nullable disable
+
+using AutoMapper;
+
+namespace Bit.Infrastructure.EntityFramework.Vault.Models;
+
+public class CipherHistory : Core.Vault.Entities.CipherHistory
+{
+    public virtual Cipher Cipher { get; set; }
+}
+
+public class CipherHistoryMapperProfile : Profile
+{
+    public CipherHistoryMapperProfile()
+    {
+        CreateMap<Core.Vault.Entities.CipherHistory, CipherHistory>().ReverseMap();
+    }
+}

--- a/src/Infrastructure.EntityFramework/Vault/Repositories/CipherHistoryRepository.cs
+++ b/src/Infrastructure.EntityFramework/Vault/Repositories/CipherHistoryRepository.cs
@@ -1,0 +1,17 @@
+﻿// FIXME: Update this file to be null safe and then delete the line below
+#nullable disable
+
+using AutoMapper;
+using Bit.Core.Vault.Repositories;
+using Bit.Infrastructure.EntityFramework.Repositories;
+using Bit.Infrastructure.EntityFramework.Vault.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bit.Infrastructure.EntityFramework.Vault.Repositories;
+
+public class CipherHistoryRepository : Repository<Core.Vault.Entities.CipherHistory, CipherHistory, Guid>, ICipherHistoryRepository
+{
+    public CipherHistoryRepository(IServiceScopeFactory serviceScopeFactory, IMapper mapper)
+        : base(serviceScopeFactory, mapper, (DatabaseContext context) => context.CipherHistories)
+    { }
+}

--- a/src/Infrastructure.EntityFramework/Vault/Repositories/CipherHistoryRepository.cs
+++ b/src/Infrastructure.EntityFramework/Vault/Repositories/CipherHistoryRepository.cs
@@ -1,11 +1,16 @@
 ﻿// FIXME: Update this file to be null safe and then delete the line below
 #nullable disable
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using AutoMapper;
 using Bit.Core.Vault.Repositories;
 using Bit.Infrastructure.EntityFramework.Repositories;
 using Bit.Infrastructure.EntityFramework.Vault.Models;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
 
 namespace Bit.Infrastructure.EntityFramework.Vault.Repositories;
 
@@ -14,4 +19,18 @@ public class CipherHistoryRepository : Repository<Core.Vault.Entities.CipherHist
     public CipherHistoryRepository(IServiceScopeFactory serviceScopeFactory, IMapper mapper)
         : base(serviceScopeFactory, mapper, (DatabaseContext context) => context.CipherHistories)
     { }
+
+    public async Task<ICollection<Core.Vault.Entities.CipherHistory>> GetManyByCipherIdAsync(Guid cipherId)
+    {
+        using (var scope = ServiceScopeFactory.CreateScope())
+        {
+            var dbContext = GetDatabaseContext(scope);
+            var entities = await GetDbSet(dbContext)
+                .Where(history => history.CipherId == cipherId)
+                .OrderByDescending(history => history.HistoryDate)
+                .ToListAsync();
+
+            return Mapper.Map<ICollection<Core.Vault.Entities.CipherHistory>>(entities);
+        }
+    }
 }

--- a/src/Sql/dbo/Vault/Tables/CipherHistory.sql
+++ b/src/Sql/dbo/Vault/Tables/CipherHistory.sql
@@ -1,0 +1,26 @@
+CREATE TABLE [dbo].[CipherHistory] (
+    [Id]             UNIQUEIDENTIFIER NOT NULL,
+    [CipherId]       UNIQUEIDENTIFIER NOT NULL,
+    [UserId]         UNIQUEIDENTIFIER NULL,
+    [OrganizationId] UNIQUEIDENTIFIER NULL,
+    [Type]           TINYINT          NOT NULL,
+    [Data]           NVARCHAR (MAX)   NOT NULL,
+    [Favorites]      NVARCHAR (MAX)   NULL,
+    [Folders]        NVARCHAR (MAX)   NULL,
+    [Attachments]    NVARCHAR (MAX)   NULL,
+    [CreationDate]   DATETIME2 (7)    NOT NULL,
+    [RevisionDate]   DATETIME2 (7)    NOT NULL,
+    [DeletedDate]    DATETIME2 (7)    NULL,
+    [Reprompt]       TINYINT          NULL,
+    [Key]            VARCHAR (MAX)    NULL,
+    [ArchivedDate]   DATETIME2 (7)    NULL,
+    [HistoryDate]    DATETIME2 (7)    NOT NULL,
+    CONSTRAINT [PK_CipherHistory] PRIMARY KEY CLUSTERED ([Id] ASC),
+    CONSTRAINT [FK_CipherHistory_Cipher] FOREIGN KEY ([CipherId]) REFERENCES [dbo].[Cipher] ([Id]) ON DELETE CASCADE
+);
+
+GO
+CREATE NONCLUSTERED INDEX [IX_CipherHistory_CipherId]
+    ON [dbo].[CipherHistory]([CipherId] ASC);
+
+GO

--- a/test/Api.Test/Vault/Controllers/CiphersControllerTests.cs
+++ b/test/Api.Test/Vault/Controllers/CiphersControllerTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Security.Claims;
+﻿using System.Collections.Generic;
+using System.Security.Claims;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Bit.Api.Auth.Models.Request.Accounts;
 using Bit.Api.Vault.Controllers;
 using Bit.Api.Vault.Models;
@@ -16,6 +18,7 @@ using Bit.Core.Vault.Entities;
 using Bit.Core.Vault.Models.Data;
 using Bit.Core.Vault.Repositories;
 using Bit.Core.Vault.Services;
+using Microsoft.AspNetCore.Mvc;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
@@ -54,8 +57,247 @@ public class CiphersControllerTests
 
         var result = await sutProvider.Sut.PutPartial(cipherId, new CipherPartialRequestModel { Favorite = isFavorite, FolderId = folderId.ToString() });
 
-        Assert.Equal(folderId, result.FolderId);
-        Assert.Equal(isFavorite, result.Favorite);
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<CipherResponseModel>(okResult.Value);
+        Assert.Equal(folderId, response.FolderId);
+        Assert.Equal(isFavorite, response.Favorite);
+    }
+
+    [Theory, BitAutoData]
+    public async Task PutShare_WhenSyncConflictOccurs_ReturnsConflictResponse(
+        User user,
+        Cipher cipher,
+        CipherDetails serverCipher,
+        SutProvider<CiphersController> sutProvider)
+    {
+        var cipherId = Guid.NewGuid();
+        var organizationId = Guid.NewGuid();
+        cipher.Id = cipherId;
+        cipher.UserId = user.Id;
+        cipher.OrganizationId = null;
+        cipher.Type = CipherType.SecureNote;
+        cipher.Data = "{}";
+        cipher.RevisionDate = DateTime.UtcNow;
+        cipher.ArchivedDate = null;
+
+        serverCipher.Id = cipherId;
+        serverCipher.UserId = user.Id;
+        serverCipher.OrganizationId = organizationId;
+        serverCipher.Type = CipherType.SecureNote;
+        serverCipher.Data = "{\"source\":\"server\"}";
+        serverCipher.ArchivedDate = null;
+
+        var model = new CipherShareRequestModel
+        {
+            Cipher = new CipherRequestModel
+            {
+                Type = CipherType.SecureNote,
+                Data = "{}",
+                OrganizationId = organizationId.ToString(),
+                LastKnownRevisionDate = cipher.RevisionDate
+            },
+            CollectionIds = new[] { Guid.NewGuid().ToString() }
+        };
+
+        sutProvider.GetDependency<IUserService>()
+            .GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>())
+            .Returns(user);
+
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetByIdAsync(cipherId)
+            .Returns(cipher);
+
+        sutProvider.GetDependency<ICurrentContext>()
+            .OrganizationUser(organizationId)
+            .Returns(true);
+
+        sutProvider.GetDependency<ICipherService>()
+            .ShareAsync(Arg.Any<Cipher>(), Arg.Any<Cipher>(), organizationId, Arg.Any<IEnumerable<Guid>>(), user.Id, model.Cipher.LastKnownRevisionDate)
+            .Returns(Task.FromException(new SyncConflictException(new Cipher { Id = cipherId })));
+
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetByIdAsync(cipherId, user.Id)
+            .Returns(serverCipher);
+
+        sutProvider.GetDependency<IApplicationCacheService>()
+            .GetOrganizationAbilitiesAsync()
+            .Returns(new Dictionary<Guid, OrganizationAbility>
+            {
+                { organizationId, new OrganizationAbility { Id = organizationId } }
+            });
+
+        var result = await sutProvider.Sut.PutShare(cipherId, model);
+
+        var conflict = Assert.IsType<ConflictObjectResult>(result.Result);
+        var response = Assert.IsType<CipherResponseModel>(conflict.Value);
+        Assert.Equal(serverCipher.Id, response.Id);
+        Assert.Equal(serverCipher.Data, response.Data);
+    }
+
+    [Theory, BitAutoData]
+    public async Task PutPartial_WhenSyncConflictOccurs_ReturnsConflictResponse(
+        User user,
+        Guid folderId,
+        CipherDetails serverCipher,
+        SutProvider<CiphersController> sutProvider)
+    {
+        var cipherId = Guid.NewGuid();
+        serverCipher.Id = cipherId;
+        serverCipher.UserId = user.Id;
+        serverCipher.OrganizationId = null;
+        serverCipher.Type = CipherType.SecureNote;
+        serverCipher.Data = "{\"source\":\"server\"}";
+
+        sutProvider.GetDependency<IUserService>()
+            .GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>())
+            .Returns(user);
+
+        sutProvider.GetDependency<ICipherRepository>()
+            .UpdatePartialAsync(cipherId, user.Id, (Guid?)folderId, true)
+            .Returns(Task.FromException(new SyncConflictException(new Cipher { Id = cipherId })));
+
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetByIdAsync(cipherId, user.Id)
+            .Returns(serverCipher);
+
+        sutProvider.GetDependency<IApplicationCacheService>()
+            .GetOrganizationAbilitiesAsync()
+            .Returns(new Dictionary<Guid, OrganizationAbility>());
+
+        var result = await sutProvider.Sut.PutPartial(cipherId, new CipherPartialRequestModel { Favorite = true, FolderId = folderId.ToString() });
+
+        var conflict = Assert.IsType<ConflictObjectResult>(result.Result);
+        var response = Assert.IsType<CipherResponseModel>(conflict.Value);
+        Assert.Equal(serverCipher.Id, response.Id);
+    }
+
+    [Theory, BitAutoData]
+    public async Task PutAdmin_WhenSyncConflictOccurs_ReturnsConflictResponse(
+        Guid userId,
+        CurrentContextOrganization organization,
+        CipherOrganizationDetails existingCipher,
+        CipherOrganizationDetails serverCipher,
+        SutProvider<CiphersController> sutProvider)
+    {
+        var cipherId = Guid.NewGuid();
+        var organizationId = Guid.NewGuid();
+        organization.Id = organizationId;
+        organization.Type = OrganizationUserType.Admin;
+
+        existingCipher.Id = cipherId;
+        existingCipher.OrganizationId = organizationId;
+        existingCipher.Type = CipherType.SecureNote;
+        existingCipher.Data = "{}";
+        existingCipher.RevisionDate = DateTime.UtcNow;
+
+        serverCipher.Id = cipherId;
+        serverCipher.OrganizationId = organizationId;
+        serverCipher.Type = CipherType.SecureNote;
+        serverCipher.Data = "{\"source\":\"server\"}";
+        serverCipher.RevisionDate = existingCipher.RevisionDate.AddSeconds(5);
+
+        var model = new CipherRequestModel
+        {
+            Type = CipherType.SecureNote,
+            Data = "{}",
+            OrganizationId = organizationId.ToString(),
+            LastKnownRevisionDate = existingCipher.RevisionDate
+        };
+
+        sutProvider.GetDependency<IUserService>()
+            .GetProperUserId(Arg.Any<ClaimsPrincipal>())
+            .Returns(userId);
+
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetOrganizationDetailsByIdAsync(cipherId)
+            .Returns(existingCipher, serverCipher);
+
+        sutProvider.GetDependency<ICurrentContext>()
+            .GetOrganization(organizationId)
+            .Returns(organization);
+
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetManyByOrganizationIdAsync(organizationId)
+            .Returns(new List<Cipher> { existingCipher });
+
+        sutProvider.GetDependency<IApplicationCacheService>()
+            .GetOrganizationAbilityAsync(organizationId)
+            .Returns(new OrganizationAbility
+            {
+                Id = organizationId,
+                AllowAdminAccessToAllCollectionItems = true
+            });
+
+        sutProvider.GetDependency<ICollectionCipherRepository>()
+            .GetManyByUserIdCipherIdAsync(userId, cipherId)
+            .Returns(new List<CollectionCipher>());
+
+        sutProvider.GetDependency<ICipherService>()
+            .SaveAsync(Arg.Any<Cipher>(), userId, model.LastKnownRevisionDate, Arg.Any<IEnumerable<Guid>>(), true, false)
+            .Returns(Task.FromException(new SyncConflictException(new Cipher { Id = cipherId })));
+
+        var result = await sutProvider.Sut.PutAdmin(cipherId, model);
+
+        var conflict = Assert.IsType<ConflictObjectResult>(result.Result);
+        var response = Assert.IsType<CipherMiniResponseModel>(conflict.Value);
+        Assert.Equal(serverCipher.Id, response.Id);
+        Assert.Equal(serverCipher.Data, response.Data);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Put_WhenSyncConflictOccurs_ReturnsConflictResponse(
+        User user,
+        CipherDetails clientCipher,
+        CipherDetails serverCipher,
+        SutProvider<CiphersController> sutProvider)
+    {
+        var cipherId = Guid.NewGuid();
+        clientCipher.Id = cipherId;
+        clientCipher.UserId = user.Id;
+        clientCipher.OrganizationId = null;
+        clientCipher.Type = CipherType.SecureNote;
+        clientCipher.Data = "{}";
+        clientCipher.RevisionDate = DateTime.UtcNow;
+        serverCipher.Id = cipherId;
+        serverCipher.UserId = user.Id;
+        serverCipher.OrganizationId = null;
+        serverCipher.Type = CipherType.SecureNote;
+        serverCipher.Data = "{\"source\":\"server\"}";
+        serverCipher.RevisionDate = clientCipher.RevisionDate.AddSeconds(5);
+
+        var model = new CipherRequestModel
+        {
+            Type = CipherType.SecureNote,
+            Data = "{}",
+            LastKnownRevisionDate = clientCipher.RevisionDate
+        };
+
+        sutProvider.GetDependency<IUserService>()
+            .GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>())
+            .Returns(user);
+
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetByIdAsync(cipherId, user.Id)
+            .Returns(clientCipher, serverCipher);
+
+        sutProvider.GetDependency<ICollectionCipherRepository>()
+            .GetManyByUserIdCipherIdAsync(user.Id, cipherId)
+            .Returns(new List<CollectionCipher>());
+
+        sutProvider.GetDependency<IApplicationCacheService>()
+            .GetOrganizationAbilitiesAsync()
+            .Returns(new Dictionary<Guid, OrganizationAbility>());
+
+        sutProvider.GetDependency<ICipherService>()
+            .SaveDetailsAsync(Arg.Any<CipherDetails>(), user.Id, model.LastKnownRevisionDate, Arg.Any<IEnumerable<Guid>>())
+            .Returns(Task.FromException(new SyncConflictException(new Cipher { Id = cipherId })));
+
+        var result = await sutProvider.Sut.Put(cipherId, model);
+
+        var conflict = Assert.IsType<ConflictObjectResult>(result.Result);
+        var response = Assert.IsType<CipherResponseModel>(conflict.Value);
+        Assert.Equal(serverCipher.Id, response.Id);
+        Assert.Equal(serverCipher.Data, response.Data);
     }
 
     [Theory, BitAutoData]

--- a/test/Core.Test/Vault/Services/CipherServiceTests.cs
+++ b/test/Core.Test/Vault/Services/CipherServiceTests.cs
@@ -35,10 +35,20 @@ public class CipherServiceTests
     [Theory, BitAutoData]
     public async Task SaveAsync_WrongRevisionDate_Throws(SutProvider<CipherService> sutProvider, Cipher cipher)
     {
+        cipher.Id = cipher.Id == Guid.Empty ? Guid.NewGuid() : cipher.Id;
+        cipher.UserId ??= Guid.NewGuid();
+
+        var existingCipher = cipher.Clone();
         var lastKnownRevisionDate = cipher.RevisionDate.AddDays(-1);
 
-        var exception = await Assert.ThrowsAsync<BadRequestException>(
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetByIdAsync(cipher.Id)
+            .Returns(existingCipher);
+
+        var exception = await Assert.ThrowsAsync<SyncConflictException>(
             () => sutProvider.Sut.SaveAsync(cipher, cipher.UserId.Value, lastKnownRevisionDate));
+
+        Assert.Equal(existingCipher.Id, exception.ServerCipher.Id);
         Assert.Contains("out of date", exception.Message);
     }
 
@@ -46,10 +56,35 @@ public class CipherServiceTests
     public async Task SaveDetailsAsync_WrongRevisionDate_Throws(SutProvider<CipherService> sutProvider,
         CipherDetails cipherDetails)
     {
+        cipherDetails.Id = cipherDetails.Id == Guid.Empty ? Guid.NewGuid() : cipherDetails.Id;
+        cipherDetails.UserId ??= Guid.NewGuid();
+
+        var existingCipher = new Cipher
+        {
+            Id = cipherDetails.Id,
+            UserId = cipherDetails.UserId,
+            OrganizationId = cipherDetails.OrganizationId,
+            RevisionDate = cipherDetails.RevisionDate,
+            CreationDate = cipherDetails.CreationDate,
+            Data = cipherDetails.Data,
+            Favorites = cipherDetails.Favorites,
+            Folders = cipherDetails.Folders,
+            Attachments = cipherDetails.Attachments,
+            Type = cipherDetails.Type,
+            Key = cipherDetails.Key,
+            Reprompt = cipherDetails.Reprompt,
+            ArchivedDate = cipherDetails.ArchivedDate,
+            DeletedDate = cipherDetails.DeletedDate
+        };
         var lastKnownRevisionDate = cipherDetails.RevisionDate.AddDays(-1);
 
-        var exception = await Assert.ThrowsAsync<BadRequestException>(
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetByIdAsync(cipherDetails.Id)
+            .Returns(existingCipher);
+
+        var exception = await Assert.ThrowsAsync<SyncConflictException>(
             () => sutProvider.Sut.SaveDetailsAsync(cipherDetails, cipherDetails.UserId.Value, lastKnownRevisionDate));
+        Assert.Equal(existingCipher.Id, exception.ServerCipher.Id);
         Assert.Contains("out of date", exception.Message);
     }
 
@@ -65,7 +100,7 @@ public class CipherServiceTests
             [Guid.NewGuid().ToString()] = new CipherAttachment.MetaData { }
         });
 
-        var exception = await Assert.ThrowsAsync<BadRequestException>(
+        var exception = await Assert.ThrowsAsync<SyncConflictException>(
             () => sutProvider.Sut.ShareAsync(cipher, cipher, organization.Id, collectionIds, cipher.UserId.Value,
             lastKnownRevisionDate));
         Assert.Contains("out of date", exception.Message);
@@ -84,7 +119,7 @@ public class CipherServiceTests
 
         var cipherInfos = ciphers.Select(c => (c, (DateTime?)c.RevisionDate.AddDays(-1)));
 
-        var exception = await Assert.ThrowsAsync<BadRequestException>(
+        var exception = await Assert.ThrowsAsync<SyncConflictException>(
             () => sutProvider.Sut.ShareManyAsync(cipherInfos, organizationId, collectionIds, ciphers.First().UserId.Value));
         Assert.Contains("out of date", exception.Message);
     }
@@ -96,9 +131,46 @@ public class CipherServiceTests
         SutProvider<CipherService> sutProvider, Cipher cipher)
     {
         var lastKnownRevisionDate = string.IsNullOrEmpty(revisionDateString) ? (DateTime?)null : cipher.RevisionDate;
+        cipher.Id = cipher.Id == Guid.Empty ? Guid.NewGuid() : cipher.Id;
+        cipher.UserId ??= Guid.NewGuid();
+
+        var existingCipher = cipher.Clone();
+
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetByIdAsync(cipher.Id)
+            .Returns(existingCipher);
 
         await sutProvider.Sut.SaveAsync(cipher, cipher.UserId.Value, lastKnownRevisionDate);
         await sutProvider.GetDependency<ICipherRepository>().Received(1).ReplaceAsync(cipher);
+    }
+
+    [Theory, BitAutoData]
+    public async Task SaveAsync_Update_CreatesHistorySnapshot(
+        SutProvider<CipherService> sutProvider,
+        Cipher cipher)
+    {
+        cipher.Id = cipher.Id == Guid.Empty ? Guid.NewGuid() : cipher.Id;
+        cipher.UserId ??= Guid.NewGuid();
+        cipher.Data = "{\"name\":\"local\"}";
+        var lastKnownRevisionDate = cipher.RevisionDate;
+
+        var existingCipher = cipher.Clone();
+        existingCipher.Data = "{\"name\":\"server\"}";
+
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetByIdAsync(cipher.Id)
+            .Returns(existingCipher);
+        sutProvider.GetDependency<ICipherRepository>()
+            .ReplaceAsync(cipher)
+            .Returns(Task.CompletedTask);
+
+        await sutProvider.Sut.SaveAsync(cipher, cipher.UserId.Value, lastKnownRevisionDate);
+
+        await sutProvider.GetDependency<ICipherHistoryRepository>().Received(1)
+            .CreateAsync(Arg.Is<CipherHistory>(h =>
+                h.CipherId == existingCipher.Id &&
+                h.Data == existingCipher.Data &&
+                h.UserId == existingCipher.UserId));
     }
 
     [Theory]
@@ -108,9 +180,78 @@ public class CipherServiceTests
         SutProvider<CipherService> sutProvider, CipherDetails cipherDetails)
     {
         var lastKnownRevisionDate = string.IsNullOrEmpty(revisionDateString) ? (DateTime?)null : cipherDetails.RevisionDate;
+        cipherDetails.Id = cipherDetails.Id == Guid.Empty ? Guid.NewGuid() : cipherDetails.Id;
+        cipherDetails.UserId ??= Guid.NewGuid();
+        cipherDetails.OrganizationId = null;
+
+        var existingCipher = new Cipher
+        {
+            Id = cipherDetails.Id,
+            UserId = cipherDetails.UserId,
+            OrganizationId = cipherDetails.OrganizationId,
+            RevisionDate = cipherDetails.RevisionDate,
+            CreationDate = cipherDetails.CreationDate,
+            Data = cipherDetails.Data,
+            Favorites = cipherDetails.Favorites,
+            Folders = cipherDetails.Folders,
+            Attachments = cipherDetails.Attachments,
+            Type = cipherDetails.Type,
+            Key = cipherDetails.Key,
+            Reprompt = cipherDetails.Reprompt,
+            ArchivedDate = cipherDetails.ArchivedDate,
+            DeletedDate = cipherDetails.DeletedDate
+        };
+
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetByIdAsync(cipherDetails.Id)
+            .Returns(existingCipher);
 
         await sutProvider.Sut.SaveDetailsAsync(cipherDetails, cipherDetails.UserId.Value, lastKnownRevisionDate);
         await sutProvider.GetDependency<ICipherRepository>().Received(1).ReplaceAsync(cipherDetails);
+    }
+
+    [Theory, BitAutoData]
+    public async Task SaveDetailsAsync_Update_CreatesHistorySnapshot(
+        SutProvider<CipherService> sutProvider,
+        CipherDetails cipherDetails)
+    {
+        cipherDetails.Id = cipherDetails.Id == Guid.Empty ? Guid.NewGuid() : cipherDetails.Id;
+        cipherDetails.UserId ??= Guid.NewGuid();
+        cipherDetails.OrganizationId = null;
+        cipherDetails.Data = "{\"name\":\"local\"}";
+        var lastKnownRevisionDate = cipherDetails.RevisionDate;
+
+        var existingCipher = new Cipher
+        {
+            Id = cipherDetails.Id,
+            UserId = cipherDetails.UserId,
+            OrganizationId = cipherDetails.OrganizationId,
+            RevisionDate = cipherDetails.RevisionDate,
+            CreationDate = cipherDetails.CreationDate,
+            Data = "{\"name\":\"server\"}",
+            Favorites = cipherDetails.Favorites,
+            Folders = cipherDetails.Folders,
+            Attachments = cipherDetails.Attachments,
+            Type = cipherDetails.Type,
+            Key = cipherDetails.Key,
+            Reprompt = cipherDetails.Reprompt,
+            ArchivedDate = cipherDetails.ArchivedDate,
+            DeletedDate = cipherDetails.DeletedDate
+        };
+
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetByIdAsync(cipherDetails.Id)
+            .Returns(existingCipher);
+        sutProvider.GetDependency<ICipherRepository>()
+            .ReplaceAsync(cipherDetails)
+            .Returns(Task.CompletedTask);
+
+        await sutProvider.Sut.SaveDetailsAsync(cipherDetails, cipherDetails.UserId.Value, lastKnownRevisionDate);
+
+        await sutProvider.GetDependency<ICipherHistoryRepository>().Received(1)
+            .CreateAsync(Arg.Is<CipherHistory>(h =>
+                h.CipherId == existingCipher.Id &&
+                h.Data == existingCipher.Data));
     }
 
     [Theory, BitAutoData]
@@ -121,7 +262,7 @@ public class CipherServiceTests
         var fileName = "test.txt";
         var key = "test-key";
 
-        var exception = await Assert.ThrowsAsync<BadRequestException>(
+        var exception = await Assert.ThrowsAsync<SyncConflictException>(
             () => sutProvider.Sut.CreateAttachmentAsync(cipher, stream, fileName, key, 100, savingUserId, false, lastKnownRevisionDate));
         Assert.Contains("out of date", exception.Message);
     }
@@ -181,7 +322,7 @@ public class CipherServiceTests
         var fileName = "test.txt";
         var fileSize = 100L;
 
-        var exception = await Assert.ThrowsAsync<BadRequestException>(
+        var exception = await Assert.ThrowsAsync<SyncConflictException>(
             () => sutProvider.Sut.CreateAttachmentForDelayedUploadAsync(cipher, key, fileName, fileSize, false, savingUserId, lastKnownRevisionDate));
         Assert.Contains("out of date", exception.Message);
     }
@@ -239,7 +380,7 @@ public class CipherServiceTests
             Key = "test-key"
         };
 
-        var exception = await Assert.ThrowsAsync<BadRequestException>(
+        var exception = await Assert.ThrowsAsync<SyncConflictException>(
             () => sutProvider.Sut.UploadFileForExistingAttachmentAsync(stream, cipher, attachment, lastKnownRevisionDate));
         Assert.Contains("out of date", exception.Message);
     }
@@ -295,7 +436,7 @@ public class CipherServiceTests
         var key = "test-key";
         var attachmentId = "attachment-id";
 
-        var exception = await Assert.ThrowsAsync<BadRequestException>(
+        var exception = await Assert.ThrowsAsync<SyncConflictException>(
             () => sutProvider.Sut.CreateAttachmentShareAsync(cipher, stream, fileName, key, 100, attachmentId, organizationId, lastKnownRevisionDate));
         Assert.Contains("out of date", exception.Message);
     }

--- a/util/Migrator/DbScripts/2025-10-26_00_AddCipherHistory.sql
+++ b/util/Migrator/DbScripts/2025-10-26_00_AddCipherHistory.sql
@@ -1,0 +1,131 @@
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.tables
+    WHERE name = 'CipherHistory'
+      AND schema_id = SCHEMA_ID('dbo')
+)
+BEGIN
+    CREATE TABLE [dbo].[CipherHistory] (
+        [Id]             UNIQUEIDENTIFIER NOT NULL,
+        [CipherId]       UNIQUEIDENTIFIER NOT NULL,
+        [UserId]         UNIQUEIDENTIFIER NULL,
+        [OrganizationId] UNIQUEIDENTIFIER NULL,
+        [Type]           TINYINT          NOT NULL,
+        [Data]           NVARCHAR (MAX)   NOT NULL,
+        [Favorites]      NVARCHAR (MAX)   NULL,
+        [Folders]        NVARCHAR (MAX)   NULL,
+        [Attachments]    NVARCHAR (MAX)   NULL,
+        [CreationDate]   DATETIME2 (7)    NOT NULL,
+        [RevisionDate]   DATETIME2 (7)    NOT NULL,
+        [DeletedDate]    DATETIME2 (7)    NULL,
+        [Reprompt]       TINYINT          NULL,
+        [Key]            VARCHAR (MAX)    NULL,
+        [ArchivedDate]   DATETIME2 (7)    NULL,
+        [HistoryDate]    DATETIME2 (7)    NOT NULL,
+        CONSTRAINT [PK_CipherHistory] PRIMARY KEY CLUSTERED ([Id] ASC)
+    );
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.foreign_keys
+    WHERE name = 'FK_CipherHistory_Cipher'
+)
+BEGIN
+    ALTER TABLE [dbo].[CipherHistory]
+    ADD CONSTRAINT [FK_CipherHistory_Cipher]
+        FOREIGN KEY ([CipherId])
+        REFERENCES [dbo].[Cipher] ([Id])
+        ON DELETE CASCADE;
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CipherHistory_CipherId'
+      AND object_id = OBJECT_ID('[dbo].[CipherHistory]')
+)
+BEGIN
+    CREATE NONCLUSTERED INDEX [IX_CipherHistory_CipherId]
+        ON [dbo].[CipherHistory]([CipherId] ASC);
+END
+GO
+
+IF OBJECT_ID('[dbo].[CipherHistory_Create]') IS NOT NULL
+BEGIN
+    DROP PROCEDURE [dbo].[CipherHistory_Create];
+END
+GO
+
+CREATE PROCEDURE [dbo].[CipherHistory_Create]
+    @Id UNIQUEIDENTIFIER OUTPUT,
+    @CipherId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @Type TINYINT,
+    @Data NVARCHAR(MAX),
+    @Favorites NVARCHAR(MAX),
+    @Folders NVARCHAR(MAX),
+    @Attachments NVARCHAR(MAX),
+    @CreationDate DATETIME2(7),
+    @RevisionDate DATETIME2(7),
+    @DeletedDate DATETIME2(7),
+    @Reprompt TINYINT,
+    @Key VARCHAR(MAX),
+    @ArchivedDate DATETIME2(7),
+    @HistoryDate DATETIME2(7)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    IF @Id IS NULL
+    BEGIN
+        SET @Id = NEWID();
+    END
+
+    INSERT INTO [dbo].[CipherHistory]
+    (
+        [Id],
+        [CipherId],
+        [UserId],
+        [OrganizationId],
+        [Type],
+        [Data],
+        [Favorites],
+        [Folders],
+        [Attachments],
+        [CreationDate],
+        [RevisionDate],
+        [DeletedDate],
+        [Reprompt],
+        [Key],
+        [ArchivedDate],
+        [HistoryDate]
+    )
+    VALUES
+    (
+        @Id,
+        @CipherId,
+        @UserId,
+        @OrganizationId,
+        @Type,
+        @Data,
+        @Favorites,
+        @Folders,
+        @Attachments,
+        @CreationDate,
+        @RevisionDate,
+        @DeletedDate,
+        @Reprompt,
+        @Key,
+        @ArchivedDate,
+        @HistoryDate
+    );
+END
+GO


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27382

## 📔 Objective

This PR is the first step of adding **Offline Editing** capabilities to Bitwarden, which is one of the highest requested features by the community: 
[https://community.bitwarden.com/t/offline-editing-management-of-writeable-vault-items/107](https://community.bitwarden.com/t/offline-editing-management-of-writeable-vault-items/107)

This work implements the foundation for conflict detection, conflict-safe sync, and item history/restore.

### High-level goal

Enable Bitwarden clients to safely sync edits made offline or concurrently on multiple devices **without losing data**, while keeping full end-to-end encryption and zero-knowledge guarantees.

This PR introduces:
* A conflict-aware sync model based on **Last-Write-Wins (LWW)** semantics for the canonical version, plus encrypted history snapshots of every successful server-side edit for safety and auditability.
* Client-driven conflict resolution that never exposes plaintext to the server.
* APIs that let clients view and restore historical versions of an item.

This is the enabling infrastructure for Offline Editing. It is intentionally easy to implement for all clients (mobile, desktop, browser). 

Clients only need to:
- Detect sync conflicts (HTTP 409),
- Store both versions locally,
- Decide which version to keep or to merge them
- Surface item history for restore.

It is also backwards compatible: Existing clients that do not support conflict resolution continue to function.

### Behavioral summary

#### General behaviour

1. Every cipher update now snapshots the previous state into encrypted history.
2. If two devices modify the same item independently (classic offline edit case), a sync conflict is detected.
3. The server responds with HTTP 409 (Conflict) and returns the server’s current cipher.
4. The client then:
   * Preserves both its local edit and the remote/server version on the device.
   * Decides which version should become canonical. E.g. merge fields or just selects one.
   * Uploads that selected version as the new canonical item, using the latest `RevisionDate`.
5. The server automatically stores the previous canonical state in history on each successful write. Client versions that never become canonical are not persisted automatically.

#### Proposed client behavior 

Several client behaviors are supported with this PR. However, the following one is the one I think is the best from a UX and technical perspective.

**Proposed behavior for clients:**

1. Client A creates cipher C and syncs it to server.
2. Client B syncs with server and downloads cipher C
3. Client A and B now have same version of cipher C (version 0) on local device
4. Client A and Client B go offline
5. Client A edits cipher C while being offline - it's now `cipher C (version A)` (version with client A edits).
6. Client B edits cipher C while being offline - it's now `cipher C (version B)` (version with client B edits).
7. Client A comes online and syncs cipher C (version A) to server. 
8. Server does not detect any sync conflict. Server stores cipher C (version 0) to history and makes cipher C (version A) canonical. 
9. Client B comes online and tries to sync cipher C (version B).
10. The server responds to Client B with HTTP 409 (Conflict) and returns the server’s current cipher C (version A).
11. Client B decides own version of cipher C (version B) should become canonical (*Client always decides it's own version becomes canonical: last-write-wins!*)
12. Client B loads the server copy from the 409 response, apply the local edits onto it to form the new payload [replace cipher C (version A) with cipher C (version B)], set its LastKnownRevisionDate to cipher (version A)’s revision, then sync.
13. The server automatically stores the previous canonical state cipher C (version A) in history and set's clients version cipher C (version B) as *canonical*.

This approach:
* Does not need any user interaction - so sync is always automatic
* Ensures all versions are always saved to history. So user *can always go back to any version of cipher at any point in time*. This ensures no data loss.
* Avoids server-side merge logic (keeps server stateless with respect to plaintext).
* Keeps sync simple and robust.
* Works with fully encrypted ciphers, because all merge/selection logic runs locally after decryption on the client.
* Guarantees that server-accepted revisions are never silently dropped — even in multi-device race conditions.

## 📸 Screenshots

*No UI changes in this PR. The new history/restore endpoints will allow future clients to present item history and conflict views, but no user-facing UI is added here.*

## Changes

## New internal logic

- Added encrypted history tracking: created the CipherHistory table/sql, entity, repositories (Dapper + EF), service registrations, and a DbUp migration (with CipherHistory_Create proc, index, FK) so every cipher update persists a snapshot.
- Updated CipherService to look up the current record, throw a new SyncConflictException when revisions diverge, log history entries before mutations (including attachment paths and admin deletes), and reuse that helper across flows.
- Implemented conflict-aware API behavior: CiphersController now wraps write endpoints to surface HTTP 409 responses with the server cipher for user and admin scenarios, plus shared helper methods.
- Registered the new repositories, exposed the history DbSet on DatabaseContext, and introduced the SyncConflictException type.

## New API endpoints

- Added `GET /ciphers/{id}/history`
- Added `POST /ciphers/{id}/history/{historyId}/restore`
- Created CipherHistoryResponseModel to serialize history snapshots.
- Implemented ICipherService.RestoreFromHistoryAsync to snapshot the current cipher, apply historical data, log, and push updates; updated interface accordingly (src/Core/Vault/Services/*).

## Data access

- Extended ICipherHistoryRepository with GetManyByCipherIdAsync and custom GetByIdAsync; added SQL-based implementations for both Dapper and EF providers to fetch histories ordered by timestamp (src/Core/Vault/Repositories/ICipherHistoryRepository.cs, src/Infrastructure.*).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
