### PR TITLE
[PM-26581] Add missing model.type param

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationConnectionsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationConnectionsController.cs
@@ -57,7 +57,7 @@ public class OrganizationConnectionsController : Controller
     [HttpPost]
     public async Task<OrganizationConnectionResponseModel> CreateConnection([FromBody] OrganizationConnectionRequestModel model)
     {
-        if (!await HasPermissionAsync(model?.OrganizationId))
+        if (!await HasPermissionAsync(model?.OrganizationId, model?.Type))
         {
             throw new BadRequestException($"You do not have permission to create a connection of type {model.Type}.");
         }

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationConnectionsControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationConnectionsControllerTests.cs
@@ -50,15 +50,54 @@ public class OrganizationConnectionsControllerTests
 
     [Theory]
     [BitAutoData]
-    public async Task CreateConnection_CloudBillingSync_RequiresOwnerPermissions(SutProvider<OrganizationConnectionsController> sutProvider)
+    public async Task CreateConnection_CloudBillingSync_RequiresOwnerPermissions(Guid organizationId,
+        SutProvider<OrganizationConnectionsController> sutProvider)
     {
         var model = new OrganizationConnectionRequestModel
         {
             Type = OrganizationConnectionType.CloudBillingSync,
+            OrganizationId = organizationId,
         };
         var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.CreateConnection(model));
 
         Assert.Contains($"You do not have permission to create a connection of type", exception.Message);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task CreateConnection_Scim_RequiresManageScimPermission(Guid organizationId,
+        SutProvider<OrganizationConnectionsController> sutProvider)
+    {
+        var model = new OrganizationConnectionRequestModel
+        {
+            Type = OrganizationConnectionType.Scim,
+            OrganizationId = organizationId,
+        };
+
+        sutProvider.GetDependency<ICurrentContext>().ManageScim(organizationId).Returns(false);
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.CreateConnection(model));
+
+        Assert.Contains($"You do not have permission to create a connection of type", exception.Message);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task CreateConnection_Scim_Success(OrganizationConnectionRequestModel model, ScimConfig config,
+        SutProvider<OrganizationConnectionsController> sutProvider)
+    {
+        model.Type = OrganizationConnectionType.Scim;
+        model.Config = JsonDocumentFromObject(config);
+        var typedModel = new OrganizationConnectionRequestModel<ScimConfig>(model);
+
+        sutProvider.GetDependency<ICurrentContext>().ManageScim(model.OrganizationId).Returns(true);
+        sutProvider.GetDependency<ICreateOrganizationConnectionCommand>().CreateAsync<ScimConfig>(default)
+            .ReturnsForAnyArgs(typedModel.ToData(Guid.NewGuid()).ToEntity());
+
+        await sutProvider.Sut.CreateConnection(model);
+
+        await sutProvider.GetDependency<ICreateOrganizationConnectionCommand>().Received(1)
+            .CreateAsync(Arg.Is(AssertHelper.AssertPropertyEqual(typedModel.ToData())));
     }
 
     [Theory]
@@ -73,6 +112,7 @@ public class OrganizationConnectionsControllerTests
         var existing = typedModel.ToData(existingEntityId).ToEntity();
 
         sutProvider.GetDependency<ICurrentContext>().OrganizationOwner(model.OrganizationId).Returns(true);
+        sutProvider.GetDependency<ICurrentContext>().ManageScim(model.OrganizationId).Returns(true);
 
         sutProvider.GetDependency<IOrganizationConnectionRepository>().GetByOrganizationIdTypeAsync(model.OrganizationId, type).Returns(new[] { existing });
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-26581
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
The missing `Model.Type` param caused the switch statement in `HasPermissionAsync` to check if the user is an owner rather than check if you have the `ManageScim` permission.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
