### PR TITLE
[PM-28025] Re-add web-push feature flag

### DIFF
--- a/src/Api/Models/Response/ConfigResponseModel.cs
+++ b/src/Api/Models/Response/ConfigResponseModel.cs
@@ -1,6 +1,7 @@
 ﻿// FIXME: Update this file to be null safe and then delete the line below
 #nullable disable
 
+using Bit.Core;
 using Bit.Core.Enums;
 using Bit.Core.Models.Api;
 using Bit.Core.Services;
@@ -45,7 +46,8 @@ public class ConfigResponseModel : ResponseModel
             Sso = globalSettings.BaseServiceUri.Sso
         };
         FeatureStates = featureService.GetAll();
-        Push = PushSettings.Build(globalSettings);
+        var webPushEnabled = FeatureStates.TryGetValue(FeatureFlagKeys.WebPush, out var webPushEnabledValue) ? (bool)webPushEnabledValue : false;
+        Push = PushSettings.Build(webPushEnabled, globalSettings);
         Settings = new ServerSettingsResponseModel
         {
             DisableUserRegistration = globalSettings.DisableUserRegistration
@@ -74,9 +76,9 @@ public class PushSettings
     public PushTechnologyType PushTechnology { get; private init; }
     public string VapidPublicKey { get; private init; }
 
-    public static PushSettings Build(IGlobalSettings globalSettings)
+    public static PushSettings Build(bool webPushEnabled, IGlobalSettings globalSettings)
     {
-        var vapidPublicKey = globalSettings.WebPush.VapidPublicKey;
+        var vapidPublicKey = webPushEnabled ? globalSettings.WebPush.VapidPublicKey : null;
         var pushTechnology = vapidPublicKey != null ? PushTechnologyType.WebPush : PushTechnologyType.SignalR;
         return new()
         {

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -228,6 +228,7 @@ public static class FeatureFlagKeys
     public const string CxpExportMobile = "cxp-export-mobile";
 
     /* Platform Team */
+    public const string WebPush = "web-push";
     public const string IpcChannelFramework = "ipc-channel-framework";
     public const string PushNotificationsWhenLocked = "pm-19388-push-notifications-when-locked";
     public const string PushNotificationsWhenInactive = "pm-25130-receive-push-notifications-for-inactive-users";

--- a/test/IntegrationTestCommon/Factories/WebApplicationFactoryBase.cs
+++ b/test/IntegrationTestCommon/Factories/WebApplicationFactoryBase.cs
@@ -154,6 +154,7 @@ public abstract class WebApplicationFactoryBase<T> : WebApplicationFactory<T>
 
             // Web push notifications
             { "globalSettings:webPush:vapidPublicKey", "BGBtAM0bU3b5jsB14IjBYarvJZ6rWHilASLudTTYDDBi7a-3kebo24Yus_xYeOMZ863flAXhFAbkL6GVSrxgErg" },
+            { "globalSettings:launchDarkly:flagValues:web-push", "true" },
         };
 
         // Some database drivers modify the connection string


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-28025

## 📔 Objective

This reverts commit 1c60b805bf80c190332f954e0922d7544eb77284. Due to a latent Chromium bug causing Chromium to still present system notifications even for `userVisibleOnly: false` being passed when calling `subscribe()` on the Push Manager API.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
