### PR TITLE
[PM-26377] Add Auto Confirm Policy

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/IPolicyValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/IPolicyValidator.cs
@@ -9,6 +9,10 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies;
 /// <summary>
 /// Defines behavior and functionality for a given PolicyType.
 /// </summary>
+/// <remarks>
+/// All methods defined in this interface are for the PolicyService#SavePolicy method. This needs to be supported until
+/// we successfully refactor policy validators over to policy validation handlers
+/// </remarks>
 public interface IPolicyValidator
 {
     /// <summary>

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyServiceCollectionExtensions.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyServiceCollectionExtensions.cs
@@ -53,7 +53,7 @@ public static class PolicyServiceCollectionExtensions
         services.AddScoped<IPolicyUpdateEvent, FreeFamiliesForEnterprisePolicyValidator>();
         services.AddScoped<IPolicyUpdateEvent, OrganizationDataOwnershipPolicyValidator>();
         services.AddScoped<IPolicyUpdateEvent, UriMatchDefaultPolicyValidator>();
-        services.AddScoped<IPolicyUpdateEvent, AutomaticUserConfirmationPolicyValidationHandler>();
+        services.AddScoped<IPolicyUpdateEvent, AutomaticUserConfirmationPolicyEventHandler>();
     }
 
     private static void AddPolicyRequirements(this IServiceCollection services)

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyUpdateEvents/Interfaces/IEnforceDependentPoliciesEvent.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyUpdateEvents/Interfaces/IEnforceDependentPoliciesEvent.cs
@@ -2,6 +2,13 @@
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyUpdateEvents.Interfaces;
 
+/// <summary>
+/// Represents all policies required to be enabled before the given policy can be enabled.
+/// </summary>
+/// <remarks>
+/// This interface is intended for policy event handlers that mandate the activation of other policies
+/// as prerequisites for enabling the associated policy.
+/// </remarks>
 public interface IEnforceDependentPoliciesEvent : IPolicyUpdateEvent
 {
     /// <summary>

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyUpdateEvents/Interfaces/IOnPolicyPreUpdateEvent.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyUpdateEvents/Interfaces/IOnPolicyPreUpdateEvent.cs
@@ -3,6 +3,12 @@ using Bit.Core.AdminConsole.OrganizationFeatures.Policies.Models;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyUpdateEvents.Interfaces;
 
+/// <summary>
+/// Represents all side effects that should be executed before a policy is upserted.
+/// </summary>
+/// <remarks>
+/// This should be added to policy handlers that need to perform side effects before policy upserts.
+/// </remarks>
 public interface IOnPolicyPreUpdateEvent : IPolicyUpdateEvent
 {
     /// <summary>

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyUpdateEvents/Interfaces/IPolicyUpdateEvent.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyUpdateEvents/Interfaces/IPolicyUpdateEvent.cs
@@ -2,6 +2,12 @@
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyUpdateEvents.Interfaces;
 
+/// <summary>
+/// Represents the policy to be upserted.
+/// </summary>
+/// <remarks>
+/// This is used for the VNextSavePolicyCommand. All policy handlers should implement this interface.
+/// </remarks>
 public interface IPolicyUpdateEvent
 {
     /// <summary>

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyUpdateEvents/Interfaces/IPolicyValidationEvent.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyUpdateEvents/Interfaces/IPolicyValidationEvent.cs
@@ -3,12 +3,17 @@ using Bit.Core.AdminConsole.OrganizationFeatures.Policies.Models;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyUpdateEvents.Interfaces;
 
+/// <summary>
+/// Represents all validations that need to be run to enable or disable the given policy.
+/// </summary>
+/// <remarks>
+/// This is used for the VNextSavePolicyCommand. This optional but should be implemented for all policies that have
+/// certain requirements for the given organization.
+/// </remarks>
 public interface IPolicyValidationEvent : IPolicyUpdateEvent
 {
     /// <summary>
-    /// Performs side effects after a policy is validated but before it is saved.
-    /// For example, this can be used to remove non-compliant users from the organization.
-    /// Implementation is optional; by default, it will not perform any side effects.
+    /// Performs any validations required to enable or disable the policy.
     /// </summary>
     /// <param name="policyRequest">The policy save request containing the policy update and metadata</param>
     /// <param name="currentPolicy">The current policy, if any</param>

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyValidators/AutomaticUserConfirmationPolicyEventHandler.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyValidators/AutomaticUserConfirmationPolicyEventHandler.cs
@@ -9,7 +9,7 @@ using Bit.Core.Repositories;
 namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyValidators;
 
 /// <summary>
-/// Represents a validation handler for the Automatic User Confirmation policy.
+/// Represents an event handler for the Automatic User Confirmation policy.
 ///
 /// This class validates that the following conditions are met:
 /// <ul>
@@ -23,13 +23,13 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyValidators;
 ///     <li>Sets the UseAutomaticUserConfirmation organization feature to match the policy update</li>
 /// </ul>
 /// </summary>
-public class AutomaticUserConfirmationPolicyValidationHandler(
+public class AutomaticUserConfirmationPolicyEventHandler(
     IOrganizationUserRepository organizationUserRepository,
     IProviderUserRepository providerUserRepository,
     IPolicyRepository policyRepository,
     IOrganizationRepository organizationRepository,
     TimeProvider timeProvider)
-    : IPolicyValidator, IPolicyValidationEvent, IOnPolicyPreUpdateEvent
+    : IPolicyValidator, IPolicyValidationEvent, IOnPolicyPreUpdateEvent, IEnforceDependentPoliciesEvent
 {
     public PolicyType Type => PolicyType.AutomaticUserConfirmation;
     public async Task ExecutePreUpsertSideEffectAsync(SavePolicyModel policyRequest, Policy? currentPolicy) =>

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyValidators/AutomaticUserConfirmationPolicyEventHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyValidators/AutomaticUserConfirmationPolicyEventHandlerTests.cs
@@ -18,12 +18,12 @@ using Xunit;
 namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.Policies.PolicyValidators;
 
 [SutProviderCustomize]
-public class AutomaticUserConfirmationPolicyValidationHandlerTests
+public class AutomaticUserConfirmationPolicyEventHandlerTests
 {
     [Theory, BitAutoData]
     public async Task ValidateAsync_EnablingPolicy_SingleOrgNotEnabled_ReturnsError(
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation)] PolicyUpdate policyUpdate,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         sutProvider.GetDependency<IPolicyRepository>()
@@ -41,7 +41,7 @@ public class AutomaticUserConfirmationPolicyValidationHandlerTests
     public async Task ValidateAsync_EnablingPolicy_SingleOrgPolicyDisabled_ReturnsError(
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation)] PolicyUpdate policyUpdate,
         [Policy(PolicyType.SingleOrg, false)] Policy singleOrgPolicy,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         singleOrgPolicy.OrganizationId = policyUpdate.OrganizationId;
@@ -62,7 +62,7 @@ public class AutomaticUserConfirmationPolicyValidationHandlerTests
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation)] PolicyUpdate policyUpdate,
         [Policy(PolicyType.SingleOrg)] Policy singleOrgPolicy,
         Guid nonCompliantUserId,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         singleOrgPolicy.OrganizationId = policyUpdate.OrganizationId;
@@ -109,7 +109,7 @@ public class AutomaticUserConfirmationPolicyValidationHandlerTests
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation)] PolicyUpdate policyUpdate,
         [Policy(PolicyType.SingleOrg)] Policy singleOrgPolicy,
         Guid userId,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         singleOrgPolicy.OrganizationId = policyUpdate.OrganizationId;
@@ -160,7 +160,7 @@ public class AutomaticUserConfirmationPolicyValidationHandlerTests
     public async Task ValidateAsync_EnablingPolicy_ProviderUsersExist_ReturnsError(
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation)] PolicyUpdate policyUpdate,
         [Policy(PolicyType.SingleOrg)] Policy singleOrgPolicy,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         singleOrgPolicy.OrganizationId = policyUpdate.OrganizationId;
@@ -197,7 +197,7 @@ public class AutomaticUserConfirmationPolicyValidationHandlerTests
     public async Task ValidateAsync_EnablingPolicy_AllValidationsPassed_ReturnsEmptyString(
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation)] PolicyUpdate policyUpdate,
         [Policy(PolicyType.SingleOrg)] Policy singleOrgPolicy,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         singleOrgPolicy.OrganizationId = policyUpdate.OrganizationId;
@@ -239,7 +239,7 @@ public class AutomaticUserConfirmationPolicyValidationHandlerTests
     public async Task ValidateAsync_PolicyAlreadyEnabled_ReturnsEmptyString(
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation)] PolicyUpdate policyUpdate,
         [Policy(PolicyType.AutomaticUserConfirmation)] Policy currentPolicy,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         currentPolicy.OrganizationId = policyUpdate.OrganizationId;
@@ -258,7 +258,7 @@ public class AutomaticUserConfirmationPolicyValidationHandlerTests
     public async Task ValidateAsync_DisablingPolicy_ReturnsEmptyString(
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation, false)] PolicyUpdate policyUpdate,
         [Policy(PolicyType.AutomaticUserConfirmation)] Policy currentPolicy,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         currentPolicy.OrganizationId = policyUpdate.OrganizationId;
@@ -278,7 +278,7 @@ public class AutomaticUserConfirmationPolicyValidationHandlerTests
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation)] PolicyUpdate policyUpdate,
         [Policy(PolicyType.SingleOrg)] Policy singleOrgPolicy,
         Guid nonCompliantOwnerId,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         singleOrgPolicy.OrganizationId = policyUpdate.OrganizationId;
@@ -324,7 +324,7 @@ public class AutomaticUserConfirmationPolicyValidationHandlerTests
     public async Task ValidateAsync_EnablingPolicy_InvitedUsersExcluded_FromComplianceCheck(
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation)] PolicyUpdate policyUpdate,
         [Policy(PolicyType.SingleOrg)] Policy singleOrgPolicy,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         singleOrgPolicy.OrganizationId = policyUpdate.OrganizationId;
@@ -362,7 +362,7 @@ public class AutomaticUserConfirmationPolicyValidationHandlerTests
     public async Task ValidateAsync_EnablingPolicy_RevokedUsersExcluded_FromComplianceCheck(
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation)] PolicyUpdate policyUpdate,
         [Policy(PolicyType.SingleOrg)] Policy singleOrgPolicy,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         singleOrgPolicy.OrganizationId = policyUpdate.OrganizationId;
@@ -401,7 +401,7 @@ public class AutomaticUserConfirmationPolicyValidationHandlerTests
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation)] PolicyUpdate policyUpdate,
         [Policy(PolicyType.SingleOrg)] Policy singleOrgPolicy,
         Guid nonCompliantUserId,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         singleOrgPolicy.OrganizationId = policyUpdate.OrganizationId;
@@ -447,7 +447,7 @@ public class AutomaticUserConfirmationPolicyValidationHandlerTests
     public async Task ValidateAsync_EnablingPolicy_EmptyOrganization_ReturnsEmptyString(
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation)] PolicyUpdate policyUpdate,
         [Policy(PolicyType.SingleOrg)] Policy singleOrgPolicy,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         singleOrgPolicy.OrganizationId = policyUpdate.OrganizationId;
@@ -475,7 +475,7 @@ public class AutomaticUserConfirmationPolicyValidationHandlerTests
     public async Task ValidateAsync_WithSavePolicyModel_CallsValidateWithPolicyUpdate(
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation)] PolicyUpdate policyUpdate,
         [Policy(PolicyType.SingleOrg)] Policy singleOrgPolicy,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         singleOrgPolicy.OrganizationId = policyUpdate.OrganizationId;
@@ -505,7 +505,7 @@ public class AutomaticUserConfirmationPolicyValidationHandlerTests
     public async Task OnSaveSideEffectsAsync_EnablingPolicy_SetsUseAutomaticUserConfirmationToTrue(
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation)] PolicyUpdate policyUpdate,
         Organization organization,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         organization.Id = policyUpdate.OrganizationId;
@@ -531,7 +531,7 @@ public class AutomaticUserConfirmationPolicyValidationHandlerTests
     public async Task OnSaveSideEffectsAsync_DisablingPolicy_SetsUseAutomaticUserConfirmationToFalse(
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation, false)] PolicyUpdate policyUpdate,
         Organization organization,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         organization.Id = policyUpdate.OrganizationId;
@@ -556,7 +556,7 @@ public class AutomaticUserConfirmationPolicyValidationHandlerTests
     [Theory, BitAutoData]
     public async Task OnSaveSideEffectsAsync_OrganizationNotFound_DoesNotThrowException(
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation)] PolicyUpdate policyUpdate,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         sutProvider.GetDependency<IOrganizationRepository>()
@@ -577,7 +577,7 @@ public class AutomaticUserConfirmationPolicyValidationHandlerTests
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation)] PolicyUpdate policyUpdate,
         [Policy(PolicyType.AutomaticUserConfirmation)] Policy currentPolicy,
         Organization organization,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         organization.Id = policyUpdate.OrganizationId;
@@ -604,7 +604,7 @@ public class AutomaticUserConfirmationPolicyValidationHandlerTests
     public async Task OnSaveSideEffectsAsync_UpdatesRevisionDate(
         [PolicyUpdate(PolicyType.AutomaticUserConfirmation)] PolicyUpdate policyUpdate,
         Organization organization,
-        SutProvider<AutomaticUserConfirmationPolicyValidationHandler> sutProvider)
+        SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
         organization.Id = policyUpdate.OrganizationId;


### PR DESCRIPTION
## 🎟️ Tracking
[PM-26377](https://bitwarden.atlassian.net/browse/PM-26377)

## 📔 Objective

Add validation checks to make sure organizations meet all the requirements before admins can turn on the Auto Confirm policy.

### What gets checked
Before allowing the Auto Confirm policy to be enabled, we now verify that:
1. Single Org policy is already on - This is a prerequisite that must be enabled first
2. All users comply with Single Org policy - Everyone in the organization needs to meet the Single Org requirements (including Owners and Admins)
3. No Provider users exist - The organization can't have any members with Provider user type

### How it works
When an admin tries to enable the Auto Confirm policy, we run through these checks one by one. If something doesn't pass, we'll send back a clear error message explaining what went wrong, and the policy won't be turned on. The policy only gets enabled if everything checks out.

This prevents admins from accidentally enabling Auto Confirm when their organization isn't ready for it.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26377]: https://bitwarden.atlassian.net/browse/PM-26377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ