### PR TITLE
[PM-34570] Expired or Cancelled Claimed User Throws Billing Exception on Subscription Cancel

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/DeleteClaimedAccount/DeleteClaimedOrganizationUserAccountCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/DeleteClaimedAccount/DeleteClaimedOrganizationUserAccountCommand.cs
@@ -1,10 +1,12 @@
 ﻿using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interfaces;
 using Bit.Core.AdminConsole.Utilities.v2.Results;
 using Bit.Core.AdminConsole.Utilities.v2.Validation;
+using Bit.Core.Billing;
 using Bit.Core.Billing.Models;
 using Bit.Core.Billing.Services;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
+using Bit.Core.Exceptions;
 using Bit.Core.Platform.Push;
 using Bit.Core.Repositories;
 using Bit.Core.Services;

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/DeleteClaimedAccount/DeleteClaimedOrganizationUserAccountCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/DeleteClaimedAccount/DeleteClaimedOrganizationUserAccountCommand.cs
@@ -145,7 +145,7 @@ public class DeleteClaimedOrganizationUserAccountCommand(
                     await userService.CancelPremiumAsync(user);
                 }
             }
-            catch (Exception exception)
+            catch (Exception exception) when (exception is GatewayException or BillingException)
             {
                 logger.LogWarning(exception, "Failed to cancel premium subscription for {userId}.", user.Id);
             }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/DeleteClaimedAccount/DeleteClaimedOrganizationUserAccountCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/DeleteClaimedAccount/DeleteClaimedOrganizationUserAccountCommand.cs
@@ -5,7 +5,6 @@ using Bit.Core.Billing.Models;
 using Bit.Core.Billing.Services;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
-using Bit.Core.Exceptions;
 using Bit.Core.Platform.Push;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
@@ -133,6 +132,7 @@ public class DeleteClaimedOrganizationUserAccountCommand(
             {
                 if (featureService.IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal))
                 {
+                    // In cases where the subscription is not active, the cancellation will fail and be logged.
                     await subscriberService.CancelSubscription(
                         user,
                         cancelImmediately: false,
@@ -143,7 +143,7 @@ public class DeleteClaimedOrganizationUserAccountCommand(
                     await userService.CancelPremiumAsync(user);
                 }
             }
-            catch (GatewayException exception)
+            catch (Exception exception)
             {
                 logger.LogWarning(exception, "Failed to cancel premium subscription for {userId}.", user.Id);
             }

--- a/src/Core/AdminConsole/OrganizationFeatures/Organizations/OrganizationDeleteCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Organizations/OrganizationDeleteCommand.cs
@@ -2,6 +2,7 @@
 using Bit.Core.AdminConsole.OrganizationFeatures.Organizations.Interfaces;
 using Bit.Core.Auth.Enums;
 using Bit.Core.Auth.Repositories;
+using Bit.Core.Billing;
 using Bit.Core.Billing.Services;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;

--- a/src/Core/AdminConsole/OrganizationFeatures/Organizations/OrganizationDeleteCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Organizations/OrganizationDeleteCommand.cs
@@ -60,7 +60,7 @@ public class OrganizationDeleteCommand : IOrganizationDeleteCommand
                     await _paymentService.CancelSubscriptionAsync(organization, eop);
                 }
             }
-            catch (Exception exception)
+            catch (Exception exception) when (exception is GatewayException or BillingException)
             {
                 _logger.LogWarning(exception, "Failed to cancel subscription for organization {OrganizationId}", organization.Id);
             }

--- a/src/Core/AdminConsole/OrganizationFeatures/Organizations/OrganizationDeleteCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Organizations/OrganizationDeleteCommand.cs
@@ -2,11 +2,11 @@
 using Bit.Core.AdminConsole.OrganizationFeatures.Organizations.Interfaces;
 using Bit.Core.Auth.Enums;
 using Bit.Core.Auth.Repositories;
-using Bit.Core.Billing;
 using Bit.Core.Billing.Services;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
+using Microsoft.Extensions.Logging;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.Organizations;
 
@@ -18,6 +18,7 @@ public class OrganizationDeleteCommand : IOrganizationDeleteCommand
     private readonly ISsoConfigRepository _ssoConfigRepository;
     private readonly ISubscriberService _subscriberService;
     private readonly IFeatureService _featureService;
+    private readonly ILogger<OrganizationDeleteCommand> _logger;
 
     public OrganizationDeleteCommand(
         IApplicationCacheService applicationCacheService,
@@ -25,7 +26,8 @@ public class OrganizationDeleteCommand : IOrganizationDeleteCommand
         IStripePaymentService paymentService,
         ISsoConfigRepository ssoConfigRepository,
         ISubscriberService subscriberService,
-        IFeatureService featureService)
+        IFeatureService featureService,
+        ILogger<OrganizationDeleteCommand> logger)
     {
         _applicationCacheService = applicationCacheService;
         _organizationRepository = organizationRepository;
@@ -33,6 +35,7 @@ public class OrganizationDeleteCommand : IOrganizationDeleteCommand
         _ssoConfigRepository = ssoConfigRepository;
         _subscriberService = subscriberService;
         _featureService = featureService;
+        _logger = logger;
     }
 
     public async Task DeleteAsync(Organization organization)
@@ -48,6 +51,7 @@ public class OrganizationDeleteCommand : IOrganizationDeleteCommand
 
                 if (_featureService.IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal))
                 {
+                    // In cases where the subscription is not active, the cancellation will fail and be logged.
                     await _subscriberService.CancelSubscription(organization, cancelImmediately: !eop);
                 }
                 else
@@ -55,8 +59,10 @@ public class OrganizationDeleteCommand : IOrganizationDeleteCommand
                     await _paymentService.CancelSubscriptionAsync(organization, eop);
                 }
             }
-            catch (GatewayException) { }
-            catch (BillingException) { }
+            catch (Exception exception)
+            {
+                _logger.LogWarning(exception, "Failed to cancel subscription for organization {OrganizationId}", organization.Id);
+            }
         }
 
         await _organizationRepository.DeleteAsync(organization);

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/DeleteClaimedAccountvNext/DeleteClaimedOrganizationUserAccountCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/DeleteClaimedAccountvNext/DeleteClaimedOrganizationUserAccountCommandTests.cs
@@ -14,7 +14,6 @@ using Bit.Core.Services;
 using Bit.Core.Test.AutoFixture.OrganizationUserFixtures;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
-using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/DeleteClaimedAccountvNext/DeleteClaimedOrganizationUserAccountCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/DeleteClaimedAccountvNext/DeleteClaimedOrganizationUserAccountCommandTests.cs
@@ -2,6 +2,7 @@
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interfaces;
 using Bit.Core.AdminConsole.Utilities.v2;
 using Bit.Core.AdminConsole.Utilities.v2.Validation;
+using Bit.Core.Billing;
 using Bit.Core.Billing.Models;
 using Bit.Core.Billing.Services;
 using Bit.Core.Entities;
@@ -339,7 +340,7 @@ public class DeleteClaimedOrganizationUserAccountCommandTests
 
     [Theory]
     [BitAutoData]
-    public async Task DeleteManyUsersAsync_CancelPremiumsAsync_FlagDisabled_HandlesGatewayExceptionAndLogsWarning(
+    public async Task DeleteManyUsersAsync_CancelPremiumsAsync_FlagDisabled_HandlesGatewayException(
         SutProvider<DeleteClaimedOrganizationUserAccountCommand> sutProvider,
         User user,
         Guid organizationId,
@@ -385,20 +386,11 @@ public class DeleteClaimedOrganizationUserAccountCommandTests
 
         await sutProvider.GetDependency<IUserService>().Received(1).CancelPremiumAsync(user);
         await AssertSuccessfulUserOperations(sutProvider, [user], [orgUser]);
-
-        sutProvider.GetDependency<ILogger<DeleteClaimedOrganizationUserAccountCommand>>()
-            .Received(1)
-            .Log(
-                LogLevel.Warning,
-                Arg.Any<EventId>(),
-                Arg.Is<object>(o => o.ToString()!.Contains($"Failed to cancel premium subscription for {user.Id}")),
-                gatewayException,
-                Arg.Any<Func<object, Exception?, string>>());
     }
 
     [Theory]
     [BitAutoData]
-    public async Task DeleteManyUsersAsync_CancelPremiumsAsync_FlagEnabled_HandlesGatewayExceptionAndLogsWarning(
+    public async Task DeleteManyUsersAsync_CancelPremiumsAsync_FlagEnabled_HandlesGatewayException(
         SutProvider<DeleteClaimedOrganizationUserAccountCommand> sutProvider,
         User user,
         Guid organizationId,
@@ -450,17 +442,114 @@ public class DeleteClaimedOrganizationUserAccountCommandTests
                 Arg.Is<OffboardingSurveyResponse>(r => r.UserId == user.Id));
         await sutProvider.GetDependency<IUserService>().DidNotReceiveWithAnyArgs().CancelPremiumAsync(default);
         await AssertSuccessfulUserOperations(sutProvider, [user], [orgUser]);
-
-        sutProvider.GetDependency<ILogger<DeleteClaimedOrganizationUserAccountCommand>>()
-            .Received(1)
-            .Log(
-                LogLevel.Warning,
-                Arg.Any<EventId>(),
-                Arg.Is<object>(o => o.ToString()!.Contains($"Failed to cancel premium subscription for {user.Id}")),
-                gatewayException,
-                Arg.Any<Func<object, Exception?, string>>());
     }
 
+
+    [Theory]
+    [BitAutoData]
+    public async Task DeleteManyUsersAsync_CancelPremiumsAsync_FlagDisabled_HandlesBillingExceptionAndLogsWarning(
+        SutProvider<DeleteClaimedOrganizationUserAccountCommand> sutProvider,
+        User user,
+        Guid organizationId,
+        Guid deletingUserId,
+        [OrganizationUser] OrganizationUser orgUser)
+    {
+        orgUser.UserId = user.Id;
+        orgUser.OrganizationId = organizationId;
+
+        var request = new DeleteUserValidationRequest
+        {
+            OrganizationId = organizationId,
+            OrganizationUserId = orgUser.Id,
+            OrganizationUser = orgUser,
+            User = user,
+            DeletingUserId = deletingUserId,
+            IsClaimed = true
+        };
+        var validationResult = CreateSuccessfulValidationResult(request);
+
+        SetupRepositoryMocks(sutProvider,
+            new List<OrganizationUser> { orgUser },
+            [user],
+            organizationId,
+            new Dictionary<Guid, bool> { { orgUser.Id, true } });
+
+        SetupValidatorMock(sutProvider, [validationResult]);
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal)
+            .Returns(false);
+
+        var billingException = new BillingException();
+        sutProvider.GetDependency<IUserService>()
+            .CancelPremiumAsync(user)
+            .ThrowsAsync(billingException);
+
+        var results = await sutProvider.Sut.DeleteManyUsersAsync(organizationId, [orgUser.Id], deletingUserId);
+
+        var resultsList = results.ToList();
+        Assert.Single(resultsList);
+        Assert.True(resultsList.First().Result.IsSuccess);
+
+        await sutProvider.GetDependency<IUserService>().Received(1).CancelPremiumAsync(user);
+        await AssertSuccessfulUserOperations(sutProvider, [user], [orgUser]);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task DeleteManyUsersAsync_CancelPremiumsAsync_FlagEnabled_HandlesBillingException(
+        SutProvider<DeleteClaimedOrganizationUserAccountCommand> sutProvider,
+        User user,
+        Guid organizationId,
+        Guid deletingUserId,
+        [OrganizationUser] OrganizationUser orgUser)
+    {
+        orgUser.UserId = user.Id;
+        orgUser.OrganizationId = organizationId;
+
+        var request = new DeleteUserValidationRequest
+        {
+            OrganizationId = organizationId,
+            OrganizationUserId = orgUser.Id,
+            OrganizationUser = orgUser,
+            User = user,
+            DeletingUserId = deletingUserId,
+            IsClaimed = true
+        };
+        var validationResult = CreateSuccessfulValidationResult(request);
+
+        SetupRepositoryMocks(sutProvider,
+            new List<OrganizationUser> { orgUser },
+            [user],
+            organizationId,
+            new Dictionary<Guid, bool> { { orgUser.Id, true } });
+
+        SetupValidatorMock(sutProvider, [validationResult]);
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal)
+            .Returns(true);
+
+        var billingException = new BillingException();
+        sutProvider.GetDependency<ISubscriberService>()
+            .CancelSubscription(user, cancelImmediately: false, Arg.Any<OffboardingSurveyResponse>())
+            .ThrowsAsync(billingException);
+
+        var results = await sutProvider.Sut.DeleteManyUsersAsync(organizationId, [orgUser.Id], deletingUserId);
+
+        var resultsList = results.ToList();
+        Assert.Single(resultsList);
+        Assert.True(resultsList.First().Result.IsSuccess);
+
+        await sutProvider.GetDependency<ISubscriberService>()
+            .Received(1)
+            .CancelSubscription(
+                user,
+                cancelImmediately: false,
+                Arg.Is<OffboardingSurveyResponse>(r => r.UserId == user.Id));
+        await sutProvider.GetDependency<IUserService>().DidNotReceiveWithAnyArgs().CancelPremiumAsync(default);
+        await AssertSuccessfulUserOperations(sutProvider, [user], [orgUser]);
+    }
 
     [Theory]
     [BitAutoData]

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/Organizations/OrganizationDeleteCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/Organizations/OrganizationDeleteCommandTests.cs
@@ -4,6 +4,7 @@ using Bit.Core.Auth.Entities;
 using Bit.Core.Auth.Enums;
 using Bit.Core.Auth.Models.Data;
 using Bit.Core.Auth.Repositories;
+using Bit.Core.Billing;
 using Bit.Core.Billing.Services;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
@@ -12,6 +13,7 @@ using Bit.Core.Test.AutoFixture.OrganizationFixtures;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.Organizations;
@@ -96,5 +98,50 @@ public class OrganizationDeleteCommandTests
         await sutProvider.GetDependency<ISubscriberService>()
             .DidNotReceiveWithAnyArgs()
             .CancelSubscription(default, default, default);
+    }
+
+    [Theory, PaidOrganizationCustomize, BitAutoData]
+    public async Task Delete_WhenFlagEnabled_HandlesBillingException(
+        Organization organization,
+        SutProvider<OrganizationDeleteCommand> sutProvider)
+    {
+        organization.GatewaySubscriptionId = "sub_123";
+        organization.ExpirationDate = DateTime.UtcNow.AddDays(10);
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal)
+            .Returns(true);
+
+        var billingException = new BillingException();
+        sutProvider.GetDependency<ISubscriberService>()
+            .CancelSubscription(organization, cancelImmediately: false)
+            .ThrowsAsync(billingException);
+
+        await sutProvider.Sut.DeleteAsync(organization);
+
+        await sutProvider.GetDependency<IOrganizationRepository>().Received(1).DeleteAsync(organization);
+
+    }
+
+    [Theory, PaidOrganizationCustomize, BitAutoData]
+    public async Task Delete_WhenFlagDisabled_HandlesBillingException(
+        Organization organization,
+        SutProvider<OrganizationDeleteCommand> sutProvider)
+    {
+        organization.GatewaySubscriptionId = "sub_123";
+        organization.ExpirationDate = DateTime.UtcNow.AddDays(10);
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal)
+            .Returns(false);
+
+        var billingException = new BillingException();
+        sutProvider.GetDependency<IStripePaymentService>()
+            .CancelSubscriptionAsync(organization, Arg.Any<bool>())
+            .ThrowsAsync(billingException);
+
+        await sutProvider.Sut.DeleteAsync(organization);
+
+        await sutProvider.GetDependency<IOrganizationRepository>().Received(1).DeleteAsync(organization);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-34570

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Improves exception handling and test coverage for subscription cancellation logic in organization and user deletion flows. It generalizes exception handling to catch all exceptions (not just gateway or billing exceptions), ensures proper logging, and adds new tests to verify behavior when `BillingException` is thrown. 