### PR TITLE
[PM-33375] Fix Local Swagger Authentication

### DIFF
--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -336,9 +336,12 @@ public class Startup
                     [
                         new OpenApiSecurityRequirement
                         {
-                            [new OpenApiSecuritySchemeReference("oauth2-client-credentials")] = [ApiScopes.ApiOrganization]
+                            [new OpenApiSecuritySchemeReference("oauth2-client-credentials", swaggerDoc)] = [ApiScopes.ApiOrganization]
                         },
                     ];
+
+                    swaggerDoc.Workspace = new OpenApiWorkspace();
+                    swaggerDoc.RegisterComponents();
                 });
             });
 


### PR DESCRIPTION
## 🎟️ Tracking
[PM-33375](https://bitwarden.atlassian.net/browse/PM-33375)

## 📔 Objective
Swagger no longer sends the Authorization header with the OAuth2 ClientCredentials bearer token when handling requests. This fixes that by mirroring [what aspnet does under the hood.](https://grep.app/dotnet/aspnetcore/main/src/OpenApi/src/Services/OpenApiDocumentService.cs?q=RegisterComponents#L88)

## 📸 Screenshots
<img width="1358" height="1228" alt="image" src="https://github.com/user-attachments/assets/9210f262-044b-461f-896d-dd5088465463" />


[PM-33375]: https://bitwarden.atlassian.net/browse/PM-33375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ