### PR TITLE
Enqueue support for Mailer

### DIFF
--- a/src/Admin/HostedServices/AzureQueueMailHostedService.cs
+++ b/src/Admin/HostedServices/AzureQueueMailHostedService.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Azure.Storage.Queues;
 using Azure.Storage.Queues.Models;
 using Bit.Core.Models.Mail;
+using Bit.Core.Platform.Mail.Mailer;
 using Bit.Core.Services;
 using Bit.Core.Settings;
 using Bit.Core.Utilities;
@@ -16,6 +17,7 @@ public class AzureQueueMailHostedService : IHostedService
     private readonly ILogger<AzureQueueMailHostedService> _logger;
     private readonly GlobalSettings _globalSettings;
     private readonly IMailService _mailService;
+    private readonly IMailer _mailer;
     private CancellationTokenSource _cts;
     private Task _executingTask;
 
@@ -24,10 +26,12 @@ public class AzureQueueMailHostedService : IHostedService
     public AzureQueueMailHostedService(
         ILogger<AzureQueueMailHostedService> logger,
         IMailService mailService,
+        IMailer mailer,
         GlobalSettings globalSettings)
     {
         _logger = logger;
         _mailService = mailService;
+        _mailer = mailer;
         _globalSettings = globalSettings;
     }
 
@@ -72,13 +76,13 @@ public class AzureQueueMailHostedService : IHostedService
                     {
                         foreach (var mailQueueMessage in root.Deserialize<List<MailQueueMessage>>())
                         {
-                            await _mailService.SendEnqueuedMailMessageAsync(mailQueueMessage);
+                            await ProcessMailMessageAsync(mailQueueMessage);
                         }
                     }
                     else if (root.ValueKind == JsonValueKind.Object)
                     {
                         var mailQueueMessage = root.Deserialize<MailQueueMessage>();
-                        await _mailService.SendEnqueuedMailMessageAsync(mailQueueMessage);
+                        await ProcessMailMessageAsync(mailQueueMessage);
                     }
                 }
                 catch (Exception e)
@@ -100,5 +104,22 @@ public class AzureQueueMailHostedService : IHostedService
     private async Task<QueueMessage[]> RetrieveMessagesAsync()
     {
         return (await _mailQueueClient.ReceiveMessagesAsync(maxMessages: 32))?.Value ?? new QueueMessage[] { };
+    }
+
+    /// <summary>
+    /// Processes a single mail message, checking if it's an IMailer message or HandlebarsMailService message.
+    /// </summary>
+    private async Task ProcessMailMessageAsync(MailQueueMessage message)
+    {
+        if (message.IsMailerMessage)
+        {
+            // IMailer message - delegate to mailer to render view and send
+            await _mailer.SendEnqueuedMailerMessageAsync(message);
+        }
+        else
+        {
+            // Template-based message from HandlebarsMailService
+            await _mailService.SendEnqueuedMailMessageAsync(message);
+        }
     }
 }

--- a/src/Core/Models/Mail/IMailQueueMessage.cs
+++ b/src/Core/Models/Mail/IMailQueueMessage.cs
@@ -8,4 +8,14 @@ public interface IMailQueueMessage
     string Category { get; set; }
     string TemplateName { get; set; }
     object Model { get; set; }
+
+    /// <summary>
+    /// Indicates if this is an IMailer message (uses view rendering) vs HandlebarsMailService message (uses template rendering).
+    /// </summary>
+    public bool IsMailerMessage { get; set; }
+
+    /// <summary>
+    /// Additional metadata for delivery (e.g., SendGridBypassListManagement).
+    /// </summary>
+    public IDictionary<string, object>? MetaData { get; set; }
 }

--- a/src/Core/Models/Mail/MailQueueMessage.cs
+++ b/src/Core/Models/Mail/MailQueueMessage.cs
@@ -17,6 +17,18 @@ public class MailQueueMessage : IMailQueueMessage
     [JsonConverter(typeof(HandlebarsObjectJsonConverter))]
     public object Model { get; set; }
 
+    /// <summary>
+    /// Indicates if this is an IMailer message (uses view rendering) vs HandlebarsMailService message (uses template rendering).
+    /// True for IMailer messages, false or null for HandlebarsMailService messages.
+    /// </summary>
+    public bool IsMailerMessage { get; set; }
+
+    /// <summary>
+    /// Additional metadata for delivery (e.g., SendGridBypassListManagement).
+    /// Used by both IMailer and HandlebarsMailService messages.
+    /// </summary>
+    public IDictionary<string, object> MetaData { get; set; }
+
     public MailQueueMessage() { }
 
     public MailQueueMessage(MailMessage message, string templateName, object model)

--- a/src/Core/Platform/Mail/Mailer/IMailer.cs
+++ b/src/Core/Platform/Mail/Mailer/IMailer.cs
@@ -1,4 +1,6 @@
-﻿namespace Bit.Core.Platform.Mail.Mailer;
+﻿using Bit.Core.Models.Mail;
+
+namespace Bit.Core.Platform.Mail.Mailer;
 
 #nullable enable
 
@@ -12,4 +14,17 @@ public interface IMailer
     /// </summary>
     /// <param name="message"></param>
     public Task SendEmail<T>(BaseMail<T> message) where T : BaseMailView;
+
+    /// <summary>
+    /// Enqueues email messages for asynchronous delivery.
+    /// </summary>
+    /// <param name="messages">The email messages to enqueue</param>
+    /// <typeparam name="T">The type of the mail view</typeparam>
+    public Task EnqueueEmailsAsync<T>(IEnumerable<BaseMail<T>> messages) where T : BaseMailView;
+
+    /// <summary>
+    /// Sends a previously enqueued IMailer message by rendering the stored view and sending.
+    /// </summary>
+    /// <param name="queueMessage">The enqueued message containing view data</param>
+    public Task SendEnqueuedMailerMessageAsync(IMailQueueMessage queueMessage);
 }

--- a/src/Core/Platform/Mail/Mailer/Mailer.cs
+++ b/src/Core/Platform/Mail/Mailer/Mailer.cs
@@ -1,27 +1,23 @@
 ﻿using Bit.Core.Models.Mail;
 using Bit.Core.Platform.Mail.Delivery;
+using Bit.Core.Platform.Mail.Enqueuing;
 
 namespace Bit.Core.Platform.Mail.Mailer;
 
-#nullable enable
-
-public class Mailer(IMailRenderer renderer, IMailDeliveryService mailDeliveryService) : IMailer
+public class Mailer(
+    IMailRenderer renderer,
+    IMailDeliveryService mailDeliveryService,
+    IMailEnqueuingService mailEnqueuingService) : IMailer
 {
     public async Task SendEmail<T>(BaseMail<T> message) where T : BaseMailView
     {
         var content = await renderer.RenderAsync(message.View);
 
-        var metadata = new Dictionary<string, object>();
-        if (message.IgnoreSuppressList)
-        {
-            metadata.Add("SendGridBypassListManagement", true);
-        }
-
         var mailMessage = new MailMessage
         {
             ToEmails = message.ToEmails,
             Subject = message.Subject,
-            MetaData = metadata,
+            MetaData = BuildMailMetadata(message.IgnoreSuppressList),
             HtmlContent = content.html,
             TextContent = content.txt,
             Category = message.Category,
@@ -29,4 +25,69 @@ public class Mailer(IMailRenderer renderer, IMailDeliveryService mailDeliverySer
 
         await mailDeliveryService.SendEmailAsync(mailMessage);
     }
+
+    public async Task EnqueueEmailsAsync<T>(IEnumerable<BaseMail<T>> messages) where T : BaseMailView
+    {
+        var queueMessages = messages.Select(message => new MailQueueMessage
+        {
+            Subject = message.Subject,
+            ToEmails = message.ToEmails,
+            Category = message.Category ?? "Default",
+            TemplateName = typeof(T).AssemblyQualifiedName ?? throw new InvalidOperationException(),
+            Model = message.View,
+            IsMailerMessage = true,
+            MetaData = BuildMailMetadata(message.IgnoreSuppressList)
+        })
+            .ToList();
+
+        await mailEnqueuingService.EnqueueManyAsync(queueMessages, SendEnqueuedMailerMessageAsync);
+    }
+
+    /// <summary>
+    /// Sends a previously enqueued IMailer message by rendering the stored view and sending.
+    /// </summary>
+    public async Task SendEnqueuedMailerMessageAsync(IMailQueueMessage mailQueueMessage)
+    {
+        if (!mailQueueMessage.IsMailerMessage)
+        {
+            throw new InvalidOperationException(
+                "Expected IMailer message (IsMailerMessage = true)");
+        }
+
+        var viewType = Type.GetType(mailQueueMessage.TemplateName);
+        if (viewType == null)
+        {
+            throw new InvalidOperationException(
+                $"Could not resolve view type: {mailQueueMessage.TemplateName}");
+        }
+
+        if (mailQueueMessage.Model is not BaseMailView view)
+        {
+            throw new InvalidOperationException(
+                $"Model is not a BaseMailView: {mailQueueMessage.Model.GetType().FullName}");
+        }
+
+        var content = await renderer.RenderAsync(view);
+
+        var mailMessage = new MailMessage
+        {
+            ToEmails = mailQueueMessage.ToEmails,
+            Subject = mailQueueMessage.Subject,
+            BccEmails = mailQueueMessage.BccEmails,
+            Category = mailQueueMessage.Category,
+            MetaData = mailQueueMessage.MetaData ?? new Dictionary<string, object>(),
+            HtmlContent = content.html,
+            TextContent = content.txt
+        };
+
+        await mailDeliveryService.SendEmailAsync(mailMessage);
+    }
+
+    /// <summary>
+    /// Builds metadata dictionary for mail delivery based on mail settings.
+    /// </summary>
+    private static Dictionary<string, object> BuildMailMetadata(bool ignoreSuppressList) =>
+        ignoreSuppressList
+            ? new Dictionary<string, object> { { "SendGridBypassListManagement", true } }
+            : new Dictionary<string, object>();
 }

--- a/test/Core.Test/Auth/UserFeatures/EmergencyAccess/EmergencyAccessMailTests.cs
+++ b/test/Core.Test/Auth/UserFeatures/EmergencyAccess/EmergencyAccessMailTests.cs
@@ -32,9 +32,11 @@ public class EmergencyAccessMailTests
         var logger = Substitute.For<ILogger<HandlebarMailRenderer>>();
         var globalSettings = new GlobalSettings { SelfHosted = false };
         var deliveryService = Substitute.For<IMailDeliveryService>();
+        var enqueuingService = Substitute.For<Bit.Core.Platform.Mail.Enqueuing.IMailEnqueuingService>();
         var mailer = new Mailer(
             new HandlebarMailRenderer(logger, globalSettings),
-            deliveryService);
+            deliveryService,
+            enqueuingService);
 
         var mail = new EmergencyAccessRemoveGranteesMail
         {
@@ -73,9 +75,11 @@ public class EmergencyAccessMailTests
         var logger = Substitute.For<ILogger<HandlebarMailRenderer>>();
         var globalSettings = new GlobalSettings { SelfHosted = false };
         var deliveryService = Substitute.For<IMailDeliveryService>();
+        var enqueuingService = Substitute.For<Bit.Core.Platform.Mail.Enqueuing.IMailEnqueuingService>();
         var mailer = new Mailer(
             new HandlebarMailRenderer(logger, globalSettings),
-            deliveryService);
+            deliveryService,
+            enqueuingService);
 
         var granteeEmails = new[] { "Alice@test.dev", "Bob@test.dev", "Carol@test.dev" };
 

--- a/test/Core.Test/Platform/Mailer/MailerTest.cs
+++ b/test/Core.Test/Platform/Mailer/MailerTest.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Core.Models.Mail;
 using Bit.Core.Platform.Mail.Delivery;
+using Bit.Core.Platform.Mail.Enqueuing;
 using Bit.Core.Platform.Mail.Mailer;
 using Bit.Core.Settings;
 using Bit.Core.Test.Platform.Mailer.TestMail;
@@ -11,14 +12,28 @@ namespace Bit.Core.Test.Platform.Mailer;
 
 public class MailerTest
 {
+    private readonly IMailRenderer _mockRenderer;
+    private readonly IMailDeliveryService _mockDeliveryService;
+    private readonly IMailEnqueuingService _mockEnqueuingService;
+    private readonly Core.Platform.Mail.Mailer.Mailer _mailer;
+
+    public MailerTest()
+    {
+        _mockRenderer = Substitute.For<IMailRenderer>();
+        _mockDeliveryService = Substitute.For<IMailDeliveryService>();
+        _mockEnqueuingService = Substitute.For<IMailEnqueuingService>();
+        _mailer = new Core.Platform.Mail.Mailer.Mailer(_mockRenderer, _mockDeliveryService, _mockEnqueuingService);
+    }
+
     [Fact]
     public async Task SendEmailAsync()
     {
         var logger = Substitute.For<ILogger<HandlebarMailRenderer>>();
         var globalSettings = new GlobalSettings { SelfHosted = false };
         var deliveryService = Substitute.For<IMailDeliveryService>();
+        var enqueuingService = Substitute.For<IMailEnqueuingService>();
 
-        var mailer = new Core.Platform.Mail.Mailer.Mailer(new HandlebarMailRenderer(logger, globalSettings), deliveryService);
+        var mailer = new Core.Platform.Mail.Mailer.Mailer(new HandlebarMailRenderer(logger, globalSettings), deliveryService, enqueuingService);
 
         var mail = new TestMail.TestMail()
         {
@@ -39,4 +54,210 @@ public class MailerTest
         Assert.Equivalent("Hello John Smith", sentMessage.TextContent.Trim());
         Assert.Equivalent("Hello <b>John Smith</b>", sentMessage.HtmlContent.Trim());
     }
+
+    [Fact]
+    public async Task EnqueueEmailsAsync_StoresViewDataAndDoesNotRender()
+    {
+        var testView = new TestMailView { Name = "Test Content" };
+        var testMail = new TestMail.TestMail
+        {
+            ToEmails = ["test@example.com"],
+            View = testView
+        };
+
+        List<MailQueueMessage> capturedMessages = null;
+        _mockEnqueuingService.EnqueueManyAsync(
+            Arg.Do<IEnumerable<IMailQueueMessage>>(msgs =>
+                capturedMessages = msgs.Cast<MailQueueMessage>().ToList()),
+            Arg.Any<Func<IMailQueueMessage, Task>>())
+            .Returns(Task.CompletedTask);
+
+        await _mailer.EnqueueEmailsAsync([testMail]);
+
+        await _mockRenderer.DidNotReceive().RenderAsync(Arg.Any<BaseMailView>());
+        Assert.NotNull(capturedMessages);
+        Assert.Single(capturedMessages);
+
+        var message = capturedMessages[0];
+        Assert.Equal("Test Email", message.Subject);
+        Assert.Equal(["test@example.com"], message.ToEmails);
+        Assert.Equal("Default", message.Category);
+        Assert.Equal(typeof(TestMailView).AssemblyQualifiedName, message.TemplateName);
+        Assert.IsType<TestMailView>(message.Model);
+        Assert.True(message.IsMailerMessage);
+    }
+
+    [Fact]
+    public async Task EnqueueEmailsAsync_HandlesMetadataCorrectly()
+    {
+        var messages = new BaseMail<TestMailView>[]
+        {
+            new TestMailIgnoreSuppressList
+            {
+                ToEmails = ["test1@example.com"],
+                View = new TestMailView { Name = "Content 1" }
+            },
+            new TestMail.TestMail
+            {
+                ToEmails = ["test2@example.com"],
+                View = new TestMailView { Name = "Content 2" }
+            }
+        };
+
+        List<MailQueueMessage> capturedMessages = null;
+        _mockEnqueuingService.EnqueueManyAsync(
+            Arg.Do<IEnumerable<IMailQueueMessage>>(msgs =>
+                capturedMessages = msgs.Cast<MailQueueMessage>().ToList()),
+            Arg.Any<Func<IMailQueueMessage, Task>>())
+            .Returns(Task.CompletedTask);
+
+        await _mailer.EnqueueEmailsAsync(messages);
+
+        Assert.NotNull(capturedMessages);
+        Assert.Equal(2, capturedMessages.Count);
+
+        Assert.True(capturedMessages[0].MetaData!.ContainsKey("SendGridBypassListManagement"));
+        Assert.True((bool)capturedMessages[0].MetaData["SendGridBypassListManagement"]);
+
+        Assert.False(capturedMessages[1].MetaData!.ContainsKey("SendGridBypassListManagement"));
+    }
+
+    [Fact]
+    public async Task EnqueueEmailsAsync_ProcessesMultipleMessages()
+    {
+        var messages = new[]
+        {
+            new TestMail.TestMail
+            {
+                ToEmails = ["test1@example.com"],
+                Subject = "Subject 1",
+                View = new TestMailView { Name = "Content 1" }
+            },
+            new TestMail.TestMail
+            {
+                ToEmails = ["test2@example.com"],
+                Subject = "Subject 2",
+                View = new TestMailView { Name = "Content 2" }
+            },
+            new TestMail.TestMail
+            {
+                ToEmails = ["test3@example.com"],
+                Subject = "Subject 3",
+                View = new TestMailView { Name = "Content 3" }
+            }
+        };
+
+        List<MailQueueMessage> capturedMessages = null;
+        _mockEnqueuingService.EnqueueManyAsync(
+            Arg.Do<IEnumerable<IMailQueueMessage>>(msgs =>
+                capturedMessages = msgs.Cast<MailQueueMessage>().ToList()),
+            Arg.Any<Func<IMailQueueMessage, Task>>())
+            .Returns(Task.CompletedTask);
+
+        await _mailer.EnqueueEmailsAsync(messages);
+
+        await _mockRenderer.DidNotReceive().RenderAsync(Arg.Any<BaseMailView>());
+        Assert.NotNull(capturedMessages);
+        Assert.Equal(3, capturedMessages.Count);
+        Assert.All(capturedMessages, msg => Assert.True(msg.IsMailerMessage));
+    }
+
+    [Fact]
+    public async Task SendEnqueuedMailerMessageAsync_RendersAndSends()
+    {
+        var testView = new TestMailView { Name = "Test Content" };
+        var queueMessage = new MailQueueMessage
+        {
+            Subject = "Test Subject",
+            ToEmails = ["test@example.com"],
+            Category = "TestCategory",
+            TemplateName = typeof(TestMailView).AssemblyQualifiedName!,
+            Model = testView,
+            IsMailerMessage = true,
+            MetaData = new Dictionary<string, object> { { "SendGridBypassListManagement", true } }
+        };
+
+        _mockRenderer.RenderAsync(Arg.Any<BaseMailView>())
+            .Returns(("<html>Test</html>", "Test"));
+
+        MailMessage? sentMessage = null;
+        await _mockDeliveryService.SendEmailAsync(Arg.Do<MailMessage>(msg => sentMessage = msg));
+
+        await _mailer.SendEnqueuedMailerMessageAsync(queueMessage);
+
+        await _mockRenderer.Received(1).RenderAsync(Arg.Is<TestMailView>(v => v == testView));
+        await _mockDeliveryService.Received(1).SendEmailAsync(Arg.Any<MailMessage>());
+
+        Assert.NotNull(sentMessage);
+        Assert.Equal("Test Subject", sentMessage.Subject);
+        Assert.Equal(["test@example.com"], sentMessage.ToEmails);
+        Assert.Equal("TestCategory", sentMessage.Category);
+        Assert.Equal("<html>Test</html>", sentMessage.HtmlContent);
+        Assert.Equal("Test", sentMessage.TextContent);
+        Assert.True(sentMessage.MetaData.ContainsKey("SendGridBypassListManagement"));
+        Assert.True((bool)sentMessage.MetaData["SendGridBypassListManagement"]);
+    }
+
+    [Fact]
+    public async Task SendEnqueuedMailerMessageAsync_ThrowsWhenNotMailerMessage()
+    {
+        var queueMessage = new MailQueueMessage
+        {
+            Subject = "Test",
+            ToEmails = ["test@example.com"],
+            IsMailerMessage = false
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _mailer.SendEnqueuedMailerMessageAsync(queueMessage));
+    }
+
+    [Fact]
+    public async Task EnqueueAndSend_FullRoundTrip()
+    {
+        var testView = new TestMailView { Name = "John Doe" };
+        var testMail = new TestMailIgnoreSuppressList
+        {
+            ToEmails = ["test@example.com"],
+            Subject = "Round Trip Test",
+            View = testView
+        };
+
+        MailQueueMessage capturedQueueMessage = null;
+        _mockEnqueuingService.EnqueueManyAsync(
+            Arg.Do<IEnumerable<IMailQueueMessage>>(msgs =>
+                capturedQueueMessage = msgs.Cast<MailQueueMessage>().First()),
+            Arg.Any<Func<IMailQueueMessage, Task>>())
+            .Returns(Task.CompletedTask);
+
+        _mockRenderer.RenderAsync(Arg.Any<BaseMailView>())
+            .Returns(("<html>Hello John Doe</html>", "Hello John Doe"));
+
+        MailMessage sentMessage = null;
+        await _mockDeliveryService.SendEmailAsync(Arg.Do<MailMessage>(msg => sentMessage = msg));
+
+        // Act
+        await _mailer.EnqueueEmailsAsync([testMail]);
+        await _mailer.SendEnqueuedMailerMessageAsync(capturedQueueMessage);
+
+        // Assert
+        await _mockRenderer.Received(1).RenderAsync(Arg.Is<TestMailView>(v => v.Name == "John Doe"));
+        await _mockDeliveryService.Received(1).SendEmailAsync(Arg.Any<MailMessage>());
+
+        Assert.NotNull(sentMessage);
+        Assert.Equal("Round Trip Test", sentMessage.Subject);
+        Assert.Equal(["test@example.com"], sentMessage.ToEmails);
+        Assert.Equal("Default", sentMessage.Category);
+        Assert.Equal("<html>Hello John Doe</html>", sentMessage.HtmlContent);
+        Assert.Equal("Hello John Doe", sentMessage.TextContent);
+        Assert.True(sentMessage.MetaData.ContainsKey("SendGridBypassListManagement"));
+        Assert.True((bool)sentMessage.MetaData["SendGridBypassListManagement"]);
+    }
+}
+
+// Test helper class with IgnoreSuppressList override
+public class TestMailIgnoreSuppressList : BaseMail<TestMailView>
+{
+    public override string Subject { get; set; } = "Test Subject";
+    public override bool IgnoreSuppressList => true;
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32842

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds enqueue support to `IMailer` which enqueues the emails rather than sending them immediately. To achieve this we had to add two new fields to `IMailQueueMessage`, `IsMailerMessage` which indicates where to route the message and `MetaData`.

> Still need to test this.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
