### PR TITLE
[PM-33298] Fix InvalidCastException when uploading attachments as admin

### DIFF
--- a/src/Core/Vault/Services/Implementations/CipherService.cs
+++ b/src/Core/Vault/Services/Implementations/CipherService.cs
@@ -233,7 +233,14 @@ public class CipherService : ICipherService
 
         // Update the revision date when an attachment is added
         cipher.RevisionDate = DateTime.UtcNow;
-        await _cipherRepository.ReplaceAsync((CipherDetails)cipher);
+        if (cipher is CipherDetails cipherDetails)
+        {
+            await _cipherRepository.ReplaceAsync(cipherDetails);
+        }
+        else
+        {
+            await _cipherRepository.ReplaceAsync(cipher);
+        }
 
         await _pushService.PushSyncCipherUpdateAsync(cipher, null);
 
@@ -287,7 +294,14 @@ public class CipherService : ICipherService
 
         // Update the revision date when an attachment is added
         cipher.RevisionDate = DateTime.UtcNow;
-        await _cipherRepository.ReplaceAsync((CipherDetails)cipher);
+        if (cipher is CipherDetails cipherDetails)
+        {
+            await _cipherRepository.ReplaceAsync(cipherDetails);
+        }
+        else
+        {
+            await _cipherRepository.ReplaceAsync(cipher);
+        }
 
         // push
         await _pushService.PushSyncCipherUpdateAsync(cipher, null);
@@ -898,9 +912,13 @@ public class CipherService : ICipherService
         {
             await _cipherRepository.ReplaceAsync(cipher);
         }
+        else if (cipher is CipherDetails cipherDetails)
+        {
+            await _cipherRepository.ReplaceAsync(cipherDetails);
+        }
         else
         {
-            await _cipherRepository.ReplaceAsync((CipherDetails)cipher);
+            await _cipherRepository.ReplaceAsync(cipher);
         }
 
         // push


### PR DESCRIPTION
Fixes #7062

## Problem

When uploading attachments via admin endpoints, `GetOrganizationDetailsByIdAsync` returns a `CipherOrganizationDetails` which is then passed into `CreateAttachmentForDelayedUploadAsync` / `CreateAttachmentAsync`. These methods cast the cipher to `CipherDetails` when calling `ReplaceAsync`, but `CipherOrganizationDetails` is a *parent* of `CipherDetails`, so the downcast fails with an `InvalidCastException`.

## Fix

Use pattern matching (`is CipherDetails`) to call the appropriate `ReplaceAsync` overload. When the cipher is a `CipherDetails`, use the specific overload; otherwise fall back to the base `ReplaceAsync(Cipher)` overload.

Applied to all three occurrences in `CipherService.cs`:
- `CreateAttachmentForDelayedUploadAsync`
- `CreateAttachmentAsync`
- `DeleteAttachmentAsync`