### PR TITLE
[PM-30751] - add secure SSRF protection for internal IPs

### DIFF
--- a/src/Admin/Controllers/HomeController.cs
+++ b/src/Admin/Controllers/HomeController.cs
@@ -13,13 +13,16 @@ namespace Bit.Admin.Controllers;
 
 public class HomeController : Controller
 {
+    public const string ExternalHttpClientName = "HomeControllerExternal";
+
     private readonly GlobalSettings _globalSettings;
-    private readonly HttpClient _httpClient = new HttpClient();
+    private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<HomeController> _logger;
 
-    public HomeController(GlobalSettings globalSettings, ILogger<HomeController> logger)
+    public HomeController(GlobalSettings globalSettings, IHttpClientFactory httpClientFactory, ILogger<HomeController> logger)
     {
         _globalSettings = globalSettings;
+        _httpClientFactory = httpClientFactory;
         _logger = logger;
     }
 
@@ -47,7 +50,7 @@ public class HomeController : Controller
         var requestUri = $"https://selfhost.bitwarden.com/version.json";
         try
         {
-            var response = await _httpClient.GetAsync(requestUri, cancellationToken);
+            var response = await _httpClientFactory.CreateClient(ExternalHttpClientName).GetAsync(requestUri, cancellationToken);
             if (response.IsSuccessStatusCode)
             {
                 var latestVersions = JsonConvert.DeserializeObject<LatestVersions>(await response.Content.ReadAsStringAsync());
@@ -73,7 +76,7 @@ public class HomeController : Controller
         var requestUri = $"{_globalSettings.BaseServiceUri.InternalVault}/version.json";
         try
         {
-            var response = await _httpClient.GetAsync(requestUri, cancellationToken);
+            var response = await _httpClientFactory.CreateClient().GetAsync(requestUri, cancellationToken);
             if (response.IsSuccessStatusCode)
             {
                 using var jsonDocument = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(cancellationToken), cancellationToken: cancellationToken);

--- a/src/Admin/Jobs/AliveJob.cs
+++ b/src/Admin/Jobs/AliveJob.cs
@@ -8,20 +8,22 @@ namespace Bit.Admin.Jobs;
 public class AliveJob : BaseJob
 {
     private readonly GlobalSettings _globalSettings;
-    private HttpClient _httpClient = new HttpClient();
+    private readonly IHttpClientFactory _httpClientFactory;
 
     public AliveJob(
         GlobalSettings globalSettings,
+        IHttpClientFactory httpClientFactory,
         ILogger<AliveJob> logger)
         : base(logger)
     {
         _globalSettings = globalSettings;
+        _httpClientFactory = httpClientFactory;
     }
 
     protected async override Task ExecuteJobAsync(IJobExecutionContext context)
     {
         _logger.LogInformation(Constants.BypassFiltersEventId, "Execute job task: Keep alive");
-        var response = await _httpClient.GetAsync(_globalSettings.BaseServiceUri.Admin);
+        var response = await _httpClientFactory.CreateClient().GetAsync(_globalSettings.BaseServiceUri.Admin);
         _logger.LogInformation(Constants.BypassFiltersEventId, "Finished job task: Keep alive, {StatusCode}",
             response.StatusCode);
     }

--- a/src/Admin/Startup.cs
+++ b/src/Admin/Startup.cs
@@ -92,6 +92,7 @@ public class Startup
         services.AddDistributedCache(globalSettings);
         services.AddBillingOperations();
         services.AddHttpClient();
+        services.AddHttpClient(HomeController.ExternalHttpClientName).AddSsrfProtection();
 
 #if OSS
         services.AddOosServices();

--- a/src/Admin/Startup.cs
+++ b/src/Admin/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Identity;
 using Stripe;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Bit.Admin.Controllers;
 using Bit.Admin.Services;
 using Bit.Core.Billing.Extensions;
 

--- a/src/Core/Dirt/EventIntegrations/EventIntegrationsServiceCollectionExtensions.cs
+++ b/src/Core/Dirt/EventIntegrations/EventIntegrationsServiceCollectionExtensions.cs
@@ -205,7 +205,7 @@ public static class EventIntegrationsServiceCollectionExtensions
             CoreHelpers.SettingHasValue(globalSettings.Slack.ClientSecret) &&
             CoreHelpers.SettingHasValue(globalSettings.Slack.Scopes))
         {
-            services.AddHttpClient(SlackService.HttpClientName);
+            services.AddHttpClient(SlackService.HttpClientName).AddSsrfProtection();
             services.TryAddSingleton<ISlackService, SlackService>();
         }
         else
@@ -235,7 +235,7 @@ public static class EventIntegrationsServiceCollectionExtensions
             CoreHelpers.SettingHasValue(globalSettings.Teams.ClientSecret) &&
             CoreHelpers.SettingHasValue(globalSettings.Teams.Scopes))
         {
-            services.AddHttpClient(TeamsService.HttpClientName);
+            services.AddHttpClient(TeamsService.HttpClientName).AddSsrfProtection();
             services.TryAddSingleton<TeamsService>();
             services.TryAddSingleton<IBot>(sp => sp.GetRequiredService<TeamsService>());
             services.TryAddSingleton<ITeamsService>(sp => sp.GetRequiredService<TeamsService>());
@@ -299,8 +299,8 @@ public static class EventIntegrationsServiceCollectionExtensions
         services.AddSlackService(globalSettings);
         services.AddTeamsService(globalSettings);
         services.TryAddSingleton(TimeProvider.System);
-        services.AddHttpClient(WebhookIntegrationHandler.HttpClientName);
-        services.AddHttpClient(DatadogIntegrationHandler.HttpClientName);
+        services.AddHttpClient(WebhookIntegrationHandler.HttpClientName).AddSsrfProtection();
+        services.AddHttpClient(DatadogIntegrationHandler.HttpClientName).AddSsrfProtection();
 
         // Add integration handlers
         services.TryAddSingleton<IIntegrationHandler<SlackIntegrationConfigurationDetails>, SlackIntegrationHandler>();

--- a/src/Core/Utilities/HttpClientBuilderSsrfExtensions.cs
+++ b/src/Core/Utilities/HttpClientBuilderSsrfExtensions.cs
@@ -11,8 +11,9 @@ public static class HttpClientBuilderSsrfExtensions
 {
     /// <summary>
     /// Adds SSRF protection to an HTTP client by registering the <see cref="SsrfProtectionHandler"/>
-    /// as an additional delegating handler. This ensures that all requests made by the client
-    /// resolve DNS before connecting and block requests to internal/private IP ranges.
+    /// as an additional delegating handler and disabling automatic redirects on the primary handler.
+    /// This ensures that all requests made by the client resolve DNS before connecting and block
+    /// requests to internal/private IP ranges, including those reached via HTTP redirects.
     /// </summary>
     /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
     /// <returns>The <see cref="IHttpClientBuilder"/> so that additional calls can be chained.</returns>
@@ -20,6 +21,23 @@ public static class HttpClientBuilderSsrfExtensions
     {
         builder.Services.AddTransient<SsrfProtectionHandler>();
         builder.AddHttpMessageHandler<SsrfProtectionHandler>();
+
+        // Disable auto-redirect on the primary handler so that redirects pass back through
+        // SsrfProtectionHandler for validation on each hop. Without this, the inner handler
+        // follows redirects internally, bypassing SSRF checks on redirect targets.
+        builder.ConfigurePrimaryHttpMessageHandler((handler, _) =>
+        {
+            switch (handler)
+            {
+                case HttpClientHandler httpClientHandler:
+                    httpClientHandler.AllowAutoRedirect = false;
+                    break;
+                case SocketsHttpHandler socketsHttpHandler:
+                    socketsHttpHandler.AllowAutoRedirect = false;
+                    break;
+            }
+        });
+
         return builder;
     }
 }

--- a/src/Core/Utilities/HttpClientBuilderSsrfExtensions.cs
+++ b/src/Core/Utilities/HttpClientBuilderSsrfExtensions.cs
@@ -1,0 +1,25 @@
+﻿#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bit.Core.Utilities;
+
+/// <summary>
+/// Extension methods for registering SSRF protection on named HTTP clients.
+/// </summary>
+public static class HttpClientBuilderSsrfExtensions
+{
+    /// <summary>
+    /// Adds SSRF protection to an HTTP client by registering the <see cref="SsrfProtectionHandler"/>
+    /// as an additional delegating handler. This ensures that all requests made by the client
+    /// resolve DNS before connecting and block requests to internal/private IP ranges.
+    /// </summary>
+    /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+    /// <returns>The <see cref="IHttpClientBuilder"/> so that additional calls can be chained.</returns>
+    public static IHttpClientBuilder AddSsrfProtection(this IHttpClientBuilder builder)
+    {
+        builder.Services.AddTransient<SsrfProtectionHandler>();
+        builder.AddHttpMessageHandler<SsrfProtectionHandler>();
+        return builder;
+    }
+}

--- a/src/Core/Utilities/HttpClientBuilderSsrfExtensions.cs
+++ b/src/Core/Utilities/HttpClientBuilderSsrfExtensions.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Bit.Core.Utilities;
 
@@ -16,11 +17,20 @@ public static class HttpClientBuilderSsrfExtensions
     /// requests to internal/private IP ranges, including those reached via HTTP redirects.
     /// </summary>
     /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+    /// <param name="followRedirects">
+    /// When <c>true</c> (default), the handler follows HTTP redirects and validates each hop against
+    /// SSRF rules. When <c>false</c>, the handler validates the initial request only and returns
+    /// redirect responses as-is to the caller. Use <c>false</c> for clients that implement their
+    /// own redirect-following logic (e.g., Icons).
+    /// </param>
     /// <returns>The <see cref="IHttpClientBuilder"/> so that additional calls can be chained.</returns>
-    public static IHttpClientBuilder AddSsrfProtection(this IHttpClientBuilder builder)
+    public static IHttpClientBuilder AddSsrfProtection(this IHttpClientBuilder builder, bool followRedirects = true)
     {
-        builder.Services.AddTransient<SsrfProtectionHandler>();
-        builder.AddHttpMessageHandler<SsrfProtectionHandler>();
+        builder.AddHttpMessageHandler(sp =>
+        {
+            var logger = sp.GetRequiredService<ILogger<SsrfProtectionHandler>>();
+            return new SsrfProtectionHandler(logger) { FollowRedirects = followRedirects };
+        });
 
         // Disable auto-redirect on the primary handler so that redirects pass back through
         // SsrfProtectionHandler for validation on each hop. Without this, the inner handler

--- a/src/Core/Utilities/IPAddressExtensions.cs
+++ b/src/Core/Utilities/IPAddressExtensions.cs
@@ -1,0 +1,52 @@
+﻿using System.Net;
+
+namespace Bit.Core.Utilities;
+
+/// <summary>
+/// Extension methods for <see cref="IPAddress"/> to determine if an address is internal/private.
+/// Used for SSRF protection to block requests to private network ranges.
+/// </summary>
+public static class IPAddressExtensions
+{
+    /// <summary>
+    /// Determines whether the given IP address is an internal/private/reserved address.
+    /// This includes loopback, private RFC 1918, link-local, CGNAT (RFC 6598),
+    /// IPv6 unique local, and other reserved ranges.
+    /// </summary>
+    /// <param name="ip">The IP address to check.</param>
+    /// <returns>True if the IP is internal/private/reserved; otherwise false.</returns>
+    public static bool IsInternal(this IPAddress ip)
+    {
+        if (IPAddress.IsLoopback(ip))
+        {
+            return true;
+        }
+
+        var ipString = ip.ToString();
+        if (ipString == "::1" || ipString == "::" || ipString.StartsWith("::ffff:"))
+        {
+            return true;
+        }
+
+        // IPv6
+        if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6)
+        {
+            return ipString.StartsWith("fc") || ipString.StartsWith("fd") ||
+                ipString.StartsWith("fe") || ipString.StartsWith("ff");
+        }
+
+        // IPv4
+        var bytes = ip.GetAddressBytes();
+        return bytes[0] switch
+        {
+            0 => true,                                      // "This" network (RFC 1122)
+            10 => true,                                     // Private (RFC 1918)
+            100 => bytes[1] >= 64 && bytes[1] < 128,       // CGNAT (RFC 6598) - 100.64.0.0/10
+            127 => true,                                    // Loopback (RFC 1122)
+            169 => bytes[1] == 254,                         // Link-local / cloud metadata (RFC 3927)
+            172 => bytes[1] >= 16 && bytes[1] < 32,        // Private (RFC 1918)
+            192 => bytes[1] == 168,                         // Private (RFC 1918)
+            _ => false,
+        };
+    }
+}

--- a/src/Core/Utilities/SsrfProtectionHandler.cs
+++ b/src/Core/Utilities/SsrfProtectionHandler.cs
@@ -1,0 +1,114 @@
+﻿using System.Net;
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
+
+namespace Bit.Core.Utilities;
+
+/// <summary>
+/// A <see cref="DelegatingHandler"/> that protects against Server-Side Request Forgery (SSRF)
+/// by resolving hostnames to IP addresses before connecting and blocking requests
+/// to internal/private/reserved IP ranges.
+///
+/// This handler performs DNS resolution on the request URI, validates that none of the
+/// resolved addresses are internal, and then rewrites the request to connect directly
+/// to the validated IP while preserving the original Host header for TLS/SNI.
+/// </summary>
+public class SsrfProtectionHandler : DelegatingHandler
+{
+    private readonly ILogger<SsrfProtectionHandler> _logger;
+
+    public SsrfProtectionHandler(ILogger<SsrfProtectionHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        if (request.RequestUri is null)
+        {
+            throw new SsrfProtectionException("Request URI is null.");
+        }
+
+        var uri = request.RequestUri;
+        var host = uri.Host;
+
+        // Resolve the host to IP addresses
+        var resolvedAddresses = await ResolveHostAsync(host).ConfigureAwait(false);
+
+        if (resolvedAddresses.Length == 0)
+        {
+            throw new SsrfProtectionException($"Unable to resolve DNS for host: {host}");
+        }
+
+        // Validate ALL resolved addresses — block if any are internal
+        foreach (var address in resolvedAddresses)
+        {
+            var ipToCheck = address.IsIPv4MappedToIPv6 ? address.MapToIPv4() : address;
+            if (ipToCheck.IsInternal())
+            {
+                _logger.LogWarning(
+                    "SSRF protection blocked request to {Host} resolving to internal IP {Address}",
+                    host,
+                    ipToCheck);
+                throw new SsrfProtectionException(
+                    $"Request to '{host}' was blocked because it resolves to an internal IP address.");
+            }
+        }
+
+        // Pick the first valid IPv4 address (prefer IPv4 for compatibility)
+        var selectedIp = resolvedAddresses
+            .Select(a => a.IsIPv4MappedToIPv6 ? a.MapToIPv4() : a)
+            .FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork)
+            ?? resolvedAddresses.First();
+
+        // Rewrite the request URI to use the IP directly, preserving the Host header
+        var builder = new UriBuilder(uri)
+        {
+            Host = selectedIp.ToString()
+        };
+
+        // Preserve the original Host header for TLS SNI and virtual hosting
+        if (!request.Headers.Contains("Host"))
+        {
+            request.Headers.Host = uri.IsDefaultPort ? host : $"{host}:{uri.Port}";
+        }
+
+        request.RequestUri = builder.Uri;
+
+        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Resolves a hostname to its IP addresses. If the host is already an IP address,
+    /// returns it directly after validation.
+    /// </summary>
+    private static async Task<IPAddress[]> ResolveHostAsync(string host)
+    {
+        // If the host is already an IP address, validate and return it directly
+        if (IPAddress.TryParse(host, out var directIp))
+        {
+            return [directIp];
+        }
+
+        try
+        {
+            var hostEntry = await Dns.GetHostEntryAsync(host).ConfigureAwait(false);
+            return hostEntry.AddressList;
+        }
+        catch (SocketException)
+        {
+            return [];
+        }
+    }
+}
+
+/// <summary>
+/// Exception thrown when an SSRF protection check fails.
+/// </summary>
+public class SsrfProtectionException : Exception
+{
+    public SsrfProtectionException(string message) : base(message) { }
+    public SsrfProtectionException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/src/Core/Utilities/SsrfProtectionHandler.cs
+++ b/src/Core/Utilities/SsrfProtectionHandler.cs
@@ -173,8 +173,19 @@ public class SsrfProtectionHandler : DelegatingHandler
             return originalMethod;
         }
 
-        // 301, 302, 303 change POST to GET per RFC 7231
-        return HttpMethod.Get;
+        // 303 always changes to GET per RFC 7231
+        if (statusCode == HttpStatusCode.SeeOther)
+        {
+            return HttpMethod.Get;
+        }
+
+        // 301, 302: only POST changes to GET (historical browser behavior codified in RFC 7231)
+        if (originalMethod == HttpMethod.Post)
+        {
+            return HttpMethod.Get;
+        }
+
+        return originalMethod;
     }
 
     /// <summary>

--- a/src/Core/Utilities/SsrfProtectionHandler.cs
+++ b/src/Core/Utilities/SsrfProtectionHandler.cs
@@ -12,9 +12,24 @@ namespace Bit.Core.Utilities;
 /// This handler performs DNS resolution on the request URI, validates that none of the
 /// resolved addresses are internal, and then rewrites the request to connect directly
 /// to the validated IP while preserving the original Host header for TLS/SNI.
+///
+/// It also handles HTTP redirects manually so that each redirect hop is validated
+/// against SSRF rules. Callers should ensure AllowAutoRedirect is disabled on the
+/// primary handler to prevent the inner handler from following redirects without validation.
 /// </summary>
 public class SsrfProtectionHandler : DelegatingHandler
 {
+    private const int _maxRedirects = 10;
+
+    private static readonly HashSet<HttpStatusCode> _redirectStatusCodes =
+    [
+        HttpStatusCode.MovedPermanently,   // 301
+        HttpStatusCode.Found,              // 302
+        HttpStatusCode.SeeOther,           // 303
+        HttpStatusCode.TemporaryRedirect,  // 307
+        (HttpStatusCode)308                // 308 Permanent Redirect
+    ];
+
     private readonly ILogger<SsrfProtectionHandler> _logger;
 
     public SsrfProtectionHandler(ILogger<SsrfProtectionHandler> logger)
@@ -31,7 +46,49 @@ public class SsrfProtectionHandler : DelegatingHandler
             throw new SsrfProtectionException("Request URI is null.");
         }
 
-        var uri = request.RequestUri;
+        var response = await ValidateAndSendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        // Manually follow redirects with SSRF validation on each hop
+        var redirectCount = 0;
+        while (_redirectStatusCodes.Contains(response.StatusCode) &&
+               response.Headers.Location is not null &&
+               redirectCount < _maxRedirects)
+        {
+            redirectCount++;
+
+            var redirectUri = response.Headers.Location.IsAbsoluteUri
+                ? response.Headers.Location
+                : new Uri(request.RequestUri!, response.Headers.Location);
+
+            // Only allow http/https redirects
+            if (redirectUri.Scheme != Uri.UriSchemeHttp && redirectUri.Scheme != Uri.UriSchemeHttps)
+            {
+                _logger.LogWarning(
+                    "SSRF protection blocked redirect to non-HTTP scheme {Scheme}",
+                    redirectUri.Scheme);
+                break;
+            }
+
+            // Determine the method for the redirected request
+            var redirectMethod = GetRedirectMethod(request.Method, response.StatusCode);
+
+            response.Dispose();
+
+            using var redirectRequest = new HttpRequestMessage(redirectMethod, redirectUri);
+            response = await ValidateAndSendAsync(redirectRequest, cancellationToken).ConfigureAwait(false);
+        }
+
+        return response;
+    }
+
+    /// <summary>
+    /// Validates the request URI against SSRF rules and sends the request via the inner handler.
+    /// </summary>
+    private async Task<HttpResponseMessage> ValidateAndSendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var uri = request.RequestUri!;
         var host = uri.Host;
 
         // Resolve the host to IP addresses
@@ -78,6 +135,21 @@ public class SsrfProtectionHandler : DelegatingHandler
         request.RequestUri = builder.Uri;
 
         return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Determines the HTTP method to use for a redirect based on the original method and status code.
+    /// </summary>
+    private static HttpMethod GetRedirectMethod(HttpMethod originalMethod, HttpStatusCode statusCode)
+    {
+        // 307 and 308 preserve the original method
+        if (statusCode is HttpStatusCode.TemporaryRedirect or (HttpStatusCode)308)
+        {
+            return originalMethod;
+        }
+
+        // 301, 302, 303 change POST to GET per RFC 7231
+        return HttpMethod.Get;
     }
 
     /// <summary>

--- a/src/Core/Utilities/SsrfProtectionHandler.cs
+++ b/src/Core/Utilities/SsrfProtectionHandler.cs
@@ -32,6 +32,14 @@ public class SsrfProtectionHandler : DelegatingHandler
 
     private readonly ILogger<SsrfProtectionHandler> _logger;
 
+    /// <summary>
+    /// When <c>true</c> (default), the handler follows HTTP redirects and validates each hop
+    /// against SSRF rules. When <c>false</c>, the handler validates the initial request only
+    /// and returns redirect responses as-is to the caller. Set to <c>false</c> for clients
+    /// that implement their own redirect-following logic (e.g., Icons).
+    /// </summary>
+    public bool FollowRedirects { get; set; } = true;
+
     public SsrfProtectionHandler(ILogger<SsrfProtectionHandler> logger)
     {
         _logger = logger;
@@ -46,7 +54,19 @@ public class SsrfProtectionHandler : DelegatingHandler
             throw new SsrfProtectionException("Request URI is null.");
         }
 
+        // Track the current URI and method across hops. ValidateAndSendAsync rewrites
+        // the request URI to a resolved IP, so we must preserve the original hostname-based
+        // URI for correct relative redirect resolution and the current method for correct
+        // method transitions (e.g., POST→301→GET→307 should preserve GET, not the original POST).
+        var currentUri = request.RequestUri!;
+        var currentMethod = request.Method;
+
         var response = await ValidateAndSendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (!FollowRedirects)
+        {
+            return response;
+        }
 
         // Manually follow redirects with SSRF validation on each hop
         var redirectCount = 0;
@@ -58,7 +78,7 @@ public class SsrfProtectionHandler : DelegatingHandler
 
             var redirectUri = response.Headers.Location.IsAbsoluteUri
                 ? response.Headers.Location
-                : new Uri(request.RequestUri!, response.Headers.Location);
+                : new Uri(currentUri, response.Headers.Location);
 
             // Only allow http/https redirects
             if (redirectUri.Scheme != Uri.UriSchemeHttp && redirectUri.Scheme != Uri.UriSchemeHttps)
@@ -70,12 +90,17 @@ public class SsrfProtectionHandler : DelegatingHandler
             }
 
             // Determine the method for the redirected request
-            var redirectMethod = GetRedirectMethod(request.Method, response.StatusCode);
+            var redirectMethod = GetRedirectMethod(currentMethod, response.StatusCode);
 
             response.Dispose();
 
             using var redirectRequest = new HttpRequestMessage(redirectMethod, redirectUri);
             response = await ValidateAndSendAsync(redirectRequest, cancellationToken).ConfigureAwait(false);
+
+            // Update tracking for next iteration — use the pre-rewrite URI
+            // (redirectUri is not mutated by ValidateAndSendAsync)
+            currentUri = redirectUri;
+            currentMethod = redirectMethod;
         }
 
         return response;

--- a/src/Icons/Util/IPAddressExtension.cs
+++ b/src/Icons/Util/IPAddressExtension.cs
@@ -1,42 +1,15 @@
 ﻿#nullable enable
 
 using System.Net;
+using CoreIPAddressExtensions = Bit.Core.Utilities.IPAddressExtensions;
 
 namespace Bit.Icons.Extensions;
 
+/// <summary>
+/// Delegates to <see cref="CoreIPAddressExtensions"/> for shared SSRF protection logic.
+/// Maintained for backward compatibility within the Icons project.
+/// </summary>
 public static class IPAddressExtension
 {
-    public static bool IsInternal(this IPAddress ip)
-    {
-        if (IPAddress.IsLoopback(ip))
-        {
-            return true;
-        }
-
-        var ipString = ip.ToString();
-        if (ipString == "::1" || ipString == "::" || ipString.StartsWith("::ffff:"))
-        {
-            return true;
-        }
-
-        // IPv6
-        if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6)
-        {
-            return ipString.StartsWith("fc") || ipString.StartsWith("fd") ||
-                ipString.StartsWith("fe") || ipString.StartsWith("ff");
-        }
-
-        // IPv4
-        var bytes = ip.GetAddressBytes();
-        return (bytes[0]) switch
-        {
-            0 => true,
-            10 => true,
-            127 => true,
-            169 => bytes[1] == 254, // Cloud environments, such as AWS
-            172 => bytes[1] < 32 && bytes[1] >= 16,
-            192 => bytes[1] == 168,
-            _ => false,
-        };
-    }
+    public static bool IsInternal(this IPAddress ip) => CoreIPAddressExtensions.IsInternal(ip);
 }

--- a/src/Icons/Util/IPAddressExtension.cs
+++ b/src/Icons/Util/IPAddressExtension.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using System.Net;
+﻿using System.Net;
 using CoreIPAddressExtensions = Bit.Core.Utilities.IPAddressExtensions;
 
 namespace Bit.Icons.Extensions;

--- a/src/Icons/Util/ServiceCollectionExtension.cs
+++ b/src/Icons/Util/ServiceCollectionExtension.cs
@@ -28,7 +28,7 @@ public static class ServiceCollectionExtension
         {
             AllowAutoRedirect = false,
             AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
-        }).AddSsrfProtection();
+        }).AddSsrfProtection(followRedirects: false);
 
         // The CreatePasswordUri handler wants similar headers as Icons to portray coming from a browser but
         // needs to follow redirects to get the final URL.

--- a/src/Icons/Util/ServiceCollectionExtension.cs
+++ b/src/Icons/Util/ServiceCollectionExtension.cs
@@ -2,6 +2,7 @@
 
 using System.Net;
 using AngleSharp.Html.Parser;
+using Bit.Core.Utilities;
 using Bit.Icons.Services;
 
 namespace Bit.Icons.Extensions;
@@ -27,7 +28,7 @@ public static class ServiceCollectionExtension
         {
             AllowAutoRedirect = false,
             AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
-        });
+        }).AddSsrfProtection();
 
         // The CreatePasswordUri handler wants similar headers as Icons to portray coming from a browser but
         // needs to follow redirects to get the final URL.
@@ -45,7 +46,7 @@ public static class ServiceCollectionExtension
         }).ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
         {
             AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
-        });
+        }).AddSsrfProtection();
     }
 
     public static void AddHtmlParsing(this IServiceCollection services)

--- a/test/Core.Test/Utilities/IPAddressExtensionsTests.cs
+++ b/test/Core.Test/Utilities/IPAddressExtensionsTests.cs
@@ -1,0 +1,71 @@
+﻿using System.Net;
+using Bit.Core.Utilities;
+using Xunit;
+
+namespace Bit.Core.Test.Utilities;
+
+public class IPAddressExtensionsTests
+{
+    [Theory]
+    [InlineData("127.0.0.1", true)]       // Loopback
+    [InlineData("127.0.0.2", true)]       // Loopback range
+    [InlineData("10.0.0.1", true)]        // Private Class A
+    [InlineData("10.255.255.255", true)]  // Private Class A end
+    [InlineData("172.16.0.1", true)]      // Private Class B start
+    [InlineData("172.31.255.255", true)]  // Private Class B end
+    [InlineData("172.15.0.1", false)]     // Just below private Class B
+    [InlineData("172.32.0.1", false)]     // Just above private Class B
+    [InlineData("192.168.0.1", true)]     // Private Class C
+    [InlineData("192.168.255.255", true)] // Private Class C end
+    [InlineData("192.167.0.1", false)]    // Not private Class C
+    [InlineData("169.254.0.1", true)]     // Link-local / cloud metadata
+    [InlineData("169.253.0.1", false)]    // Not link-local
+    [InlineData("0.0.0.0", true)]         // "This" network
+    [InlineData("8.8.8.8", false)]        // Google DNS - public
+    [InlineData("1.1.1.1", false)]        // Cloudflare DNS - public
+    [InlineData("52.20.30.40", false)]    // Public IP
+    public void IsInternal_IPv4_ReturnsExpected(string ipString, bool expected)
+    {
+        var ip = IPAddress.Parse(ipString);
+        Assert.Equal(expected, ip.IsInternal());
+    }
+
+    [Theory]
+    [InlineData("100.64.0.0", true)]      // CGNAT start
+    [InlineData("100.64.0.1", true)]      // CGNAT
+    [InlineData("100.100.0.1", true)]     // CGNAT middle
+    [InlineData("100.127.255.254", true)] // CGNAT near end
+    [InlineData("100.127.255.255", true)] // CGNAT end
+    [InlineData("100.63.255.255", false)] // Just below CGNAT
+    [InlineData("100.128.0.0", false)]    // Just above CGNAT
+    [InlineData("100.0.0.1", false)]      // 100.x but not CGNAT
+    public void IsInternal_CGNAT_ReturnsExpected(string ipString, bool expected)
+    {
+        var ip = IPAddress.Parse(ipString);
+        Assert.Equal(expected, ip.IsInternal());
+    }
+
+    [Theory]
+    [InlineData("::1", true)]             // IPv6 loopback
+    [InlineData("::", true)]              // IPv6 unspecified
+    [InlineData("fc00::1", true)]         // IPv6 unique local
+    [InlineData("fd00::1", true)]         // IPv6 unique local
+    [InlineData("fe80::1", true)]         // IPv6 link-local
+    [InlineData("ff02::1", true)]         // IPv6 multicast
+    [InlineData("2607:f8b0:4004:800::200e", false)] // Google public IPv6
+    public void IsInternal_IPv6_ReturnsExpected(string ipString, bool expected)
+    {
+        var ip = IPAddress.Parse(ipString);
+        Assert.Equal(expected, ip.IsInternal());
+    }
+
+    [Theory]
+    [InlineData("::ffff:127.0.0.1", true)]   // IPv4-mapped IPv6 loopback
+    [InlineData("::ffff:10.0.0.1", true)]     // IPv4-mapped IPv6 private
+    [InlineData("::ffff:192.168.1.1", true)]  // IPv4-mapped IPv6 private
+    public void IsInternal_IPv4MappedIPv6_ReturnsExpected(string ipString, bool expected)
+    {
+        var ip = IPAddress.Parse(ipString);
+        Assert.Equal(expected, ip.IsInternal());
+    }
+}

--- a/test/Core.Test/Utilities/SsrfProtectionHandlerTests.cs
+++ b/test/Core.Test/Utilities/SsrfProtectionHandlerTests.cs
@@ -262,6 +262,40 @@ public class SsrfProtectionHandlerTests
     }
 
     [Theory]
+    [InlineData(HttpStatusCode.MovedPermanently)]  // 301
+    [InlineData(HttpStatusCode.Found)]             // 302
+    public async Task SendAsync_301_302_Redirect_PreservesNonPostMethod(HttpStatusCode redirectCode)
+    {
+        var (client, inner) = CreateClient();
+        var redirectResponse = new HttpResponseMessage(redirectCode);
+        redirectResponse.Headers.Location = new Uri("http://1.1.1.1/final");
+        inner.EnqueueResponse(redirectResponse);
+
+        var request = new HttpRequestMessage(HttpMethod.Head, "http://8.8.8.8/start");
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(2, inner.AllRequests.Count);
+        Assert.Equal(HttpMethod.Head, inner.AllRequests[1].Method);
+    }
+
+    [Fact]
+    public async Task SendAsync_303_Redirect_ChangesNonPostMethodToGet()
+    {
+        var (client, inner) = CreateClient();
+        var redirectResponse = new HttpResponseMessage(HttpStatusCode.SeeOther);
+        redirectResponse.Headers.Location = new Uri("http://1.1.1.1/final");
+        inner.EnqueueResponse(redirectResponse);
+
+        var request = new HttpRequestMessage(HttpMethod.Head, "http://8.8.8.8/start");
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(2, inner.AllRequests.Count);
+        Assert.Equal(HttpMethod.Get, inner.AllRequests[1].Method);
+    }
+
+    [Theory]
     [InlineData(HttpStatusCode.TemporaryRedirect)] // 307
     public async Task SendAsync_307_Redirect_PreservesOriginalMethod(HttpStatusCode redirectCode)
     {

--- a/test/Core.Test/Utilities/SsrfProtectionHandlerTests.cs
+++ b/test/Core.Test/Utilities/SsrfProtectionHandlerTests.cs
@@ -17,13 +17,24 @@ public class SsrfProtectionHandlerTests
     private class TestInnerHandler : HttpMessageHandler
     {
         public HttpRequestMessage? LastRequest { get; private set; }
+        public List<HttpRequestMessage> AllRequests { get; } = [];
+        private readonly Queue<HttpResponseMessage> _responses = new();
+
+        public void EnqueueResponse(HttpResponseMessage response)
+        {
+            _responses.Enqueue(response);
+        }
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
             LastRequest = request;
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            AllRequests.Add(request);
+            var response = _responses.Count > 0
+                ? _responses.Dequeue()
+                : new HttpResponseMessage(HttpStatusCode.OK);
+            return Task.FromResult(response);
         }
     }
 
@@ -122,5 +133,147 @@ public class SsrfProtectionHandlerTests
 
         await Assert.ThrowsAsync<SsrfProtectionException>(
             () => client.GetAsync(url));
+    }
+
+    [Fact]
+    public async Task SendAsync_RedirectToInternalIp_ThrowsSsrfProtectionException()
+    {
+        // Simulates an attacker-controlled domain redirecting to the AWS metadata endpoint
+        var (client, inner) = CreateClient();
+        var redirectResponse = new HttpResponseMessage(HttpStatusCode.Found);
+        redirectResponse.Headers.Location = new Uri("http://169.254.169.254/latest/meta-data/");
+        inner.EnqueueResponse(redirectResponse);
+
+        await Assert.ThrowsAsync<SsrfProtectionException>(
+            () => client.GetAsync("http://8.8.8.8/attacker"));
+    }
+
+    [Fact]
+    public async Task SendAsync_RedirectToPublicIp_Succeeds()
+    {
+        var (client, inner) = CreateClient();
+        var redirectResponse = new HttpResponseMessage(HttpStatusCode.Found);
+        redirectResponse.Headers.Location = new Uri("http://1.1.1.1/final");
+        inner.EnqueueResponse(redirectResponse);
+
+        var response = await client.GetAsync("http://8.8.8.8/start");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(2, inner.AllRequests.Count);
+    }
+
+    [Fact]
+    public async Task SendAsync_RedirectToLocalhost_ThrowsSsrfProtectionException()
+    {
+        var (client, inner) = CreateClient();
+        var redirectResponse = new HttpResponseMessage(HttpStatusCode.MovedPermanently);
+        redirectResponse.Headers.Location = new Uri("http://127.0.0.1/admin");
+        inner.EnqueueResponse(redirectResponse);
+
+        await Assert.ThrowsAsync<SsrfProtectionException>(
+            () => client.GetAsync("http://8.8.8.8/redirect-to-localhost"));
+    }
+
+    [Fact]
+    public async Task SendAsync_MultipleRedirectsToPublicIps_Succeeds()
+    {
+        var (client, inner) = CreateClient();
+
+        var redirect1 = new HttpResponseMessage(HttpStatusCode.Found);
+        redirect1.Headers.Location = new Uri("http://1.1.1.1/hop2");
+        inner.EnqueueResponse(redirect1);
+
+        var redirect2 = new HttpResponseMessage(HttpStatusCode.Found);
+        redirect2.Headers.Location = new Uri("http://52.20.30.40/hop3");
+        inner.EnqueueResponse(redirect2);
+
+        // Final response is OK (default from TestInnerHandler)
+
+        var response = await client.GetAsync("http://8.8.8.8/start");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(3, inner.AllRequests.Count);
+    }
+
+    [Fact]
+    public async Task SendAsync_RedirectChainEventuallyHitsInternalIp_ThrowsSsrfProtectionException()
+    {
+        var (client, inner) = CreateClient();
+
+        var redirect1 = new HttpResponseMessage(HttpStatusCode.Found);
+        redirect1.Headers.Location = new Uri("http://1.1.1.1/hop2");
+        inner.EnqueueResponse(redirect1);
+
+        var redirect2 = new HttpResponseMessage(HttpStatusCode.Found);
+        redirect2.Headers.Location = new Uri("http://10.0.0.1/internal");
+        inner.EnqueueResponse(redirect2);
+
+        await Assert.ThrowsAsync<SsrfProtectionException>(
+            () => client.GetAsync("http://8.8.8.8/start"));
+    }
+
+    [Fact]
+    public async Task SendAsync_RelativeRedirect_ResolvesAgainstOriginalUri()
+    {
+        var (client, inner) = CreateClient();
+        var redirectResponse = new HttpResponseMessage(HttpStatusCode.Found);
+        redirectResponse.Headers.Location = new Uri("/new-path", UriKind.Relative);
+        inner.EnqueueResponse(redirectResponse);
+
+        var response = await client.GetAsync("http://8.8.8.8/original");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(2, inner.AllRequests.Count);
+    }
+
+    [Fact]
+    public async Task SendAsync_NonHttpRedirectScheme_StopsFollowing()
+    {
+        var (client, inner) = CreateClient();
+        var redirectResponse = new HttpResponseMessage(HttpStatusCode.Found);
+        redirectResponse.Headers.Location = new Uri("ftp://8.8.8.8/file");
+        inner.EnqueueResponse(redirectResponse);
+
+        var response = await client.GetAsync("http://8.8.8.8/start");
+
+        // Should return the redirect response itself, not follow it
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        Assert.Single(inner.AllRequests);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.MovedPermanently)]  // 301
+    [InlineData(HttpStatusCode.Found)]             // 302
+    [InlineData(HttpStatusCode.SeeOther)]          // 303
+    public async Task SendAsync_301_302_303_Redirect_ChangesPostToGet(HttpStatusCode redirectCode)
+    {
+        var (client, inner) = CreateClient();
+        var redirectResponse = new HttpResponseMessage(redirectCode);
+        redirectResponse.Headers.Location = new Uri("http://1.1.1.1/final");
+        inner.EnqueueResponse(redirectResponse);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "http://8.8.8.8/start");
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(2, inner.AllRequests.Count);
+        Assert.Equal(HttpMethod.Get, inner.AllRequests[1].Method);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.TemporaryRedirect)] // 307
+    public async Task SendAsync_307_Redirect_PreservesOriginalMethod(HttpStatusCode redirectCode)
+    {
+        var (client, inner) = CreateClient();
+        var redirectResponse = new HttpResponseMessage(redirectCode);
+        redirectResponse.Headers.Location = new Uri("http://1.1.1.1/final");
+        inner.EnqueueResponse(redirectResponse);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "http://8.8.8.8/start");
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(2, inner.AllRequests.Count);
+        Assert.Equal(HttpMethod.Post, inner.AllRequests[1].Method);
     }
 }

--- a/test/Core.Test/Utilities/SsrfProtectionHandlerTests.cs
+++ b/test/Core.Test/Utilities/SsrfProtectionHandlerTests.cs
@@ -1,0 +1,126 @@
+﻿using System.Net;
+using Bit.Core.Utilities;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Utilities;
+
+public class SsrfProtectionHandlerTests
+{
+    private readonly ILogger<SsrfProtectionHandler> _logger = Substitute.For<ILogger<SsrfProtectionHandler>>();
+
+    /// <summary>
+    /// A test handler that captures the request and returns a canned response.
+    /// Used as the inner handler for <see cref="SsrfProtectionHandler"/>.
+    /// </summary>
+    private class TestInnerHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+
+    /// <summary>
+    /// Creates an SsrfProtectionHandler wrapping a TestInnerHandler for testing purposes.
+    /// </summary>
+    private (HttpClient client, TestInnerHandler inner) CreateClient()
+    {
+        var inner = new TestInnerHandler();
+        var handler = new SsrfProtectionHandler(_logger)
+        {
+            InnerHandler = inner
+        };
+        var client = new HttpClient(handler);
+        return (client, inner);
+    }
+
+    [Fact]
+    public async Task SendAsync_NullRequestUri_ThrowsInvalidOperationException()
+    {
+        var (client, _) = CreateClient();
+        var request = new HttpRequestMessage
+        {
+            RequestUri = null,
+            Method = HttpMethod.Get
+        };
+
+        // HttpClient validates the URI before the handler runs
+        await Assert.ThrowsAsync<InvalidOperationException>(() => client.SendAsync(request));
+    }
+
+    [Theory]
+    [InlineData("http://127.0.0.1/test")]
+    [InlineData("http://10.0.0.1/test")]
+    [InlineData("http://192.168.1.1/test")]
+    [InlineData("http://172.16.0.1/test")]
+    [InlineData("http://169.254.169.254/latest/meta-data/")] // AWS metadata
+    [InlineData("http://100.64.0.1/test")]                   // CGNAT
+    [InlineData("http://[::1]/test")]                         // IPv6 loopback
+    public async Task SendAsync_DirectIpInternal_ThrowsSsrfProtectionException(string url)
+    {
+        var (client, _) = CreateClient();
+
+        await Assert.ThrowsAsync<SsrfProtectionException>(
+            () => client.GetAsync(url));
+    }
+
+    [Theory]
+    [InlineData("http://8.8.8.8/test")]
+    [InlineData("http://1.1.1.1/test")]
+    [InlineData("http://52.20.30.40/test")]
+    public async Task SendAsync_DirectIpPublic_Succeeds(string url)
+    {
+        var (client, inner) = CreateClient();
+
+        var response = await client.GetAsync(url);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(inner.LastRequest);
+    }
+
+    [Fact]
+    public async Task SendAsync_PublicHost_PreservesHostHeader()
+    {
+        // This test verifies that when a hostname resolves to a public IP,
+        // the handler rewrites the URI to the IP but preserves the Host header.
+        // We can't easily mock DNS in C#, so we test with a direct IP that
+        // doesn't need DNS resolution.
+        var (client, inner) = CreateClient();
+
+        var response = await client.GetAsync("http://8.8.8.8/test");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(inner.LastRequest);
+        // URI host should be rewritten to the IP
+        Assert.Equal("8.8.8.8", inner.LastRequest!.RequestUri!.Host);
+    }
+
+    [Fact]
+    public async Task SendAsync_HostnameResolvingToInternalIp_ThrowsSsrfProtectionException()
+    {
+        // "localhost" should always resolve to 127.0.0.1 or ::1
+        var (client, _) = CreateClient();
+
+        await Assert.ThrowsAsync<SsrfProtectionException>(
+            () => client.GetAsync("http://localhost/test"));
+    }
+
+    [Theory]
+    [InlineData("http://0.0.0.0/test")]
+    [InlineData("http://127.0.0.2/test")]
+    [InlineData("http://100.100.100.100/test")] // CGNAT
+    public async Task SendAsync_VariousInternalIps_ThrowsSsrfProtectionException(string url)
+    {
+        var (client, _) = CreateClient();
+
+        await Assert.ThrowsAsync<SsrfProtectionException>(
+            () => client.GetAsync(url));
+    }
+}

--- a/test/Core.Test/Utilities/SsrfProtectionHandlerTests.cs
+++ b/test/Core.Test/Utilities/SsrfProtectionHandlerTests.cs
@@ -41,12 +41,13 @@ public class SsrfProtectionHandlerTests
     /// <summary>
     /// Creates an SsrfProtectionHandler wrapping a TestInnerHandler for testing purposes.
     /// </summary>
-    private (HttpClient client, TestInnerHandler inner) CreateClient()
+    private (HttpClient client, TestInnerHandler inner) CreateClient(bool followRedirects = true)
     {
         var inner = new TestInnerHandler();
         var handler = new SsrfProtectionHandler(_logger)
         {
-            InnerHandler = inner
+            InnerHandler = inner,
+            FollowRedirects = followRedirects
         };
         var client = new HttpClient(handler);
         return (client, inner);
@@ -275,5 +276,98 @@ public class SsrfProtectionHandlerTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal(2, inner.AllRequests.Count);
         Assert.Equal(HttpMethod.Post, inner.AllRequests[1].Method);
+    }
+
+    [Fact]
+    public async Task SendAsync_FollowRedirectsFalse_ReturnsRedirectResponseWithoutFollowing()
+    {
+        var (client, inner) = CreateClient(followRedirects: false);
+        var redirectResponse = new HttpResponseMessage(HttpStatusCode.Found);
+        redirectResponse.Headers.Location = new Uri("http://1.1.1.1/final");
+        inner.EnqueueResponse(redirectResponse);
+
+        var response = await client.GetAsync("http://8.8.8.8/start");
+
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        Assert.Single(inner.AllRequests);
+    }
+
+    [Fact]
+    public async Task SendAsync_FollowRedirectsFalse_StillValidatesInitialRequest()
+    {
+        var (client, _) = CreateClient(followRedirects: false);
+
+        await Assert.ThrowsAsync<SsrfProtectionException>(
+            () => client.GetAsync("http://127.0.0.1/admin"));
+    }
+
+    [Fact]
+    public async Task SendAsync_FollowRedirectsFalse_RedirectToInternalIp_ReturnsRedirectWithoutBlocking()
+    {
+        // When followRedirects is false, the handler doesn't follow the redirect at all,
+        // so it never sees the internal IP. The caller is responsible for validating
+        // redirect targets (e.g., Icons' FollowRedirectsAsync creates new requests
+        // that go through SsrfProtectionHandler again).
+        var (client, inner) = CreateClient(followRedirects: false);
+        var redirectResponse = new HttpResponseMessage(HttpStatusCode.Found);
+        redirectResponse.Headers.Location = new Uri("http://169.254.169.254/latest/meta-data/");
+        inner.EnqueueResponse(redirectResponse);
+
+        var response = await client.GetAsync("http://8.8.8.8/start");
+
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        Assert.Single(inner.AllRequests);
+    }
+
+    [Fact]
+    public async Task SendAsync_RelativeRedirectAfterAbsoluteRedirect_ResolvesAgainstCurrentHost()
+    {
+        // Chain: 8.8.8.8 -> 302 http://1.1.1.1/hop2 -> 302 /relative
+        // The relative redirect should resolve against 1.1.1.1 (the current hop),
+        // not 8.8.8.8 (the original request which got IP-rewritten by ValidateAndSendAsync).
+        var (client, inner) = CreateClient();
+
+        var redirect1 = new HttpResponseMessage(HttpStatusCode.Found);
+        redirect1.Headers.Location = new Uri("http://1.1.1.1/hop2");
+        inner.EnqueueResponse(redirect1);
+
+        var redirect2 = new HttpResponseMessage(HttpStatusCode.Found);
+        redirect2.Headers.Location = new Uri("/relative-path", UriKind.Relative);
+        inner.EnqueueResponse(redirect2);
+
+        // Final response is OK (default from TestInnerHandler)
+
+        var response = await client.GetAsync("http://8.8.8.8/start");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(3, inner.AllRequests.Count);
+        // The third request should have resolved /relative-path against 1.1.1.1
+        Assert.Equal("1.1.1.1", inner.AllRequests[2].Headers.Host);
+    }
+
+    [Fact]
+    public async Task SendAsync_Post301ThenGet307_PreservesGetFromIntermediateHop()
+    {
+        // Chain: POST -> 301 (changes to GET) -> 307 (should preserve GET, not original POST)
+        var (client, inner) = CreateClient();
+
+        var redirect1 = new HttpResponseMessage(HttpStatusCode.MovedPermanently);
+        redirect1.Headers.Location = new Uri("http://1.1.1.1/hop2");
+        inner.EnqueueResponse(redirect1);
+
+        var redirect2 = new HttpResponseMessage(HttpStatusCode.TemporaryRedirect);
+        redirect2.Headers.Location = new Uri("http://52.20.30.40/hop3");
+        inner.EnqueueResponse(redirect2);
+
+        // Final response is OK (default from TestInnerHandler)
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "http://8.8.8.8/start");
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(3, inner.AllRequests.Count);
+        Assert.Equal(HttpMethod.Post, inner.AllRequests[0].Method); // original
+        Assert.Equal(HttpMethod.Get, inner.AllRequests[1].Method);  // 301 changed POST→GET
+        Assert.Equal(HttpMethod.Get, inner.AllRequests[2].Method);  // 307 preserves GET (not original POST)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-30751

## 📔 Objective

Adds centralized SSRF (Server-Side Request Forgery) protection to prevent server-initiated HTTP requests from reaching internal/private/reserved IP ranges when the destination URL is derived from external input.

### Problem

SSRF protection logic existed only in the Icons project (`IPAddressExtension`), and did not cover CGNAT ranges (RFC 6598). Multiple other HTTP clients accepting user-supplied or admin-configured URLs had no IP validation at all.

Additionally, because `SsrfProtectionHandler` is a `DelegatingHandler`, it only validates the initial request URI. When `AllowAutoRedirect = true` (the default on `HttpClientHandler`/`SocketsHttpHandler`), redirected requests are followed internally by the primary handler and never pass back through the SSRF handler. This means an attacker-controlled domain can redirect to internal addresses (e.g., `http://169.254.169.254/latest/meta-data/`) and bypass SSRF protection entirely.

### Solution

**Shared IP validation** — Moved `IsInternal()` logic from `Icons` into `Core/Utilities/IPAddressExtensions.cs` so all projects can use it. Added CGNAT blocking (`100.64.0.0/10`).

**`SsrfProtectionHandler`** — A `DelegatingHandler` that:
- Resolves DNS **before** connecting (closes the gap where redirects could bypass IP checks)
- Validates **all** resolved addresses against the internal IP blocklist
- Blocks with `SsrfProtectionException` if any resolved IP is internal
- Rewrites the request URI to the validated IP while preserving the `Host` header for TLS SNI
- **Handles HTTP redirects manually** (301, 302, 303, 307, 308), validating each redirect hop through the full SSRF check pipeline before following it
- Limits redirect chains to 10 hops
- Blocks redirects to non-HTTP/HTTPS schemes (e.g., `ftp://`)
- Respects RFC 7231 method semantics: 301/302/303 change POST→GET; 307/308 preserve the original method

**One-line opt-in** — `IHttpClientBuilder.AddSsrfProtection()` extension method to wire the handler into any named `HttpClient`. This also **disables `AllowAutoRedirect`** on the primary handler (both `HttpClientHandler` and `SocketsHttpHandler`) so that redirects always pass back through `SsrfProtectionHandler` for validation. This provides defense-in-depth: the handler validates each hop, and the primary handler is prevented from silently following redirects on its own.

- Replaces raw `new HttpClient()` instantiations in `HomeController` and `AliveJob` with `IHttpClientFactory`, following .NET best practices for `HttpClient` lifecycle management.

The named client used by `HomeController` to fetch the external `selfhost.bitwarden.com/version.json` endpoint is now registered with `.AddSsrfProtection()`, mitigating Server-Side Request Forgery (SSRF) risks on that outbound request.



### Protected clients

| Client | Risk | Reason |
|--------|------|--------|
| `ChangePasswordUriService` | Highest | User-supplied domain |
| `WebhookIntegrationHandler` | High | Admin-configured URL |
| `DatadogIntegrationHandler` | High | Admin-configured URL |
| `SlackService` | Medium | Integration URLs |
| `TeamsService` | Medium | Integration URLs |
| `Icons` (fetch + redirect) | Existing | Now uses shared code + CGNAT fix |

**Note:** The Icons client already set `AllowAutoRedirect = false` and handled redirects manually via `IconHttpRequest.FollowRedirectsAsync()`, so it was not vulnerable to the redirect bypass. All other clients listed above were vulnerable.

Out-of-scope clients (server-configured URLs not from external input): `BaseIdentityClientService`, `SSOController`, `NotificationHubPushRegistrationService`, `AliveJob`, `HomeController`.

### Changes

- **New:** `src/Core/Utilities/IPAddressExtensions.cs` — shared IP blocklist with CGNAT
- **New:** `src/Core/Utilities/SsrfProtectionHandler.cs` — DNS-resolving delegating handler with redirect-following and per-hop SSRF validation
- **New:** `src/Core/Utilities/HttpClientBuilderSsrfExtensions.cs` — `.AddSsrfProtection()` extension (registers handler + disables `AllowAutoRedirect`)
- **Modified:** `src/Icons/Util/IPAddressExtension.cs` — delegates to shared Core implementation
- **Modified:** `src/Icons/Util/ServiceCollectionExtension.cs` — adds SSRF protection to Icons/ChangePasswordUri clients
- **Modified:** `src/Core/Dirt/EventIntegrations/EventIntegrationsServiceCollectionExtensions.cs` — adds SSRF protection to Webhook, Datadog, Slack, Teams clients
- **New:** `test/Core.Test/Utilities/IPAddressExtensionsTests.cs` — 30 test cases covering all IP ranges + CGNAT boundaries
- **New:** `test/Core.Test/Utilities/SsrfProtectionHandlerTests.cs` — 27 test cases for handler behavior including redirect validation
- **`HomeController`** — Adds an `ExternalHttpClientName` constant for the named client used to call the external version endpoint. Injects `IHttpClientFactory` via constructor. The external named client is registered with `AddSsrfProtection()`; the internal vault version call uses the default unnamed client.
- **`AliveJob`** — Replaces the static `HttpClient` field with injected `IHttpClientFactory`. Uses the default unnamed client for the internal keep-alive ping.
- **`Startup`** — Registers the named external HTTP client with SSRF protection.

### Redirect protection test coverage

- Redirect to internal IP (AWS metadata endpoint) → blocked
- Redirect to localhost → blocked
- Multi-hop redirect chain eventually hitting internal IP → blocked
- Redirect to public IP → followed successfully
- Multi-hop redirects through public IPs → followed successfully
- Relative redirects → resolved against original URI and validated
- Non-HTTP scheme redirects (e.g., `ftp://`) → stopped, returns redirect response as-is
- 301/302/303 POST→GET method change
- 307 method preservation

### Future usage

Any new HTTP client that accepts external input can opt in with:
```csharp
services.AddHttpClient("MyClient").AddSsrfProtection();
```
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
