### PR TITLE
[PM-30185] Fix email fallback logic to ignore empty primary email

### DIFF
--- a/bitwarden_license/src/Scim/Models/BaseScimUserModel.cs
+++ b/bitwarden_license/src/Scim/Models/BaseScimUserModel.cs
@@ -18,8 +18,8 @@ public abstract class BaseScimUserModel : BaseScimModel
     public string UserName { get; set; }
     public NameModel Name { get; set; }
     public List<EmailModel> Emails { get; set; }
-    public string PrimaryEmail => Emails?.FirstOrDefault(e => e.Primary)?.Value;
-    public string WorkEmail => Emails?.FirstOrDefault(e => e.Type == "work")?.Value;
+    public string PrimaryEmail => Emails?.FirstOrDefault(e => e.Primary && !string.IsNullOrWhiteSpace(e.Value))?.Value;
+    public string WorkEmail => Emails?.FirstOrDefault(e => e.Type == "work" && !string.IsNullOrWhiteSpace(e.Value))?.Value;
     public string DisplayName { get; set; }
     public bool Active { get; set; }
     public List<string> Groups { get; set; }

--- a/bitwarden_license/src/Scim/Models/ScimUserRequestModel.cs
+++ b/bitwarden_license/src/Scim/Models/ScimUserRequestModel.cs
@@ -74,7 +74,7 @@ public class ScimUserRequestModel : BaseScimUserModel
                 email = WorkEmail?.ToLowerInvariant();
                 if (string.IsNullOrWhiteSpace(email))
                 {
-                    email = Emails?.FirstOrDefault()?.Value?.ToLowerInvariant();
+                    email = Emails?.FirstOrDefault(e => !string.IsNullOrWhiteSpace(e.Value))?.Value?.ToLowerInvariant();
                 }
 
                 return email;

--- a/bitwarden_license/test/Scim.Test/Users/PostUserCommandTests.cs
+++ b/bitwarden_license/test/Scim.Test/Users/PostUserCommandTests.cs
@@ -67,6 +67,55 @@ public class PostUserCommandTests
 
     [Theory]
     [BitAutoData]
+    public async Task PostUser_EmptyPrimaryEmail_WithNonEmptyFallbackEmail_UsesNonEmptyEmail(
+        SutProvider<PostUserCommand> sutProvider,
+        string externalId,
+        Guid organizationId,
+        ICollection<OrganizationUserUserDetails> organizationUsers,
+        Core.Entities.OrganizationUser newUser,
+        Organization organization)
+    {
+        const string nonEmptyEmail = "user1@minimumviable.horse";
+        var scimUserRequestModel = new ScimUserRequestModel
+        {
+            ExternalId = externalId,
+            Active = true,
+            Schemas = [ScimConstants.Scim2SchemaUser],
+            Emails =
+            [
+                new BaseScimUserModel.EmailModel { Primary = true, Type = "internal", Value = "" },
+                new BaseScimUserModel.EmailModel { Primary = false, Type = "external", Value = nonEmptyEmail }
+            ]
+        };
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetManyDetailsByOrganizationAsync(organizationId)
+            .Returns(organizationUsers);
+
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organizationId).Returns(organization);
+
+        sutProvider.GetDependency<IStripePaymentService>().HasSecretsManagerStandalone(organization).Returns(true);
+
+        sutProvider.GetDependency<IOrganizationService>()
+            .InviteUserAsync(organizationId,
+                invitingUserId: null,
+                EventSystemUser.SCIM,
+                Arg.Is<OrganizationUserInvite>(i => i.Emails.Single().Equals(nonEmptyEmail)),
+                externalId)
+            .Returns(newUser);
+
+        var user = await sutProvider.Sut.PostUserAsync(organizationId, scimUserRequestModel);
+
+        await sutProvider.GetDependency<IOrganizationService>().Received(1).InviteUserAsync(
+            organizationId,
+            invitingUserId: null,
+            EventSystemUser.SCIM,
+            Arg.Is<OrganizationUserInvite>(i => i.Emails.Single().Equals(nonEmptyEmail)),
+            externalId);
+    }
+
+    [Theory]
+    [BitAutoData]
     public async Task PostUser_NullEmail_Throws(SutProvider<PostUserCommand> sutProvider, Guid organizationId)
     {
         var scimUserRequestModel = new ScimUserRequestModel


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-30185
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Changes email fallback logic in SCIM invite to ignore the blank primary email if a valid secondary email is provided
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
