### PR TITLE
Add database support for handling OrganizationConnection migration

### DIFF
--- a/src/Core/Dirt/Repositories/IOrganizationIntegrationRepository.cs
+++ b/src/Core/Dirt/Repositories/IOrganizationIntegrationRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Core.Dirt.Entities;
+using Bit.Core.Dirt.Enums;
 using Bit.Core.Repositories;
 
 namespace Bit.Core.Dirt.Repositories;
@@ -8,4 +9,6 @@ public interface IOrganizationIntegrationRepository : IRepository<OrganizationIn
     Task<List<OrganizationIntegration>> GetManyByOrganizationAsync(Guid organizationId);
 
     Task<OrganizationIntegration?> GetByTeamsConfigurationTenantIdTeamId(string tenantId, string teamId);
+
+    Task<OrganizationIntegration?> GetByOrganizationIdTypeAsync(Guid organizationId, IntegrationType type);
 }

--- a/src/Infrastructure.Dapper/Dirt/Repositories/OrganizationIntegrationRepository.cs
+++ b/src/Infrastructure.Dapper/Dirt/Repositories/OrganizationIntegrationRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Data;
 using Bit.Core.Dirt.Entities;
+using Bit.Core.Dirt.Enums;
 using Bit.Core.Dirt.Repositories;
 using Bit.Core.Settings;
 using Bit.Infrastructure.Dapper.Repositories;
@@ -38,6 +39,19 @@ public class OrganizationIntegrationRepository : Repository<OrganizationIntegrat
             var result = await connection.QuerySingleOrDefaultAsync<OrganizationIntegration>(
                 "[dbo].[OrganizationIntegration_ReadByTeamsConfigurationTenantIdTeamId]",
                 new { TenantId = tenantId, TeamId = teamId },
+                commandType: CommandType.StoredProcedure);
+
+            return result;
+        }
+    }
+
+    public async Task<OrganizationIntegration?> GetByOrganizationIdTypeAsync(Guid organizationId, IntegrationType type)
+    {
+        using (var connection = new SqlConnection(ConnectionString))
+        {
+            var result = await connection.QuerySingleOrDefaultAsync<OrganizationIntegration>(
+                "[dbo].[OrganizationIntegration_ReadByOrganizationIdType]",
+                new { OrganizationId = organizationId, Type = type },
                 commandType: CommandType.StoredProcedure);
 
             return result;

--- a/src/Infrastructure.EntityFramework/Dirt/Repositories/OrganizationIntegrationRepository.cs
+++ b/src/Infrastructure.EntityFramework/Dirt/Repositories/OrganizationIntegrationRepository.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using Bit.Core.Dirt.Enums;
 using Bit.Core.Dirt.Repositories;
 using Bit.Infrastructure.EntityFramework.Dirt.Repositories.Queries;
 using Bit.Infrastructure.EntityFramework.Repositories;
@@ -35,6 +36,16 @@ public class OrganizationIntegrationRepository :
         {
             var dbContext = GetDatabaseContext(scope);
             var query = new OrganizationIntegrationReadByTeamsConfigurationTenantIdTeamIdQuery(tenantId: tenantId, teamId: teamId);
+            return await query.Run(dbContext).SingleOrDefaultAsync();
+        }
+    }
+
+    public async Task<OrganizationIntegration?> GetByOrganizationIdTypeAsync(Guid organizationId, IntegrationType type)
+    {
+        using (var scope = ServiceScopeFactory.CreateScope())
+        {
+            var dbContext = GetDatabaseContext(scope);
+            var query = new OrganizationIntegrationReadByOrganizationIdTypeQuery(organizationId, type);
             return await query.Run(dbContext).SingleOrDefaultAsync();
         }
     }

--- a/src/Infrastructure.EntityFramework/Dirt/Repositories/Queries/OrganizationIntegrationReadByOrganizationIdTypeQuery.cs
+++ b/src/Infrastructure.EntityFramework/Dirt/Repositories/Queries/OrganizationIntegrationReadByOrganizationIdTypeQuery.cs
@@ -1,0 +1,32 @@
+﻿using Bit.Core.Dirt.Entities;
+using Bit.Core.Dirt.Enums;
+using Bit.Infrastructure.EntityFramework.Repositories;
+using Bit.Infrastructure.EntityFramework.Repositories.Queries;
+
+namespace Bit.Infrastructure.EntityFramework.Dirt.Repositories.Queries;
+
+public class OrganizationIntegrationReadByOrganizationIdTypeQuery : IQuery<OrganizationIntegration>
+{
+    private readonly Guid _organizationId;
+    private readonly IntegrationType _type;
+
+    public OrganizationIntegrationReadByOrganizationIdTypeQuery(Guid organizationId, IntegrationType type)
+    {
+        _organizationId = organizationId;
+        _type = type;
+    }
+
+    public IQueryable<OrganizationIntegration> Run(DatabaseContext dbContext)
+    {
+        var query = from oi in dbContext.OrganizationIntegrations
+                    where oi.OrganizationId == _organizationId && oi.Type == _type
+                    select new OrganizationIntegration()
+                    {
+                        Id = oi.Id,
+                        OrganizationId = oi.OrganizationId,
+                        Type = oi.Type,
+                        Configuration = oi.Configuration,
+                    };
+        return query;
+    }
+}

--- a/src/Sql/dbo/Stored Procedures/OrganizationIntegration_ReadByOrganizationIdType.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationIntegration_ReadByOrganizationIdType.sql
@@ -1,0 +1,15 @@
+CREATE PROCEDURE [dbo].[OrganizationIntegration_ReadByOrganizationIdType]
+    @OrganizationId UNIQUEIDENTIFIER,
+    @Type SMALLINT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+SELECT
+    *
+FROM
+    [dbo].[OrganizationIntegrationView]
+WHERE
+    [OrganizationId] = @OrganizationId
+    AND [Type] = @Type
+END

--- a/util/Migrator/DbScripts/2025-12-30_00_OrganizationIntegration_AddBillingSyncScimSupport.sql
+++ b/util/Migrator/DbScripts/2025-12-30_00_OrganizationIntegration_AddBillingSyncScimSupport.sql
@@ -1,0 +1,16 @@
+CREATE OR ALTER PROCEDURE [dbo].[OrganizationIntegration_ReadByOrganizationIdType]
+    @OrganizationId UNIQUEIDENTIFIER,
+    @Type SMALLINT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+SELECT
+    *
+FROM
+    [dbo].[OrganizationIntegrationView]
+WHERE
+    [OrganizationId] = @OrganizationId
+    AND [Type] = @Type
+END
+GO


### PR DESCRIPTION
## 📔 Objective

This PR is step one of our effort to move `OrganizationConnection` records and handling into our newer `OrganizationIntegration` architecture. This PR is just additive for now. It adds new repository methods to `IOrganizationIntegrationRepository` in anticipation of using these methods to handle what we're currently doing in the `IOrganizationConnectionRepository`

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
