### PR TITLE
[PM-23059] Provider Users who are also Organization Members cannot edit or delete items via Admin Console when admins can manage all items

### DIFF
--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -403,8 +403,8 @@ public class CiphersController : Controller
         var org = _currentContext.GetOrganization(organizationId);
 
         // If we're not an "admin" we don't need to check the ciphers
-        if (org is not ({Type: OrganizationUserType.Owner or OrganizationUserType.Admin} or
-            {Permissions.EditAnyCollection: true}))
+        if (org is not ({ Type: OrganizationUserType.Owner or OrganizationUserType.Admin } or
+            { Permissions.EditAnyCollection: true }))
         {
             return false;
         }
@@ -418,8 +418,8 @@ public class CiphersController : Controller
         var org = _currentContext.GetOrganization(organizationId);
 
         // If we're not an "admin" we don't need to check the ciphers
-        if (org is not ({Type: OrganizationUserType.Owner or OrganizationUserType.Admin} or
-            {Permissions.EditAnyCollection: true}))
+        if (org is not ({ Type: OrganizationUserType.Owner or OrganizationUserType.Admin } or
+            { Permissions.EditAnyCollection: true }))
         {
             return false;
         }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-23059
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
An MSP managing multiple client organizations is experiencing an issue with one specific organization where they are unable to edit any items. This includes actions such as deleting, modifying, or moving items into a collection.

However, they can still perform other actions within the organization, such as inviting members and creating new collections.

Notably, the issue only occurs in the web app, they are able to edit entries via the browser extension and desktop app without any problems.

The error message they're getting is: An error has occurred. Resource not found.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/a97ccae6-d170-4f2c-8f53-57ba4650904d


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
