### PR TITLE
[PM-33890] Set up Stripe Subscription Schedule API operations

### DIFF
--- a/src/Core/Billing/Services/IStripeAdapter.cs
+++ b/src/Core/Billing/Services/IStripeAdapter.cs
@@ -54,4 +54,9 @@ public interface IStripeAdapter
     Task<List<Product>> ListProductsAsync(ProductListOptions options = null);
     Task<StripeList<Subscription>> ListSubscriptionsAsync(SubscriptionListOptions options = null);
     Task<Session> CreateBillingPortalSessionAsync(SessionCreateOptions options);
+    Task<SubscriptionSchedule> CreateSubscriptionScheduleAsync(SubscriptionScheduleCreateOptions options);
+    Task<SubscriptionSchedule> GetSubscriptionScheduleAsync(string id, SubscriptionScheduleGetOptions options = null);
+    Task<StripeList<SubscriptionSchedule>> ListSubscriptionSchedulesAsync(SubscriptionScheduleListOptions options);
+    Task<SubscriptionSchedule> UpdateSubscriptionScheduleAsync(string id, SubscriptionScheduleUpdateOptions options);
+    Task<SubscriptionSchedule> ReleaseSubscriptionScheduleAsync(string id, SubscriptionScheduleReleaseOptions options = null);
 }

--- a/src/Core/Billing/Services/Implementations/StripeAdapter.cs
+++ b/src/Core/Billing/Services/Implementations/StripeAdapter.cs
@@ -31,6 +31,7 @@ public class StripeAdapter : IStripeAdapter
     private readonly CouponService _couponService;
     private readonly ProductService _productService;
     private readonly SessionService _billingPortalSessionService;
+    private readonly SubscriptionScheduleService _subscriptionScheduleService;
 
     public StripeAdapter()
     {
@@ -51,6 +52,7 @@ public class StripeAdapter : IStripeAdapter
         _couponService = new CouponService();
         _productService = new ProductService();
         _billingPortalSessionService = new SessionService();
+        _subscriptionScheduleService = new SubscriptionScheduleService();
     }
 
     /**************
@@ -243,4 +245,22 @@ public class StripeAdapter : IStripeAdapter
      **********************/
     public Task<Session> CreateBillingPortalSessionAsync(SessionCreateOptions options) =>
         _billingPortalSessionService.CreateAsync(options);
+
+    /***************************
+     ** SUBSCRIPTION SCHEDULE **
+     ***************************/
+    public Task<SubscriptionSchedule> CreateSubscriptionScheduleAsync(SubscriptionScheduleCreateOptions options) =>
+        _subscriptionScheduleService.CreateAsync(options);
+
+    public Task<SubscriptionSchedule> GetSubscriptionScheduleAsync(string id, SubscriptionScheduleGetOptions options = null) =>
+        _subscriptionScheduleService.GetAsync(id, options);
+
+    public Task<StripeList<SubscriptionSchedule>> ListSubscriptionSchedulesAsync(SubscriptionScheduleListOptions options) =>
+        _subscriptionScheduleService.ListAsync(options);
+
+    public Task<SubscriptionSchedule> UpdateSubscriptionScheduleAsync(string id, SubscriptionScheduleUpdateOptions options) =>
+        _subscriptionScheduleService.UpdateAsync(id, options);
+
+    public Task<SubscriptionSchedule> ReleaseSubscriptionScheduleAsync(string id, SubscriptionScheduleReleaseOptions options = null) =>
+        _subscriptionScheduleService.ReleaseAsync(id, options);
 }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -190,6 +190,7 @@ public static class FeatureFlagKeys
     public const string PM29108_EnablePersonalDiscounts = "pm-29108-enable-personal-discounts";
     public const string PM29593_PremiumToOrganizationUpgrade = "pm-29593-premium-to-organization-upgrade";
     public const string PM32581_UseUpdateOrganizationSubscriptionCommand = "pm-32581-use-update-organization-subscription-command";
+    public const string PM32645_DeferPriceMigrationToRenewal = "pm-32645-defer-price-migration-to-renewal";
 
     /* Key Management Team */
     public const string PrivateKeyRegeneration = "pm-12241-private-key-regeneration";


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-33890

## 📔 Objective

Registers the `pm-32645-defer-price-migration-to-renewal` feature flag and adds `SubscriptionSchedule` CRUD operations (Create, Get, List, Update, Release) to `IStripeAdapter` / `StripeAdapter`. Bitwarden has no existing `SubscriptionSchedule` usage — this establishes the API surface needed for all downstream schedule work in the [PM-32645](https://bitwarden.atlassian.net/browse/PM-32645) epic.

No behavioral change — pure infrastructure.


[PM-32645]: https://bitwarden.atlassian.net/browse/PM-32645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ