### PR TITLE
[PM-33415] Fix add-on items being billed immediately instead of prorated

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/Organizations/BulkUpdateOrganizationSubscriptionsCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Organizations/BulkUpdateOrganizationSubscriptionsCommand.cs
@@ -27,9 +27,9 @@ public class BulkUpdateOrganizationSubscriptionsCommand(
         {
             if (useUpdateOrganizationSubscriptionCommand)
             {
-                var changeSet = OrganizationSubscriptionChangeSet.UpdatePasswordManagerSeats(
-                    subscriptionUpdate.Plan!,
-                    subscriptionUpdate.Seats);
+                var changeSet = OrganizationSubscriptionChangeSet.Builder(subscriptionUpdate.Plan!)
+                    .UpdatePasswordManagerSeats(subscriptionUpdate.Seats)
+                    .Build();
 
                 var result =
                     await updateOrganizationSubscriptionCommand.Run(subscriptionUpdate.Organization, changeSet);

--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -157,7 +157,8 @@ public class OrganizationService : IOrganizationService
             organization,
             storageAdjustmentGb,
             plan.PasswordManager.StripeStoragePlanId,
-            plan.PasswordManager.BaseStorageGb);
+            plan.PasswordManager.BaseStorageGb,
+            plan);
         await ReplaceAndUpdateCacheAsync(organization);
         return secret;
     }
@@ -308,7 +309,9 @@ public class OrganizationService : IOrganizationService
 
         if (_featureService.IsEnabled(FeatureFlagKeys.PM32581_UseUpdateOrganizationSubscriptionCommand))
         {
-            var changeSet = OrganizationSubscriptionChangeSet.UpdatePasswordManagerSeats(plan, additionalSeats);
+            var changeSet = OrganizationSubscriptionChangeSet.Builder(plan)
+                .UpdatePasswordManagerSeats(additionalSeats)
+                .Build();
             var result = await _updateOrganizationSubscriptionCommand.Run(organization, changeSet);
             result.GetValueOrThrow();
         }

--- a/src/Core/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommand.cs
+++ b/src/Core/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommand.cs
@@ -78,7 +78,7 @@ public class UpdateOrganizationSubscriptionCommand(
 
         await ReconcileTaxExemptionAsync(subscription.Customer);
 
-        var hasStructuralChanges = changeSet.Changes.Any(change => change.IsStructural);
+        var hasStructuralChanges = changeSet.ChargeImmediately;
         var isChargedAutomatically = subscription.CollectionMethod == CollectionMethod.ChargeAutomatically;
         var isBilledAnnually = subscription.Items.FirstOrDefault()?.Price.Recurring?.Interval == Intervals.Year;
 

--- a/src/Core/Billing/Organizations/Commands/UpgradeOrganizationPlanVNextCommand.cs
+++ b/src/Core/Billing/Organizations/Commands/UpgradeOrganizationPlanVNextCommand.cs
@@ -103,30 +103,22 @@ public class UpgradeOrganizationPlanVNextCommand(
             return new None();
         }
 
-        var builder = OrganizationSubscriptionChangeSet.Builder();
+        var builder = OrganizationSubscriptionChangeSet.Builder(currentPlan);
 
-        builder.ChangeItemPrice(
-            GetPasswordManagerPriceId(currentPlan),
-            GetPasswordManagerPriceId(plan));
+        builder.ChangePasswordManagerPrice(plan);
 
         if (organization.MaxStorageGb > currentPlan.PasswordManager.BaseStorageGb)
         {
-            builder.ChangeItemPrice(
-                currentPlan.PasswordManager.StripeStoragePlanId,
-                plan.PasswordManager.StripeStoragePlanId);
+            builder.ChangeStoragePrice(plan);
         }
 
         if (organization.UseSecretsManager)
         {
-            builder.ChangeItemPrice(
-                currentPlan.SecretsManager.StripeSeatPlanId,
-                plan.SecretsManager.StripeSeatPlanId);
+            builder.ChangeSecretsManagerSeatPrice(plan);
 
             if (organization.SmServiceAccounts > currentPlan.SecretsManager.BaseServiceAccount)
             {
-                builder.ChangeItemPrice(
-                    currentPlan.SecretsManager.StripeServiceAccountPlanId,
-                    plan.SecretsManager.StripeServiceAccountPlanId);
+                builder.ChangeServiceAccountPrice(plan);
             }
         }
 
@@ -142,11 +134,6 @@ public class UpgradeOrganizationPlanVNextCommand(
 
         return result.Map(_ => new None());
     });
-
-    private static string GetPasswordManagerPriceId(Plan plan) =>
-        plan.HasNonSeatBasedPasswordManagerPlan()
-            ? plan.PasswordManager.StripePlanId
-            : plan.PasswordManager.StripeSeatPlanId;
 
     private async Task UpdateOrganizationFeaturesAsync(
         Organization organization,

--- a/src/Core/Billing/Organizations/Models/OrganizationSubscriptionChangeSet.cs
+++ b/src/Core/Billing/Organizations/Models/OrganizationSubscriptionChangeSet.cs
@@ -1,4 +1,4 @@
-﻿using Bit.Core.Models.StaticStore;
+using Bit.Core.Models.StaticStore;
 using OneOf;
 
 namespace Bit.Core.Billing.Organizations.Models;
@@ -9,7 +9,7 @@ namespace Bit.Core.Billing.Organizations.Models;
 public record AddItem(string PriceId, int Quantity);
 
 /// <summary>
-/// Replaces an existing line item's price (e.g. switching from monthly to annual billing).
+/// Replaces an existing line item's price (e.g. upgrading from Teams to Enterprise).
 /// Optionally updates the quantity; if <c>null</c>, the current quantity is preserved.
 /// </summary>
 public record ChangeItemPrice(string CurrentPriceId, string UpdatedPriceId, int? Quantity);
@@ -26,8 +26,6 @@ public record UpdateItemQuantity(string PriceId, int Quantity);
 
 /// <summary>
 /// A union type representing a single change to apply to an organization's Stripe subscription.
-/// A change is considered "structural" (triggering immediate invoicing) if it adds, removes,
-/// or re-prices a line item, or sets a quantity to 0. Non-structural quantity updates use prorations.
 /// </summary>
 public class OrganizationSubscriptionChange(OneOf<AddItem, ChangeItemPrice, RemoveItem, UpdateItemQuantity> input)
     : OneOfBase<AddItem, ChangeItemPrice, RemoveItem, UpdateItemQuantity>(input)
@@ -43,90 +41,171 @@ public class OrganizationSubscriptionChange(OneOf<AddItem, ChangeItemPrice, Remo
 
     public static implicit operator OrganizationSubscriptionChange(UpdateItemQuantity updateItemQuantity) =>
         new(updateItemQuantity);
-
-    public bool IsItemAddition => IsT0;
-    public bool IsItemPriceChange => IsT1;
-    public bool IsItemRemoval => IsT2;
-    public bool IsItemQuantityUpdate => IsT3;
-    public bool IsStructural => !IsItemQuantityUpdate || AsT3.Quantity == 0;
 }
 
 /// <summary>
 /// A collection of <see cref="OrganizationSubscriptionChange"/> items to apply atomically to
-/// an organization's Stripe subscription. Use the static factory methods for common single-change
-/// operations, or <see cref="Builder"/> for composing multiple changes.
+/// an organization's Stripe subscription. Use <see cref="Builder"/> to compose changes using
+/// domain-specific methods that encapsulate the correct Stripe price IDs and proration behavior.
 /// </summary>
 public record OrganizationSubscriptionChangeSet
 {
     public required IReadOnlyList<OrganizationSubscriptionChange> Changes { get; init; } = [];
 
-    public static OrganizationSubscriptionChangeSet UpdatePasswordManagerSeats(Plan plan, int seats) =>
-        new()
-        {
-            Changes =
-            [
-                new UpdateItemQuantity(plan.PasswordManager.StripeSeatPlanId, seats)
-            ]
-        };
+    /// <summary>
+    /// When <c>true</c>, all changes in this set use <c>ProrationBehavior.AlwaysInvoice</c>
+    /// to bill immediately. Set automatically by the builder for structural operations
+    /// (plan upgrades, sponsorship swaps). When <c>false</c> (the default), changes are prorated.
+    /// </summary>
+    public bool ChargeImmediately { get; init; }
 
-    public static OrganizationSubscriptionChangeSet UpdateStorage(Plan plan, int storage) =>
-        new()
-        {
-            Changes =
-            [
-                new UpdateItemQuantity(plan.PasswordManager.StripeStoragePlanId, storage)
-            ]
-        };
-
-    public static OrganizationSubscriptionChangeSet UpdateSecretsManagerSeats(Plan plan, int seats) =>
-        new()
-        {
-            Changes =
-            [
-                new UpdateItemQuantity(plan.SecretsManager.StripeSeatPlanId, seats)
-            ]
-        };
-
-    public static OrganizationSubscriptionChangeSet UpdateSecretsManagerServiceAccounts(Plan plan, int serviceAccounts) =>
-        new()
-        {
-            Changes =
-            [
-                new UpdateItemQuantity(plan.SecretsManager.StripeServiceAccountPlanId, serviceAccounts)
-            ]
-        };
-
-    public static OrganizationSubscriptionChangeSetBuilder Builder() => new();
+    public static OrganizationSubscriptionChangeSetBuilder Builder(Plan plan) => new(plan);
 }
 
-public class OrganizationSubscriptionChangeSetBuilder
+/// <summary>
+/// Builds an <see cref="OrganizationSubscriptionChangeSet"/> using domain-specific methods that
+/// encapsulate the correct Stripe price IDs and proration behavior. Structural operations
+/// (plan upgrades, sponsorship swaps) automatically set
+/// <see cref="OrganizationSubscriptionChangeSet.ChargeImmediately"/> so that they are billed
+/// immediately. All other operations (add-ons, seat updates) default to proration.
+/// </summary>
+public class OrganizationSubscriptionChangeSetBuilder(Plan currentPlan)
 {
     private readonly List<OrganizationSubscriptionChange> _changes = [];
+    private bool _chargeImmediately;
 
-    public OrganizationSubscriptionChangeSetBuilder AddItem(string priceId, int quantity)
+    // Add-on operations (prorated by default)
+
+    /// <summary>
+    /// Adds a new storage line item to the subscription. Use when the organization has no
+    /// existing additional storage (first-time add).
+    /// </summary>
+    public OrganizationSubscriptionChangeSetBuilder AddStorage(int quantity)
     {
-        _changes.Add(new AddItem(priceId, quantity));
+        _changes.Add(new AddItem(currentPlan.PasswordManager.StripeStoragePlanId, quantity));
         return this;
     }
 
-    public OrganizationSubscriptionChangeSetBuilder ChangeItemPrice(string currentPriceId, string updatedPriceId, int? quantity = null)
+    /// <summary>
+    /// Updates the quantity of an existing storage line item.
+    /// </summary>
+    public OrganizationSubscriptionChangeSetBuilder UpdateStorage(int quantity)
     {
-        _changes.Add(new ChangeItemPrice(currentPriceId, updatedPriceId, quantity));
+        _changes.Add(new UpdateItemQuantity(currentPlan.PasswordManager.StripeStoragePlanId, quantity));
         return this;
     }
 
-    public OrganizationSubscriptionChangeSetBuilder RemoveItem(string priceId)
+    /// <summary>
+    /// Adds a new SM service account line item to the subscription. Use when the organization
+    /// has no existing additional service accounts (first-time add).
+    /// </summary>
+    public OrganizationSubscriptionChangeSetBuilder AddServiceAccounts(int quantity)
     {
-        _changes.Add(new RemoveItem(priceId));
+        _changes.Add(new AddItem(currentPlan.SecretsManager.StripeServiceAccountPlanId, quantity));
         return this;
     }
 
-    public OrganizationSubscriptionChangeSetBuilder UpdateItemQuantity(string priceId, int quantity)
+    /// <summary>
+    /// Updates the quantity of an existing SM service account line item.
+    /// </summary>
+    public OrganizationSubscriptionChangeSetBuilder UpdateServiceAccounts(int quantity)
     {
-        _changes.Add(new UpdateItemQuantity(priceId, quantity));
+        _changes.Add(new UpdateItemQuantity(currentPlan.SecretsManager.StripeServiceAccountPlanId, quantity));
+        return this;
+    }
+
+    // Seat operations
+
+    /// <summary>
+    /// Updates the quantity of the Password Manager seat line item.
+    /// </summary>
+    public OrganizationSubscriptionChangeSetBuilder UpdatePasswordManagerSeats(int quantity)
+    {
+        _changes.Add(new UpdateItemQuantity(currentPlan.PasswordManager.StripeSeatPlanId, quantity));
+        return this;
+    }
+
+    /// <summary>
+    /// Updates the quantity of the Secrets Manager seat line item.
+    /// </summary>
+    public OrganizationSubscriptionChangeSetBuilder UpdateSecretsManagerSeats(int quantity)
+    {
+        _changes.Add(new UpdateItemQuantity(currentPlan.SecretsManager.StripeSeatPlanId, quantity));
+        return this;
+    }
+
+    // Structural operations (charge immediately)
+
+    /// <summary>
+    /// Replaces the current plan's base line item with a sponsored plan. Removes the current
+    /// plan's line item and adds the sponsored plan's line item with quantity 1.
+    /// </summary>
+    public OrganizationSubscriptionChangeSetBuilder EstablishSponsorship(SponsoredPlan sponsoredPlan)
+    {
+        _changes.Add(new RemoveItem(currentPlan.PasswordManager.StripePlanId));
+        _changes.Add(new AddItem(sponsoredPlan.StripePlanId, 1));
+        _chargeImmediately = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Swaps the Password Manager plan price from the current plan to <paramref name="targetPlan"/>.
+    /// Handles both seat-based and non-seat-based plans.
+    /// </summary>
+    public OrganizationSubscriptionChangeSetBuilder ChangePasswordManagerPrice(Plan targetPlan)
+    {
+        _changes.Add(new ChangeItemPrice(
+            GetPasswordManagerPriceId(currentPlan),
+            GetPasswordManagerPriceId(targetPlan),
+            null));
+        _chargeImmediately = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Swaps the storage price from the current plan to <paramref name="targetPlan"/>.
+    /// </summary>
+    public OrganizationSubscriptionChangeSetBuilder ChangeStoragePrice(Plan targetPlan)
+    {
+        _changes.Add(new ChangeItemPrice(
+            currentPlan.PasswordManager.StripeStoragePlanId,
+            targetPlan.PasswordManager.StripeStoragePlanId,
+            null));
+        _chargeImmediately = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Swaps the Secrets Manager seat price from the current plan to <paramref name="targetPlan"/>.
+    /// </summary>
+    public OrganizationSubscriptionChangeSetBuilder ChangeSecretsManagerSeatPrice(Plan targetPlan)
+    {
+        _changes.Add(new ChangeItemPrice(
+            currentPlan.SecretsManager.StripeSeatPlanId,
+            targetPlan.SecretsManager.StripeSeatPlanId,
+            null));
+        _chargeImmediately = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Swaps the SM service account price from the current plan to <paramref name="targetPlan"/>.
+    /// </summary>
+    public OrganizationSubscriptionChangeSetBuilder ChangeServiceAccountPrice(Plan targetPlan)
+    {
+        _changes.Add(new ChangeItemPrice(
+            currentPlan.SecretsManager.StripeServiceAccountPlanId,
+            targetPlan.SecretsManager.StripeServiceAccountPlanId,
+            null));
+        _chargeImmediately = true;
         return this;
     }
 
     public OrganizationSubscriptionChangeSet Build() =>
-        new() { Changes = _changes.AsReadOnly() };
+        new() { Changes = [.. _changes], ChargeImmediately = _chargeImmediately };
+
+    private static string GetPasswordManagerPriceId(Plan p) =>
+        p.HasNonSeatBasedPasswordManagerPlan()
+            ? p.PasswordManager.StripePlanId
+            : p.PasswordManager.StripeSeatPlanId;
 }

--- a/src/Core/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/Cloud/SetUpSponsorshipCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSponsorships/FamiliesForEnterprise/Cloud/SetUpSponsorshipCommand.cs
@@ -78,9 +78,8 @@ public class SetUpSponsorshipCommand : ISetUpSponsorshipCommand
         if (_featureService.IsEnabled(FeatureFlagKeys.PM32581_UseUpdateOrganizationSubscriptionCommand))
         {
             var existingPlan = await _pricingClient.GetPlanOrThrow(sponsoredOrganization.PlanType);
-            var changeSet = OrganizationSubscriptionChangeSet.Builder()
-                .RemoveItem(existingPlan.PasswordManager.StripePlanId)
-                .AddItem(sponsoredPlan.StripePlanId, 1)
+            var changeSet = OrganizationSubscriptionChangeSet.Builder(existingPlan)
+                .EstablishSponsorship(sponsoredPlan)
                 .Build();
 
             var result = await _updateOrganizationSubscriptionCommand.Run(sponsoredOrganization, changeSet);

--- a/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpdateSecretsManagerSubscriptionCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpdateSecretsManagerSubscriptionCommand.cs
@@ -71,28 +71,22 @@ public class UpdateSecretsManagerSubscriptionCommand : IUpdateSecretsManagerSubs
     {
         if (_featureService.IsEnabled(FeatureFlagKeys.PM32581_UseUpdateOrganizationSubscriptionCommand))
         {
-            var builder = OrganizationSubscriptionChangeSet.Builder();
+            var builder = OrganizationSubscriptionChangeSet.Builder(update.Plan);
 
             if (update.SmSeatsChanged)
             {
-                builder.UpdateItemQuantity(
-                    update.Plan.SecretsManager.StripeSeatPlanId,
-                    update.SmSeatsExcludingBase);
+                builder.UpdateSecretsManagerSeats(update.SmSeatsExcludingBase);
             }
 
             if (update.SmServiceAccountsChanged)
             {
                 if (update.Organization.SmServiceAccounts > update.Plan.SecretsManager.BaseServiceAccount)
                 {
-                    builder.UpdateItemQuantity(
-                        update.Plan.SecretsManager.StripeServiceAccountPlanId,
-                        update.SmServiceAccountsExcludingBase);
+                    builder.UpdateServiceAccounts(update.SmServiceAccountsExcludingBase);
                 }
                 else
                 {
-                    builder.AddItem(
-                        update.Plan.SecretsManager.StripeServiceAccountPlanId,
-                        update.SmServiceAccountsExcludingBase);
+                    builder.AddServiceAccounts(update.SmServiceAccountsExcludingBase);
                 }
             }
 

--- a/src/Core/Utilities/BillingHelpers.cs
+++ b/src/Core/Utilities/BillingHelpers.cs
@@ -4,6 +4,7 @@ using Bit.Core.Billing.Organizations.Models;
 using Bit.Core.Billing.Services;
 using Bit.Core.Entities;
 using Bit.Core.Exceptions;
+using Bit.Core.Models.StaticStore;
 using Bit.Core.Services;
 
 namespace Bit.Core.Utilities;
@@ -17,7 +18,8 @@ public static class BillingHelpers
         IStorableSubscriber storableSubscriber,
         short storageAdjustmentGb,
         string storagePlanId,
-        short baseStorageGb)
+        short baseStorageGb,
+        Plan? plan = null)
     {
         if (storableSubscriber == null)
         {
@@ -62,23 +64,24 @@ public static class BillingHelpers
 
         if (storableSubscriber is Organization organization &&
             updateOrganizationSubscriptionCommand != null &&
+            plan != null &&
             featureService.IsEnabled(FeatureFlagKeys.PM32581_UseUpdateOrganizationSubscriptionCommand))
         {
-            var builder = OrganizationSubscriptionChangeSet.Builder();
-            if (organization.MaxStorageGb > baseStorageGb)
+            var builder = OrganizationSubscriptionChangeSet.Builder(plan);
+            if (organization.MaxStorageGb > plan.PasswordManager.BaseStorageGb)
             {
-                builder.UpdateItemQuantity(storagePlanId, additionalStorage);
+                builder.UpdateStorage(additionalStorage);
             }
             else
             {
-                builder.AddItem(storagePlanId, additionalStorage);
+                builder.AddStorage(additionalStorage);
             }
 
             var changeSet = builder.Build();
             var result = await updateOrganizationSubscriptionCommand.Run(organization, changeSet);
             result.GetValueOrThrow();
             storableSubscriber.MaxStorageGb = newStorageGb;
-            return null!;
+            return null;
         }
 
         var paymentIntentClientSecret = await paymentService.AdjustStorageAsync(storableSubscriber,

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/Organizations/BulkUpdateOrganizationSubscriptionsCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/Organizations/BulkUpdateOrganizationSubscriptionsCommandTests.cs
@@ -182,7 +182,7 @@ public class BulkUpdateOrganizationSubscriptionsCommandTests
                 Arg.Is<Organization>(x => x.Id == organization.Id),
                 Arg.Is<OrganizationSubscriptionChangeSet>(cs =>
                     cs.Changes.Count == 1 &&
-                    cs.Changes[0].IsItemQuantityUpdate &&
+                    !cs.ChargeImmediately &&
                     cs.Changes[0].AsT3.PriceId == plan.PasswordManager.StripeSeatPlanId &&
                     cs.Changes[0].AsT3.Quantity == organization.Seats!.Value));
 

--- a/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
@@ -1438,7 +1438,7 @@ public class OrganizationServiceTests
 
         await sutProvider.GetDependency<IUpdateOrganizationSubscriptionCommand>().Received(1)
             .Run(organization, Arg.Is<OrganizationSubscriptionChangeSet>(cs =>
-                cs.Changes.Count == 1 && cs.Changes[0].IsItemAddition));
+                cs.Changes.Count == 1 && !cs.ChargeImmediately));
         await sutProvider.GetDependency<IStripePaymentService>().DidNotReceiveWithAnyArgs()
             .AdjustStorageAsync(default, default, default);
         Assert.Equal((short)2, organization.MaxStorageGb);
@@ -1470,7 +1470,7 @@ public class OrganizationServiceTests
 
         await sutProvider.GetDependency<IUpdateOrganizationSubscriptionCommand>().Received(1)
             .Run(organization, Arg.Is<OrganizationSubscriptionChangeSet>(cs =>
-                cs.Changes.Count == 1 && cs.Changes[0].IsItemQuantityUpdate));
+                cs.Changes.Count == 1 && !cs.ChargeImmediately));
         await sutProvider.GetDependency<IStripePaymentService>().DidNotReceiveWithAnyArgs()
             .AdjustStorageAsync(default, default, default);
         Assert.Equal((short)3, organization.MaxStorageGb);

--- a/test/Core.Test/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommandTests.cs
+++ b/test/Core.Test/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommandTests.cs
@@ -356,7 +356,7 @@ public class UpdateOrganizationSubscriptionCommandTests
     }
 
     [Fact]
-    public async Task Run_StructuralChange_SetsAlwaysInvoiceProration()
+    public async Task Run_ChargeImmediately_SetsAlwaysInvoiceProration()
     {
         var organization = CreateOrganization();
         var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
@@ -364,10 +364,10 @@ public class UpdateOrganizationSubscriptionCommandTests
         SetupGetSubscription(organization, subscription);
         SetupUpdateSubscription(subscription);
 
-        // AddItem is structural (IsStructural = !IsItemQuantityUpdate = true)
         var changeSet = new OrganizationSubscriptionChangeSet
         {
-            Changes = [new AddItem("price_storage", 1)]
+            Changes = [new AddItem("price_storage", 1)],
+            ChargeImmediately = true
         };
 
         var result = await _command.Run(organization, changeSet);
@@ -380,7 +380,7 @@ public class UpdateOrganizationSubscriptionCommandTests
     }
 
     [Fact]
-    public async Task Run_NonStructuralChange_SetsCreateProrationsProration()
+    public async Task Run_NotChargeImmediately_SetsCreateProrationsProration()
     {
         var organization = CreateOrganization();
         var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
@@ -388,7 +388,6 @@ public class UpdateOrganizationSubscriptionCommandTests
         SetupGetSubscription(organization, subscription);
         SetupUpdateSubscription(subscription);
 
-        // UpdateItemQuantity is non-structural
         var changeSet = new OrganizationSubscriptionChangeSet
         {
             Changes = [new UpdateItemQuantity("price_seats", 10)]
@@ -404,7 +403,7 @@ public class UpdateOrganizationSubscriptionCommandTests
     }
 
     [Fact]
-    public async Task Run_StructuralChange_ChargeAutomatically_SetsPendingIfIncomplete()
+    public async Task Run_ChargeImmediately_ChargeAutomatically_SetsPendingIfIncomplete()
     {
         var organization = CreateOrganization();
         var subscription = CreateSubscription(
@@ -416,7 +415,8 @@ public class UpdateOrganizationSubscriptionCommandTests
 
         var changeSet = new OrganizationSubscriptionChangeSet
         {
-            Changes = [new AddItem("price_storage", 1)]
+            Changes = [new AddItem("price_storage", 1)],
+            ChargeImmediately = true
         };
 
         var result = await _command.Run(organization, changeSet);
@@ -429,7 +429,7 @@ public class UpdateOrganizationSubscriptionCommandTests
     }
 
     [Fact]
-    public async Task Run_StructuralChange_SendInvoice_NoPaymentBehavior()
+    public async Task Run_ChargeImmediately_SendInvoice_NoPaymentBehavior()
     {
         var organization = CreateOrganization();
         var subscription = CreateSubscription(
@@ -441,7 +441,8 @@ public class UpdateOrganizationSubscriptionCommandTests
 
         var changeSet = new OrganizationSubscriptionChangeSet
         {
-            Changes = [new AddItem("price_storage", 1)]
+            Changes = [new AddItem("price_storage", 1)],
+            ChargeImmediately = true
         };
 
         var result = await _command.Run(organization, changeSet);
@@ -454,7 +455,7 @@ public class UpdateOrganizationSubscriptionCommandTests
     }
 
     [Fact]
-    public async Task Run_NonStructuralChange_ChargeAutomatically_NoPaymentBehavior()
+    public async Task Run_NotChargeImmediately_ChargeAutomatically_NoPaymentBehavior()
     {
         var organization = CreateOrganization();
         var subscription = CreateSubscription(
@@ -532,7 +533,7 @@ public class UpdateOrganizationSubscriptionCommandTests
     }
 
     [Fact]
-    public async Task Run_AnnualBilling_Structural_NoPendingInvoiceItemInterval()
+    public async Task Run_AnnualBilling_ChargeImmediately_NoPendingInvoiceItemInterval()
     {
         var organization = CreateOrganization();
         var subscription = CreateSubscription(
@@ -545,7 +546,8 @@ public class UpdateOrganizationSubscriptionCommandTests
 
         var changeSet = new OrganizationSubscriptionChangeSet
         {
-            Changes = [new AddItem("price_storage", 1)]
+            Changes = [new AddItem("price_storage", 1)],
+            ChargeImmediately = true
         };
 
         var result = await _command.Run(organization, changeSet);
@@ -611,7 +613,8 @@ public class UpdateOrganizationSubscriptionCommandTests
 
         var changeSet = new OrganizationSubscriptionChangeSet
         {
-            Changes = [new AddItem("price_storage", 1)]
+            Changes = [new AddItem("price_storage", 1)],
+            ChargeImmediately = true
         };
 
         var result = await _command.Run(organization, changeSet);
@@ -624,7 +627,7 @@ public class UpdateOrganizationSubscriptionCommandTests
     }
 
     [Fact]
-    public async Task Run_SendInvoice_Structural_NonDraftInvoice_DoesNotFinalizeOrSend()
+    public async Task Run_SendInvoice_ChargeImmediately_NonDraftInvoice_DoesNotFinalizeOrSend()
     {
         var organization = CreateOrganization();
         var subscription = CreateSubscription(
@@ -647,7 +650,8 @@ public class UpdateOrganizationSubscriptionCommandTests
 
         var changeSet = new OrganizationSubscriptionChangeSet
         {
-            Changes = [new AddItem("price_storage", 1)]
+            Changes = [new AddItem("price_storage", 1)],
+            ChargeImmediately = true
         };
 
         var result = await _command.Run(organization, changeSet);
@@ -660,7 +664,7 @@ public class UpdateOrganizationSubscriptionCommandTests
     }
 
     [Fact]
-    public async Task Run_ChargeAutomatically_Structural_DoesNotProcessInvoice()
+    public async Task Run_ChargeAutomatically_ChargeImmediately_DoesNotProcessInvoice()
     {
         var organization = CreateOrganization();
         var subscription = CreateSubscription(
@@ -680,7 +684,8 @@ public class UpdateOrganizationSubscriptionCommandTests
 
         var changeSet = new OrganizationSubscriptionChangeSet
         {
-            Changes = [new AddItem("price_storage", 1)]
+            Changes = [new AddItem("price_storage", 1)],
+            ChargeImmediately = true
         };
 
         var result = await _command.Run(organization, changeSet);
@@ -693,7 +698,7 @@ public class UpdateOrganizationSubscriptionCommandTests
     }
 
     [Fact]
-    public async Task Run_SendInvoice_NonStructural_DoesNotProcessInvoice()
+    public async Task Run_SendInvoice_NotChargeImmediately_DoesNotProcessInvoice()
     {
         var organization = CreateOrganization();
         var subscription = CreateSubscription(

--- a/test/Core.Test/Billing/Organizations/Commands/UpgradeOrganizationPlanVNextCommandTests.cs
+++ b/test/Core.Test/Billing/Organizations/Commands/UpgradeOrganizationPlanVNextCommandTests.cs
@@ -180,7 +180,7 @@ public class UpgradeOrganizationPlanVNextCommandTests
             organization,
             Arg.Is<OrganizationSubscriptionChangeSet>(cs =>
                 cs.Changes.Count >= 1 &&
-                cs.Changes.Any(c => c.IsItemPriceChange)));
+                cs.ChargeImmediately));
         await _organizationService.Received(1).ReplaceAndUpdateCacheAsync(organization, null);
         Assert.Equal(targetPlan.Name, organization.Plan);
         Assert.Equal(targetPlan.Type, organization.PlanType);
@@ -203,7 +203,8 @@ public class UpgradeOrganizationPlanVNextCommandTests
         await _updateOrganizationSubscriptionCommand.Received(1).Run(
             organization,
             Arg.Is<OrganizationSubscriptionChangeSet>(cs =>
-                cs.Changes.Count(c => c.IsItemPriceChange) == 2));
+                cs.Changes.Count == 2 &&
+                cs.ChargeImmediately));
     }
 
     [Fact]
@@ -224,7 +225,8 @@ public class UpgradeOrganizationPlanVNextCommandTests
         await _updateOrganizationSubscriptionCommand.Received(1).Run(
             organization,
             Arg.Is<OrganizationSubscriptionChangeSet>(cs =>
-                cs.Changes.Count(c => c.IsItemPriceChange) >= 2));
+                cs.Changes.Count >= 2 &&
+                cs.ChargeImmediately));
     }
 
     [Fact]
@@ -248,7 +250,8 @@ public class UpgradeOrganizationPlanVNextCommandTests
         await _updateOrganizationSubscriptionCommand.Received(1).Run(
             organization,
             Arg.Is<OrganizationSubscriptionChangeSet>(cs =>
-                cs.Changes.Count(c => c.IsItemPriceChange) == 3));
+                cs.Changes.Count == 3 &&
+                cs.ChargeImmediately));
     }
 
     [Fact]

--- a/test/Core.Test/Billing/Organizations/Models/OrganizationSubscriptionChangeSetTests.cs
+++ b/test/Core.Test/Billing/Organizations/Models/OrganizationSubscriptionChangeSetTests.cs
@@ -1,254 +1,288 @@
-﻿using Bit.Core.Billing.Enums;
+using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Organizations.Models;
+using Bit.Core.Models.StaticStore;
 using Bit.Core.Test.Billing.Mocks;
 using Xunit;
 
 namespace Bit.Core.Test.Billing.Organizations.Models;
 
-public class OrganizationSubscriptionChangeTests
-{
-    [Fact]
-    public void ImplicitConversion_AddItem_SetsCorrectFlags()
-    {
-        OrganizationSubscriptionChange change = new AddItem("price_123", 5);
-
-        Assert.True(change.IsItemAddition);
-        Assert.False(change.IsItemPriceChange);
-        Assert.False(change.IsItemRemoval);
-        Assert.False(change.IsItemQuantityUpdate);
-        Assert.True(change.IsStructural);
-    }
-
-    [Fact]
-    public void ImplicitConversion_ChangeItemPrice_SetsCorrectFlags()
-    {
-        OrganizationSubscriptionChange change = new ChangeItemPrice("price_old", "price_new", null);
-
-        Assert.False(change.IsItemAddition);
-        Assert.True(change.IsItemPriceChange);
-        Assert.False(change.IsItemRemoval);
-        Assert.False(change.IsItemQuantityUpdate);
-        Assert.True(change.IsStructural);
-    }
-
-    [Fact]
-    public void ImplicitConversion_RemoveItem_SetsCorrectFlags()
-    {
-        OrganizationSubscriptionChange change = new RemoveItem("price_123");
-
-        Assert.False(change.IsItemAddition);
-        Assert.False(change.IsItemPriceChange);
-        Assert.True(change.IsItemRemoval);
-        Assert.False(change.IsItemQuantityUpdate);
-        Assert.True(change.IsStructural);
-    }
-
-    [Fact]
-    public void ImplicitConversion_UpdateItemQuantity_SetsCorrectFlags()
-    {
-        OrganizationSubscriptionChange change = new UpdateItemQuantity("price_123", 10);
-
-        Assert.False(change.IsItemAddition);
-        Assert.False(change.IsItemPriceChange);
-        Assert.False(change.IsItemRemoval);
-        Assert.True(change.IsItemQuantityUpdate);
-        Assert.False(change.IsStructural);
-    }
-
-    [Fact]
-    public void ImplicitConversion_UpdateItemQuantityToZero_IsStructural()
-    {
-        OrganizationSubscriptionChange change = new UpdateItemQuantity("price_123", 0);
-
-        Assert.True(change.IsItemQuantityUpdate);
-        Assert.True(change.IsStructural);
-    }
-}
-
-public class OrganizationSubscriptionChangeSetTests
-{
-    [Fact]
-    public void UpdatePasswordManagerSeats_CreatesCorrectChangeSet()
-    {
-        var plan = MockPlans.Get(PlanType.TeamsAnnually);
-
-        var changeSet = OrganizationSubscriptionChangeSet.UpdatePasswordManagerSeats(plan, 25);
-
-        var change = Assert.Single(changeSet.Changes);
-        Assert.True(change.IsItemQuantityUpdate);
-        Assert.False(change.IsStructural);
-
-        var update = change.AsT3;
-        Assert.Equal(plan.PasswordManager.StripeSeatPlanId, update.PriceId);
-        Assert.Equal(25, update.Quantity);
-    }
-
-    [Fact]
-    public void UpdateStorage_CreatesCorrectChangeSet()
-    {
-        var plan = MockPlans.Get(PlanType.TeamsAnnually);
-
-        var changeSet = OrganizationSubscriptionChangeSet.UpdateStorage(plan, 3);
-
-        var change = Assert.Single(changeSet.Changes);
-        Assert.True(change.IsItemQuantityUpdate);
-
-        var update = change.AsT3;
-        Assert.Equal(plan.PasswordManager.StripeStoragePlanId, update.PriceId);
-        Assert.Equal(3, update.Quantity);
-    }
-
-    [Fact]
-    public void UpdateSecretsManagerSeats_CreatesCorrectChangeSet()
-    {
-        var plan = MockPlans.Get(PlanType.TeamsAnnually);
-
-        var changeSet = OrganizationSubscriptionChangeSet.UpdateSecretsManagerSeats(plan, 10);
-
-        var change = Assert.Single(changeSet.Changes);
-        Assert.True(change.IsItemQuantityUpdate);
-
-        var update = change.AsT3;
-        Assert.Equal(plan.SecretsManager.StripeSeatPlanId, update.PriceId);
-        Assert.Equal(10, update.Quantity);
-    }
-
-    [Fact]
-    public void UpdateSecretsManagerServiceAccounts_CreatesCorrectChangeSet()
-    {
-        var plan = MockPlans.Get(PlanType.TeamsAnnually);
-
-        var changeSet = OrganizationSubscriptionChangeSet.UpdateSecretsManagerServiceAccounts(plan, 50);
-
-        var change = Assert.Single(changeSet.Changes);
-        Assert.True(change.IsItemQuantityUpdate);
-
-        var update = change.AsT3;
-        Assert.Equal(plan.SecretsManager.StripeServiceAccountPlanId, update.PriceId);
-        Assert.Equal(50, update.Quantity);
-    }
-}
-
 public class OrganizationSubscriptionChangeSetBuilderTests
 {
+    private static Plan GetPlan(PlanType planType = PlanType.TeamsAnnually) =>
+        MockPlans.Get(planType);
+
     [Fact]
-    public void AddItem_AddsToChanges()
+    public void AddStorage_DoesNotSetChargeImmediately()
     {
-        var changeSet = new OrganizationSubscriptionChangeSetBuilder()
-            .AddItem("price_add", 3)
+        var plan = GetPlan();
+        var changeSet = OrganizationSubscriptionChangeSet.Builder(plan)
+            .AddStorage(3)
             .Build();
 
-        var change = Assert.Single(changeSet.Changes);
-        Assert.True(change.IsItemAddition);
+        Assert.False(changeSet.ChargeImmediately);
 
+        var change = Assert.Single(changeSet.Changes);
         var item = change.AsT0;
-        Assert.Equal("price_add", item.PriceId);
+        Assert.Equal(plan.PasswordManager.StripeStoragePlanId, item.PriceId);
         Assert.Equal(3, item.Quantity);
     }
 
     [Fact]
-    public void ChangeItemPrice_AddsToChanges()
+    public void UpdateStorage_DoesNotSetChargeImmediately()
     {
-        var changeSet = new OrganizationSubscriptionChangeSetBuilder()
-            .ChangeItemPrice("price_old", "price_new")
+        var plan = GetPlan();
+        var changeSet = OrganizationSubscriptionChangeSet.Builder(plan)
+            .UpdateStorage(5)
             .Build();
 
-        var change = Assert.Single(changeSet.Changes);
-        Assert.True(change.IsItemPriceChange);
-
-        var item = change.AsT1;
-        Assert.Equal("price_old", item.CurrentPriceId);
-        Assert.Equal("price_new", item.UpdatedPriceId);
-        Assert.Null(item.Quantity);
-    }
-
-    [Fact]
-    public void ChangeItemPrice_WithQuantity_AddsToChanges()
-    {
-        var changeSet = new OrganizationSubscriptionChangeSetBuilder()
-            .ChangeItemPrice("price_old", "price_new", 7)
-            .Build();
+        Assert.False(changeSet.ChargeImmediately);
 
         var change = Assert.Single(changeSet.Changes);
-        var item = change.AsT1;
-        Assert.Equal(7, item.Quantity);
-    }
-
-    [Fact]
-    public void RemoveItem_AddsToChanges()
-    {
-        var changeSet = new OrganizationSubscriptionChangeSetBuilder()
-            .RemoveItem("price_remove")
-            .Build();
-
-        var change = Assert.Single(changeSet.Changes);
-        Assert.True(change.IsItemRemoval);
-
-        var item = change.AsT2;
-        Assert.Equal("price_remove", item.PriceId);
-    }
-
-    [Fact]
-    public void UpdateItemQuantity_AddsToChanges()
-    {
-        var changeSet = new OrganizationSubscriptionChangeSetBuilder()
-            .UpdateItemQuantity("price_qty", 15)
-            .Build();
-
-        var change = Assert.Single(changeSet.Changes);
-        Assert.True(change.IsItemQuantityUpdate);
-
         var item = change.AsT3;
-        Assert.Equal("price_qty", item.PriceId);
-        Assert.Equal(15, item.Quantity);
+        Assert.Equal(plan.PasswordManager.StripeStoragePlanId, item.PriceId);
+        Assert.Equal(5, item.Quantity);
     }
 
     [Fact]
-    public void Build_WithMultipleChanges_PreservesOrder()
+    public void AddServiceAccounts_DoesNotSetChargeImmediately()
     {
-        var changeSet = new OrganizationSubscriptionChangeSetBuilder()
-            .AddItem("price_1", 1)
-            .RemoveItem("price_2")
-            .ChangeItemPrice("price_3", "price_4")
-            .UpdateItemQuantity("price_5", 10)
+        var plan = GetPlan();
+        var changeSet = OrganizationSubscriptionChangeSet.Builder(plan)
+            .AddServiceAccounts(10)
             .Build();
 
-        Assert.Equal(4, changeSet.Changes.Count);
-        Assert.True(changeSet.Changes[0].IsItemAddition);
-        Assert.True(changeSet.Changes[1].IsItemRemoval);
-        Assert.True(changeSet.Changes[2].IsItemPriceChange);
-        Assert.True(changeSet.Changes[3].IsItemQuantityUpdate);
+        Assert.False(changeSet.ChargeImmediately);
+
+        var change = Assert.Single(changeSet.Changes);
+        var item = change.AsT0;
+        Assert.Equal(plan.SecretsManager.StripeServiceAccountPlanId, item.PriceId);
+        Assert.Equal(10, item.Quantity);
+    }
+
+    [Fact]
+    public void UpdateServiceAccounts_DoesNotSetChargeImmediately()
+    {
+        var plan = GetPlan();
+        var changeSet = OrganizationSubscriptionChangeSet.Builder(plan)
+            .UpdateServiceAccounts(20)
+            .Build();
+
+        Assert.False(changeSet.ChargeImmediately);
+
+        var change = Assert.Single(changeSet.Changes);
+        var item = change.AsT3;
+        Assert.Equal(plan.SecretsManager.StripeServiceAccountPlanId, item.PriceId);
+        Assert.Equal(20, item.Quantity);
+    }
+
+    [Fact]
+    public void UpdatePasswordManagerSeats_DoesNotSetChargeImmediately()
+    {
+        var plan = GetPlan();
+        var changeSet = OrganizationSubscriptionChangeSet.Builder(plan)
+            .UpdatePasswordManagerSeats(25)
+            .Build();
+
+        Assert.False(changeSet.ChargeImmediately);
+
+        var change = Assert.Single(changeSet.Changes);
+        var item = change.AsT3;
+        Assert.Equal(plan.PasswordManager.StripeSeatPlanId, item.PriceId);
+        Assert.Equal(25, item.Quantity);
+    }
+
+    [Fact]
+    public void UpdateSecretsManagerSeats_DoesNotSetChargeImmediately()
+    {
+        var plan = GetPlan();
+        var changeSet = OrganizationSubscriptionChangeSet.Builder(plan)
+            .UpdateSecretsManagerSeats(10)
+            .Build();
+
+        Assert.False(changeSet.ChargeImmediately);
+
+        var change = Assert.Single(changeSet.Changes);
+        var item = change.AsT3;
+        Assert.Equal(plan.SecretsManager.StripeSeatPlanId, item.PriceId);
+        Assert.Equal(10, item.Quantity);
+    }
+
+    [Fact]
+    public void EstablishSponsorship_SetsChargeImmediately()
+    {
+        var plan = GetPlan(PlanType.FamiliesAnnually);
+        var sponsoredPlan = new SponsoredPlan { StripePlanId = "sponsored_plan_id" };
+
+        var changeSet = OrganizationSubscriptionChangeSet.Builder(plan)
+            .EstablishSponsorship(sponsoredPlan)
+            .Build();
+
+        Assert.True(changeSet.ChargeImmediately);
+        Assert.Equal(2, changeSet.Changes.Count);
+
+        var removeItem = changeSet.Changes[0].AsT2;
+        Assert.Equal(plan.PasswordManager.StripePlanId, removeItem.PriceId);
+
+        var addItem = changeSet.Changes[1].AsT0;
+        Assert.Equal("sponsored_plan_id", addItem.PriceId);
+        Assert.Equal(1, addItem.Quantity);
+    }
+
+    [Fact]
+    public void ChangePasswordManagerPrice_SetsChargeImmediately()
+    {
+        var currentPlan = GetPlan(PlanType.TeamsAnnually);
+        var targetPlan = GetPlan(PlanType.EnterpriseAnnually);
+
+        var changeSet = OrganizationSubscriptionChangeSet.Builder(currentPlan)
+            .ChangePasswordManagerPrice(targetPlan)
+            .Build();
+
+        Assert.True(changeSet.ChargeImmediately);
+
+        var change = Assert.Single(changeSet.Changes);
+        var priceChange = change.AsT1;
+        Assert.Equal(currentPlan.PasswordManager.StripeSeatPlanId, priceChange.CurrentPriceId);
+        Assert.Equal(targetPlan.PasswordManager.StripeSeatPlanId, priceChange.UpdatedPriceId);
+        Assert.Null(priceChange.Quantity);
+    }
+
+    [Fact]
+    public void ChangePasswordManagerPrice_NonSeatBased_UsesStripePlanId()
+    {
+        var currentPlan = GetPlan(PlanType.FamiliesAnnually);
+        var targetPlan = GetPlan(PlanType.EnterpriseAnnually);
+
+        var changeSet = OrganizationSubscriptionChangeSet.Builder(currentPlan)
+            .ChangePasswordManagerPrice(targetPlan)
+            .Build();
+
+        Assert.True(changeSet.ChargeImmediately);
+
+        var change = Assert.Single(changeSet.Changes);
+        var priceChange = change.AsT1;
+        // Families is non-seat-based, so should use StripePlanId
+        Assert.Equal(currentPlan.PasswordManager.StripePlanId, priceChange.CurrentPriceId);
+        // Enterprise is seat-based, so should use StripeSeatPlanId
+        Assert.Equal(targetPlan.PasswordManager.StripeSeatPlanId, priceChange.UpdatedPriceId);
+    }
+
+    [Fact]
+    public void ChangePasswordManagerPrice_SeatBased_UsesStripeSeatPlanId()
+    {
+        var currentPlan = GetPlan(PlanType.TeamsAnnually);
+        var targetPlan = GetPlan(PlanType.EnterpriseAnnually);
+
+        var changeSet = OrganizationSubscriptionChangeSet.Builder(currentPlan)
+            .ChangePasswordManagerPrice(targetPlan)
+            .Build();
+
+        var change = Assert.Single(changeSet.Changes);
+        var priceChange = change.AsT1;
+        Assert.Equal(currentPlan.PasswordManager.StripeSeatPlanId, priceChange.CurrentPriceId);
+        Assert.Equal(targetPlan.PasswordManager.StripeSeatPlanId, priceChange.UpdatedPriceId);
+    }
+
+    [Fact]
+    public void ChangeStoragePrice_SetsChargeImmediately()
+    {
+        var currentPlan = GetPlan(PlanType.TeamsAnnually);
+        var targetPlan = GetPlan(PlanType.EnterpriseAnnually);
+
+        var changeSet = OrganizationSubscriptionChangeSet.Builder(currentPlan)
+            .ChangeStoragePrice(targetPlan)
+            .Build();
+
+        Assert.True(changeSet.ChargeImmediately);
+
+        var change = Assert.Single(changeSet.Changes);
+        var priceChange = change.AsT1;
+        Assert.Equal(currentPlan.PasswordManager.StripeStoragePlanId, priceChange.CurrentPriceId);
+        Assert.Equal(targetPlan.PasswordManager.StripeStoragePlanId, priceChange.UpdatedPriceId);
+    }
+
+    [Fact]
+    public void ChangeSecretsManagerSeatPrice_SetsChargeImmediately()
+    {
+        var currentPlan = GetPlan(PlanType.TeamsAnnually);
+        var targetPlan = GetPlan(PlanType.EnterpriseAnnually);
+
+        var changeSet = OrganizationSubscriptionChangeSet.Builder(currentPlan)
+            .ChangeSecretsManagerSeatPrice(targetPlan)
+            .Build();
+
+        Assert.True(changeSet.ChargeImmediately);
+
+        var change = Assert.Single(changeSet.Changes);
+        var priceChange = change.AsT1;
+        Assert.Equal(currentPlan.SecretsManager.StripeSeatPlanId, priceChange.CurrentPriceId);
+        Assert.Equal(targetPlan.SecretsManager.StripeSeatPlanId, priceChange.UpdatedPriceId);
+    }
+
+    [Fact]
+    public void ChangeServiceAccountPrice_SetsChargeImmediately()
+    {
+        var currentPlan = GetPlan(PlanType.TeamsAnnually);
+        var targetPlan = GetPlan(PlanType.EnterpriseAnnually);
+
+        var changeSet = OrganizationSubscriptionChangeSet.Builder(currentPlan)
+            .ChangeServiceAccountPrice(targetPlan)
+            .Build();
+
+        Assert.True(changeSet.ChargeImmediately);
+
+        var change = Assert.Single(changeSet.Changes);
+        var priceChange = change.AsT1;
+        Assert.Equal(currentPlan.SecretsManager.StripeServiceAccountPlanId, priceChange.CurrentPriceId);
+        Assert.Equal(targetPlan.SecretsManager.StripeServiceAccountPlanId, priceChange.UpdatedPriceId);
+    }
+
+    [Fact]
+    public void Build_MixedSeatAndAddOn_DoesNotSetChargeImmediately()
+    {
+        var plan = GetPlan();
+        var changeSet = OrganizationSubscriptionChangeSet.Builder(plan)
+            .UpdatePasswordManagerSeats(10)
+            .AddStorage(3)
+            .Build();
+
+        Assert.False(changeSet.ChargeImmediately);
+        Assert.Equal(2, changeSet.Changes.Count);
+    }
+
+    [Fact]
+    public void Build_MixedStructuralAndAddOn_SetsChargeImmediately()
+    {
+        var currentPlan = GetPlan(PlanType.TeamsAnnually);
+        var targetPlan = GetPlan(PlanType.EnterpriseAnnually);
+
+        var changeSet = OrganizationSubscriptionChangeSet.Builder(currentPlan)
+            .UpdateStorage(5)
+            .ChangePasswordManagerPrice(targetPlan)
+            .Build();
+
+        Assert.True(changeSet.ChargeImmediately);
+        Assert.Equal(2, changeSet.Changes.Count);
     }
 
     [Fact]
     public void Build_WithNoChanges_ReturnsEmptyChangeSet()
     {
-        var changeSet = new OrganizationSubscriptionChangeSetBuilder()
-            .Build();
+        var plan = GetPlan();
+        var changeSet = OrganizationSubscriptionChangeSet.Builder(plan).Build();
 
         Assert.Empty(changeSet.Changes);
+        Assert.False(changeSet.ChargeImmediately);
     }
 
     [Fact]
     public void Build_ReturnsReadOnlyChanges()
     {
-        var changeSet = new OrganizationSubscriptionChangeSetBuilder()
-            .AddItem("price_1", 1)
+        var plan = GetPlan();
+        var changeSet = OrganizationSubscriptionChangeSet.Builder(plan)
+            .AddStorage(1)
             .Build();
 
         Assert.IsAssignableFrom<IReadOnlyList<OrganizationSubscriptionChange>>(changeSet.Changes);
-    }
-
-    [Fact]
-    public void Build_MixedStructuralAndNonStructural()
-    {
-        var changeSet = new OrganizationSubscriptionChangeSetBuilder()
-            .AddItem("price_add", 1)
-            .UpdateItemQuantity("price_qty", 5)
-            .Build();
-
-        Assert.Equal(2, changeSet.Changes.Count);
-        Assert.True(changeSet.Changes[0].IsStructural);
-        Assert.False(changeSet.Changes[1].IsStructural);
     }
 }

--- a/test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/UpdateSecretsManagerSubscriptionCommandTests.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/UpdateSecretsManagerSubscriptionCommandTests.cs
@@ -818,8 +818,7 @@ public class UpdateSecretsManagerSubscriptionCommandTests
         await sutProvider.GetDependency<IUpdateOrganizationSubscriptionCommand>().Received(1)
             .Run(organization, Arg.Is<OrganizationSubscriptionChangeSet>(cs =>
                 cs.Changes.Count == 2 &&
-                cs.Changes[0].IsItemQuantityUpdate &&
-                cs.Changes[1].IsItemQuantityUpdate));
+                !cs.ChargeImmediately));
         await sutProvider.GetDependency<IStripePaymentService>().DidNotReceiveWithAnyArgs()
             .AdjustSmSeatsAsync(default, default, default);
         await sutProvider.GetDependency<IStripePaymentService>().DidNotReceiveWithAnyArgs()
@@ -862,8 +861,7 @@ public class UpdateSecretsManagerSubscriptionCommandTests
         await sutProvider.GetDependency<IUpdateOrganizationSubscriptionCommand>().Received(1)
             .Run(organization, Arg.Is<OrganizationSubscriptionChangeSet>(cs =>
                 cs.Changes.Count == 2 &&
-                cs.Changes[0].IsItemQuantityUpdate &&
-                cs.Changes[1].IsItemAddition));
+                !cs.ChargeImmediately));
         await sutProvider.GetDependency<IStripePaymentService>().DidNotReceiveWithAnyArgs()
             .AdjustSmSeatsAsync(default, default, default);
         await sutProvider.GetDependency<IStripePaymentService>().DidNotReceiveWithAnyArgs()


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33415

## 📔 Objective

Fixes a QA bug from the PM-32581 work where storage and SM service accounts were classified as "structural" changes, forcing `ProrationBehavior.AlwaysInvoice` (immediate billing) instead of `ProrationBehavior.CreateProrations`.

**Root cause**: `IsStructural` on `OrganizationSubscriptionChange` treated all `AddItem`, `RemoveItem`, and `UpdateItemQuantity(qty=0)` as structural. There was no way to distinguish between structural changes (adding SM product, changing plan price) and add-on changes (storage, service accounts).

**Fix**: Replace per-change `IsStructural` inspection with a changeset-level `ChargeImmediately` flag. Replace generic builder methods (`AddItem`, `RemoveItem`, etc.) with domain-specific methods (`AddStorage`, `UpdateServiceAccounts`, `EstablishSponsorship`, `ChangePasswordManagerPrice`, etc.) that encapsulate correct Stripe price IDs and proration behavior. Structural methods automatically set `ChargeImmediately = true`; add-on and seat methods leave the default (`false` = prorate).