### PR TITLE
[PM-31433] Extension Prompt Account Age Feature Flag

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -258,6 +258,7 @@ public static class FeatureFlagKeys
     public const string PM30521_AutofillButtonViewLoginScreen = "pm-30521-autofill-button-view-login-screen";
     public const string PM32180_PremiumUpsellAccountAge = "pm-32180-premium-upsell-account-age";
     public const string PM29438_WelcomeDialogWithExtensionPrompt = "pm-29438-welcome-dialog-with-extension-prompt";
+    public const string PM29438_DialogWithExtensionPromptAccountAge = "pm-29438-dialog-with-extension-prompt-account-age";
     public const string PM31039_ItemActionInExtension = "pm-31039-item-action-in-extension";
 
     /* Innovation Team */


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31433](https://bitwarden.atlassian.net/browse/PM-31433)

## 📔 Objective

Adds feature flag associated for the account age extension prompt.

## 📸 Screenshots

N/A

[PM-31433]: https://bitwarden.atlassian.net/browse/PM-31433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ