### PR TITLE
[PM-31889] - Validate Org ID && User Org ID Match for Reset Password

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -227,7 +227,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
     public async Task<OrganizationUserResetPasswordDetailsResponseModel> GetResetPasswordDetails(Guid orgId, Guid id)
     {
         var organizationUser = await _organizationUserRepository.GetByIdAsync(id);
-        if (organizationUser is null || organizationUser.UserId is null)
+        if (organizationUser is null || organizationUser.OrganizationId != orgId || organizationUser.UserId is null)
         {
             throw new NotFoundException();
         }


### PR DESCRIPTION
## 🎟️ Tracking
[PM-31889](https://bitwarden.atlassian.net/browse/PM-31889)

## 📔 Objective
This endpoint lacked verification that the organization of the passed-in user matches the organization of the orgId parameter. Further details are in the ticket and the vulnerability report therein.

[PM-31889]: https://bitwarden.atlassian.net/browse/PM-31889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ