### PR TITLE
Auth/PM-21720 - RegisterFinishResponseModel - remove deprecated CaptchaBypassToken

### DIFF
--- a/src/Identity/Models/Response/Accounts/RegisterFinishResponseModel.cs
+++ b/src/Identity/Models/Response/Accounts/RegisterFinishResponseModel.cs
@@ -5,13 +5,5 @@ namespace Bit.Identity.Models.Response.Accounts;
 public class RegisterFinishResponseModel : ResponseModel
 {
     public RegisterFinishResponseModel()
-        : base("registerFinish")
-    {
-        // We are setting this to an empty string so that old mobile clients don't break, as they reqiure a non-null value.
-        // This will be cleaned up in https://bitwarden.atlassian.net/browse/PM-21720.
-        CaptchaBypassToken = string.Empty;
-    }
-
-    public string CaptchaBypassToken { get; set; }
-
+        : base("registerFinish") { }
 }


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21720

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Clean up deprecated code. Note: I considered deleting the `RegisterFinishResponseModel` since it has no properties + converting to `IActionResult`, but I chose to avoid changing the API for now and the typed return is more explicit. It's also harmless and easy to extend if need be in the future. 
