### PR TITLE
SHOT-71: Migrate self-host ownership over to SHOT

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 
 # Multiple owners
 .devcontainer/**
-dev/docker-compose.yml @bitwarden/dept-bre
+dev/docker-compose.yml
 
 # Scanning tools
 .checkmarx/ @bitwarden/team-appsec

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,10 +11,6 @@
 **/docker-compose.yml @bitwarden/team-appsec @bitwarden/dept-shot
 **/entrypoint.sh @bitwarden/team-appsec @bitwarden/dept-shot
 
-# Multiple owners
-.devcontainer/**
-dev/docker-compose.yml
-
 # Scanning tools
 .checkmarx/ @bitwarden/team-appsec
 
@@ -116,6 +112,8 @@ util/RustSdk @bitwarden/team-sdk-sme
 # Multiple owners - DO NOT REMOVE (BRE)
 **/packages.lock.json
 Directory.Build.props
+.devcontainer/**
+dev/docker-compose.yml
 
 # Claude related files
 .claude/ @bitwarden/team-ai-sme

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,11 +5,15 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 ## Docker-related files
-**/Dockerfile @bitwarden/team-appsec @bitwarden/dept-bre
-**/*.Dockerfile @bitwarden/team-appsec @bitwarden/dept-bre
-**/*.dockerignore @bitwarden/team-appsec @bitwarden/dept-bre
-**/docker-compose.yml @bitwarden/team-appsec @bitwarden/dept-bre
-**/entrypoint.sh @bitwarden/team-appsec @bitwarden/dept-bre
+**/Dockerfile @bitwarden/team-appsec @bitwarden/dept-shot
+**/*.Dockerfile @bitwarden/team-appsec @bitwarden/dept-shot
+**/*.dockerignore @bitwarden/team-appsec @bitwarden/dept-shot
+**/docker-compose.yml @bitwarden/team-appsec @bitwarden/dept-shot
+**/entrypoint.sh @bitwarden/team-appsec @bitwarden/dept-shot
+
+# Dev environment Docker-related files
+.devcontainer/** @bitwarden/dept-bre
+dev/docker-compose.yml @bitwarden/dept-bre
 
 # Scanning tools
 .checkmarx/ @bitwarden/team-appsec
@@ -35,7 +39,8 @@ util/SqlServerEFScaffold/** @bitwarden/dept-dbops
 util/SqliteMigrations/** @bitwarden/dept-dbops
 
 # Shared util projects
-util/Setup/** @bitwarden/dept-bre @bitwarden/team-platform-dev
+util/MsSqlMigratorUtility/** @bitwarden/team-platform-dev
+util/Setup/** @bitwarden/dept-shot @bitwarden/team-platform-dev
 
 # UIF
 src/Core/MailTemplates/Mjml @bitwarden/team-ui-foundation # Teams are expected to own sub-directories of this project

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,8 +11,8 @@
 **/docker-compose.yml @bitwarden/team-appsec @bitwarden/dept-shot
 **/entrypoint.sh @bitwarden/team-appsec @bitwarden/dept-shot
 
-# Dev environment Docker-related files
-.devcontainer/** @bitwarden/dept-bre
+# Multiple owners
+.devcontainer/**
 dev/docker-compose.yml @bitwarden/dept-bre
 
 # Scanning tools


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/SHOT-71
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
This moves the ownership from @bitwarden/dept-bre to @bitwarden/dept-shot for Self-host components following the outline here https://bitwarden.atlassian.net/wiki/spaces/SHOT/pages/1333362690/Self-host+ownership.


<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
