### PR TITLE
Add template context fields for Elastic integration

### DIFF
--- a/src/Core/AdminConsole/Models/Data/EventIntegrations/IntegrationTemplateContext.cs
+++ b/src/Core/AdminConsole/Models/Data/EventIntegrations/IntegrationTemplateContext.cs
@@ -23,7 +23,17 @@ public class IntegrationTemplateContext(EventMessage eventMessage)
     public Guid? CollectionId => Event.CollectionId;
     public Guid? GroupId => Event.GroupId;
     public Guid? PolicyId => Event.PolicyId;
+    public Guid? IdempotencyId => Event.IdempotencyId;
+    public Guid? ProviderId => Event.ProviderId;
+    public Guid? ProviderUserId => Event.ProviderUserId;
+    public Guid? ProviderOrganizationId => Event.ProviderOrganizationId;
+    public Guid? InstallationId => Event.InstallationId;
+    public Guid? SecretId => Event.SecretId;
+    public Guid? ProjectId => Event.ProjectId;
+    public Guid? ServiceAccountId => Event.ServiceAccountId;
+    public Guid? GrantedServiceAccountId => Event.GrantedServiceAccountId;
 
+    public string DateIso8601 => Date.ToString("o");
     public string EventMessage => JsonSerializer.Serialize(Event);
 
     public User? User { get; set; }


### PR DESCRIPTION
## 📔 Objective

While building a POC integration to Elastic, I discovered that they want a specific timestamp date format (ISO 8601). In addition, I noticed that there were a very fields on our `EventMessage` object that I hadn't exposed on the `IntegrationTemplateContext` object. This PR adds these fields to the template context to allow them to be easily picked up in templates and specifically used as part of the Elastic integration.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
