### PR TITLE
[PM-30460] update storage job to also update database max storage

### DIFF
--- a/src/Billing/Jobs/ReconcileAdditionalStorageJob.cs
+++ b/src/Billing/Jobs/ReconcileAdditionalStorageJob.cs
@@ -288,7 +288,7 @@ public class ReconcileAdditionalStorageJob(
         }
 
         // Otherwise, no change
-        return (short)currentQuantity;
+        return (short)(_includedStorageGb + currentQuantity);
     }
 
     public async Task<bool> UpdateDatabaseMaxStorageAsync(

--- a/test/Billing.Test/Jobs/ReconcileAdditionalStorageJobTests.cs
+++ b/test/Billing.Test/Jobs/ReconcileAdditionalStorageJobTests.cs
@@ -1165,7 +1165,7 @@ public class ReconcileAdditionalStorageJobTests
         var result = _sut.CalculateNewMaxStorageGb(currentQuantity, updateOptions);
 
         // Assert
-        Assert.Equal((short)currentQuantity, result);
+        Assert.Equal(5 + currentQuantity, result);
     }
 
     [Fact]
@@ -1199,7 +1199,7 @@ public class ReconcileAdditionalStorageJobTests
         var result = _sut.CalculateNewMaxStorageGb(currentQuantity, updateOptions);
 
         // Assert
-        Assert.Equal((short)currentQuantity, result);
+        Assert.Equal(5 + currentQuantity, result);
     }
 
     #endregion


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-30460

## 📔 Objective

Fixes an oversight so that the reconcile storage job also updates the database MaxStorageGb after stripe reconciliation.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
