### PR TITLE
Revert "Auth/PM-3287 - Remove deprecated ResetMasterPassword property from IdentityTokenResponse"

### DIFF
--- a/src/Identity/IdentityServer/RequestValidators/BaseRequestValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/BaseRequestValidator.cs
@@ -671,6 +671,7 @@ public abstract class BaseRequestValidator<T> where T : class
 
         customResponse.Add("MasterPasswordPolicy", await GetMasterPasswordPolicyAsync(user));
         customResponse.Add("ForcePasswordReset", user.ForcePasswordReset);
+        customResponse.Add("ResetMasterPassword", string.IsNullOrWhiteSpace(user.MasterPassword));
         customResponse.Add("Kdf", (byte)user.Kdf);
         customResponse.Add("KdfIterations", user.KdfIterations);
         customResponse.Add("KdfMemory", user.KdfMemory);

--- a/src/Identity/IdentityServer/RequestValidators/CustomTokenRequestValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/CustomTokenRequestValidator.cs
@@ -4,6 +4,7 @@ using Bit.Core;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
 using Bit.Core.AdminConsole.Services;
 using Bit.Core.Auth.IdentityServer;
+using Bit.Core.Auth.Models.Api.Response;
 using Bit.Core.Auth.Repositories;
 using Bit.Core.Context;
 using Bit.Core.Entities;
@@ -154,7 +155,23 @@ public class CustomTokenRequestValidator : BaseRequestValidator<CustomTokenReque
             {
                 // KeyConnectorUrl is configured in the CLI client, we just need to tell the client to use it
                 context.Result.CustomResponse["ApiUseKeyConnector"] = true;
+                context.Result.CustomResponse["ResetMasterPassword"] = false;
             }
+            return Task.CompletedTask;
+        }
+
+        // Key connector data should have already been set in the decryption options
+        // for backwards compatibility we set them this way too. We can eventually get rid of this once we clean up
+        // ResetMasterPassword
+        if (!context.Result.CustomResponse.TryGetValue("UserDecryptionOptions", out var userDecryptionOptionsObj) ||
+            userDecryptionOptionsObj is not UserDecryptionOptions userDecryptionOptions)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (userDecryptionOptions is { KeyConnectorOption: { } })
+        {
+            context.Result.CustomResponse["ResetMasterPassword"] = false;
         }
 
         return Task.CompletedTask;

--- a/test/Identity.IntegrationTest/Endpoints/IdentityServerTests.cs
+++ b/test/Identity.IntegrationTest/Endpoints/IdentityServerTests.cs
@@ -70,6 +70,7 @@ public class IdentityServerTests : IClassFixture<IdentityApplicationFactory>
         var root = body.RootElement;
         AssertRefreshTokenExists(root);
         AssertHelper.AssertJsonProperty(root, "ForcePasswordReset", JsonValueKind.False);
+        AssertHelper.AssertJsonProperty(root, "ResetMasterPassword", JsonValueKind.False);
         var kdf = AssertHelper.AssertJsonProperty(root, "Kdf", JsonValueKind.Number).GetInt32();
         Assert.Equal(0, kdf);
         var kdfIterations = AssertHelper.AssertJsonProperty(root, "KdfIterations", JsonValueKind.Number).GetInt32();


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PM-3287
Reverts bitwarden/server#6676 as mobile clients need to make the property optional otherwise login breaks on `ios` and `android`. 