### PR TITLE
[BRE-1615] Bump node version to latest LTS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
         with:
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
-          node-version: "16"
+          node-version: "24"
 
       - name: Print environment
         run: |


### PR DESCRIPTION
## 🎟️ Tracking
[BRE-1615](https://bitwarden.atlassian.net/browse/BRE-1615)

## 📔 Objective
The version of `node` used in the `build.yml`:
- is EOL
- unsupported by the latest [version](https://github.com/webpack/webpack-cli/blob/HEAD/CHANGELOG.md#601-2024-12-20) of `webpack-cli`

This PR bumps `node` to the latest [LTS version](https://nodejs.org/en/about/previous-releases)

[BRE-1615]: https://bitwarden.atlassian.net/browse/BRE-1615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ