### PR TITLE
[PM-27882] Revert row bulletin changes for confirmation templates.

### DIFF
--- a/src/Core/AdminConsole/Models/Mail/Mailer/OrganizationConfirmation/OrganizationConfirmationEnterpriseTeamsView.html.hbs
+++ b/src/Core/AdminConsole/Models/Mail/Mailer/OrganizationConfirmation/OrganizationConfirmationEnterpriseTeamsView.html.hbs
@@ -87,12 +87,6 @@
         .mj-bw-ac-icon-row-text-column {
           width: 100% !important;
         }
-        .mj-bw-ac-icon-row-bullet {
-          display: block !important;
-        }
-        .mj-bw-ac-icon-row-text-inline {
-          display: none !important;
-        }
       }
     
     </style>
@@ -356,8 +350,7 @@
               <tr>
                 <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
                   
-      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>Your account is owned by {{OrganizationName}} and is subject to their security and management policies.</li></ul>
-                <span class="mj-bw-ac-icon-row-text-inline">Your account is owned by {{OrganizationName}} and is subject to their security and management policies.</span></div>
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">Your account is owned by {{OrganizationName}} and is subject to their security and management policies.</div>
     
                 </td>
               </tr>
@@ -431,8 +424,7 @@
               <tr>
                 <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
                   
-      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>You can easily access and share passwords with your team.</li></ul>
-                <span class="mj-bw-ac-icon-row-text-inline">You can easily access and share passwords with your team.</span></div>
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">You can easily access and share passwords with your team.</div>
     
                 </td>
               </tr>

--- a/src/Core/AdminConsole/Models/Mail/Mailer/OrganizationConfirmation/OrganizationConfirmationFamilyFreeView.html.hbs
+++ b/src/Core/AdminConsole/Models/Mail/Mailer/OrganizationConfirmation/OrganizationConfirmationFamilyFreeView.html.hbs
@@ -91,12 +91,6 @@
         .mj-bw-ac-icon-row-text-column {
           width: 100% !important;
         }
-        .mj-bw-ac-icon-row-bullet {
-          display: block !important;
-        }
-        .mj-bw-ac-icon-row-text-inline {
-          display: none !important;
-        }
       }
     
     </style>
@@ -364,8 +358,7 @@
               <tr>
                 <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
                   
-      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>You can access passwords {{OrganizationName}} has shared with you.</li></ul>
-                <span class="mj-bw-ac-icon-row-text-inline">You can access passwords {{OrganizationName}} has shared with you.</span></div>
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">You can access passwords {{OrganizationName}} has shared with you.</div>
     
                 </td>
               </tr>
@@ -439,8 +432,7 @@
               <tr>
                 <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
                   
-      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>You can easily share passwords with friends, family, or coworkers.</li></ul>
-                <span class="mj-bw-ac-icon-row-text-inline">You can easily share passwords with friends, family, or coworkers.</span></div>
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">You can easily share passwords with friends, family, or coworkers.</div>
     
                 </td>
               </tr>

--- a/src/Core/MailTemplates/Mjml/.mjmlconfig
+++ b/src/Core/MailTemplates/Mjml/.mjmlconfig
@@ -7,6 +7,7 @@
     "emails/AdminConsole/components/mj-bw-inviter-info",
     "emails/AdminConsole/components/mj-bw-ac-hero",
     "emails/AdminConsole/components/mj-bw-ac-icon-row",
+    "emails/AdminConsole/components/mj-bw-ac-icon-row-without-bulletins",
     "emails/AdminConsole/components/mj-bw-ac-learn-more-footer"
   ]
 }

--- a/src/Core/MailTemplates/Mjml/emails/AdminConsole/OrganizationConfirmation/organization-confirmation-enterprise-teams.mjml
+++ b/src/Core/MailTemplates/Mjml/emails/AdminConsole/OrganizationConfirmation/organization-confirmation-enterprise-teams.mjml
@@ -26,12 +26,12 @@
                     </mj-text>
                 </mj-column>
             </mj-section>
-            <mj-bw-ac-icon-row
+            <mj-bw-ac-icon-row-without-bulletins
                     icon-src="https://assets.bitwarden.com/email/v1/icon-enterprise.png"
                     icon-alt="Organization Icon"
                     text="Your account is owned by {{OrganizationName}} and is subject to their security and management policies."
             />
-            <mj-bw-ac-icon-row
+            <mj-bw-ac-icon-row-without-bulletins
                     icon-src="https://assets.bitwarden.com/email/v1/icon-account-switching-new.png"
                     icon-alt="Share Icon"
                     text="You can easily access and share passwords with your team."

--- a/src/Core/MailTemplates/Mjml/emails/AdminConsole/OrganizationConfirmation/organization-confirmation-family-free.mjml
+++ b/src/Core/MailTemplates/Mjml/emails/AdminConsole/OrganizationConfirmation/organization-confirmation-family-free.mjml
@@ -26,18 +26,18 @@
                     </mj-text>
                 </mj-column>
             </mj-section>
-            <mj-bw-ac-icon-row
+            <mj-bw-ac-icon-row-without-bulletins
                     icon-src="https://assets.bitwarden.com/email/v1/icon-item-type.png"
                     icon-alt="Group Users Icon"
                     text="You can access passwords {{OrganizationName}} has shared with you.">
-            </mj-bw-ac-icon-row>
-            <mj-bw-ac-icon-row
+            </mj-bw-ac-icon-row-without-bulletins>
+            <mj-bw-ac-icon-row-without-bulletins
                     icon-src="https://assets.bitwarden.com/email/v1/icon-account-switching-new.png"
                     icon-alt="Share Icon"
                     text="You can easily share passwords with friends, family, or coworkers."
                     foot-url-text="Share passwords in Bitwarden"
                     foot-url="https://bitwarden.com/help/sharing">
-            </mj-bw-ac-icon-row>
+            </mj-bw-ac-icon-row-without-bulletins>
         </mj-wrapper>
 
         <!-- Download Mobile Apps Section -->

--- a/src/Core/MailTemplates/Mjml/emails/AdminConsole/components/mj-bw-ac-icon-row-without-bulletins.js
+++ b/src/Core/MailTemplates/Mjml/emails/AdminConsole/components/mj-bw-ac-icon-row-without-bulletins.js
@@ -1,0 +1,103 @@
+const { BodyComponent } = require("mjml-core");
+
+const BODY_TEXT_STYLES = `
+  font-family="'Helvetica Neue', Helvetica, Arial, sans-serif"
+  font-size="16px"
+  font-weight="400"
+  line-height="24px"
+`;
+
+class MjBwAcIconRowWithoutBulletins extends BodyComponent {
+    static dependencies = {
+        "mj-column": ["mj-bw-ac-icon-row-without-bulletins"],
+        "mj-wrapper": ["mj-bw-ac-icon-row-without-bulletins"],
+        "mj-bw-ac-icon-row-without-bulletins": [],
+    };
+
+    static allowedAttributes = {
+        "icon-src": "string",
+        "icon-alt": "string",
+        "head-url-text": "string",
+        "head-url": "string",
+        text: "string",
+        "foot-url-text": "string",
+        "foot-url": "string",
+    };
+
+    static defaultAttributes = {};
+
+    headStyle = (breakpoint) => {
+        return `
+      @media only screen and (max-width:${breakpoint}) {
+        .mj-bw-ac-icon-row-text {
+          padding-left: 15px !important;
+          padding-right: 15px !important;
+          line-height: 20px;
+        }
+        .mj-bw-ac-icon-row-icon {
+          display: none !important;
+          width: 0 !important;
+          max-width: 0 !important;
+        }
+        .mj-bw-ac-icon-row-text-column {
+          width: 100% !important;
+        }
+      }
+    `;
+    };
+
+    render() {
+        const headAnchorElement =
+            this.getAttribute("head-url-text") && this.getAttribute("head-url")
+                ? `
+            <mj-text css-class="mj-bw-ac-icon-row-text" padding="5px 10px 0px 10px" ${BODY_TEXT_STYLES}>
+                <a href="${this.getAttribute("head-url")}" class="link">
+                    ${this.getAttribute("head-url-text")}
+                    <span style="text-decoration: none">
+                      <img src="https://assets.bitwarden.com/email/v1/bwi-external-link-16px.png"
+                        alt="External Link Icon"
+                        width="16px"
+                        style="vertical-align: middle;"
+                      />
+                    </span>
+                  </a>
+            </mj-text>`
+                : "";
+
+        const footAnchorElement =
+            this.getAttribute("foot-url-text") && this.getAttribute("foot-url")
+                ? `<mj-text css-class="mj-bw-ac-icon-row-text" padding="0px" ${BODY_TEXT_STYLES}>
+                <a href="${this.getAttribute("foot-url")}" class="link">
+                    ${this.getAttribute("foot-url-text")}
+              </a>
+          </mj-text>`
+                : "";
+
+        return this.renderMJML(
+            `
+      <mj-section background-color="#fff" padding="0px 10px 24px 10px">
+        <mj-group css-class="mj-bw-ac-icon-row">
+          <mj-column width="15%" vertical-align="middle" css-class="mj-bw-ac-icon-row-icon">
+            <mj-image
+              src="${this.getAttribute("icon-src")}"
+              alt="${this.getAttribute("icon-alt")}"
+              width="48px"
+              padding="0px 10px 0px 5px"
+              border-radius="8px"
+            />
+          </mj-column>
+          <mj-column width="85%" vertical-align="middle" css-class="mj-bw-ac-icon-row-text-column">
+              ${headAnchorElement}
+              <mj-text css-class="mj-bw-ac-icon-row-text" padding="0px 0px 0px 0px" ${BODY_TEXT_STYLES}>
+                ${this.getAttribute("text")}
+              </mj-text>
+              ${footAnchorElement}
+          </mj-column>
+        </mj-group>
+      </mj-section>
+    `,
+        );
+    }
+}
+
+module.exports = MjBwAcIconRowWithoutBulletins;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27882


## 📔 Objective

This is to revert the previous [change](https://github.com/bitwarden/server/pull/7010) of adding the bulletin row. Since it's a shared component, I decided to create another component for the old version to reduce complexity.

## 📸 Screenshots

Family/Free

<img width="1536" height="2738" alt="image" src="https://github.com/user-attachments/assets/fc475e4a-0a5c-414f-b9f9-28e04370bf97" />

<img width="1404" height="2174" alt="image" src="https://github.com/user-attachments/assets/0cf16acb-0b58-4a13-ac20-30842cef5f3d" />

Enterprise/Teams

<img width="1322" height="2668" alt="image" src="https://github.com/user-attachments/assets/d6f9c465-ef7a-4947-a936-051d7aee01c4" />

<img width="1480" height="1670" alt="image" src="https://github.com/user-attachments/assets/ec9fac66-ac3a-4d16-b2d7-c038a2dc4e71" />
