### PR TITLE
[PM-33163] Fix admin panel version fetch error handling

### DIFF
--- a/src/Admin/Controllers/HomeController.cs
+++ b/src/Admin/Controllers/HomeController.cs
@@ -80,14 +80,25 @@ public class HomeController : Controller
                 var root = jsonDocument.RootElement;
                 return new JsonResult(root.GetProperty("version").GetString());
             }
+
+            _logger.LogWarning(
+                "Failed to fetch installed web version from {RequestUri}. Status code: {StatusCode}",
+                requestUri, response.StatusCode);
         }
         catch (HttpRequestException e)
         {
             _logger.LogError(e, "Error encountered while sending GET request to {RequestUri}", requestUri);
-            return new JsonResult("Unable to fetch installed version") { StatusCode = StatusCodes.Status500InternalServerError };
+        }
+        catch (TaskCanceledException e) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogError(e, "Request timed out while fetching installed web version from {RequestUri}", requestUri);
+        }
+        catch (Exception e) when (e is JsonException or InvalidOperationException or KeyNotFoundException)
+        {
+            _logger.LogError(e, "Error parsing version response from {RequestUri}", requestUri);
         }
 
-        return new JsonResult("-");
+        return new JsonResult("Unable to fetch installed version") { StatusCode = StatusCodes.Status500InternalServerError };
     }
 
     private class LatestVersions


### PR DESCRIPTION
Fixes #7142

## Summary
Improved error handling in `GetInstalledWebVersion` to catch all failure scenarios that occur behind reverse proxies:

- **TaskCanceledException**: Request timeouts (common behind slow proxies)
- **JsonException/KeyNotFoundException**: Malformed or unexpected responses
- **Non-success HTTP status**: Now logs a warning instead of silently returning "-"

Previously only `HttpRequestException` was caught, so timeouts and parse errors would result in unhandled exceptions, leaving the version display stuck on the spinner.

## Test plan
- Deploy behind a reverse proxy and verify the admin panel shows "Unable to fetch installed version" instead of hanging
- Verify normal version fetch still works when web vault is accessible
- Check logs for appropriate error/warning messages