### PR TITLE
[PM-33972] Remove pm-26140-marketing-initiated-premium-flow feature flag

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -160,7 +160,6 @@ public static class FeatureFlagKeys
     public const string DisableAlternateLoginMethods = "pm-22110-disable-alternate-login-methods";
     public const string PM2035PasskeyUnlock = "pm-2035-passkey-unlock";
     public const string MjmlWelcomeEmailTemplates = "pm-21741-mjml-welcome-email";
-    public const string MarketingInitiatedPremiumFlow = "pm-26140-marketing-initiated-premium-flow";
     public const string PrefetchPasswordPrelogin = "pm-23801-prefetch-password-prelogin";
     public const string SafariAccountSwitching = "pm-5594-safari-account-switching";
     public const string PM27086_UpdateAuthenticationApisForInputPassword = "pm-27086-update-authentication-apis-for-input-password";

--- a/src/Identity/Controllers/AccountsController.cs
+++ b/src/Identity/Controllers/AccountsController.cs
@@ -105,12 +105,8 @@ public class AccountsController : Controller
     [HttpPost("register/send-verification-email")]
     public async Task<IActionResult> PostRegisterSendVerificationEmail([FromBody] RegisterSendVerificationEmailRequestModel model)
     {
-        // Only pass fromMarketing if the feature flag is enabled
-        var isMarketingFeatureEnabled = _featureService.IsEnabled(FeatureFlagKeys.MarketingInitiatedPremiumFlow);
-        var fromMarketing = isMarketingFeatureEnabled ? model.FromMarketing : null;
-
         var token = await _sendVerificationEmailForRegistrationCommand.Run(model.Email, model.Name,
-            model.ReceiveMarketingEmails, fromMarketing);
+            model.ReceiveMarketingEmails, model.FromMarketing);
 
         if (token != null)
         {

--- a/test/Identity.Test/Controllers/AccountsControllerTests.cs
+++ b/test/Identity.Test/Controllers/AccountsControllerTests.cs
@@ -278,7 +278,7 @@ public class AccountsControllerTests : IDisposable
 
     [Theory]
     [BitAutoData]
-    public async Task PostRegisterSendEmailVerification_WhenFeatureFlagEnabled_PassesFromMarketingToCommandAsync(
+    public async Task PostRegisterSendEmailVerification_PassesFromMarketingToCommandAsync(
         string email, string name, bool receiveMarketingEmails)
     {
         // Arrange
@@ -291,38 +291,12 @@ public class AccountsControllerTests : IDisposable
             FromMarketing = fromMarketing,
         };
 
-        _featureService.IsEnabled(FeatureFlagKeys.MarketingInitiatedPremiumFlow).Returns(true);
-
         // Act
         await _sut.PostRegisterSendVerificationEmail(model);
 
         // Assert
         await _sendVerificationEmailForRegistrationCommand.Received(1)
             .Run(email, name, receiveMarketingEmails, fromMarketing);
-    }
-
-    [Theory]
-    [BitAutoData]
-    public async Task PostRegisterSendEmailVerification_WhenFeatureFlagDisabled_PassesNullFromMarketingToCommandAsync(
-        string email, string name, bool receiveMarketingEmails)
-    {
-        // Arrange
-        var model = new RegisterSendVerificationEmailRequestModel
-        {
-            Email = email,
-            Name = name,
-            ReceiveMarketingEmails = receiveMarketingEmails,
-            FromMarketing = MarketingInitiativeConstants.Premium, // model includes FromMarketing: "premium"
-        };
-
-        _featureService.IsEnabled(FeatureFlagKeys.MarketingInitiatedPremiumFlow).Returns(false);
-
-        // Act
-        await _sut.PostRegisterSendVerificationEmail(model);
-
-        // Assert
-        await _sendVerificationEmailForRegistrationCommand.Received(1)
-            .Run(email, name, receiveMarketingEmails, null); // fromMarketing gets ignored and null gets passed
     }
 
     [Theory, BitAutoData]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33972

## 📔 Objective

Removes `pm-26140-marketing-initiated-premium-flow` from server, along with check in `send-verification-email`.

This flag did not exist on `clients` and so can be removed safely on the server.
