### PR TITLE
[PM-33910] feat: Add collection-scoped API keys for vault access

### DIFF
--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -91,6 +91,12 @@ public class CiphersController : Controller
             throw new NotFoundException();
         }
 
+        // Collection-scoped API key: verify the cipher belongs to the scoped collection
+        if (_currentContext.CollectionId.HasValue)
+        {
+            await EnsureCipherInScopedCollectionAsync(id);
+        }
+
         var organizationAbilities = await _applicationCacheService.GetOrganizationAbilitiesAsync();
 
         return new CipherResponseModel(cipher, user, organizationAbilities, _globalSettings);
@@ -122,6 +128,12 @@ public class CiphersController : Controller
             throw new NotFoundException();
         }
 
+        // Collection-scoped API key: verify the cipher belongs to the scoped collection
+        if (_currentContext.CollectionId.HasValue)
+        {
+            await EnsureCipherInScopedCollectionAsync(id);
+        }
+
         var organizationAbilities = await _applicationCacheService.GetOrganizationAbilitiesAsync();
         var collectionCiphers = await _collectionCipherRepository.GetManyByUserIdCipherIdAsync(user.Id, id);
         return new CipherDetailsResponseModel(cipher, user, organizationAbilities, _globalSettings, collectionCiphers);
@@ -147,6 +159,18 @@ public class CiphersController : Controller
             var collectionCiphers = await _collectionCipherRepository.GetManyByUserIdAsync(user.Id);
             collectionCiphersGroupDict = collectionCiphers.GroupBy(c => c.CipherId).ToDictionary(s => s.Key);
         }
+
+        // Collection-scoped API key: filter ciphers to only those in the scoped collection
+        if (_currentContext.CollectionId.HasValue && collectionCiphersGroupDict != null)
+        {
+            var scopedCollectionId = _currentContext.CollectionId.Value;
+            var cipherIdsInCollection = collectionCiphersGroupDict
+                .Where(kvp => kvp.Value.Any(cc => cc.CollectionId == scopedCollectionId))
+                .Select(kvp => kvp.Key)
+                .ToHashSet();
+            ciphers = ciphers.Where(c => cipherIdsInCollection.Contains(c.Id)).ToList();
+        }
+
         var organizationAbilities = await _applicationCacheService.GetOrganizationAbilitiesAsync();
         var responses = ciphers.Select(cipher => new CipherDetailsResponseModel(
             cipher,
@@ -1697,6 +1721,21 @@ public class CiphersController : Controller
     private async Task<CipherDetails> GetByIdAsync(Guid cipherId, Guid userId)
     {
         return await _cipherRepository.GetByIdAsync(cipherId, userId);
+    }
+
+    /// <summary>
+    /// Verifies that a cipher belongs to the collection scoped in the current API key.
+    /// Throws NotFoundException if the cipher is not in the scoped collection.
+    /// </summary>
+    private async Task EnsureCipherInScopedCollectionAsync(Guid cipherId)
+    {
+        var scopedCollectionId = _currentContext.CollectionId.Value;
+        var user = await _userService.GetUserByPrincipalAsync(User);
+        var collectionCiphers = await _collectionCipherRepository.GetManyByUserIdCipherIdAsync(user.Id, cipherId);
+        if (!collectionCiphers.Any(cc => cc.CollectionId == scopedCollectionId))
+        {
+            throw new NotFoundException();
+        }
     }
 
     private DateTime? GetLastKnownRevisionDateFromForm()

--- a/src/Api/Vault/Controllers/CollectionApiKeysController.cs
+++ b/src/Api/Vault/Controllers/CollectionApiKeysController.cs
@@ -1,0 +1,115 @@
+using Bit.Api.Vault.Models.Request;
+using Bit.Api.Vault.Models.Response;
+using Bit.Core.Context;
+using Bit.Core.Exceptions;
+using Bit.Core.Repositories;
+using Bit.Core.SecretsManager.Repositories;
+using Bit.Core.Vault.Commands.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bit.Api.Vault.Controllers;
+
+/// <summary>
+/// Manages collection-scoped API keys for AI agents and machine clients.
+/// These keys provide vault access limited to a specific collection within an organization.
+/// </summary>
+[Route("organizations/{orgId}/collections/{collectionId}/api-keys")]
+[Authorize("Application")]
+public class CollectionApiKeysController : Controller
+{
+    private readonly ICollectionRepository _collectionRepository;
+    private readonly IApiKeyRepository _apiKeyRepository;
+    private readonly ICreateCollectionApiKeyCommand _createCollectionApiKeyCommand;
+    private readonly ICurrentContext _currentContext;
+
+    public CollectionApiKeysController(
+        ICollectionRepository collectionRepository,
+        IApiKeyRepository apiKeyRepository,
+        ICreateCollectionApiKeyCommand createCollectionApiKeyCommand,
+        ICurrentContext currentContext)
+    {
+        _collectionRepository = collectionRepository;
+        _apiKeyRepository = apiKeyRepository;
+        _createCollectionApiKeyCommand = createCollectionApiKeyCommand;
+        _currentContext = currentContext;
+    }
+
+    /// <summary>
+    /// Creates a new collection-scoped API key. Only organization admins/owners can create these.
+    /// The client_secret is returned ONCE in the response and cannot be retrieved again.
+    /// </summary>
+    [HttpPost]
+    public async Task<CollectionApiKeyCreationResponseModel> CreateAsync(
+        [FromRoute] Guid orgId,
+        [FromRoute] Guid collectionId,
+        [FromBody] CollectionApiKeyCreateRequestModel request)
+    {
+        // Verify the caller is an org admin or owner
+        if (!await _currentContext.OrganizationAdmin(orgId) &&
+            !await _currentContext.OrganizationOwner(orgId))
+        {
+            throw new NotFoundException();
+        }
+
+        // Verify the collection exists and belongs to this org
+        var collection = await _collectionRepository.GetByIdAsync(collectionId);
+        if (collection == null || collection.OrganizationId != orgId)
+        {
+            throw new NotFoundException();
+        }
+
+        var apiKey = request.ToApiKey(orgId, collectionId);
+        var result = await _createCollectionApiKeyCommand.CreateAsync(apiKey);
+
+        return new CollectionApiKeyCreationResponseModel(result);
+    }
+
+    /// <summary>
+    /// Lists all API keys for a collection. Does not return client secrets.
+    /// </summary>
+    [HttpGet]
+    public async Task<IEnumerable<CollectionApiKeyResponseModel>> ListAsync(
+        [FromRoute] Guid orgId,
+        [FromRoute] Guid collectionId)
+    {
+        if (!await _currentContext.OrganizationAdmin(orgId) &&
+            !await _currentContext.OrganizationOwner(orgId))
+        {
+            throw new NotFoundException();
+        }
+
+        var collection = await _collectionRepository.GetByIdAsync(collectionId);
+        if (collection == null || collection.OrganizationId != orgId)
+        {
+            throw new NotFoundException();
+        }
+
+        var apiKeys = await _apiKeyRepository.GetManyByCollectionIdAsync(collectionId);
+        return apiKeys.Select(k => new CollectionApiKeyResponseModel(k));
+    }
+
+    /// <summary>
+    /// Revokes (deletes) a collection API key.
+    /// </summary>
+    [HttpDelete("{apiKeyId}")]
+    public async Task RevokeAsync(
+        [FromRoute] Guid orgId,
+        [FromRoute] Guid collectionId,
+        [FromRoute] Guid apiKeyId)
+    {
+        if (!await _currentContext.OrganizationAdmin(orgId) &&
+            !await _currentContext.OrganizationOwner(orgId))
+        {
+            throw new NotFoundException();
+        }
+
+        var apiKey = await _apiKeyRepository.GetByIdAsync(apiKeyId);
+        if (apiKey == null || apiKey.CollectionId != collectionId || apiKey.OrganizationId != orgId)
+        {
+            throw new NotFoundException();
+        }
+
+        await _apiKeyRepository.DeleteAsync(apiKey);
+    }
+}

--- a/src/Api/Vault/Controllers/SyncController.cs
+++ b/src/Api/Vault/Controllers/SyncController.cs
@@ -118,6 +118,24 @@ public class SyncController : Controller
             collectionCiphersGroupDict = collectionCiphers.GroupBy(c => c.CipherId).ToDictionary(s => s.Key);
         }
 
+        // Collection-scoped API key: filter ciphers and collections to the scoped collection only
+        if (_currentContext.CollectionId.HasValue)
+        {
+            var scopedCollectionId = _currentContext.CollectionId.Value;
+            if (collections != null)
+            {
+                collections = collections.Where(c => c.Id == scopedCollectionId);
+            }
+            if (collectionCiphersGroupDict != null)
+            {
+                var cipherIdsInCollection = collectionCiphersGroupDict
+                    .Where(kvp => kvp.Value.Any(cc => cc.CollectionId == scopedCollectionId))
+                    .Select(kvp => kvp.Key)
+                    .ToHashSet();
+                ciphers = ciphers.Where(c => cipherIdsInCollection.Contains(c.Id)).ToList();
+            }
+        }
+
         var userTwoFactorEnabled = await _twoFactorIsEnabledQuery.TwoFactorIsEnabledAsync(user);
         var userHasPremiumFromOrganization = await _userService.HasPremiumFromOrganization(user);
         var organizationClaimingActiveUser = await _userService.GetOrganizationsClaimingUserAsync(user.Id);

--- a/src/Api/Vault/Models/Request/CollectionApiKeyCreateRequestModel.cs
+++ b/src/Api/Vault/Models/Request/CollectionApiKeyCreateRequestModel.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel.DataAnnotations;
+using Bit.Core.SecretsManager.Entities;
+using Bit.Core.Utilities;
+
+namespace Bit.Api.Vault.Models.Request;
+
+public class CollectionApiKeyCreateRequestModel : IValidatableObject
+{
+    [Required]
+    [EncryptedString]
+    [EncryptedStringLength(200)]
+    public required string Name { get; set; }
+
+    [Required]
+    [EncryptedString]
+    [EncryptedStringLength(4000)]
+    public required string EncryptedPayload { get; set; }
+
+    [Required]
+    [EncryptedString]
+    public required string Key { get; set; }
+
+    public DateTime? ExpireAt { get; set; }
+
+    public ApiKey ToApiKey(Guid organizationId, Guid collectionId)
+    {
+        return new ApiKey()
+        {
+            OrganizationId = organizationId,
+            CollectionId = collectionId,
+            Name = Name,
+            Key = Key,
+            ExpireAt = ExpireAt,
+            Scope = "[\"api.vault\"]",
+            EncryptedPayload = EncryptedPayload,
+        };
+    }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (ExpireAt != null && ExpireAt <= DateTime.UtcNow)
+        {
+            yield return new ValidationResult(
+                "Please select an expiration date that is in the future.");
+        }
+    }
+}

--- a/src/Api/Vault/Models/Response/CollectionApiKeyCreationResponseModel.cs
+++ b/src/Api/Vault/Models/Response/CollectionApiKeyCreationResponseModel.cs
@@ -1,0 +1,35 @@
+#nullable enable
+using Bit.Core.Models.Api;
+using Bit.Core.SecretsManager.Models.Data;
+
+namespace Bit.Api.Vault.Models.Response;
+
+public class CollectionApiKeyCreationResponseModel : ResponseModel
+{
+    private const string _objectName = "collectionApiKeyCreation";
+
+    public CollectionApiKeyCreationResponseModel(ApiKeyClientSecretDetails details) : base(_objectName)
+    {
+        Id = details.ApiKey.Id;
+        Name = details.ApiKey.Name;
+        OrganizationId = details.ApiKey.OrganizationId;
+        CollectionId = details.ApiKey.CollectionId;
+        ExpireAt = details.ApiKey.ExpireAt;
+        CreationDate = details.ApiKey.CreationDate;
+        RevisionDate = details.ApiKey.RevisionDate;
+        ClientSecret = details.ClientSecret;
+    }
+
+    public CollectionApiKeyCreationResponseModel() : base(_objectName)
+    {
+    }
+
+    public Guid Id { get; set; }
+    public string? Name { get; set; }
+    public Guid? OrganizationId { get; set; }
+    public Guid? CollectionId { get; set; }
+    public string? ClientSecret { get; set; }
+    public DateTime? ExpireAt { get; set; }
+    public DateTime CreationDate { get; set; }
+    public DateTime RevisionDate { get; set; }
+}

--- a/src/Api/Vault/Models/Response/CollectionApiKeyResponseModel.cs
+++ b/src/Api/Vault/Models/Response/CollectionApiKeyResponseModel.cs
@@ -1,0 +1,36 @@
+#nullable enable
+using Bit.Core.Models.Api;
+using Bit.Core.SecretsManager.Entities;
+
+namespace Bit.Api.Vault.Models.Response;
+
+/// <summary>
+/// Response model for listing collection API keys. Does NOT include client secret.
+/// </summary>
+public class CollectionApiKeyResponseModel : ResponseModel
+{
+    private const string _objectName = "collectionApiKey";
+
+    public CollectionApiKeyResponseModel(ApiKey apiKey) : base(_objectName)
+    {
+        Id = apiKey.Id;
+        Name = apiKey.Name;
+        OrganizationId = apiKey.OrganizationId;
+        CollectionId = apiKey.CollectionId;
+        ExpireAt = apiKey.ExpireAt;
+        CreationDate = apiKey.CreationDate;
+        RevisionDate = apiKey.RevisionDate;
+    }
+
+    public CollectionApiKeyResponseModel() : base(_objectName)
+    {
+    }
+
+    public Guid Id { get; set; }
+    public string? Name { get; set; }
+    public Guid? OrganizationId { get; set; }
+    public Guid? CollectionId { get; set; }
+    public DateTime? ExpireAt { get; set; }
+    public DateTime CreationDate { get; set; }
+    public DateTime RevisionDate { get; set; }
+}

--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -38,6 +38,7 @@ public class CurrentContext(
     public virtual List<CurrentContextProvider> Providers { get; set; }
     public virtual Guid? InstallationId { get; set; }
     public virtual Guid? OrganizationId { get; set; }
+    public virtual Guid? CollectionId { get; set; }
     public virtual string ClientId { get; set; }
     public virtual Version ClientVersion { get; set; }
     public virtual bool ClientVersionIsPrerelease { get; set; }
@@ -153,6 +154,13 @@ public class CurrentContext(
         if (IdentityClientType == IdentityClientType.ServiceAccount)
         {
             ServiceAccountOrganizationId = new Guid(GetClaimValue(claimsDict, Claims.Organization));
+        }
+
+        // Parse collection_id claim for collection-scoped API keys
+        var collectionIdClaim = GetClaimValue(claimsDict, "collection_id");
+        if (collectionIdClaim != null && Guid.TryParse(collectionIdClaim, out var collectionIdGuid))
+        {
+            CollectionId = collectionIdGuid;
         }
 
         DeviceIdentifier = GetClaimValue(claimsDict, Claims.Device);

--- a/src/Core/Context/ICurrentContext.cs
+++ b/src/Core/Context/ICurrentContext.cs
@@ -30,6 +30,11 @@ public interface ICurrentContext
     List<CurrentContextOrganization> Organizations { get; set; }
     Guid? InstallationId { get; set; }
     Guid? OrganizationId { get; set; }
+    /// <summary>
+    /// When the current identity is a collection-scoped API key, this contains the collection ID
+    /// from the JWT claims. Used to filter vault queries to only items in this collection.
+    /// </summary>
+    Guid? CollectionId { get; set; }
     IdentityClientType IdentityClientType { get; set; }
     string ClientId { get; set; }
     Version? ClientVersion { get; set; }

--- a/src/Core/SecretsManager/Entities/ApiKey.cs
+++ b/src/Core/SecretsManager/Entities/ApiKey.cs
@@ -10,6 +10,16 @@ public class ApiKey : ITableObject<Guid>
 {
     public Guid Id { get; set; }
     public Guid? ServiceAccountId { get; set; }
+    /// <summary>
+    /// Direct organization reference for collection-scoped API keys.
+    /// For service account keys, the org is derived via the ServiceAccount relationship.
+    /// </summary>
+    public Guid? OrganizationId { get; set; }
+    /// <summary>
+    /// When set, this API key can only access vault items within this collection.
+    /// NULL means organization-wide access (backwards compatible).
+    /// </summary>
+    public Guid? CollectionId { get; set; }
     [MaxLength(200)]
     public required string Name { get; set; }
     [MaxLength(128)]

--- a/src/Core/SecretsManager/Models/Data/ApiKeyDetails.cs
+++ b/src/Core/SecretsManager/Models/Data/ApiKeyDetails.cs
@@ -14,6 +14,8 @@ public class ApiKeyDetails : ApiKey
     {
         Id = apiKey.Id;
         ServiceAccountId = apiKey.ServiceAccountId;
+        OrganizationId = apiKey.OrganizationId;
+        CollectionId = apiKey.CollectionId;
         Name = apiKey.Name;
         ClientSecretHash = apiKey.ClientSecretHash;
         Scope = apiKey.Scope;
@@ -39,4 +41,16 @@ public class ServiceAccountApiKeyDetails : ApiKeyDetails
     }
 
     public Guid ServiceAccountOrganizationId { get; set; }
+}
+
+public class CollectionApiKeyDetails : ApiKeyDetails
+{
+    public CollectionApiKeyDetails()
+    {
+    }
+
+    [SetsRequiredMembers]
+    public CollectionApiKeyDetails(ApiKey apiKey) : base(apiKey)
+    {
+    }
 }

--- a/src/Core/SecretsManager/Repositories/IApiKeyRepository.cs
+++ b/src/Core/SecretsManager/Repositories/IApiKeyRepository.cs
@@ -8,5 +8,7 @@ public interface IApiKeyRepository : IRepository<ApiKey, Guid>
 {
     Task<ApiKeyDetails> GetDetailsByIdAsync(Guid id);
     Task<ICollection<ApiKey>> GetManyByServiceAccountIdAsync(Guid id);
+    Task<ICollection<ApiKey>> GetManyByCollectionIdAsync(Guid collectionId);
+    Task<ApiKey?> GetByClientSecretHashAsync(string clientSecretHash);
     Task DeleteManyAsync(IEnumerable<ApiKey> objs);
 }

--- a/src/Core/Vault/Commands/CreateCollectionApiKeyCommand.cs
+++ b/src/Core/Vault/Commands/CreateCollectionApiKeyCommand.cs
@@ -1,0 +1,55 @@
+using System.Security.Cryptography;
+using System.Text;
+using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Models.Data;
+using Bit.Core.SecretsManager.Repositories;
+using Bit.Core.Utilities;
+using Bit.Core.Vault.Commands.Interfaces;
+
+namespace Bit.Core.Vault.Commands;
+
+public class CreateCollectionApiKeyCommand : ICreateCollectionApiKeyCommand
+{
+    private const int ClientSecretMaxLength = 30;
+    private readonly IApiKeyRepository _apiKeyRepository;
+
+    public CreateCollectionApiKeyCommand(IApiKeyRepository apiKeyRepository)
+    {
+        _apiKeyRepository = apiKeyRepository;
+    }
+
+    public async Task<ApiKeyClientSecretDetails> CreateAsync(ApiKey apiKey)
+    {
+        if (apiKey.CollectionId == null)
+        {
+            throw new ArgumentException("CollectionId is required for collection-scoped API keys.");
+        }
+
+        if (apiKey.OrganizationId == null)
+        {
+            throw new ArgumentException("OrganizationId is required for collection-scoped API keys.");
+        }
+
+        apiKey.Id = CoreHelpers.GenerateComb();
+        var clientSecret = CoreHelpers.SecureRandomString(ClientSecretMaxLength);
+        apiKey.ClientSecretHash = GetHash(clientSecret);
+        apiKey.CreationDate = DateTime.UtcNow;
+        apiKey.RevisionDate = DateTime.UtcNow;
+
+        await _apiKeyRepository.CreateAsync(apiKey);
+
+        return new ApiKeyClientSecretDetails
+        {
+            ApiKey = apiKey,
+            ClientSecret = clientSecret,
+        };
+    }
+
+    private static string GetHash(string input)
+    {
+        using var sha = SHA256.Create();
+        var bytes = Encoding.UTF8.GetBytes(input);
+        var hash = sha.ComputeHash(bytes);
+        return Convert.ToBase64String(hash);
+    }
+}

--- a/src/Core/Vault/Commands/Interfaces/ICreateCollectionApiKeyCommand.cs
+++ b/src/Core/Vault/Commands/Interfaces/ICreateCollectionApiKeyCommand.cs
@@ -1,0 +1,9 @@
+using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Models.Data;
+
+namespace Bit.Core.Vault.Commands.Interfaces;
+
+public interface ICreateCollectionApiKeyCommand
+{
+    Task<ApiKeyClientSecretDetails> CreateAsync(ApiKey apiKey);
+}

--- a/src/Core/Vault/VaultServiceCollectionExtensions.cs
+++ b/src/Core/Vault/VaultServiceCollectionExtensions.cs
@@ -28,5 +28,6 @@ public static class VaultServiceCollectionExtensions
         services.AddScoped<IUnarchiveCiphersCommand, UnarchiveCiphersCommand>();
         services.AddScoped<IMarkNotificationsForTaskAsDeletedCommand, MarkNotificationsForTaskAsDeletedCommand>();
         services.AddScoped<IGetTaskMetricsForOrganizationQuery, GetTaskMetricsForOrganizationQuery>();
+        services.AddScoped<ICreateCollectionApiKeyCommand, CreateCollectionApiKeyCommand>();
     }
 }

--- a/src/Identity/IdentityServer/Enums/CustomGrantTypes.cs
+++ b/src/Identity/IdentityServer/Enums/CustomGrantTypes.cs
@@ -8,4 +8,5 @@ public static class CustomGrantTypes
     public const string SendAccess = "send_access";
     // TODO: PM-24471 replace magic string with a constant for webauthn
     public const string WebAuthn = "webauthn";
+    public const string VaultApiKey = "vault_api_key";
 }

--- a/src/Identity/IdentityServer/RequestValidators/VaultApiKeyGrantValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/VaultApiKeyGrantValidator.cs
@@ -1,0 +1,107 @@
+using System.Security.Claims;
+using Bit.Core.Auth.Identity;
+using Bit.Core.SecretsManager.Repositories;
+using Bit.Identity.IdentityServer.Enums;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Validation;
+
+namespace Bit.Identity.IdentityServer.RequestValidators;
+
+/// <summary>
+/// Validates vault_api_key grant type requests for collection-scoped API keys.
+/// Allows AI agents and machine clients to authenticate with a client_id + client_secret
+/// that is scoped to a specific collection within an organization.
+/// </summary>
+public class VaultApiKeyGrantValidator : IExtensionGrantValidator
+{
+    private readonly IApiKeyRepository _apiKeyRepository;
+
+    public VaultApiKeyGrantValidator(IApiKeyRepository apiKeyRepository)
+    {
+        _apiKeyRepository = apiKeyRepository;
+    }
+
+    string IExtensionGrantValidator.GrantType => CustomGrantTypes.VaultApiKey;
+
+    public async Task ValidateAsync(ExtensionGrantValidationContext context)
+    {
+        var clientId = context.Request.Raw.Get("client_id");
+        var clientSecret = context.Request.Raw.Get("client_secret");
+
+        if (string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(clientSecret))
+        {
+            context.Result = new GrantValidationResult(
+                TokenRequestErrors.InvalidGrant,
+                "client_id and client_secret are required.");
+            return;
+        }
+
+        if (!Guid.TryParse(clientId, out var apiKeyId))
+        {
+            context.Result = new GrantValidationResult(
+                TokenRequestErrors.InvalidGrant,
+                "client_id must be a valid GUID.");
+            return;
+        }
+
+        var apiKey = await _apiKeyRepository.GetDetailsByIdAsync(apiKeyId);
+
+        if (apiKey == null)
+        {
+            context.Result = new GrantValidationResult(
+                TokenRequestErrors.InvalidGrant,
+                "Invalid client credentials.");
+            return;
+        }
+
+        // Verify this is a collection-scoped key (not a service account key)
+        if (apiKey.CollectionId == null || apiKey.OrganizationId == null)
+        {
+            context.Result = new GrantValidationResult(
+                TokenRequestErrors.InvalidGrant,
+                "This API key is not collection-scoped. Use the appropriate grant type.");
+            return;
+        }
+
+        // Check expiration
+        if (apiKey.ExpireAt.HasValue && apiKey.ExpireAt.Value < DateTime.UtcNow)
+        {
+            context.Result = new GrantValidationResult(
+                TokenRequestErrors.InvalidGrant,
+                "API key has expired.");
+            return;
+        }
+
+        // Verify the client secret hash
+        var hash = HashSecret(clientSecret);
+        if (!string.Equals(hash, apiKey.ClientSecretHash, StringComparison.Ordinal))
+        {
+            context.Result = new GrantValidationResult(
+                TokenRequestErrors.InvalidGrant,
+                "Invalid client credentials.");
+            return;
+        }
+
+        // Build claims for the collection-scoped token
+        var claims = new List<Claim>
+        {
+            new(Claims.Type, IdentityClientType.Organization.ToString()),
+            new(Claims.Organization, apiKey.OrganizationId.Value.ToString()),
+            new("collection_id", apiKey.CollectionId.Value.ToString()),
+            new("scope", string.Join(" ", apiKey.GetScopes())),
+        };
+
+        context.Result = new GrantValidationResult(
+            subject: apiKey.Id.ToString(),
+            authenticationMethod: CustomGrantTypes.VaultApiKey,
+            claims: claims);
+    }
+
+    private static string HashSecret(string input)
+    {
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        var bytes = System.Text.Encoding.UTF8.GetBytes(input);
+        var hash = sha.ComputeHash(bytes);
+        return Convert.ToBase64String(hash);
+    }
+}

--- a/src/Identity/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Identity/Utilities/ServiceCollectionExtensions.cs
@@ -63,7 +63,8 @@ public static class ServiceCollectionExtensions
             .AddClientStore<DynamicClientStore>()
             .AddIdentityServerCertificate(env, globalSettings)
             .AddExtensionGrantValidator<WebAuthnGrantValidator>()
-            .AddExtensionGrantValidator<SendAccessGrantValidator>();
+            .AddExtensionGrantValidator<SendAccessGrantValidator>()
+            .AddExtensionGrantValidator<VaultApiKeyGrantValidator>();
 
         if (!globalSettings.SelfHosted)
         {

--- a/src/Infrastructure.Dapper/SecretsManager/Repositories/ApiKeyRepository.cs
+++ b/src/Infrastructure.Dapper/SecretsManager/Repositories/ApiKeyRepository.cs
@@ -46,6 +46,28 @@ public class ApiKeyRepository : Repository<ApiKey, Guid>, IApiKeyRepository
         return results.ToList();
     }
 
+    public async Task<ICollection<ApiKey>> GetManyByCollectionIdAsync(Guid collectionId)
+    {
+        using var connection = new SqlConnection(ConnectionString);
+        var results = await connection.QueryAsync<ApiKey>(
+            $"[{Schema}].[ApiKey_ReadByCollectionId]",
+            new { CollectionId = collectionId },
+            commandType: CommandType.StoredProcedure);
+
+        return results.ToList();
+    }
+
+    public async Task<ApiKey> GetByClientSecretHashAsync(string clientSecretHash)
+    {
+        using var connection = new SqlConnection(ConnectionString);
+        var results = await connection.QueryAsync<ApiKey>(
+            $"[{Schema}].[ApiKey_ReadByClientSecretHash]",
+            new { ClientSecretHash = clientSecretHash },
+            commandType: CommandType.StoredProcedure);
+
+        return results.SingleOrDefault();
+    }
+
     public async Task DeleteManyAsync(IEnumerable<ApiKey> objs)
     {
         using var connection = new SqlConnection(ConnectionString);

--- a/src/Infrastructure.EntityFramework/SecretsManager/Configurations/ApiKeyEntityTypeConfiguration.cs
+++ b/src/Infrastructure.EntityFramework/SecretsManager/Configurations/ApiKeyEntityTypeConfiguration.cs
@@ -20,6 +20,14 @@ public class ApiKeyEntityTypeConfiguration : IEntityTypeConfiguration<ApiKey>
             .HasIndex(s => s.ServiceAccountId)
             .IsClustered(false);
 
+        builder
+            .HasIndex(s => s.CollectionId)
+            .IsClustered(false);
+
+        builder
+            .HasIndex(s => s.OrganizationId)
+            .IsClustered(false);
+
         builder.ToTable(nameof(ApiKey));
     }
 }

--- a/src/Infrastructure.EntityFramework/SecretsManager/Models/ApiKey.cs
+++ b/src/Infrastructure.EntityFramework/SecretsManager/Models/ApiKey.cs
@@ -8,6 +8,8 @@ namespace Bit.Infrastructure.EntityFramework.SecretsManager.Models;
 public class ApiKey : Core.SecretsManager.Entities.ApiKey
 {
     public virtual ServiceAccount ServiceAccount { get; set; }
+    public virtual Bit.Infrastructure.EntityFramework.AdminConsole.Models.Organization Organization { get; set; }
+    public virtual Bit.Infrastructure.EntityFramework.Models.Collection Collection { get; set; }
 }
 
 public class ApiKeyMapperProfile : Profile

--- a/src/Infrastructure.EntityFramework/SecretsManager/Repositories/ApiKeyRepository.cs
+++ b/src/Infrastructure.EntityFramework/SecretsManager/Repositories/ApiKeyRepository.cs
@@ -37,6 +37,26 @@ public class ApiKeyRepository : Repository<Core.SecretsManager.Entities.ApiKey, 
         return Mapper.Map<List<Core.SecretsManager.Entities.ApiKey>>(apiKeys);
     }
 
+    public async Task<ICollection<Core.SecretsManager.Entities.ApiKey>> GetManyByCollectionIdAsync(Guid collectionId)
+    {
+        using var scope = ServiceScopeFactory.CreateScope();
+        var dbContext = GetDatabaseContext(scope);
+        var apiKeys = await GetDbSet(dbContext).Where(e => e.CollectionId == collectionId).ToListAsync();
+
+        return Mapper.Map<List<Core.SecretsManager.Entities.ApiKey>>(apiKeys);
+    }
+
+    public async Task<Core.SecretsManager.Entities.ApiKey?> GetByClientSecretHashAsync(string clientSecretHash)
+    {
+        using var scope = ServiceScopeFactory.CreateScope();
+        var dbContext = GetDatabaseContext(scope);
+        var apiKey = await GetDbSet(dbContext)
+            .Where(e => e.ClientSecretHash == clientSecretHash)
+            .FirstOrDefaultAsync();
+
+        return apiKey == null ? null : Mapper.Map<Core.SecretsManager.Entities.ApiKey>(apiKey);
+    }
+
     public async Task DeleteManyAsync(IEnumerable<Core.SecretsManager.Entities.ApiKey> objs)
     {
         using var scope = ServiceScopeFactory.CreateScope();

--- a/src/Sql/dbo/SecretsManager/Stored Procedures/ApiKey/ApiKey_Create.sql
+++ b/src/Sql/dbo/SecretsManager/Stored Procedures/ApiKey/ApiKey_Create.sql
@@ -1,6 +1,8 @@
 CREATE PROCEDURE [dbo].[ApiKey_Create]
     @Id UNIQUEIDENTIFIER OUTPUT,
     @ServiceAccountId UNIQUEIDENTIFIER,
+    @OrganizationId UNIQUEIDENTIFIER,
+    @CollectionId UNIQUEIDENTIFIER,
     @Name VARCHAR(200),
     @ClientSecretHash VARCHAR(128),
     @Scope NVARCHAR(4000),
@@ -17,6 +19,8 @@ BEGIN
     (
         [Id],
         [ServiceAccountId],
+        [OrganizationId],
+        [CollectionId],
         [Name],
         [ClientSecretHash],
         [Scope],
@@ -30,6 +34,8 @@ BEGIN
     (
         @Id,
         @ServiceAccountId,
+        @OrganizationId,
+        @CollectionId,
         @Name,
         @ClientSecretHash,
         @Scope,

--- a/src/Sql/dbo/SecretsManager/Stored Procedures/ApiKey/ApiKey_ReadByClientSecretHash.sql
+++ b/src/Sql/dbo/SecretsManager/Stored Procedures/ApiKey/ApiKey_ReadByClientSecretHash.sql
@@ -1,0 +1,13 @@
+CREATE PROCEDURE [dbo].[ApiKey_ReadByClientSecretHash]
+    @ClientSecretHash VARCHAR(128)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT TOP 1
+        *
+    FROM
+        [dbo].[ApiKeyView]
+    WHERE
+        [ClientSecretHash] = @ClientSecretHash
+END

--- a/src/Sql/dbo/SecretsManager/Stored Procedures/ApiKey/ApiKey_ReadByCollectionId.sql
+++ b/src/Sql/dbo/SecretsManager/Stored Procedures/ApiKey/ApiKey_ReadByCollectionId.sql
@@ -1,0 +1,13 @@
+CREATE PROCEDURE [dbo].[ApiKey_ReadByCollectionId]
+    @CollectionId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        *
+    FROM
+        [dbo].[ApiKeyView]
+    WHERE
+        [CollectionId] = @CollectionId
+END

--- a/src/Sql/dbo/SecretsManager/Tables/ApiKey.sql
+++ b/src/Sql/dbo/SecretsManager/Tables/ApiKey.sql
@@ -1,6 +1,8 @@
 ﻿CREATE TABLE [dbo].[ApiKey] (
     [Id]                    UNIQUEIDENTIFIER,
     [ServiceAccountId]      UNIQUEIDENTIFIER NULL,
+    [OrganizationId]        UNIQUEIDENTIFIER NULL,
+    [CollectionId]          UNIQUEIDENTIFIER NULL,
     [Name]                  VARCHAR(200) NOT NULL,
     [ClientSecretHash]      VARCHAR(128) NULL,
     [Scope]                 NVARCHAR (4000) NOT NULL,
@@ -10,9 +12,19 @@
     [CreationDate]          DATETIME2(7) NOT NULL,
     [RevisionDate]          DATETIME2(7) NOT NULL,
     CONSTRAINT [PK_ApiKey] PRIMARY KEY CLUSTERED ([Id] ASC),
-    CONSTRAINT [FK_ApiKey_ServiceAccountId] FOREIGN KEY ([ServiceAccountId]) REFERENCES [dbo].[ServiceAccount] ([Id])
+    CONSTRAINT [FK_ApiKey_ServiceAccountId] FOREIGN KEY ([ServiceAccountId]) REFERENCES [dbo].[ServiceAccount] ([Id]),
+    CONSTRAINT [FK_ApiKey_OrganizationId] FOREIGN KEY ([OrganizationId]) REFERENCES [dbo].[Organization] ([Id]),
+    CONSTRAINT [FK_ApiKey_CollectionId] FOREIGN KEY ([CollectionId]) REFERENCES [dbo].[Collection] ([Id])
 );
 
 GO
 CREATE NONCLUSTERED INDEX [IX_ApiKey_ServiceAccountId]
     ON [dbo].[ApiKey]([ServiceAccountId] ASC);
+
+GO
+CREATE NONCLUSTERED INDEX [IX_ApiKey_CollectionId]
+    ON [dbo].[ApiKey]([CollectionId] ASC);
+
+GO
+CREATE NONCLUSTERED INDEX [IX_ApiKey_OrganizationId]
+    ON [dbo].[ApiKey]([OrganizationId] ASC);

--- a/test/Api.Test/Vault/Controllers/CiphersControllerTests.cs
+++ b/test/Api.Test/Vault/Controllers/CiphersControllerTests.cs
@@ -2451,4 +2451,233 @@ public class CiphersControllerTests
         Assert.Equal(fileName, fileResult.FileDownloadName);
         Assert.Same(stream, fileResult.FileStream);
     }
+
+    #region Collection-Scoped API Key Filtering
+
+    [Theory, BitAutoData]
+    public async Task Get_WithCollectionScope_CipherInCollection_ReturnsCipher(
+        User user, SutProvider<CiphersController> sutProvider)
+    {
+        var cipherId = Guid.NewGuid();
+        var collectionId = Guid.NewGuid();
+        var orgId = Guid.NewGuid();
+        var cipher = new CipherDetails
+        {
+            Id = cipherId,
+            UserId = user.Id,
+            OrganizationId = orgId,
+            Type = CipherType.Login,
+            Data = "{}"
+        };
+
+        sutProvider.GetDependency<IUserService>()
+            .GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>())
+            .Returns(user);
+
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetByIdAsync(cipherId, user.Id)
+            .Returns(cipher);
+
+        sutProvider.GetDependency<ICurrentContext>()
+            .CollectionId.Returns(collectionId);
+
+        sutProvider.GetDependency<ICollectionCipherRepository>()
+            .GetManyByUserIdCipherIdAsync(user.Id, cipherId)
+            .Returns(new List<CollectionCipher>
+            {
+                new() { CipherId = cipherId, CollectionId = collectionId }
+            });
+
+        sutProvider.GetDependency<IApplicationCacheService>()
+            .GetOrganizationAbilitiesAsync()
+            .Returns(new Dictionary<Guid, OrganizationAbility>
+            {
+                { orgId, new OrganizationAbility { Id = orgId } }
+            });
+
+        var result = await sutProvider.Sut.Get(cipherId);
+        Assert.NotNull(result);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Get_WithCollectionScope_CipherNotInCollection_ThrowsNotFound(
+        User user, SutProvider<CiphersController> sutProvider)
+    {
+        var cipherId = Guid.NewGuid();
+        var collectionId = Guid.NewGuid();
+        var otherCollectionId = Guid.NewGuid();
+        var cipher = new CipherDetails
+        {
+            Id = cipherId,
+            UserId = user.Id,
+            OrganizationId = Guid.NewGuid(),
+            Type = CipherType.Login,
+            Data = "{}"
+        };
+
+        sutProvider.GetDependency<IUserService>()
+            .GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>())
+            .Returns(user);
+
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetByIdAsync(cipherId, user.Id)
+            .Returns(cipher);
+
+        sutProvider.GetDependency<ICurrentContext>()
+            .CollectionId.Returns(collectionId);
+
+        // Cipher belongs to a different collection
+        sutProvider.GetDependency<ICollectionCipherRepository>()
+            .GetManyByUserIdCipherIdAsync(user.Id, cipherId)
+            .Returns(new List<CollectionCipher>
+            {
+                new() { CipherId = cipherId, CollectionId = otherCollectionId }
+            });
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.Get(cipherId));
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetAll_WithCollectionScope_FiltersToScopedCollection(
+        User user, SutProvider<CiphersController> sutProvider)
+    {
+        var collectionId = Guid.NewGuid();
+        var otherCollectionId = Guid.NewGuid();
+        var orgId = Guid.NewGuid();
+
+        var cipher1 = new CipherDetails
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.Id,
+            OrganizationId = orgId,
+            Type = CipherType.Login,
+            Data = "{}"
+        };
+        var cipher2 = new CipherDetails
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.Id,
+            OrganizationId = orgId,
+            Type = CipherType.Login,
+            Data = "{}"
+        };
+        var cipher3 = new CipherDetails
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.Id,
+            OrganizationId = orgId,
+            Type = CipherType.Login,
+            Data = "{}"
+        };
+
+        sutProvider.GetDependency<IUserService>()
+            .GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>())
+            .Returns(user);
+
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetManyByUserIdAsync(user.Id, withOrganizations: true)
+            .Returns(new List<CipherDetails> { cipher1, cipher2, cipher3 });
+
+        sutProvider.GetDependency<ICurrentContext>()
+            .Organizations.Returns(new List<CurrentContextOrganization>
+            {
+                new() { Id = orgId }
+            });
+
+        sutProvider.GetDependency<ICurrentContext>()
+            .CollectionId.Returns(collectionId);
+
+        // cipher1 and cipher3 are in the scoped collection, cipher2 is in a different collection
+        var collectionCiphers = new List<CollectionCipher>
+        {
+            new() { CipherId = cipher1.Id, CollectionId = collectionId },
+            new() { CipherId = cipher2.Id, CollectionId = otherCollectionId },
+            new() { CipherId = cipher3.Id, CollectionId = collectionId }
+        };
+
+        sutProvider.GetDependency<ICollectionCipherRepository>()
+            .GetManyByUserIdAsync(user.Id)
+            .Returns(collectionCiphers);
+
+        sutProvider.GetDependency<IApplicationCacheService>()
+            .GetOrganizationAbilitiesAsync()
+            .Returns(new Dictionary<Guid, OrganizationAbility>
+            {
+                { orgId, new OrganizationAbility { Id = orgId } }
+            });
+
+        var result = await sutProvider.Sut.GetAll();
+
+        // Only cipher1 and cipher3 should be returned (in the scoped collection)
+        Assert.Equal(2, result.Data.Count());
+        var resultIds = result.Data.Select(r => r.Id).ToHashSet();
+        Assert.Contains(cipher1.Id, resultIds);
+        Assert.Contains(cipher3.Id, resultIds);
+        Assert.DoesNotContain(cipher2.Id, resultIds);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetAll_WithoutCollectionScope_ReturnsAllCiphers(
+        User user, SutProvider<CiphersController> sutProvider)
+    {
+        var orgId = Guid.NewGuid();
+        var cipher1 = new CipherDetails
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.Id,
+            OrganizationId = orgId,
+            Type = CipherType.Login,
+            Data = "{}"
+        };
+        var cipher2 = new CipherDetails
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.Id,
+            OrganizationId = orgId,
+            Type = CipherType.Login,
+            Data = "{}"
+        };
+
+        sutProvider.GetDependency<IUserService>()
+            .GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>())
+            .Returns(user);
+
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetManyByUserIdAsync(user.Id, withOrganizations: true)
+            .Returns(new List<CipherDetails> { cipher1, cipher2 });
+
+        sutProvider.GetDependency<ICurrentContext>()
+            .Organizations.Returns(new List<CurrentContextOrganization>
+            {
+                new() { Id = orgId }
+            });
+
+        // No collection scope
+        sutProvider.GetDependency<ICurrentContext>()
+            .CollectionId.Returns((Guid?)null);
+
+        var collectionCiphers = new List<CollectionCipher>
+        {
+            new() { CipherId = cipher1.Id, CollectionId = Guid.NewGuid() },
+            new() { CipherId = cipher2.Id, CollectionId = Guid.NewGuid() }
+        };
+
+        sutProvider.GetDependency<ICollectionCipherRepository>()
+            .GetManyByUserIdAsync(user.Id)
+            .Returns(collectionCiphers);
+
+        sutProvider.GetDependency<IApplicationCacheService>()
+            .GetOrganizationAbilitiesAsync()
+            .Returns(new Dictionary<Guid, OrganizationAbility>
+            {
+                { orgId, new OrganizationAbility { Id = orgId } }
+            });
+
+        var result = await sutProvider.Sut.GetAll();
+
+        // Both ciphers should be returned when no collection scope
+        Assert.Equal(2, result.Data.Count());
+    }
+
+    #endregion
 }

--- a/test/Core.Test/Vault/Commands/CreateCollectionApiKeyCommandTests.cs
+++ b/test/Core.Test/Vault/Commands/CreateCollectionApiKeyCommandTests.cs
@@ -1,0 +1,117 @@
+using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Repositories;
+using Bit.Core.Vault.Commands;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Vault.Commands;
+
+[SutProviderCustomize]
+public class CreateCollectionApiKeyCommandTests
+{
+    [Theory, BitAutoData]
+    public async Task CreateAsync_NullCollectionId_ThrowsArgumentException(
+        SutProvider<CreateCollectionApiKeyCommand> sutProvider,
+        ApiKey apiKey)
+    {
+        apiKey.CollectionId = null;
+        apiKey.OrganizationId = Guid.NewGuid();
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => sutProvider.Sut.CreateAsync(apiKey));
+
+        Assert.Contains("CollectionId", exception.Message);
+
+        await sutProvider.GetDependency<IApiKeyRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .CreateAsync(default);
+    }
+
+    [Theory, BitAutoData]
+    public async Task CreateAsync_NullOrganizationId_ThrowsArgumentException(
+        SutProvider<CreateCollectionApiKeyCommand> sutProvider,
+        ApiKey apiKey)
+    {
+        apiKey.CollectionId = Guid.NewGuid();
+        apiKey.OrganizationId = null;
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => sutProvider.Sut.CreateAsync(apiKey));
+
+        Assert.Contains("OrganizationId", exception.Message);
+
+        await sutProvider.GetDependency<IApiKeyRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .CreateAsync(default);
+    }
+
+    [Theory, BitAutoData]
+    public async Task CreateAsync_ValidInput_GeneratesIdAndSecret(
+        SutProvider<CreateCollectionApiKeyCommand> sutProvider,
+        ApiKey apiKey)
+    {
+        apiKey.CollectionId = Guid.NewGuid();
+        apiKey.OrganizationId = Guid.NewGuid();
+        apiKey.Id = Guid.Empty; // Should be overwritten
+
+        var result = await sutProvider.Sut.CreateAsync(apiKey);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.ClientSecret);
+        Assert.NotEmpty(result.ClientSecret);
+        Assert.Equal(30, result.ClientSecret.Length);
+        Assert.NotEqual(Guid.Empty, result.ApiKey.Id);
+        Assert.NotNull(result.ApiKey.ClientSecretHash);
+        Assert.NotEmpty(result.ApiKey.ClientSecretHash);
+    }
+
+    [Theory, BitAutoData]
+    public async Task CreateAsync_ValidInput_SetsTimestamps(
+        SutProvider<CreateCollectionApiKeyCommand> sutProvider,
+        ApiKey apiKey)
+    {
+        apiKey.CollectionId = Guid.NewGuid();
+        apiKey.OrganizationId = Guid.NewGuid();
+        var beforeCreate = DateTime.UtcNow;
+
+        var result = await sutProvider.Sut.CreateAsync(apiKey);
+
+        Assert.True(result.ApiKey.CreationDate >= beforeCreate);
+        Assert.True(result.ApiKey.RevisionDate >= beforeCreate);
+    }
+
+    [Theory, BitAutoData]
+    public async Task CreateAsync_ValidInput_CallsRepository(
+        SutProvider<CreateCollectionApiKeyCommand> sutProvider,
+        ApiKey apiKey)
+    {
+        apiKey.CollectionId = Guid.NewGuid();
+        apiKey.OrganizationId = Guid.NewGuid();
+
+        await sutProvider.Sut.CreateAsync(apiKey);
+
+        await sutProvider.GetDependency<IApiKeyRepository>()
+            .Received(1)
+            .CreateAsync(apiKey);
+    }
+
+    [Theory, BitAutoData]
+    public async Task CreateAsync_ValidInput_HashMatchesSecret(
+        SutProvider<CreateCollectionApiKeyCommand> sutProvider,
+        ApiKey apiKey)
+    {
+        apiKey.CollectionId = Guid.NewGuid();
+        apiKey.OrganizationId = Guid.NewGuid();
+
+        var result = await sutProvider.Sut.CreateAsync(apiKey);
+
+        // Verify that hashing the returned client secret produces the stored hash
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        var bytes = System.Text.Encoding.UTF8.GetBytes(result.ClientSecret);
+        var expectedHash = Convert.ToBase64String(sha.ComputeHash(bytes));
+
+        Assert.Equal(expectedHash, result.ApiKey.ClientSecretHash);
+    }
+}

--- a/test/Identity.Test/IdentityServer/RequestValidators/VaultApiKeyGrantValidatorTests.cs
+++ b/test/Identity.Test/IdentityServer/RequestValidators/VaultApiKeyGrantValidatorTests.cs
@@ -1,0 +1,305 @@
+using System.Collections.Specialized;
+using Bit.Core.Auth.Identity;
+using Bit.Core.SecretsManager.Entities;
+using Bit.Core.SecretsManager.Models.Data;
+using Bit.Core.SecretsManager.Repositories;
+using Bit.Identity.IdentityServer.Enums;
+using Bit.Identity.IdentityServer.RequestValidators;
+using Bit.Identity.Test.AutoFixture;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Duende.IdentityServer.Validation;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Identity.Test.IdentityServer.RequestValidators;
+
+[SutProviderCustomize]
+public class VaultApiKeyGrantValidatorTests
+{
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_MissingClientId_ReturnsInvalidGrant(
+        [ValidatedTokenRequest] ValidatedTokenRequest tokenRequest,
+        SutProvider<VaultApiKeyGrantValidator> sutProvider)
+    {
+        tokenRequest.Raw = new NameValueCollection
+        {
+            { "client_secret", "some-secret" },
+        };
+
+        var context = new ExtensionGrantValidationContext { Request = tokenRequest };
+
+        await sutProvider.Sut.ValidateAsync(context);
+
+        Assert.True(context.Result.IsError);
+        Assert.Contains("client_id and client_secret are required", context.Result.ErrorDescription);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_MissingClientSecret_ReturnsInvalidGrant(
+        [ValidatedTokenRequest] ValidatedTokenRequest tokenRequest,
+        SutProvider<VaultApiKeyGrantValidator> sutProvider)
+    {
+        tokenRequest.Raw = new NameValueCollection
+        {
+            { "client_id", Guid.NewGuid().ToString() },
+        };
+
+        var context = new ExtensionGrantValidationContext { Request = tokenRequest };
+
+        await sutProvider.Sut.ValidateAsync(context);
+
+        Assert.True(context.Result.IsError);
+        Assert.Contains("client_id and client_secret are required", context.Result.ErrorDescription);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_InvalidGuidClientId_ReturnsInvalidGrant(
+        [ValidatedTokenRequest] ValidatedTokenRequest tokenRequest,
+        SutProvider<VaultApiKeyGrantValidator> sutProvider)
+    {
+        tokenRequest.Raw = new NameValueCollection
+        {
+            { "client_id", "not-a-guid" },
+            { "client_secret", "some-secret" },
+        };
+
+        var context = new ExtensionGrantValidationContext { Request = tokenRequest };
+
+        await sutProvider.Sut.ValidateAsync(context);
+
+        Assert.True(context.Result.IsError);
+        Assert.Contains("client_id must be a valid GUID", context.Result.ErrorDescription);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_ApiKeyNotFound_ReturnsInvalidGrant(
+        [ValidatedTokenRequest] ValidatedTokenRequest tokenRequest,
+        SutProvider<VaultApiKeyGrantValidator> sutProvider)
+    {
+        var apiKeyId = Guid.NewGuid();
+        tokenRequest.Raw = new NameValueCollection
+        {
+            { "client_id", apiKeyId.ToString() },
+            { "client_secret", "some-secret" },
+        };
+
+        sutProvider.GetDependency<IApiKeyRepository>()
+            .GetDetailsByIdAsync(apiKeyId)
+            .Returns((ApiKeyDetails)null);
+
+        var context = new ExtensionGrantValidationContext { Request = tokenRequest };
+
+        await sutProvider.Sut.ValidateAsync(context);
+
+        Assert.True(context.Result.IsError);
+        Assert.Contains("Invalid client credentials", context.Result.ErrorDescription);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_NotCollectionScoped_ReturnsInvalidGrant(
+        [ValidatedTokenRequest] ValidatedTokenRequest tokenRequest,
+        SutProvider<VaultApiKeyGrantValidator> sutProvider)
+    {
+        var apiKeyId = Guid.NewGuid();
+        var apiKey = CreateApiKeyDetails(apiKeyId);
+        apiKey.CollectionId = null; // Not collection-scoped
+
+        tokenRequest.Raw = new NameValueCollection
+        {
+            { "client_id", apiKeyId.ToString() },
+            { "client_secret", "test-secret" },
+        };
+
+        sutProvider.GetDependency<IApiKeyRepository>()
+            .GetDetailsByIdAsync(apiKeyId)
+            .Returns(apiKey);
+
+        var context = new ExtensionGrantValidationContext { Request = tokenRequest };
+
+        await sutProvider.Sut.ValidateAsync(context);
+
+        Assert.True(context.Result.IsError);
+        Assert.Contains("not collection-scoped", context.Result.ErrorDescription);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_ExpiredKey_ReturnsInvalidGrant(
+        [ValidatedTokenRequest] ValidatedTokenRequest tokenRequest,
+        SutProvider<VaultApiKeyGrantValidator> sutProvider)
+    {
+        var apiKeyId = Guid.NewGuid();
+        var clientSecret = "test-secret";
+        var apiKey = CreateApiKeyDetails(apiKeyId, clientSecret);
+        apiKey.ExpireAt = DateTime.UtcNow.AddDays(-1); // Expired yesterday
+
+        tokenRequest.Raw = new NameValueCollection
+        {
+            { "client_id", apiKeyId.ToString() },
+            { "client_secret", clientSecret },
+        };
+
+        sutProvider.GetDependency<IApiKeyRepository>()
+            .GetDetailsByIdAsync(apiKeyId)
+            .Returns(apiKey);
+
+        var context = new ExtensionGrantValidationContext { Request = tokenRequest };
+
+        await sutProvider.Sut.ValidateAsync(context);
+
+        Assert.True(context.Result.IsError);
+        Assert.Contains("expired", context.Result.ErrorDescription);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_WrongSecret_ReturnsInvalidGrant(
+        [ValidatedTokenRequest] ValidatedTokenRequest tokenRequest,
+        SutProvider<VaultApiKeyGrantValidator> sutProvider)
+    {
+        var apiKeyId = Guid.NewGuid();
+        var apiKey = CreateApiKeyDetails(apiKeyId, "correct-secret");
+
+        tokenRequest.Raw = new NameValueCollection
+        {
+            { "client_id", apiKeyId.ToString() },
+            { "client_secret", "wrong-secret" },
+        };
+
+        sutProvider.GetDependency<IApiKeyRepository>()
+            .GetDetailsByIdAsync(apiKeyId)
+            .Returns(apiKey);
+
+        var context = new ExtensionGrantValidationContext { Request = tokenRequest };
+
+        await sutProvider.Sut.ValidateAsync(context);
+
+        Assert.True(context.Result.IsError);
+        Assert.Contains("Invalid client credentials", context.Result.ErrorDescription);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_ValidKey_ReturnsSuccessWithClaims(
+        [ValidatedTokenRequest] ValidatedTokenRequest tokenRequest,
+        SutProvider<VaultApiKeyGrantValidator> sutProvider)
+    {
+        var apiKeyId = Guid.NewGuid();
+        var orgId = Guid.NewGuid();
+        var collectionId = Guid.NewGuid();
+        var clientSecret = "valid-test-secret";
+        var apiKey = CreateApiKeyDetails(apiKeyId, clientSecret, orgId, collectionId);
+
+        tokenRequest.Raw = new NameValueCollection
+        {
+            { "client_id", apiKeyId.ToString() },
+            { "client_secret", clientSecret },
+        };
+
+        sutProvider.GetDependency<IApiKeyRepository>()
+            .GetDetailsByIdAsync(apiKeyId)
+            .Returns(apiKey);
+
+        var context = new ExtensionGrantValidationContext { Request = tokenRequest };
+
+        await sutProvider.Sut.ValidateAsync(context);
+
+        Assert.False(context.Result.IsError);
+        Assert.NotNull(context.Result.Subject);
+
+        var claims = context.Result.Subject.Claims.ToList();
+        Assert.Contains(claims, c => c.Type == Claims.Type
+            && c.Value == IdentityClientType.Organization.ToString());
+        Assert.Contains(claims, c => c.Type == Claims.Organization
+            && c.Value == orgId.ToString());
+        Assert.Contains(claims, c => c.Type == "collection_id"
+            && c.Value == collectionId.ToString());
+        Assert.Contains(claims, c => c.Type == "scope");
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_NoExpiration_ReturnsSuccess(
+        [ValidatedTokenRequest] ValidatedTokenRequest tokenRequest,
+        SutProvider<VaultApiKeyGrantValidator> sutProvider)
+    {
+        var apiKeyId = Guid.NewGuid();
+        var clientSecret = "no-expiry-secret";
+        var apiKey = CreateApiKeyDetails(apiKeyId, clientSecret);
+        apiKey.ExpireAt = null; // No expiration
+
+        tokenRequest.Raw = new NameValueCollection
+        {
+            { "client_id", apiKeyId.ToString() },
+            { "client_secret", clientSecret },
+        };
+
+        sutProvider.GetDependency<IApiKeyRepository>()
+            .GetDetailsByIdAsync(apiKeyId)
+            .Returns(apiKey);
+
+        var context = new ExtensionGrantValidationContext { Request = tokenRequest };
+
+        await sutProvider.Sut.ValidateAsync(context);
+
+        Assert.False(context.Result.IsError);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_FutureExpiration_ReturnsSuccess(
+        [ValidatedTokenRequest] ValidatedTokenRequest tokenRequest,
+        SutProvider<VaultApiKeyGrantValidator> sutProvider)
+    {
+        var apiKeyId = Guid.NewGuid();
+        var clientSecret = "future-expiry-secret";
+        var apiKey = CreateApiKeyDetails(apiKeyId, clientSecret);
+        apiKey.ExpireAt = DateTime.UtcNow.AddDays(30); // Expires in 30 days
+
+        tokenRequest.Raw = new NameValueCollection
+        {
+            { "client_id", apiKeyId.ToString() },
+            { "client_secret", clientSecret },
+        };
+
+        sutProvider.GetDependency<IApiKeyRepository>()
+            .GetDetailsByIdAsync(apiKeyId)
+            .Returns(apiKey);
+
+        var context = new ExtensionGrantValidationContext { Request = tokenRequest };
+
+        await sutProvider.Sut.ValidateAsync(context);
+
+        Assert.False(context.Result.IsError);
+    }
+
+    private static CollectionApiKeyDetails CreateApiKeyDetails(
+        Guid id,
+        string clientSecret = "test-secret",
+        Guid? organizationId = null,
+        Guid? collectionId = null)
+    {
+        organizationId ??= Guid.NewGuid();
+        collectionId ??= Guid.NewGuid();
+
+        // Use the ApiKey base entity first, then wrap in CollectionApiKeyDetails
+        var apiKey = new ApiKey
+        {
+            Id = id,
+            Name = "Test Collection Key",
+            OrganizationId = organizationId,
+            CollectionId = collectionId,
+            ClientSecretHash = HashSecret(clientSecret),
+            Scope = "[\"api.vault\"]",
+            EncryptedPayload = "encrypted-payload",
+            Key = "encryption-key",
+            ExpireAt = DateTime.UtcNow.AddDays(90),
+        };
+
+        return new CollectionApiKeyDetails(apiKey);
+    }
+
+    private static string HashSecret(string input)
+    {
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        var bytes = System.Text.Encoding.UTF8.GetBytes(input);
+        var hash = sha.ComputeHash(bytes);
+        return Convert.ToBase64String(hash);
+    }
+}


### PR DESCRIPTION
## Summary

Adds collection-scoped API keys that restrict vault access to items within a specific collection. This enables AI agents and automation tools to access only designated vault items rather than entire organizations.

Related: #7252

## Changes

### Data Model (Phase 2)
- Extended \ApiKey\ entity with \Guid? OrganizationId\ and \Guid? CollectionId\
- Added \GetManyByCollectionIdAsync\ and \GetByClientSecretHashAsync\ to \IApiKeyRepository\
- SQL migration: ALTER TABLE ApiKey + FKs, indexes, stored procedures
- Dapper + EF implementations

### Authentication (Phase 3)
- New \VaultApiKeyGrantValidator\ with grant_type=\ault_api_key\
- Validates client_id/client_secret, checks expiration
- Emits JWT with \collection_id\ claim for server-side filtering

### API Endpoint (Phase 4)
- \CollectionApiKeysController\: POST/GET/DELETE at \/organizations/{orgId}/collections/{collectionId}/api-keys\
- \CreateCollectionApiKeyCommand\: COMB GUID generation, 30-char secret, SHA256 hashing

### Query Filtering (Phase 5)
- \CiphersController.Get/GetDetails\: Verifies cipher belongs to scoped collection
- \CiphersController.GetAll\: Filters cipher list to scoped collection
- \SyncController.Get\: Filters ciphers and collections to scoped collection
- \ICurrentContext.CollectionId\: Parsed from JWT \collection_id\ claim

### Tests (Phase 6)
- 10 VaultApiKeyGrantValidator tests (error/rejection/success paths)
- 6 CreateCollectionApiKeyCommand tests (validation + generation)
- 4 Collection cipher filtering tests (positive/negative/backwards compat)
- All 130 existing CiphersController tests pass (no regressions)

## Security
- Server-enforced collection scoping — no client-side bypass possible
- NULL CollectionId = org-wide access (backwards compatible)
- API keys have expiration enforcement
- Client secret shown once, stored as SHA256 hash

## CLA
CLA signed by contributor (Tamir Dresher).