### PR TITLE
[PM-33164] Fix OIDC response_mode to use spec-compliant default

### DIFF
--- a/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
+++ b/bitwarden_license/src/Sso/Utilities/DynamicAuthenticationSchemeProvider.cs
@@ -299,7 +299,7 @@ public class DynamicAuthenticationSchemeProvider : AuthenticationSchemeProvider
             ClientId = config.ClientId,
             ClientSecret = config.ClientSecret,
             ResponseType = "code",
-            ResponseMode = "form_post",
+            ResponseMode = "query",
             SignInScheme = AuthenticationSchemes.BitwardenExternalCookieAuthenticationScheme,
             SignOutScheme = IdentityServerConstants.SignoutScheme,
             SaveTokens = false, // reduce overall request size


### PR DESCRIPTION
Fixes #5461

## Summary
Changed the hardcoded `response_mode` from `form_post` to `query` for external IdP OIDC configurations in `DynamicAuthenticationSchemeProvider`.

Per the [OpenID Connect Discovery 1.0 spec](https://openid.net/specs/openid-connect-discovery-1_0.html), when the `response_modes_supported` field is omitted from the IdP discovery document, the default supported modes are `query` and `fragment` — **not** `form_post`.

This fix resolves SSO login failures with strict IdPs (e.g., Kanidm) that do not support `form_post` and actively reject requests using it. The `query` mode is already what Bitwarden accepts on the callback path, so this change aligns the request with actual behavior.

## Test plan
- Verify SSO login works with IdPs that only support `query` response mode
- Verify SSO login still works with IdPs that support both `query` and `form_post`
- Check that the OIDC authorization redirect uses `response_mode=query`