### PR TITLE
[PM-34039] [Defect] Discount Eligibility Endpoint Shows "New Users Only" Discounts 

### DIFF
--- a/src/Core/Billing/Services/DiscountAudienceFilters/UserHasNoPreviousSubscriptionsFilter.cs
+++ b/src/Core/Billing/Services/DiscountAudienceFilters/UserHasNoPreviousSubscriptionsFilter.cs
@@ -93,7 +93,8 @@ public class UserHasNoPreviousSubscriptionsFilter : IDiscountAudienceFilter
             var subscriptions = await stripeAdapter.ListSubscriptionsAsync(new SubscriptionListOptions
             {
                 Customer = user.GatewayCustomerId,
-                Expand = ["data.items.data.price"]
+                Expand = ["data.items.data.price"],
+                Status = "all"
             });
             return subscriptions.Data.Any(subscription =>
                 subscription.Items.Data.Any(item => premiumPriceIds.Contains(item.Price.Id)));

--- a/test/Core.Test/Billing/Services/DiscountAudienceFilters/UserHasNoPreviousSubscriptionsFilterTests.cs
+++ b/test/Core.Test/Billing/Services/DiscountAudienceFilters/UserHasNoPreviousSubscriptionsFilterTests.cs
@@ -118,7 +118,8 @@ public class UserHasNoPreviousSubscriptionsFilterTests
 
         Assert.False(result[DiscountTierType.Premium]);
         await _pricingClient.Received(1).ListPremiumPlans();
-        await _stripeAdapter.Received(1).ListSubscriptionsAsync(Arg.Any<SubscriptionListOptions>());
+        await _stripeAdapter.Received(1).ListSubscriptionsAsync(
+            Arg.Is<SubscriptionListOptions>(o => o.Status == "all"));
     }
 
     [Theory, BitAutoData]
@@ -334,6 +335,7 @@ public class UserHasNoPreviousSubscriptionsFilterTests
         await _organizationUserRepository.Received(1)
             .GetManyDetailsByUserAsync(user.Id, OrganizationUserStatusType.Confirmed);
         await _pricingClient.Received(1).ListPremiumPlans();
-        await _stripeAdapter.Received(1).ListSubscriptionsAsync(Arg.Any<SubscriptionListOptions>());
+        await _stripeAdapter.Received(1).ListSubscriptionsAsync(
+            Arg.Is<SubscriptionListOptions>(o => o.Status == "all"));
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Updates the logic for retrieving user subscriptions to ensure all subscription statuses are considered when checking for previous premium subscriptions. The tests are also updated to verify this new behavior.