### PR TITLE
Adjust README header level for better formatting

### DIFF
--- a/src/Identity/IdentityServer/RequestValidators/SendAccess/readme.md
+++ b/src/Identity/IdentityServer/RequestValidators/SendAccess/readme.md
@@ -4,7 +4,7 @@ This feature supports the ability of Tools to require specific claims for access
 
 In order to access Send data a user must meet the requirements laid out in these request validators.
 
-> [!IMPORTANT] String Constants
+> [!IMPORTANT]
 > The string constants contained herein are used in conjunction with the Auth module in the SDK. Any change to these string values _must_ be intentional and _must_ have a corresponding change in the SDK.
 
 There is snapshot testing that will fail if the strings change to help detect unintended changes to the string constants.


### PR DESCRIPTION
## 📔 Objective

The `README` for Send Access management didn't have a consistent H1/H2 structure, causing some issues with formatting in any automation that assumes that the H1 element is the "title" of the document.

## 📸 Screenshots
### Before
<img width="1111" height="519" alt="image" src="https://github.com/user-attachments/assets/79546fbc-566d-483c-872e-5a46c141f547" />

### After
<img width="1111" height="519" alt="image" src="https://github.com/user-attachments/assets/264f4ff1-28e9-4157-ab97-ce5886c7a050" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
