### PR TITLE
[PM-31736] User-friendly cookie vendor error message

### DIFF
--- a/src/Api/Platform/SsoCookieVendor/Controllers/SsoCookieVendorController.cs
+++ b/src/Api/Platform/SsoCookieVendor/Controllers/SsoCookieVendorController.cs
@@ -12,9 +12,10 @@ namespace Bit.Api.Platform.SsoCookieVendor;
 /// </summary>
 [Route("sso-cookie-vendor")]
 [SelfHosted(SelfHostedOnly = true)]
-public class SsoCookieVendorController(IGlobalSettings globalSettings) : Controller
+public class SsoCookieVendorController(IGlobalSettings globalSettings, ILogger<SsoCookieVendorController> logger) : Controller
 {
     private readonly IGlobalSettings _globalSettings = globalSettings;
+    private readonly ILogger<SsoCookieVendorController> _logger = logger;
     private const int _maxShardCount = 20;
     private const int _maxUriLength = 8192;
 
@@ -33,13 +34,15 @@ public class SsoCookieVendorController(IGlobalSettings globalSettings) : Control
         var bootstrap = _globalSettings.Communication?.Bootstrap;
         if (string.IsNullOrEmpty(bootstrap) || !bootstrap.Equals("ssoCookieVendor", StringComparison.OrdinalIgnoreCase))
         {
-            return NotFound();
+            _logger.LogWarning("SSO cookie vendor endpoint reached but bootstrap is not configured.");
+            return ResponseHTML(StatusCodes.Status404NotFound);
         }
 
         var cookieName = _globalSettings.Communication?.SsoCookieVendor?.CookieName;
         if (string.IsNullOrWhiteSpace(cookieName))
         {
-            return StatusCode(500, "SSO cookie vendor is not properly configured");
+            _logger.LogError("SSO cookie vendor is not properly configured: CookieName is missing.");
+            return ResponseHTML(StatusCodes.Status500InternalServerError);
         }
 
         var uri = string.Empty;
@@ -54,16 +57,33 @@ public class SsoCookieVendorController(IGlobalSettings globalSettings) : Control
 
         if (uri == string.Empty)
         {
-            return NotFound("No SSO cookies found");
+            _logger.LogWarning("No SSO cookies found.");
+            return ResponseHTML(StatusCodes.Status404NotFound);
         }
 
         if (uri.Length > _maxUriLength)
         {
-            return BadRequest();
+            _logger.LogError("Generated SSO redirect URI exceeds maximum length of {MaxUriLength}.", _maxUriLength);
+            return ResponseHTML(StatusCodes.Status400BadRequest);
         }
 
         return Redirect(uri);
     }
+
+    private static ContentResult ResponseHTML(int statusCode) => new()
+    {
+        StatusCode = statusCode,
+        ContentType = "text/html",
+        Content = $"""
+            <!DOCTYPE html>
+            <html lang="en">
+            <head><meta charset="utf-8"><title>Error</title></head>
+            <body>
+                <p>Error code {statusCode}. Please return to the Bitwarden app and try again.</p>
+            </body>
+            </html>
+            """
+    };
 
     private bool TryGetCookie(string cookieName, out Dictionary<string, string> cookie)
     {

--- a/test/Api.Test/Platform/SsoCookieVendor/Controllers/SsoCookieVendorControllerTests.cs
+++ b/test/Api.Test/Platform/SsoCookieVendor/Controllers/SsoCookieVendorControllerTests.cs
@@ -4,6 +4,7 @@ using Bit.Api.Platform.SsoCookieVendor;
 using Bit.Core.Settings;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
 
@@ -27,7 +28,8 @@ public class SsoCookieVendorControllerTests : IDisposable
                 }
             }
         };
-        _sut = new SsoCookieVendorController(_globalSettings);
+        var logger = Substitute.For<ILogger<SsoCookieVendorController>>();
+        _sut = new SsoCookieVendorController(_globalSettings, logger);
     }
 
     public void Dispose()
@@ -81,7 +83,11 @@ public class SsoCookieVendorControllerTests : IDisposable
         var result = _sut.Get();
 
         // Assert
-        Assert.IsType<NotFoundResult>(result);
+        var result404 = Assert.IsType<ContentResult>(result);
+        Assert.Equal(404, result404.StatusCode);
+        Assert.Equal("text/html", result404.ContentType);
+        Assert.Contains("Error code 404", result404.Content);
+        Assert.Contains("Please return to the Bitwarden app and try again", result404.Content);
     }
 
     [Fact]
@@ -95,8 +101,12 @@ public class SsoCookieVendorControllerTests : IDisposable
         var result = _sut.Get();
 
         // Assert
-        var statusCodeResult = Assert.IsType<ObjectResult>(result);
-        Assert.Equal(500, statusCodeResult.StatusCode);
+        var contentResult = Assert.IsType<ContentResult>(result);
+        Assert.Equal(500, contentResult.StatusCode);
+        Assert.Equal("text/html", contentResult.ContentType);
+        Assert.Contains("Error code 500", contentResult.Content);
+        Assert.Contains("Please return to the Bitwarden app and try again", contentResult.Content);
+        Assert.DoesNotContain("SSO cookie vendor is not properly configured", contentResult.Content);
     }
 
     [Fact]
@@ -110,8 +120,12 @@ public class SsoCookieVendorControllerTests : IDisposable
         var result = _sut.Get();
 
         // Assert
-        var statusCodeResult = Assert.IsType<ObjectResult>(result);
-        Assert.Equal(500, statusCodeResult.StatusCode);
+        var contentResult = Assert.IsType<ContentResult>(result);
+        Assert.Equal(500, contentResult.StatusCode);
+        Assert.Equal("text/html", contentResult.ContentType);
+        Assert.Contains("Error code 500", contentResult.Content);
+        Assert.Contains("Please return to the Bitwarden app and try again", contentResult.Content);
+        Assert.DoesNotContain("SSO cookie vendor is not properly configured", contentResult.Content);
     }
 
     [Fact]
@@ -218,7 +232,12 @@ public class SsoCookieVendorControllerTests : IDisposable
         var result = _sut.Get();
 
         // Assert
-        Assert.IsType<NotFoundObjectResult>(result);
+        var contentResult = Assert.IsType<ContentResult>(result);
+        Assert.Equal(404, contentResult.StatusCode);
+        Assert.Equal("text/html", contentResult.ContentType);
+        Assert.Contains("Error code 404", contentResult.Content);
+        Assert.Contains("Please return to the Bitwarden app and try again", contentResult.Content);
+        Assert.DoesNotContain("No SSO cookies found", contentResult.Content);
     }
 
     [Fact]
@@ -231,7 +250,12 @@ public class SsoCookieVendorControllerTests : IDisposable
         var result = _sut.Get();
 
         // Assert
-        Assert.IsType<NotFoundObjectResult>(result);
+        var contentResult = Assert.IsType<ContentResult>(result);
+        Assert.Equal(404, contentResult.StatusCode);
+        Assert.Equal("text/html", contentResult.ContentType);
+        Assert.Contains("Error code 404", contentResult.Content);
+        Assert.Contains("Please return to the Bitwarden app and try again", contentResult.Content);
+        Assert.DoesNotContain("No SSO cookies found", contentResult.Content);
     }
 
     [Fact]
@@ -249,7 +273,12 @@ public class SsoCookieVendorControllerTests : IDisposable
         var result = _sut.Get();
 
         // Assert
-        Assert.IsType<NotFoundObjectResult>(result);
+        var contentResult = Assert.IsType<ContentResult>(result);
+        Assert.Equal(404, contentResult.StatusCode);
+        Assert.Equal("text/html", contentResult.ContentType);
+        Assert.Contains("Error code 404", contentResult.Content);
+        Assert.Contains("Please return to the Bitwarden app and try again", contentResult.Content);
+        Assert.DoesNotContain("No SSO cookies found", contentResult.Content);
     }
 
     [Fact]
@@ -269,7 +298,11 @@ public class SsoCookieVendorControllerTests : IDisposable
         var result = _sut.Get();
 
         // Assert
-        Assert.IsType<BadRequestResult>(result);
+        var contentResult = Assert.IsType<ContentResult>(result);
+        Assert.Equal(400, contentResult.StatusCode);
+        Assert.Equal("text/html", contentResult.ContentType);
+        Assert.Contains("Error code 400", contentResult.Content);
+        Assert.Contains("Please return to the Bitwarden app and try again", contentResult.Content);
     }
 
     [Fact]
@@ -306,7 +339,12 @@ public class SsoCookieVendorControllerTests : IDisposable
         var result = _sut.Get();
 
         // Assert
-        Assert.IsType<NotFoundObjectResult>(result);
+        var contentResult = Assert.IsType<ContentResult>(result);
+        Assert.Equal(404, contentResult.StatusCode);
+        Assert.Equal("text/html", contentResult.ContentType);
+        Assert.Contains("Error code 404", contentResult.Content);
+        Assert.Contains("Please return to the Bitwarden app and try again", contentResult.Content);
+        Assert.DoesNotContain("No SSO cookies found", contentResult.Content);
     }
 
     [Fact]


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31736](https://bitwarden.atlassian.net/browse/PM-31736)

## 📔 Objective

The SSO cookie vendor endpoint produced responses that were not very user-friendly. This PR sends those messages to the log instead, and responds simply with an HTTP status code as an error code and asks the user to return to the app and try again.


[PM-31736]: https://bitwarden.atlassian.net/browse/PM-31736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ