### PR TITLE
[PM-29090][Step 2] Remove the server feature flag

### DIFF
--- a/src/Core/Billing/Pricing/PricingClient.cs
+++ b/src/Core/Billing/Pricing/PricingClient.cs
@@ -1,6 +1,5 @@
 ﻿using System.Net;
 using System.Net.Http.Json;
-using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Pricing.Organizations;
 using Bit.Core.Exceptions;
@@ -12,7 +11,6 @@ namespace Bit.Core.Billing.Pricing;
 
 using OrganizationPlan = Bit.Core.Models.StaticStore.Plan;
 using PremiumPlan = Premium.Plan;
-using Purchasable = Premium.Purchasable;
 
 public class PricingClient(
     IFeatureService featureService,
@@ -99,14 +97,6 @@ public class PricingClient(
             return [];
         }
 
-        var fetchPremiumPriceFromPricingService =
-            featureService.IsEnabled(FeatureFlagKeys.PM26793_FetchPremiumPriceFromPricingService);
-
-        if (!fetchPremiumPriceFromPricingService)
-        {
-            return [CurrentPremiumPlan];
-        }
-
         var response = await httpClient.GetAsync("plans/premium");
 
         if (response.IsSuccessStatusCode)
@@ -163,13 +153,4 @@ public class PricingClient(
             plan.LookupKey = "families-2025";
         return plan;
     }
-
-    private static PremiumPlan CurrentPremiumPlan => new()
-    {
-        Name = "Premium",
-        Available = true,
-        LegacyYear = null,
-        Seat = new Purchasable { Price = 10M, StripePriceId = StripeConstants.Prices.PremiumAnnually },
-        Storage = new Purchasable { Price = 4M, StripePriceId = StripeConstants.Prices.StoragePlanPersonal, Provided = 1 }
-    };
 }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -184,7 +184,6 @@ public static class FeatureFlagKeys
     public const string TrialPayment = "PM-8163-trial-payment";
     public const string PM24032_NewNavigationPremiumUpgradeButton = "pm-24032-new-navigation-premium-upgrade-button";
     public const string PM23713_PremiumBadgeOpensNewPremiumUpgradeDialog = "pm-23713-premium-badge-opens-new-premium-upgrade-dialog";
-    public const string PM26793_FetchPremiumPriceFromPricingService = "pm-26793-fetch-premium-price-from-pricing-service";
     public const string PM23341_Milestone_2 = "pm-23341-milestone-2";
     public const string PM26462_Milestone_3 = "pm-26462-milestone-3";
     public const string PM28265_EnableReconcileAdditionalStorageJob = "pm-28265-enable-reconcile-additional-storage-job";


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-29090

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Removes the feature flag pm-26793-fetch-premium-price-from-pricing-service which has been enabled and validated in production.

  **Changes**

  **This PR cleans up the feature flag by:**

  1. Removed feature flag constant from src/Core/Constants.cs
    - Deleted PM26793_FetchPremiumPriceFromPricingService constant
  2. Simplified PricingClient.ListPremiumPlans() method in src/Core/Billing/Pricing/PricingClient.cs
    - Removed feature flag check that toggled between fetching premium plans from the pricing service vs. using a hardcoded plan
    - Now always fetches premium plans from the pricing service (the enabled behavior)
    - Removed the CurrentPremiumPlan static property which was only used when the flag was disabled
    - Cleaned up unused using directives

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
