### PR TITLE
[PM-33212] Finalize Org Data Ownership Policy Requirement

### DIFF
--- a/src/Core/Tools/ImportFeatures/ImportCiphersCommand.cs
+++ b/src/Core/Tools/ImportFeatures/ImportCiphersCommand.cs
@@ -1,15 +1,12 @@
 ﻿// FIXME: Update this file to be null safe and then delete the line below
 #nullable disable
 
-using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
-using Bit.Core.AdminConsole.Services;
 using Bit.Core.Entities;
 using Bit.Core.Exceptions;
 using Bit.Core.Platform.Push;
 using Bit.Core.Repositories;
-using Bit.Core.Services;
 using Bit.Core.Tools.ImportFeatures.Interfaces;
 using Bit.Core.Vault.Entities;
 using Bit.Core.Vault.Models.Data;
@@ -22,12 +19,10 @@ public class ImportCiphersCommand : IImportCiphersCommand
     private readonly ICipherRepository _cipherRepository;
     private readonly IFolderRepository _folderRepository;
     private readonly IPushNotificationService _pushService;
-    private readonly IPolicyService _policyService;
     private readonly IOrganizationRepository _organizationRepository;
     private readonly IOrganizationUserRepository _organizationUserRepository;
     private readonly ICollectionRepository _collectionRepository;
     private readonly IPolicyRequirementQuery _policyRequirementQuery;
-    private readonly IFeatureService _featureService;
 
     public ImportCiphersCommand(
         ICipherRepository cipherRepository,
@@ -36,9 +31,7 @@ public class ImportCiphersCommand : IImportCiphersCommand
         IOrganizationRepository organizationRepository,
         IOrganizationUserRepository organizationUserRepository,
         IPushNotificationService pushService,
-        IPolicyService policyService,
-        IPolicyRequirementQuery policyRequirementQuery,
-        IFeatureService featureService)
+        IPolicyRequirementQuery policyRequirementQuery)
     {
         _cipherRepository = cipherRepository;
         _folderRepository = folderRepository;
@@ -46,9 +39,7 @@ public class ImportCiphersCommand : IImportCiphersCommand
         _organizationUserRepository = organizationUserRepository;
         _collectionRepository = collectionRepository;
         _pushService = pushService;
-        _policyService = policyService;
         _policyRequirementQuery = policyRequirementQuery;
-        _featureService = featureService;
     }
 
     public async Task ImportIntoIndividualVaultAsync(
@@ -58,11 +49,10 @@ public class ImportCiphersCommand : IImportCiphersCommand
         Guid importingUserId)
     {
         // Make sure the user can save new ciphers to their personal vault
-        var organizationDataOwnershipEnabled = _featureService.IsEnabled(FeatureFlagKeys.PolicyRequirements)
-            ? (await _policyRequirementQuery.GetAsync<OrganizationDataOwnershipPolicyRequirement>(importingUserId)).State == OrganizationDataOwnershipState.Enabled
-            : await _policyService.AnyPoliciesApplicableToUserAsync(importingUserId, PolicyType.OrganizationDataOwnership);
+        var organizationDataOwnershipPolicyRequirement =
+            await _policyRequirementQuery.GetAsync<OrganizationDataOwnershipPolicyRequirement>(importingUserId);
 
-        if (organizationDataOwnershipEnabled)
+        if (organizationDataOwnershipPolicyRequirement.State == OrganizationDataOwnershipState.Enabled)
         {
             throw new BadRequestException("You cannot import items into your personal vault because you are " +
                 "a member of an organization which forbids it.");

--- a/src/Core/Vault/Services/Implementations/CipherService.cs
+++ b/src/Core/Vault/Services/Implementations/CipherService.cs
@@ -3,10 +3,8 @@
 
 using System.Text.Json;
 using Bit.Core.AdminConsole.Entities;
-using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
-using Bit.Core.AdminConsole.Services;
 using Bit.Core.Billing.Pricing;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
@@ -32,14 +30,12 @@ public class CipherService : ICipherService
     private readonly ICollectionRepository _collectionRepository;
     private readonly IUserRepository _userRepository;
     private readonly IOrganizationRepository _organizationRepository;
-    private readonly IOrganizationUserRepository _organizationUserRepository;
     private readonly ICollectionCipherRepository _collectionCipherRepository;
     private readonly ISecurityTaskRepository _securityTaskRepository;
     private readonly IPushNotificationService _pushService;
     private readonly IAttachmentStorageService _attachmentStorageService;
     private readonly IEventService _eventService;
     private readonly IUserService _userService;
-    private readonly IPolicyService _policyService;
     private readonly GlobalSettings _globalSettings;
     private const long _fileSizeLeeway = 1024L * 1024L; // 1MB
     private readonly IGetCipherPermissionsForUserQuery _getCipherPermissionsForUserQuery;
@@ -54,14 +50,12 @@ public class CipherService : ICipherService
         ICollectionRepository collectionRepository,
         IUserRepository userRepository,
         IOrganizationRepository organizationRepository,
-        IOrganizationUserRepository organizationUserRepository,
         ICollectionCipherRepository collectionCipherRepository,
         ISecurityTaskRepository securityTaskRepository,
         IPushNotificationService pushService,
         IAttachmentStorageService attachmentStorageService,
         IEventService eventService,
         IUserService userService,
-        IPolicyService policyService,
         GlobalSettings globalSettings,
         IGetCipherPermissionsForUserQuery getCipherPermissionsForUserQuery,
         IPolicyRequirementQuery policyRequirementQuery,
@@ -74,14 +68,12 @@ public class CipherService : ICipherService
         _collectionRepository = collectionRepository;
         _userRepository = userRepository;
         _organizationRepository = organizationRepository;
-        _organizationUserRepository = organizationUserRepository;
         _collectionCipherRepository = collectionCipherRepository;
         _securityTaskRepository = securityTaskRepository;
         _pushService = pushService;
         _attachmentStorageService = attachmentStorageService;
         _eventService = eventService;
         _userService = userService;
-        _policyService = policyService;
         _globalSettings = globalSettings;
         _getCipherPermissionsForUserQuery = getCipherPermissionsForUserQuery;
         _policyRequirementQuery = policyRequirementQuery;
@@ -152,11 +144,10 @@ public class CipherService : ICipherService
             }
             else
             {
-                var organizationDataOwnershipEnabled = _featureService.IsEnabled(FeatureFlagKeys.PolicyRequirements)
-                    ? (await _policyRequirementQuery.GetAsync<OrganizationDataOwnershipPolicyRequirement>(savingUserId)).State == OrganizationDataOwnershipState.Enabled
-                    : await _policyService.AnyPoliciesApplicableToUserAsync(savingUserId, PolicyType.OrganizationDataOwnership);
+                var organizationDataOwnershipPolicyRequirement =
+                    await _policyRequirementQuery.GetAsync<OrganizationDataOwnershipPolicyRequirement>(savingUserId);
 
-                if (organizationDataOwnershipEnabled)
+                if (organizationDataOwnershipPolicyRequirement.State == OrganizationDataOwnershipState.Enabled)
                 {
                     throw new BadRequestException("Due to an Enterprise Policy, you are restricted from saving items to your personal vault.");
                 }

--- a/test/Core.Test/Tools/ImportFeatures/ImportCiphersAsyncCommandTests.cs
+++ b/test/Core.Test/Tools/ImportFeatures/ImportCiphersAsyncCommandTests.cs
@@ -1,14 +1,11 @@
 ﻿using Bit.Core.AdminConsole.Entities;
-using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
-using Bit.Core.AdminConsole.Services;
 using Bit.Core.Entities;
 using Bit.Core.Exceptions;
 using Bit.Core.Platform.Push;
 using Bit.Core.Repositories;
-using Bit.Core.Services;
 using Bit.Core.Test.AutoFixture.CipherFixtures;
 using Bit.Core.Tools.ImportFeatures;
 using Bit.Core.Vault.Entities;
@@ -26,43 +23,11 @@ namespace Bit.Core.Test.Tools.ImportFeatures;
 public class ImportCiphersAsyncCommandTests
 {
     [Theory, BitAutoData]
-    public async Task ImportIntoIndividualVaultAsync_Success(
+    public async Task ImportIntoIndividualVaultAsync_WithOrganizationDataOwnershipPolicyDisabled_Success(
         Guid importingUserId,
         List<CipherDetails> ciphers,
         SutProvider<ImportCiphersCommand> sutProvider)
     {
-        sutProvider.GetDependency<IPolicyService>()
-            .AnyPoliciesApplicableToUserAsync(importingUserId, PolicyType.OrganizationDataOwnership)
-            .Returns(false);
-
-        sutProvider.GetDependency<IFolderRepository>()
-            .GetManyByUserIdAsync(importingUserId)
-            .Returns(new List<Folder>());
-
-        var folders = new List<Folder> { new Folder { UserId = importingUserId } };
-
-        var folderRelationships = new List<KeyValuePair<int, int>>();
-
-        // Act
-        await sutProvider.Sut.ImportIntoIndividualVaultAsync(folders, ciphers, folderRelationships, importingUserId);
-
-        // Assert
-        await sutProvider.GetDependency<ICipherRepository>()
-            .Received(1)
-            .CreateAsync(importingUserId, ciphers, Arg.Any<List<Folder>>());
-        await sutProvider.GetDependency<IPushNotificationService>().Received(1).PushSyncVaultAsync(importingUserId);
-    }
-
-    [Theory, BitAutoData]
-    public async Task ImportIntoIndividualVaultAsync_WithPolicyRequirementsEnabled_WithOrganizationDataOwnershipPolicyDisabled_Success(
-        Guid importingUserId,
-        List<CipherDetails> ciphers,
-        SutProvider<ImportCiphersCommand> sutProvider)
-    {
-        sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.PolicyRequirements)
-            .Returns(true);
-
         sutProvider.GetDependency<IPolicyRequirementQuery>()
             .GetAsync<OrganizationDataOwnershipPolicyRequirement>(importingUserId)
             .Returns(new OrganizationDataOwnershipPolicyRequirement(
@@ -86,7 +51,7 @@ public class ImportCiphersAsyncCommandTests
     }
 
     [Theory, BitAutoData]
-    public async Task ImportIntoIndividualVaultAsync_ThrowsBadRequestException(
+    public async Task ImportIntoIndividualVaultAsync_WithOrganizationDataOwnershipPolicyEnabled_ThrowsBadRequestException(
         List<Folder> folders,
         List<CipherDetails> ciphers,
         SutProvider<ImportCiphersCommand> sutProvider)
@@ -94,32 +59,6 @@ public class ImportCiphersAsyncCommandTests
         var userId = Guid.NewGuid();
         folders.ForEach(f => f.UserId = userId);
         ciphers.ForEach(c => c.UserId = userId);
-
-        sutProvider.GetDependency<IPolicyService>()
-            .AnyPoliciesApplicableToUserAsync(userId, PolicyType.OrganizationDataOwnership)
-            .Returns(true);
-
-        var folderRelationships = new List<KeyValuePair<int, int>>();
-
-        var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
-            sutProvider.Sut.ImportIntoIndividualVaultAsync(folders, ciphers, folderRelationships, userId));
-
-        Assert.Equal("You cannot import items into your personal vault because you are a member of an organization which forbids it.", exception.Message);
-    }
-
-    [Theory, BitAutoData]
-    public async Task ImportIntoIndividualVaultAsync_WithPolicyRequirementsEnabled_WithOrganizationDataOwnershipPolicyEnabled_ThrowsBadRequestException(
-        List<Folder> folders,
-        List<CipherDetails> ciphers,
-        SutProvider<ImportCiphersCommand> sutProvider)
-    {
-        var userId = Guid.NewGuid();
-        folders.ForEach(f => f.UserId = userId);
-        ciphers.ForEach(c => c.UserId = userId);
-
-        sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.PolicyRequirements)
-            .Returns(true);
 
         sutProvider.GetDependency<IPolicyRequirementQuery>()
             .GetAsync<OrganizationDataOwnershipPolicyRequirement>(userId)
@@ -142,10 +81,6 @@ public class ImportCiphersAsyncCommandTests
         SutProvider<ImportCiphersCommand> sutProvider
     )
     {
-        sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.PolicyRequirements)
-            .Returns(true);
-
         sutProvider.GetDependency<IPolicyRequirementQuery>()
             .GetAsync<OrganizationDataOwnershipPolicyRequirement>(importingUserId)
             .Returns(new OrganizationDataOwnershipPolicyRequirement(
@@ -337,9 +272,11 @@ public class ImportCiphersAsyncCommandTests
         ciphers[0].UserId = importingUserId;
         ciphers[0].ArchivedDate = archivedDate;
 
-        sutProvider.GetDependency<IPolicyService>()
-            .AnyPoliciesApplicableToUserAsync(importingUserId, PolicyType.OrganizationDataOwnership)
-            .Returns(false);
+        sutProvider.GetDependency<IPolicyRequirementQuery>()
+            .GetAsync<OrganizationDataOwnershipPolicyRequirement>(importingUserId)
+            .Returns(new OrganizationDataOwnershipPolicyRequirement(
+                OrganizationDataOwnershipState.Disabled,
+                []));
 
         sutProvider.GetDependency<IFolderRepository>()
             .GetManyByUserIdAsync(importingUserId)

--- a/test/Core.Test/Vault/Services/CipherServiceTests.cs
+++ b/test/Core.Test/Vault/Services/CipherServiceTests.cs
@@ -4,7 +4,6 @@ using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
-using Bit.Core.AdminConsole.Services;
 using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Pricing;
 using Bit.Core.Billing.Pricing.Premium;
@@ -238,9 +237,11 @@ public class CipherServiceTests
         cipher.UserId = savingUserId;
         cipher.OrganizationId = null;
 
-        sutProvider.GetDependency<IPolicyService>()
-            .AnyPoliciesApplicableToUserAsync(savingUserId, PolicyType.OrganizationDataOwnership)
-            .Returns(true);
+        sutProvider.GetDependency<IPolicyRequirementQuery>()
+            .GetAsync<OrganizationDataOwnershipPolicyRequirement>(savingUserId)
+            .Returns(new OrganizationDataOwnershipPolicyRequirement(
+                OrganizationDataOwnershipState.Enabled,
+                [new PolicyDetails()]));
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.SaveDetailsAsync(cipher, savingUserId, null));
@@ -257,58 +258,6 @@ public class CipherServiceTests
         cipher.Id = default;
         cipher.UserId = savingUserId;
         cipher.OrganizationId = null;
-
-        sutProvider.GetDependency<IPolicyService>()
-            .AnyPoliciesApplicableToUserAsync(savingUserId, PolicyType.OrganizationDataOwnership)
-            .Returns(false);
-
-        await sutProvider.Sut.SaveDetailsAsync(cipher, savingUserId, null);
-
-        await sutProvider.GetDependency<ICipherRepository>()
-            .Received(1)
-            .CreateAsync(cipher);
-    }
-
-    [Theory]
-    [BitAutoData]
-    public async Task SaveDetailsAsync_PersonalVault_WithPolicyRequirementsEnabled_WithOrganizationDataOwnershipPolicyEnabled_Throws(
-        SutProvider<CipherService> sutProvider,
-        CipherDetails cipher,
-        Guid savingUserId)
-    {
-        cipher.Id = default;
-        cipher.UserId = savingUserId;
-        cipher.OrganizationId = null;
-
-        sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.PolicyRequirements)
-            .Returns(true);
-
-        sutProvider.GetDependency<IPolicyRequirementQuery>()
-            .GetAsync<OrganizationDataOwnershipPolicyRequirement>(savingUserId)
-            .Returns(new OrganizationDataOwnershipPolicyRequirement(
-                OrganizationDataOwnershipState.Enabled,
-                [new PolicyDetails()]));
-
-        var exception = await Assert.ThrowsAsync<BadRequestException>(
-            () => sutProvider.Sut.SaveDetailsAsync(cipher, savingUserId, null));
-        Assert.Contains("restricted from saving items to your personal vault", exception.Message);
-    }
-
-    [Theory]
-    [BitAutoData]
-    public async Task SaveDetailsAsync_PersonalVault_WithPolicyRequirementsEnabled_WithOrganizationDataOwnershipPolicyDisabled_Succeeds(
-        SutProvider<CipherService> sutProvider,
-        CipherDetails cipher,
-        Guid savingUserId)
-    {
-        cipher.Id = default;
-        cipher.UserId = savingUserId;
-        cipher.OrganizationId = null;
-
-        sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.PolicyRequirements)
-            .Returns(true);
 
         sutProvider.GetDependency<IPolicyRequirementQuery>()
             .GetAsync<OrganizationDataOwnershipPolicyRequirement>(savingUserId)


### PR DESCRIPTION
## 🎟️ Tracking
[PM-33212](https://bitwarden.atlassian.net/browse/PM-33212)

## 📔 Objective
AC is moving on from the PolicyRequirements feature flag, and committing to its removal (and subsequent enablement).

This PR handles the code around the organization data ownership flag, and is now using PolicyRequirements where it can. The majority of this PR was spent removing tests that are no longer applicable.


[PM-33212]: https://bitwarden.atlassian.net/browse/PM-33212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ