### PR TITLE
[PM-29708] validate domain of email on SSO provisioning

### DIFF
--- a/src/Core/Auth/UserFeatures/Registration/Implementations/RegisterUserCommand.cs
+++ b/src/Core/Auth/UserFeatures/Registration/Implementations/RegisterUserCommand.cs
@@ -99,6 +99,9 @@ public class RegisterUserCommand : IRegisterUserCommand
 
     public async Task<IdentityResult> RegisterSSOAutoProvisionedUserAsync(User user, Organization organization)
     {
+        // Validate that the email domain is not blocked by another organization's policy
+        await ValidateEmailDomainNotBlockedAsync(user.Email, organization.Id);
+
         var result = await _userService.CreateUserAsync(user);
         if (result == IdentityResult.Success)
         {

--- a/test/Core.Test/Auth/UserFeatures/Registration/RegisterUserCommandTests.cs
+++ b/test/Core.Test/Auth/UserFeatures/Registration/RegisterUserCommandTests.cs
@@ -1382,4 +1382,90 @@ public class RegisterUserCommandTests
             .Received(1)
             .SendOrganizationUserWelcomeEmailAsync(user, organization.DisplayName());
     }
+
+    [Theory, BitAutoData]
+    public async Task RegisterSSOAutoProvisionedUserAsync_WithBlockedDomain_ThrowsException(
+        User user,
+        Organization organization,
+        SutProvider<RegisterUserCommand> sutProvider)
+    {
+        // Arrange
+        user.Email = "user@blocked-domain.com";
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.BlockClaimedDomainAccountCreation)
+            .Returns(true);
+
+        sutProvider.GetDependency<IOrganizationDomainRepository>()
+            .HasVerifiedDomainWithBlockClaimedDomainPolicyAsync("blocked-domain.com", organization.Id)
+            .Returns(true);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
+            sutProvider.Sut.RegisterSSOAutoProvisionedUserAsync(user, organization));
+        Assert.Equal("This email address is claimed by an organization using Bitwarden.", exception.Message);
+    }
+
+    [Theory, BitAutoData]
+    public async Task RegisterSSOAutoProvisionedUserAsync_WithOwnClaimedDomain_Succeeds(
+        User user,
+        Organization organization,
+        SutProvider<RegisterUserCommand> sutProvider)
+    {
+        // Arrange
+        user.Email = "user@company-domain.com";
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.BlockClaimedDomainAccountCreation)
+            .Returns(true);
+
+        // Domain is claimed by THIS organization, so it should be allowed
+        sutProvider.GetDependency<IOrganizationDomainRepository>()
+            .HasVerifiedDomainWithBlockClaimedDomainPolicyAsync("company-domain.com", organization.Id)
+            .Returns(false); // Not blocked because organization.Id is excluded
+
+        sutProvider.GetDependency<IUserService>()
+            .CreateUserAsync(user)
+            .Returns(IdentityResult.Success);
+
+        // Act
+        var result = await sutProvider.Sut.RegisterSSOAutoProvisionedUserAsync(user, organization);
+
+        // Assert
+        Assert.True(result.Succeeded);
+        await sutProvider.GetDependency<IUserService>()
+            .Received(1)
+            .CreateUserAsync(user);
+    }
+
+    [Theory, BitAutoData]
+    public async Task RegisterSSOAutoProvisionedUserAsync_WithNonClaimedDomain_Succeeds(
+        User user,
+        Organization organization,
+        SutProvider<RegisterUserCommand> sutProvider)
+    {
+        // Arrange
+        user.Email = "user@unclaimed-domain.com";
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.BlockClaimedDomainAccountCreation)
+            .Returns(true);
+
+        sutProvider.GetDependency<IOrganizationDomainRepository>()
+            .HasVerifiedDomainWithBlockClaimedDomainPolicyAsync("unclaimed-domain.com", organization.Id)
+            .Returns(false); // Domain is not claimed by any org
+
+        sutProvider.GetDependency<IUserService>()
+            .CreateUserAsync(user)
+            .Returns(IdentityResult.Success);
+
+        // Act
+        var result = await sutProvider.Sut.RegisterSSOAutoProvisionedUserAsync(user, organization);
+
+        // Assert
+        Assert.True(result.Succeeded);
+        await sutProvider.GetDependency<IUserService>()
+            .Received(1)
+            .CreateUserAsync(user);
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29708

## 📔 Objective

### Fix SSO Bypass for BlockClaimedDomainAccountCreation Policy

#### Problem
Users with email addresses from claimed domains could bypass the `BlockClaimedDomainAccountCreation` policy when authenticating via SSO (both org invite acceptance and JIT provisioning). This allowed them to join organizations other than the one that claimed their domain.

#### Solution
Added domain validation to `RegisterSSOAutoProvisionedUserAsync()` method before user creation. The validation:
- Blocks users from joining organizations if their email domain is claimed by a different organization
- Allows users to join their own organization (the one that claimed their domain) via `excludeOrganizationId`
- Uses the same validation logic as regular registration flows

#### Changes
- **Core**: Added 1 line to `RegisterUserCommand.RegisterSSOAutoProvisionedUserAsync()` to call `ValidateEmailDomainNotBlockedAsync(user.Email, organization.Id)`
- **Tests**: Added 3 unit tests covering blocked domain, own domain, and unclaimed domain scenarios

#### Testing
- ✅ All 47 RegisterUserCommand tests pass
- ✅ 3 new SSO-specific tests pass
- ✅ Follows existing pattern from `RegisterUserViaOrganizationInviteToken()`

#### Fixes QA Scenarios
- ❌ SSO invite with Require SSO - now properly blocked
- ❌ JIT provisioning via SSO - now properly blocked
- ✅ Users can still SSO into their own organization
