### PR TITLE
Incrementing our sdk-internal references to their latest released versions

### DIFF
--- a/util/RustSdk/rust/Cargo.lock
+++ b/util/RustSdk/rust/Cargo.lock
@@ -64,6 +64,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "argon2"
 version = "0.6.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,26 +161,42 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bitwarden-api-api"
-version = "1.0.0"
-source = "git+https://github.com/bitwarden/sdk-internal.git?rev=7080159154a42b59028ccb9f5af62bf087e565f9#7080159154a42b59028ccb9f5af62bf087e565f9"
+version = "2.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal.git?rev=abba7fdab687753268b63248ec22639dff35d07c#abba7fdab687753268b63248ec22639dff35d07c"
 dependencies = [
  "async-trait",
+ "bitwarden-api-base",
  "reqwest",
+ "reqwest-middleware",
  "serde",
  "serde_json",
  "serde_repr",
  "serde_with",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "bitwarden-api-base"
+version = "2.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal.git?rev=abba7fdab687753268b63248ec22639dff35d07c#abba7fdab687753268b63248ec22639dff35d07c"
+dependencies = [
+ "reqwest",
+ "reqwest-middleware",
+ "serde_json",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
 name = "bitwarden-api-identity"
-version = "1.0.0"
-source = "git+https://github.com/bitwarden/sdk-internal.git?rev=7080159154a42b59028ccb9f5af62bf087e565f9#7080159154a42b59028ccb9f5af62bf087e565f9"
+version = "2.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal.git?rev=abba7fdab687753268b63248ec22639dff35d07c#abba7fdab687753268b63248ec22639dff35d07c"
 dependencies = [
  "async-trait",
+ "bitwarden-api-base",
  "reqwest",
+ "reqwest-middleware",
  "serde",
  "serde_json",
  "serde_repr",
@@ -178,9 +206,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitwarden-api-key-connector"
+version = "2.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal.git?rev=abba7fdab687753268b63248ec22639dff35d07c#abba7fdab687753268b63248ec22639dff35d07c"
+dependencies = [
+ "async-trait",
+ "bitwarden-api-base",
+ "mockall",
+ "reqwest",
+ "reqwest-middleware",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "bitwarden-collections"
-version = "1.0.0"
-source = "git+https://github.com/bitwarden/sdk-internal.git?rev=7080159154a42b59028ccb9f5af62bf087e565f9#7080159154a42b59028ccb9f5af62bf087e565f9"
+version = "2.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal.git?rev=abba7fdab687753268b63248ec22639dff35d07c#abba7fdab687753268b63248ec22639dff35d07c"
 dependencies = [
  "bitwarden-api-api",
  "bitwarden-core",
@@ -189,18 +232,20 @@ dependencies = [
  "bitwarden-uuid",
  "serde",
  "serde_repr",
- "thiserror 2.0.12",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
 [[package]]
 name = "bitwarden-core"
-version = "1.0.0"
-source = "git+https://github.com/bitwarden/sdk-internal.git?rev=7080159154a42b59028ccb9f5af62bf087e565f9#7080159154a42b59028ccb9f5af62bf087e565f9"
+version = "2.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal.git?rev=abba7fdab687753268b63248ec22639dff35d07c#abba7fdab687753268b63248ec22639dff35d07c"
 dependencies = [
  "async-trait",
  "bitwarden-api-api",
+ "bitwarden-api-base",
  "bitwarden-api-identity",
+ "bitwarden-api-key-connector",
  "bitwarden-crypto",
  "bitwarden-encoding",
  "bitwarden-error",
@@ -208,9 +253,9 @@ dependencies = [
  "bitwarden-uuid",
  "chrono",
  "getrandom 0.2.16",
- "log",
  "rand 0.8.5",
  "reqwest",
+ "reqwest-middleware",
  "rustls",
  "rustls-platform-verifier",
  "schemars 1.0.4",
@@ -219,7 +264,8 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "serde_repr",
- "thiserror 2.0.12",
+ "thiserror 1.0.69",
+ "tracing",
  "uuid",
  "zeroize",
  "zxcvbn",
@@ -227,8 +273,8 @@ dependencies = [
 
 [[package]]
 name = "bitwarden-crypto"
-version = "1.0.0"
-source = "git+https://github.com/bitwarden/sdk-internal.git?rev=7080159154a42b59028ccb9f5af62bf087e565f9#7080159154a42b59028ccb9f5af62bf087e565f9"
+version = "2.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal.git?rev=abba7fdab687753268b63248ec22639dff35d07c#abba7fdab687753268b63248ec22639dff35d07c"
 dependencies = [
  "aes",
  "argon2",
@@ -256,7 +302,8 @@ dependencies = [
  "sha1",
  "sha2",
  "subtle",
- "thiserror 2.0.12",
+ "thiserror 1.0.69",
+ "tracing",
  "typenum",
  "uuid",
  "zeroize",
@@ -265,27 +312,27 @@ dependencies = [
 
 [[package]]
 name = "bitwarden-encoding"
-version = "1.0.0"
-source = "git+https://github.com/bitwarden/sdk-internal.git?rev=7080159154a42b59028ccb9f5af62bf087e565f9#7080159154a42b59028ccb9f5af62bf087e565f9"
+version = "2.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal.git?rev=abba7fdab687753268b63248ec22639dff35d07c#abba7fdab687753268b63248ec22639dff35d07c"
 dependencies = [
  "data-encoding",
  "data-encoding-macro",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bitwarden-error"
-version = "1.0.0"
-source = "git+https://github.com/bitwarden/sdk-internal.git?rev=7080159154a42b59028ccb9f5af62bf087e565f9#7080159154a42b59028ccb9f5af62bf087e565f9"
+version = "2.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal.git?rev=abba7fdab687753268b63248ec22639dff35d07c#abba7fdab687753268b63248ec22639dff35d07c"
 dependencies = [
  "bitwarden-error-macro",
 ]
 
 [[package]]
 name = "bitwarden-error-macro"
-version = "1.0.0"
-source = "git+https://github.com/bitwarden/sdk-internal.git?rev=7080159154a42b59028ccb9f5af62bf087e565f9#7080159154a42b59028ccb9f5af62bf087e565f9"
+version = "2.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal.git?rev=abba7fdab687753268b63248ec22639dff35d07c#abba7fdab687753268b63248ec22639dff35d07c"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -295,8 +342,8 @@ dependencies = [
 
 [[package]]
 name = "bitwarden-state"
-version = "1.0.0"
-source = "git+https://github.com/bitwarden/sdk-internal.git?rev=7080159154a42b59028ccb9f5af62bf087e565f9#7080159154a42b59028ccb9f5af62bf087e565f9"
+version = "2.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal.git?rev=abba7fdab687753268b63248ec22639dff35d07c#abba7fdab687753268b63248ec22639dff35d07c"
 dependencies = [
  "async-trait",
  "bitwarden-error",
@@ -306,36 +353,36 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 1.0.69",
  "tokio",
  "tsify",
 ]
 
 [[package]]
 name = "bitwarden-threading"
-version = "1.0.0"
-source = "git+https://github.com/bitwarden/sdk-internal.git?rev=7080159154a42b59028ccb9f5af62bf087e565f9#7080159154a42b59028ccb9f5af62bf087e565f9"
+version = "2.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal.git?rev=abba7fdab687753268b63248ec22639dff35d07c#abba7fdab687753268b63248ec22639dff35d07c"
 dependencies = [
  "bitwarden-error",
- "log",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]
 name = "bitwarden-uuid"
-version = "1.0.0"
-source = "git+https://github.com/bitwarden/sdk-internal.git?rev=7080159154a42b59028ccb9f5af62bf087e565f9#7080159154a42b59028ccb9f5af62bf087e565f9"
+version = "2.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal.git?rev=abba7fdab687753268b63248ec22639dff35d07c#abba7fdab687753268b63248ec22639dff35d07c"
 dependencies = [
  "bitwarden-uuid-macro",
 ]
 
 [[package]]
 name = "bitwarden-uuid-macro"
-version = "1.0.0"
-source = "git+https://github.com/bitwarden/sdk-internal.git?rev=7080159154a42b59028ccb9f5af62bf087e565f9#7080159154a42b59028ccb9f5af62bf087e565f9"
+version = "2.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal.git?rev=abba7fdab687753268b63248ec22639dff35d07c#abba7fdab687753268b63248ec22639dff35d07c"
 dependencies = [
  "quote",
  "syn",
@@ -343,8 +390,8 @@ dependencies = [
 
 [[package]]
 name = "bitwarden-vault"
-version = "1.0.0"
-source = "git+https://github.com/bitwarden/sdk-internal.git?rev=7080159154a42b59028ccb9f5af62bf087e565f9#7080159154a42b59028ccb9f5af62bf087e565f9"
+version = "2.0.0"
+source = "git+https://github.com/bitwarden/sdk-internal.git?rev=abba7fdab687753268b63248ec22639dff35d07c#abba7fdab687753268b63248ec22639dff35d07c"
 dependencies = [
  "bitwarden-api-api",
  "bitwarden-collections",
@@ -366,7 +413,8 @@ dependencies = [
  "sha1",
  "sha2",
  "subtle",
- "thiserror 2.0.12",
+ "thiserror 1.0.69",
+ "tracing",
  "uuid",
  "zxcvbn",
 ]
@@ -572,9 +620,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "coset"
-version = "0.3.8"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8cc80f631f8307b887faca24dcc3abc427cd0367f6eb6188f6e8f5b7ad8fb"
+checksum = "844c9268d02cc99addebeb0dd6703508d6f0cc09ff86dda3f1350b4bccfbc00e"
 dependencies = [
  "ciborium",
  "ciborium-io",
@@ -825,6 +873,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +970,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "futures"
@@ -1575,6 +1635,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,6 +1857,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -2024,6 +2136,21 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
 ]
 
 [[package]]
@@ -2540,6 +2667,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2737,7 +2870,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/util/RustSdk/rust/Cargo.toml
+++ b/util/RustSdk/rust/Cargo.toml
@@ -13,9 +13,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 base64 = "0.22.1"
-bitwarden-core = { git = "https://github.com/bitwarden/sdk-internal.git", rev = "7080159154a42b59028ccb9f5af62bf087e565f9", features = ["internal"] }
-bitwarden-crypto = { git = "https://github.com/bitwarden/sdk-internal.git", rev = "7080159154a42b59028ccb9f5af62bf087e565f9" }
-bitwarden-vault = { git = "https://github.com/bitwarden/sdk-internal.git", rev = "7080159154a42b59028ccb9f5af62bf087e565f9" }
+bitwarden-core = { git = "https://github.com/bitwarden/sdk-internal.git", rev = "abba7fdab687753268b63248ec22639dff35d07c", features = ["internal"] }
+bitwarden-crypto = { git = "https://github.com/bitwarden/sdk-internal.git", rev = "abba7fdab687753268b63248ec22639dff35d07c" }
+bitwarden-vault = { git = "https://github.com/bitwarden/sdk-internal.git", rev = "abba7fdab687753268b63248ec22639dff35d07c" }
 serde = "=1.0.219"
 serde_json = "=1.0.141"
 

--- a/util/RustSdk/rust/src/cipher.rs
+++ b/util/RustSdk/rust/src/cipher.rs
@@ -196,6 +196,7 @@ mod tests {
             view_password: true,
             local_data: None,
             attachments: None,
+            attachment_decryption_failures: None,
             fields: None,
             password_history: None,
             creation_date: "2025-01-01T00:00:00Z".parse().unwrap(),


### PR DESCRIPTION
## 🎟️ Tracking


## 📔 Objective

We need to ensure that our usage of our `sdk-internal` crates does not get too far out of date; so bumping to the latest supported version.  I used Claude Code to help me find the latest version and then to bump our code along. I have a follow-up PR for later today that includes a Claude things to help the next person do this work quicker. 

### Testing following updates

✅ The Seeder API creation flow worked for the Single User Scene; able to login successfully
✅ The Seeder Utility creation flow worked for all code paths; able to login successfully with many users of varying types of accounts.