### PR TITLE
PM-33194 single integration of a type only

### DIFF
--- a/src/Api/Dirt/Controllers/OrganizationIntegrationController.cs
+++ b/src/Api/Dirt/Controllers/OrganizationIntegrationController.cs
@@ -31,8 +31,17 @@ public class OrganizationIntegrationController(
             .ToList();
     }
 
+    /// <summary>
+    /// Creates a new organization integration. 
+    /// Validates that only one integration of each type can exist per organization.
+    /// </summary>
+    /// <param name="organizationId"></param>
+    /// <param name="model"></param>
+    /// <returns></returns>
+    /// <exception cref="NotFoundException">Not enough permissions to access the organization.</exception>
+    /// <exception cref="ConflictResult">When an integration of the same type already exists for the organization.</exception>
     [HttpPost("")]
-    public async Task<OrganizationIntegrationResponseModel> CreateAsync(Guid organizationId, [FromBody] OrganizationIntegrationRequestModel model)
+    public async Task<ActionResult<OrganizationIntegrationResponseModel>> CreateAsync(Guid organizationId, [FromBody] OrganizationIntegrationRequestModel model)
     {
         if (!await HasPermission(organizationId))
         {
@@ -40,9 +49,16 @@ public class OrganizationIntegrationController(
         }
 
         var integration = model.ToOrganizationIntegration(organizationId);
+
+        var canCreate = await createCommand.CanCreateAsync(integration);
+        if (!canCreate)
+        {
+            return Conflict();
+        }
+
         var created = await createCommand.CreateAsync(integration);
 
-        return new OrganizationIntegrationResponseModel(created);
+        return Ok(new OrganizationIntegrationResponseModel(created));
     }
 
     [HttpPut("{integrationId:guid}")]

--- a/src/Api/Dirt/Controllers/OrganizationIntegrationController.cs
+++ b/src/Api/Dirt/Controllers/OrganizationIntegrationController.cs
@@ -43,6 +43,11 @@ public class OrganizationIntegrationController(
     [HttpPost("")]
     public async Task<ActionResult<OrganizationIntegrationResponseModel>> CreateAsync(Guid organizationId, [FromBody] OrganizationIntegrationRequestModel model)
     {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
         if (!await HasPermission(organizationId))
         {
             throw new NotFoundException();

--- a/src/Core/Dirt/EventIntegrations/OrganizationIntegrations/CreateOrganizationIntegrationCommand.cs
+++ b/src/Core/Dirt/EventIntegrations/OrganizationIntegrations/CreateOrganizationIntegrationCommand.cs
@@ -17,11 +17,21 @@ public class CreateOrganizationIntegrationCommand(
     IFusionCache cache)
     : ICreateOrganizationIntegrationCommand
 {
-    public async Task<OrganizationIntegration> CreateAsync(OrganizationIntegration integration)
+    public async Task<bool> CanCreateAsync(OrganizationIntegration integration)
     {
         var existingIntegrations = await integrationRepository
             .GetManyByOrganizationAsync(integration.OrganizationId);
         if (existingIntegrations.Any(i => i.Type == integration.Type))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    public async Task<OrganizationIntegration> CreateAsync(OrganizationIntegration integration)
+    {
+        if (await CanCreateAsync(integration) == false)
         {
             throw new BadRequestException("An integration of this type already exists for this organization.");
         }

--- a/src/Core/Dirt/EventIntegrations/OrganizationIntegrations/Interfaces/ICreateOrganizationIntegrationCommand.cs
+++ b/src/Core/Dirt/EventIntegrations/OrganizationIntegrations/Interfaces/ICreateOrganizationIntegrationCommand.cs
@@ -15,4 +15,12 @@ public interface ICreateOrganizationIntegrationCommand
     /// <exception cref="Exceptions.BadRequestException">Thrown when an integration
     /// of the same type already exists for the organization.</exception>
     Task<OrganizationIntegration> CreateAsync(OrganizationIntegration integration);
+
+    /// <summary>
+    /// Checks if a new organization integration can be created based on existing integrations.
+    /// Enforces a validation to ensure that only one integration of each type can exist per organization.
+    /// </summary>
+    /// <param name="integration"></param>
+    /// <returns></returns>
+    Task<bool> CanCreateAsync(OrganizationIntegration integration);
 }

--- a/test/Api.Test/Dirt/Controllers/OrganizationIntegrationControllerTests.cs
+++ b/test/Api.Test/Dirt/Controllers/OrganizationIntegrationControllerTests.cs
@@ -89,6 +89,9 @@ public class OrganizationIntegrationControllerTests
             .OrganizationOwner(organizationId)
             .Returns(true);
         sutProvider.GetDependency<ICreateOrganizationIntegrationCommand>()
+            .CanCreateAsync(Arg.Any<OrganizationIntegration>())
+            .Returns(true);
+        sutProvider.GetDependency<ICreateOrganizationIntegrationCommand>()
             .CreateAsync(Arg.Any<OrganizationIntegration>())
             .Returns(integration);
 
@@ -98,7 +101,31 @@ public class OrganizationIntegrationControllerTests
             .CreateAsync(Arg.Is<OrganizationIntegration>(i =>
                 i.OrganizationId == organizationId &&
                 i.Type == IntegrationType.Webhook));
-        Assert.IsType<OrganizationIntegrationResponseModel>(response);
+        Assert.IsType<ActionResult<OrganizationIntegrationResponseModel>>(response);
+        Assert.IsType<OkObjectResult>(response.Result);
+    }
+
+    [Theory, BitAutoData]
+    public async Task CreateAsync_TheTypeAlreadyExists_ThrowsConflict(
+        SutProvider<OrganizationIntegrationController> sutProvider,
+        Guid organizationId,
+        OrganizationIntegration integration)
+    {
+        sutProvider.Sut.Url = Substitute.For<IUrlHelper>();
+        sutProvider.GetDependency<ICurrentContext>()
+            .OrganizationOwner(organizationId)
+            .Returns(true);
+        sutProvider.GetDependency<ICreateOrganizationIntegrationCommand>()
+            .CanCreateAsync(Arg.Any<OrganizationIntegration>())
+            .Returns(false);
+        sutProvider.GetDependency<ICreateOrganizationIntegrationCommand>()
+            .CreateAsync(Arg.Any<OrganizationIntegration>())
+            .Returns(integration);
+
+        var response = await sutProvider.Sut.CreateAsync(organizationId, _webhookRequestModel);
+
+        Assert.IsType<ActionResult<OrganizationIntegrationResponseModel>>(response);
+        Assert.IsType<ConflictResult>(response.Result);
     }
 
     [Theory, BitAutoData]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33194

## 📔 Objective

When creating an integration, if another integration of the same type already exists, return a 409 conflict 
The client will handle this conflict and create an appropriate response.

## 📸 Screenshots

<img width="2034" height="1158" alt="image" src="https://github.com/user-attachments/assets/fd92768f-6841-48b9-a4e5-aa0231b0b0c8" />
