### PR TITLE
[PM-27579] bw sync does not pull in new items stored in a collection

### DIFF
--- a/src/Sql/dbo/Vault/Stored Procedures/Cipher/Cipher_CreateWithCollections.sql
+++ b/src/Sql/dbo/Vault/Stored Procedures/Cipher/Cipher_CreateWithCollections.sql
@@ -25,7 +25,7 @@ BEGIN
     EXEC @UpdateCollectionsSuccess = [dbo].[Cipher_UpdateCollections] @Id, @UserId, @OrganizationId, @CollectionIds
 
     -- Bump the account revision date AFTER collections are assigned.
-    IF @UpdateCollectionsSuccess = 0 AND @OrganizationId IS NOT NULL
+    IF @UpdateCollectionsSuccess = 0
     BEGIN
         EXEC [dbo].[User_BumpAccountRevisionDateByCipherId] @Id, @OrganizationId
     END

--- a/util/Migrator/DbScripts/2025-11-10_00_BumpAccountRevisionDateCipherWithCollection.sql
+++ b/util/Migrator/DbScripts/2025-11-10_00_BumpAccountRevisionDateCipherWithCollection.sql
@@ -25,7 +25,7 @@ BEGIN
     EXEC @UpdateCollectionsSuccess = [dbo].[Cipher_UpdateCollections] @Id, @UserId, @OrganizationId, @CollectionIds
 
     -- Bump the account revision date AFTER collections are assigned.
-    IF @UpdateCollectionsSuccess = 0 AND @OrganizationId IS NOT NULL
+    IF @UpdateCollectionsSuccess = 0
     BEGIN
         EXEC [dbo].[User_BumpAccountRevisionDateByCipherId] @Id, @OrganizationId
     END


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-27579
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
**Root Cause:** `User_BumpAccountRevisionDateByCipherId` was called before collections were assigned to the cipher. The procedure queries `CollectionCipher` to determine which users have access, but since collections didn't exist yet, it found 0 users and updated no revision dates. This prevented clients from syncing the newly created cipher.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/5e2682ce-0bbe-4190-b16e-95239f18726c


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
