### PR TITLE
Resolve conflict with Docker ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -97,9 +97,7 @@ src/Admin/Views/Tools @bitwarden/team-billing-dev
 .github/workflows/test-database.yml @bitwarden/team-platform-dev
 .github/workflows/test.yml @bitwarden/team-platform-dev
 **/*Platform* @bitwarden/team-platform-dev
-**/.dockerignore @bitwarden/team-platform-dev
-**/Dockerfile @bitwarden/team-platform-dev
-**/entrypoint.sh @bitwarden/team-platform-dev
+
 # The PushType enum is expected to be editted by anyone without need for Platform review
 src/Core/Platform/Push/PushType.cs
 


### PR DESCRIPTION
## 🎟️ Tracking

Noticed with #6912 review.

## 📔 Objective

Reverts #5820. BRE and AppSec own Docker-related configuration.
