### PR TITLE
[PM-34440] Fix cache duplicate-key error

### DIFF
--- a/src/Core/Services/Implementations/FeatureRoutedCacheService.cs
+++ b/src/Core/Services/Implementations/FeatureRoutedCacheService.cs
@@ -29,6 +29,7 @@ public class FeatureRoutedCacheService(
     {
         var allProviderAbilities = await inMemoryApplicationCacheService.GetProviderAbilitiesAsync();
         return providerIds
+            .Distinct()
             .Where(allProviderAbilities.ContainsKey)
             .ToDictionary(id => id, id => allProviderAbilities[id]);
     }
@@ -37,6 +38,7 @@ public class FeatureRoutedCacheService(
     {
         var allOrganizationAbilities = await inMemoryApplicationCacheService.GetOrganizationAbilitiesAsync();
         return orgIds
+            .Distinct()
             .Where(allOrganizationAbilities.ContainsKey)
             .ToDictionary(id => id, id => allOrganizationAbilities[id]);
     }

--- a/test/Core.Test/Services/Implementations/FeatureRoutedCacheServiceTests.cs
+++ b/test/Core.Test/Services/Implementations/FeatureRoutedCacheServiceTests.cs
@@ -156,6 +156,25 @@ public class FeatureRoutedCacheServiceTests
     }
 
     [Theory, BitAutoData]
+    public async Task GetProviderAbilitiesAsync_WhenDuplicateIdsProvided_DoesNotThrowAndReturnsSingleEntry(
+        SutProvider<FeatureRoutedCacheService> sutProvider,
+        ProviderAbility ability)
+    {
+        // Arrange
+        var allAbilities = new Dictionary<Guid, ProviderAbility> { [ability.Id] = ability };
+        sutProvider.GetDependency<IVCurrentInMemoryApplicationCacheService>()
+            .GetProviderAbilitiesAsync()
+            .Returns(allAbilities);
+
+        // Act - passing the same ID twice simulates a provider with duplicate entries
+        var result = await sutProvider.Sut.GetProviderAbilitiesAsync([ability.Id, ability.Id]);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(ability, result[ability.Id]);
+    }
+
+    [Theory, BitAutoData]
     public async Task GetOrganizationAbilitiesAsync_ReturnsOnlyMatchingAbilities(
         SutProvider<FeatureRoutedCacheService> sutProvider,
         OrganizationAbility matchedAbility,
@@ -178,6 +197,26 @@ public class FeatureRoutedCacheServiceTests
         Assert.Single(result);
         Assert.Equal(matchedAbility, result[matchedAbility.Id]);
     }
+
+    [Theory, BitAutoData]
+    public async Task GetOrganizationAbilitiesAsync_WhenDuplicateIdsProvided_DoesNotThrowAndReturnsSingleEntry(
+        SutProvider<FeatureRoutedCacheService> sutProvider,
+        OrganizationAbility ability)
+    {
+        // Arrange
+        var allAbilities = new Dictionary<Guid, OrganizationAbility> { [ability.Id] = ability };
+        sutProvider.GetDependency<IVCurrentInMemoryApplicationCacheService>()
+            .GetOrganizationAbilitiesAsync()
+            .Returns(allAbilities);
+
+        // Act - passing the same ID twice simulates a user with duplicate org memberships
+        var result = await sutProvider.Sut.GetOrganizationAbilitiesAsync([ability.Id, ability.Id]);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(ability, result[ability.Id]);
+    }
+
 
     [Theory, BitAutoData]
     public async Task GetOrganizationAbilitiesAsync_WhenNoIdsMatched_ReturnsEmptyDictionary(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34440

## 📔 Objective


Root cause: This happens when the calling code passes duplicate IDs. The GetOrganizationAbilitiesAsync method turns the result into a dictionary, which doesn't allow duplicates.

Fix: 
1. Change both GetOrganizationAbilitiesAsync and GetProviderAbilitiesAsync to perform a Distinct on the input IDs.
2. Add unit tests.

## 📸 Screenshots

The test is for GetOrganizationAbilitiesAsync, but the same logic applies to GetProviderAbilitiesAsync as well.

Current state 

https://github.com/user-attachments/assets/f943c45d-6ee5-410f-bbce-7be9b0d45a31

After fix

https://github.com/user-attachments/assets/e49ef89d-d7fe-407f-a949-ca9e96a22f2b


