### PR TITLE
Remove obsolete client flags

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -152,10 +152,6 @@ public static class FeatureFlagKeys
     public const string DesktopMigrationMilestone4 = "desktop-ui-migration-milestone-4";
 
     /* Auth Team */
-    public const string TwoFactorExtensionDataPersistence = "pm-9115-two-factor-extension-data-persistence";
-    public const string BrowserExtensionLoginApproval = "pm-14938-browser-extension-login-approvals";
-    public const string SetInitialPasswordRefactor = "pm-16117-set-initial-password-refactor";
-    public const string ChangeExistingPasswordRefactor = "pm-16117-change-existing-password-refactor";
     public const string Otp6Digits = "pm-18612-otp-6-digits";
     public const string DisableAlternateLoginMethods = "pm-22110-disable-alternate-login-methods";
     public const string PM2035PasskeyUnlock = "pm-2035-passkey-unlock";


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-22608
https://bitwarden.atlassian.net/browse/PM-33341
https://bitwarden.atlassian.net/browse/PM-20443

## 📔 Objective

These 4 flags were for controlling logic only on `clients`, and that logic was already removed in previous client releases, in the commits listed below.

This PR removes the flags from the server, because all clients that rely on the flag are now outside of our backward compatibility window.

I opted to combine these into a single PR to reduce PR noise.  If separate PRs are preferred I can create them.

Flag | Removed from clients | Client commit | Last client with flag | Safe server version | Status
-- | -- | -- | -- | -- | --
pm-9115-two-factor-extension-data-persistence | 2025-07-10 | [c5be837](https://github.com/bitwarden/clients/commit/c5be837b51c556c2e9614d188a27c76682edb172)| browser-v2025.6.x | v2025.9.0 | ✅ Safe
pm-16117-set-initial-password-refactor | 2025-07-24 | [b3db1b7](https://github.com/bitwarden/clients/commit/b3db1b79cea7c99ba610866b86fc7188a1cf1150)	 | browser-v2025.7.x | v2025.10.0 | ✅ Safe
pm-16117-change-existing-password-refactor | 2025-07-24 | [b3db1b7](https://github.com/bitwarden/clients/commit/b3db1b79cea7c99ba610866b86fc7188a1cf1150) | browser-v2025.7.x | v2025.10.0 | ✅ Safe
pm-14938-browser-extension-login-approvals | 2025-09-29 | [5f7e1f9](https://github.com/bitwarden/clients/commit/5f7e1f99bf5826026181443c00e123b919f10968) | browser-v2025.9.x | v2025.12.0 | ✅ Safe

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
