### PR TITLE
Fix out of date seed endpoint example

### DIFF
--- a/util/SeederApi/README.md
+++ b/util/SeederApi/README.md
@@ -38,7 +38,7 @@ The API will start on the configured port (typically `http://localhost:5000`).
 ### Seeding Data
 
 Send a POST request to `/seed` with a scene template name and optional arguments. Include the `X-Play-Id` header to
-track the seeded data for later cleanup:
+track the seeded data for later cleanup. You need to set the password argument to a master password for the mock user account that is at least 8-characters. You should always use an email address with a top-level domain of example.com (see RFC 2606 — guaranteed unresolvable for more details).
 
 ```bash
 curl -X POST http://localhost:5000/seed \
@@ -47,7 +47,8 @@ curl -X POST http://localhost:5000/seed \
   -d '{
     "template": "SingleUserScene",
     "arguments": {
-      "email": "test@example.com"
+      "email": "test@example.com",
+      "password": "REPLACE_ME"
     }
   }'
 ```


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Found this because Claude made a subpar testing plan for #7074

Follow-up PR with Claude Tooling that includes a nice little reminder stop hook to _nudge_ us if we are working on the Seeder to double-check our documentation for necessary changes #7077
