### PR TITLE
[PM-19143] Fix custom permissions not persisting via InviteOrganizationUsersCommand

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/Models/CreateOrganizationUserExtensions.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/Models/CreateOrganizationUserExtensions.cs
@@ -9,22 +9,31 @@ public static class CreateOrganizationUserExtensions
 {
     public static CreateOrganizationUser MapToDataModel(this OrganizationUserInviteCommandModel organizationUserInvite,
         DateTimeOffset performedAt,
-        InviteOrganization organization) =>
-        new()
+        InviteOrganization organization)
+    {
+        var orgUser = new OrganizationUser
         {
-            OrganizationUser = new OrganizationUser
-            {
-                Id = CoreHelpers.GenerateComb(),
-                OrganizationId = organization.OrganizationId,
-                Email = organizationUserInvite.Email.ToLowerInvariant(),
-                Type = organizationUserInvite.Type,
-                Status = OrganizationUserStatusType.Invited,
-                AccessSecretsManager = organizationUserInvite.AccessSecretsManager,
-                ExternalId = string.IsNullOrWhiteSpace(organizationUserInvite.ExternalId) ? null : organizationUserInvite.ExternalId,
-                CreationDate = performedAt.UtcDateTime,
-                RevisionDate = performedAt.UtcDateTime
-            },
+            Id = CoreHelpers.GenerateComb(),
+            OrganizationId = organization.OrganizationId,
+            Email = organizationUserInvite.Email.ToLowerInvariant(),
+            Type = organizationUserInvite.Type,
+            Status = OrganizationUserStatusType.Invited,
+            AccessSecretsManager = organizationUserInvite.AccessSecretsManager,
+            ExternalId = string.IsNullOrWhiteSpace(organizationUserInvite.ExternalId) ? null : organizationUserInvite.ExternalId,
+            CreationDate = performedAt.UtcDateTime,
+            RevisionDate = performedAt.UtcDateTime
+        };
+
+        if (organizationUserInvite.Type == OrganizationUserType.Custom)
+        {
+            orgUser.SetPermissions(organizationUserInvite.Permissions);
+        }
+
+        return new CreateOrganizationUser
+        {
+            OrganizationUser = orgUser,
             Collections = organizationUserInvite.AssignedCollections,
             Groups = organizationUserInvite.Groups
         };
+    }
 }

--- a/test/Api.IntegrationTest/AdminConsole/Public/Controllers/MembersControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Public/Controllers/MembersControllerTests.cs
@@ -412,11 +412,28 @@ public class MembersControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
             .Returns(true);
 
         var email = $"integration-test{Guid.NewGuid()}@bitwarden.com";
+        var expectedPermissions = new PermissionsModel
+        {
+            AccessEventLogs = true,
+            AccessImportExport = true,
+            AccessReports = true,
+            CreateNewCollections = true,
+            EditAnyCollection = true,
+            DeleteAnyCollection = true,
+            ManageGroups = true,
+            ManagePolicies = true,
+            ManageSso = true,
+            ManageUsers = true,
+            ManageResetPassword = true,
+            ManageScim = true,
+        };
+
         var request = new MemberCreateRequestModel
         {
             Email = email,
             Type = OrganizationUserType.Custom,
             ExternalId = "myCustomUser",
+            Permissions = expectedPermissions,
             Collections = [],
             Groups = []
         };
@@ -431,6 +448,8 @@ public class MembersControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
         Assert.Equal(OrganizationUserType.Custom, result.Type);
         Assert.Equal("myCustomUser", result.ExternalId);
         Assert.Empty(result.Collections);
+        Assert.NotNull(result.Permissions);
+        AssertHelper.AssertPropertyEqual(expectedPermissions, result.Permissions);
 
         var organizationUserRepository = _factory.GetService<IOrganizationUserRepository>();
         var orgUser = await organizationUserRepository.GetByIdAsync(result.Id);
@@ -441,6 +460,26 @@ public class MembersControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
         Assert.Equal("myCustomUser", orgUser.ExternalId);
         Assert.Equal(OrganizationUserStatusType.Invited, orgUser.Status);
         Assert.Equal(_organization.Id, orgUser.OrganizationId);
+
+        var dbPermissions = orgUser.GetPermissions();
+        Assert.NotNull(dbPermissions);
+        AssertHelper.AssertPropertyEqual(
+            new Permissions
+            {
+                AccessEventLogs = true,
+                AccessImportExport = true,
+                AccessReports = true,
+                CreateNewCollections = true,
+                EditAnyCollection = true,
+                DeleteAnyCollection = true,
+                ManageGroups = true,
+                ManagePolicies = true,
+                ManageSso = true,
+                ManageUsers = true,
+                ManageResetPassword = true,
+                ManageScim = true,
+            },
+            dbPermissions);
     }
 
     [Fact]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-19143

## 📔 Objective

`MapToDataModel` was not calling `SetPermissions()` on the `OrganizationUser` entity, so custom permissions were never written to the database when inviting through `POST /public/members` with the feature flag enabled. Adds the missing call and strengthens the integration test to cover permissions.

