### PR TITLE
[PM-33153] Fix: Double HTML encoding in emergency access emails

### DIFF
--- a/src/Core/Platform/Mail/HandlebarsMailService.cs
+++ b/src/Core/Platform/Mail/HandlebarsMailService.cs
@@ -1187,7 +1187,7 @@ public class HandlebarsMailService : IMailService
         var message = CreateDefaultMessage($"Emergency Access Contact Invite", emergencyAccess.Email);
         var model = new EmergencyAccessInvitedViewModel
         {
-            Name = CoreHelpers.SanitizeForEmail(name),
+            Name = CoreHelpers.SanitizeForEmail(name, false),
             Email = WebUtility.UrlEncode(emergencyAccess.Email),
             Id = emergencyAccess.Id.ToString(),
             Token = WebUtility.UrlEncode(token),
@@ -1218,7 +1218,7 @@ public class HandlebarsMailService : IMailService
         var message = CreateDefaultMessage($"You Have Been Confirmed as Emergency Access Contact", email);
         var model = new EmergencyAccessConfirmedViewModel
         {
-            Name = CoreHelpers.SanitizeForEmail(grantorName),
+            Name = CoreHelpers.SanitizeForEmail(grantorName, false),
             WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
             SiteName = _globalSettings.SiteName
         };
@@ -1235,7 +1235,7 @@ public class HandlebarsMailService : IMailService
 
         var model = new EmergencyAccessRecoveryViewModel
         {
-            Name = CoreHelpers.SanitizeForEmail(initiatingName),
+            Name = CoreHelpers.SanitizeForEmail(initiatingName, false),
             Action = emergencyAccess.Type.ToString(),
             DaysLeft = emergencyAccess.WaitTimeDays - Convert.ToInt32((remainingTime).TotalDays),
         };
@@ -1249,7 +1249,7 @@ public class HandlebarsMailService : IMailService
         var message = CreateDefaultMessage("Emergency Access Approved", email);
         var model = new EmergencyAccessApprovedViewModel
         {
-            Name = CoreHelpers.SanitizeForEmail(approvingName),
+            Name = CoreHelpers.SanitizeForEmail(approvingName, false),
         };
         await AddMessageContentAsync(message, "Auth.EmergencyAccessApproved", model);
         message.Category = "EmergencyAccessApproved";
@@ -1261,7 +1261,7 @@ public class HandlebarsMailService : IMailService
         var message = CreateDefaultMessage("Emergency Access Rejected", email);
         var model = new EmergencyAccessRejectedViewModel
         {
-            Name = CoreHelpers.SanitizeForEmail(rejectingName),
+            Name = CoreHelpers.SanitizeForEmail(rejectingName, false),
         };
         await AddMessageContentAsync(message, "Auth.EmergencyAccessRejected", model);
         message.Category = "EmergencyAccessRejected";
@@ -1276,7 +1276,7 @@ public class HandlebarsMailService : IMailService
 
         var model = new EmergencyAccessRecoveryViewModel
         {
-            Name = CoreHelpers.SanitizeForEmail(initiatingName),
+            Name = CoreHelpers.SanitizeForEmail(initiatingName, false),
             Action = emergencyAccess.Type.ToString(),
             DaysLeft = emergencyAccess.WaitTimeDays - Convert.ToInt32((remainingTime).TotalDays),
         };
@@ -1290,7 +1290,7 @@ public class HandlebarsMailService : IMailService
         var message = CreateDefaultMessage("Emergency Access Granted", email);
         var model = new EmergencyAccessRecoveryTimedOutViewModel
         {
-            Name = CoreHelpers.SanitizeForEmail(initiatingName),
+            Name = CoreHelpers.SanitizeForEmail(initiatingName, false),
             Action = emergencyAccess.Type.ToString(),
         };
         await AddMessageContentAsync(message, "Auth.EmergencyAccessRecoveryTimedOut", model);


### PR DESCRIPTION
## Summary
- Fixes #4845
- Emergency access emails display special characters as HTML entities (e.g. `&#252;` instead of `ü`)
- Root cause: `SanitizeForEmail()` defaults to `htmlEncode: true`, calling `HttpUtility.HtmlEncode()`. Handlebars `{{Name}}` then HTML-encodes again (double encoding)
- Fixed by passing `htmlEncode: false` to all 7 emergency access email methods in `HandlebarsMailService.cs`
- Matches the pattern already used by other email methods in the same file (e.g. organization emails at line ~332, ~348, ~458)

## Changed methods
- `SendEmergencyAccessInviteEmailAsync`
- `SendEmergencyAccessConfirmedEmailAsync`
- `SendEmergencyAccessRecoveryInitiated`
- `SendEmergencyAccessRecoveryApproved`
- `SendEmergencyAccessRecoveryRejected`
- `SendEmergencyAccessRecoveryReminder`
- `SendEmergencyAccessRecoveryTimedOut`

## Test plan
- [ ] Create account with special characters in name (e.g. umlauts: ü, ö, ä)
- [ ] Invite someone for emergency access
- [ ] Verify invitation email displays name correctly (not as HTML entities)
- [ ] Confirm emergency access and verify confirmation email