### PR TITLE
[PM-32463] Remove organization enabled filter from database query/view

### DIFF
--- a/src/Infrastructure.EntityFramework/Vault/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.EntityFramework/Vault/Repositories/CipherRepository.cs
@@ -1065,7 +1065,6 @@ public class CipherRepository : Repository<Core.Vault.Entities.Cipher, Cipher, G
         var query = from c in dbContext.Ciphers.AsNoTracking()
                     where c.UserId == null
                        && c.OrganizationId == organizationId
-                       && c.Organization.Enabled
                        && (
                             c.CollectionCiphers.Count() == 0
                             || c.CollectionCiphers.Any(cc => (int)cc.Collection.Type != defaultTypeInt)

--- a/src/Sql/dbo/Views/OrganizationCipherDetailsCollectionsView.sql
+++ b/src/Sql/dbo/Views/OrganizationCipherDetailsCollectionsView.sql
@@ -24,5 +24,4 @@ AS
     INNER JOIN [dbo].[Organization] O ON C.[OrganizationId] = O.[Id]
     LEFT JOIN [dbo].[CollectionCipher] CC ON CC.[CipherId] = C.[Id]
     LEFT JOIN [dbo].[Collection] COL ON CC.[CollectionId] = COL.[Id]
-    WHERE C.[UserId] IS NULL -- Organization ciphers only
-      AND O.[Enabled] = 1; -- Only enabled organizations
+    WHERE C.[UserId] IS NULL; -- Organization ciphers only

--- a/util/Migrator/DbScripts/2026-02-18_01_RemoveEnabledFilterFromOrganizationCipherDetailsCollectionsView.sql
+++ b/util/Migrator/DbScripts/2026-02-18_01_RemoveEnabledFilterFromOrganizationCipherDetailsCollectionsView.sql
@@ -1,0 +1,70 @@
+-- Remove Organization.Enabled filter from OrganizationCipherDetailsCollectionsView
+
+CREATE OR ALTER VIEW [dbo].[OrganizationCipherDetailsCollectionsView]
+AS
+    SELECT
+      C.[Id],
+      C.[UserId],
+      C.[OrganizationId],
+      C.[Type],
+      C.[Data],
+      C.[Attachments],
+      C.[Favorites],
+      C.[Folders],
+      C.[CreationDate],
+      C.[RevisionDate],
+      C.[DeletedDate],
+      C.[Reprompt],
+      C.[Key],
+      CASE
+          WHEN O.[UseTotp] = 1 THEN 1
+          ELSE 0
+      END AS [OrganizationUseTotp],
+      CC.[CollectionId],
+      COL.[Type] AS [CollectionType]
+    FROM [dbo].[Cipher] C
+    INNER JOIN [dbo].[Organization] O ON C.[OrganizationId] = O.[Id]
+    LEFT JOIN [dbo].[CollectionCipher] CC ON CC.[CipherId] = C.[Id]
+    LEFT JOIN [dbo].[Collection] COL ON CC.[CollectionId] = COL.[Id]
+    WHERE C.[UserId] IS NULL; -- Organization ciphers only
+GO
+
+-- Recreate dependent stored procedure
+CREATE OR ALTER PROCEDURE
+  [dbo].[CipherOrganizationDetails_ReadByOrganizationIdExcludingDefaultCollections]
+      @OrganizationId UNIQUEIDENTIFIER
+  AS
+  BEGIN
+      SET NOCOUNT ON;
+
+      WITH [NonDefaultCiphers] AS (
+          SELECT DISTINCT [Id]
+          FROM [dbo].[OrganizationCipherDetailsCollectionsView]
+          WHERE [OrganizationId] = @OrganizationId
+              AND ([CollectionId] IS NULL
+              OR [CollectionType] <> 1)
+      )
+
+      SELECT
+          V.[Id],
+          V.[UserId],
+          V.[OrganizationId],
+          V.[Type],
+          V.[Data],
+          V.[Favorites],
+          V.[Folders],
+          V.[Attachments],
+          V.[CreationDate],
+          V.[RevisionDate],
+          V.[DeletedDate],
+          V.[Reprompt],
+          V.[Key],
+          V.[OrganizationUseTotp],
+          V.[CollectionId]  -- For Dapper splitOn parameter
+      FROM [dbo].[OrganizationCipherDetailsCollectionsView] V
+      INNER JOIN [NonDefaultCiphers] NDC ON V.[Id] = NDC.[Id]
+      WHERE V.[OrganizationId] = @OrganizationId
+          AND (V.[CollectionId] IS NULL OR V.[CollectionType] <> 1)
+      ORDER BY V.[RevisionDate] DESC;
+  END;
+  GO


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32463](https://bitwarden.atlassian.net/browse/PM-32463)

## 📔 Objective

Re-allow disabled orgs to access their shared organization vault items in the admin console.


[PM-32463]: https://bitwarden.atlassian.net/browse/PM-32463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ