### PR TITLE
[PM-27599] remove hardcoded storage values, fetch from pricing service instead

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/Organizations/CloudOrganizationSignUpCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Organizations/CloudOrganizationSignUpCommand.cs
@@ -75,8 +75,7 @@ public class CloudOrganizationSignUpCommand(
             PlanType = plan!.Type,
             Seats = (short)(plan.PasswordManager.BaseSeats + signup.AdditionalSeats),
             MaxCollections = plan.PasswordManager.MaxCollections,
-            MaxStorageGb = !plan.PasswordManager.BaseStorageGb.HasValue ?
-                (short?)null : (short)(plan.PasswordManager.BaseStorageGb.Value + signup.AdditionalStorageGb),
+            MaxStorageGb = (short)(plan.PasswordManager.BaseStorageGb + signup.AdditionalStorageGb),
             UsePolicies = plan.HasPolicies,
             UseSso = plan.HasSso,
             UseGroups = plan.HasGroups,

--- a/src/Core/AdminConsole/OrganizationFeatures/Organizations/ProviderClientOrganizationSignUpCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Organizations/ProviderClientOrganizationSignUpCommand.cs
@@ -73,7 +73,7 @@ public class ProviderClientOrganizationSignUpCommand : IProviderClientOrganizati
             PlanType = plan!.Type,
             Seats = signup.AdditionalSeats,
             MaxCollections = plan.PasswordManager.MaxCollections,
-            MaxStorageGb = 1,
+            MaxStorageGb = plan.PasswordManager.BaseStorageGb,
             UsePolicies = plan.HasPolicies,
             UseSso = plan.HasSso,
             UseOrganizationDomains = plan.HasOrganizationDomains,

--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -148,7 +148,7 @@ public class OrganizationService : IOrganizationService
         }
 
         var secret = await BillingHelpers.AdjustStorageAsync(_paymentService, organization, storageAdjustmentGb,
-            plan.PasswordManager.StripeStoragePlanId);
+            plan.PasswordManager.StripeStoragePlanId, plan.PasswordManager.BaseStorageGb);
         await ReplaceAndUpdateCacheAsync(organization);
         return secret;
     }

--- a/src/Core/Billing/Models/StaticStore/Plan.cs
+++ b/src/Core/Billing/Models/StaticStore/Plan.cs
@@ -97,7 +97,7 @@ public abstract record Plan
         public decimal PremiumAccessOptionPrice { get; init; }
         public short? MaxSeats { get; init; }
         // Storage
-        public short? BaseStorageGb { get; init; }
+        public short BaseStorageGb { get; init; }
         public bool HasAdditionalStorageOption { get; init; }
         public decimal AdditionalStoragePricePerGb { get; init; }
         public string StripeStoragePlanId { get; init; }

--- a/src/Core/Billing/Pricing/Organizations/PlanAdapter.cs
+++ b/src/Core/Billing/Pricing/Organizations/PlanAdapter.cs
@@ -99,7 +99,7 @@ public record PlanAdapter : Core.Models.StaticStore.Plan
             _ => true);
         var baseSeats = GetBaseSeats(plan.Seats);
         var maxSeats = GetMaxSeats(plan.Seats);
-        var baseStorageGb = (short?)plan.Storage?.Provided;
+        var baseStorageGb = (short)(plan.Storage?.Provided ?? 0);
         var hasAdditionalStorageOption = plan.Storage != null;
         var additionalStoragePricePerGb = plan.Storage?.Price ?? 0;
         var stripeStoragePlanId = plan.Storage?.StripePriceId;

--- a/src/Core/Billing/Pricing/Premium/Purchasable.cs
+++ b/src/Core/Billing/Pricing/Premium/Purchasable.cs
@@ -4,4 +4,5 @@ public class Purchasable
 {
     public string StripePriceId { get; init; } = null!;
     public decimal Price { get; init; }
+    public int Provided { get; init; }
 }

--- a/src/Core/Billing/Pricing/PricingClient.cs
+++ b/src/Core/Billing/Pricing/PricingClient.cs
@@ -186,6 +186,6 @@ public class PricingClient(
         Available = true,
         LegacyYear = null,
         Seat = new Purchasable { Price = 10M, StripePriceId = StripeConstants.Prices.PremiumAnnually },
-        Storage = new Purchasable { Price = 4M, StripePriceId = StripeConstants.Prices.StoragePlanPersonal }
+        Storage = new Purchasable { Price = 4M, StripePriceId = StripeConstants.Prices.StoragePlanPersonal, Provided = 1 }
     };
 }

--- a/src/Core/Models/Business/CompleteSubscriptionUpdate.cs
+++ b/src/Core/Models/Business/CompleteSubscriptionUpdate.cs
@@ -299,7 +299,7 @@ public class CompleteSubscriptionUpdate : SubscriptionUpdate
                 ? organization.SmServiceAccounts - plan.SecretsManager.BaseServiceAccount
                 : 0,
             PurchasedAdditionalStorage = organization.MaxStorageGb.HasValue
-                ? organization.MaxStorageGb.Value - (plan.PasswordManager.BaseStorageGb ?? 0) :
+                ? organization.MaxStorageGb.Value - plan.PasswordManager.BaseStorageGb :
                 0
         };
 }

--- a/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpgradeOrganizationPlanCommand.cs
@@ -254,9 +254,7 @@ public class UpgradeOrganizationPlanCommand : IUpgradeOrganizationPlanCommand
         organization.UseApi = newPlan.HasApi;
         organization.SelfHost = newPlan.HasSelfHost;
         organization.UsePolicies = newPlan.HasPolicies;
-        organization.MaxStorageGb = !newPlan.PasswordManager.BaseStorageGb.HasValue
-            ? (short?)null
-            : (short)(newPlan.PasswordManager.BaseStorageGb.Value + upgrade.AdditionalStorageGb);
+        organization.MaxStorageGb = (short)(newPlan.PasswordManager.BaseStorageGb + upgrade.AdditionalStorageGb);
         organization.UseGroups = newPlan.HasGroups;
         organization.UseDirectory = newPlan.HasDirectory;
         organization.UseEvents = newPlan.HasEvents;

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -904,7 +904,6 @@ public class UserService : UserManager<User>, IUserService
         }
         else
         {
-            user.MaxStorageGb = (short)(1 + additionalStorageGb);
             user.LicenseKey = CoreHelpers.SecureRandomString(20);
         }
 
@@ -977,7 +976,8 @@ public class UserService : UserManager<User>, IUserService
 
         var premiumPlan = await _pricingClient.GetAvailablePremiumPlan();
 
-        var secret = await BillingHelpers.AdjustStorageAsync(_paymentService, user, storageAdjustmentGb, premiumPlan.Storage.StripePriceId);
+        var baseStorageGb = (short)premiumPlan.Storage.Provided;
+        var secret = await BillingHelpers.AdjustStorageAsync(_paymentService, user, storageAdjustmentGb, premiumPlan.Storage.StripePriceId, baseStorageGb);
         await SaveUserAsync(user);
         return secret;
     }

--- a/src/Core/Utilities/BillingHelpers.cs
+++ b/src/Core/Utilities/BillingHelpers.cs
@@ -7,7 +7,7 @@ namespace Bit.Core.Utilities;
 public static class BillingHelpers
 {
     internal static async Task<string> AdjustStorageAsync(IPaymentService paymentService, IStorableSubscriber storableSubscriber,
-        short storageAdjustmentGb, string storagePlanId)
+        short storageAdjustmentGb, string storagePlanId, short baseStorageGb)
     {
         if (storableSubscriber == null)
         {
@@ -30,9 +30,9 @@ public static class BillingHelpers
         }
 
         var newStorageGb = (short)(storableSubscriber.MaxStorageGb.Value + storageAdjustmentGb);
-        if (newStorageGb < 1)
+        if (newStorageGb < baseStorageGb)
         {
-            newStorageGb = 1;
+            newStorageGb = baseStorageGb;
         }
 
         if (newStorageGb > 100)
@@ -48,7 +48,7 @@ public static class BillingHelpers
                 "Delete some stored data first.");
         }
 
-        var additionalStorage = newStorageGb - 1;
+        var additionalStorage = newStorageGb - baseStorageGb;
         var paymentIntentClientSecret = await paymentService.AdjustStorageAsync(storableSubscriber,
             additionalStorage, storagePlanId);
         storableSubscriber.MaxStorageGb = newStorageGb;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27599

## 📔 Objective

Remove all hardcoded 1GB values for included storage, instead pulling from the plan itself.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
