### PR TITLE
PM-29652: Increase the limit of passkeys to 25

### DIFF
--- a/src/Core/Auth/UserFeatures/WebAuthnLogin/Implementations/CreateWebAuthnLoginCredentialCommand.cs
+++ b/src/Core/Auth/UserFeatures/WebAuthnLogin/Implementations/CreateWebAuthnLoginCredentialCommand.cs
@@ -11,7 +11,7 @@ namespace Bit.Core.Auth.UserFeatures.WebAuthnLogin.Implementations;
 
 internal class CreateWebAuthnLoginCredentialCommand : ICreateWebAuthnLoginCredentialCommand
 {
-    public const int MaxCredentialsPerUser = 5;
+    public const int MaxCredentialsPerUser = 25;
 
     private readonly IFido2 _fido2;
     private readonly IWebAuthnCredentialRepository _webAuthnCredentialRepository;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29652

## 📔 Objective

This PR bumps our passkey limit from 5 -> 25 for users. There was no specific reason 5 was picked, and with the upcoming Login in passkey features a higher number is more reasonable to avoid users running into the limit.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Related to UI change: https://github.com/bitwarden/clients/pull/17931

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
