### PR TITLE
[PM-31747] Risk Insights Download Endpoint

### DIFF
--- a/src/Api/Dirt/Models/Response/OrganizationReportIdResponseModel.cs
+++ b/src/Api/Dirt/Models/Response/OrganizationReportIdResponseModel.cs
@@ -1,0 +1,29 @@
+using Bit.Core.Dirt.Entities;
+
+namespace Bit.Api.Dirt.Models.Response;
+
+/// <summary>
+/// Lightweight response model for organization report operations that returns
+/// only essential metadata without large data fields (ReportData, SummaryData, ApplicationData).
+/// Used to avoid JSON serialization limits when handling large reports.
+/// </summary>
+public class OrganizationReportIdResponseModel
+{
+    public Guid Id { get; set; }
+    public Guid OrganizationId { get; set; }
+    public DateTime? CreationDate { get; set; }
+    public DateTime? RevisionDate { get; set; }
+
+    public OrganizationReportIdResponseModel(OrganizationReport organizationReport)
+    {
+        if (organizationReport == null)
+        {
+            return;
+        }
+
+        Id = organizationReport.Id;
+        OrganizationId = organizationReport.OrganizationId;
+        CreationDate = organizationReport.CreationDate;
+        RevisionDate = organizationReport.RevisionDate;
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking
[PM-31747](https://bitwarden.atlassian.net/browse/PM-31747)

## 📔 Objective

This pull request adds a download route for the latest organization report, updates the `RequestSizeLimit` for the endpoints that save or update a report, and updates save endpoints to not attempt to return the large report data. This is to support saving reports that are too large for the current restraints.

- Add new `GET /reports/organizations/{organizationId}/latest/download` endpoint that returns organization reports as downloadable JSON files to support large reports (30MB+)
- Create `OrganizationReportIdResponseModel` lightweight response model returning only metadata for endpoints
    - `POST /reports/organizations/{organizationId}`
    - `PATCH /reports/organizations/{organizationId}/data/report/{reportId}`
- Add [RequestSizeLimit(Constants.FileSize501mb)] attribute to POST and PATCH endpoints for report creation/updates
- Add EscapeJsonString() helper method to properly escape JSON strings in download endpoint


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-31747]: https://bitwarden.atlassian.net/browse/PM-31747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ