### PR TITLE
Update requirements for RabbitMQ and Azure Service Bus configuration

### DIFF
--- a/src/Core/AdminConsole/EventIntegrations/EventIntegrationsServiceCollectionExtensions.cs
+++ b/src/Core/AdminConsole/EventIntegrations/EventIntegrationsServiceCollectionExtensions.cs
@@ -528,17 +528,21 @@ public static class EventIntegrationsServiceCollectionExtensions
     /// <returns>True if all required RabbitMQ settings are present; otherwise, false.</returns>
     /// <remarks>
     /// Requires all the following settings to be configured:
-    /// - EventLogging.RabbitMq.HostName
-    /// - EventLogging.RabbitMq.Username
-    /// - EventLogging.RabbitMq.Password
-    /// - EventLogging.RabbitMq.EventExchangeName
+    /// <list type="bullet">
+    ///   <item><description>EventLogging.RabbitMq.HostName</description></item>
+    ///   <item><description>EventLogging.RabbitMq.Username</description></item>
+    ///   <item><description>EventLogging.RabbitMq.Password</description></item>
+    ///   <item><description>EventLogging.RabbitMq.EventExchangeName</description></item>
+    ///   <item><description>EventLogging.RabbitMq.IntegrationExchangeName</description></item>
+    /// </list>
     /// </remarks>
     internal static bool IsRabbitMqEnabled(GlobalSettings settings)
     {
         return CoreHelpers.SettingHasValue(settings.EventLogging.RabbitMq.HostName) &&
                CoreHelpers.SettingHasValue(settings.EventLogging.RabbitMq.Username) &&
                CoreHelpers.SettingHasValue(settings.EventLogging.RabbitMq.Password) &&
-               CoreHelpers.SettingHasValue(settings.EventLogging.RabbitMq.EventExchangeName);
+               CoreHelpers.SettingHasValue(settings.EventLogging.RabbitMq.EventExchangeName) &&
+               CoreHelpers.SettingHasValue(settings.EventLogging.RabbitMq.IntegrationExchangeName);
     }
 
     /// <summary>
@@ -547,13 +551,17 @@ public static class EventIntegrationsServiceCollectionExtensions
     /// <param name="settings">The global settings containing Azure Service Bus configuration.</param>
     /// <returns>True if all required Azure Service Bus settings are present; otherwise, false.</returns>
     /// <remarks>
-    /// Requires both of the following settings to be configured:
-    /// - EventLogging.AzureServiceBus.ConnectionString
-    /// - EventLogging.AzureServiceBus.EventTopicName
+    /// Requires all of the following settings to be configured:
+    /// <list type="bullet">
+    ///   <item><description>EventLogging.AzureServiceBus.ConnectionString</description></item>
+    ///   <item><description>EventLogging.AzureServiceBus.EventTopicName</description></item>
+    ///   <item><description>EventLogging.AzureServiceBus.IntegrationTopicName</description></item>
+    /// </list>
     /// </remarks>
     internal static bool IsAzureServiceBusEnabled(GlobalSettings settings)
     {
         return CoreHelpers.SettingHasValue(settings.EventLogging.AzureServiceBus.ConnectionString) &&
-               CoreHelpers.SettingHasValue(settings.EventLogging.AzureServiceBus.EventTopicName);
+               CoreHelpers.SettingHasValue(settings.EventLogging.AzureServiceBus.EventTopicName) &&
+               CoreHelpers.SettingHasValue(settings.EventLogging.AzureServiceBus.IntegrationTopicName);
     }
 }

--- a/test/Core.Test/AdminConsole/EventIntegrations/EventIntegrationServiceCollectionExtensionsTests.cs
+++ b/test/Core.Test/AdminConsole/EventIntegrations/EventIntegrationServiceCollectionExtensionsTests.cs
@@ -200,7 +200,8 @@ public class EventIntegrationServiceCollectionExtensionsTests
             ["GlobalSettings:EventLogging:RabbitMq:HostName"] = "localhost",
             ["GlobalSettings:EventLogging:RabbitMq:Username"] = "user",
             ["GlobalSettings:EventLogging:RabbitMq:Password"] = "pass",
-            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = "exchange"
+            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = "exchange",
+            ["GlobalSettings:EventLogging:RabbitMq:IntegrationExchangeName"] = "integration"
         });
 
         Assert.True(EventIntegrationsServiceCollectionExtensions.IsRabbitMqEnabled(globalSettings));
@@ -214,7 +215,8 @@ public class EventIntegrationServiceCollectionExtensionsTests
             ["GlobalSettings:EventLogging:RabbitMq:HostName"] = null,
             ["GlobalSettings:EventLogging:RabbitMq:Username"] = "user",
             ["GlobalSettings:EventLogging:RabbitMq:Password"] = "pass",
-            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = "exchange"
+            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = "exchange",
+            ["GlobalSettings:EventLogging:RabbitMq:IntegrationExchangeName"] = "integration"
         });
 
         Assert.False(EventIntegrationsServiceCollectionExtensions.IsRabbitMqEnabled(globalSettings));
@@ -228,7 +230,8 @@ public class EventIntegrationServiceCollectionExtensionsTests
             ["GlobalSettings:EventLogging:RabbitMq:HostName"] = "localhost",
             ["GlobalSettings:EventLogging:RabbitMq:Username"] = null,
             ["GlobalSettings:EventLogging:RabbitMq:Password"] = "pass",
-            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = "exchange"
+            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = "exchange",
+            ["GlobalSettings:EventLogging:RabbitMq:IntegrationExchangeName"] = "integration"
         });
 
         Assert.False(EventIntegrationsServiceCollectionExtensions.IsRabbitMqEnabled(globalSettings));
@@ -242,21 +245,38 @@ public class EventIntegrationServiceCollectionExtensionsTests
             ["GlobalSettings:EventLogging:RabbitMq:HostName"] = "localhost",
             ["GlobalSettings:EventLogging:RabbitMq:Username"] = "user",
             ["GlobalSettings:EventLogging:RabbitMq:Password"] = null,
-            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = "exchange"
+            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = "exchange",
+            ["GlobalSettings:EventLogging:RabbitMq:IntegrationExchangeName"] = "integration"
         });
 
         Assert.False(EventIntegrationsServiceCollectionExtensions.IsRabbitMqEnabled(globalSettings));
     }
 
     [Fact]
-    public void IsRabbitMqEnabled_MissingExchangeName_ReturnsFalse()
+    public void IsRabbitMqEnabled_MissingEventExchangeName_ReturnsFalse()
     {
         var globalSettings = CreateGlobalSettings(new Dictionary<string, string?>
         {
             ["GlobalSettings:EventLogging:RabbitMq:HostName"] = "localhost",
             ["GlobalSettings:EventLogging:RabbitMq:Username"] = "user",
             ["GlobalSettings:EventLogging:RabbitMq:Password"] = "pass",
-            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = null
+            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = null,
+            ["GlobalSettings:EventLogging:RabbitMq:IntegrationExchangeName"] = "integration"
+        });
+
+        Assert.False(EventIntegrationsServiceCollectionExtensions.IsRabbitMqEnabled(globalSettings));
+    }
+
+    [Fact]
+    public void IsRabbitMqEnabled_MissingIntegrationExchangeName_ReturnsFalse()
+    {
+        var globalSettings = CreateGlobalSettings(new Dictionary<string, string?>
+        {
+            ["GlobalSettings:EventLogging:RabbitMq:HostName"] = "localhost",
+            ["GlobalSettings:EventLogging:RabbitMq:Username"] = "user",
+            ["GlobalSettings:EventLogging:RabbitMq:Password"] = "pass",
+            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = "exchange",
+            ["GlobalSettings:EventLogging:RabbitMq:IntegrationExchangeName"] = null
         });
 
         Assert.False(EventIntegrationsServiceCollectionExtensions.IsRabbitMqEnabled(globalSettings));
@@ -268,7 +288,8 @@ public class EventIntegrationServiceCollectionExtensionsTests
         var globalSettings = CreateGlobalSettings(new Dictionary<string, string?>
         {
             ["GlobalSettings:EventLogging:AzureServiceBus:ConnectionString"] = "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=test",
-            ["GlobalSettings:EventLogging:AzureServiceBus:EventTopicName"] = "events"
+            ["GlobalSettings:EventLogging:AzureServiceBus:EventTopicName"] = "events",
+            ["GlobalSettings:EventLogging:AzureServiceBus:IntegrationTopicName"] = "integration"
         });
 
         Assert.True(EventIntegrationsServiceCollectionExtensions.IsAzureServiceBusEnabled(globalSettings));
@@ -280,19 +301,34 @@ public class EventIntegrationServiceCollectionExtensionsTests
         var globalSettings = CreateGlobalSettings(new Dictionary<string, string?>
         {
             ["GlobalSettings:EventLogging:AzureServiceBus:ConnectionString"] = null,
-            ["GlobalSettings:EventLogging:AzureServiceBus:EventTopicName"] = "events"
+            ["GlobalSettings:EventLogging:AzureServiceBus:EventTopicName"] = "events",
+            ["GlobalSettings:EventLogging:AzureServiceBus:IntegrationTopicName"] = "integration"
         });
 
         Assert.False(EventIntegrationsServiceCollectionExtensions.IsAzureServiceBusEnabled(globalSettings));
     }
 
     [Fact]
-    public void IsAzureServiceBusEnabled_MissingTopicName_ReturnsFalse()
+    public void IsAzureServiceBusEnabled_MissingEventTopicName_ReturnsFalse()
     {
         var globalSettings = CreateGlobalSettings(new Dictionary<string, string?>
         {
             ["GlobalSettings:EventLogging:AzureServiceBus:ConnectionString"] = "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=test",
-            ["GlobalSettings:EventLogging:AzureServiceBus:EventTopicName"] = null
+            ["GlobalSettings:EventLogging:AzureServiceBus:EventTopicName"] = null,
+            ["GlobalSettings:EventLogging:AzureServiceBus:IntegrationTopicName"] = "integration"
+        });
+
+        Assert.False(EventIntegrationsServiceCollectionExtensions.IsAzureServiceBusEnabled(globalSettings));
+    }
+
+    [Fact]
+    public void IsAzureServiceBusEnabled_MissingIntegrationTopicName_ReturnsFalse()
+    {
+        var globalSettings = CreateGlobalSettings(new Dictionary<string, string?>
+        {
+            ["GlobalSettings:EventLogging:AzureServiceBus:ConnectionString"] = "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=test",
+            ["GlobalSettings:EventLogging:AzureServiceBus:EventTopicName"] = "events",
+            ["GlobalSettings:EventLogging:AzureServiceBus:IntegrationTopicName"] = null
         });
 
         Assert.False(EventIntegrationsServiceCollectionExtensions.IsAzureServiceBusEnabled(globalSettings));
@@ -601,7 +637,8 @@ public class EventIntegrationServiceCollectionExtensionsTests
             ["GlobalSettings:EventLogging:RabbitMq:HostName"] = "localhost",
             ["GlobalSettings:EventLogging:RabbitMq:Username"] = "user",
             ["GlobalSettings:EventLogging:RabbitMq:Password"] = "pass",
-            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = "exchange"
+            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = "exchange",
+            ["GlobalSettings:EventLogging:RabbitMq:IntegrationExchangeName"] = "integration"
         });
 
         // Add prerequisites
@@ -624,7 +661,8 @@ public class EventIntegrationServiceCollectionExtensionsTests
         var globalSettings = CreateGlobalSettings(new Dictionary<string, string?>
         {
             ["GlobalSettings:EventLogging:AzureServiceBus:ConnectionString"] = "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=test",
-            ["GlobalSettings:EventLogging:AzureServiceBus:EventTopicName"] = "events"
+            ["GlobalSettings:EventLogging:AzureServiceBus:EventTopicName"] = "events",
+            ["GlobalSettings:EventLogging:AzureServiceBus:IntegrationTopicName"] = "integration"
         });
 
         // Add prerequisites
@@ -650,8 +688,10 @@ public class EventIntegrationServiceCollectionExtensionsTests
             ["GlobalSettings:EventLogging:RabbitMq:Username"] = "user",
             ["GlobalSettings:EventLogging:RabbitMq:Password"] = "pass",
             ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = "exchange",
+            ["GlobalSettings:EventLogging:RabbitMq:IntegrationExchangeName"] = "integration",
             ["GlobalSettings:EventLogging:AzureServiceBus:ConnectionString"] = "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=test",
-            ["GlobalSettings:EventLogging:AzureServiceBus:EventTopicName"] = "events"
+            ["GlobalSettings:EventLogging:AzureServiceBus:EventTopicName"] = "events",
+            ["GlobalSettings:EventLogging:AzureServiceBus:IntegrationTopicName"] = "integration"
         });
 
         // Add prerequisites
@@ -694,7 +734,8 @@ public class EventIntegrationServiceCollectionExtensionsTests
         var globalSettings = CreateGlobalSettings(new Dictionary<string, string?>
         {
             ["GlobalSettings:EventLogging:AzureServiceBus:ConnectionString"] = "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=test",
-            ["GlobalSettings:EventLogging:AzureServiceBus:EventTopicName"] = "events"
+            ["GlobalSettings:EventLogging:AzureServiceBus:EventTopicName"] = "events",
+            ["GlobalSettings:EventLogging:AzureServiceBus:IntegrationTopicName"] = "integration"
         });
 
         services.AddEventWriteServices(globalSettings);
@@ -712,7 +753,8 @@ public class EventIntegrationServiceCollectionExtensionsTests
             ["GlobalSettings:EventLogging:RabbitMq:HostName"] = "localhost",
             ["GlobalSettings:EventLogging:RabbitMq:Username"] = "user",
             ["GlobalSettings:EventLogging:RabbitMq:Password"] = "pass",
-            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = "exchange"
+            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = "exchange",
+            ["GlobalSettings:EventLogging:RabbitMq:IntegrationExchangeName"] = "integration"
         });
 
         services.AddEventWriteServices(globalSettings);
@@ -769,10 +811,12 @@ public class EventIntegrationServiceCollectionExtensionsTests
         {
             ["GlobalSettings:EventLogging:AzureServiceBus:ConnectionString"] = "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=test",
             ["GlobalSettings:EventLogging:AzureServiceBus:EventTopicName"] = "events",
+            ["GlobalSettings:EventLogging:AzureServiceBus:IntegrationTopicName"] = "integration",
             ["GlobalSettings:EventLogging:RabbitMq:HostName"] = "localhost",
             ["GlobalSettings:EventLogging:RabbitMq:Username"] = "user",
             ["GlobalSettings:EventLogging:RabbitMq:Password"] = "pass",
-            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = "exchange"
+            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = "exchange",
+            ["GlobalSettings:EventLogging:RabbitMq:IntegrationExchangeName"] = "integration"
         });
 
         services.AddEventWriteServices(globalSettings);
@@ -789,7 +833,8 @@ public class EventIntegrationServiceCollectionExtensionsTests
         var globalSettings = CreateGlobalSettings(new Dictionary<string, string?>
         {
             ["GlobalSettings:EventLogging:AzureServiceBus:ConnectionString"] = "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=test",
-            ["GlobalSettings:EventLogging:AzureServiceBus:EventTopicName"] = "events"
+            ["GlobalSettings:EventLogging:AzureServiceBus:EventTopicName"] = "events",
+            ["GlobalSettings:EventLogging:AzureServiceBus:IntegrationTopicName"] = "integration"
         });
 
         // Add prerequisites
@@ -826,7 +871,8 @@ public class EventIntegrationServiceCollectionExtensionsTests
             ["GlobalSettings:EventLogging:RabbitMq:HostName"] = "localhost",
             ["GlobalSettings:EventLogging:RabbitMq:Username"] = "user",
             ["GlobalSettings:EventLogging:RabbitMq:Password"] = "pass",
-            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = "exchange"
+            ["GlobalSettings:EventLogging:RabbitMq:EventExchangeName"] = "exchange",
+            ["GlobalSettings:EventLogging:RabbitMq:IntegrationExchangeName"] = "integration"
         });
 
         // Add prerequisites


### PR DESCRIPTION
## 📔 Objective

We were previously not explicitly checking for:
- `globalSettings.EventLogging.AzureServiceBus.IntegrationTopicName` (in IsAzureServiceBusEnabled)
- `globalSettings.EventLogging.RabbitMq.IntegrationExchangeName` (in IsRabbitMqEnabled)

This was working because we had explicitly declared the ASB integration topic name in our configs (see note) and it was therefore not failing. However, without these two checks, it was previously possible to configure Rabbit or ASB such that it would start up and attempt to use it, but fail because the integration topic/exchange was `null`. This PR adds a check and explicit tests so that we don't fail on startup.

I will also be issuing a companion PR to the contributing docs to update them to be more explicit about this requirement.

*Note*: I did check with Tyler Dawes just to verify we have this set.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
