### PR TITLE
[PM-32508] Remove plan-type endpoint which is no longer used

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationsController.cs
@@ -572,16 +572,4 @@ public class OrganizationsController : Controller
         return new OrganizationResponseModel(organization, plan);
     }
 
-    [HttpGet("{id}/plan-type")]
-    public async Task<PlanType> GetPlanType(string id)
-    {
-        var orgIdGuid = new Guid(id);
-        var organization = await _organizationRepository.GetByIdAsync(orgIdGuid);
-        if (organization == null)
-        {
-            throw new NotFoundException();
-        }
-
-        return organization.PlanType;
-    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32508

## 📔 Objective

Removes the plan-type endpoint from OrganizationsController which is no longer used by AdminConsole team or any teams to resolve vulnerability where this endpoint could be used to find out organization's plan type if the ID is known...
