### PR TITLE
[PM-33157] Fix: Deprecated nginx http2 directive in config template

### DIFF
--- a/util/Setup/Templates/NginxConfig.hbs
+++ b/util/Setup/Templates/NginxConfig.hbs
@@ -15,8 +15,9 @@ server {
 }
 
 server {
-  listen 8443 ssl http2;
-  listen [::]:8443 ssl http2;
+  listen 8443 ssl;
+  listen [::]:8443 ssl;
+  http2 on;
   server_name {{{Domain}}};
 
   ssl_certificate {{{CertificatePath}}};


### PR DESCRIPTION
## Summary
- Fixes #6949
- The `listen ... http2` directive has been deprecated since nginx 1.25.1
- Updated `NginxConfig.hbs` template to use separate `http2 on;` directive
- Before: `listen 8443 ssl http2;`
- After: `listen 8443 ssl;` + `http2 on;`

## Test plan
- [ ] Run `./bitwarden.sh rebuild` to regenerate nginx config
- [ ] Verify no deprecation warnings in nginx error log
- [ ] Verify HTTP/2 still works for HTTPS connections