### PR TITLE
[PM-27468] [PM-28737] - Adding Auto Confirm Policy Event Handler as PolicyValidator

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyServiceCollectionExtensions.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyServiceCollectionExtensions.cs
@@ -35,6 +35,7 @@ public static class PolicyServiceCollectionExtensions
         services.AddScoped<IPolicyValidator, MaximumVaultTimeoutPolicyValidator>();
         services.AddScoped<IPolicyValidator, UriMatchDefaultPolicyValidator>();
         services.AddScoped<IPolicyValidator, FreeFamiliesForEnterprisePolicyValidator>();
+        services.AddScoped<IPolicyValidator, AutomaticUserConfirmationPolicyEventHandler>();
     }
 
     [Obsolete("Use AddPolicyUpdateEvents instead.")]


### PR DESCRIPTION
## 🎟️ Tracking
[PM-27468](https://bitwarden.atlassian.net/browse/PM-27468)
[PM-28737](https://bitwarden.atlassian.net/browse/PM-28737)

## 📔 Objective
The reigstration of the `AutomaticUserConfirmationPolicyEventHandler` as an `IPolicyValidator` was missed in initial implementation.  Since, `FeatureFlagKeys.CreateDefaultLocation` and `FeatureFlagKeys.PolicyValidatorsRefactor` was not enabled, the new flow of using the vNext save policy was not called. This adds the event handler to the DI container to support the previous flow.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27468]: https://bitwarden.atlassian.net/browse/PM-27468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-28737]: https://bitwarden.atlassian.net/browse/PM-28737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ