### PR TITLE
[PM-30682] Add missing null check, update tests

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyValidators/AutomaticUserConfirmationPolicyEventHandler.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyValidators/AutomaticUserConfirmationPolicyEventHandler.cs
@@ -74,8 +74,10 @@ public class AutomaticUserConfirmationPolicyEventHandler(
     private async Task<string> ValidateUserComplianceWithSingleOrgAsync(Guid organizationId,
         ICollection<OrganizationUserUserDetails> organizationUsers)
     {
-        var userIds = organizationUsers.Where(x => x.UserId is not null)
-            .Select(x => x.UserId!.Value);
+        var userIds = organizationUsers.Where(
+                u => u.UserId is not null &&
+                u.Status != OrganizationUserStatusType.Invited)
+            .Select(u => u.UserId!.Value);
 
         var hasNonCompliantUser = (await organizationUserRepository.GetManyByManyUsersAsync(userIds))
             .Any(uo => uo.OrganizationId != organizationId

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyValidators/AutomaticUserConfirmationPolicyEventHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyValidators/AutomaticUserConfirmationPolicyEventHandlerTests.cs
@@ -283,7 +283,7 @@ public class AutomaticUserConfirmationPolicyEventHandlerTests
             OrganizationId = policyUpdate.OrganizationId,
             Type = OrganizationUserType.User,
             Status = OrganizationUserStatusType.Invited,
-            UserId = null, // Invited users have null UserId
+            UserId = null,
             Email = "invited@example.com"
         };
 
@@ -308,14 +308,14 @@ public class AutomaticUserConfirmationPolicyEventHandlerTests
         Guid confirmedUserId,
         SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
-        // Arrange - Mix of invited users (null UserId) and confirmed users
+        // Arrange
         var invitedUser = new OrganizationUserUserDetails
         {
             Id = Guid.NewGuid(),
             OrganizationId = policyUpdate.OrganizationId,
             Type = OrganizationUserType.User,
             Status = OrganizationUserStatusType.Invited,
-            UserId = null, // Invited users have null UserId
+            UserId = null,
             Email = "invited@example.com"
         };
 
@@ -347,7 +347,6 @@ public class AutomaticUserConfirmationPolicyEventHandlerTests
         // Assert
         Assert.True(string.IsNullOrEmpty(result));
 
-        // Verify that GetManyByManyUsersAsync was called only with non-null UserIds
         await sutProvider.GetDependency<IOrganizationUserRepository>()
             .Received(1)
             .GetManyByManyUsersAsync(Arg.Is<IEnumerable<Guid>>(ids => ids.Count() == 1 && ids.First() == confirmedUserId));


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-30682
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Fixes a LINQ bug where we attempt to check for `UserId` which may be `null` (i.e. invited users) when enforcing the policy validator.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
