### PR TITLE
[PM-32008] Add scope comment for SecurityTaskAuthorizationHandler

### DIFF
--- a/src/Api/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Api/Utilities/ServiceCollectionExtensions.cs
@@ -93,6 +93,8 @@ public static class ServiceCollectionExtensions
     public static void AddAuthorizationHandlers(this IServiceCollection services)
     {
         services.AddScoped<IAuthorizationHandler, VaultExportAuthorizationHandler>();
+        // SecurityTaskAuthorizationHandler must remain scoped. It caches cipher permissions per-request.
+        // Changing to singleton would allow one user's cached permissions to be reused by other users in the same organization.
         services.AddScoped<IAuthorizationHandler, SecurityTaskAuthorizationHandler>();
         services.AddScoped<IAuthorizationHandler, SecurityTaskOrganizationAuthorizationHandler>();
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32008](https://bitwarden.atlassian.net/browse/PM-32008)

## 📔 Objective

Add comment for `SecurityTaskAuthorizationHandler` to ensure that it stays initialized with `AddScoped` to avoid any security risks with permission caching.   

## 📸 Screenshots

N/A

[PM-32008]: https://bitwarden.atlassian.net/browse/PM-32008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ