### PR TITLE
[PM-24759] Add Method for Retrieving Policy Requirements for Multiple Users

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/IPolicyRequirementQuery.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/IPolicyRequirementQuery.cs
@@ -21,11 +21,11 @@ public interface IPolicyRequirementQuery
     /// The policy requirement represents how one or more policy types should be enforced against the users.
     /// </summary>
     /// <returns>
-    /// A list of applicable policy requirements in corresponding order of the submitted user IDs.
+    /// A collection of tuples pairing each user ID with their corresponding policy requirement.
     /// </returns>
     /// <param name="userIds">The users that you need to enforce the policy against.</param>
     /// <typeparam name="T">The IPolicyRequirement that corresponds to the policy you want to enforce.</typeparam>
-    Task<IEnumerable<T>> GetAsync<T>(IEnumerable<Guid> userIds) where T : IPolicyRequirement;
+    Task<IEnumerable<(Guid UserId, T Requirement)>> GetAsync<T>(IEnumerable<Guid> userIds) where T : IPolicyRequirement;
 
     /// <summary>
     /// Get all organization user IDs within an organization that are affected by a given policy type.

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/Implementations/PolicyRequirementQuery.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/Implementations/PolicyRequirementQuery.cs
@@ -11,9 +11,9 @@ public class PolicyRequirementQuery(
     : IPolicyRequirementQuery
 {
     public async Task<T> GetAsync<T>(Guid userId) where T : IPolicyRequirement
-        => (await GetAsync<T>([userId])).Single();
+        => (await GetAsync<T>([userId])).Single().Requirement;
 
-    public async Task<IEnumerable<T>> GetAsync<T>(IEnumerable<Guid> userIds) where T : IPolicyRequirement
+    public async Task<IEnumerable<(Guid UserId, T Requirement)>> GetAsync<T>(IEnumerable<Guid> userIds) where T : IPolicyRequirement
     {
         var factory = factories.OfType<IPolicyRequirementFactory<T>>().SingleOrDefault();
         if (factory is null)
@@ -27,7 +27,7 @@ public class PolicyRequirementQuery(
             .Where(factory.Enforce)
             .ToLookup(l => l.UserId);
 
-        var policyRequirements = userIdList.Select(u => factory.Create(policyDetailsByUser[u]));
+        var policyRequirements = userIdList.Select(u => (u, factory.Create(policyDetailsByUser[u])));
 
         return policyRequirements;
     }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyRequirementQueryTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyRequirementQueryTests.cs
@@ -83,10 +83,12 @@ public class PolicyRequirementQueryTests
         var requirements = (await sut.GetAsync<TestPolicyRequirement>([userIdA, userIdB])).ToList();
 
         Assert.Equal(2, requirements.Count);
-        Assert.Contains(policyA, requirements[0].Policies);
-        Assert.DoesNotContain(policyB, requirements[0].Policies);
-        Assert.Contains(policyB, requirements[1].Policies);
-        Assert.DoesNotContain(policyA, requirements[1].Policies);
+        Assert.Equal(userIdA, requirements[0].UserId);
+        Assert.Equal(userIdB, requirements[1].UserId);
+        Assert.Contains(policyA, requirements[0].Requirement.Policies);
+        Assert.DoesNotContain(policyB, requirements[0].Requirement.Policies);
+        Assert.Contains(policyB, requirements[1].Requirement.Policies);
+        Assert.DoesNotContain(policyA, requirements[1].Requirement.Policies);
     }
 
     [Theory, BitAutoData]
@@ -107,8 +109,8 @@ public class PolicyRequirementQueryTests
 
         var requirements = (await sut.GetAsync<TestPolicyRequirement>([userIdA, userIdB])).ToList();
 
-        Assert.Contains(policyA, requirements[0].Policies);
-        Assert.Empty(requirements[1].Policies);
+        Assert.Contains(policyA, requirements[0].Requirement.Policies);
+        Assert.Empty(requirements[1].Requirement.Policies);
         callback.Received()(Arg.Is(policyA));
         callback.Received()(Arg.Is(policyB));
     }
@@ -134,9 +136,9 @@ public class PolicyRequirementQueryTests
         var requirements = (await sut.GetAsync<TestPolicyRequirement>([userIdA, userIdB])).ToList();
 
         Assert.Equal(2, requirements.Count);
-        Assert.Contains(enforcedPolicyA, requirements[0].Policies);
-        Assert.DoesNotContain(notEnforcedPolicyA, requirements[0].Policies);
-        Assert.Contains(enforcedPolicyB, requirements[1].Policies);
+        Assert.Contains(enforcedPolicyA, requirements[0].Requirement.Policies);
+        Assert.DoesNotContain(notEnforcedPolicyA, requirements[0].Requirement.Policies);
+        Assert.Contains(enforcedPolicyB, requirements[1].Requirement.Policies);
     }
 
     [Theory, BitAutoData]
@@ -164,8 +166,10 @@ public class PolicyRequirementQueryTests
         var requirements = (await sut.GetAsync<TestPolicyRequirement>([userIdA, userIdB])).ToList();
 
         Assert.Equal(2, requirements.Count);
-        Assert.Empty(requirements[0].Policies);
-        Assert.Empty(requirements[1].Policies);
+        Assert.Equal(userIdA, requirements[0].UserId);
+        Assert.Equal(userIdB, requirements[1].UserId);
+        Assert.Empty(requirements[0].Requirement.Policies);
+        Assert.Empty(requirements[1].Requirement.Policies);
     }
 
     [Theory, BitAutoData]
@@ -185,8 +189,10 @@ public class PolicyRequirementQueryTests
         var requirements = (await sut.GetAsync<TestPolicyRequirement>([userIdA, userIdB])).ToList();
 
         Assert.Equal(2, requirements.Count);
-        Assert.Contains(policyA, requirements[0].Policies);
-        Assert.Empty(requirements[1].Policies);
+        Assert.Equal(userIdA, requirements[0].UserId);
+        Assert.Equal(userIdB, requirements[1].UserId);
+        Assert.Contains(policyA, requirements[0].Requirement.Policies);
+        Assert.Empty(requirements[1].Requirement.Policies);
     }
 
     [Theory, BitAutoData]


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-24759

## 📔 Objective
Following existing patterns, we want to expose a `GetAsync` method in the query class that supports single and collection parameters. This PR opens PolicyRequirementQuery's ability to load requirements given a list of user IDs. 

We're also now delegating requests for single users to this collection-based request, unifying logic across both methods.

Tested by validating the MasterPasswordPolicyRequirement was enforced against a user upon login.
## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
