### PR TITLE
Add configurable queue name support to AzureQueueHostedService

### DIFF
--- a/src/EventsProcessor/AzureQueueHostedService.cs
+++ b/src/EventsProcessor/AzureQueueHostedService.cs
@@ -57,14 +57,16 @@ public class AzureQueueHostedService : IHostedService, IDisposable
     private async Task ExecuteAsync(CancellationToken cancellationToken)
     {
         var storageConnectionString = _configuration["azureStorageConnectionString"];
-        if (string.IsNullOrWhiteSpace(storageConnectionString))
+        var queueName = _configuration["azureQueueServiceQueueName"];
+        if (string.IsNullOrWhiteSpace(storageConnectionString) ||
+            string.IsNullOrWhiteSpace(queueName))
         {
             return;
         }
 
         var repo = new Core.Repositories.TableStorage.EventRepository(storageConnectionString);
         _eventWriteService = new RepositoryEventWriteService(repo);
-        _queueClient = new QueueClient(storageConnectionString, "event");
+        _queueClient = new QueueClient(storageConnectionString, queueName);
 
         while (!cancellationToken.IsCancellationRequested)
         {


### PR DESCRIPTION
## 📔 Objective

Now that we have transitioned to use Azure Service Bus in production for our event integrations, the `AzureQueueHostedService` was somewhat obsolete. We were still running it to drain the Azure Queue for events, but we were not adding any events to that queue anymore (they all go to ASB instead). This meant it was still sending its regular interval read requests, but they would always return zero, resulting in needless traffic.

This PR adds a configuration property to pass in the queue name. It follows the convention we had with the connection string. Since we don't want to adjust the connection string in production (it is tied to other features), the queue name provides us a way to short-circuit the queue service. If the queue name is not preset, it will simply return

  - Added configurable queue name support to `AzureQueueHostedService`
  - Queue name is now read from `azureStorageQueueName` IConfiguration key
  - Maintains backward compatibility with early return pattern

### Configuration required to maintain existing functionality

To maintain the same functionality as the hardcoded version, the following configuration **must be set**:

  **appsettings.json:**
  ```json
  {
    "azureStorageQueueName": "event"
  }
```

In our case, we will leave this empty in all environments (including production), which will accomplish the task of turning off the read service on the azure queue. If anyone was using this in self-hosted or otherwise, they'll need to add the setting to continue using it as it was.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
