### PR TITLE
[PM-30805] Expand `invoice.customer` on first premium invoice purchased with PayPal

### DIFF
--- a/src/Core/Billing/Premium/Commands/CreatePremiumCloudHostedSubscriptionCommand.cs
+++ b/src/Core/Billing/Premium/Commands/CreatePremiumCloudHostedSubscriptionCommand.cs
@@ -361,7 +361,8 @@ public class CreatePremiumCloudHostedSubscriptionCommand(
 
         var invoice = await stripeAdapter.UpdateInvoiceAsync(subscription.LatestInvoiceId, new InvoiceUpdateOptions
         {
-            AutoAdvance = false
+            AutoAdvance = false,
+            Expand = ["customer"]
         });
 
         await braintreeService.PayInvoice(new UserId(userId), invoice);

--- a/test/Core.Test/Billing/Premium/Commands/CreatePremiumCloudHostedSubscriptionCommandTests.cs
+++ b/test/Core.Test/Billing/Premium/Commands/CreatePremiumCloudHostedSubscriptionCommandTests.cs
@@ -266,7 +266,10 @@ public class CreatePremiumCloudHostedSubscriptionCommandTests
         await _stripeAdapter.Received(1).CreateSubscriptionAsync(Arg.Any<SubscriptionCreateOptions>());
         await _subscriberService.Received(1).CreateBraintreeCustomer(user, paymentMethod.Token);
         await _stripeAdapter.Received(1).UpdateInvoiceAsync(mockSubscription.LatestInvoiceId,
-            Arg.Is<InvoiceUpdateOptions>(opts => opts.AutoAdvance == false));
+            Arg.Is<InvoiceUpdateOptions>(opts =>
+                opts.AutoAdvance == false &&
+                opts.Expand != null &&
+                opts.Expand.Contains("customer")));
         await _braintreeService.Received(1).PayInvoice(Arg.Any<SubscriberId>(), mockInvoice);
         await _userService.Received(1).SaveUserAsync(user);
         await _pushNotificationService.Received(1).PushSyncVaultAsync(user.Id);
@@ -502,7 +505,10 @@ public class CreatePremiumCloudHostedSubscriptionCommandTests
         Assert.True(user.Premium);
         Assert.Equal(mockSubscription.GetCurrentPeriodEnd(), user.PremiumExpirationDate);
         await _stripeAdapter.Received(1).UpdateInvoiceAsync(mockSubscription.LatestInvoiceId,
-            Arg.Is<InvoiceUpdateOptions>(opts => opts.AutoAdvance == false));
+            Arg.Is<InvoiceUpdateOptions>(opts =>
+                opts.AutoAdvance == false &&
+                opts.Expand != null &&
+                opts.Expand.Contains("customer")));
         await _braintreeService.Received(1).PayInvoice(Arg.Any<SubscriberId>(), mockInvoice);
     }
 
@@ -612,7 +618,10 @@ public class CreatePremiumCloudHostedSubscriptionCommandTests
         Assert.False(user.Premium);
         Assert.Null(user.PremiumExpirationDate);
         await _stripeAdapter.Received(1).UpdateInvoiceAsync(mockSubscription.LatestInvoiceId,
-            Arg.Is<InvoiceUpdateOptions>(opts => opts.AutoAdvance == false));
+            Arg.Is<InvoiceUpdateOptions>(opts =>
+                opts.AutoAdvance == false &&
+                opts.Expand != null &&
+                opts.Expand.Contains("customer")));
         await _braintreeService.Received(1).PayInvoice(Arg.Any<SubscriberId>(), mockInvoice);
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-30805

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

**RCA**
The `BraintreeService.PayInvoice` requires the `Invoice.Customer` property to be expanded. The invocation in the `CreatePremiumCloudHostedSubscriptionCommand` was not doing so.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/48b4eb32-64c4-42a1-8e94-7843527e4a74



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
