### PR TITLE
Update the Seeder update skill removing references to unused crates

### DIFF
--- a/.claude/skills/bump-rust-sdk/SKILL.md
+++ b/.claude/skills/bump-rust-sdk/SKILL.md
@@ -7,12 +7,14 @@ description: This skill should be used when the user asks to "bump the Rust SDK"
 
 ## Overview
 
-The server's `util/RustSdk/rust/Cargo.toml` pins three crates from the `bitwarden/sdk-internal`
-repository by git rev: `bitwarden-core`, `bitwarden-crypto`, and `bitwarden-vault`. These must
-be periodically bumped to stay aligned with the Bitwarden client applications.
+The server's `util/RustSdk/rust/Cargo.toml` pins `bitwarden-crypto` from the
+`bitwarden/sdk-internal` repository by git rev. This must be periodically bumped to stay
+aligned with the Bitwarden client applications.
 
 The RustSdk is used by the Seeder to produce cryptographically correct Protected Data for
-integration testing. It is NOT part of the production server runtime.
+integration testing. It is NOT part of the production server runtime. The Rust layer provides
+generic field-level encryption (`encrypt_string`, `decrypt_string`, `encrypt_fields`) and
+key generation — the C# Seeder drives which fields to encrypt via `EncryptPropertyAttribute`.
 
 ## Key Challenge: NPM-to-Git-Rev Mapping
 
@@ -60,19 +62,19 @@ Query the GitHub Actions API to find the commit that produced that NPM build. Se
 
 ### Step 3: Analyze Breaking Changes
 
-Compare the current pinned rev against the target rev, focusing on the three crates:
+Compare the current pinned rev against the target rev, focusing on `bitwarden-crypto`:
 
 ```bash
 cd /path/to/sdk-internal
-git log --oneline <old-rev>..<new-rev> -- crates/bitwarden-core crates/bitwarden-crypto crates/bitwarden-vault
+git log --oneline <old-rev>..<new-rev> -- crates/bitwarden-crypto
 ```
 
 Cross-reference each commit against the API surface documented in `references/api-surface.md`.
 
 ### Step 4: Apply Changes
 
-1. Update `Cargo.toml` — bump all three rev pins to the same SHA
-2. Fix any compilation errors from breaking changes (type renames, new struct fields, etc.)
+1. Update `Cargo.toml` — bump the `bitwarden-crypto` rev pin to the new SHA
+2. Fix any compilation errors from breaking changes (type renames, new parameters, etc.)
 3. Add `#[allow(deprecated)]` for any newly-deprecated APIs (with a comment explaining why)
 
 ### Step 5: Build and Verify (Claude)
@@ -119,7 +121,7 @@ Two mechanisms enforce this:
    modified but `api-surface.md` was not updated in the same session.
 
 To regenerate: read all `.rs` files in `util/RustSdk/rust/src/`, extract every `use` statement
-from the three bitwarden crates, and rewrite `references/api-surface.md` to match.
+from `bitwarden_crypto`, and rewrite `references/api-surface.md` to match.
 
 ## Additional Resources
 
@@ -129,13 +131,13 @@ from the three bitwarden crates, and rewrite `references/api-surface.md` to matc
   queries, breaking change analysis checklist, human verification commands, and a worked example
   from the Feb 2026 bump
 - **`references/api-surface.md`** — Complete inventory of types, traits, and functions the RustSdk
-  imports from each crate, used to assess breaking change impact
+  imports from `bitwarden-crypto`, used to assess breaking change impact
 
 ## Files Modified in a Typical Bump
 
-| File                              | Change                                             |
-| --------------------------------- | -------------------------------------------------- |
-| `util/RustSdk/rust/Cargo.toml`    | Rev pin update                                     |
-| `util/RustSdk/rust/src/*.rs`      | Type renames, new struct fields, deprecation fixes |
-| `util/RustSdk/rust/Cargo.lock`    | Auto-regenerated (commit alongside)                |
-| `util/RustSdk/NativeMethods.g.cs` | Should NOT change (verify)                         |
+| File                              | Change                                          |
+| --------------------------------- | ----------------------------------------------- |
+| `util/RustSdk/rust/Cargo.toml`    | `bitwarden-crypto` rev pin update               |
+| `util/RustSdk/rust/src/*.rs`      | Type renames, new parameters, deprecation fixes |
+| `util/RustSdk/rust/Cargo.lock`    | Auto-regenerated (commit alongside)             |
+| `util/RustSdk/NativeMethods.g.cs` | Should NOT change (verify)                      |

--- a/.claude/skills/bump-rust-sdk/references/api-surface.md
+++ b/.claude/skills/bump-rust-sdk/references/api-surface.md
@@ -3,72 +3,58 @@
 > **Auto-generated from actual source files.** Last updated: 2026-02-25
 > Pinned rev: `abba7fdab687753268b63248ec22639dff35d07c`
 
-This documents every type, trait, and function the server's RustSdk imports from the three
-sdk-internal crates. Use this to assess breaking change impact when bumping revs.
+This documents every type, trait, and function the server's RustSdk imports from
+`bitwarden-crypto`. Use this to assess breaking change impact when bumping revs.
 
 **Location:** `util/RustSdk/rust/src/`
 
-## bitwarden-crypto (primary dependency)
+## bitwarden-crypto
 
-### Types Used
+### Types Used — lib.rs (key generation and management)
 
-| Type                      | File              | Usage                                                                                        |
-| ------------------------- | ----------------- | -------------------------------------------------------------------------------------------- |
-| `BitwardenLegacyKeyBytes` | lib.rs, cipher.rs | `BitwardenLegacyKeyBytes::from()` — wraps raw key bytes for `SymmetricCryptoKey::try_from()` |
-| `HashPurpose`             | lib.rs            | `HashPurpose::ServerAuthorization` enum variant                                              |
-| `Kdf`                     | lib.rs            | `Kdf::PBKDF2 { iterations }` enum variant with `NonZeroU32`                                  |
-| `KeyStore`                | cipher.rs         | `KeyStore::<KeyIds>::default()`, `.context_mut()`, `.add_local_symmetric_key()`              |
-| `MasterKey`               | lib.rs            | `MasterKey::derive()`, `.derive_master_key_hash()`, `.make_user_key()`                       |
-| `PrivateKey`              | lib.rs            | `PrivateKey::from_pem()`, `.to_public_key()`, `.to_der()`                                    |
-| `PublicKey`               | lib.rs            | `PublicKey::from_der()`                                                                      |
-| `RsaKeyPair`              | lib.rs            | Struct literal: `RsaKeyPair { private, public }`                                             |
-| `SpkiPublicKeyBytes`      | lib.rs            | `SpkiPublicKeyBytes::from()` — wraps public key DER bytes                                    |
-| `SymmetricCryptoKey`      | lib.rs, cipher.rs | `.make_aes256_cbc_hmac_key()`, `::try_from()`, `.to_base64()`                                |
-| `UnsignedSharedKey`       | lib.rs            | `::encapsulate_key_unsigned()` (deprecated — wrapped with `#[allow(deprecated)]`)            |
-| `UserKey`                 | lib.rs            | `UserKey::new()`, `.make_key_pair()`, `.0` field access                                      |
+| Type                      | Usage                                                                                        |
+| ------------------------- | -------------------------------------------------------------------------------------------- |
+| `BitwardenLegacyKeyBytes` | `BitwardenLegacyKeyBytes::from()` — wraps raw key bytes for `SymmetricCryptoKey::try_from()` |
+| `HashPurpose`             | `HashPurpose::ServerAuthorization` enum variant                                              |
+| `Kdf`                     | `Kdf::PBKDF2 { iterations }` enum variant with `NonZeroU32`                                  |
+| `MasterKey`               | `MasterKey::derive()`, `.derive_master_key_hash()`, `.make_user_key()`                       |
+| `PrivateKey`              | `PrivateKey::from_pem()`, `.to_public_key()`, `.to_der()`                                    |
+| `PublicKey`               | `PublicKey::from_der()`                                                                      |
+| `RsaKeyPair`              | Struct literal: `RsaKeyPair { private, public }`                                             |
+| `SpkiPublicKeyBytes`      | `SpkiPublicKeyBytes::from()` — wraps public key DER bytes                                    |
+| `SymmetricCryptoKey`      | `.make_aes256_cbc_hmac_key()`, `::try_from()`, `.to_base64()`                                |
+| `UnsignedSharedKey`       | `::encapsulate_key_unsigned()` (deprecated — wrapped with `#[allow(deprecated)]`)            |
+| `UserKey`                 | `UserKey::new()`, `.make_key_pair()`, `.0` field access                                      |
+
+### Types Used — cipher.rs (field-level encryption)
+
+| Type                      | Usage                                                                                           |
+| ------------------------- | ----------------------------------------------------------------------------------------------- |
+| `BitwardenLegacyKeyBytes` | `BitwardenLegacyKeyBytes::from()` — wraps raw key bytes for `SymmetricCryptoKey::try_from()`    |
+| `EncString`               | `enc_str.parse::<EncString>()`, `.to_string()` — parsed from and serialized to EncString format |
+| `SymmetricCryptoKey`      | `::try_from()`, `.make_aes256_cbc_hmac_key()`, `.to_base64()` — key construction and testing    |
 
 ### Traits Used
 
-| Trait                  | File              | Methods Called                                                             |
-| ---------------------- | ----------------- | -------------------------------------------------------------------------- |
-| `KeyEncryptable`       | lib.rs, cipher.rs | `.encrypt_with_key(&key)` — encrypts DER bytes and strings                 |
-| `CompositeEncryptable` | cipher.rs         | `.encrypt_composite(&mut ctx, key_id)` — encrypts `CipherView` -> `Cipher` |
-| `Decryptable`          | cipher.rs         | `.decrypt(&mut ctx, key_id)` — decrypts `Cipher` -> `CipherView`           |
+| Trait            | File      | Methods Called                                                       |
+| ---------------- | --------- | -------------------------------------------------------------------- |
+| `KeyEncryptable` | lib.rs    | `.encrypt_with_key(&key)` — encrypts DER bytes and strings           |
+| `KeyEncryptable` | cipher.rs | `.encrypt_with_key(&key)` — encrypts plaintext strings to EncStrings |
+| `KeyDecryptable` | cipher.rs | `.decrypt_with_key(&key)` — decrypts EncString back to plaintext     |
 
-## bitwarden-core (minimal dependency)
+## FFI Functions Exposed
 
-| Type                     | File      | Usage                                        |
-| ------------------------ | --------- | -------------------------------------------- |
-| `key_management::KeyIds` | cipher.rs | Generic type parameter: `KeyStore::<KeyIds>` |
+The Rust layer exposes these functions to C# via csbindgen:
 
-## bitwarden-vault (data model dependency)
-
-### Production Code
-
-| Type         | File      | Usage                                                 |
-| ------------ | --------- | ----------------------------------------------------- |
-| `Cipher`     | cipher.rs | Protected Data container (encrypted), deserialized from JSON via serde |
-| `CipherView` | cipher.rs | Vault Data in Use (decrypted view), serialized to/from JSON via serde  |
-
-### Test-Only Types
-
-| Type                 | File            | Usage                                                                                                                                      |
-| -------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `CipherRepromptType` | cipher.rs tests | `CipherRepromptType::None` enum variant                                                                                                    |
-| `CipherType`         | cipher.rs tests | `CipherType::Login` enum variant                                                                                                           |
-| `LoginView`          | cipher.rs tests | Struct literal with fields: `username`, `password`, `password_revision_date`, `uris`, `totp`, `autofill_on_page_load`, `fido2_credentials` |
-
-### CipherView Fields (used in test struct literal)
-
-The test helper `create_test_cipher_view()` constructs a `CipherView` with these fields:
-
-`id`, `organization_id`, `folder_id`, `collection_ids`, `key`, `name`, `notes`, `type`,
-`login`, `identity`, `card`, `secure_note`, `ssh_key`, `favorite`, `reprompt`,
-`organization_use_totp`, `edit`, `permissions`, `view_password`, `local_data`, `attachments`,
-`attachment_decryption_failures`, `fields`, `password_history`, `creation_date`, `deleted_date`,
-`revision_date`, `archived_date`
-
-Any new required field added to `CipherView` upstream will break this struct literal.
+| Function                         | File      | Purpose                                                   |
+| -------------------------------- | --------- | --------------------------------------------------------- |
+| `generate_user_keys`             | lib.rs    | Derive master key, user key, key pair from email/password |
+| `generate_organization_keys`     | lib.rs    | Generate org symmetric key + RSA key pair                 |
+| `generate_user_organization_key` | lib.rs    | Encapsulate org key with user's public key (unsigned)     |
+| `encrypt_string`                 | cipher.rs | Encrypt a single plaintext string with a symmetric key    |
+| `decrypt_string`                 | cipher.rs | Decrypt an EncString with a symmetric key                 |
+| `encrypt_fields`                 | cipher.rs | Encrypt specified fields in a JSON object by dot-path     |
+| `free_c_string`                  | lib.rs    | Free a C string returned by any of the above functions    |
 
 ## Breaking Change Risk Matrix
 
@@ -77,9 +63,9 @@ When reviewing upstream commits, prioritize checking for changes to:
 **Critical (compilation failure):**
 
 - Any type rename or removal listed above
-- New required fields on `CipherView`, `Cipher`, or `LoginView`
-- Changes to `KeyStore` generic parameters or `context_mut()` method
-- Changes to encryption/decryption trait method signatures
+- Changes to `EncString` parsing or serialization format
+- Changes to `KeyEncryptable` or `KeyDecryptable` trait method signatures
+- Changes to `SymmetricCryptoKey::try_from()` or `BitwardenLegacyKeyBytes`
 
 **High (runtime failure):**
 
@@ -96,21 +82,12 @@ When reviewing upstream commits, prioritize checking for changes to:
 **Low (transparent):**
 
 - Internal implementation changes that don't affect the public API
-- New optional fields on structs (serde defaults to `None` for `Option<T>`)
 - New methods added to existing types (additive, non-breaking)
 
 ## How to Check for Changes
-
-For each crate, check the public API exports:
 
 ```bash
 cd /path/to/sdk-internal
 # bitwarden-crypto public API
 git diff <old>..<new> -- crates/bitwarden-crypto/src/lib.rs crates/bitwarden-crypto/src/keys/mod.rs
-
-# bitwarden-vault Cipher/CipherView changes
-git diff <old>..<new> -- crates/bitwarden-vault/src/cipher/cipher.rs crates/bitwarden-vault/src/cipher/login.rs
-
-# bitwarden-core KeyIds
-git diff <old>..<new> -- crates/bitwarden-core/src/key_management/mod.rs
 ```

--- a/.claude/skills/bump-rust-sdk/references/methodology.md
+++ b/.claude/skills/bump-rust-sdk/references/methodology.md
@@ -8,9 +8,6 @@
 grep 'rev = ' util/RustSdk/rust/Cargo.toml
 ```
 
-All three crates (`bitwarden-core`, `bitwarden-crypto`, `bitwarden-vault`) must always pin to
-the **same rev**. If they don't, something is wrong.
-
 ### 2. Identify the Target Version from Clients
 
 Determine the latest production release tag from the clients repo:
@@ -62,35 +59,32 @@ This shows when the current pin was made and what commit it corresponds to.
 
 ### 5. Analyze Breaking Changes
 
-List all commits touching the three crates between the old and new revs:
+List all commits touching `bitwarden-crypto` between the old and new revs:
 
 ```bash
 cd /path/to/sdk-internal
-git log --oneline <old-rev>..<new-rev> -- \
-  crates/bitwarden-core crates/bitwarden-crypto crates/bitwarden-vault
+git log --oneline <old-rev>..<new-rev> -- crates/bitwarden-crypto
 ```
 
 For each commit, check for:
 
 - **Type renames** (e.g., `AsymmetricCryptoKey` -> `PrivateKey`)
-- **New required struct fields** (e.g., new `Option<T>` fields on `CipherView`)
 - **Removed or deprecated functions** (look for `#[deprecated]` annotations)
 - **Changed function signatures** (parameter types, return types)
 - **Trait changes** (new required methods, changed generic bounds)
 
-To check the public API diff for a specific crate:
+To check the public API diff:
 
 ```bash
 git diff <old-rev>..<new-rev> -- crates/bitwarden-crypto/src/keys/mod.rs
 git diff <old-rev>..<new-rev> -- crates/bitwarden-crypto/src/lib.rs
-git diff <old-rev>..<new-rev> -- crates/bitwarden-vault/src/cipher/cipher.rs
 ```
 
 Cross-reference findings against `references/api-surface.md` to assess impact.
 
 ### 6. Apply Code Changes
 
-1. **Cargo.toml** — Update all three `rev = "..."` to the new SHA
+1. **Cargo.toml** — Update the `bitwarden-crypto` `rev = "..."` to the new SHA
 2. **Rust source files** — Fix compilation errors from breaking changes
 3. **Deprecation warnings** — Add `#[allow(deprecated)]` with a comment explaining why
 4. Do NOT make unrelated formatting or style changes
@@ -119,8 +113,8 @@ dotnet test test/SeederApi.IntegrationTest/
 cargo fmt --check
 ```
 
-**Key validation:** The `encrypt_decrypt_roundtrip_preserves_plaintext` test proves the new SDK
-version correctly encrypts and decrypts Vault Data. If this passes, the crypto is working.
+**Key validation:** The `encrypt_string_decrypt_string_roundtrip` test proves the new SDK
+version correctly encrypts and decrypts data. If this passes, the crypto is working.
 
 ### 8. Human Verification (HUMAN ONLY — Claude does NOT run these)
 
@@ -183,13 +177,12 @@ This section documents the actual bump performed in Feb 2026 as a reference.
 
 ### Breaking Changes Found
 
-| Change                                                    | Impact                                   | Fix                                        |
-| --------------------------------------------------------- | ---------------------------------------- | ------------------------------------------ |
-| `AsymmetricCryptoKey` renamed to `PrivateKey`             | Import + usage in lib.rs                 | Rename type                                |
-| `AsymmetricPublicCryptoKey` renamed to `PublicKey`        | Import + usage in lib.rs                 | Rename type                                |
-| `CipherView` added `attachment_decryption_failures` field | Test struct literal in cipher.rs         | Add `attachment_decryption_failures: None` |
-| `PrivateKey::to_der()` returns `Pkcs8PrivateKeyBytes`     | Low risk — auto-refs to `KeyEncryptable` | No code change needed                      |
-| `encapsulate_key_unsigned` deprecated                     | Deprecation warning                      | `#[allow(deprecated)]` + comment           |
+| Change                                                | Impact                           | Fix                                      |
+| ----------------------------------------------------- | -------------------------------- | ---------------------------------------- |
+| `AsymmetricCryptoKey` renamed to `PrivateKey`          | Import + usage in lib.rs         | Rename type                              |
+| `AsymmetricPublicCryptoKey` renamed to `PublicKey`     | Import + usage in lib.rs         | Rename type                              |
+| `PrivateKey::to_der()` returns `Pkcs8PrivateKeyBytes` | Low risk — auto-refs             | No code change needed                    |
+| `encapsulate_key_unsigned` deprecated                  | Deprecation warning              | `#[allow(deprecated)]` + comment         |
 
 ### Cargo.lock Review
 
@@ -200,7 +193,7 @@ This section documents the actual bump performed in Feb 2026 as a reference.
 
 ### Results
 
-- 7/7 Rust unit tests passed
-- 65/65 C# integration tests passed
+- All Rust unit tests passed
+- All C# integration tests passed
 - NativeMethods.g.cs unchanged
 - Human verification: login, vault decryption, seeding all confirmed working


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31013](https://bitwarden.atlassian.net/browse/PM-31013)

## 📔 Objective

In #7211, we decoupled internal only crates from use within the Seeder. We now need to update our Seeder update `SKILL.md` and supporting documentation. 

[PM-31013]: https://bitwarden.atlassian.net/browse/PM-31013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ