### PR TITLE
[PM-22435] chore: remove create default collections ff ref

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -142,7 +142,6 @@ public static class FeatureFlagKeys
     /* Admin Console Team */
     public const string PolicyRequirements = "pm-14439-policy-requirements";
     public const string ScimInviteUserOptimization = "pm-16811-optimize-invite-user-flow-to-fail-fast";
-    public const string CreateDefaultLocation = "pm-19467-create-default-location";
     public const string AutomaticConfirmUsers = "pm-19934-auto-confirm-organization-users";
     public const string ScimRevokeV2 = "pm-32394-scim-revoke-put-v2";
     public const string BulkReinviteUI = "pm-28416-bulk-reinvite-ux-improvements";


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-22435

## 📔 Objective

> Remove `pm-19467-create-default-location` ff reference. Backwards compatibility window has been met
