### PR TITLE
Update publish workflow to take release branch name as input

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,14 @@ on:
         required: true
         type: string
         default: latest
+      branch:
+        description: "Branch to publish from"
+        required: true
+        type: choice
+        options:
+          - rc
+          - hotfix-rc
+        default: rc
       dry_run:
         description: "Dry Run"
         type: boolean
@@ -24,7 +32,6 @@ jobs:
     permissions:
       deployments: write
     outputs:
-      branch-name: ${{ steps.branch.outputs.branch-name }}
       deployment-id: ${{ steps.deployment.outputs.deployment_id }}
       release-version: ${{ steps.version-output.outputs.version }}
     steps:
@@ -43,12 +50,6 @@ jobs:
             echo "Release Version: ${VERSION}"
             echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Get branch name
-        id: branch
-        run: |
-          BRANCH_NAME=$(basename "${GITHUB_REF}")
-          echo "branch-name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub deployment
         if: ${{ !inputs.dry_run }}
@@ -70,7 +71,7 @@ jobs:
       id-token: write
     env:
       _RELEASE_VERSION: ${{ needs.setup.outputs.release-version }}
-      _BRANCH_NAME: ${{ needs.setup.outputs.branch-name }}
+      _BRANCH_NAME: ${{ inputs.branch }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
- [BRE-1678](https://bitwarden.atlassian.net/browse/BRE-1678?atlOrigin=eyJpIjoiMTQzMzVhOTQ2ZDBiNGZlYWExYTJkZDRhYzdjZjc1NGYiLCJwIjoiaiJ9)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds a release branch choice input so that we don't accidentally tag any branch images as the release version and `latest`.


[BRE-1678]: https://bitwarden.atlassian.net/browse/BRE-1678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[Workflow Test Run](https://github.com/bitwarden/server/actions/runs/22650901118)