### PR TITLE
[PM-29981] Add repo call to check if existing collection already has access setup

### DIFF
--- a/src/Core/OrganizationFeatures/OrganizationCollections/UpdateCollectionCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationCollections/UpdateCollectionCommand.cs
@@ -51,13 +51,28 @@ public class UpdateCollectionCommand : IUpdateCollectionCommand
             throw new BadRequestException("The Manage property is mutually exclusive and cannot be true while the ReadOnly or HidePasswords properties are also true.");
         }
 
-        // A collection should always have someone with Can Manage permissions
-        var groupHasManageAccess = groupsList?.Any(g => g.Manage) ?? false;
-        var userHasManageAccess = usersList?.Any(u => u.Manage) ?? false;
-        if (!groupHasManageAccess && !userHasManageAccess && !org.AllowAdminAccessToAllCollectionItems)
+        // A collection should always have someone with Can Manage permissions.
+        // When groups or users is null it means "don't change that association", so we must
+        // fall back to the existing relationships when evaluating this rule.
+        if (!org.AllowAdminAccessToAllCollectionItems)
         {
-            throw new BadRequestException(
-                "At least one member or group must have can manage permission.");
+            IEnumerable<CollectionAccessSelection> groupsForValidation = groupsList;
+            IEnumerable<CollectionAccessSelection> usersForValidation = usersList;
+
+            if (groupsForValidation == null || usersForValidation == null)
+            {
+                var (_, currentAccess) = await _collectionRepository.GetByIdWithAccessAsync(collection.Id);
+                groupsForValidation ??= currentAccess.Groups;
+                usersForValidation ??= currentAccess.Users;
+            }
+
+            var groupHasManageAccess = groupsForValidation?.Any(g => g.Manage) ?? false;
+            var userHasManageAccess = usersForValidation?.Any(u => u.Manage) ?? false;
+            if (!groupHasManageAccess && !userHasManageAccess)
+            {
+                throw new BadRequestException(
+                    "At least one member or group must have can manage permission.");
+            }
         }
 
         await _collectionRepository.ReplaceAsync(collection, org.UseGroups ? groupsList : null, usersList);

--- a/test/Core.Test/OrganizationFeatures/OrganizationCollections/UpdateCollectionCommandTests.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationCollections/UpdateCollectionCommandTests.cs
@@ -21,12 +21,20 @@ public class UpdateCollectionCommandTests
 {
     [Theory, BitAutoData]
     public async Task UpdateAsync_WithoutGroupsAndUsers_ReplacesCollection(
-        Organization organization, Collection collection, SutProvider<UpdateCollectionCommand> sutProvider)
+        Organization organization, Collection collection,
+        [CollectionAccessSelectionCustomize(true)] IEnumerable<CollectionAccessSelection> existingUsers,
+        SutProvider<UpdateCollectionCommand> sutProvider)
     {
+        organization.AllowAdminAccessToAllCollectionItems = false;
         var creationDate = collection.CreationDate;
         sutProvider.GetDependency<IOrganizationRepository>()
             .GetByIdAsync(organization.Id)
             .Returns(organization);
+        sutProvider.GetDependency<ICollectionRepository>()
+            .GetByIdWithAccessAsync(collection.Id)
+            .Returns(new Tuple<Collection?, CollectionAccessDetails>(
+                collection,
+                new CollectionAccessDetails { Groups = [], Users = existingUsers }));
         var utcNow = DateTime.UtcNow;
 
         await sutProvider.Sut.UpdateAsync(collection, null, null);
@@ -129,6 +137,12 @@ public class UpdateCollectionCommandTests
         sutProvider.GetDependency<IOrganizationRepository>()
             .GetByIdAsync(organization.Id)
             .Returns(organization);
+        // groups is null so the command will fetch existing access; return no manage access
+        sutProvider.GetDependency<ICollectionRepository>()
+            .GetByIdWithAccessAsync(collection.Id)
+            .Returns(new Tuple<Collection?, CollectionAccessDetails>(
+                collection,
+                new CollectionAccessDetails { Groups = [], Users = [] }));
 
         var ex = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.UpdateAsync(collection, null, users));
         Assert.Contains("At least one member or group must have can manage permission.", ex.Message);
@@ -187,5 +201,119 @@ public class UpdateCollectionCommandTests
         await sutProvider.GetDependency<IEventService>()
             .DidNotReceiveWithAnyArgs()
             .LogCollectionEventAsync(default, default);
+    }
+
+    /// <summary>
+    /// Replication of bug: passing null groups (don't update groups) when an existing user has Can Manage
+    /// should succeed, not throw.
+    /// </summary>
+    [Theory, BitAutoData]
+    public async Task UpdateAsync_NullGroups_ExistingUserHasManage_Succeeds(
+        Organization organization, Collection collection,
+        [CollectionAccessSelectionCustomize(true)] IEnumerable<CollectionAccessSelection> existingUsers,
+        SutProvider<UpdateCollectionCommand> sutProvider)
+    {
+        organization.AllowAdminAccessToAllCollectionItems = false;
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetByIdAsync(organization.Id)
+            .Returns(organization);
+        sutProvider.GetDependency<ICollectionRepository>()
+            .GetByIdWithAccessAsync(collection.Id)
+            .Returns(new Tuple<Collection?, CollectionAccessDetails>(
+                collection,
+                new CollectionAccessDetails { Groups = [], Users = existingUsers }));
+
+        await sutProvider.Sut.UpdateAsync(collection, null, null);
+
+        await sutProvider.GetDependency<ICollectionRepository>()
+            .Received(1)
+            .ReplaceAsync(collection, Arg.Is<List<CollectionAccessSelection>>(l => l == null), Arg.Is<List<CollectionAccessSelection>>(l => l == null));
+        await sutProvider.GetDependency<IEventService>()
+            .Received(1)
+            .LogCollectionEventAsync(collection, EventType.Collection_Updated);
+    }
+
+    /// <summary>
+    /// Replication of bug: passing groups without Can Manage when an existing user has Can Manage
+    /// should succeed, not throw.
+    /// </summary>
+    [Theory, BitAutoData]
+    public async Task UpdateAsync_NullUsers_ExistingGroupHasManage_NewGroupsLackManage_Throws(
+        Organization organization, Collection collection,
+        [CollectionAccessSelectionCustomize] IEnumerable<CollectionAccessSelection> newGroups,
+        [CollectionAccessSelectionCustomize(true)] IEnumerable<CollectionAccessSelection> existingUsers,
+        SutProvider<UpdateCollectionCommand> sutProvider)
+    {
+        organization.AllowAdminAccessToAllCollectionItems = false;
+        organization.UseGroups = true;
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetByIdAsync(organization.Id)
+            .Returns(organization);
+        // users is null, so existing users are fetched — they have Can Manage
+        sutProvider.GetDependency<ICollectionRepository>()
+            .GetByIdWithAccessAsync(collection.Id)
+            .Returns(new Tuple<Collection?, CollectionAccessDetails>(
+                collection,
+                new CollectionAccessDetails { Groups = [], Users = existingUsers }));
+
+        // New groups have no manage, but existing users do — should succeed
+        await sutProvider.Sut.UpdateAsync(collection, newGroups, null);
+
+        await sutProvider.GetDependency<ICollectionRepository>()
+            .Received(1)
+            .ReplaceAsync(collection, Arg.Any<List<CollectionAccessSelection>>(), Arg.Is<List<CollectionAccessSelection>>(l => l == null));
+        await sutProvider.GetDependency<IEventService>()
+            .Received(1)
+            .LogCollectionEventAsync(collection, EventType.Collection_Updated);
+    }
+
+    /// <summary>
+    /// Passing groups without Can Manage when existing users also have no Can Manage should throw.
+    /// </summary>
+    [Theory, BitAutoData]
+    public async Task UpdateAsync_NullUsers_NoManageAnywhere_Throws(
+        Organization organization, Collection collection,
+        [CollectionAccessSelectionCustomize] IEnumerable<CollectionAccessSelection> newGroups,
+        [CollectionAccessSelectionCustomize] IEnumerable<CollectionAccessSelection> existingUsers,
+        SutProvider<UpdateCollectionCommand> sutProvider)
+    {
+        organization.AllowAdminAccessToAllCollectionItems = false;
+        organization.UseGroups = true;
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetByIdAsync(organization.Id)
+            .Returns(organization);
+        sutProvider.GetDependency<ICollectionRepository>()
+            .GetByIdWithAccessAsync(collection.Id)
+            .Returns(new Tuple<Collection?, CollectionAccessDetails>(
+                collection,
+                new CollectionAccessDetails { Groups = [], Users = existingUsers }));
+
+        var ex = await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.UpdateAsync(collection, newGroups, null));
+        Assert.Contains("At least one member or group must have can manage permission.", ex.Message);
+    }
+
+    /// <summary>
+    /// When AllowAdminAccessToAllCollectionItems is true the manage check is skipped entirely,
+    /// even with null groups/users — no call to GetByIdWithAccessAsync should occur.
+    /// </summary>
+    [Theory, BitAutoData]
+    public async Task UpdateAsync_AdminAccessToAllItems_SkipsManageCheck(
+        Organization organization, Collection collection,
+        SutProvider<UpdateCollectionCommand> sutProvider)
+    {
+        organization.AllowAdminAccessToAllCollectionItems = true;
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetByIdAsync(organization.Id)
+            .Returns(organization);
+
+        await sutProvider.Sut.UpdateAsync(collection, null, null);
+
+        await sutProvider.GetDependency<ICollectionRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .GetByIdWithAccessAsync(default);
+        await sutProvider.GetDependency<ICollectionRepository>()
+            .Received(1)
+            .ReplaceAsync(collection, null, null);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-29981
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Fixes an issue in the `UpdateCollectionCommand` where it does not check if there is already some `can mange` access configured when groups or users is null in the request payload
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
