### PR TITLE
[PM-29653] Align PoliciesController.Put With VNext

### DIFF
--- a/src/Api/AdminConsole/Controllers/PoliciesController.cs
+++ b/src/Api/AdminConsole/Controllers/PoliciesController.cs
@@ -183,14 +183,7 @@ public class PoliciesController : Controller
     [HttpPut("{type}")]
     public async Task<PolicyResponseModel> Put(Guid orgId, PolicyType type, [FromBody] PolicyRequestModel model)
     {
-        if (!await _currentContext.ManagePolicies(orgId))
-        {
-            throw new NotFoundException();
-        }
-
-        var policyUpdate = await model.ToPolicyUpdateAsync(orgId, type, _currentContext);
-        var policy = await _savePolicyCommand.SaveAsync(policyUpdate);
-        return new PolicyResponseModel(policy);
+        return await PutVNext(orgId, type, new SavePolicyRequest { Policy = model });
     }
 
     [HttpPut("{type}/vnext")]

--- a/test/Api.Test/Controllers/PoliciesControllerTests.cs
+++ b/test/Api.Test/Controllers/PoliciesControllerTests.cs
@@ -442,6 +442,48 @@ public class PoliciesControllerTests
 
     [Theory]
     [BitAutoData]
+    public async Task Put_UsesVNextSavePolicyCommand(
+        SutProvider<PoliciesController> sutProvider, Guid orgId,
+        SavePolicyRequest model, Policy policy, Guid userId)
+    {
+        // Arrange
+        policy.Data = null;
+
+        sutProvider.GetDependency<ICurrentContext>()
+            .UserId
+            .Returns(userId);
+
+        sutProvider.GetDependency<ICurrentContext>()
+            .OrganizationOwner(orgId)
+            .Returns(true);
+
+        sutProvider.GetDependency<IVNextSavePolicyCommand>()
+            .SaveAsync(Arg.Any<SavePolicyModel>())
+            .Returns(policy);
+
+        // Act
+        var result = await sutProvider.Sut.Put(orgId, policy.Type, model.Policy);
+
+        // Assert
+        await sutProvider.GetDependency<IVNextSavePolicyCommand>()
+            .Received(1)
+            .SaveAsync(Arg.Is<SavePolicyModel>(m => m.PolicyUpdate.OrganizationId == orgId &&
+                                                    m.PolicyUpdate.Type == policy.Type &&
+                                                    m.PolicyUpdate.Enabled == model.Policy.Enabled &&
+                                                    m.PerformedBy.UserId == userId &&
+                                                    m.PerformedBy.IsOrganizationOwnerOrProvider == true));
+
+        await sutProvider.GetDependency<ISavePolicyCommand>()
+            .DidNotReceiveWithAnyArgs()
+            .VNextSaveAsync(default);
+
+        Assert.NotNull(result);
+        Assert.Equal(policy.Id, result.Id);
+        Assert.Equal(policy.Type, result.Type);
+    }
+
+    [Theory]
+    [BitAutoData]
     public async Task PutVNext_UsesVNextSavePolicyCommand(
         SutProvider<PoliciesController> sutProvider, Guid orgId,
         SavePolicyRequest model, Policy policy, Guid userId)


### PR DESCRIPTION
## 🎟️ Tracking
[PM-29653](https://bitwarden.atlassian.net/browse/PM-29653)

## 📔 Objective
We are gradually phasing out the old PUT policy behavior. Our last move in this regard was to redirect all clients calls to use the VNext API endpoint, now we're executing similar behavior server-side by forward calls to the old API endpoint.


[PM-29653]: https://bitwarden.atlassian.net/browse/PM-29653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ