### PR TITLE
PM-33964 - Cache seeded RSA key material in LazyLock

### DIFF
--- a/test/SeederApi.IntegrationTest/RustSdkCipherTests.cs
+++ b/test/SeederApi.IntegrationTest/RustSdkCipherTests.cs
@@ -452,4 +452,33 @@ public sealed class RustSdkCipherTests
         Assert.DoesNotContain("BEGIN FAKE OPENSSH PRIVATE KEY", cipher.Data);
         Assert.DoesNotContain("ssh-ed25519", cipher.Data);
     }
+
+    [Fact]
+    public void GenerateUserKeys_ReturnsValidKeys()
+    {
+        var keys = RustSdkService.GenerateUserKeys("test@example.com", "TestPassword123!", 5000);
+
+        Assert.NotNull(keys.MasterPasswordHash);
+        Assert.NotEmpty(keys.MasterPasswordHash);
+        Assert.NotNull(keys.Key);
+        Assert.NotEmpty(keys.Key);
+        Assert.NotNull(keys.EncryptedUserKey);
+        Assert.StartsWith("2.", keys.EncryptedUserKey);
+        Assert.NotNull(keys.PublicKey);
+        Assert.NotEmpty(keys.PublicKey);
+        Assert.NotNull(keys.PrivateKey);
+        Assert.StartsWith("2.", keys.PrivateKey);
+    }
+
+    [Fact]
+    public void GenerateUserKeys_PublicKey_WorksWithOrganizationKeyWrapping()
+    {
+        var userKeys = RustSdkService.GenerateUserKeys("test@example.com", "TestPassword123!", 5000);
+        var orgKeys = RustSdkService.GenerateOrganizationKeys();
+
+        var wrappedOrgKey = RustSdkService.GenerateUserOrganizationKey(userKeys.PublicKey, orgKeys.Key);
+
+        Assert.NotNull(wrappedOrgKey);
+        Assert.NotEmpty(wrappedOrgKey);
+    }
 }

--- a/util/RustSdk/rust/src/lib.rs
+++ b/util/RustSdk/rust/src/lib.rs
@@ -5,13 +5,15 @@ mod cipher;
 use std::{
     ffi::{c_char, CStr, CString},
     num::NonZeroU32,
+    sync::LazyLock,
 };
 
 use base64::{engine::general_purpose::STANDARD, Engine};
 
 use bitwarden_crypto::{
-    BitwardenLegacyKeyBytes, HashPurpose, Kdf, KeyEncryptable, MasterKey, PrivateKey, PublicKey,
-    RsaKeyPair, SpkiPublicKeyBytes, SymmetricCryptoKey, UnsignedSharedKey, UserKey,
+    BitwardenLegacyKeyBytes, HashPurpose, Kdf, KeyEncryptable, MasterKey, Pkcs8PrivateKeyBytes,
+    PrivateKey, PublicKey, RsaKeyPair, SpkiPublicKeyBytes, SymmetricCryptoKey, UnsignedSharedKey,
+    UserKey,
 };
 
 #[no_mangle]
@@ -58,7 +60,14 @@ fn error_response(message: &str) -> *const c_char {
     CString::new(json).unwrap().into_raw()
 }
 
-fn keypair(key: &SymmetricCryptoKey) -> RsaKeyPair {
+/// Cached DER-encoded RSA key material derived from the seeded PEM constant.
+/// Parsed once on first use; only the per-user symmetric encryption remains per-call.
+struct CachedRsaMaterial {
+    private_der: Pkcs8PrivateKeyBytes,
+    public_der: SpkiPublicKeyBytes,
+}
+
+static SEEDED_RSA_MATERIAL: LazyLock<CachedRsaMaterial> = LazyLock::new(|| {
     const RSA_PRIVATE_KEY: &str = "-----BEGIN PRIVATE KEY-----
 MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCXRVrCX+2hfOQS
 8HzYUS2oc/jGVTZpv+/Ryuoh9d8ihYX9dd0cYh2tl6KWdFc88lPUH11Oxqy20Rk2
@@ -88,14 +97,27 @@ WjyxP5ZvXu7U96jaJRI8PFMoE06WeVYcdIzrID2HvqH+w0UQJFrLJ/0Mn4stFAEz
 XKZBokBGnjFnTnKcs7nv/O8=
 -----END PRIVATE KEY-----";
 
-    let private_key = PrivateKey::from_pem(RSA_PRIVATE_KEY).unwrap();
-    let public_key = private_key.to_public_key().to_der().unwrap();
+    let private_key = PrivateKey::from_pem(RSA_PRIVATE_KEY).expect("seeded RSA PEM must be valid");
+    let public_der = private_key
+        .to_public_key()
+        .to_der()
+        .expect("seeded public key DER conversion must succeed");
+    let private_der = private_key
+        .to_der()
+        .expect("seeded private key DER conversion must succeed");
 
-    let p = private_key.to_der().unwrap();
+    CachedRsaMaterial {
+        private_der,
+        public_der,
+    }
+});
+
+fn keypair(key: &SymmetricCryptoKey) -> RsaKeyPair {
+    let material = &*SEEDED_RSA_MATERIAL;
 
     RsaKeyPair {
-        private: p.encrypt_with_key(key).unwrap(),
-        public: public_key.into(),
+        private: material.private_der.clone().encrypt_with_key(key).unwrap(),
+        public: material.public_der.clone().into(),
     }
 }
 
@@ -157,5 +179,72 @@ pub unsafe extern "C" fn generate_user_organization_key(
 pub unsafe extern "C" fn free_c_string(str: *mut c_char) {
     unsafe {
         drop(CString::from_raw(str));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitwarden_crypto::SymmetricCryptoKey;
+
+    #[test]
+    fn keypair_produces_valid_encstring_format() {
+        let key = SymmetricCryptoKey::make_aes256_cbc_hmac_key();
+        let pair = keypair(&key);
+
+        let private_str = pair.private.to_string();
+        let public_str = pair.public.to_string();
+
+        assert!(
+            private_str.starts_with("2."),
+            "encrypted private key must be EncString format, got: {}",
+            &private_str[..20.min(private_str.len())]
+        );
+        assert!(
+            !public_str.is_empty(),
+            "public key must be non-empty"
+        );
+    }
+
+    #[test]
+    fn keypair_different_keys_produce_different_private_keys() {
+        let key1 = SymmetricCryptoKey::make_aes256_cbc_hmac_key();
+        let key2 = SymmetricCryptoKey::make_aes256_cbc_hmac_key();
+
+        let pair1 = keypair(&key1);
+        let pair2 = keypair(&key2);
+
+        assert_ne!(
+            pair1.private.to_string(),
+            pair2.private.to_string(),
+            "different symmetric keys must produce different encrypted private keys"
+        );
+        assert_eq!(
+            pair1.public.to_string(),
+            pair2.public.to_string(),
+            "public key must be identical regardless of symmetric key (same PEM source)"
+        );
+    }
+
+    #[test]
+    fn keypair_same_key_produces_consistent_public_key() {
+        let key = SymmetricCryptoKey::make_aes256_cbc_hmac_key();
+
+        let pair1 = keypair(&key);
+        let pair2 = keypair(&key);
+
+        assert_eq!(
+            pair1.public.to_string(),
+            pair2.public.to_string(),
+            "cached public key must be stable across calls"
+        );
+        assert!(
+            pair1.private.to_string().starts_with("2."),
+            "first call must produce valid EncString"
+        );
+        assert!(
+            pair2.private.to_string().starts_with("2."),
+            "second call must produce valid EncString"
+        );
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33964](https://bitwarden.atlassian.net/browse/PM-33964)
[PM-33967](https://bitwarden.atlassian.net/browse/PM-33967)

## 📔 Objective


The Seeder's `keypair()` function re-parses the same hardcoded RSA PEM constant and re-derives DER bytes on every call — identical work repeated per user inside `CreateUsersStep`'s `Parallel.For`. This PR caches the invariant material in a `LazyLock<CachedRsaMaterial>` static so PEM parsing and DER conversion happen exactly once, while per-user symmetric key encryption (`encrypt_with_key`) remains per-call.

### Key changes

- **RSA key material caching** (`util/RustSdk/rust/src/lib.rs`) — `LazyLock<CachedRsaMaterial>` caches `Pkcs8PrivateKeyBytes` + `SpkiPublicKeyBytes` from the seeded PEM constant. `keypair()` clones cached DER and encrypts per-user. Thread-safe, immutable, no mutable global state.
- **Rust unit tests** for `keypair()` — validates EncString format, per-user key isolation, and cache stability
- **Integration tests** for `GenerateUserKeys()` — validates all output fields and end-to-end public key org wrapping

## 🧪 Testing

<details><summary>Expand for A/B benchmark and regression results</summary>

### A/B Performance (main vs cached, single run per preset)

| Preset | Users | Ciphers | Main | Cached | Delta |
|---|---|---|---|---|---|
| Large Org Modern (500u/10Kc/85g) | 501 | 10,000 | 38.51s | **32.78s** | **-14.9%** |
| xl-highperm-weyland-yutani | 5,001 | 24,344 | 50.89s | **49.37s** | **-3.0%** |
| zero-knowledge-labs-enterprise | 386 | 265 | 18.05s | **17.89s** | **-0.9%** |
| enterprise-basic (600k KDF) | 5 | 24 | 5.26s | **4.92s** | **-6.4%** |

Performance improved or held steady across all 4 presets. No regressions.

### Entity Count Verification 

| Preset | Users | Groups | Collections | Ciphers | Match |
|---|---|---|---|---|---|
| Large Org Modern | 501 | 85 | — | 10,000 | ✅ |
| xl-highperm-weyland-yutani | 5,001 | 500 | 1,200 | 24,344 | ✅ |
| zero-knowledge-labs-enterprise | 386 | 42 | 53 | 265 | ✅ |
| enterprise-basic (600k KDF) | 5 | 1 | 36 | 24 | ✅ |


### Security Review

- Cached DER bytes are the same key material already present as a PEM `const` — no new security surface
- Per-user `encrypt_with_key` still per-call — zero-knowledge invariant preserved
- `LazyLock` is thread-safe, immutable after init, no interior mutability

</details>




[PM-33964]: https://bitwarden.atlassian.net/browse/PM-33964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-33967]: https://bitwarden.atlassian.net/browse/PM-33967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ