### PR TITLE
[PM-18069] Add the Server SDK to Billing

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,6 +5,7 @@
   },
   "msbuild-sdks": {
     "Microsoft.Build.Traversal": "4.1.0",
-    "Microsoft.Build.Sql": "1.0.0"
+    "Microsoft.Build.Sql": "1.0.0",
+    "Bitwarden.Server.Sdk": "1.2.0"
   }
 }

--- a/src/Billing/Billing.csproj
+++ b/src/Billing/Billing.csproj
@@ -1,7 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <Sdk Name="Bitwarden.Server.Sdk" />
 
   <PropertyGroup>
     <UserSecretsId>bitwarden-Billing</UserSecretsId>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Server SDK settings">
+    <!-- These features will be gradually turned on -->
+    <BitIncludeFeatures>false</BitIncludeFeatures>
+    <BitIncludeTelemetry>false</BitIncludeTelemetry>
+    <BitIncludeAuthentication>false</BitIncludeAuthentication>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Billing' " />

--- a/src/Billing/Program.cs
+++ b/src/Billing/Program.cs
@@ -8,6 +8,7 @@ public class Program
     {
         Host
             .CreateDefaultBuilder(args)
+            .UseBitwardenSdk()
             .ConfigureWebHostDefaults(webBuilder =>
             {
                 webBuilder.UseStartup<Startup>();


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-18069

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds the SDK with all features turned off for the time being to the Billing project. Billing was chosen because it interacts with our `billing-relay` project. This means once telemetry is turned on we will be able to see distributed spans for actions that originally take place there and then make a request here.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
