### PR TITLE
[PM-32829] Cipher Key for unassigned ciphers

### DIFF
--- a/src/Infrastructure.EntityFramework/Vault/Repositories/Queries/CipherOrganizationDetailsReadByIdQuery.cs
+++ b/src/Infrastructure.EntityFramework/Vault/Repositories/Queries/CipherOrganizationDetailsReadByIdQuery.cs
@@ -33,6 +33,8 @@ public class CipherOrganizationDetailsReadByIdQuery : IQuery<CipherOrganizationD
                         CreationDate = c.CreationDate,
                         RevisionDate = c.RevisionDate,
                         DeletedDate = c.DeletedDate,
+                        Key = c.Key,
+                        Reprompt = c.Reprompt,
                         OrganizationUseTotp = o.UseTotp,
                     };
         return query;

--- a/src/Infrastructure.EntityFramework/Vault/Repositories/Queries/CipherOrganizationDetailsReadByOrganizationIdQuery.cs
+++ b/src/Infrastructure.EntityFramework/Vault/Repositories/Queries/CipherOrganizationDetailsReadByOrganizationIdQuery.cs
@@ -39,6 +39,7 @@ public class CipherOrganizationDetailsReadByOrganizationIdQuery : IQuery<CipherO
                         RevisionDate = c.RevisionDate,
                         DeletedDate = c.DeletedDate,
                         Key = c.Key,
+                        Reprompt = c.Reprompt,
                         OrganizationUseTotp = o.UseTotp,
                     };
 

--- a/src/Infrastructure.EntityFramework/Vault/Repositories/Queries/CipherOrganizationDetailsReadByOrganizationIdQuery.cs
+++ b/src/Infrastructure.EntityFramework/Vault/Repositories/Queries/CipherOrganizationDetailsReadByOrganizationIdQuery.cs
@@ -38,6 +38,7 @@ public class CipherOrganizationDetailsReadByOrganizationIdQuery : IQuery<CipherO
                         CreationDate = c.CreationDate,
                         RevisionDate = c.RevisionDate,
                         DeletedDate = c.DeletedDate,
+                        Key = c.Key,
                         OrganizationUseTotp = o.UseTotp,
                     };
 

--- a/test/Infrastructure.EFIntegration.Test/Vault/Repositories/CipherRepositoryTests.cs
+++ b/test/Infrastructure.EFIntegration.Test/Vault/Repositories/CipherRepositoryTests.cs
@@ -7,6 +7,7 @@ using Bit.Core.Vault.Entities;
 using Bit.Infrastructure.EFIntegration.Test.AutoFixture;
 using Bit.Infrastructure.EFIntegration.Test.Repositories.EqualityComparers;
 using Bit.Infrastructure.EntityFramework.Repositories.Queries;
+using Bit.Infrastructure.EntityFramework.Repositories.Vault.Queries;
 using Bit.Test.Common.AutoFixture.Attributes;
 using LinqToDB;
 using Xunit;
@@ -366,6 +367,48 @@ public class CipherRepositoryTests
 
             var bumpedUser = await efUserRepos[i].GetByIdAsync(efUser.Id);
             Assert.Equal(DateTime.UtcNow.ToShortDateString(), bumpedUser.AccountRevisionDate.ToShortDateString());
+        }
+    }
+
+    [CiSkippedTheory, EfOrganizationCipherCustomize, BitAutoData]
+    public async Task CipherOrganizationDetailsReadByOrganizationIdQuery_ReturnsAllProperties(
+        Cipher cipher,
+        Organization org,
+        List<EfVaultRepo.CipherRepository> suts,
+        List<EfRepo.OrganizationRepository> efOrgRepos)
+    {
+        foreach (var sut in suts)
+        {
+            var i = suts.IndexOf(sut);
+
+            var efOrg = await efOrgRepos[i].CreateAsync(org);
+            efOrgRepos[i].ClearChangeTracking();
+
+            cipher.OrganizationId = efOrg.Id;
+            cipher.UserId = null;
+
+            var createdCipher = await sut.CreateAsync(cipher);
+            sut.ClearChangeTracking();
+
+            var query = new CipherOrganizationDetailsReadByOrganizationIdQuery(efOrg.Id);
+            var result = await sut.Run(query).ToListAsync();
+
+            Assert.Single(result);
+            var resultCipher = result[0];
+
+            Assert.Equal(createdCipher.Id, resultCipher.Id);
+            Assert.Null(resultCipher.UserId);
+            Assert.Equal(efOrg.Id, resultCipher.OrganizationId);
+            Assert.Equal(createdCipher.Type, resultCipher.Type);
+            Assert.Equal(createdCipher.Data, resultCipher.Data);
+            Assert.Equal(createdCipher.Favorites, resultCipher.Favorites);
+            Assert.Equal(createdCipher.Folders, resultCipher.Folders);
+            Assert.Equal(createdCipher.Attachments, resultCipher.Attachments);
+            Assert.Equal(createdCipher.CreationDate, resultCipher.CreationDate);
+            Assert.Equal(createdCipher.RevisionDate, resultCipher.RevisionDate);
+            Assert.Equal(createdCipher.DeletedDate, resultCipher.DeletedDate);
+            Assert.Equal(createdCipher.Key, resultCipher.Key);
+            Assert.Equal(efOrg.UseTotp, resultCipher.OrganizationUseTotp);
         }
     }
 }

--- a/test/Infrastructure.EFIntegration.Test/Vault/Repositories/CipherRepositoryTests.cs
+++ b/test/Infrastructure.EFIntegration.Test/Vault/Repositories/CipherRepositoryTests.cs
@@ -8,6 +8,7 @@ using Bit.Infrastructure.EFIntegration.Test.AutoFixture;
 using Bit.Infrastructure.EFIntegration.Test.Repositories.EqualityComparers;
 using Bit.Infrastructure.EntityFramework.Repositories.Queries;
 using Bit.Infrastructure.EntityFramework.Repositories.Vault.Queries;
+using Bit.Infrastructure.EntityFramework.Vault.Repositories.Queries;
 using Bit.Test.Common.AutoFixture.Attributes;
 using LinqToDB;
 using Xunit;
@@ -408,6 +409,50 @@ public class CipherRepositoryTests
             Assert.Equal(createdCipher.RevisionDate, resultCipher.RevisionDate);
             Assert.Equal(createdCipher.DeletedDate, resultCipher.DeletedDate);
             Assert.Equal(createdCipher.Key, resultCipher.Key);
+            Assert.Equal(createdCipher.Reprompt, resultCipher.Reprompt);
+            Assert.Equal(efOrg.UseTotp, resultCipher.OrganizationUseTotp);
+        }
+    }
+
+    [CiSkippedTheory, EfOrganizationCipherCustomize, BitAutoData]
+    public async Task CipherOrganizationDetailsReadByIdQuery_ReturnsAllProperties(
+        Cipher cipher,
+        Organization org,
+        List<EfVaultRepo.CipherRepository> suts,
+        List<EfRepo.OrganizationRepository> efOrgRepos)
+    {
+        foreach (var sut in suts)
+        {
+            var i = suts.IndexOf(sut);
+
+            var efOrg = await efOrgRepos[i].CreateAsync(org);
+            efOrgRepos[i].ClearChangeTracking();
+
+            cipher.OrganizationId = efOrg.Id;
+            cipher.UserId = null;
+
+            var createdCipher = await sut.CreateAsync(cipher);
+            sut.ClearChangeTracking();
+
+            var query = new CipherOrganizationDetailsReadByIdQuery(createdCipher.Id);
+            var result = await sut.Run(query).ToListAsync();
+
+            Assert.Single(result);
+            var resultCipher = result[0];
+
+            Assert.Equal(createdCipher.Id, resultCipher.Id);
+            Assert.Null(resultCipher.UserId);
+            Assert.Equal(efOrg.Id, resultCipher.OrganizationId);
+            Assert.Equal(createdCipher.Type, resultCipher.Type);
+            Assert.Equal(createdCipher.Data, resultCipher.Data);
+            Assert.Equal(createdCipher.Favorites, resultCipher.Favorites);
+            Assert.Equal(createdCipher.Folders, resultCipher.Folders);
+            Assert.Equal(createdCipher.Attachments, resultCipher.Attachments);
+            Assert.Equal(createdCipher.CreationDate, resultCipher.CreationDate);
+            Assert.Equal(createdCipher.RevisionDate, resultCipher.RevisionDate);
+            Assert.Equal(createdCipher.DeletedDate, resultCipher.DeletedDate);
+            Assert.Equal(createdCipher.Key, resultCipher.Key);
+            Assert.Equal(createdCipher.Reprompt, resultCipher.Reprompt);
             Assert.Equal(efOrg.UseTotp, resultCipher.OrganizationUseTotp);
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32829](https://bitwarden.atlassian.net/browse/PM-32829)

## 📔 Objective

Return the cipher key when fetching ciphers by the organization for EF, without the key SDK decryption fails.

## 📸 Screenshots

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/daab1968-2290-4f2b-bee8-58ca13cf1cbf" />|<video src="https://github.com/user-attachments/assets/80aa96b0-f4a2-46dc-a3dd-504bce3b4da1" />|



[PM-32829]: https://bitwarden.atlassian.net/browse/PM-32829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ