### PR TITLE
Add startup art to seeder utility

### DIFF
--- a/util/SeederUtility/Program.cs
+++ b/util/SeederUtility/Program.cs
@@ -7,8 +7,87 @@ public class Program
 {
     private static int Main(string[] args)
     {
+        PrintBanner();
+
         return new AppRunner<Program>()
             .Run(args);
+    }
+
+    private static void PrintBanner()
+    {
+        var brightGreen = "\x1b[92m";
+        var green = "\x1b[32m";
+        var brown = "\x1b[38;2;128;60;30m";
+        var cyan = "\x1b[36m";
+        var bold = "\x1b[1m";
+        var reset = "\x1b[0m";
+
+        // Art sections: leaves (bright green), stem (green), seed (brown)
+        (string Color, string Art)[] sections =
+        [
+            (brightGreen, """
+                                            ...........
+                                         ..::------==:.
+                                       ..-----=====+-.
+                                     ..----======+=-.
+                                     .--==+=======-.
+                                    .-===========...
+                .------:::...      ..=+=======-...
+                .-=====-----:.    .:=:.........
+                 .-+=======----...:=..
+                  .-=======+==--..=:....
+                   ..===========:=-.....
+                     .:========+=+:..
+                      ....:----:-=:..
+                """),
+            (green, """
+                         ..:=:.
+                           .+:
+                           .=-..
+                           .-=.....
+                           .:=:....
+                           ..=:.
+                             --.
+                """),
+            (brown, """
+                     ...-======:..:-...=#####*-..
+                  ..:====--=======-=+##*******###-.
+                  .==------=======**************###:
+                 .==----=======+***************#####.
+                .:+========++*****************######-
+                ..##************************########.
+                  :*###*****************###########:.
+                  ..-#########***################=..
+                     .:*######################*-..
+                        ..-=+*###########*=-.....
+                           .................
+                """),
+        ];
+
+        var allLines = sections
+            .SelectMany(s => s.Art.Split('\n'))
+            .Where(l => !string.IsNullOrWhiteSpace(l));
+        var minIndent = allLines.Min(l => l.Length - l.TrimStart().Length);
+
+        Console.WriteLine();
+        foreach (var (color, art) in sections)
+        {
+            foreach (var line in art.Split('\n'))
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                Console.WriteLine($"{color}{line[minIndent..]}{reset}");
+            }
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"  {bold}{cyan}╔══════════════════════════════╗{reset}");
+        Console.WriteLine($"  {bold}{cyan}║      SEEDER    UTILITY       ║{reset}");
+        Console.WriteLine($"  {bold}{cyan}╚══════════════════════════════╝{reset}");
+        Console.WriteLine();
     }
 
     [Subcommand]


### PR DESCRIPTION
## 🎟️ Tracking

Testing some Claude functions. Wanted to see what it could do with image-to-text.

## 📔 Objective

Adds a silly little seed graphic for when the utility starts up.

## 📸 Screenshots

<img width="247" height="493" alt="image" src="https://github.com/user-attachments/assets/3ad5fb0f-4901-4e64-9178-f7ff5f7e7645" />
