### PR TITLE
[PM-32762] [PM-32744] Register feature flag for default import My Items destination

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -245,6 +245,7 @@ public static class FeatureFlagKeys
     public const string ChromiumImporterWithABE = "pm-25855-chromium-importer-abe";
     public const string SendUIRefresh = "pm-28175-send-ui-refresh";
     public const string SendEmailOTP = "pm-19051-send-email-verification";
+    public const string DefaultImportMyItems = "pm-32744-default-import-my-items";
 
     /* Vault Team */
     public const string CipherKeyEncryption = "cipher-key-encryption";


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32744

## 📔 Objective

Registers a new feature flag, pm-32744-default-import-my-items, that will gate client-side behaviour to default the import destination to the user's "My Items" collection when the Enforce organization data ownership policy is active.

When an organization enables the Enforce organization data ownership policy, members are prohibited from storing items in their personal "My Vault". To enforce this, the import tool hides the "My Vault" option from the destination selector and falls back to requiring the user to pick an organization. However, it currently leaves the collection selector blank - meaning the user either has to manually select a destination or unknowingly submits an import with no collection assigned. The intended default is the user's My Items collection: the DefaultUserCollection that the policy provisions for each member within the org.

This server PR is a prerequisite for the client-side fix, which is gated behind this flag.

## 📸 Screenshots

Please view the clients PR: https://github.com/bitwarden/clients/pull/19242
