### PR TITLE
[PM-32774] Add Melio to global equivalent domains

### DIFF
--- a/src/Core/Enums/GlobalEquivalentDomainsType.cs
+++ b/src/Core/Enums/GlobalEquivalentDomainsType.cs
@@ -93,4 +93,5 @@ public enum GlobalEquivalentDomainsType : byte
     TakeawayEU = 88,
     Atlassian = 89,
     Pinterest = 90,
+    Melio = 91,
 }

--- a/src/Core/Utilities/StaticStore.cs
+++ b/src/Core/Utilities/StaticStore.cs
@@ -103,6 +103,7 @@ public static class StaticStore
         GlobalDomains.Add(GlobalEquivalentDomainsType.TakeawayEU, new List<string> { "takeaway.com", "just-eat.dk", "just-eat.no", "just-eat.fr", "just-eat.ch", "lieferando.de", "lieferando.at", "thuisbezorgd.nl", "pyszne.pl" });
         GlobalDomains.Add(GlobalEquivalentDomainsType.Atlassian, new List<string> { "atlassian.com", "bitbucket.org", "trello.com", "statuspage.io", "atlassian.net", "jira.com" });
         GlobalDomains.Add(GlobalEquivalentDomainsType.Pinterest, new List<string> { "pinterest.com", "pinterest.com.au", "pinterest.cl", "pinterest.de", "pinterest.dk", "pinterest.es", "pinterest.fr", "pinterest.co.uk", "pinterest.jp", "pinterest.co.kr", "pinterest.nz", "pinterest.pt", "pinterest.se" });
+        GlobalDomains.Add(GlobalEquivalentDomainsType.Melio, new List<string> { "melio.com", "meliopayments.com" });
         #endregion
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

Community contribution — no Jira ticket.

## 📔 Objective

Add `melio.com` and `meliopayments.com` as global equivalent domains so that Bitwarden users with credentials saved under either domain are not affected by Melio's domain switch (`melio.com` now redirects to `meliopayments.com`).

Changes:
- Added `Melio = 91` to the `GlobalEquivalentDomainsType` enum
- Added the corresponding domain mapping in `StaticStore.cs`