### PR TITLE
PM-33964 - Fix silent switch defaults in Seeder with fail-fast throws

### DIFF
--- a/util/Seeder/Data/Generators/CardDataGenerator.cs
+++ b/util/Seeder/Data/Generators/CardDataGenerator.cs
@@ -68,7 +68,7 @@ internal sealed class CardDataGenerator
         // Latin America
         "Elo" => faker.PickRandom("4011", "4312", "4389", "5041", "5066", "5067", "6277", "6362", "6363") + faker.Random.ReplaceNumbers("############"),
 
-        _ => faker.Finance.CreditCardNumber()
+        _ => throw new ArgumentException($"Unknown card brand: '{brand}'", nameof(brand))
     };
 
     private static string GenerateCode(string brand, Faker faker) =>

--- a/util/Seeder/Data/Generators/CipherUsernameGenerator.cs
+++ b/util/Seeder/Data/Generators/CipherUsernameGenerator.cs
@@ -97,7 +97,7 @@ internal sealed class CipherUsernameGenerator
             UsernameCategory.PhoneNumber => GeneratePhoneNumber(seededFaker, index),
             UsernameCategory.LegacySystem => GenerateLegacySystem(firstName, lastName, index),
             UsernameCategory.RandomAlphanumeric => GenerateRandomAlphanumeric(seededFaker),
-            _ => GenerateCorporateEmail(firstName, lastName, domain ?? "example.com")
+            _ => throw new ArgumentOutOfRangeException(nameof(category), category, null)
         };
     }
 
@@ -115,7 +115,7 @@ internal sealed class CipherUsernameGenerator
             UsernamePatternType.LastDotFirst => $"{last}.{first}@{domain}",
             UsernamePatternType.First_Last => $"{first}_{last}@{domain}",
             UsernamePatternType.LastFirst => $"{last}{f}@{domain}",
-            _ => $"{first}.{last}@{domain}"
+            _ => throw new ArgumentOutOfRangeException(nameof(_corporateEmailPattern), _corporateEmailPattern, null)
         };
     }
 
@@ -226,7 +226,7 @@ internal sealed class CipherUsernameGenerator
         GeographicRegion.MiddleEast => PickLocale(MiddleEastLocales, seed),
         GeographicRegion.Africa => PickLocale(AfricanLocales, seed),
         GeographicRegion.Global => "en",
-        _ => "en"
+        _ => throw new ArgumentOutOfRangeException(nameof(region), region, null)
     };
 
     private static string PickLocale(string[] locales, int seed)

--- a/util/Seeder/Data/Generators/IdentityDataGenerator.cs
+++ b/util/Seeder/Data/Generators/IdentityDataGenerator.cs
@@ -64,7 +64,8 @@ internal sealed class IdentityDataGenerator(int seed, GeographicRegion region = 
         GeographicRegion.Europe => $"AB {10 + (index % 90):D2} {10 + ((index + 1) % 90):D2} {10 + ((index + 2) % 90):D2} C",
         GeographicRegion.AsiaPacific => $"{1000 + (index % 9000):D4}-{1000 + ((index + 1) % 9000):D4}-{1000 + ((index + 2) % 9000):D4}",
         GeographicRegion.LatinAmerica => $"{100 + (index % 900):D3}.{100 + ((index + 1) % 900):D3}.{100 + ((index + 2) % 900):D3}-{10 + (index % 90):D2}",
-        _ => $"{100 + (index % 899):D3}-{10 + (index % 90):D2}-{1000 + (index % 9000):D4}"
+        GeographicRegion.MiddleEast or GeographicRegion.Africa or GeographicRegion.Global => $"{100 + (index % 899):D3}-{10 + (index % 90):D2}-{1000 + (index % 9000):D4}",
+        _ => throw new ArgumentOutOfRangeException(nameof(_region), _region, null)
     };
 
     private static string GeneratePassportNumberByIndex(int index) =>
@@ -81,7 +82,8 @@ internal sealed class IdentityDataGenerator(int seed, GeographicRegion region = 
         GeographicRegion.LatinAmerica => faker.PickRandom("BR", "MX", "AR", "CO", "CL"),
         GeographicRegion.MiddleEast => faker.PickRandom("AE", "SA", "IL", "TR"),
         GeographicRegion.Africa => faker.PickRandom("ZA", "NG", "EG", "KE"),
-        _ => faker.Address.CountryCode()
+        GeographicRegion.Global => faker.Address.CountryCode(),
+        _ => throw new ArgumentOutOfRangeException(nameof(_region), _region, null)
     };
 
     private static string MapRegionToLocale(GeographicRegion region) => region switch
@@ -92,6 +94,7 @@ internal sealed class IdentityDataGenerator(int seed, GeographicRegion region = 
         GeographicRegion.LatinAmerica => "es",
         GeographicRegion.MiddleEast => "en",
         GeographicRegion.Africa => "en",
-        _ => "en"
+        GeographicRegion.Global => "en",
+        _ => throw new ArgumentOutOfRangeException(nameof(region), region, null)
     };
 }

--- a/util/Seeder/Data/Generators/SecureNoteDataGenerator.cs
+++ b/util/Seeder/Data/Generators/SecureNoteDataGenerator.cs
@@ -57,7 +57,7 @@ internal sealed class SecureNoteDataGenerator(int seed)
         "Expense System" => $"{faker.PickRandom("Concur", "Expensify", "SAP", "Corporate Card")} Access",
         "Coffee Machine" => $"{faker.PickRandom("Break Room", "Executive Lounge", "Cafeteria", "Kitchen")} Coffee Machine",
         "Parking Garage" => $"{faker.Address.StreetName()} Parking",
-        _ => faker.Lorem.Sentence(3)
+        _ => throw new ArgumentException($"Unknown note category: '{category}'", nameof(category))
     };
 
     private static string GenerateNoteContent(string category, Faker faker) => category switch
@@ -165,6 +165,6 @@ internal sealed class SecureNoteDataGenerator(int seed)
             Emergency Exit: {faker.PickRandom("Stairwell B", "North ramp", "Elevator to lobby")}
             """,
 
-        _ => faker.Lorem.Paragraph()
+        _ => throw new ArgumentException($"Unknown note category: '{category}'", nameof(category))
     };
 }

--- a/util/Seeder/Data/Static/Passwords.cs
+++ b/util/Seeder/Data/Static/Passwords.cs
@@ -191,7 +191,7 @@ internal static class Passwords
         PasswordStrength.Fair => Fair,
         PasswordStrength.Strong => Strong,
         PasswordStrength.VeryStrong => VeryStrong,
-        _ => Strong
+        _ => throw new ArgumentOutOfRangeException(nameof(strength), strength, null)
     };
 
     /// <summary>

--- a/util/Seeder/Factories/PlanFeatures.cs
+++ b/util/Seeder/Factories/PlanFeatures.cs
@@ -115,6 +115,8 @@ public static class PlanFeatures
             PlanType.TeamsStarter => (10, 10, 10),
             PlanType.EnterpriseMonthly => (1, 185, 17),
             PlanType.EnterpriseAnnually => (1, 12000, 60),
+            // Intentional: PlanType has 20+ variants including legacy plans. Seeder only models
+            // the 7 current plans; all others get reasonable defaults. Not a bug.
             _ => (1, 100, 10)
         };
 

--- a/util/Seeder/Factories/SeedItemMapping.cs
+++ b/util/Seeder/Factories/SeedItemMapping.cs
@@ -12,7 +12,8 @@ internal static class SeedItemMapping
         "hidden" => 1,
         "boolean" => 2,
         "linked" => 3,
-        _ => 0 // text
+        "text" => 0,
+        _ => throw new ArgumentException($"Unknown field type: '{type}'", nameof(type))
     };
 
     internal static List<FieldViewDto>? MapFields(List<SeedField>? fields) =>
@@ -30,6 +31,7 @@ internal static class SeedItemMapping
         "exact" => 3,
         "regex" => 4,
         "never" => 5,
-        _ => 0 // domain
+        "domain" => 0,
+        _ => throw new ArgumentException($"Unknown URI match type: '{match}'", nameof(match))
     };
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33964](https://bitwarden.atlassian.net/browse/PM-33964)

## 📔 Objective

Enforce the Seeder's default: throw rule by replacing 12 silent `_ =>` fallbacks across 6 files with explicit throw statements, preventing future enum or string additions from silently producing incorrect data. Three IdentityDataGenerator switches that were actively hit by MiddleEast, Africa, and Global regions now have explicit cases preserving the original behavior before the throw guard. One intentional fallback in `PlanFeatures.cs` (covering 20+ legacy plan types) was documented with a comment rather than changed.


[PM-33964]: https://bitwarden.atlassian.net/browse/PM-33964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ