### PR TITLE
[PM-31088]: (feature-flag) saltForUser should emit salt from master password unlock data

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -168,6 +168,7 @@ public static class FeatureFlagKeys
     public const string SafariAccountSwitching = "pm-5594-safari-account-switching";
     public const string PM27086_UpdateAuthenticationApisForInputPassword = "pm-27086-update-authentication-apis-for-input-password";
     public const string PM27044_UpdateRegistrationApis = "pm-27044-update-registration-apis";
+    public const string PM31088_MasterPasswordServiceEmitSalt = "pm-31088-master-password-service-emit-salt";
 
     /* Autofill Team */
     public const string SSHAgent = "ssh-agent";


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31088](https://bitwarden.atlassian.net/browse/PM-31088)

:octocat: Related `clients` PR [18976](https://github.com/bitwarden/clients/pull/18976)

## 📔 Objective

Add feature flag for `saltForUser$` updates in related `clients` PR.

## 📸 Screenshots

See related `clients` PR [18976](https://github.com/bitwarden/clients/pull/18976).


[PM-31088]: https://bitwarden.atlassian.net/browse/PM-31088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ