### PR TITLE
BRE-1678 - Add multi-arch image support to Docker images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,15 +4,15 @@ run-name: Publish ${{ inputs.dry_run && '(Dry Run)' || '' }}
 on:
   workflow_dispatch:
     inputs:
-      dry_run:
-        description: "Dry Run"
-        type: boolean
-        default: false
       version:
         description: 'Version to publish (default: latest release)'
         required: true
         type: string
         default: latest
+      dry_run:
+        description: "Dry Run"
+        type: boolean
+        default: false
 
 env:
   _AZ_REGISTRY: "bitwardenprod.azurecr.io"
@@ -32,6 +32,7 @@ jobs:
         id: version-output
         env:
           INPUT_VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ "${INPUT_VERSION}" == "latest" || "${INPUT_VERSION}" == "" ]]; then
             VERSION=$(gh api repos/bitwarden/server/releases/latest --jq '.tag_name | ltrimstr("v")')


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
- [BRE-1678](https://bitwarden.atlassian.net/browse/BRE-1678?atlOrigin=eyJpIjoiZWNjMmZiYjJiODg0NDEwNjk0YWFhN2M5OTA1ZjY4ZmEiLCJwIjoiaiJ9)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR makes sure to copy all architectures for each image when tagging them with the release version and latest. I also optimized the dry run input to be a boolean and removed the other options as they weren't really used. The GitHub API call has been optimized using the `latest` endpoint. The version input can now support tags with or without the `v`.

[Workflow Test Run](https://github.com/bitwarden/server/actions/runs/22590753773)


[BRE-1678]: https://bitwarden.atlassian.net/browse/BRE-1678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Fixes https://github.com/bitwarden/self-host/issues/364