### PR TITLE
[PM-32007] Use kebab instead of snake case for cookie vendor

### DIFF
--- a/src/Api/Platform/SsoCookieVendor/Controllers/SsoCookieVendorController.cs
+++ b/src/Api/Platform/SsoCookieVendor/Controllers/SsoCookieVendorController.cs
@@ -3,7 +3,7 @@ using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Bit.Api.Controllers;
+namespace Bit.Api.Platform.SsoCookieVendor;
 
 /// <summary>
 /// Provides an endpoint to read an SSO cookie and redirect to a custom URI

--- a/test/Api.Test/Platform/SsoCookieVendor/Controllers/SsoCookieVendorControllerTests.cs
+++ b/test/Api.Test/Platform/SsoCookieVendor/Controllers/SsoCookieVendorControllerTests.cs
@@ -1,13 +1,13 @@
 ﻿#nullable enable
 
-using Bit.Api.Controllers;
+using Bit.Api.Platform.SsoCookieVendor;
 using Bit.Core.Settings;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Api.Test.Controllers;
+namespace Bit.Api.Test.Platform.SsoCookieVendor.Controllers;
 
 public class SsoCookieVendorControllerTests : IDisposable
 {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32007](https://bitwarden.atlassian.net/browse/PM-32007)

## 📔 Objective

Change `bitwarden://sso_cookie_vendor` to `bitwarden://sso-cookie-vendor` for consistency with other `bitwarden` scheme URIs.

Also moved cookie vending files to Platform-owned directories for codeowners.

[PM-32007]: https://bitwarden.atlassian.net/browse/PM-32007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ