### PR TITLE
[PM-22110] Remove pm-22110-disable-alternate-login-methods feature flag

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -157,7 +157,6 @@ public static class FeatureFlagKeys
 
     /* Auth Team */
     public const string Otp6Digits = "pm-18612-otp-6-digits";
-    public const string DisableAlternateLoginMethods = "pm-22110-disable-alternate-login-methods";
     public const string PM2035PasskeyUnlock = "pm-2035-passkey-unlock";
     public const string MjmlWelcomeEmailTemplates = "pm-21741-mjml-welcome-email";
     public const string MarketingInitiatedPremiumFlow = "pm-26140-marketing-initiated-premium-flow";


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-28329

## 📔 Objective

Removes `pm-22110-disable-alternate-login-methods` feature flag from server.

This flag was not ever used on the server and was removed from `clients` as follows:

 | Location | Status | Details |
  |---|---|---|
  | **Clients** | ✅ Removed | [23ac477](https://github.com/bitwarden/clients/commit/23ac477bbc120c331da5cb70bea86c6b8c2cc91a) (2025-11-21) |

  ### Timeline

  | Milestone | Version |
  |---|---|
  | First client **without** flag | `2026.1.0` |
  | Last client **with** flag | `2025.11.1` |
  | Server safe to remove | `2026.2.0` (last client + 3 months) |
  | Current server version | `v2026.3.0` |

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
