### PR TITLE
Have AppSec own Checkmarx config

### DIFF
--- a/.checkmarx/config.yml
+++ b/.checkmarx/config.yml
@@ -11,3 +11,7 @@ checkmarx:
         filter: "!test"
       kics:
         filter: "!dev,!.devcontainer"
+      sca:
+        filter: "!dev,!.devcontainer"
+      containers:
+        filter: "!dev,!.devcontainer"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,9 @@
 **/docker-compose.yml @bitwarden/team-appsec @bitwarden/dept-bre
 **/entrypoint.sh @bitwarden/team-appsec @bitwarden/dept-bre
 
+# Scanning tools
+.checkmarx/ @bitwarden/team-appsec
+
 ## BRE team owns these workflows ##
 .github/workflows/publish.yml @bitwarden/dept-bre
 


### PR DESCRIPTION
## 🎟️ Tracking

Noticed while reviewing a PR.

## 📔 Objective

Indicates AppSec should own configuration in the `.checkmarx` folder. Also adds some sensible additions to the configuration for development files.
