### PR TITLE
Add Entity Framework migration validation to verify_migrations script

### DIFF
--- a/dev/verify_migrations.ps1
+++ b/dev/verify_migrations.ps1
@@ -212,6 +212,8 @@ foreach ($migrationPathInfo in $efMigrationPaths) {
 
     # Group migrations by base name (without .Designer.cs suffix)
     $migrationGroups = @{}
+    $unmatchedFiles = @()
+
     foreach ($migration in $addedMigrations) {
         $migrationName = Split-Path -Leaf $migration
 
@@ -223,6 +225,25 @@ foreach ($migrationPathInfo in $efMigrationPaths) {
             }
             $migrationGroups[$baseName] += $migrationName
         }
+        else {
+            # Track files that don't match the expected pattern
+            $unmatchedFiles += $migrationName
+        }
+    }
+
+    # Flag any files that don't match the expected pattern
+    if ($unmatchedFiles.Count -gt 0) {
+        Write-Host "ERROR: The following migration files do not match the required format:"
+        foreach ($unmatchedFile in $unmatchedFiles) {
+            Write-Host "  - $unmatchedFile"
+        }
+        Write-Host ""
+        Write-Host "Required format: YYYYMMDDHHMMSS_Description.cs or YYYYMMDDHHMMSS_Description.Designer.cs"
+        Write-Host "  - YYYYMMDDHHMMSS: 14-digit timestamp (Year, Month, Day, Hour, Minute, Second)"
+        Write-Host "  - Description: Descriptive name using PascalCase"
+        Write-Host "Example: 20250115120000_AddNewFeature.cs and 20250115120000_AddNewFeature.Designer.cs"
+        Write-Host ""
+        $efValidationFailed = $true
     }
 
     foreach ($baseName in $migrationGroups.Keys | Sort-Object) {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/DBOPS-72

## 📔 Objective

Need to update the verify_migrations.ps1 to also validate EF migration script names.

Enhances dev/verify_migrations.ps1 to validate EF migration files in addition to SQL migrations. The script now validates migrations in util/MySqlMigrations, util/PostgresMigrations, and util/SqliteMigrations directories.

Validation includes:
- Correct naming format (YYYYMMDDHHMMSS_Description.cs)
- Both .cs and .Designer.cs files exist as pairs
- Chronological ordering of timestamps
- Excludes DatabaseContextModelSnapshot.cs files

The script provides comprehensive reporting for all migration types with a summary showing which validations passed or failed.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
