### PR TITLE
Bump Bitwarden.Server.Sdk to v1.5.1

### DIFF
--- a/global.json
+++ b/global.json
@@ -6,6 +6,6 @@
   "msbuild-sdks": {
     "Microsoft.Build.Traversal": "4.1.0",
     "Microsoft.Build.Sql": "1.0.0",
-    "Bitwarden.Server.Sdk": "1.5.0"
+    "Bitwarden.Server.Sdk": "1.5.1"
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This bumps the Bitwarden.Server.Sdk for all services to `1.5.0` the only difference between this and `1.4.0` is that the SDK will now look for a `DD_ENV` environment variable and automatically set a `env` resource attribute based on the value there.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
