### PR TITLE
fix(repository-management): job-level permissions

### DIFF
--- a/.github/workflows/repository-management.yml
+++ b/.github/workflows/repository-management.yml
@@ -241,5 +241,10 @@ jobs:
   move_edd_db_scripts:
     name: Move EDD database scripts
     needs: cut_branch
-    permissions: {}
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+      id-token: write
     uses: ./.github/workflows/_move_edd_db_scripts.yml
+    secrets: inherit


### PR DESCRIPTION


## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Failing workflow run: https://github.com/bitwarden/server/actions/runs/23314091253

[Slack thread](https://bitwarden.slack.com/archives/C024Z7LQNLB/p1773950790033519)

Add grant job-level permissions to `move_edd_db_secrets`.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
