### PR TITLE
[PM-32796] Fix bulk reinvite timeouts by moving updated org emails from IMailer to IMailService

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/AutoConfirmUser/AutomaticallyConfirmOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/AutoConfirmUser/AutomaticallyConfirmOrganizationUserCommand.cs
@@ -190,7 +190,7 @@ public class AutomaticallyConfirmOrganizationUserCommand(IOrganizationUserReposi
         }
         else
         {
-            await mailService.SendOrganizationConfirmedEmailAsync(organization.Name, userEmail, accessSecretsManager);
+            await mailService.SendOrganizationConfirmedEmailAsync(organization.DisplayName(), userEmail, accessSecretsManager);
         }
     }
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/ConfirmOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/ConfirmOrganizationUserCommand.cs
@@ -51,7 +51,8 @@ public class ConfirmOrganizationUserCommand : IConfirmOrganizationUserCommand
         IPolicyRequirementQuery policyRequirementQuery,
         IFeatureService featureService,
         ICollectionRepository collectionRepository,
-        IAutomaticUserConfirmationPolicyEnforcementValidator automaticUserConfirmationPolicyEnforcementValidator, ISendOrganizationConfirmationCommand sendOrganizationConfirmationCommand)
+        IAutomaticUserConfirmationPolicyEnforcementValidator automaticUserConfirmationPolicyEnforcementValidator,
+        ISendOrganizationConfirmationCommand sendOrganizationConfirmationCommand)
     {
         _organizationRepository = organizationRepository;
         _organizationUserRepository = organizationUserRepository;

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/BulkResendOrganizationInvitesCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/BulkResendOrganizationInvitesCommand.cs
@@ -59,7 +59,7 @@ public class BulkResendOrganizationInvitesCommand : IBulkResendOrganizationInvit
         if (validUsers.Any())
         {
             await _sendOrganizationInvitesCommand.SendInvitesAsync(
-                new SendInvitesRequest(validUsers, org));
+                new SendInvitesRequest(validUsers, org, invitingUserId: invitingUserId));
 
             result.AddRange(validUsers.Select(u => Tuple.Create(u, "")));
         }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/ResendOrganizationInviteCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/ResendOrganizationInviteCommand.cs
@@ -45,12 +45,14 @@ public class ResendOrganizationInviteCommand : IResendOrganizationInviteCommand
         {
             throw new BadRequestException("Organization invalid.");
         }
-        await SendInviteAsync(organizationUser, organization, initOrganization);
+        await SendInviteAsync(organizationUser, organization, initOrganization, invitingUserId);
     }
 
-    private async Task SendInviteAsync(OrganizationUser organizationUser, Organization organization, bool initOrganization) =>
+    private async Task SendInviteAsync(OrganizationUser organizationUser, Organization organization,
+        bool initOrganization, Guid? invitingUserId) =>
         await _sendOrganizationInvitesCommand.SendInvitesAsync(new SendInvitesRequest(
             users: [organizationUser],
             organization: organization,
-            initOrganization: initOrganization));
+            initOrganization: initOrganization,
+            invitingUserId: invitingUserId));
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommand.cs
@@ -1,23 +1,17 @@
 ﻿// FIXME: Update this file to be null safe and then delete the line below
 #nullable disable
 
-using System.Net;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Enums;
-using Bit.Core.AdminConsole.Models.Mail.Mailer.OrganizationInvite;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.InviteUsers.Models;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
 using Bit.Core.Auth.Models.Business;
 using Bit.Core.Auth.Models.Business.Tokenables;
 using Bit.Core.Auth.Repositories;
-using Bit.Core.Billing.Constants;
-using Bit.Core.Billing.Enums;
 using Bit.Core.Entities;
 using Bit.Core.Models.Mail;
-using Bit.Core.Platform.Mail.Mailer;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
-using Bit.Core.Settings;
 using Bit.Core.Tokens;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.InviteUsers;
@@ -29,42 +23,27 @@ public class SendOrganizationInvitesCommand(
     IOrgUserInviteTokenableFactory orgUserInviteTokenableFactory,
     IDataProtectorTokenFactory<OrgUserInviteTokenable> dataProtectorTokenFactory,
     IMailService mailService,
-    IMailer mailer,
-    IFeatureService featureService,
-    GlobalSettings globalSettings) : ISendOrganizationInvitesCommand
+    IFeatureService featureService) : ISendOrganizationInvitesCommand
 {
-    // New user (no existing account) email constants
-    private const string _newUserSubject = "set up a Bitwarden account for you";
-    private const string _newUserTitle = "set up a Bitwarden password manager account for you.";
-    private const string _newUserButton = "Finish account setup";
-
-    // Existing user email constants
-    private const string _existingUserSubject = "invited you to their Bitwarden organization";
-    private const string _existingUserTitle = "invited you to join them on Bitwarden";
-    private const string _existingUserButton = "Accept invitation";
-
-    // Free organization email constants
-    private const string _freeOrgNewUserSubject = "You have been invited to Bitwarden Password Manager";
-    private const string _freeOrgExistingUserSubject = "You have been invited to a Bitwarden Organization";
-    private const string _freeOrgTitle = "You have been invited to Bitwarden Password Manager";
-
     public async Task SendInvitesAsync(SendInvitesRequest request)
     {
-        var orgInvitesInfo = await BuildOrganizationInvitesInfoAsync(request.Users, request.Organization, request.InitOrganization);
-
         if (featureService.IsEnabled(FeatureFlagKeys.UpdateJoinOrganizationEmailTemplate))
         {
             var inviterEmail = await GetInviterEmailAsync(request.InvitingUserId);
-            await SendNewInviteEmailsAsync(orgInvitesInfo, inviterEmail);
+            var orgInvitesInfo = await BuildOrganizationInvitesInfoAsync(
+                request.Users, request.Organization, request.InitOrganization, inviterEmail);
+            await mailService.SendUpdatedOrganizationInviteEmailsAsync(orgInvitesInfo);
         }
         else
         {
+            var orgInvitesInfo = await BuildOrganizationInvitesInfoAsync(
+                request.Users, request.Organization, request.InitOrganization);
             await mailService.SendOrganizationInviteEmailsAsync(orgInvitesInfo);
         }
     }
 
     private async Task<OrganizationInvitesInfo> BuildOrganizationInvitesInfoAsync(IEnumerable<OrganizationUser> orgUsers,
-        Organization organization, bool initOrganization = false)
+        Organization organization, bool initOrganization = false, string inviterEmail = null)
     {
         // Materialize the sequence into a list to avoid multiple enumeration warnings
         var orgUsersList = orgUsers.ToList();
@@ -109,225 +88,9 @@ public class SendOrganizationInvitesCommand(
             orgSsoLoginRequiredPolicyEnabled,
             orgUsersWithExpTokens,
             orgUserHasExistingUserDict,
-            initOrganization
+            initOrganization,
+            inviterEmail
         );
-    }
-
-    private async Task SendNewInviteEmailsAsync(OrganizationInvitesInfo orgInvitesInfo, string inviterEmail)
-    {
-        foreach (var (orgUser, token) in orgInvitesInfo.OrgUserTokenPairs)
-        {
-            var userHasExistingUser = orgInvitesInfo.OrgUserHasExistingUserDict[orgUser.Id];
-
-            await SendInviteEmailAsync(
-                userHasExistingUser,
-                orgInvitesInfo,
-                orgUser,
-                token,
-                inviterEmail
-            );
-        }
-    }
-
-    private async Task SendInviteEmailAsync(
-        bool userHasExistingUser,
-        OrganizationInvitesInfo orgInvitesInfo,
-        OrganizationUser orgUser,
-        ExpiringToken token,
-        string inviterEmail)
-    {
-        if (PlanConstants.EnterprisePlanTypes.Contains(orgInvitesInfo.PlanType) ||
-            PlanConstants.TeamsPlanTypes.Contains(orgInvitesInfo.PlanType) ||
-            orgInvitesInfo.PlanType == PlanType.TeamsStarter ||
-            orgInvitesInfo.PlanType == PlanType.TeamsStarter2023 ||
-            orgInvitesInfo.PlanType == PlanType.Custom)
-        {
-            if (userHasExistingUser)
-            {
-                await SendEnterpriseTeamsExistingUserInviteAsync(orgInvitesInfo, orgUser, token, inviterEmail);
-            }
-            else
-            {
-                await SendEnterpriseTeamsNewUserInviteAsync(orgInvitesInfo, orgUser, token, inviterEmail);
-            }
-        }
-        else if (PlanConstants.FamiliesPlanTypes.Contains(orgInvitesInfo.PlanType))
-        {
-            if (userHasExistingUser)
-            {
-                await SendFamiliesExistingUserInviteAsync(orgInvitesInfo, orgUser, token, inviterEmail);
-            }
-            else
-            {
-                await SendFamiliesNewUserInviteAsync(orgInvitesInfo, orgUser, token, inviterEmail);
-            }
-        }
-        else
-        {
-            // Free plan (default)
-            await SendFreeOrganizationInviteAsync(orgInvitesInfo, orgUser, token, inviterEmail, userHasExistingUser);
-        }
-    }
-
-    private async Task SendEnterpriseTeamsNewUserInviteAsync(
-        OrganizationInvitesInfo orgInvitesInfo, OrganizationUser orgUser, ExpiringToken token, string inviterEmail)
-    {
-        var organizationName = WebUtility.HtmlDecode(orgInvitesInfo.OrganizationName);
-        var mail = new OrganizationInviteEnterpriseTeamsNewUser
-        {
-            ToEmails = [orgUser.Email],
-            Subject = $"{organizationName} {_newUserSubject}",
-            View = CreateEnterpriseTeamsNewUserView(orgInvitesInfo, orgUser, token, inviterEmail)
-        };
-        await mailer.SendEmail(mail);
-    }
-
-    private async Task SendEnterpriseTeamsExistingUserInviteAsync(
-        OrganizationInvitesInfo orgInvitesInfo, OrganizationUser orgUser, ExpiringToken token, string inviterEmail)
-    {
-        var organizationName = WebUtility.HtmlDecode(orgInvitesInfo.OrganizationName);
-        var mail = new OrganizationInviteEnterpriseTeamsExistingUser
-        {
-            ToEmails = [orgUser.Email],
-            Subject = $"{organizationName} {_existingUserSubject}",
-            View = CreateEnterpriseTeamsExistingUserView(orgInvitesInfo, orgUser, token, inviterEmail)
-        };
-        await mailer.SendEmail(mail);
-    }
-
-    private async Task SendFamiliesNewUserInviteAsync(
-        OrganizationInvitesInfo orgInvitesInfo, OrganizationUser orgUser, ExpiringToken token, string inviterEmail)
-    {
-        var organizationName = WebUtility.HtmlDecode(orgInvitesInfo.OrganizationName);
-        var mail = new OrganizationInviteFamiliesNewUser
-        {
-            ToEmails = [orgUser.Email],
-            Subject = $"{organizationName} {_newUserSubject}",
-            View = CreateFamiliesNewUserView(orgInvitesInfo, orgUser, token, inviterEmail)
-        };
-        await mailer.SendEmail(mail);
-    }
-
-    private async Task SendFamiliesExistingUserInviteAsync(
-        OrganizationInvitesInfo orgInvitesInfo, OrganizationUser orgUser, ExpiringToken token, string inviterEmail)
-    {
-        var organizationName = WebUtility.HtmlDecode(orgInvitesInfo.OrganizationName);
-        var mail = new OrganizationInviteFamiliesExistingUser
-        {
-            ToEmails = [orgUser.Email],
-            Subject = $"{organizationName} {_existingUserSubject}",
-            View = CreateFamiliesExistingUserView(orgInvitesInfo, orgUser, token, inviterEmail)
-        };
-        await mailer.SendEmail(mail);
-    }
-
-    private async Task SendFreeOrganizationInviteAsync(
-        OrganizationInvitesInfo orgInvitesInfo, OrganizationUser orgUser, ExpiringToken token, string inviterEmail, bool userHasExistingUser)
-    {
-        var mail = new OrganizationInviteFree
-        {
-            ToEmails = [orgUser.Email],
-            Subject = userHasExistingUser ? _freeOrgExistingUserSubject : _freeOrgNewUserSubject,
-            View = CreateFreeView(orgInvitesInfo, orgUser, token, inviterEmail)
-        };
-        await mailer.SendEmail(mail);
-    }
-
-    private OrganizationInviteEnterpriseTeamsNewUserView CreateEnterpriseTeamsNewUserView(
-        OrganizationInvitesInfo orgInvitesInfo, OrganizationUser orgUser, ExpiringToken token, string inviterEmail)
-    {
-        var organizationName = WebUtility.HtmlDecode(orgInvitesInfo.OrganizationName);
-        return new OrganizationInviteEnterpriseTeamsNewUserView
-        {
-            OrganizationName = organizationName,
-            Email = orgUser.Email,
-            ExpirationDate = FormatExpirationDate(token.ExpirationDate),
-            Url = BuildInvitationUrl(orgInvitesInfo, orgUser, token),
-            ButtonText = _newUserButton,
-            InviterEmail = inviterEmail
-        };
-    }
-
-    private OrganizationInviteEnterpriseTeamsExistingUserView CreateEnterpriseTeamsExistingUserView(
-        OrganizationInvitesInfo orgInvitesInfo, OrganizationUser orgUser, ExpiringToken token, string inviterEmail)
-    {
-        var organizationName = WebUtility.HtmlDecode(orgInvitesInfo.OrganizationName);
-        return new OrganizationInviteEnterpriseTeamsExistingUserView
-        {
-            OrganizationName = organizationName,
-            Email = orgUser.Email,
-            ExpirationDate = FormatExpirationDate(token.ExpirationDate),
-            Url = BuildInvitationUrl(orgInvitesInfo, orgUser, token),
-            ButtonText = _existingUserButton,
-            InviterEmail = inviterEmail
-        };
-    }
-
-    private OrganizationInviteFamiliesNewUserView CreateFamiliesNewUserView(
-        OrganizationInvitesInfo orgInvitesInfo, OrganizationUser orgUser, ExpiringToken token, string inviterEmail)
-    {
-        var organizationName = WebUtility.HtmlDecode(orgInvitesInfo.OrganizationName);
-        return new OrganizationInviteFamiliesNewUserView
-        {
-            OrganizationName = organizationName,
-            Email = orgUser.Email,
-            ExpirationDate = FormatExpirationDate(token.ExpirationDate),
-            Url = BuildInvitationUrl(orgInvitesInfo, orgUser, token),
-            ButtonText = _newUserButton,
-            InviterEmail = inviterEmail
-        };
-    }
-
-    private OrganizationInviteFamiliesExistingUserView CreateFamiliesExistingUserView(
-        OrganizationInvitesInfo orgInvitesInfo, OrganizationUser orgUser, ExpiringToken token, string inviterEmail)
-    {
-        var organizationName = WebUtility.HtmlDecode(orgInvitesInfo.OrganizationName);
-        return new OrganizationInviteFamiliesExistingUserView
-        {
-            OrganizationName = organizationName,
-            Email = orgUser.Email,
-            ExpirationDate = FormatExpirationDate(token.ExpirationDate),
-            Url = BuildInvitationUrl(orgInvitesInfo, orgUser, token),
-            ButtonText = _existingUserButton,
-            InviterEmail = inviterEmail
-        };
-    }
-
-    private OrganizationInviteFreeView CreateFreeView(
-        OrganizationInvitesInfo orgInvitesInfo, OrganizationUser orgUser, ExpiringToken token, string inviterEmail)
-    {
-        var organizationName = WebUtility.HtmlDecode(orgInvitesInfo.OrganizationName);
-        return new OrganizationInviteFreeView
-        {
-            OrganizationName = organizationName,
-            Email = orgUser.Email,
-            ExpirationDate = FormatExpirationDate(token.ExpirationDate),
-            Url = BuildInvitationUrl(orgInvitesInfo, orgUser, token),
-            ButtonText = _existingUserButton,
-            InviterEmail = inviterEmail
-        };
-    }
-
-    private string BuildInvitationUrl(OrganizationInvitesInfo orgInvitesInfo, OrganizationUser orgUser, ExpiringToken token)
-    {
-        var baseUrl = $"{globalSettings.BaseServiceUri.VaultWithHash}/accept-organization";
-        var queryParams = new List<string>
-        {
-            $"organizationId={orgUser.OrganizationId}",
-            $"organizationUserId={orgUser.Id}",
-            $"email={WebUtility.UrlEncode(orgUser.Email)}",
-            $"organizationName={WebUtility.UrlEncode(orgInvitesInfo.OrganizationName)}",
-            $"token={WebUtility.UrlEncode(token.Token)}",
-            $"initOrganization={orgInvitesInfo.InitOrganization}",
-            $"orgUserHasExistingUser={orgInvitesInfo.OrgUserHasExistingUserDict[orgUser.Id]}"
-        };
-
-        if (orgInvitesInfo.OrgSsoEnabled && orgInvitesInfo.OrgSsoLoginRequiredPolicyEnabled)
-        {
-            queryParams.Add($"orgSsoIdentifier={orgInvitesInfo.OrgSsoIdentifier}");
-        }
-
-        return $"{baseUrl}?{string.Join("&", queryParams)}";
     }
 
     private async Task<string> GetInviterEmailAsync(Guid? invitingUserId)
@@ -340,7 +103,4 @@ public class SendOrganizationInvitesCommand(
         var invitingUser = await userRepository.GetByIdAsync(invitingUserId.Value);
         return invitingUser?.Email;
     }
-
-    private static string FormatExpirationDate(DateTime expirationDate) =>
-        $"{expirationDate.ToLongDateString()} {expirationDate.ToShortTimeString()} UTC";
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/OrganizationConfirmation/ISendOrganizationConfirmationCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/OrganizationConfirmation/ISendOrganizationConfirmationCommand.cs
@@ -11,12 +11,4 @@ public interface ISendOrganizationConfirmationCommand
     /// <param name="userEmail">The email address of the user to send the confirmation to.</param>
     /// <param name="accessSecretsManager">Whether the user has access to Secrets Manager.</param>
     Task SendConfirmationAsync(Organization organization, string userEmail, bool accessSecretsManager);
-
-    /// <summary>
-    /// Sends organization confirmation emails to multiple users.
-    /// </summary>
-    /// <param name="organization">The organization to send the confirmation emails for.</param>
-    /// <param name="userEmails">The email addresses of the users to send confirmations to.</param>
-    /// <param name="accessSecretsManager">Whether the users have access to Secrets Manager.</param>
-    Task SendConfirmationsAsync(Organization organization, IEnumerable<string> userEmails, bool accessSecretsManager);
 }

--- a/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationConfirmation/OrganizationConfirmationEnterpriseTeamsView.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationConfirmation/OrganizationConfirmationEnterpriseTeamsView.html.hbs
@@ -1,0 +1,794 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>
+    <title></title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-70 { width:70% !important; max-width: 70%; }
+.mj-column-per-30 { width:30% !important; max-width: 30%; }
+.mj-column-per-100 { width:100% !important; max-width: 100%; }
+.mj-column-per-15 { width:15% !important; max-width: 15%; }
+.mj-column-per-85 { width:85% !important; max-width: 85%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-70 { width:70% !important; max-width: 70%; }
+.moz-text-html .mj-column-per-30 { width:30% !important; max-width: 30%; }
+.moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+.moz-text-html .mj-column-per-15 { width:15% !important; max-width: 15%; }
+.moz-text-html .mj-column-per-85 { width:85% !important; max-width: 85%; }
+    </style>
+    
+    
+  
+    
+    <style type="text/css">
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-hero-responsive-img {
+          display: none !important;
+        }
+      }
+    
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-learn-more-footer-responsive-img {
+          display: none !important;
+        }
+      }
+    
+
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile { width: 100% !important; }
+      td.mj-full-width-mobile { width: auto !important; }
+    }
+  
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-icon-row-text {
+          padding-left: 15px !important;
+          padding-right: 15px !important;
+          line-height: 20px;
+        }
+        .mj-bw-ac-icon-row-icon {
+          display: none !important;
+          width: 0 !important;
+          max-width: 0 !important;
+        }
+        .mj-bw-ac-icon-row-text-column {
+          width: 100% !important;
+        }
+      }
+    
+    </style>
+     
+    <style type="text/css">
+.border-fix > table {
+    border-collapse: separate !important;
+  }
+  .border-fix > table > tbody > tr > td {
+    border-radius: 3px;
+  }
+    </style>
+    <!-- Include shared head styles -->
+  </head>
+  <body style="word-spacing:normal;background-color:#e6e9ef;">
+    
+    
+      <div style="background-color:#e6e9ef;" lang="und" dir="auto">
+        <!-- Blue Header Section -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="border-fix-outlook" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div class="border-fix" style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><![endif]-->
+            
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#175ddc;background-color:#175ddc;width:100%;border-radius:4px 4px 0px 0px;">
+        <tbody>
+          <tr>
+            <td>
+              
+        
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#175ddc" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+        
+      <div style="margin:0px auto;border-radius:4px 4px 0px 0px;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;border-radius:4px 4px 0px 0px;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:434px;" ><![endif]-->
+            
+      <div class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:150px;">
+              
+      <img alt src="https://bitwarden.com/images/logo-horizontal-white.png" style="border:0;display:block;outline:none;text-decoration:none;height:30px;width:100%;font-size:16px;" width="150" height="30">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;padding-bottom:0;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#ffffff;"><h1 style="font-weight: 400; font-size: 24px; line-height: 32px">
+              You can now share passwords with members of <b>{{OrganizationName}}!</b>
+            </h1></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
+        <tbody>
+          <tr>
+            <td align="center" bgcolor="#ffffff" role="presentation" style="border:none;border-radius:20px;cursor:auto;mso-padding-alt:12px 24px;background:#ffffff;" valign="middle">
+              <a href="{{WebVaultUrl}}" style="display:inline-block;background:#ffffff;color:#1A41AC;font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:12px 24px;mso-padding-alt:0px;border-radius:20px;" target="_blank">
+                <b>Log in</b>
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td><td class="" style="vertical-align:bottom;width:186px;" ><![endif]-->
+            
+      <div class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:bottom;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:bottom;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="right" class="mj-bw-ac-hero-responsive-img" style="font-size:0px;padding:0px 20px 0px 0px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:155px;">
+              
+      <img alt src="https://assets.bitwarden.com/email/v1/ac-spot-enterprise.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="155" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+        
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+      
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Main Content -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:5px 20px 8px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:10px 10px 16px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:15px 15px 0px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:24px;text-align:left;color:#1B2029;">As a member of <b>{{ OrganizationName }}</b>:</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Organization Icon" src="https://assets.bitwarden.com/email/v1/icon-enterprise.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">Your account is owned by {{OrganizationName}} and is subject to their security and management policies.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Share Icon" src="https://assets.bitwarden.com/email/v1/icon-account-switching-new.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">You can easily access and share passwords with your team.</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><a href="https://bitwarden.com/help/sharing" class="link" style="text-decoration: none; color: #175ddc; font-weight: 600;">
+                    Share passwords in Bitwarden
+              </a></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Learn More Section -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:8px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#F3F6F9" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#F3F6F9;background-color:#F3F6F9;margin:0px auto;border-radius:0px 0px 4px 4px;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F3F6F9;background-color:#F3F6F9;width:100%;border-radius:0px 0px 4px 4px;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:14px 10px 14px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:420px;" ><![endif]-->
+            
+      <div class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 15px 10px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#1B2029;"><p style="font-size: 18px; line-height: 28px; font-weight: 500; margin: 0 0 8px 0;">
+              Learn more about Bitwarden
+            </p>
+            <p style="font-size: 16px; line-height: 24px; margin: 0;">
+              Find user guides, product documentation, and videos on the
+              <a href="https://bitwarden.com/help/" class="link" style="text-decoration: none; color: #175ddc; font-weight: 600;"> Bitwarden Help Center</a>.
+            </p></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td><td class="" style="vertical-align:bottom;width:180px;" ><![endif]-->
+            
+      <div class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:bottom;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:bottom;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="right" class="mj-bw-ac-learn-more-footer-responsive-img" style="font-size:0px;padding:0px 15px 0px 0px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:94px;">
+              
+      <img alt src="https://assets.bitwarden.com/email/v1/spot-community.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="94" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Footer -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:5px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:620px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      
+     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://x.com/bitwarden" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-x-twitter.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.reddit.com/r/Bitwarden/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-reddit.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://community.bitwarden.com/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-discourse.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://github.com/bitwarden" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-github.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.youtube.com/channel/UCId9a_jQqvJre0_dE2lE_Rw" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-youtube.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.linkedin.com/company/bitwarden1/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-linkedin.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.facebook.com/bitwarden/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-facebook.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;line-height:16px;text-align:center;color:#5A6D91;"><p style="margin-bottom: 5px; margin-top: 5px">
+        © {{ CurrentYear }} Bitwarden Inc. 1 N. Calle Cesar Chavez, Suite 102,
+        Santa Barbara, CA, USA
+      </p>
+      <p style="margin-top: 5px">
+        Always confirm you are on a trusted Bitwarden domain before logging
+        in:<br>
+        <a href="https://bitwarden.com/" style="text-decoration: none; color: #175ddc; font-weight: 400">bitwarden.com</a>
+        |
+        <a href="https://bitwarden.com/help/emails-from-bitwarden/" style="text-decoration: none; color: #175ddc; font-weight: 400">Learn why we include this</a>
+      </p></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationConfirmation/OrganizationConfirmationEnterpriseTeamsView.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationConfirmation/OrganizationConfirmationEnterpriseTeamsView.text.hbs
@@ -1,0 +1,4 @@
+{{#>TitleContactUsTextLayout}}
+    You may now access logins and other items {{OrganizationName}} has shared with you from your Bitwarden vault.
+    Tip: Use the Bitwarden mobile app to quickly save logins and auto-fill forms. Download from the App Store or Google Play.
+{{/TitleContactUsTextLayout}}

--- a/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationConfirmation/OrganizationConfirmationFamilyFreeView.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationConfirmation/OrganizationConfirmationFamilyFreeView.html.hbs
@@ -1,0 +1,969 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>
+    <title></title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-70 { width:70% !important; max-width: 70%; }
+.mj-column-per-30 { width:30% !important; max-width: 30%; }
+.mj-column-per-100 { width:100% !important; max-width: 100%; }
+.mj-column-per-15 { width:15% !important; max-width: 15%; }
+.mj-column-per-85 { width:85% !important; max-width: 85%; }
+.mj-column-px-159 { width:159px !important; max-width: 159px; }
+.mj-column-px-140 { width:140px !important; max-width: 140px; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-70 { width:70% !important; max-width: 70%; }
+.moz-text-html .mj-column-per-30 { width:30% !important; max-width: 30%; }
+.moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+.moz-text-html .mj-column-per-15 { width:15% !important; max-width: 15%; }
+.moz-text-html .mj-column-per-85 { width:85% !important; max-width: 85%; }
+.moz-text-html .mj-column-px-159 { width:159px !important; max-width: 159px; }
+.moz-text-html .mj-column-px-140 { width:140px !important; max-width: 140px; }
+    </style>
+    
+    
+  
+    
+    <style type="text/css">
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-hero-responsive-img {
+          display: none !important;
+        }
+      }
+    
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-learn-more-footer-responsive-img {
+          display: none !important;
+        }
+      }
+    
+
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile { width: 100% !important; }
+      td.mj-full-width-mobile { width: auto !important; }
+    }
+  
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-icon-row-text {
+          padding-left: 15px !important;
+          padding-right: 15px !important;
+          line-height: 20px;
+        }
+        .mj-bw-ac-icon-row-icon {
+          display: none !important;
+          width: 0 !important;
+          max-width: 0 !important;
+        }
+        .mj-bw-ac-icon-row-text-column {
+          width: 100% !important;
+        }
+      }
+    
+    </style>
+     
+    <style type="text/css">
+.border-fix > table {
+    border-collapse: separate !important;
+  }
+  .border-fix > table > tbody > tr > td {
+    border-radius: 3px;
+  }
+@media only screen and (max-width: 480px) {
+    .hide-mobile {
+      display: none !important;
+    }
+  }
+    </style>
+    <!-- Include shared head styles -->
+<!-- Include admin console shared styles -->
+  </head>
+  <body style="word-spacing:normal;background-color:#e6e9ef;">
+    
+    
+      <div style="background-color:#e6e9ef;" lang="und" dir="auto">
+        <!-- Blue Header Section -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="border-fix-outlook" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div class="border-fix" style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><![endif]-->
+            
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#175ddc;background-color:#175ddc;width:100%;border-radius:4px 4px 0px 0px;">
+        <tbody>
+          <tr>
+            <td>
+              
+        
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#175ddc" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+        
+      <div style="margin:0px auto;border-radius:4px 4px 0px 0px;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;border-radius:4px 4px 0px 0px;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:434px;" ><![endif]-->
+            
+      <div class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:150px;">
+              
+      <img alt src="https://bitwarden.com/images/logo-horizontal-white.png" style="border:0;display:block;outline:none;text-decoration:none;height:30px;width:100%;font-size:16px;" width="150" height="30">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;padding-bottom:0;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue','Inter',Helvetica,Arial,sans-serif;font-size:16px;line-height:1;text-align:left;color:#ffffff;"><h1 style="font-weight: 400; font-size: 24px; line-height: 32px">
+              You can now share passwords with members of <b>{{OrganizationName}}!</b>
+            </h1></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
+        <tbody>
+          <tr>
+            <td align="center" bgcolor="#ffffff" role="presentation" style="border:none;border-radius:20px;cursor:auto;mso-padding-alt:12px 24px;background:#ffffff;" valign="middle">
+              <a href="{{WebVaultUrl}}" style="display:inline-block;background:#ffffff;color:#1A41AC;font-family:'Helvetica Neue','Inter',Helvetica,Arial,sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:12px 24px;mso-padding-alt:0px;border-radius:20px;" target="_blank">
+                <b>Log in</b>
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td><td class="" style="vertical-align:bottom;width:186px;" ><![endif]-->
+            
+      <div class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:bottom;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:bottom;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="right" class="mj-bw-ac-hero-responsive-img" style="font-size:0px;padding:0px 20px 0px 0px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:155px;">
+              
+      <img alt src="https://assets.bitwarden.com/email/v1/ac-spot-family.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="155" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+        
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+      
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Main Content -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:5px 20px 8px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:10px 10px 16px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:15px 15px 0px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue','Inter',Helvetica,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;color:#1B2029;">As a member of <b>{{ OrganizationName }}</b>:</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Group Users Icon" src="https://assets.bitwarden.com/email/v1/icon-item-type.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">You can access passwords {{OrganizationName}} has shared with you.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Share Icon" src="https://assets.bitwarden.com/email/v1/icon-account-switching-new.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">You can easily share passwords with friends, family, or coworkers.</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><a href="https://bitwarden.com/help/sharing" class="link" style="text-decoration: none; color: #175ddc; font-weight: 600;">
+                    Share passwords in Bitwarden
+              </a></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Download Mobile Apps Section -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:8px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:32px 10px 0px 25px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:585px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:0 0 16px 0;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue','Inter',Helvetica,Arial,sans-serif;font-size:18px;font-weight:500;line-height:24px;text-align:left;color:#1B2029;">Download Bitwarden on all devices</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0 0 24px 0;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue','Inter',Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">Already using the
+            <a href="https://bitwarden.com/download/" class="link" style="text-decoration: none; color: #175ddc; font-weight: 600;">browser extension</a>? Download the Bitwarden mobile app from the
+            <a href="https://apps.apple.com/us/app/bitwarden-password-manager/id1137397744" class="link" style="text-decoration: none; color: #175ddc; font-weight: 600;">App Store</a>
+            or
+            <a href="https://play.google.com/store/apps/details?id=com.x8bit.bitwarden" class="link" style="text-decoration: none; color: #175ddc; font-weight: 600;">Google Play</a>
+            to quickly save logins and autofill forms on the go.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0 10px 32px 25px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="width:585px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:top;width:159px;" ><![endif]-->
+                
+      <div class="mj-column-px-159 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:27.17948717948718%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" class="hide-mobile" style="font-size:0px;padding:0 24px 0 0;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:135px;">
+              
+        <a href="https://apps.apple.com/us/app/bitwarden-password-manager/id1137397744" target="_blank">
+          
+      <img alt="Download on the App Store" src="https://assets.bitwarden.com/email/v1/ac-apple-store.png" style="border:0;display:block;outline:none;text-decoration:none;height:40px;width:100%;font-size:16px;" width="135" height="40">
+    
+        </a>
+      
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:top;width:140px;" ><![endif]-->
+                
+      <div class="mj-column-px-140 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:23.931623931623932%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" class="hide-mobile" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:140px;">
+              
+        <a href="https://play.google.com/store/apps/details?id=com.x8bit.bitwarden" target="_blank">
+          
+      <img alt="Get it on Google Play" src="https://assets.bitwarden.com/email/v1/ac-google-play.png" style="border:0;display:block;outline:none;text-decoration:none;height:40px;width:100%;font-size:16px;" width="140" height="40">
+    
+        </a>
+      
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Learn More Section -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:8px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#F3F6F9" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#F3F6F9;background-color:#F3F6F9;margin:0px auto;border-radius:0px 0px 4px 4px;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F3F6F9;background-color:#F3F6F9;width:100%;border-radius:0px 0px 4px 4px;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:14px 10px 14px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:420px;" ><![endif]-->
+            
+      <div class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 15px 10px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue','Inter',Helvetica,Arial,sans-serif;font-size:16px;line-height:1;text-align:left;color:#1B2029;"><p style="font-size: 18px; line-height: 28px; font-weight: 500; margin: 0 0 8px 0;">
+              Learn more about Bitwarden
+            </p>
+            <p style="font-size: 16px; line-height: 24px; margin: 0;">
+              Find user guides, product documentation, and videos on the
+              <a href="https://bitwarden.com/help/" class="link" style="text-decoration: none; color: #175ddc; font-weight: 600;"> Bitwarden Help Center</a>.
+            </p></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td><td class="" style="vertical-align:bottom;width:180px;" ><![endif]-->
+            
+      <div class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:bottom;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:bottom;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="right" class="mj-bw-ac-learn-more-footer-responsive-img" style="font-size:0px;padding:0px 15px 0px 0px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:94px;">
+              
+      <img alt src="https://assets.bitwarden.com/email/v1/spot-community.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="94" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Footer -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:5px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:620px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      
+     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://x.com/bitwarden" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-x-twitter.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.reddit.com/r/Bitwarden/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-reddit.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://community.bitwarden.com/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-discourse.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://github.com/bitwarden" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-github.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.youtube.com/channel/UCId9a_jQqvJre0_dE2lE_Rw" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-youtube.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.linkedin.com/company/bitwarden1/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-linkedin.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.facebook.com/bitwarden/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-facebook.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue','Inter',Helvetica,Arial,sans-serif;font-size:12px;line-height:16px;text-align:center;color:#5A6D91;"><p style="margin-bottom: 5px; margin-top: 5px">
+        © {{ CurrentYear }} Bitwarden Inc. 1 N. Calle Cesar Chavez, Suite 102,
+        Santa Barbara, CA, USA
+      </p>
+      <p style="margin-top: 5px">
+        Always confirm you are on a trusted Bitwarden domain before logging
+        in:<br>
+        <a href="https://bitwarden.com/" style="text-decoration: none; color: #175ddc; font-weight: 400">bitwarden.com</a>
+        |
+        <a href="https://bitwarden.com/help/emails-from-bitwarden/" style="text-decoration: none; color: #175ddc; font-weight: 400">Learn why we include this</a>
+      </p></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationConfirmation/OrganizationConfirmationFamilyFreeView.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationConfirmation/OrganizationConfirmationFamilyFreeView.text.hbs
@@ -1,0 +1,4 @@
+{{#>TitleContactUsTextLayout}}
+    You may now access logins and other items {{OrganizationName}} has shared with you from your Bitwarden vault.
+    Tip: Use the Bitwarden mobile app to quickly save logins and auto-fill forms. Download from the App Store or Google Play.
+{{/TitleContactUsTextLayout}}

--- a/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteEnterpriseTeamsExistingUserView.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteEnterpriseTeamsExistingUserView.html.hbs
@@ -1,0 +1,976 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>
+    <title></title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-70 { width:70% !important; max-width: 70%; }
+.mj-column-per-30 { width:30% !important; max-width: 30%; }
+.mj-column-per-100 { width:100% !important; max-width: 100%; }
+.mj-column-per-15 { width:15% !important; max-width: 15%; }
+.mj-column-per-85 { width:85% !important; max-width: 85%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-70 { width:70% !important; max-width: 70%; }
+.moz-text-html .mj-column-per-30 { width:30% !important; max-width: 30%; }
+.moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+.moz-text-html .mj-column-per-15 { width:15% !important; max-width: 15%; }
+.moz-text-html .mj-column-per-85 { width:85% !important; max-width: 85%; }
+    </style>
+    
+    
+  
+    
+    <style type="text/css">
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-hero-responsive-img {
+          display: none !important;
+        }
+      }
+    
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-learn-more-footer-responsive-img {
+          display: none !important;
+        }
+      }
+    
+
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile { width: 100% !important; }
+      td.mj-full-width-mobile { width: auto !important; }
+    }
+  
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-icon-row-text {
+          padding-left: 15px !important;
+          padding-right: 15px !important;
+          line-height: 20px;
+        }
+        .mj-bw-ac-icon-row-icon {
+          display: none !important;
+          width: 0 !important;
+          max-width: 0 !important;
+        }
+        .mj-bw-ac-icon-row-text-column {
+          width: 100% !important;
+        }
+        .mj-bw-ac-icon-row-bullet {
+          display: block !important;
+        }
+        .mj-bw-ac-icon-row-text-inline {
+          display: none !important;
+        }
+      }
+    
+    </style>
+     
+    <style type="text/css">
+.border-fix > table {
+    border-collapse: separate !important;
+  }
+  .border-fix > table > tbody > tr > td {
+    border-radius: 3px;
+  }
+    </style>
+    
+  </head>
+  <body style="word-spacing:normal;background-color:#e6e9ef;">
+    
+    
+      <div class="border-fix" style="background-color:#e6e9ef;" lang="und" dir="auto">
+        <!-- Blue Header Section -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="border-fix-outlook" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div class="border-fix" style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><![endif]-->
+            
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#175ddc;background-color:#175ddc;width:100%;border-radius:4px 4px 0px 0px;">
+        <tbody>
+          <tr>
+            <td>
+              
+        
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#175ddc" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+        
+      <div style="margin:0px auto;border-radius:4px 4px 0px 0px;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;border-radius:4px 4px 0px 0px;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:434px;" ><![endif]-->
+            
+      <div class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:150px;">
+              
+      <img alt src="https://bitwarden.com/images/logo-horizontal-white.png" style="border:0;display:block;outline:none;text-decoration:none;height:30px;width:100%;font-size:16px;" width="150" height="30">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;padding-bottom:0;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#ffffff;"><h1 style="font-weight: 400; font-size: 24px; line-height: 32px">
+              <b>{{OrganizationName}}</b> invited you to join them on Bitwarden
+            </h1></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
+        <tbody>
+          <tr>
+            <td align="center" bgcolor="#ffffff" role="presentation" style="border:none;border-radius:20px;cursor:auto;mso-padding-alt:12px 24px;background:#ffffff;" valign="middle">
+              <a href="{{Url}}" style="display:inline-block;background:#ffffff;color:#1A41AC;font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:12px 24px;mso-padding-alt:0px;border-radius:20px;" target="_blank">
+                <b>{{ButtonText}}</b>
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td><td class="" style="vertical-align:bottom;width:186px;" ><![endif]-->
+            
+      <div class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:bottom;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:bottom;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="right" class="mj-bw-ac-hero-responsive-img" style="font-size:0px;padding:0px 20px 0px 0px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:155px;">
+              
+      <img alt src="https://assets.bitwarden.com/email/v1/spot-enterprise.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="155" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+        
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+      
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Main Content -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:5px 20px 8px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:10px 10px 16px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:15px 15px 0px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:24px;text-align:left;color:#1B2029;"><b>{{OrganizationName}}</b> is rolling out Bitwarden to increase security and protect your sensitive data. Once you accept this invitation, you can:</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Store Icon" src="https://assets.bitwarden.com/email/v1/icon-item-type.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>Store logins securely so you never forget your passwords.</li></ul>
+                <span class="mj-bw-ac-icon-row-text-inline">Store logins securely so you never forget your passwords.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Autofill Icon" src="https://assets.bitwarden.com/email/v1/icon-autofill.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>Sign in to accounts quickly by filling passwords with one click.</li></ul>
+                <span class="mj-bw-ac-icon-row-text-inline">Sign in to accounts quickly by filling passwords with one click.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Share Icon" src="https://assets.bitwarden.com/email/v1/icon-account-switching-new.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>Share logins easily with your team.</li></ul>
+                <span class="mj-bw-ac-icon-row-text-inline">Share logins easily with your team.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 12px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:0px 15px 15px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;line-height:16px;text-align:left;color:#1B2029;">{{#if InviterEmail}}
+            This invitation was sent by <a href="mailto:{{InviterEmail}}" style="color: #175ddc; text-decoration: none;">{{InviterEmail}}</a> and expires {{ExpirationDate}}
+            {{else}}
+            This invitation expires {{ExpirationDate}}
+            {{/if}}</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Policy Warning Section -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:8px 20px 8px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:10px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:15px 15px 8px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:18px;font-weight:500;line-height:28px;text-align:left;color:#1B2029;">Your existing account will be owned by {{OrganizationName}}</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0px 15px 15px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:24px;text-align:left;color:#1B2029;">By accepting this invitation, your account ({{Email}}) will be owned by <b>{{OrganizationName}}</b> and will be subject to their security and management policies. Contact your administrator with any questions or concerns.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Learn More Section -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:8px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#F3F6F9" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#F3F6F9;background-color:#F3F6F9;margin:0px auto;border-radius:0px 0px 4px 4px;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F3F6F9;background-color:#F3F6F9;width:100%;border-radius:0px 0px 4px 4px;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:14px 10px 14px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:420px;" ><![endif]-->
+            
+      <div class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 15px 10px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#1B2029;"><p style="font-size: 18px; line-height: 28px; font-weight: 500; margin: 0 0 8px 0;">
+              Learn more about Bitwarden
+            </p>
+            <p style="font-size: 16px; line-height: 24px; margin: 0;">
+              Find user guides, product documentation, and videos on the
+              <a href="https://bitwarden.com/help/" class="link" style="text-decoration: none; color: #175ddc; font-weight: 600;"> Bitwarden Help Center</a>.
+            </p></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td><td class="" style="vertical-align:bottom;width:180px;" ><![endif]-->
+            
+      <div class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:bottom;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:bottom;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="right" class="mj-bw-ac-learn-more-footer-responsive-img" style="font-size:0px;padding:0px 15px 0px 0px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:94px;">
+              
+      <img alt src="https://assets.bitwarden.com/email/v1/spot-community.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="94" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Footer -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:5px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:620px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      
+     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://x.com/bitwarden" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-x-twitter.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.reddit.com/r/Bitwarden/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-reddit.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://community.bitwarden.com/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-discourse.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://github.com/bitwarden" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-github.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.youtube.com/channel/UCId9a_jQqvJre0_dE2lE_Rw" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-youtube.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.linkedin.com/company/bitwarden1/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-linkedin.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.facebook.com/bitwarden/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-facebook.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;line-height:16px;text-align:center;color:#5A6D91;"><p style="margin-bottom: 5px; margin-top: 5px">
+        © {{ CurrentYear }} Bitwarden Inc. 1 N. Calle Cesar Chavez, Suite 102, Santa
+        Barbara, CA, USA
+      </p>
+      <p style="margin-top: 5px">
+        Always confirm you are on a trusted Bitwarden domain before logging
+        in:<br>
+        <a href="https://bitwarden.com/" style="text-decoration:none;color:#175ddc; font-weight:400">bitwarden.com</a> |
+        <a href="https://bitwarden.com/help/emails-from-bitwarden/" style="text-decoration:none; color:#175ddc; font-weight:400">Learn why we include this</a>
+      </p></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteEnterpriseTeamsExistingUserView.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteEnterpriseTeamsExistingUserView.text.hbs
@@ -1,0 +1,19 @@
+{{#>TitleContactUsTextLayout}}
+{{OrganizationName}} is rolling out Bitwarden to increase security and protect your sensitive data. Once you accept this invitation, you can:
+
+- Store logins securely so you never forget your passwords.
+- Sign in to accounts quickly by filling passwords with one click.
+- Share logins easily with your team.
+
+{{#if InviterEmail}}
+This invitation was sent by {{InviterEmail}} and expires {{ExpirationDate}}.
+{{else}}
+This invitation expires {{ExpirationDate}}.
+{{/if}}
+
+Your existing account will be owned by {{OrganizationName}}
+
+By accepting this invitation, your account ({{Email}}) will be owned by {{OrganizationName}} and will be subject to their security and management policies. Contact your administrator with any questions or concerns.
+
+Accept invitation: {{Url}}
+{{/TitleContactUsTextLayout}}

--- a/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteEnterpriseTeamsNewUserView.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteEnterpriseTeamsNewUserView.html.hbs
@@ -1,0 +1,908 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>
+    <title></title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-70 { width:70% !important; max-width: 70%; }
+.mj-column-per-30 { width:30% !important; max-width: 30%; }
+.mj-column-per-100 { width:100% !important; max-width: 100%; }
+.mj-column-per-15 { width:15% !important; max-width: 15%; }
+.mj-column-per-85 { width:85% !important; max-width: 85%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-70 { width:70% !important; max-width: 70%; }
+.moz-text-html .mj-column-per-30 { width:30% !important; max-width: 30%; }
+.moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+.moz-text-html .mj-column-per-15 { width:15% !important; max-width: 15%; }
+.moz-text-html .mj-column-per-85 { width:85% !important; max-width: 85%; }
+    </style>
+    
+    
+  
+    
+    <style type="text/css">
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-hero-responsive-img {
+          display: none !important;
+        }
+      }
+    
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-learn-more-footer-responsive-img {
+          display: none !important;
+        }
+      }
+    
+
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile { width: 100% !important; }
+      td.mj-full-width-mobile { width: auto !important; }
+    }
+  
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-icon-row-text {
+          padding-left: 15px !important;
+          padding-right: 15px !important;
+          line-height: 20px;
+        }
+        .mj-bw-ac-icon-row-icon {
+          display: none !important;
+          width: 0 !important;
+          max-width: 0 !important;
+        }
+        .mj-bw-ac-icon-row-text-column {
+          width: 100% !important;
+        }
+        .mj-bw-ac-icon-row-bullet {
+          display: block !important;
+        }
+        .mj-bw-ac-icon-row-text-inline {
+          display: none !important;
+        }
+      }
+    
+    </style>
+     
+    <style type="text/css">
+.border-fix > table {
+    border-collapse: separate !important;
+  }
+  .border-fix > table > tbody > tr > td {
+    border-radius: 3px;
+  }
+    </style>
+    
+  </head>
+  <body style="word-spacing:normal;background-color:#e6e9ef;">
+    
+    
+      <div class="border-fix" style="background-color:#e6e9ef;" lang="und" dir="auto">
+        <!-- Blue Header Section -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="border-fix-outlook" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div class="border-fix" style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><![endif]-->
+            
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#175ddc;background-color:#175ddc;width:100%;border-radius:4px 4px 0px 0px;">
+        <tbody>
+          <tr>
+            <td>
+              
+        
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#175ddc" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+        
+      <div style="margin:0px auto;border-radius:4px 4px 0px 0px;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;border-radius:4px 4px 0px 0px;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:434px;" ><![endif]-->
+            
+      <div class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:150px;">
+              
+      <img alt src="https://bitwarden.com/images/logo-horizontal-white.png" style="border:0;display:block;outline:none;text-decoration:none;height:30px;width:100%;font-size:16px;" width="150" height="30">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;padding-bottom:0;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#ffffff;"><h1 style="font-weight: 400; font-size: 24px; line-height: 32px">
+              <b>{{OrganizationName}}</b> set up a Bitwarden password manager account for you.
+            </h1></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
+        <tbody>
+          <tr>
+            <td align="center" bgcolor="#ffffff" role="presentation" style="border:none;border-radius:20px;cursor:auto;mso-padding-alt:12px 24px;background:#ffffff;" valign="middle">
+              <a href="{{Url}}" style="display:inline-block;background:#ffffff;color:#1A41AC;font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:12px 24px;mso-padding-alt:0px;border-radius:20px;" target="_blank">
+                <b>{{ButtonText}}</b>
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td><td class="" style="vertical-align:bottom;width:186px;" ><![endif]-->
+            
+      <div class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:bottom;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:bottom;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="right" class="mj-bw-ac-hero-responsive-img" style="font-size:0px;padding:0px 20px 0px 0px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:155px;">
+              
+      <img alt src="https://assets.bitwarden.com/email/v1/spot-enterprise.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="155" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+        
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+      
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Main Content -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:5px 20px 8px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:10px 10px 16px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:15px 15px 0px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:24px;text-align:left;color:#1B2029;"><b>{{OrganizationName}}</b> is rolling out Bitwarden to increase security and protect your sensitive data. Once you finish account setup, you can:</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Store Icon" src="https://assets.bitwarden.com/email/v1/icon-item-type.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>Store logins securely so you never forget your passwords.</li></ul>
+                <span class="mj-bw-ac-icon-row-text-inline">Store logins securely so you never forget your passwords.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Autofill Icon" src="https://assets.bitwarden.com/email/v1/icon-autofill.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>Sign in to accounts quickly by filling passwords with one click.</li></ul>
+                <span class="mj-bw-ac-icon-row-text-inline">Sign in to accounts quickly by filling passwords with one click.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Share Icon" src="https://assets.bitwarden.com/email/v1/icon-account-switching-new.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>Share logins easily with your team.</li></ul>
+                <span class="mj-bw-ac-icon-row-text-inline">Share logins easily with your team.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 12px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:0px 15px 15px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;line-height:16px;text-align:left;color:#1B2029;">{{#if InviterEmail}}
+            This invitation was sent by <a href="mailto:{{InviterEmail}}" style="color: #175ddc; text-decoration: none;">{{InviterEmail}}</a> and expires {{ExpirationDate}}
+            {{else}}
+            This invitation expires {{ExpirationDate}}
+            {{/if}}</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Learn More Section -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:8px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#F3F6F9" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#F3F6F9;background-color:#F3F6F9;margin:0px auto;border-radius:0px 0px 4px 4px;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F3F6F9;background-color:#F3F6F9;width:100%;border-radius:0px 0px 4px 4px;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:14px 10px 14px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:420px;" ><![endif]-->
+            
+      <div class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 15px 10px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#1B2029;"><p style="font-size: 18px; line-height: 28px; font-weight: 500; margin: 0 0 8px 0;">
+              Learn more about Bitwarden
+            </p>
+            <p style="font-size: 16px; line-height: 24px; margin: 0;">
+              Find user guides, product documentation, and videos on the
+              <a href="https://bitwarden.com/help/" class="link" style="text-decoration: none; color: #175ddc; font-weight: 600;"> Bitwarden Help Center</a>.
+            </p></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td><td class="" style="vertical-align:bottom;width:180px;" ><![endif]-->
+            
+      <div class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:bottom;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:bottom;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="right" class="mj-bw-ac-learn-more-footer-responsive-img" style="font-size:0px;padding:0px 15px 0px 0px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:94px;">
+              
+      <img alt src="https://assets.bitwarden.com/email/v1/spot-community.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="94" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Footer -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:5px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:620px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      
+     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://x.com/bitwarden" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-x-twitter.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.reddit.com/r/Bitwarden/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-reddit.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://community.bitwarden.com/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-discourse.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://github.com/bitwarden" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-github.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.youtube.com/channel/UCId9a_jQqvJre0_dE2lE_Rw" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-youtube.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.linkedin.com/company/bitwarden1/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-linkedin.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.facebook.com/bitwarden/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-facebook.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;line-height:16px;text-align:center;color:#5A6D91;"><p style="margin-bottom: 5px; margin-top: 5px">
+        © {{ CurrentYear }} Bitwarden Inc. 1 N. Calle Cesar Chavez, Suite 102, Santa
+        Barbara, CA, USA
+      </p>
+      <p style="margin-top: 5px">
+        Always confirm you are on a trusted Bitwarden domain before logging
+        in:<br>
+        <a href="https://bitwarden.com/" style="text-decoration:none;color:#175ddc; font-weight:400">bitwarden.com</a> |
+        <a href="https://bitwarden.com/help/emails-from-bitwarden/" style="text-decoration:none; color:#175ddc; font-weight:400">Learn why we include this</a>
+      </p></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteEnterpriseTeamsNewUserView.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteEnterpriseTeamsNewUserView.text.hbs
@@ -1,0 +1,15 @@
+{{#>TitleContactUsTextLayout}}
+{{OrganizationName}} is rolling out Bitwarden to increase security and protect your sensitive data. Once you finish account setup, you can:
+
+- Store logins securely so you never forget your passwords.
+- Sign in to accounts quickly by filling passwords with one click.
+- Share logins easily with your team.
+
+{{#if InviterEmail}}
+This invitation was sent by {{InviterEmail}} and expires {{ExpirationDate}}.
+{{else}}
+This invitation expires {{ExpirationDate}}.
+{{/if}}
+
+Finish account setup: {{Url}}
+{{/TitleContactUsTextLayout}}

--- a/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteFamiliesExistingUserView.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteFamiliesExistingUserView.html.hbs
@@ -1,0 +1,908 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>
+    <title></title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-70 { width:70% !important; max-width: 70%; }
+.mj-column-per-30 { width:30% !important; max-width: 30%; }
+.mj-column-per-100 { width:100% !important; max-width: 100%; }
+.mj-column-per-15 { width:15% !important; max-width: 15%; }
+.mj-column-per-85 { width:85% !important; max-width: 85%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-70 { width:70% !important; max-width: 70%; }
+.moz-text-html .mj-column-per-30 { width:30% !important; max-width: 30%; }
+.moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+.moz-text-html .mj-column-per-15 { width:15% !important; max-width: 15%; }
+.moz-text-html .mj-column-per-85 { width:85% !important; max-width: 85%; }
+    </style>
+    
+    
+  
+    
+    <style type="text/css">
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-hero-responsive-img {
+          display: none !important;
+        }
+      }
+    
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-learn-more-footer-responsive-img {
+          display: none !important;
+        }
+      }
+    
+
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile { width: 100% !important; }
+      td.mj-full-width-mobile { width: auto !important; }
+    }
+  
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-icon-row-text {
+          padding-left: 15px !important;
+          padding-right: 15px !important;
+          line-height: 20px;
+        }
+        .mj-bw-ac-icon-row-icon {
+          display: none !important;
+          width: 0 !important;
+          max-width: 0 !important;
+        }
+        .mj-bw-ac-icon-row-text-column {
+          width: 100% !important;
+        }
+        .mj-bw-ac-icon-row-bullet {
+          display: block !important;
+        }
+        .mj-bw-ac-icon-row-text-inline {
+          display: none !important;
+        }
+      }
+    
+    </style>
+     
+    <style type="text/css">
+.border-fix > table {
+    border-collapse: separate !important;
+  }
+  .border-fix > table > tbody > tr > td {
+    border-radius: 3px;
+  }
+    </style>
+    
+  </head>
+  <body style="word-spacing:normal;background-color:#e6e9ef;">
+    
+    
+      <div class="border-fix" style="background-color:#e6e9ef;" lang="und" dir="auto">
+        <!-- Blue Header Section -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="border-fix-outlook" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div class="border-fix" style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><![endif]-->
+            
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#175ddc;background-color:#175ddc;width:100%;border-radius:4px 4px 0px 0px;">
+        <tbody>
+          <tr>
+            <td>
+              
+        
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#175ddc" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+        
+      <div style="margin:0px auto;border-radius:4px 4px 0px 0px;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;border-radius:4px 4px 0px 0px;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:434px;" ><![endif]-->
+            
+      <div class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:150px;">
+              
+      <img alt src="https://bitwarden.com/images/logo-horizontal-white.png" style="border:0;display:block;outline:none;text-decoration:none;height:30px;width:100%;font-size:16px;" width="150" height="30">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;padding-bottom:0;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#ffffff;"><h1 style="font-weight: 400; font-size: 24px; line-height: 32px">
+              <b>{{OrganizationName}}</b> invited you to join them on Bitwarden
+            </h1></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
+        <tbody>
+          <tr>
+            <td align="center" bgcolor="#ffffff" role="presentation" style="border:none;border-radius:20px;cursor:auto;mso-padding-alt:12px 24px;background:#ffffff;" valign="middle">
+              <a href="{{Url}}" style="display:inline-block;background:#ffffff;color:#1A41AC;font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:12px 24px;mso-padding-alt:0px;border-radius:20px;" target="_blank">
+                <b>{{ButtonText}}</b>
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td><td class="" style="vertical-align:bottom;width:186px;" ><![endif]-->
+            
+      <div class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:bottom;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:bottom;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="right" class="mj-bw-ac-hero-responsive-img" style="font-size:0px;padding:0px 20px 0px 0px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:155px;">
+              
+      <img alt src="https://assets.bitwarden.com/email/v1/spot-family-homes.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="155" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+        
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+      
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Main Content -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:5px 20px 8px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:10px 10px 16px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:15px 15px 0px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:24px;text-align:left;color:#1B2029;"><b>{{OrganizationName}}</b> is using Bitwarden to simplify password sharing and protect your sensitive data. Once you accept this invitation, you can:</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Store Icon" src="https://assets.bitwarden.com/email/v1/icon-item-type.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>Store logins securely so you never forget your passwords.</li></ul>
+                <span class="mj-bw-ac-icon-row-text-inline">Store logins securely so you never forget your passwords.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Autofill Icon" src="https://assets.bitwarden.com/email/v1/icon-autofill.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>Sign in to accounts quickly by filling passwords with one click.</li></ul>
+                <span class="mj-bw-ac-icon-row-text-inline">Sign in to accounts quickly by filling passwords with one click.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Share Icon" src="https://assets.bitwarden.com/email/v1/icon-account-switching-new.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>Share logins easily with your friends, family, or coworkers.</li></ul>
+                <span class="mj-bw-ac-icon-row-text-inline">Share logins easily with your friends, family, or coworkers.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 12px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:0px 15px 15px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;line-height:16px;text-align:left;color:#1B2029;">{{#if InviterEmail}}
+            This invitation was sent by <a href="mailto:{{InviterEmail}}" style="color: #175ddc; text-decoration: none;">{{InviterEmail}}</a> and expires {{ExpirationDate}}
+            {{else}}
+            This invitation expires {{ExpirationDate}}
+            {{/if}}</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Learn More Section -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:8px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#F3F6F9" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#F3F6F9;background-color:#F3F6F9;margin:0px auto;border-radius:0px 0px 4px 4px;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F3F6F9;background-color:#F3F6F9;width:100%;border-radius:0px 0px 4px 4px;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:14px 10px 14px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:420px;" ><![endif]-->
+            
+      <div class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 15px 10px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#1B2029;"><p style="font-size: 18px; line-height: 28px; font-weight: 500; margin: 0 0 8px 0;">
+              Learn more about Bitwarden
+            </p>
+            <p style="font-size: 16px; line-height: 24px; margin: 0;">
+              Find user guides, product documentation, and videos on the
+              <a href="https://bitwarden.com/help/" class="link" style="text-decoration: none; color: #175ddc; font-weight: 600;"> Bitwarden Help Center</a>.
+            </p></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td><td class="" style="vertical-align:bottom;width:180px;" ><![endif]-->
+            
+      <div class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:bottom;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:bottom;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="right" class="mj-bw-ac-learn-more-footer-responsive-img" style="font-size:0px;padding:0px 15px 0px 0px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:94px;">
+              
+      <img alt src="https://assets.bitwarden.com/email/v1/spot-community.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="94" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Footer -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:5px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:620px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      
+     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://x.com/bitwarden" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-x-twitter.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.reddit.com/r/Bitwarden/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-reddit.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://community.bitwarden.com/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-discourse.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://github.com/bitwarden" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-github.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.youtube.com/channel/UCId9a_jQqvJre0_dE2lE_Rw" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-youtube.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.linkedin.com/company/bitwarden1/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-linkedin.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.facebook.com/bitwarden/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-facebook.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;line-height:16px;text-align:center;color:#5A6D91;"><p style="margin-bottom: 5px; margin-top: 5px">
+        © {{ CurrentYear }} Bitwarden Inc. 1 N. Calle Cesar Chavez, Suite 102, Santa
+        Barbara, CA, USA
+      </p>
+      <p style="margin-top: 5px">
+        Always confirm you are on a trusted Bitwarden domain before logging
+        in:<br>
+        <a href="https://bitwarden.com/" style="text-decoration:none;color:#175ddc; font-weight:400">bitwarden.com</a> |
+        <a href="https://bitwarden.com/help/emails-from-bitwarden/" style="text-decoration:none; color:#175ddc; font-weight:400">Learn why we include this</a>
+      </p></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteFamiliesExistingUserView.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteFamiliesExistingUserView.text.hbs
@@ -1,0 +1,15 @@
+{{#>TitleContactUsTextLayout}}
+{{OrganizationName}} is using Bitwarden to simplify password sharing and protect your sensitive data. Once you accept this invitation, you can:
+
+- Store logins securely so you never forget your passwords.
+- Sign in to accounts quickly by filling passwords with one click.
+- Share logins easily with your friends, family, or coworkers.
+
+{{#if InviterEmail}}
+This invitation was sent by {{InviterEmail}} and expires {{ExpirationDate}}.
+{{else}}
+This invitation expires {{ExpirationDate}}.
+{{/if}}
+
+Accept invitation: {{Url}}
+{{/TitleContactUsTextLayout}}

--- a/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteFamiliesNewUserView.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteFamiliesNewUserView.html.hbs
@@ -1,0 +1,908 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>
+    <title></title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-70 { width:70% !important; max-width: 70%; }
+.mj-column-per-30 { width:30% !important; max-width: 30%; }
+.mj-column-per-100 { width:100% !important; max-width: 100%; }
+.mj-column-per-15 { width:15% !important; max-width: 15%; }
+.mj-column-per-85 { width:85% !important; max-width: 85%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-70 { width:70% !important; max-width: 70%; }
+.moz-text-html .mj-column-per-30 { width:30% !important; max-width: 30%; }
+.moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+.moz-text-html .mj-column-per-15 { width:15% !important; max-width: 15%; }
+.moz-text-html .mj-column-per-85 { width:85% !important; max-width: 85%; }
+    </style>
+    
+    
+  
+    
+    <style type="text/css">
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-hero-responsive-img {
+          display: none !important;
+        }
+      }
+    
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-learn-more-footer-responsive-img {
+          display: none !important;
+        }
+      }
+    
+
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile { width: 100% !important; }
+      td.mj-full-width-mobile { width: auto !important; }
+    }
+  
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-icon-row-text {
+          padding-left: 15px !important;
+          padding-right: 15px !important;
+          line-height: 20px;
+        }
+        .mj-bw-ac-icon-row-icon {
+          display: none !important;
+          width: 0 !important;
+          max-width: 0 !important;
+        }
+        .mj-bw-ac-icon-row-text-column {
+          width: 100% !important;
+        }
+        .mj-bw-ac-icon-row-bullet {
+          display: block !important;
+        }
+        .mj-bw-ac-icon-row-text-inline {
+          display: none !important;
+        }
+      }
+    
+    </style>
+     
+    <style type="text/css">
+.border-fix > table {
+    border-collapse: separate !important;
+  }
+  .border-fix > table > tbody > tr > td {
+    border-radius: 3px;
+  }
+    </style>
+    
+  </head>
+  <body style="word-spacing:normal;background-color:#e6e9ef;">
+    
+    
+      <div class="border-fix" style="background-color:#e6e9ef;" lang="und" dir="auto">
+        <!-- Blue Header Section -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="border-fix-outlook" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div class="border-fix" style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><![endif]-->
+            
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#175ddc;background-color:#175ddc;width:100%;border-radius:4px 4px 0px 0px;">
+        <tbody>
+          <tr>
+            <td>
+              
+        
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#175ddc" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+        
+      <div style="margin:0px auto;border-radius:4px 4px 0px 0px;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;border-radius:4px 4px 0px 0px;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:434px;" ><![endif]-->
+            
+      <div class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:150px;">
+              
+      <img alt src="https://bitwarden.com/images/logo-horizontal-white.png" style="border:0;display:block;outline:none;text-decoration:none;height:30px;width:100%;font-size:16px;" width="150" height="30">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;padding-bottom:0;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#ffffff;"><h1 style="font-weight: 400; font-size: 24px; line-height: 32px">
+              <b>{{OrganizationName}}</b> set up a Bitwarden password manager account for you.
+            </h1></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
+        <tbody>
+          <tr>
+            <td align="center" bgcolor="#ffffff" role="presentation" style="border:none;border-radius:20px;cursor:auto;mso-padding-alt:12px 24px;background:#ffffff;" valign="middle">
+              <a href="{{Url}}" style="display:inline-block;background:#ffffff;color:#1A41AC;font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:12px 24px;mso-padding-alt:0px;border-radius:20px;" target="_blank">
+                <b>{{ButtonText}}</b>
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td><td class="" style="vertical-align:bottom;width:186px;" ><![endif]-->
+            
+      <div class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:bottom;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:bottom;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="right" class="mj-bw-ac-hero-responsive-img" style="font-size:0px;padding:0px 20px 0px 0px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:155px;">
+              
+      <img alt src="https://assets.bitwarden.com/email/v1/spot-family-homes.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="155" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+        
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+      
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Main Content -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:5px 20px 8px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:10px 10px 16px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:15px 15px 0px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:24px;text-align:left;color:#1B2029;"><b>{{OrganizationName}}</b> is using Bitwarden to simplify password sharing and protect your sensitive data. Once you finish account setup, you can:</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Store Icon" src="https://assets.bitwarden.com/email/v1/icon-item-type.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>Store logins securely so you never forget your passwords.</li></ul>
+                <span class="mj-bw-ac-icon-row-text-inline">Store logins securely so you never forget your passwords.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Autofill Icon" src="https://assets.bitwarden.com/email/v1/icon-autofill.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>Sign in to accounts quickly by filling passwords with one click.</li></ul>
+                <span class="mj-bw-ac-icon-row-text-inline">Sign in to accounts quickly by filling passwords with one click.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Share Icon" src="https://assets.bitwarden.com/email/v1/icon-account-switching-new.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>Share logins easily with your friends, family, or coworkers.</li></ul>
+                <span class="mj-bw-ac-icon-row-text-inline">Share logins easily with your friends, family, or coworkers.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 12px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:0px 15px 15px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;line-height:16px;text-align:left;color:#1B2029;">{{#if InviterEmail}}
+            This invitation was sent by <a href="mailto:{{InviterEmail}}" style="color: #175ddc; text-decoration: none;">{{InviterEmail}}</a> and expires {{ExpirationDate}}
+            {{else}}
+            This invitation expires {{ExpirationDate}}
+            {{/if}}</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Learn More Section -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:8px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#F3F6F9" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#F3F6F9;background-color:#F3F6F9;margin:0px auto;border-radius:0px 0px 4px 4px;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F3F6F9;background-color:#F3F6F9;width:100%;border-radius:0px 0px 4px 4px;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:14px 10px 14px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:420px;" ><![endif]-->
+            
+      <div class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 15px 10px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#1B2029;"><p style="font-size: 18px; line-height: 28px; font-weight: 500; margin: 0 0 8px 0;">
+              Learn more about Bitwarden
+            </p>
+            <p style="font-size: 16px; line-height: 24px; margin: 0;">
+              Find user guides, product documentation, and videos on the
+              <a href="https://bitwarden.com/help/" class="link" style="text-decoration: none; color: #175ddc; font-weight: 600;"> Bitwarden Help Center</a>.
+            </p></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td><td class="" style="vertical-align:bottom;width:180px;" ><![endif]-->
+            
+      <div class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:bottom;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:bottom;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="right" class="mj-bw-ac-learn-more-footer-responsive-img" style="font-size:0px;padding:0px 15px 0px 0px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:94px;">
+              
+      <img alt src="https://assets.bitwarden.com/email/v1/spot-community.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="94" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Footer -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:5px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:620px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      
+     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://x.com/bitwarden" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-x-twitter.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.reddit.com/r/Bitwarden/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-reddit.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://community.bitwarden.com/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-discourse.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://github.com/bitwarden" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-github.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.youtube.com/channel/UCId9a_jQqvJre0_dE2lE_Rw" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-youtube.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.linkedin.com/company/bitwarden1/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-linkedin.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.facebook.com/bitwarden/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-facebook.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;line-height:16px;text-align:center;color:#5A6D91;"><p style="margin-bottom: 5px; margin-top: 5px">
+        © {{ CurrentYear }} Bitwarden Inc. 1 N. Calle Cesar Chavez, Suite 102, Santa
+        Barbara, CA, USA
+      </p>
+      <p style="margin-top: 5px">
+        Always confirm you are on a trusted Bitwarden domain before logging
+        in:<br>
+        <a href="https://bitwarden.com/" style="text-decoration:none;color:#175ddc; font-weight:400">bitwarden.com</a> |
+        <a href="https://bitwarden.com/help/emails-from-bitwarden/" style="text-decoration:none; color:#175ddc; font-weight:400">Learn why we include this</a>
+      </p></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteFamiliesNewUserView.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteFamiliesNewUserView.text.hbs
@@ -1,0 +1,15 @@
+{{#>TitleContactUsTextLayout}}
+{{OrganizationName}} is using Bitwarden to simplify password sharing and protect your sensitive data. Once you finish account setup, you can:
+
+- Store logins securely so you never forget your passwords.
+- Sign in to accounts quickly by filling passwords with one click.
+- Share logins easily with your friends, family, or coworkers.
+
+{{#if InviterEmail}}
+This invitation was sent by {{InviterEmail}} and expires {{ExpirationDate}}.
+{{else}}
+This invitation expires {{ExpirationDate}}.
+{{/if}}
+
+Finish account setup: {{Url}}
+{{/TitleContactUsTextLayout}}

--- a/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteFreeView.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteFreeView.html.hbs
@@ -1,0 +1,908 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>
+    <title></title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-70 { width:70% !important; max-width: 70%; }
+.mj-column-per-30 { width:30% !important; max-width: 30%; }
+.mj-column-per-100 { width:100% !important; max-width: 100%; }
+.mj-column-per-15 { width:15% !important; max-width: 15%; }
+.mj-column-per-85 { width:85% !important; max-width: 85%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-70 { width:70% !important; max-width: 70%; }
+.moz-text-html .mj-column-per-30 { width:30% !important; max-width: 30%; }
+.moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+.moz-text-html .mj-column-per-15 { width:15% !important; max-width: 15%; }
+.moz-text-html .mj-column-per-85 { width:85% !important; max-width: 85%; }
+    </style>
+    
+    
+  
+    
+    <style type="text/css">
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-hero-responsive-img {
+          display: none !important;
+        }
+      }
+    
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-learn-more-footer-responsive-img {
+          display: none !important;
+        }
+      }
+    
+
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile { width: 100% !important; }
+      td.mj-full-width-mobile { width: auto !important; }
+    }
+  
+
+      @media only screen and (max-width:480px) {
+        .mj-bw-ac-icon-row-text {
+          padding-left: 15px !important;
+          padding-right: 15px !important;
+          line-height: 20px;
+        }
+        .mj-bw-ac-icon-row-icon {
+          display: none !important;
+          width: 0 !important;
+          max-width: 0 !important;
+        }
+        .mj-bw-ac-icon-row-text-column {
+          width: 100% !important;
+        }
+        .mj-bw-ac-icon-row-bullet {
+          display: block !important;
+        }
+        .mj-bw-ac-icon-row-text-inline {
+          display: none !important;
+        }
+      }
+    
+    </style>
+     
+    <style type="text/css">
+.border-fix > table {
+    border-collapse: separate !important;
+  }
+  .border-fix > table > tbody > tr > td {
+    border-radius: 3px;
+  }
+    </style>
+    
+  </head>
+  <body style="word-spacing:normal;background-color:#e6e9ef;">
+    
+    
+      <div class="border-fix" style="background-color:#e6e9ef;" lang="und" dir="auto">
+        <!-- Blue Header Section -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="border-fix-outlook" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div class="border-fix" style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><![endif]-->
+            
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#175ddc;background-color:#175ddc;width:100%;border-radius:4px 4px 0px 0px;">
+        <tbody>
+          <tr>
+            <td>
+              
+        
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#175ddc" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+        
+      <div style="margin:0px auto;border-radius:4px 4px 0px 0px;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;border-radius:4px 4px 0px 0px;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:434px;" ><![endif]-->
+            
+      <div class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:150px;">
+              
+      <img alt src="https://bitwarden.com/images/logo-horizontal-white.png" style="border:0;display:block;outline:none;text-decoration:none;height:30px;width:100%;font-size:16px;" width="150" height="30">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;padding-bottom:0;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#ffffff;"><h1 style="font-weight: 400; font-size: 24px; line-height: 32px">
+              You have been invited to Bitwarden Password Manager
+            </h1></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
+        <tbody>
+          <tr>
+            <td align="center" bgcolor="#ffffff" role="presentation" style="border:none;border-radius:20px;cursor:auto;mso-padding-alt:12px 24px;background:#ffffff;" valign="middle">
+              <a href="{{Url}}" style="display:inline-block;background:#ffffff;color:#1A41AC;font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:12px 24px;mso-padding-alt:0px;border-radius:20px;" target="_blank">
+                <b>{{ButtonText}}</b>
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td><td class="" style="vertical-align:bottom;width:186px;" ><![endif]-->
+            
+      <div class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:bottom;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:bottom;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="right" class="mj-bw-ac-hero-responsive-img" style="font-size:0px;padding:0px 20px 0px 0px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:155px;">
+              
+      <img alt src="https://assets.bitwarden.com/email/v1/spot-family-homes.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="155" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+        
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+      
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Main Content -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:5px 20px 8px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:10px 10px 16px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:15px 15px 0px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:24px;text-align:left;color:#1B2029;">Bitwarden is a password manager used to simplify password sharing and protect your sensitive data. Once you accept this invitation, you can:</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Store Icon" src="https://assets.bitwarden.com/email/v1/icon-item-type.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>Securely store logins so you never forget your passwords.</li></ul>
+                <span class="mj-bw-ac-icon-row-text-inline">Securely store logins so you never forget your passwords.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Autofill Icon" src="https://assets.bitwarden.com/email/v1/icon-autofill.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>Sign in to accounts quickly by filling passwords with one click.</li></ul>
+                <span class="mj-bw-ac-icon-row-text-inline">Sign in to accounts quickly by filling passwords with one click.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 24px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-bw-ac-icon-row-outlook" style="width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix mj-bw-ac-icon-row" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+        <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:90px;" ><![endif]-->
+                
+      <div class="mj-column-per-15 mj-outlook-group-fix mj-bw-ac-icon-row-icon" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:15%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0px 10px 0px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:48px;">
+              
+      <img alt="Share Icon" src="https://assets.bitwarden.com/email/v1/icon-account-switching-new.png" style="border:0;border-radius:8px;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="48" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td><td style="vertical-align:middle;width:510px;" ><![endif]-->
+                
+      <div class="mj-column-per-85 mj-outlook-group-fix mj-bw-ac-icon-row-text-column" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:85%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="mj-bw-ac-icon-row-text" style="font-size:0px;padding:0px 0px 0px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><ul class="mj-bw-ac-icon-row-bullet" style="display: none; margin: 0; padding-left: 24px;"><li>Share logins easily with your friends, family, or coworkers.</li></ul>
+                <span class="mj-bw-ac-icon-row-text-inline">Share logins easily with your friends, family, or coworkers.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 10px 12px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:0px 15px 15px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;line-height:16px;text-align:left;color:#1B2029;">{{#if InviterEmail}}
+            This invitation was sent by <a href="mailto:{{InviterEmail}}" style="color: #175ddc; text-decoration: none;">{{InviterEmail}}</a> and expires {{ExpirationDate}}
+            {{else}}
+            This invitation expires {{ExpirationDate}}
+            {{/if}}</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Learn More Section -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:8px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:620px;" width="620" bgcolor="#F3F6F9" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#F3F6F9;background-color:#F3F6F9;margin:0px auto;border-radius:0px 0px 4px 4px;max-width:620px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F3F6F9;background-color:#F3F6F9;width:100%;border-radius:0px 0px 4px 4px;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:14px 10px 14px 10px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:420px;" ><![endif]-->
+            
+      <div class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 15px 10px 15px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#1B2029;"><p style="font-size: 18px; line-height: 28px; font-weight: 500; margin: 0 0 8px 0;">
+              Learn more about Bitwarden
+            </p>
+            <p style="font-size: 16px; line-height: 24px; margin: 0;">
+              Find user guides, product documentation, and videos on the
+              <a href="https://bitwarden.com/help/" class="link" style="text-decoration: none; color: #175ddc; font-weight: 600;"> Bitwarden Help Center</a>.
+            </p></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td><td class="" style="vertical-align:bottom;width:180px;" ><![endif]-->
+            
+      <div class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:bottom;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:bottom;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="right" class="mj-bw-ac-learn-more-footer-responsive-img" style="font-size:0px;padding:0px 15px 0px 0px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:94px;">
+              
+      <img alt src="https://assets.bitwarden.com/email/v1/spot-community.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="94" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Footer -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:5px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:620px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      
+     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://x.com/bitwarden" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-x-twitter.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.reddit.com/r/Bitwarden/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-reddit.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://community.bitwarden.com/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-discourse.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://github.com/bitwarden" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-github.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.youtube.com/channel/UCId9a_jQqvJre0_dE2lE_Rw" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-youtube.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.linkedin.com/company/bitwarden1/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-linkedin.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.facebook.com/bitwarden/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-facebook.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;line-height:16px;text-align:center;color:#5A6D91;"><p style="margin-bottom: 5px; margin-top: 5px">
+        © {{ CurrentYear }} Bitwarden Inc. 1 N. Calle Cesar Chavez, Suite 102, Santa
+        Barbara, CA, USA
+      </p>
+      <p style="margin-top: 5px">
+        Always confirm you are on a trusted Bitwarden domain before logging
+        in:<br>
+        <a href="https://bitwarden.com/" style="text-decoration:none;color:#175ddc; font-weight:400">bitwarden.com</a> |
+        <a href="https://bitwarden.com/help/emails-from-bitwarden/" style="text-decoration:none; color:#175ddc; font-weight:400">Learn why we include this</a>
+      </p></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteFreeView.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/AdminConsole/OrganizationInvite/OrganizationInviteFreeView.text.hbs
@@ -1,0 +1,15 @@
+{{#>TitleContactUsTextLayout}}
+Bitwarden is a password manager used to simplify password sharing and protect your sensitive data. Once you accept this invitation, you can:
+
+- Securely store logins so you never forget your passwords.
+- Sign in to accounts quickly by filling passwords with one click.
+- Share logins easily with your friends, family, or coworkers.
+
+{{#if InviterEmail}}
+This invitation was sent by {{InviterEmail}} and expires {{ExpirationDate}}.
+{{else}}
+This invitation expires {{ExpirationDate}}.
+{{/if}}
+
+Accept invitation: {{Url}}
+{{/TitleContactUsTextLayout}}

--- a/src/Core/Models/Mail/OrganizationInvitesInfo.cs
+++ b/src/Core/Models/Mail/OrganizationInvitesInfo.cs
@@ -15,7 +15,8 @@ public class OrganizationInvitesInfo
         bool orgSsoLoginRequiredPolicyEnabled,
         IEnumerable<(OrganizationUser orgUser, ExpiringToken token)> orgUserTokenPairs,
         Dictionary<Guid, bool> orgUserHasExistingUserDict,
-        bool initOrganization = false
+        bool initOrganization = false,
+        string inviterEmail = null
         )
     {
         OrganizationName = org.DisplayName();
@@ -30,6 +31,7 @@ public class OrganizationInvitesInfo
 
         OrgUserTokenPairs = orgUserTokenPairs;
         OrgUserHasExistingUserDict = orgUserHasExistingUserDict;
+        InviterEmail = inviterEmail;
     }
 
     public string OrganizationName { get; }
@@ -41,5 +43,6 @@ public class OrganizationInvitesInfo
     public bool OrgSsoLoginRequiredPolicyEnabled { get; }
     public IEnumerable<(OrganizationUser OrgUser, ExpiringToken Token)> OrgUserTokenPairs { get; }
     public Dictionary<Guid, bool> OrgUserHasExistingUserDict { get; }
+    public string InviterEmail { get; }
 
 }

--- a/src/Core/Platform/Mail/IMailService.cs
+++ b/src/Core/Platform/Mail/IMailService.cs
@@ -69,10 +69,12 @@ public interface IMailService
     /// </summary>
     /// <param name="orgInvitesInfo">The information required to send the organization invites.</param>
     Task SendOrganizationInviteEmailsAsync(OrganizationInvitesInfo orgInvitesInfo);
+    Task SendUpdatedOrganizationInviteEmailsAsync(OrganizationInvitesInfo orgInvitesInfo);
     Task SendOrganizationMaxSeatLimitReachedEmailAsync(Organization organization, int maxSeatCount, IEnumerable<string> ownerEmails);
     Task SendOrganizationAutoscaledEmailAsync(Organization organization, int initialSeatCount, IEnumerable<string> ownerEmails);
     Task SendOrganizationAcceptedEmailAsync(Organization organization, string userIdentifier, IEnumerable<string> adminEmails, bool hasAccessSecretsManager = false);
     Task SendOrganizationConfirmedEmailAsync(string organizationName, string email, bool hasAccessSecretsManager = false);
+    Task SendUpdatedOrganizationConfirmedEmailAsync(Organization organization, string userEmail, bool accessSecretsManager = false);
     Task SendOrganizationUserRevokedForTwoFactorPolicyEmailAsync(string organizationName, string email);
     Task SendOrganizationUserRevokedForPolicySingleOrgEmailAsync(string organizationName, string email);
     Task SendPasswordlessSignInAsync(string returnUrl, string token, string email);

--- a/src/Core/Platform/Mail/NoopMailService.cs
+++ b/src/Core/Platform/Mail/NoopMailService.cs
@@ -78,7 +78,17 @@ public class NoopMailService : IMailService
         return Task.FromResult(0);
     }
 
+    public Task SendUpdatedOrganizationConfirmedEmailAsync(Organization organization, string userEmail, bool accessSecretsManager = false)
+    {
+        return Task.FromResult(0);
+    }
+
     public Task SendOrganizationInviteEmailsAsync(OrganizationInvitesInfo orgInvitesInfo)
+    {
+        return Task.FromResult(0);
+    }
+
+    public Task SendUpdatedOrganizationInviteEmailsAsync(OrganizationInvitesInfo orgInvitesInfo)
     {
         return Task.FromResult(0);
     }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/AutoConfirmUsers/AutomaticallyConfirmUsersCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/AutoConfirmUsers/AutomaticallyConfirmUsersCommandTests.cs
@@ -390,7 +390,7 @@ public class AutomaticallyConfirmUsersCommandTests
 
         var emailException = new Exception("Email sending failed");
         sutProvider.GetDependency<IMailService>()
-            .SendOrganizationConfirmedEmailAsync(organization.Name, user.Email, organizationUser.AccessSecretsManager)
+            .SendOrganizationConfirmedEmailAsync(organization.DisplayName(), user.Email, organizationUser.AccessSecretsManager)
             .ThrowsAsync(emailException);
 
         // Act
@@ -705,7 +705,7 @@ public class AutomaticallyConfirmUsersCommandTests
         await sutProvider.GetDependency<IMailService>()
             .Received(1)
             .SendOrganizationConfirmedEmailAsync(
-                organization.Name,
+                organization.DisplayName(),
                 user.Email,
                 organizationUser.AccessSecretsManager);
 
@@ -722,7 +722,7 @@ public class AutomaticallyConfirmUsersCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task SendOrganizationConfirmedEmailAsync_WithFeatureFlagOn_UsesNewMailer(
+    public async Task SendOrganizationConfirmedEmailAsync_WithFeatureFlagOn_CallsSendOrganizationConfirmationCommand(
         Organization organization,
         string userEmail,
         SutProvider<AutomaticallyConfirmOrganizationUserCommand> sutProvider)
@@ -741,8 +741,8 @@ public class AutomaticallyConfirmUsersCommandTests
             .Received(1)
             .SendConfirmationAsync(organization, userEmail, accessSecretsManager);
         await sutProvider.GetDependency<IMailService>()
-            .DidNotReceive()
-            .SendOrganizationConfirmedEmailAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
+            .DidNotReceiveWithAnyArgs()
+            .SendOrganizationConfirmedEmailAsync(default, default, default);
     }
 
     [Theory]
@@ -764,9 +764,9 @@ public class AutomaticallyConfirmUsersCommandTests
         // Assert
         await sutProvider.GetDependency<IMailService>()
             .Received(1)
-            .SendOrganizationConfirmedEmailAsync(organization.Name, userEmail, accessSecretsManager);
+            .SendOrganizationConfirmedEmailAsync(organization.DisplayName(), userEmail, accessSecretsManager);
         await sutProvider.GetDependency<ISendOrganizationConfirmationCommand>()
-            .DidNotReceive()
-            .SendConfirmationAsync(Arg.Any<Organization>(), Arg.Any<string>(), Arg.Any<bool>());
+            .DidNotReceiveWithAnyArgs()
+            .SendConfirmationAsync(default, default, default);
     }
 }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/ConfirmOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/ConfirmOrganizationUserCommandTests.cs
@@ -797,7 +797,7 @@ public class ConfirmOrganizationUserCommandTests
     }
 
     [Theory, BitAutoData]
-    public async Task SendOrganizationConfirmedEmailAsync_WithFeatureFlagOn_UsesNewMailer(
+    public async Task SendOrganizationConfirmedEmailAsync_WithFeatureFlagOn_CallsSendOrganizationConfirmationCommand(
         Organization org,
         string userEmail,
         SutProvider<ConfirmOrganizationUserCommand> sutProvider)
@@ -816,8 +816,8 @@ public class ConfirmOrganizationUserCommandTests
             .Received(1)
             .SendConfirmationAsync(org, userEmail, accessSecretsManager);
         await sutProvider.GetDependency<IMailService>()
-            .DidNotReceive()
-            .SendOrganizationConfirmedEmailAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
+            .DidNotReceiveWithAnyArgs()
+            .SendOrganizationConfirmedEmailAsync(default, default, default);
     }
 
     [Theory, BitAutoData]
@@ -840,7 +840,7 @@ public class ConfirmOrganizationUserCommandTests
             .Received(1)
             .SendOrganizationConfirmedEmailAsync(org.DisplayName(), userEmail, accessSecretsManager);
         await sutProvider.GetDependency<ISendOrganizationConfirmationCommand>()
-            .DidNotReceive()
-            .SendConfirmationAsync(Arg.Any<Organization>(), Arg.Any<string>(), Arg.Any<bool>());
+            .DidNotReceiveWithAnyArgs()
+            .SendConfirmationAsync(default, default, default);
     }
 }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/OrganizationConfirmation/SendOrganizationConfirmationCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/OrganizationConfirmation/SendOrganizationConfirmationCommandTests.cs
@@ -1,8 +1,7 @@
 ﻿using Bit.Core.AdminConsole.Entities;
-using Bit.Core.AdminConsole.Models.Mail.Mailer.OrganizationConfirmation;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.OrganizationConfirmation;
 using Bit.Core.Billing.Enums;
-using Bit.Core.Platform.Mail.Mailer;
+using Bit.Core.Services;
 using Bit.Core.Test.AutoFixture.OrganizationFixtures;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
@@ -16,230 +15,39 @@ public class SendOrganizationConfirmationCommandTests
 {
     [Theory]
     [OrganizationCustomize, BitAutoData]
-    public async Task SendConfirmationAsync_EnterpriseOrganization_SendsEnterpriseTeamsEmail(
+    public async Task SendConfirmationAsync_EnterpriseOrg_CallsUpdatedConfirmedEmail(
         Organization organization,
         string userEmail,
         SutProvider<SendOrganizationConfirmationCommand> sutProvider)
     {
         // Arrange
         organization.PlanType = PlanType.EnterpriseAnnually;
-        organization.Name = "Test Enterprise Org";
 
         // Act
-        await sutProvider.Sut.SendConfirmationAsync(organization, userEmail, false);
+        await sutProvider.Sut.SendConfirmationAsync(organization, userEmail, true);
 
         // Assert
-        await sutProvider.GetDependency<IMailer>().Received(1)
-            .SendEmail(Arg.Is<OrganizationConfirmationEnterpriseTeams>(mail =>
-                mail.ToEmails.Contains(userEmail) &&
-                mail.ToEmails.Count() == 1 &&
-                mail.View.OrganizationName == organization.Name &&
-                mail.Subject == GetSubject(organization.Name)));
+        await sutProvider.GetDependency<IMailService>()
+            .Received(1)
+            .SendUpdatedOrganizationConfirmedEmailAsync(organization, userEmail, true);
     }
 
     [Theory]
     [OrganizationCustomize, BitAutoData]
-    public async Task SendConfirmationAsync_TeamsOrganization_SendsEnterpriseTeamsEmail(
-        Organization organization,
-        string userEmail,
-        SutProvider<SendOrganizationConfirmationCommand> sutProvider)
-    {
-        // Arrange
-        organization.PlanType = PlanType.TeamsAnnually;
-        organization.Name = "Test Teams Org";
-
-        // Act
-        await sutProvider.Sut.SendConfirmationAsync(organization, userEmail, false);
-
-        // Assert
-        await sutProvider.GetDependency<IMailer>().Received(1)
-            .SendEmail(Arg.Is<OrganizationConfirmationEnterpriseTeams>(mail =>
-                mail.ToEmails.Contains(userEmail) &&
-                mail.ToEmails.Count() == 1 &&
-                mail.View.OrganizationName == organization.Name &&
-                mail.Subject == GetSubject(organization.Name)));
-    }
-
-    [Theory]
-    [OrganizationCustomize, BitAutoData]
-    public async Task SendConfirmationAsync_FamilyOrganization_SendsFamilyFreeEmail(
+    public async Task SendConfirmationAsync_FamiliesOrg_CallsUpdatedConfirmedEmail(
         Organization organization,
         string userEmail,
         SutProvider<SendOrganizationConfirmationCommand> sutProvider)
     {
         // Arrange
         organization.PlanType = PlanType.FamiliesAnnually;
-        organization.Name = "Test Family Org";
 
         // Act
         await sutProvider.Sut.SendConfirmationAsync(organization, userEmail, false);
 
         // Assert
-        await sutProvider.GetDependency<IMailer>().Received(1)
-            .SendEmail(Arg.Is<OrganizationConfirmationFamilyFree>(mail =>
-                mail.ToEmails.Contains(userEmail) &&
-                mail.ToEmails.Count() == 1 &&
-                mail.View.OrganizationName == organization.Name &&
-                mail.Subject == GetSubject(organization.Name)));
+        await sutProvider.GetDependency<IMailService>()
+            .Received(1)
+            .SendUpdatedOrganizationConfirmedEmailAsync(organization, userEmail, false);
     }
-
-    [Theory]
-    [OrganizationCustomize, BitAutoData]
-    public async Task SendConfirmationAsync_FreeOrganization_SendsFamilyFreeEmail(
-        Organization organization,
-        string userEmail,
-        SutProvider<SendOrganizationConfirmationCommand> sutProvider)
-    {
-        // Arrange
-        organization.PlanType = PlanType.Free;
-        organization.Name = "Test Free Org";
-
-        // Act
-        await sutProvider.Sut.SendConfirmationAsync(organization, userEmail, false);
-
-        // Assert
-        await sutProvider.GetDependency<IMailer>().Received(1)
-            .SendEmail(Arg.Is<OrganizationConfirmationFamilyFree>(mail =>
-                mail.ToEmails.Contains(userEmail) &&
-                mail.ToEmails.Count() == 1 &&
-                mail.View.OrganizationName == organization.Name &&
-                mail.Subject == GetSubject(organization.Name)));
-    }
-
-    [Theory]
-    [OrganizationCustomize, BitAutoData]
-    public async Task SendConfirmationsAsync_MultipleUsers_SendsSingleEmail(
-        Organization organization,
-        List<string> userEmails,
-        SutProvider<SendOrganizationConfirmationCommand> sutProvider)
-    {
-        // Arrange
-        organization.PlanType = PlanType.EnterpriseAnnually;
-        organization.Name = "Test Enterprise Org";
-
-        // Act
-        await sutProvider.Sut.SendConfirmationsAsync(organization, userEmails, false);
-
-        // Assert
-        await sutProvider.GetDependency<IMailer>().Received(1)
-            .SendEmail(Arg.Is<OrganizationConfirmationEnterpriseTeams>(mail =>
-                mail.ToEmails.SequenceEqual(userEmails) &&
-                mail.View.OrganizationName == organization.Name));
-    }
-
-    [Theory]
-    [OrganizationCustomize, BitAutoData]
-    public async Task SendConfirmationsAsync_EmptyUserList_DoesNotSendEmail(
-        Organization organization,
-        SutProvider<SendOrganizationConfirmationCommand> sutProvider)
-    {
-        // Arrange
-        organization.PlanType = PlanType.EnterpriseAnnually;
-        organization.Name = "Test Enterprise Org";
-
-        // Act
-        await sutProvider.Sut.SendConfirmationsAsync(organization, [], false);
-
-        // Assert
-        await sutProvider.GetDependency<IMailer>().DidNotReceive()
-            .SendEmail(Arg.Any<OrganizationConfirmationEnterpriseTeams>());
-        await sutProvider.GetDependency<IMailer>().DidNotReceive()
-            .SendEmail(Arg.Any<OrganizationConfirmationFamilyFree>());
-    }
-
-    [Theory]
-    [OrganizationCustomize, BitAutoData]
-    public async Task SendConfirmationAsync_HtmlEncodedOrganizationName_DecodesNameCorrectly(
-        Organization organization,
-        string userEmail,
-        SutProvider<SendOrganizationConfirmationCommand> sutProvider)
-    {
-        // Arrange
-        organization.PlanType = PlanType.EnterpriseAnnually;
-        organization.Name = "Test &amp; Company";
-        var expectedDecodedName = "Test & Company";
-
-        // Act
-        await sutProvider.Sut.SendConfirmationAsync(organization, userEmail, false);
-
-        // Assert
-        await sutProvider.GetDependency<IMailer>().Received(1)
-            .SendEmail(Arg.Is<OrganizationConfirmationEnterpriseTeams>(mail =>
-                mail.View.OrganizationName == expectedDecodedName));
-    }
-
-    [Theory]
-    [OrganizationCustomize, BitAutoData]
-    public async Task SendConfirmationAsync_AllEnterpriseTeamsPlanTypes_SendsEnterpriseTeamsEmail(
-        Organization organization,
-        string userEmail,
-        SutProvider<SendOrganizationConfirmationCommand> sutProvider)
-    {
-        // Test all Enterprise and Teams plan types
-        var enterpriseTeamsPlanTypes = new[]
-        {
-            PlanType.TeamsMonthly2019, PlanType.TeamsAnnually2019,
-            PlanType.TeamsMonthly2020, PlanType.TeamsAnnually2020,
-            PlanType.TeamsMonthly2023, PlanType.TeamsAnnually2023,
-            PlanType.TeamsStarter2023, PlanType.TeamsMonthly,
-            PlanType.TeamsAnnually, PlanType.TeamsStarter,
-            PlanType.EnterpriseMonthly2019, PlanType.EnterpriseAnnually2019,
-            PlanType.EnterpriseMonthly2020, PlanType.EnterpriseAnnually2020,
-            PlanType.EnterpriseMonthly2023, PlanType.EnterpriseAnnually2023,
-            PlanType.EnterpriseMonthly, PlanType.EnterpriseAnnually
-        };
-
-        foreach (var planType in enterpriseTeamsPlanTypes)
-        {
-            // Arrange
-            organization.PlanType = planType;
-            organization.Name = "Test Org";
-            sutProvider.GetDependency<IMailer>().ClearReceivedCalls();
-
-            // Act
-            await sutProvider.Sut.SendConfirmationAsync(organization, userEmail, false);
-
-            // Assert
-            await sutProvider.GetDependency<IMailer>().Received(1)
-                .SendEmail(Arg.Any<OrganizationConfirmationEnterpriseTeams>());
-            await sutProvider.GetDependency<IMailer>().DidNotReceive()
-                .SendEmail(Arg.Any<OrganizationConfirmationFamilyFree>());
-        }
-    }
-
-    [Theory]
-    [OrganizationCustomize, BitAutoData]
-    public async Task SendConfirmationAsync_AllFamilyFreePlanTypes_SendsFamilyFreeEmail(
-        Organization organization,
-        string userEmail,
-        SutProvider<SendOrganizationConfirmationCommand> sutProvider)
-    {
-        // Test all Family, Free, and Custom plan types
-        var familyFreePlanTypes = new[]
-        {
-            PlanType.Free, PlanType.FamiliesAnnually2019,
-            PlanType.FamiliesAnnually2025, PlanType.FamiliesAnnually,
-            PlanType.Custom
-        };
-
-        foreach (var planType in familyFreePlanTypes)
-        {
-            // Arrange
-            organization.PlanType = planType;
-            organization.Name = "Test Org";
-            sutProvider.GetDependency<IMailer>().ClearReceivedCalls();
-
-            // Act
-            await sutProvider.Sut.SendConfirmationAsync(organization, userEmail, false);
-
-            // Assert
-            await sutProvider.GetDependency<IMailer>().Received(1)
-                .SendEmail(Arg.Any<OrganizationConfirmationFamilyFree>());
-            await sutProvider.GetDependency<IMailer>().DidNotReceive()
-                .SendEmail(Arg.Any<OrganizationConfirmationEnterpriseTeams>());
-        }
-    }
-
-    private static string GetSubject(string organizationName) => $"You can now access items from {organizationName}";
-
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32796

## 📔 Objective

When the pm-28396-update-join-organization-email-template flag is enabled, organization invite and confirmation emails are sent via IMailer, which awaits SendGrid's synchronous response per email. This causes 503s on bulk reinvites because SendGrid can't process them all within the request timeout.

This PR moves the updated email templates to use IMailService, which enqueues messages asynchronously, restoring the non-blocking behavior of the original code path.