### PR TITLE
[PM-31785] Protect Key Connector and Master Key wrapped user key and server side hash

### DIFF
--- a/src/Infrastructure.Dapper/Repositories/UserRepository.cs
+++ b/src/Infrastructure.Dapper/Repositories/UserRepository.cs
@@ -434,6 +434,13 @@ public class UserRepository : Repository<User, Guid>, IUserRepository
     public UpdateUserData SetMasterPassword(Guid userId, MasterPasswordUnlockData masterPasswordUnlockData,
         string serverSideHashedMasterPasswordAuthenticationHash, string? masterPasswordHint)
     {
+        var protectedMasterKeyWrappedUserKey = string.Concat(Constants.DatabaseFieldProtectedPrefix,
+            _dataProtector.Protect(masterPasswordUnlockData.MasterKeyWrappedUserKey));
+
+        var protectedServerSideHashedMasterPasswordAuthenticationHash = string.Concat(
+            Constants.DatabaseFieldProtectedPrefix,
+            _dataProtector.Protect(serverSideHashedMasterPasswordAuthenticationHash));
+
         return async (connection, transaction) =>
         {
             var timestamp = DateTime.UtcNow;
@@ -443,9 +450,9 @@ public class UserRepository : Repository<User, Guid>, IUserRepository
                 new
                 {
                     Id = userId,
-                    MasterPassword = serverSideHashedMasterPasswordAuthenticationHash,
+                    MasterPassword = protectedServerSideHashedMasterPasswordAuthenticationHash,
                     MasterPasswordHint = masterPasswordHint,
-                    Key = masterPasswordUnlockData.MasterKeyWrappedUserKey,
+                    Key = protectedMasterKeyWrappedUserKey,
                     Kdf = masterPasswordUnlockData.Kdf.KdfType,
                     KdfIterations = masterPasswordUnlockData.Kdf.Iterations,
                     KdfMemory = masterPasswordUnlockData.Kdf.Memory,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-31785

## 📔 Objective

During account crypto keys initialisation for SSO JIT Key Connector user registration, the Key Connector wrapped user key is unprotected by .NET Data Protection for Dapper.
The same is the case for SSO JIT Master Password and existing TDE user that needs to enroll into master password, where the master key wrapper user key and server side hashed MP authentication hash are not protected.
This PR fixes this.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
