### PR TITLE
[PM-33152] Fix: InvalidCastException on attachment upload as admin

### DIFF
--- a/src/Core/Vault/Services/Implementations/CipherService.cs
+++ b/src/Core/Vault/Services/Implementations/CipherService.cs
@@ -233,7 +233,14 @@ public class CipherService : ICipherService
 
         // Update the revision date when an attachment is added
         cipher.RevisionDate = DateTime.UtcNow;
-        await _cipherRepository.ReplaceAsync((CipherDetails)cipher);
+        if (cipher is CipherDetails cipherDetails)
+        {
+            await _cipherRepository.ReplaceAsync(cipherDetails);
+        }
+        else
+        {
+            await _cipherRepository.ReplaceAsync(cipher);
+        }
 
         await _pushService.PushSyncCipherUpdateAsync(cipher, null);
 
@@ -287,7 +294,14 @@ public class CipherService : ICipherService
 
         // Update the revision date when an attachment is added
         cipher.RevisionDate = DateTime.UtcNow;
-        await _cipherRepository.ReplaceAsync((CipherDetails)cipher);
+        if (cipher is CipherDetails details)
+        {
+            await _cipherRepository.ReplaceAsync(details);
+        }
+        else
+        {
+            await _cipherRepository.ReplaceAsync(cipher);
+        }
 
         // push
         await _pushService.PushSyncCipherUpdateAsync(cipher, null);


### PR DESCRIPTION
## Summary
- Fixes #7062
- `CipherOrganizationDetails` cannot be cast to `CipherDetails` when admin uploads attachments
- Added type check with fallback to base `ReplaceAsync(Cipher)` in two locations:
  - `CreateAttachmentForDelayedUploadAsync` (line ~236)
  - `CreateAttachmentAsync` (line ~290)
- Matches existing pattern already used in `DeleteAttachmentAsync` (line ~897)

## Test plan
- [ ] Upload attachment as org admin → should succeed (was 500 error)
- [ ] Upload attachment as regular user → should still work as before
- [ ] Delete attachment as admin → should still work (unchanged)