### PR TITLE
[PM- 21926] Add `MasterPasswordSalt` to DTOs

### DIFF
--- a/src/Api/AdminConsole/Models/Response/Organizations/OrganizationUserResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/Organizations/OrganizationUserResponseModel.cs
@@ -205,6 +205,7 @@ public class OrganizationUserResetPasswordDetailsResponseModel : ResponseModel
         KdfIterations = orgUser.KdfIterations;
         KdfMemory = orgUser.KdfMemory;
         KdfParallelism = orgUser.KdfParallelism;
+        MasterPasswordSalt = orgUser.MasterPasswordSalt;
         ResetPasswordKey = orgUser.ResetPasswordKey;
         EncryptedPrivateKey = orgUser.EncryptedPrivateKey;
     }
@@ -214,6 +215,7 @@ public class OrganizationUserResetPasswordDetailsResponseModel : ResponseModel
     public int KdfIterations { get; set; }
     public int? KdfMemory { get; set; }
     public int? KdfParallelism { get; set; }
+    public string MasterPasswordSalt { get; set; }
     public string ResetPasswordKey { get; set; }
     public string EncryptedPrivateKey { get; set; }
 }

--- a/src/Api/Auth/Models/Request/Accounts/MasterPasswordUnlockDataAndAuthenticationModel.cs
+++ b/src/Api/Auth/Models/Request/Accounts/MasterPasswordUnlockDataAndAuthenticationModel.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.Enums;
 using Bit.Core.KeyManagement.Models.Data;
 using Bit.Core.Utilities;
@@ -22,6 +20,8 @@ public class MasterPasswordUnlockAndAuthenticationDataModel : IValidatableObject
     [EncryptedString] public required string MasterKeyEncryptedUserKey { get; set; }
     [StringLength(50)]
     public string? MasterPasswordHint { get; set; }
+    [MaxLength(256)]
+    public string? MasterPasswordSalt { get; set; }
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
@@ -58,9 +58,9 @@ public class MasterPasswordUnlockAndAuthenticationDataModel : IValidatableObject
 
             MasterKeyAuthenticationHash = MasterKeyAuthenticationHash,
             MasterKeyEncryptedUserKey = MasterKeyEncryptedUserKey,
-            MasterPasswordHint = MasterPasswordHint
+            MasterPasswordHint = MasterPasswordHint,
+            MasterPasswordSalt = MasterPasswordSalt
         };
         return data;
     }
-
 }

--- a/src/Api/Vault/Models/Response/SyncResponseModel.cs
+++ b/src/Api/Vault/Models/Response/SyncResponseModel.cs
@@ -84,7 +84,7 @@ public class SyncResponseModel() : ResponseModel("sync")
                         Parallelism = user.KdfParallelism
                     },
                     MasterKeyEncryptedUserKey = user.Key!,
-                    Salt = user.Email.ToLowerInvariant()
+                    Salt = user.GetMasterPasswordSalt()
                 }
                 : null,
             WebAuthnPrfOptions = webAuthnPrfOptions.Length > 0 ? webAuthnPrfOptions : null,

--- a/src/Core/AdminConsole/Models/Data/Organizations/OrganizationUsers/OrganizationUserResetPasswordDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Organizations/OrganizationUsers/OrganizationUserResetPasswordDetails.cs
@@ -33,6 +33,7 @@ public class OrganizationUserResetPasswordDetails
         KdfIterations = user.KdfIterations;
         KdfMemory = user.KdfMemory;
         KdfParallelism = user.KdfParallelism;
+        MasterPasswordSalt = user.MasterPasswordSalt;
         ResetPasswordKey = orgUser.ResetPasswordKey;
         EncryptedPrivateKey = org.PrivateKey;
     }
@@ -41,6 +42,7 @@ public class OrganizationUserResetPasswordDetails
     public int KdfIterations { get; set; }
     public int? KdfMemory { get; set; }
     public int? KdfParallelism { get; set; }
+    public string MasterPasswordSalt { get; set; }
     public string ResetPasswordKey { get; set; }
     public string EncryptedPrivateKey { get; set; }
 }

--- a/src/Core/Auth/Models/Api/Request/Accounts/RegisterFinishRequestModel.cs
+++ b/src/Core/Auth/Models/Api/Request/Accounts/RegisterFinishRequestModel.cs
@@ -72,8 +72,7 @@ public class RegisterFinishRequestModel : IValidatableObject
             // KdfMemory and KdfParallelism are optional (only used for Argon2id)
             KdfMemory = MasterPasswordUnlock?.Kdf.Memory ?? KdfMemory,
             KdfParallelism = MasterPasswordUnlock?.Kdf.Parallelism ?? KdfParallelism,
-            // PM-28827 To be added when MasterPasswordSalt is added to the user column
-            // MasterPasswordSalt = MasterPasswordUnlock?.Salt ?? Email.ToLower().Trim(),
+            MasterPasswordSalt = MasterPasswordUnlock?.Salt,
             Key = MasterPasswordUnlock?.MasterKeyWrappedUserKey ?? UserSymmetricKey
         };
 

--- a/src/Core/Entities/User.cs
+++ b/src/Core/Entities/User.cs
@@ -116,7 +116,7 @@ public class User : ITableObject<Guid>, IStorableSubscriber, IRevisable, ITwoFac
 
     public string GetMasterPasswordSalt()
     {
-        return Email.ToLowerInvariant().Trim();
+        return MasterPasswordSalt ?? Email.ToLowerInvariant().Trim();
     }
 
     public void SetNewId()

--- a/src/Core/KeyManagement/Models/Data/MasterPasswordUnlockAndAuthenticationData.cs
+++ b/src/Core/KeyManagement/Models/Data/MasterPasswordUnlockAndAuthenticationData.cs
@@ -18,7 +18,7 @@ public class MasterPasswordUnlockAndAuthenticationData
     /// </summary>
     public required string MasterKeyEncryptedUserKey { get; set; }
     public string? MasterPasswordHint { get; set; }
-     public string? MasterPasswordSalt { get; set; }
+    public string? MasterPasswordSalt { get; set; }
 
     public bool ValidateForUser(User user)
     {

--- a/src/Core/KeyManagement/Models/Data/MasterPasswordUnlockAndAuthenticationData.cs
+++ b/src/Core/KeyManagement/Models/Data/MasterPasswordUnlockAndAuthenticationData.cs
@@ -26,7 +26,7 @@ public class MasterPasswordUnlockAndAuthenticationData
         {
             return false;
         }
-        else if (MasterPasswordSalt != user.GetMasterPasswordSalt())
+        else if (MasterPasswordSalt != null  && MasterPasswordSalt != user.GetMasterPasswordSalt())
         {
             return false;
         }

--- a/src/Core/KeyManagement/Models/Data/MasterPasswordUnlockAndAuthenticationData.cs
+++ b/src/Core/KeyManagement/Models/Data/MasterPasswordUnlockAndAuthenticationData.cs
@@ -18,10 +18,15 @@ public class MasterPasswordUnlockAndAuthenticationData
     /// </summary>
     public required string MasterKeyEncryptedUserKey { get; set; }
     public string? MasterPasswordHint { get; set; }
+     public string? MasterPasswordSalt { get; set; }
 
     public bool ValidateForUser(User user)
     {
         if (KdfType != user.Kdf || KdfMemory != user.KdfMemory || KdfParallelism != user.KdfParallelism || KdfIterations != user.KdfIterations)
+        {
+            return false;
+        }
+        else if (MasterPasswordSalt != user.GetMasterPasswordSalt())
         {
             return false;
         }

--- a/src/Core/Models/Data/UserKdfInformation.cs
+++ b/src/Core/Models/Data/UserKdfInformation.cs
@@ -8,4 +8,5 @@ public class UserKdfInformation
     public required int KdfIterations { get; set; }
     public int? KdfMemory { get; set; }
     public int? KdfParallelism { get; set; }
+    public string? MasterPasswordSalt {get; set; }
 }

--- a/src/Core/Models/Data/UserKdfInformation.cs
+++ b/src/Core/Models/Data/UserKdfInformation.cs
@@ -8,5 +8,5 @@ public class UserKdfInformation
     public required int KdfIterations { get; set; }
     public int? KdfMemory { get; set; }
     public int? KdfParallelism { get; set; }
-    public string? MasterPasswordSalt {get; set; }
+    public string? MasterPasswordSalt { get; set; }
 }

--- a/src/Core/Repositories/IUserRepository.cs
+++ b/src/Core/Repositories/IUserRepository.cs
@@ -4,8 +4,6 @@ using Bit.Core.KeyManagement.Models.Data;
 using Bit.Core.KeyManagement.UserKey;
 using Bit.Core.Models.Data;
 
-#nullable enable
-
 namespace Bit.Core.Repositories;
 
 public interface IUserRepository : IRepository<User, Guid>

--- a/src/Identity/IdentityServer/UserDecryptionOptionsBuilder.cs
+++ b/src/Identity/IdentityServer/UserDecryptionOptionsBuilder.cs
@@ -197,7 +197,7 @@ public class UserDecryptionOptionsBuilder : IUserDecryptionOptionsBuilder
                     Parallelism = _user.KdfParallelism
                 },
                 MasterKeyEncryptedUserKey = _user.Key!,
-                Salt = _user.Email.ToLowerInvariant()
+                Salt = _user.GetMasterPasswordSalt()
             };
         }
         else

--- a/src/Infrastructure.EntityFramework/Repositories/UserRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/UserRepository.cs
@@ -73,7 +73,8 @@ public class UserRepository : Repository<Core.Entities.User, User, Guid>, IUserR
                     Kdf = e.Kdf,
                     KdfIterations = e.KdfIterations,
                     KdfMemory = e.KdfMemory,
-                    KdfParallelism = e.KdfParallelism
+                    KdfParallelism = e.KdfParallelism,
+                    MasterPasswordSalt = e.MasterPasswordSalt
                 }).SingleOrDefaultAsync();
         }
     }
@@ -307,7 +308,7 @@ public class UserRepository : Repository<Core.Entities.User, User, Guid>, IUserR
         userEntity.SecurityVersion = accountKeysData.SecurityStateData.SecurityVersion;
         userEntity.SignedPublicKey = accountKeysData.PublicKeyEncryptionKeyPairData.SignedPublicKey;
 
-        // Replace existing keypair if it exists
+        // Replace existing key-pair if it exists
         var existingKeyPair = await dbContext.UserSignatureKeyPairs
             .FirstOrDefaultAsync(x => x.UserId == userId);
         if (existingKeyPair != null)

--- a/src/Sql/dbo/Stored Procedures/OrganizationUser_ReadManyResetPasswordDetailsByOrganizationUserIds.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationUser_ReadManyResetPasswordDetailsByOrganizationUserIds.sql
@@ -11,6 +11,7 @@ BEGIN
         U.[KdfIterations],
         U.[KdfMemory],
         U.[KdfParallelism],
+        U.[MasterPasswordSalt] AS [Salt],
         OU.[ResetPasswordKey],
         O.[PrivateKey] AS EncryptedPrivateKey
     FROM @OrganizationUserIds AS OUIDs

--- a/src/Sql/dbo/Stored Procedures/OrganizationUser_ReadManyResetPasswordDetailsByOrganizationUserIds.sql
+++ b/src/Sql/dbo/Stored Procedures/OrganizationUser_ReadManyResetPasswordDetailsByOrganizationUserIds.sql
@@ -11,7 +11,7 @@ BEGIN
         U.[KdfIterations],
         U.[KdfMemory],
         U.[KdfParallelism],
-        U.[MasterPasswordSalt] AS [Salt],
+        U.[MasterPasswordSalt],
         OU.[ResetPasswordKey],
         O.[PrivateKey] AS EncryptedPrivateKey
     FROM @OrganizationUserIds AS OUIDs

--- a/src/Sql/dbo/Stored Procedures/User_ReadKdfByEmail.sql
+++ b/src/Sql/dbo/Stored Procedures/User_ReadKdfByEmail.sql
@@ -8,7 +8,8 @@ BEGIN
         [Kdf],
         [KdfIterations],
         [KdfMemory],
-        [KdfParallelism]
+        [KdfParallelism],
+        [MasterPasswordSalt] AS [Salt]
     FROM
         [dbo].[User]
     WHERE

--- a/src/Sql/dbo/Stored Procedures/User_ReadKdfByEmail.sql
+++ b/src/Sql/dbo/Stored Procedures/User_ReadKdfByEmail.sql
@@ -9,7 +9,7 @@ BEGIN
         [KdfIterations],
         [KdfMemory],
         [KdfParallelism],
-        [MasterPasswordSalt] AS [Salt]
+        [MasterPasswordSalt]
     FROM
         [dbo].[User]
     WHERE

--- a/test/Api.IntegrationTest/KeyManagement/Controllers/AccountsKeyManagementControllerTests.cs
+++ b/test/Api.IntegrationTest/KeyManagement/Controllers/AccountsKeyManagementControllerTests.cs
@@ -747,6 +747,7 @@ public class AccountsKeyManagementControllerTests : IClassFixture<ApiApplication
         request.AccountUnlockData.MasterPasswordUnlockData.KdfMemory = user.KdfMemory;
         request.AccountUnlockData.MasterPasswordUnlockData.KdfParallelism = user.KdfParallelism;
         request.AccountUnlockData.MasterPasswordUnlockData.Email = user.Email;
+        request.AccountUnlockData.MasterPasswordUnlockData.MasterPasswordSalt = user.GetMasterPasswordSalt();
         request.AccountUnlockData.MasterPasswordUnlockData.MasterKeyEncryptedUserKey = _mockEncryptedString;
 
         // Unlock data arrays

--- a/test/Api.IntegrationTest/Vault/Controllers/SyncControllerTests.cs
+++ b/test/Api.IntegrationTest/Vault/Controllers/SyncControllerTests.cs
@@ -95,6 +95,28 @@ public class SyncControllerTests : IClassFixture<ApiApplicationFactory>, IAsyncL
         Assert.Equal(kdfMemory, syncResponseModel.UserDecryption.MasterPasswordUnlock.Kdf.Memory);
         Assert.Equal(kdfParallelism, syncResponseModel.UserDecryption.MasterPasswordUnlock.Kdf.Parallelism);
         Assert.Equal(user.Key, syncResponseModel.UserDecryption.MasterPasswordUnlock.MasterKeyEncryptedUserKey);
-        Assert.Equal(user.Email.ToLower(), syncResponseModel.UserDecryption.MasterPasswordUnlock.Salt);
+        Assert.Equal(user.GetMasterPasswordSalt(), syncResponseModel.UserDecryption.MasterPasswordUnlock.Salt);
+    }
+
+    [Fact]
+    public async Task Get_HaveExplicitMasterPasswordSalt_SaltReturnedInSync()
+    {
+        var tempEmail = $"integration-test{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(tempEmail);
+        await _loginHelper.LoginAsync(tempEmail);
+
+        var user = await _userRepository.GetByEmailAsync(tempEmail);
+        Assert.NotNull(user);
+        user.MasterPasswordSalt = "explicit-salt-value";
+        await _userRepository.UpsertAsync(user);
+
+        var response = await _client.GetAsync("/sync");
+        response.EnsureSuccessStatusCode();
+
+        var syncResponseModel = await response.Content.ReadFromJsonAsync<SyncResponseModel>();
+
+        Assert.NotNull(syncResponseModel);
+        Assert.NotNull(syncResponseModel.UserDecryption?.MasterPasswordUnlock);
+        Assert.Equal("explicit-salt-value", syncResponseModel.UserDecryption.MasterPasswordUnlock.Salt);
     }
 }

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
@@ -337,7 +337,8 @@ public class OrganizationUsersControllerTests
                 ou.KdfMemory == r.KdfMemory &&
                 ou.KdfParallelism == r.KdfParallelism &&
                 ou.ResetPasswordKey == r.ResetPasswordKey &&
-                ou.EncryptedPrivateKey == r.EncryptedPrivateKey)));
+                ou.EncryptedPrivateKey == r.EncryptedPrivateKey &&
+                ou.MasterPasswordSalt == r.MasterPasswordSalt)));
     }
 
     [Theory]
@@ -404,6 +405,7 @@ public class OrganizationUsersControllerTests
         Assert.Equal(user.Kdf, response.Kdf);
         Assert.Equal(user.KdfIterations, response.KdfIterations);
         Assert.Equal(org.PrivateKey, response.EncryptedPrivateKey);
+        Assert.Equal(user.MasterPasswordSalt, response.MasterPasswordSalt);
     }
 
     [Theory]

--- a/test/Api.Test/Auth/Models/Response/EmergencyAccessTakeoverResponseModelTests.cs
+++ b/test/Api.Test/Auth/Models/Response/EmergencyAccessTakeoverResponseModelTests.cs
@@ -34,18 +34,6 @@ public class EmergencyAccessTakeoverResponseModelTests
     }
 
     [Theory]
-    [BitAutoData]
-    public void Constructor_Salt_EqualsGrantorEmailLowercasedAndTrimmed(
-        EmergencyAccess emergencyAccess, User grantor)
-    {
-        grantor.Email = "  TEST@Example.COM  ";
-
-        var model = new EmergencyAccessTakeoverResponseModel(emergencyAccess, grantor);
-
-        Assert.Equal("test@example.com", model.Salt);
-    }
-
-    [Theory]
     [InlineData("user@domain.com", "user@domain.com")]
     [InlineData("USER@DOMAIN.COM", "user@domain.com")]
     [InlineData("  user@domain.com  ", "user@domain.com")]

--- a/test/Api.Test/Vault/Controllers/SyncControllerTests.cs
+++ b/test/Api.Test/Vault/Controllers/SyncControllerTests.cs
@@ -402,7 +402,7 @@ public class SyncControllerTests
         Assert.Equal(kdfMemory, result.UserDecryption.MasterPasswordUnlock.Kdf.Memory);
         Assert.Equal(kdfParallelism, result.UserDecryption.MasterPasswordUnlock.Kdf.Parallelism);
         Assert.Equal(user.Key, result.UserDecryption.MasterPasswordUnlock.MasterKeyEncryptedUserKey);
-        Assert.Equal(user.Email.ToLower(), result.UserDecryption.MasterPasswordUnlock.Salt);
+        Assert.Equal(user.GetMasterPasswordSalt(), result.UserDecryption.MasterPasswordUnlock.Salt);
     }
 
     private async Task AssertMethodsCalledAsync(IUserService userService,

--- a/test/Api.Test/Vault/Models/Response/SyncResponseModelTests.cs
+++ b/test/Api.Test/Vault/Models/Response/SyncResponseModelTests.cs
@@ -58,6 +58,7 @@ public class SyncResponseModelTests
         // Arrange
         user.MasterPassword = "hashed-password";
         user.Key = _mockEncryptedKey1;
+        user.MasterPasswordSalt = null;
         user.Kdf = KdfType.Argon2id;
         user.KdfIterations = 3;
         user.KdfMemory = 64;
@@ -70,12 +71,33 @@ public class SyncResponseModelTests
         Assert.NotNull(result.UserDecryption);
         Assert.NotNull(result.UserDecryption.MasterPasswordUnlock);
         Assert.Equal(_mockEncryptedKey1, result.UserDecryption.MasterPasswordUnlock.MasterKeyEncryptedUserKey);
-        Assert.Equal(user.Email.ToLowerInvariant(), result.UserDecryption.MasterPasswordUnlock.Salt);
+        Assert.Equal(user.GetMasterPasswordSalt(), result.UserDecryption.MasterPasswordUnlock.Salt);
         Assert.NotNull(result.UserDecryption.MasterPasswordUnlock.Kdf);
         Assert.Equal(KdfType.Argon2id, result.UserDecryption.MasterPasswordUnlock.Kdf.KdfType);
         Assert.Equal(3, result.UserDecryption.MasterPasswordUnlock.Kdf.Iterations);
         Assert.Equal(64, result.UserDecryption.MasterPasswordUnlock.Kdf.Memory);
         Assert.Equal(4, result.UserDecryption.MasterPasswordUnlock.Kdf.Parallelism);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public void Constructor_UserWithExplicitSalt_UsesMasterPasswordSalt(User user)
+    {
+        // Arrange
+        user.MasterPassword = "hashed-password";
+        user.Key = _mockEncryptedKey1;
+        user.MasterPasswordSalt = "explicit-salt-value";
+        user.Kdf = KdfType.Argon2id;
+        user.KdfIterations = 3;
+        user.KdfMemory = 64;
+        user.KdfParallelism = 4;
+
+        // Act
+        var result = CreateSyncResponseModel(user);
+
+        // Assert
+        Assert.NotNull(result.UserDecryption?.MasterPasswordUnlock);
+        Assert.Equal("explicit-salt-value", result.UserDecryption.MasterPasswordUnlock.Salt);
     }
 
     [Theory]

--- a/test/Core.Test/Auth/Models/Api/Request/Accounts/RegisterFinishRequestModelTests.cs
+++ b/test/Core.Test/Auth/Models/Api/Request/Accounts/RegisterFinishRequestModelTests.cs
@@ -181,6 +181,37 @@ public class RegisterFinishRequestModelTests
         Assert.Equal(userSymmetricKey, result.Key);
         Assert.Equal(userAsymmetricKeys.PublicKey, result.PublicKey);
         Assert.Equal(userAsymmetricKeys.EncryptedPrivateKey, result.PrivateKey);
+        Assert.Null(result.MasterPasswordSalt);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public void ToUser_WithMasterPasswordUnlock_MapsSalt(string email, string masterPasswordHint,
+        KeysRequestModel userAsymmetricKeys)
+    {
+        // Arrange
+        var model = new RegisterFinishRequestModel
+        {
+            Email = email,
+            MasterPasswordHint = masterPasswordHint,
+            UserAsymmetricKeys = userAsymmetricKeys,
+            MasterPasswordUnlock = new MasterPasswordUnlockDataRequestModel
+            {
+                Kdf = new KdfRequestModel
+                {
+                    KdfType = KdfType.PBKDF2_SHA256,
+                    Iterations = AuthConstants.PBKDF2_ITERATIONS.Default
+                },
+                MasterKeyWrappedUserKey = "wrapped-key",
+                Salt = "explicit-salt-value"
+            }
+        };
+
+        // Act
+        var resultUser = model.ToUser();
+
+        // Assert
+        Assert.Equal("explicit-salt-value", resultUser.MasterPasswordSalt);
     }
 
     [Fact]

--- a/test/Core.Test/Auth/UserFeatures/UserMasterPassword/SetInitialMasterPasswordCommandTests.cs
+++ b/test/Core.Test/Auth/UserFeatures/UserMasterPassword/SetInitialMasterPasswordCommandTests.cs
@@ -141,6 +141,48 @@ public class SetInitialMasterPasswordCommandTests
 
     [Theory]
     [BitAutoData]
+    public async Task SetInitialMasterPassword_NullSalt_UsesEmailFallback(
+        SutProvider<SetInitialMasterPasswordCommand> sutProvider,
+        User user, UserAccountKeysData accountKeys, KdfSettings kdfSettings,
+        Organization org, OrganizationUser orgUser, string serverSideHash, string masterPasswordHint)
+    {
+        // Arrange
+        user.Key = null;
+        user.MasterPasswordSalt = null;
+        var expectedSalt = user.Email.ToLowerInvariant().Trim();
+        var model = CreateValidModel(user, accountKeys, kdfSettings, org.Identifier, masterPasswordHint);
+
+        // Verify the model uses the email-derived salt
+        Assert.Equal(expectedSalt, model.MasterPasswordUnlock.Salt);
+        Assert.Equal(expectedSalt, model.MasterPasswordAuthentication.Salt);
+
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetByIdentifierAsync(org.Identifier)
+            .Returns(org);
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByOrganizationAsync(org.Id, user.Id)
+            .Returns(orgUser);
+
+        sutProvider.GetDependency<IPasswordHasher<User>>()
+            .HashPassword(user, model.MasterPasswordAuthentication.MasterPasswordAuthenticationHash)
+            .Returns(serverSideHash);
+
+        UpdateUserData mockUpdateUserData = (connection, transaction) => Task.CompletedTask;
+        sutProvider.GetDependency<IUserRepository>()
+            .SetMasterPassword(user.Id, model.MasterPasswordUnlock, serverSideHash, model.MasterPasswordHint)
+            .Returns(mockUpdateUserData);
+
+        // Act — should not throw since email fallback provides a valid salt
+        await sutProvider.Sut.SetInitialMasterPasswordAsync(user, model);
+
+        // Assert
+        await sutProvider.GetDependency<IEventService>().Received(1)
+            .LogUserEventAsync(user.Id, EventType.User_ChangedPassword);
+    }
+
+    [Theory]
+    [BitAutoData]
     public async Task SetInitialMasterPassword_InvalidOrgSsoIdentifier_ThrowsBadRequestException(
         SutProvider<SetInitialMasterPasswordCommand> sutProvider,
         User user, UserAccountKeysData accountKeys, KdfSettings kdfSettings, string orgSsoIdentifier, string masterPasswordHint)

--- a/test/Core.Test/Auth/UserFeatures/UserMasterPassword/TdeSetPasswordCommandTests.cs
+++ b/test/Core.Test/Auth/UserFeatures/UserMasterPassword/TdeSetPasswordCommandTests.cs
@@ -67,6 +67,50 @@ public class TdeSetPasswordCommandTests
 
     [Theory]
     [BitAutoData]
+    public async Task OnboardMasterPassword_NullSalt_UsesEmailFallback(
+        SutProvider<TdeSetPasswordCommand> sutProvider,
+        User user, KdfSettings kdfSettings,
+        Organization org, OrganizationUser orgUser, string serverSideHash, string masterPasswordHint)
+    {
+        // Arrange
+        user.Key = null;
+        user.PublicKey = "public-key";
+        user.PrivateKey = "private-key";
+        user.MasterPasswordSalt = null;
+        var expectedSalt = user.Email.ToLowerInvariant().Trim();
+        var model = CreateValidModel(user, kdfSettings, org.Identifier, masterPasswordHint);
+
+        // Verify the model uses the email-derived salt
+        Assert.Equal(expectedSalt, model.MasterPasswordUnlock.Salt);
+        Assert.Equal(expectedSalt, model.MasterPasswordAuthentication.Salt);
+
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetByIdentifierAsync(org.Identifier)
+            .Returns(org);
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByOrganizationAsync(org.Id, user.Id)
+            .Returns(orgUser);
+
+        sutProvider.GetDependency<IPasswordHasher<User>>()
+            .HashPassword(user, model.MasterPasswordAuthentication.MasterPasswordAuthenticationHash)
+            .Returns(serverSideHash);
+
+        UpdateUserData mockUpdateUserData = (connection, transaction) => Task.CompletedTask;
+        sutProvider.GetDependency<IUserRepository>()
+            .SetMasterPassword(user.Id, model.MasterPasswordUnlock, serverSideHash, model.MasterPasswordHint)
+            .Returns(mockUpdateUserData);
+
+        // Act — should not throw since email fallback provides a valid salt
+        await sutProvider.Sut.SetMasterPasswordAsync(user, model);
+
+        // Assert
+        await sutProvider.GetDependency<IEventService>().Received(1)
+            .LogUserEventAsync(user.Id, EventType.User_ChangedPassword);
+    }
+
+    [Theory]
+    [BitAutoData]
     public async Task OnboardMasterPassword_UserAlreadyHasPassword_ThrowsBadRequestException(
         SutProvider<TdeSetPasswordCommand> sutProvider,
         User user, KdfSettings kdfSettings, string orgSsoIdentifier, string masterPasswordHint)

--- a/test/Core.Test/KeyManagement/UserKey/RotateUserAccountKeysCommandTests.cs
+++ b/test/Core.Test/KeyManagement/UserKey/RotateUserAccountKeysCommandTests.cs
@@ -600,7 +600,9 @@ public class RotateUserAccountKeysCommandTests
         model.MasterPasswordUnlockData.KdfIterations = 3;
         model.MasterPasswordUnlockData.KdfMemory = 64;
         model.MasterPasswordUnlockData.KdfParallelism = 4;
-        // The email is the salt for the KDF and is validated currently.
+        model.MasterPasswordUnlockData.MasterPasswordSalt = user.GetMasterPasswordSalt();
+        // The email used to be the salt for the KDF and is validated currently.
+        // TODO: This can be removed once the email is no longer used as part of the KDF salt and validation is updated to reflect that.
         user.Email = model.MasterPasswordUnlockData.Email;
     }
 

--- a/test/Identity.Test/IdentityServer/UserDecryptionOptionsBuilderTests.cs
+++ b/test/Identity.Test/IdentityServer/UserDecryptionOptionsBuilderTests.cs
@@ -335,6 +335,7 @@ public class UserDecryptionOptionsBuilderTests
     public async Task Build_WhenUserHasMasterPassword_ShouldReturnMasterPasswordUnlock(User user)
     {
         user.Email = "test@example.COM";
+        user.MasterPasswordSalt = null;
 
         var result = await _builder.ForUser(user).BuildAsync();
 
@@ -344,7 +345,19 @@ public class UserDecryptionOptionsBuilderTests
         Assert.Equal(user.KdfIterations, result.MasterPasswordUnlock.Kdf.Iterations);
         Assert.Equal(user.KdfMemory, result.MasterPasswordUnlock.Kdf.Memory);
         Assert.Equal(user.KdfParallelism, result.MasterPasswordUnlock.Kdf.Parallelism);
-        Assert.Equal("test@example.com", result.MasterPasswordUnlock.Salt);
+        Assert.Equal(user.GetMasterPasswordSalt(), result.MasterPasswordUnlock.Salt);
         Assert.Equal(user.Key, result.MasterPasswordUnlock.MasterKeyEncryptedUserKey);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Build_WhenUserHasExplicitSalt_ShouldReturnExplicitSalt(User user)
+    {
+        user.MasterPasswordSalt = "explicit-salt-value";
+
+        var result = await _builder.ForUser(user).BuildAsync();
+
+        Assert.True(result.HasMasterPassword);
+        Assert.NotNull(result.MasterPasswordUnlock);
+        Assert.Equal("explicit-salt-value", result.MasterPasswordUnlock.Salt);
     }
 }

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/OrganizationUserRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/OrganizationUserRepositoryTests.cs
@@ -290,7 +290,8 @@ public class OrganizationUserRepositoryTests
             Kdf = KdfType.PBKDF2_SHA256,
             KdfIterations = 1,
             KdfMemory = 2,
-            KdfParallelism = 3
+            KdfParallelism = 3,
+            MasterPasswordSalt = "master-salt1"
         });
 
         var user2 = await userRepository.CreateAsync(new User
@@ -302,7 +303,8 @@ public class OrganizationUserRepositoryTests
             Kdf = KdfType.Argon2id,
             KdfIterations = 4,
             KdfMemory = 5,
-            KdfParallelism = 6
+            KdfParallelism = 6,
+            MasterPasswordSalt = "master-salt2"
         });
 
         var organization = await organizationRepository.CreateAsync(new Organization
@@ -352,7 +354,8 @@ public class OrganizationUserRepositoryTests
             r.KdfMemory == 2 &&
             r.KdfParallelism == 3 &&
             r.ResetPasswordKey == "resetpasswordkey1" &&
-            r.EncryptedPrivateKey == "privatekey");
+            r.EncryptedPrivateKey == "privatekey" &&
+            r.MasterPasswordSalt == "master-salt1");
         Assert.Contains(recoveryDetails, r =>
             r.OrganizationUserId == orgUser2.Id &&
             r.Kdf == KdfType.Argon2id &&
@@ -360,7 +363,8 @@ public class OrganizationUserRepositoryTests
             r.KdfMemory == 5 &&
             r.KdfParallelism == 6 &&
             r.ResetPasswordKey == "resetpasswordkey2" &&
-            r.EncryptedPrivateKey == "privatekey");
+            r.EncryptedPrivateKey == "privatekey" &&
+            r.MasterPasswordSalt == "master-salt2");
     }
 
     [DatabaseTheory, DatabaseData]

--- a/test/Infrastructure.IntegrationTest/Repositories/UserRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/Repositories/UserRepositoryTests.cs
@@ -740,6 +740,103 @@ public class UserRepositoryTests
         Assert.True(actionWasInvoked);
     }
 
+    [Theory, DatabaseData]
+    public async Task GetKdfInformationByEmailAsync_WithPbkdf2User_ReturnsKdfInformation(
+        IUserRepository userRepository)
+    {
+        // Arrange
+        var email = $"test+{Guid.NewGuid()}@example.com";
+        var salt = "test-salt-value";
+        await userRepository.CreateAsync(new User
+        {
+            Name = "Test User",
+            Email = email,
+            ApiKey = "TEST",
+            SecurityStamp = "stamp",
+            MasterPassword = "password_hash",
+            MasterPasswordSalt = salt,
+            Kdf = KdfType.PBKDF2_SHA256,
+            KdfIterations = AuthConstants.PBKDF2_ITERATIONS.Default,
+        });
+
+        // Act
+        var result = await userRepository.GetKdfInformationByEmailAsync(email);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(KdfType.PBKDF2_SHA256, result.Kdf);
+        Assert.Equal(AuthConstants.PBKDF2_ITERATIONS.Default, result.KdfIterations);
+        Assert.Null(result.KdfMemory);
+        Assert.Null(result.KdfParallelism);
+        Assert.Equal(salt, result.MasterPasswordSalt);
+    }
+
+    [Theory, DatabaseData]
+    public async Task GetKdfInformationByEmailAsync_WithArgon2idUser_ReturnsKdfInformationWithMemoryAndParallelism(
+        IUserRepository userRepository)
+    {
+        // Arrange
+        var email = $"test+{Guid.NewGuid()}@example.com";
+        var salt = "argon2-salt-value";
+        await userRepository.CreateAsync(new User
+        {
+            Name = "Test User",
+            Email = email,
+            ApiKey = "TEST",
+            SecurityStamp = "stamp",
+            MasterPassword = "password_hash",
+            MasterPasswordSalt = salt,
+            Kdf = KdfType.Argon2id,
+            KdfIterations = AuthConstants.ARGON2_ITERATIONS.Default,
+            KdfMemory = AuthConstants.ARGON2_MEMORY.Default,
+            KdfParallelism = AuthConstants.ARGON2_PARALLELISM.Default,
+        });
+
+        // Act
+        var result = await userRepository.GetKdfInformationByEmailAsync(email);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(KdfType.Argon2id, result.Kdf);
+        Assert.Equal(AuthConstants.ARGON2_ITERATIONS.Default, result.KdfIterations);
+        Assert.Equal(AuthConstants.ARGON2_MEMORY.Default, result.KdfMemory);
+        Assert.Equal(AuthConstants.ARGON2_PARALLELISM.Default, result.KdfParallelism);
+        Assert.Equal(salt, result.MasterPasswordSalt);
+    }
+
+    [Theory, DatabaseData]
+    public async Task GetKdfInformationByEmailAsync_WithNoMasterPassword_ReturnsNullSalt(
+        IUserRepository userRepository)
+    {
+        // Arrange
+        var email = $"test+{Guid.NewGuid()}@example.com";
+        await userRepository.CreateAsync(new User
+        {
+            Name = "Test User",
+            Email = email,
+            ApiKey = "TEST",
+            SecurityStamp = "stamp",
+        });
+
+        // Act
+        var result = await userRepository.GetKdfInformationByEmailAsync(email);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Null(result.MasterPasswordSalt);
+    }
+
+    [Theory, DatabaseData]
+    public async Task GetKdfInformationByEmailAsync_WithNonExistentEmail_ReturnsNull(
+        IUserRepository userRepository)
+    {
+        // Act
+        var result = await userRepository.GetKdfInformationByEmailAsync($"nonexistent+{Guid.NewGuid()}@example.com");
+
+        // Assert
+        Assert.Null(result);
+    }
+
     private static async Task RunUpdateUserDataAsync(UpdateUserData task, Database database)
     {
         if (database.Type == SupportedDatabaseProviders.SqlServer && !database.UseEf)

--- a/util/Migrator/DbScripts/2026-03-06_00_AlterReadKdfByEmail.sql
+++ b/util/Migrator/DbScripts/2026-03-06_00_AlterReadKdfByEmail.sql
@@ -1,0 +1,18 @@
+CREATE OR ALTER PROCEDURE [dbo].[User_ReadKdfByEmail]
+    @Email NVARCHAR(256)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        [Kdf],
+        [KdfIterations],
+        [KdfMemory],
+        [KdfParallelism],
+        [MasterPasswordSalt] AS [Salt]
+    FROM
+        [dbo].[User]
+    WHERE
+        [Email] = @Email
+END
+GO

--- a/util/Migrator/DbScripts/2026-03-06_00_AlterReadKdfByEmail.sql
+++ b/util/Migrator/DbScripts/2026-03-06_00_AlterReadKdfByEmail.sql
@@ -9,7 +9,7 @@ BEGIN
         [KdfIterations],
         [KdfMemory],
         [KdfParallelism],
-        [MasterPasswordSalt] AS [Salt]
+        [MasterPasswordSalt]
     FROM
         [dbo].[User]
     WHERE

--- a/util/Migrator/DbScripts/2026-03-06_01_AlterReadManyAccountRecoveryDetailsByOrganizationUserIds.sql
+++ b/util/Migrator/DbScripts/2026-03-06_01_AlterReadManyAccountRecoveryDetailsByOrganizationUserIds.sql
@@ -11,7 +11,7 @@ BEGIN
         U.[KdfIterations],
         U.[KdfMemory],
         U.[KdfParallelism],
-        U.[MasterPasswordSalt] AS [Salt],
+        U.[MasterPasswordSalt],
         OU.[ResetPasswordKey],
         O.[PrivateKey] AS EncryptedPrivateKey
     FROM @OrganizationUserIds AS OUIDs

--- a/util/Migrator/DbScripts/2026-03-06_01_AlterReadManyAccountRecoveryDetailsByOrganizationUserIds.sql
+++ b/util/Migrator/DbScripts/2026-03-06_01_AlterReadManyAccountRecoveryDetailsByOrganizationUserIds.sql
@@ -1,0 +1,26 @@
+CREATE OR ALTER PROCEDURE [dbo].[OrganizationUser_ReadManyAccountRecoveryDetailsByOrganizationUserIds]
+    @OrganizationId UNIQUEIDENTIFIER,
+    @OrganizationUserIds AS [dbo].[GuidIdArray] READONLY
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        OU.[Id] AS OrganizationUserId,
+        U.[Kdf],
+        U.[KdfIterations],
+        U.[KdfMemory],
+        U.[KdfParallelism],
+        U.[MasterPasswordSalt] AS [Salt],
+        OU.[ResetPasswordKey],
+        O.[PrivateKey] AS EncryptedPrivateKey
+    FROM @OrganizationUserIds AS OUIDs
+    INNER JOIN [dbo].[OrganizationUser] AS OU
+        ON OUIDs.[Id] = OU.[Id]
+    INNER JOIN [dbo].[Organization] AS O
+        ON OU.[OrganizationId] = O.[Id]
+    INNER JOIN [dbo].[User] U
+        ON U.[Id] = OU.[UserId]
+    WHERE OU.[OrganizationId] = @OrganizationId
+END
+GO


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-21926](https://bitwarden.atlassian.net/browse/PM-21926)
[PM-32389](https://bitwarden.atlassian.net/browse/PM-32389)
[PM-28827](https://bitwarden.atlassian.net/browse/PM-28827)
[PM-30370](https://bitwarden.atlassian.net/browse/PM-30370)
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

### PM-21926
We need to begin to return the `MasterPasswordSalt` column in queries that will expect it in the future. This PR adds the `MasterPasswordSalt` to the `ReadKdfByEmail` method in the User Repository and adds the `MasterPasswordSalt` to the `OrganizationUserResetPasswordDetails` method.

### PM-32289
We add null coalescing to the `User.GetMasterPasswordSalt()` method to be the only fallback when a `MasterPasswordSalt` is `null`. The locations that set the `Salt` to the `User.Email.Lower().Trim()` were replaced with the `User.GetMasterPasswordSalt()` method to ensure forward compatibility. 

### PM-28827
Accept the `MasterPasswordUnlockData?.Salt` from the `RegisterFinishRequestModel`. This does not do any coalescing to match the pattern where the Server only writes what the Client submits and does not try to guess.

### PM-30370
Return `User.MasterPasswordSalt()` in the `UserDecryptionResponseModel` and the `SyncResponseModel` instead of the `User.Email.ToLower().Trim()`.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


[PM-21926]: https://bitwarden.atlassian.net/browse/PM-21926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-32389]: https://bitwarden.atlassian.net/browse/PM-32389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-28827]: https://bitwarden.atlassian.net/browse/PM-28827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-30370]: https://bitwarden.atlassian.net/browse/PM-30370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ