### PR TITLE
[PM-33499] Permissive base64 decoder

### DIFF
--- a/src/Core/Utilities/EncryptedStringAttribute.cs
+++ b/src/Core/Utilities/EncryptedStringAttribute.cs
@@ -111,7 +111,7 @@ public class EncryptedStringAttribute : ValidationAttribute
             if (requiredPieces == 1)
             {
                 // Only one more part is needed so don't split and check the chunk
-                if (rest.IsEmpty || !Base64.IsValid(rest))
+                if (rest.IsEmpty || !IsValidBase64Permissive(rest))
                 {
                     return false;
                 }
@@ -128,7 +128,7 @@ public class EncryptedStringAttribute : ValidationAttribute
                 }
 
                 // Is the required chunk valid base 64?
-                if (chunk.IsEmpty || !Base64.IsValid(chunk))
+                if (chunk.IsEmpty || !IsValidBase64Permissive(chunk))
                 {
                     return false;
                 }
@@ -140,5 +140,59 @@ public class EncryptedStringAttribute : ValidationAttribute
 
         // No more parts are required, so check there are no extra parts
         return rest.IndexOf('|') == -1;
+    }
+
+    private const string _base64Chars =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    private static int Base64CharValue(char c) => c switch
+    {
+        >= 'A' and <= 'Z' => c - 'A',
+        >= 'a' and <= 'z' => c - 'a' + 26,
+        >= '0' and <= '9' => c - '0' + 52,
+        '+' => 62,
+        '/' => 63,
+        _ => -1,
+    };
+
+    /// <summary>
+    /// Validates base64 permissively — accepts non-zero trailing bits before padding.
+    /// Fast path uses SIMD-accelerated Base64.IsValid; slow path normalizes trailing
+    /// bits and re-validates.
+    /// </summary>
+    private static bool IsValidBase64Permissive(ReadOnlySpan<char> value)
+    {
+        if (Base64.IsValid(value))
+            return true;
+
+        // Check if non-canonical trailing bits are the only issue
+        if (value.IsEmpty || value.Length % 4 != 0)
+            return false;
+
+        var padCount = 0;
+        if (value[^1] == '=') { padCount++; if (value[^2] == '=') padCount++; }
+        if (padCount == 0)
+            return false; // no padding → strict was right to reject
+
+        var lastDataIdx = value.Length - padCount - 1;
+        var charVal = Base64CharValue(value[lastDataIdx]);
+        if (charVal < 0)
+            return false;
+
+        // 4 trailing bits for == padding, 2 for = padding
+        var trailingBits = padCount == 2 ? 4 : 2;
+        var canonical = charVal & ~((1 << trailingBits) - 1);
+        if (canonical == charVal)
+            return false; // already canonical — something else is wrong
+
+        // Validate prefix (before last 4-char block) with SIMD
+        if (value.Length > 4 && !Base64.IsValid(value[..^4]))
+            return false;
+
+        // Validate last block with normalized character
+        Span<char> lastBlock = stackalloc char[4];
+        value[^4..].CopyTo(lastBlock);
+        lastBlock[4 - padCount - 1] = _base64Chars[canonical];
+        return Base64.IsValid(lastBlock);
     }
 }

--- a/src/Core/Utilities/EncryptedStringAttribute.cs
+++ b/src/Core/Utilities/EncryptedStringAttribute.cs
@@ -156,43 +156,42 @@ public class EncryptedStringAttribute : ValidationAttribute
     };
 
     /// <summary>
-    /// Validates base64 permissively — accepts non-zero trailing bits before padding.
-    /// Fast path uses SIMD-accelerated Base64.IsValid; slow path normalizes trailing
-    /// bits and re-validates.
+    /// Validates base64 permissively by accepting non-zero padding bits.
     /// </summary>
     private static bool IsValidBase64Permissive(ReadOnlySpan<char> value)
     {
-        if (Base64.IsValid(value))
-            return true;
-
-        // Check if non-canonical trailing bits are the only issue
+        // Obviously not base64
         if (value.IsEmpty || value.Length % 4 != 0)
             return false;
 
+        // If there isn't any padding, there's nothing to be permissive about.
         var padCount = 0;
         if (value[^1] == '=') { padCount++; if (value[^2] == '=') padCount++; }
         if (padCount == 0)
-            return false; // no padding → strict was right to reject
+            return Base64.IsValid(value);
 
+        // Get the last non-padding char. Ensure it's in the base64 alphabet.
         var lastDataIdx = value.Length - padCount - 1;
         var charVal = Base64CharValue(value[lastDataIdx]);
         if (charVal < 0)
             return false;
 
-        // 4 trailing bits for == padding, 2 for = padding
-        var trailingBits = padCount == 2 ? 4 : 2;
-        var canonical = charVal & ~((1 << trailingBits) - 1);
-        if (canonical == charVal)
-            return false; // already canonical — something else is wrong
+        // Compute the correct char. If the original char is already valid,
+        // test the full string.
+        var dataBitMask = padCount == 2 ? 0b110000 : 0b111100;
+        var newCharVal = charVal & dataBitMask;
+        if (newCharVal == charVal)
+            return Base64.IsValid(value);
 
-        // Validate prefix (before last 4-char block) with SIMD
+        // Validate all but the last block, to minimize allocation in the next
+        // section.
         if (value.Length > 4 && !Base64.IsValid(value[..^4]))
             return false;
 
-        // Validate last block with normalized character
-        Span<char> lastBlock = stackalloc char[4];
-        value[^4..].CopyTo(lastBlock);
-        lastBlock[4 - padCount - 1] = _base64Chars[canonical];
-        return Base64.IsValid(lastBlock);
+        // Apply the correct char and validate the last block 
+        Span<char> canonical = stackalloc char[4];
+        value[^4..].CopyTo(canonical);
+        canonical[4 - padCount - 1] = _base64Chars[newCharVal];
+        return Base64.IsValid(canonical);
     }
 }

--- a/test/Core.Test/Utilities/EncryptedStringAttributeTests.cs
+++ b/test/Core.Test/Utilities/EncryptedStringAttributeTests.cs
@@ -8,8 +8,6 @@ public class EncryptedStringAttributeTests
 {
     [Theory]
     [InlineData(null)]
-    [InlineData("lGD=|Y3Q=")] // Non-canonical = padding (D=000011, trailing 2 bits=11)
-    [InlineData("0.lB==|Y3Q=")] // Non-canonical == padding (B=000001, trailing 4 bits=0001)
     [InlineData("aXY=|Y3Q=")] // Valid AesCbc256_B64
     [InlineData("aXY=|Y3Q=|cnNhQ3Q=")] // Valid AesCbc128_HmacSha256_B64
     [InlineData("Rsa2048_OaepSha256_B64.cnNhQ3Q=")]
@@ -27,6 +25,11 @@ public class EncryptedStringAttributeTests
     [InlineData("Rsa2048_OaepSha256_HmacSha256_B64.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==")] // Valid Rsa2048_OaepSha256_HmacSha256_B64 as a string
     [InlineData("6.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==")] // Valid Rsa2048_OaepSha1_HmacSha256_B64 as a number
     [InlineData("Rsa2048_OaepSha1_HmacSha256_B64.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==")]
+    [InlineData("0.AAAA|Y3Q=")] // Unpadded IV with padded CT
+    [InlineData("lGD=|lGD=")] // Non-canonical = padding on both pieces (headerless)
+    [InlineData("lB==|Y3Q=|AAAA")] // Non-canonical == padding headerless (3 pieces)
+    [InlineData("2.lGD=|lGD=|lGD=")] // Non-canonical = padding on all three pieces
+    [InlineData("0.AAAA|QmFzZTY0UGFydB==")] // Unpadded IV, non-canonical == in longer piece (exercises prefix validation)
     public void IsValid_ReturnsTrue_WhenValid(string? input)
     {
         var sut = new EncryptedStringAttribute();
@@ -67,6 +70,9 @@ public class EncryptedStringAttributeTests
     [InlineData("Rsa2048_OaepSha256_HmacSha256_B64.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA==")] // Invalid Rsa2048_OaepSha256_HmacSha256_B64 as a string
     [InlineData("6.QmFzZTY0UGFydA==|QmFzZTY0UGFydA==|QmFzZTY0UGFydA==")] // Invalid Rsa2048_OaepSha1_HmacSha256_B64 as a number
     [InlineData("Rsa2048_OaepSha1_HmacSha256_B64.QmFzZTY0UGFydA==")] // Invalid Rsa2048_OaepSha1_HmacSha256_B64 as a string
+    [InlineData("0.AA!!AB==|Y3Q=")] // Invalid char in prefix with non-canonical last char
+    [InlineData("0.AAAAB==|Y3Q=")] // Piece length not multiple of 4
+    [InlineData("0.====|Y3Q=")] // Padding-only piece
     public void IsValid_ReturnsFalse_WhenInvalid(string input)
     {
         var sut = new EncryptedStringAttribute();

--- a/test/Core.Test/Utilities/EncryptedStringAttributeTests.cs
+++ b/test/Core.Test/Utilities/EncryptedStringAttributeTests.cs
@@ -8,6 +8,8 @@ public class EncryptedStringAttributeTests
 {
     [Theory]
     [InlineData(null)]
+    [InlineData("lGD=|Y3Q=")] // Non-canonical = padding (D=000011, trailing 2 bits=11)
+    [InlineData("0.lB==|Y3Q=")] // Non-canonical == padding (B=000001, trailing 4 bits=0001)
     [InlineData("aXY=|Y3Q=")] // Valid AesCbc256_B64
     [InlineData("aXY=|Y3Q=|cnNhQ3Q=")] // Valid AesCbc128_HmacSha256_B64
     [InlineData("Rsa2048_OaepSha256_B64.cnNhQ3Q=")]


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33499](https://bitwarden.atlassian.net/browse/PM-33499)

## 📔 Objective

The .NET 9 base64 decoder/validator requires all padding bits to be zero. This PR preserves .NET 8's permissive decoding behavior for compatibility with existing data so we can safely upgrade to .NET 10.


[PM-33499]: https://bitwarden.atlassian.net/browse/PM-33499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ