### PR TITLE
[PM-33151] Fix: Register NoopBusinessUnitConverter for OSS builds

### DIFF
--- a/src/Core/Billing/Providers/Services/NoopBusinessUnitConverter.cs
+++ b/src/Core/Billing/Providers/Services/NoopBusinessUnitConverter.cs
@@ -1,0 +1,26 @@
+using Bit.Core.AdminConsole.Entities;
+using OneOf;
+
+namespace Bit.Core.Billing.Providers.Services;
+
+public class NoopBusinessUnitConverter : IBusinessUnitConverter
+{
+    public Task<Guid> FinalizeConversion(
+        Organization organization,
+        Guid userId,
+        string token,
+        string providerKey,
+        string organizationKey) => throw new NotImplementedException();
+
+    public Task<OneOf<Guid, List<string>>> InitiateConversion(
+        Organization organization,
+        string providerAdminEmail) => throw new NotImplementedException();
+
+    public Task ResendConversionInvite(
+        Organization organization,
+        string providerAdminEmail) => throw new NotImplementedException();
+
+    public Task ResetConversion(
+        Organization organization,
+        string providerAdminEmail) => throw new NotImplementedException();
+}

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ using Bit.Core.Auth.Services.Implementations;
 using Bit.Core.Auth.UserFeatures;
 using Bit.Core.Auth.UserFeatures.EmergencyAccess;
 using Bit.Core.Auth.UserFeatures.PasswordValidation;
+using Bit.Core.Billing.Providers.Services;
 using Bit.Core.Billing.Services;
 using Bit.Core.Billing.Services.Implementations;
 using Bit.Core.Billing.TrialInitiation;
@@ -366,6 +367,7 @@ public static class ServiceCollectionExtensions
     public static void AddOosServices(this IServiceCollection services)
     {
         services.AddScoped<IProviderService, NoopProviderService>();
+        services.AddTransient<IBusinessUnitConverter, NoopBusinessUnitConverter>();
         services.AddScoped<IServiceAccountRepository, NoopServiceAccountRepository>();
         services.AddScoped<ISecretRepository, NoopSecretRepository>();
         services.AddScoped<ISecretVersionRepository, NoopSecretVersionRepository>();


### PR DESCRIPTION
## Summary
- Fixes #6292
- `IBusinessUnitConverter` was only registered in the Commercial module, causing `InvalidOperationException` when compiled with OSS flag
- Added `NoopBusinessUnitConverter` following the existing Noop pattern (e.g. `NoopProviderService`)
- Registered in `AddOosServices()` in `ServiceCollectionExtensions.cs`

## Test plan
- [ ] Compile with OSS flag enabled
- [ ] Navigate to Admin Console → Members
- [ ] Verify no runtime DI error occurs