### PR TITLE
[bre-1427] resolve intermittent admin build timeouts

### DIFF
--- a/src/Admin/Dockerfile
+++ b/src/Admin/Dockerfile
@@ -1,7 +1,7 @@
 ###############################################
 #           Node.js build stage               #
 ###############################################
-FROM node:20-alpine3.21 AS node-build
+FROM --platform=$BUILDPLATFORM node:20-alpine3.21 AS node-build
 
 WORKDIR /app
 COPY src/Admin/package*.json ./


### PR DESCRIPTION
## 🎟️ Tracking
[bre-1427](https://bitwarden.atlassian.net/browse/bre-1427)

## 📔 Objective
In #5976, the new Admin service node-build stage was missing the `--platform=$BUILDPLATFORM` flag. This causes the ARM64 and ARMv7 builds to run npm ci under QEMU emulation on the AMD64 GitHub Actions runner, rather than executing natively like all other build stages.

  The emulated npm installation is significantly slower (5-10x) and intermittently times out after 45 minutes, causing workflow cancellations. This affects only the Admin service, as it's the only one with a Node.js build stage. The https://github.com/bitwarden/server/actions/workflows/build.yml?query=is%3Acancelled show this occurs multiple times daily, creating confusion and delays for QA.