### PR TITLE
[PM-21742] Fix MJML validation error.

### DIFF
--- a/src/Core/MailTemplates/Mjml/build.js
+++ b/src/Core/MailTemplates/Mjml/build.js
@@ -41,8 +41,10 @@ if (!fs.existsSync(config.outputDir)) {
   }
 }
 
-// Find all MJML files with absolute path
-const mjmlFiles = glob.sync(`${config.inputDir}/**/*.mjml`);
+// Find all MJML files with absolute paths, excluding components directories
+const mjmlFiles = glob.sync(`${config.inputDir}/**/*.mjml`, {
+  ignore: ['**/components/**']
+});
 
 console.log(`\n[INFO] Found ${mjmlFiles.length} MJML file(s) to compile...`);
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21742

## 📔 Objective

While working on this ticket, I discovered this error: 
<img width="2210" height="814" alt="image" src="https://github.com/user-attachments/assets/5839f4b1-c3b8-4935-8153-f082db34bf42" />

This validation error occurs because the build script treats this shared subcomponent as a standalone component. We have this subcomponent here because only the AC team needs it. By moving the files into an AC directory, we can reduce code review friction.

This change will make the build script recognize all “components” directories as non-standalone MJML templates.

**Note**: This has no impact on production code. We only use this build script during development.
## 📸 Screenshots

<img width="1448" height="704" alt="image" src="https://github.com/user-attachments/assets/16644978-058b-434d-b060-30657e8c89e8" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
