### PR TITLE
[PM-29840] Correcting Auto-Confirm Org Accept User Flow

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptOrgUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptOrgUserCommand.cs
@@ -269,9 +269,6 @@ public class AcceptOrgUserCommand : IAcceptOrgUserCommand
     private async Task ValidateAutomaticUserConfirmationPolicyAsync(OrganizationUser orgUser,
         ICollection<OrganizationUser> allOrgUsers, User user)
     {
-        // Org user is technically not assigned to a user at this point. Assigning user id for compliance checks.
-        orgUser.UserId = user.Id;
-
         var error = (await _automaticUserConfirmationPolicyEnforcementValidator.IsCompliantAsync(
                 new AutomaticUserConfirmationPolicyEnforcementRequest(orgUser.OrganizationId,
                     allOrgUsers.Append(orgUser),

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/AutomaticUserConfirmationPolicyEnforcementValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/AutomaticUserConfirmationPolicyEnforcementValidator.cs
@@ -19,7 +19,8 @@ public class AutomaticUserConfirmationPolicyEnforcementValidator(
 
         var currentOrganizationUser = request.AllOrganizationUsers
             .FirstOrDefault(x => x.OrganizationId == request.OrganizationId
-                                 && x.UserId == request.User.Id);
+                                 // invited users do not have a userId but will have email
+                                 && (x.UserId == request.User.Id || x.Email == request.User.Email));
 
         if (currentOrganizationUser is null)
         {


### PR DESCRIPTION
## 🎟️ Tracking
[PM-29840](https://bitwarden.atlassian.net/browse/PM-29840)

## 📔 Objective
When a user is invited to an organization, their User Id is null. This means that when we call `organizationUserRepository.GetManyByUserAsync`, the org user to accept will not be in that returned response. When checking for compliance, we need to add the user id to the invited org user, then add it to the all org users list request object.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-29840]: https://bitwarden.atlassian.net/browse/PM-29840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ