### PR TITLE
[PM-28610]Resolve the Failing InvoiceExtensionsTests

### DIFF
--- a/test/Core.Test/Billing/Extensions/InvoiceExtensionsTests.cs
+++ b/test/Core.Test/Billing/Extensions/InvoiceExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.Billing.Extensions;
+﻿using System.Globalization;
+using Bit.Core.Billing.Extensions;
 using Stripe;
 using Xunit;
 
@@ -356,9 +357,18 @@ public class InvoiceExtensionsTests
     [Fact]
     public void FormatForProvider_ComplexScenario_HandlesAllLineTypes()
     {
-        // Arrange
-        var lineItems = new StripeList<InvoiceLineItem>();
-        lineItems.Data = new List<InvoiceLineItem>
+        // Set culture to en-US to ensure consistent decimal formatting in tests
+        // This ensures tests pass on all machines regardless of system locale
+        var originalCulture = Thread.CurrentThread.CurrentCulture;
+        var originalUICulture = Thread.CurrentThread.CurrentUICulture;
+        try
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+            Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
+
+            // Arrange
+            var lineItems = new StripeList<InvoiceLineItem>();
+            lineItems.Data = new List<InvoiceLineItem>
         {
             new InvoiceLineItem
             {
@@ -372,23 +382,29 @@ public class InvoiceExtensionsTests
             new InvoiceLineItem { Description = "Custom Service", Quantity = 2, Amount = 2000 }
         };
 
-        var invoice = new Invoice
+            var invoice = new Invoice
+            {
+                Lines = lineItems,
+                TotalTaxes = [new InvoiceTotalTax { Amount = 200 }] // Additional $2.00 tax
+            };
+            var subscription = new Subscription();
+
+            // Act
+            var result = invoice.FormatForProvider(subscription);
+
+            // Assert
+            Assert.Equal(5, result.Count);
+            Assert.Equal("5 × Manage service provider (at $6.00 / month)", result[0]);
+            Assert.Equal("10 × Manage service provider (at $4.00 / month)", result[1]);
+            Assert.Equal("1 × Tax (at $8.00 / month)", result[2]);
+            Assert.Equal("Custom Service", result[3]);
+            Assert.Equal("1 × Tax (at $2.00 / month)", result[4]);
+        }
+        finally
         {
-            Lines = lineItems,
-            TotalTaxes = [new InvoiceTotalTax { Amount = 200 }] // Additional $2.00 tax
-        };
-        var subscription = new Subscription();
-
-        // Act
-        var result = invoice.FormatForProvider(subscription);
-
-        // Assert
-        Assert.Equal(5, result.Count);
-        Assert.Equal("5 × Manage service provider (at $6.00 / month)", result[0]);
-        Assert.Equal("10 × Manage service provider (at $4.00 / month)", result[1]);
-        Assert.Equal("1 × Tax (at $8.00 / month)", result[2]);
-        Assert.Equal("Custom Service", result[3]);
-        Assert.Equal("1 × Tax (at $2.00 / month)", result[4]);
+            Thread.CurrentThread.CurrentCulture = originalCulture;
+            Thread.CurrentThread.CurrentUICulture = originalUICulture;
+        }
     }
 
     #endregion


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-28610

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix this error below :

FormatForProvider_ComplexScenario_HandlesAllLineTypes [1 ms]  
Assert.Equal() Failure: Strings differ

Expected: "1 × Tax (at $0.00 / month)"
Actual:   "1 × Tax (at $8.00 / month)"
                ↑ (pos 14)

   at Bit.Core.Test.Billing.Extensions.InvoiceExtensionsTests
     .FormatForProvider_ComplexScenario_HandlesAllLineTypes()
     in /Users/oscar/Code/server/test/Core.Test/Billing/Extensions/InvoiceExtensionsTests.cs:line 389

   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
