### PR TITLE
[PM-23713] plans controller needs app authorize so desktop and browser can use

### DIFF
--- a/src/Api/Billing/Controllers/PlansController.cs
+++ b/src/Api/Billing/Controllers/PlansController.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Bit.Api.Billing.Controllers;
 
 [Route("plans")]
-[Authorize("Web")]
+[Authorize("Application")]
 public class PlansController(
     IPricingClient pricingClient) : Controller
 {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23713

## 📔 Objective

The PlansController is used from desktop and browser to fetch the premium plan for the linked ticket: interaction with premium badge. To that end, this PR updates the authorize attribute to allow requests from all apps, not just web.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
