### PR TITLE
[PM-34171] Add card scanner feature flag

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -239,6 +239,7 @@ public static class FeatureFlagKeys
     public const string CxpExportMobile = "cxp-export-mobile";
     public const string DeviceAuthKey = "pm-27581-device-auth-key";
     public const string PremiumUpgradePath = "pm-31697-premium-upgrade-path";
+    public const string MobileCardScanner = "pm-34171-card-scanner";
 
     /* Platform Team */
     public const string WebPush = "web-push";


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34171

## 📔 Objective

Add the `pm-34171-card-scanner` feature flag to gate the new mobile card scanner feature. This feature allows users to use their device camera to capture credit card details (card number, cardholder name, expiry date) and autofill them into the card cipher form. Image processing is performed locally on-device.

This PR only adds the feature flag constant to `FeatureFlagKeys` under the Mobile Team section — no behavioral changes are included.