### PR TITLE
Fix pattern matching when retrieving database migrations

### DIFF
--- a/dev/verify_migrations.ps1
+++ b/dev/verify_migrations.ps1
@@ -41,7 +41,7 @@ $migrationPath = "util/Migrator/DbScripts"
 
 # Get list of migrations from base reference
 try {
-    $baseMigrations = git ls-tree -r --name-only $BaseRef -- "$migrationPath/*.sql" 2>$null | Sort-Object
+    $baseMigrations = git ls-tree -r --name-only $BaseRef -- "$migrationPath/" 2>$null | Where-Object { $_ -like "*.sql" } | Sort-Object
     if ($LASTEXITCODE -ne 0) {
         Write-Host "Warning: Could not retrieve migrations from base reference '$BaseRef'"
         $baseMigrations = @()
@@ -53,7 +53,7 @@ catch {
 }
 
 # Get list of migrations from current reference
-$currentMigrations = git ls-tree -r --name-only $CurrentRef -- "$migrationPath/*.sql" | Sort-Object
+$currentMigrations = git ls-tree -r --name-only $CurrentRef -- "$migrationPath/" | Where-Object { $_ -like "*.sql" } | Sort-Object
 
 # Find added migrations
 $addedMigrations = $currentMigrations | Where-Object { $_ -notin $baseMigrations }


### PR DESCRIPTION
## 🎟️ Tracking

Noticed during code review of a long-running branch with a database migration.

## 📔 Objective

We have a database migration validator that ensures a migration is the most recent chronologically but it had a bug with its Git search. Fixes the issue so that migrations are detected properly.
