### PR TITLE
[PM-30245] Remove locked and inactive notifications feature flags from server

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -230,8 +230,6 @@ public static class FeatureFlagKeys
     /* Platform Team */
     public const string WebPush = "web-push";
     public const string ContentScriptIpcFramework = "content-script-ipc-channel-framework";
-    public const string PushNotificationsWhenLocked = "pm-19388-push-notifications-when-locked";
-    public const string PushNotificationsWhenInactive = "pm-25130-receive-push-notifications-for-inactive-users";
     public const string WebAuthnRelatedOrigins = "pm-30529-webauthn-related-origins";
 
     /* Tools Team */


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-30245

## 📔 Objective

Removes `pm-25130-receive-push-notifications-for-inactive-users` and `pm-19388-push-notifications-when-locked` flags from the server.  These were removed from `clients` as described below, so they are OK to remove now:

Flag | Removed in commit | Clients first release without flag | Last client release with flag | Server can remove at
-- | -- | -- | -- | --
pm-25130-receive-push-notifications-for-inactive-users | 146e2c0a12e (2025-12-29) | 2026.1.0 (all platforms) | 2025.12.1 | 2026.3.0 ✅
pm-19388-push-notifications-when-locked | 146e2c0a12e (2025-12-29) | 2026.1.0 (all platforms) | 2025.12.1 | 2026.3.0 ✅

Both flags were removed together. The last client with either flag was 2025.12.1. Server 2026.3.0's compatibility window starts at 2026.1.x, so no supported client checks these flags anymore so they safe to remove now.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
