### PR TITLE
Document email asset process

### DIFF
--- a/src/Core/MailTemplates/README.md
+++ b/src/Core/MailTemplates/README.md
@@ -76,3 +76,13 @@ The `IMailService` automatically uses both versions when sending emails:
 
 ## `*.mjml`
 This is a templating language we use to increase efficiency when creating email content. See the `MJML` [documentation](./Mjml/README.md) for more details.
+
+# Managing email assets
+
+We host assets that are included in emails at `assets.bitwarden.com`, at the `/email/v1` path. This corresponds to a static file storage container that is managed by our SRE team.  For example: https://assets.bitwarden.com/email/v1/mail-github.png. This is the URL for all assets for emails sent from any environment.
+
+## Adding an asset
+
+When you are creating an email that needs a new asset, you should first check to see if that asset already exists. The easiest way to do this is check at the corresponding `https://assets.bitwarden.com/email/v1/` URL (e.g. https://assets.bitwarden.com/email/v1/my_new_image.png). 
+
+If the asset you are adding is not there, enter a ticket for the SRE team to add the asset to the email asset container. The preferred format for assets is a `.png` file, and the file(s) should be attached to the ticket.


### PR DESCRIPTION
## 📔 Objective

We have had several discussions about the process for adding new email assets, which was never documented when we standardized on the `assets.bitwarden.com` container.

This PR adds a short documentation section on the email asset process in the `README` for creating email templates, when the assets would be used.

See [here](https://github.com/bitwarden/server/blob/65885cc8eda6e9f6798b4361c4d1b96a332be572/src/Core/MailTemplates/README.md#managing-email-assets) for well-formatted reading.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
