### PR TITLE
Ensure that the maria db password is properly set

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -77,6 +77,7 @@ services:
       - 4306:3306
     environment:
       MARIADB_USER: maria
+      MARIADB_PASSWORD: ${MARIADB_ROOT_PASSWORD}
       MARIADB_DATABASE: vault_dev
       MARIADB_RANDOM_ROOT_PASSWORD: "true"
     volumes:


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

While tracking down another local problem, I worked to setup all the other database providers and the missing variable caused problems. Claude and I fixed our woes with this change. 