### PR TITLE
Remove Gitter chat badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@
   <a href="https://github.com/bitwarden/server/actions/workflows/build.yml?query=branch:main" target="_blank">
     <img src="https://github.com/bitwarden/server/actions/workflows/build.yml/badge.svg?branch=main" alt="Github Workflow build on main" />
   </a>
-  <a href="https://gitter.im/bitwarden/Lobby" target="_blank">
-    <img src="https://badges.gitter.im/bitwarden/Lobby.svg" alt="gitter chat" />
-  </a>
 </p>
 
 ---


### PR DESCRIPTION
## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Removed the Gitter chat badge from README