### PR TITLE
[PM-31280] Always return UTC-formatted dates

### DIFF
--- a/src/Infrastructure.Dapper/Vault/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.Dapper/Vault/Repositories/CipherRepository.cs
@@ -248,7 +248,7 @@ public class CipherRepository : Repository<Cipher, Guid>, ICipherRepository
                 new { Ids = ids.ToGuidIdArrayTVP(), UserId = userId },
                 commandType: CommandType.StoredProcedure);
 
-            return results;
+            return DateTime.SpecifyKind(results, DateTimeKind.Utc);
         }
     }
 
@@ -595,7 +595,7 @@ public class CipherRepository : Repository<Cipher, Guid>, ICipherRepository
                 new { Ids = ids.ToGuidIdArrayTVP(), UserId = userId },
                 commandType: CommandType.StoredProcedure);
 
-            return results;
+            return DateTime.SpecifyKind(results, DateTimeKind.Utc);
         }
     }
 
@@ -608,7 +608,7 @@ public class CipherRepository : Repository<Cipher, Guid>, ICipherRepository
                 new { Ids = ids.ToGuidIdArrayTVP(), UserId = userId },
                 commandType: CommandType.StoredProcedure);
 
-            return results;
+            return DateTime.SpecifyKind(results, DateTimeKind.Utc);
         }
     }
 
@@ -621,7 +621,7 @@ public class CipherRepository : Repository<Cipher, Guid>, ICipherRepository
                 new { Ids = ids.ToGuidIdArrayTVP(), OrganizationId = organizationId },
                 commandType: CommandType.StoredProcedure);
 
-            return results;
+            return DateTime.SpecifyKind(results, DateTimeKind.Utc);
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-31280

## 📔 Objective

When the SDK is used for restore operations, it throws an error on the client side even though the Server operation is successful. The Rust library used expects the `Z` at the end of a timestamp to indicate it's UTC, and is failing without this. Since all our dates our UTC, this fixes the response on the server side to indicate that in the JSON response.

This PR also adds the same to the Archive/Unarchive operations, which also don't specify the UTC kind.
