### PR TITLE
[PM-33364] Fix the emergency access help URL.

### DIFF
--- a/src/Core/Auth/UserFeatures/EmergencyAccess/Mail/EmergencyAccessRemoveGranteesMailView.cs
+++ b/src/Core/Auth/UserFeatures/EmergencyAccess/Mail/EmergencyAccessRemoveGranteesMailView.cs
@@ -6,7 +6,11 @@ public class EmergencyAccessRemoveGranteesMailView : BaseMailView
 {
 
     public required IEnumerable<string> RemovedGranteeEmails { get; set; }
+    // ReSharper disable once MemberCanBeMadeStatic.Global
+#pragma warning disable CA1822
+    // Handlebars needs it to be an instance variable to work properly.
     public string EmergencyAccessHelpPageUrl => "https://bitwarden.com/help/emergency-access/";
+#pragma warning restore CA1822
 }
 
 public class EmergencyAccessRemoveGranteesMail : BaseMail<EmergencyAccessRemoveGranteesMailView>

--- a/test/Core.Test/Auth/UserFeatures/EmergencyAccess/EmergencyAccessMailTests.cs
+++ b/test/Core.Test/Auth/UserFeatures/EmergencyAccess/EmergencyAccessMailTests.cs
@@ -148,6 +148,6 @@ public class EmergencyAccessMailTests
         Assert.NotNull(mail);
         Assert.NotNull(mail.View);
         Assert.Equal(_emergencyAccessMailSubject, mail.Subject);
-        Assert.Equal(_emergencyAccessHelpUrl, EmergencyAccessRemoveGranteesMailView.EmergencyAccessHelpPageUrl);
+        Assert.Equal(_emergencyAccessHelpUrl, mail.View.EmergencyAccessHelpPageUrl);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33364

## 📔 Objective
Static methods are not available to Handlebars, causing the <a> tag to be blank, and some email clients remove the link.

The solution is to simply revert it back to an instance property.
## 📸 Screenshots

Sven's testing screenshots 

<img width="1944" height="390" alt="image" src="https://github.com/user-attachments/assets/475919e9-70e5-4656-93e9-b1b95aecaacd" />

<img width="1372" height="384" alt="image" src="https://github.com/user-attachments/assets/bfd68b8a-3bcf-40a3-a106-a8e42a75c299" />

