### PR TITLE
[PM-33980] Only verify `UseMyItems` when claim exists

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationAbility/README.md
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationAbility/README.md
@@ -263,7 +263,9 @@ For manual override capability in the admin portal:
 
 - `src/Core/Billing/Organizations/Models/OrganizationLicense.cs`
     - Add the new property to the class
-    - `VerifyData()` — Add claims validation
+    - `VerifyData()` — Add claims validation using conditional comparison
+      (`!claimsPrincipal.HasClaim(...) || claimValue == orgValue`) so that self-hosted instances
+      with licenses generated before the claim existed are not incorrectly disabled (see PM-33980)
     - `GetDataBytes()` — Add the new property to the ignored fields section (below the comment
       `// any new fields added need to be added here so that they're ignored`)
 

--- a/src/Core/Billing/Organizations/Models/OrganizationLicense.cs
+++ b/src/Core/Billing/Organizations/Models/OrganizationLicense.cs
@@ -42,6 +42,9 @@ public class OrganizationLicense : ILicense
     /// 1. Use the claims-based system instead of adding properties here
     /// 2. Add new claims to the license token
     /// 3. Validate claims in the <see cref="CanUse"/> and <see cref="VerifyData"/> methods
+    /// 4. In <see cref="VerifyData"/>, wrap new claim comparisons in a conditional
+    ///    HasClaim check so that licenses generated before the claim existed still
+    ///    validate successfully (introduced after PM-33980)
     /// </para>
     /// <para>
     /// This constructor is maintained only for backward compatibility with existing licenses.
@@ -438,6 +441,11 @@ public class OrganizationLicense : ILicense
             ? organization.PlanType is PlanType.FamiliesAnnually or PlanType.FamiliesAnnually2025
             : organization.PlanType == claimedPlanType;
 
+        // IMPORTANT: UseMyItems is the first claim to require a conditional HasClaim
+        // check because self-hosted instances may hold license files generated before
+        // this claim existed, where GetValue<T> returns the type's default (false),
+        // causing a mismatch that disables the org. Future claims MUST follow this
+        // same pattern. See PM-33980.
         return issued <= DateTime.UtcNow &&
                expires >= DateTime.UtcNow &&
                installationId == globalSettings.Installation.Id &&
@@ -469,7 +477,8 @@ public class OrganizationLicense : ILicense
                useOrganizationDomains == organization.UseOrganizationDomains &&
                useAutomaticUserConfirmation == organization.UseAutomaticUserConfirmation &&
                useDisableSmAdsForUsers == organization.UseDisableSmAdsForUsers &&
-               useMyItems == organization.UseMyItems;
+               (!claimsPrincipal.HasClaim(c => c.Type == nameof(UseMyItems))
+                   || useMyItems == organization.UseMyItems);
 
     }
 

--- a/test/Core.Test/Billing/Models/Business/OrganizationLicenseTests.cs
+++ b/test/Core.Test/Billing/Models/Business/OrganizationLicenseTests.cs
@@ -292,4 +292,129 @@ If you believe you need to change the version for a valid reason, please discuss
         // Act & Assert - Verify VerifyData passes with the UseDisableSmAdsForUsers value
         Assert.True(license.VerifyData(organization, claimsPrincipal, globalSettings));
     }
+
+    /// <summary>
+    /// Regression test for PM-33980: Self-hosted orgs disabled after updating to 2026.3.0
+    /// because their pre-existing license lacks the UseMyItems claim. VerifyData must skip
+    /// comparison for claims absent from the license.
+    /// </summary>
+    [Theory]
+    [BitAutoData(true)]
+    [BitAutoData(false)]
+    public void OrganizationLicense_VerifyData_PassesWhenUseMyItemsClaimAbsent(bool useMyItemsDbValue)
+    {
+        // Arrange
+        var organization = CreateDeterministicOrganization();
+        organization.UseMyItems = useMyItemsDbValue;
+
+        var installationId = new Guid("78900000-0000-0000-0000-000000000123");
+
+        // Build a ClaimsPrincipal with all claims VerifyData checks EXCEPT UseMyItems,
+        // simulating a license generated before UseMyItems was added.
+        var claims = BuildBaseVerifyDataClaims(organization, installationId);
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+        // Token must be non-empty to enter the claims-based VerifyData path
+        var license = new OrganizationLicense { Token = "non-empty", Expires = DateTime.MaxValue };
+
+        var globalSettings = Substitute.For<IGlobalSettings>();
+        globalSettings.Installation.Returns(new GlobalSettings.InstallationSettings
+        {
+            Id = installationId
+        });
+
+        // Act & Assert — VerifyData must pass regardless of the org's UseMyItems DB value
+        Assert.True(license.VerifyData(organization, claimsPrincipal, globalSettings));
+    }
+
+    [Theory]
+    [BitAutoData(true)]
+    [BitAutoData(false)]
+    public void OrganizationLicense_VerifyData_PassesWhenUseMyItemsClaimPresentAndMatches(bool useMyItemsValue)
+    {
+        var organization = CreateDeterministicOrganization();
+        organization.UseMyItems = useMyItemsValue;
+
+        var installationId = new Guid("78900000-0000-0000-0000-000000000123");
+
+        var claims = BuildBaseVerifyDataClaims(organization, installationId);
+        claims.Add(new Claim(nameof(OrganizationLicense.UseMyItems), useMyItemsValue.ToString()));
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+        var license = new OrganizationLicense { Token = "non-empty", Expires = DateTime.MaxValue };
+
+        var globalSettings = Substitute.For<IGlobalSettings>();
+        globalSettings.Installation.Returns(new GlobalSettings.InstallationSettings
+        {
+            Id = installationId
+        });
+
+        Assert.True(license.VerifyData(organization, claimsPrincipal, globalSettings));
+    }
+
+    [Fact]
+    public void OrganizationLicense_VerifyData_FailsWhenUseMyItemsClaimPresentAndMismatches()
+    {
+        var organization = CreateDeterministicOrganization();
+        organization.UseMyItems = true;
+
+        var installationId = new Guid("78900000-0000-0000-0000-000000000123");
+
+        var claims = BuildBaseVerifyDataClaims(organization, installationId);
+        // Claim says false, org says true — should fail
+        claims.Add(new Claim(nameof(OrganizationLicense.UseMyItems), false.ToString()));
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+        var license = new OrganizationLicense { Token = "non-empty", Expires = DateTime.MaxValue };
+
+        var globalSettings = Substitute.For<IGlobalSettings>();
+        globalSettings.Installation.Returns(new GlobalSettings.InstallationSettings
+        {
+            Id = installationId
+        });
+
+        Assert.False(license.VerifyData(organization, claimsPrincipal, globalSettings));
+    }
+
+    /// <summary>
+    /// Builds the base set of claims that VerifyData checks, excluding UseMyItems.
+    /// Callers can add or omit UseMyItems to test specific scenarios.
+    /// </summary>
+    private static List<Claim> BuildBaseVerifyDataClaims(Organization organization, Guid installationId)
+    {
+        return new List<Claim>
+        {
+            new(nameof(OrganizationLicense.Issued), DateTime.UtcNow.AddDays(-1).ToString()),
+            new(nameof(OrganizationLicense.Expires), DateTime.MaxValue.ToString()),
+            new(nameof(OrganizationLicense.InstallationId), installationId.ToString()),
+            new(nameof(OrganizationLicense.LicenseKey), organization.LicenseKey),
+            new(nameof(OrganizationLicense.Enabled), organization.Enabled.ToString()),
+            new(nameof(OrganizationLicense.PlanType), ((int)organization.PlanType).ToString()),
+            new(nameof(OrganizationLicense.Seats), organization.Seats.ToString()),
+            new(nameof(OrganizationLicense.MaxCollections), organization.MaxCollections.ToString()),
+            new(nameof(OrganizationLicense.UseGroups), organization.UseGroups.ToString()),
+            new(nameof(OrganizationLicense.UseDirectory), organization.UseDirectory.ToString()),
+            new(nameof(OrganizationLicense.UseTotp), organization.UseTotp.ToString()),
+            new(nameof(OrganizationLicense.SelfHost), organization.SelfHost.ToString()),
+            new(nameof(OrganizationLicense.Name), organization.Name),
+            new(nameof(OrganizationLicense.UsersGetPremium), organization.UsersGetPremium.ToString()),
+            new(nameof(OrganizationLicense.UseEvents), organization.UseEvents.ToString()),
+            new(nameof(OrganizationLicense.Use2fa), organization.Use2fa.ToString()),
+            new(nameof(OrganizationLicense.UseApi), organization.UseApi.ToString()),
+            new(nameof(OrganizationLicense.UsePolicies), organization.UsePolicies.ToString()),
+            new(nameof(OrganizationLicense.UseSso), organization.UseSso.ToString()),
+            new(nameof(OrganizationLicense.UseResetPassword), organization.UseResetPassword.ToString()),
+            new(nameof(OrganizationLicense.UseKeyConnector), organization.UseKeyConnector.ToString()),
+            new(nameof(OrganizationLicense.UseScim), organization.UseScim.ToString()),
+            new(nameof(OrganizationLicense.UseCustomPermissions), organization.UseCustomPermissions.ToString()),
+            new(nameof(OrganizationLicense.UseSecretsManager), organization.UseSecretsManager.ToString()),
+            new(nameof(OrganizationLicense.UsePasswordManager), organization.UsePasswordManager.ToString()),
+            new(nameof(OrganizationLicense.SmSeats), organization.SmSeats.ToString()),
+            new(nameof(OrganizationLicense.SmServiceAccounts), organization.SmServiceAccounts.ToString()),
+            new(nameof(OrganizationLicense.UseAdminSponsoredFamilies), organization.UseAdminSponsoredFamilies.ToString()),
+            new(nameof(OrganizationLicense.UseOrganizationDomains), organization.UseOrganizationDomains.ToString()),
+            new(nameof(OrganizationLicense.UseAutomaticUserConfirmation), organization.UseAutomaticUserConfirmation.ToString()),
+            new(nameof(OrganizationLicense.UseDisableSmAdsForUsers), organization.UseDisableSmAdsForUsers.ToString()),
+        };
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-33980

## 📔 Objective

The `2026.3.0` release added `UseMyItems` to the license claims factory and `VerifyData` comparison, but self-hosted instances that updated to `2026.3.0` still hold license files generated before this claim existed. The database migration sets `UseMyItems = true` for orgs with `UsePolicies = true`, but the stale license has no `UseMyItems` claim (defaulting to `false`). When `LicensingService.ValidateOrganizationsAsync()` calls `VerifyData`, the mismatch causes it to return `false`, disabling the organization with "Invalid data."

This PR wraps the `UseMyItems` comparison in a conditional `HasClaim` check so that licenses generated before the claim existed skip the comparison entirely. Once the org syncs a fresh license from cloud `2026.3.0+`, the claim will be present and validated normally.
