### PR TITLE
[PM-34049] Fix PoliciesController authorize attribute

### DIFF
--- a/src/Api/AdminConsole/Authorization/AuthorizationHandlerCollectionExtensions.cs
+++ b/src/Api/AdminConsole/Authorization/AuthorizationHandlerCollectionExtensions.cs
@@ -15,6 +15,7 @@ public static class AuthorizationHandlerCollectionExtensions
             ServiceDescriptor.Scoped<IAuthorizationHandler, BulkCollectionAuthorizationHandler>(),
             ServiceDescriptor.Scoped<IAuthorizationHandler, CollectionAuthorizationHandler>(),
             ServiceDescriptor.Scoped<IAuthorizationHandler, GroupAuthorizationHandler>(),
+            ServiceDescriptor.Scoped<IAuthorizationHandler, OrgUserLinkedToUserIdHandler>(),
             ServiceDescriptor.Scoped<IAuthorizationHandler, OrganizationRequirementHandler>(),
             ServiceDescriptor.Scoped<IAuthorizationHandler, RecoverAccountAuthorizationHandler>(),
         ]);

--- a/src/Api/AdminConsole/Authorization/OrgUserLinkedToUserIdHandler.cs
+++ b/src/Api/AdminConsole/Authorization/OrgUserLinkedToUserIdHandler.cs
@@ -1,4 +1,4 @@
-using Bit.Core.Repositories;
+﻿using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Microsoft.AspNetCore.Authorization;
 

--- a/src/Api/AdminConsole/Authorization/OrgUserLinkedToUserIdHandler.cs
+++ b/src/Api/AdminConsole/Authorization/OrgUserLinkedToUserIdHandler.cs
@@ -1,0 +1,47 @@
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Bit.Api.AdminConsole.Authorization;
+
+/// <summary>
+/// Requires that the current user has an OrganizationUser record linked to their UserId for the organization in the
+/// route. This performs a direct database lookup rather than relying on JWT claims.
+/// WARNING: DO NOT EXPAND THIS TO NEW ROUTES - SEE REMARKS BELOW
+/// </summary>
+/// <remarks>
+/// This requirement only supports existing routes that query the database by UserId + OrganizationId to check membership.
+/// This is not recommended - check JWT claims for confirmed members using <see cref="IOrganizationRequirement"/>
+/// (e.g. <c>[Authorize&lt;MemberRequirement&gt;]</c>) or create a more specific requirement for your situation.
+/// However, we have to support this logic on existing routes due to the invalid SSO JIT provisioning bug (PM-34092).
+/// This requirement should be deleted when that bug is resolved.
+/// </remarks>
+public class OrgUserLinkedToUserIdRequirement : IAuthorizationRequirement;
+
+public class OrgUserLinkedToUserIdHandler(
+    IHttpContextAccessor httpContextAccessor,
+    IOrganizationUserRepository organizationUserRepository,
+    IUserService userService)
+    : AuthorizationHandler<OrgUserLinkedToUserIdRequirement>
+{
+    protected override async Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        OrgUserLinkedToUserIdRequirement requirement)
+    {
+        var httpContext = httpContextAccessor.HttpContext
+            ?? throw new InvalidOperationException("This handler requires an HTTP context.");
+
+        var userId = userService.GetProperUserId(httpContext.User);
+        if (userId is null)
+        {
+            return;
+        }
+
+        var orgId = httpContext.GetOrganizationId();
+        var orgUser = await organizationUserRepository.GetByOrganizationAsync(orgId, userId.Value);
+        if (orgUser is not null)
+        {
+            context.Succeed(requirement);
+        }
+    }
+}

--- a/src/Api/AdminConsole/Controllers/PoliciesController.cs
+++ b/src/Api/AdminConsole/Controllers/PoliciesController.cs
@@ -108,7 +108,7 @@ public class PoliciesController : Controller
     }
 
     [HttpGet("master-password")]
-    [Authorize<MemberRequirement>]
+    [Authorize<OrgUserLinkedToUserIdRequirement>]
     public async Task<PolicyResponseModel> GetMasterPasswordPolicy(Guid orgId)
     {
         var organization = await _organizationRepository.GetByIdAsync(orgId);

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/PoliciesControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/PoliciesControllerTests.cs
@@ -9,6 +9,7 @@ using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Billing.Enums;
+using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Repositories;
 using Bit.Test.Common.Helpers;
@@ -492,6 +493,51 @@ public class PoliciesControllerTests : IClassFixture<ApiApplicationFactory>, IAs
         Assert.True(content.Enabled);
         Assert.Equal(PolicyType.MasterPassword, content.Type);
         Assert.Equal(_organization.Id, content.OrganizationId);
+    }
+
+    /// <summary>
+    /// An OrganizationUser with Invited status can still have a UserId linked due to the SSO JIT provisioning bug
+    /// (PM-34092). This requirement exists to support that case, so Invited + UserId must succeed.
+    /// </summary>
+    [Fact]
+    public async Task GetMasterPasswordPolicy_InvitedMemberWithLinkedUserId_ReturnsPolicy()
+    {
+        // Arrange
+        var policyRepository = _factory.GetService<IPolicyRepository>();
+        await policyRepository.CreateAsync(new Policy
+        {
+            OrganizationId = _organization.Id,
+            Type = PolicyType.MasterPassword,
+            Enabled = true
+        });
+
+        // Create a user account and add them to the org in Invited status (but with UserId populated)
+        var invitedEmail = $"integration-test{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(invitedEmail);
+
+        var userRepository = _factory.GetService<IUserRepository>();
+        var user = await userRepository.GetByEmailAsync(invitedEmail);
+
+        var organizationUserRepository = _factory.GetService<IOrganizationUserRepository>();
+        await organizationUserRepository.CreateAsync(new OrganizationUser
+        {
+            OrganizationId = _organization.Id,
+            UserId = user!.Id,
+            Type = OrganizationUserType.User,
+            Status = OrganizationUserStatusType.Invited
+        });
+
+        await _loginHelper.LoginAsync(invitedEmail);
+
+        // Act
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/policies/master-password");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var content = await response.Content.ReadFromJsonAsync<PolicyResponseModel>();
+        Assert.NotNull(content);
+        Assert.True(content.Enabled);
+        Assert.Equal(PolicyType.MasterPassword, content.Type);
     }
 
     [Fact]

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/PoliciesControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/PoliciesControllerTests.cs
@@ -443,6 +443,58 @@ public class PoliciesControllerTests : IClassFixture<ApiApplicationFactory>, IAs
     }
 
     [Fact]
+    public async Task GetMasterPasswordPolicy_Unauthenticated_ReturnsUnauthorized()
+    {
+        // Arrange
+        _client.DefaultRequestHeaders.Authorization = null;
+
+        // Act
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/policies/master-password");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetMasterPasswordPolicy_AuthenticatedNonMember_ReturnsForbidden()
+    {
+        // Arrange
+        var nonMemberEmail = $"integration-test{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(nonMemberEmail);
+        await _loginHelper.LoginAsync(nonMemberEmail);
+
+        // Act
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/policies/master-password");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetMasterPasswordPolicy_AuthenticatedMember_ReturnsPolicy()
+    {
+        // Arrange - owner is already logged in from InitializeAsync
+        var policyRepository = _factory.GetService<IPolicyRepository>();
+        await policyRepository.CreateAsync(new Policy
+        {
+            OrganizationId = _organization.Id,
+            Type = PolicyType.MasterPassword,
+            Enabled = true
+        });
+
+        // Act
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/policies/master-password");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var content = await response.Content.ReadFromJsonAsync<PolicyResponseModel>();
+        Assert.NotNull(content);
+        Assert.True(content.Enabled);
+        Assert.Equal(PolicyType.MasterPassword, content.Type);
+        Assert.Equal(_organization.Id, content.OrganizationId);
+    }
+
+    [Fact]
     public async Task Put_SingleOrgPolicy_RevokesNonCompliantUser()
     {
         // Arrange


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-34049

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix for #7242, which added Authorize attributes to the `PoliciesController`.

`GetMasterPasswordPolicy` was updated to use the `MemberRequirement`, which assumes a confirmed member. This seemed appropriate because the member was being checked by UserId + OrgId, which matches a confirmed state. However, due to the [invalid OrganizationUser provisioning bug](https://bitwarden.atlassian.net/browse/PM-34049), it actually matches invited users who need to set their password as well.

I have reverted the previous code, but moved it into an Authorize attribute in order to satisfy the tests (and more recent practices) of using attributes for authorization. This includes detailed xmldoc to explain this.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
