### PR TITLE
[PM-34679] Display Phase 2 prices and discount on org subscription page

### DIFF
--- a/src/Core/Billing/Services/Implementations/StripePaymentService.cs
+++ b/src/Core/Billing/Services/Implementations/StripePaymentService.cs
@@ -661,6 +661,8 @@ public class StripePaymentService : IStripePaymentService
             subscriptionInfo.CustomerDiscount = new SubscriptionInfo.BillingCustomerDiscount(discount);
         }
 
+        await ApplySchedulePhase2DataAsync(subscription, subscriptionInfo);
+
         var (suspensionDate, unpaidPeriodEndDate) = await GetSuspensionDateAsync(subscription);
 
         if (suspensionDate.HasValue && unpaidPeriodEndDate.HasValue)
@@ -700,6 +702,74 @@ public class StripePaymentService : IStripePaymentService
         }
 
         return subscriptionInfo;
+    }
+
+    private async Task ApplySchedulePhase2DataAsync(Subscription subscription, SubscriptionInfo subscriptionInfo)
+    {
+        if (string.IsNullOrEmpty(subscription.ScheduleId))
+        {
+            return;
+        }
+
+        try
+        {
+            var schedule = await _stripeAdapter.GetSubscriptionScheduleAsync(subscription.ScheduleId,
+                new SubscriptionScheduleGetOptions
+                {
+                    Expand = ["phases.discounts.coupon", "phases.items.price"]
+                });
+
+            if (schedule.Status != StripeConstants.SubscriptionScheduleStatus.Active || schedule.Phases.Count < 2)
+            {
+                return;
+            }
+
+            var phase2 = schedule.Phases[1];
+            var now = subscription.TestClock?.FrozenTime ?? DateTime.UtcNow;
+
+            if (phase2.StartDate < now)
+            {
+                return;
+            }
+
+            // Override line item amounts with Phase 2 prices
+            if (phase2.Items != null && subscriptionInfo.Subscription?.Items != null)
+            {
+                var items = subscriptionInfo.Subscription.Items.ToList();
+                foreach (var phase2Item in phase2.Items)
+                {
+                    if (phase2Item.Price is not { UnitAmount: not null, ProductId: not null })
+                    {
+                        continue;
+                    }
+
+                    var matchingItem = items.FirstOrDefault(i => i.ProductId == phase2Item.Price.ProductId);
+                    if (matchingItem != null)
+                    {
+                        matchingItem.Amount = phase2Item.Price.UnitAmount.Value / 100M;
+                    }
+                }
+
+                subscriptionInfo.Subscription.Items = items;
+            }
+
+            // Override discount with Phase 2 discount
+            var phase2Discount = phase2.Discounts?.FirstOrDefault();
+            if (phase2Discount?.Coupon != null)
+            {
+                subscriptionInfo.CustomerDiscount = new SubscriptionInfo.BillingCustomerDiscount(phase2Discount.Coupon);
+            }
+        }
+        catch (StripeException ex)
+        {
+            // Fallback: user sees current Phase 1 prices instead of Phase 2 prices.
+            // Accepted tradeoff: showing current data is better than failing the page.
+            _logger.LogWarning(ex,
+                "Failed to retrieve subscription schedule ({ScheduleId}) for subscription ({SubscriptionId}), Phase 2 data resolution. Error Code: {ErrorCode}",
+                subscription.ScheduleId,
+                subscription.Id,
+                ex.StripeError?.Code);
+        }
     }
 
     public async Task<string> AddSecretsManagerToSubscription(

--- a/src/Core/Models/Business/SubscriptionInfo.cs
+++ b/src/Core/Models/Business/SubscriptionInfo.cs
@@ -53,6 +53,20 @@ public class SubscriptionInfo
         }
 
         /// <summary>
+        /// Creates a BillingCustomerDiscount from a Stripe Coupon object.
+        /// Unlike <see cref="BillingCustomerDiscount(Discount)"/>, this constructor does not have
+        /// access to a Discount wrapper, so Active is unconditionally set to true.
+        /// </summary>
+        public BillingCustomerDiscount(Coupon coupon)
+        {
+            Id = coupon.Id;
+            Active = true;
+            PercentOff = coupon.PercentOff;
+            AmountOff = ConvertFromStripeMinorUnits(coupon.AmountOff);
+            AppliesTo = coupon.AppliesTo?.Products;
+        }
+
+        /// <summary>
         /// The Stripe coupon ID (e.g., "cm3nHfO1").
         /// Note: Only specific coupon IDs are displayed in the UI based on feature flag configuration,
         /// though Stripe may apply additional discounts that are not shown.
@@ -60,8 +74,8 @@ public class SubscriptionInfo
         public string? Id { get; set; }
 
         /// <summary>
-        /// True only for perpetual/recurring discounts (End == null).
-        /// False for any discount with an expiration date, even if not yet expired.
+        /// When constructed from a Discount, true only for perpetual discounts (End == null).
+        /// When constructed from a Coupon directly, always true (no end-date information available).
         /// Product decision for Milestone 2: only show perpetual discounts in UI.
         /// </summary>
         public bool Active { get; set; }

--- a/test/Core.Test/Billing/Services/StripePaymentServiceTests.cs
+++ b/test/Core.Test/Billing/Services/StripePaymentServiceTests.cs
@@ -10,6 +10,7 @@ using Bit.Core.Test.Billing.Mocks.Plans;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Stripe;
 using Xunit;
 
@@ -413,6 +414,409 @@ public class StripePaymentServiceTests
         await sutProvider.GetDependency<IStripeAdapter>()
             .DidNotReceive()
             .GetSubscriptionAsync(Arg.Any<string>(), Arg.Any<SubscriptionGetOptions>());
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetSubscriptionAsync_WithActiveSchedule_OverridesPricesAndDiscount(
+        SutProvider<StripePaymentService> sutProvider,
+        User subscriber)
+    {
+        // Arrange
+        subscriber.Gateway = GatewayType.Stripe;
+        subscriber.GatewayCustomerId = "cus_test123";
+        subscriber.GatewaySubscriptionId = "sub_test123";
+
+        var subscription = new Subscription
+        {
+            Id = "sub_test123",
+            Status = "active",
+            CollectionMethod = "charge_automatically",
+            ScheduleId = "sub_sched_test123",
+            Customer = new Customer { Discount = null },
+            Discounts = new List<Discount>(),
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Plan = new Plan { ProductId = "prod_families", Nickname = "Families 2019", Amount = 1200, Interval = "year" },
+                        Quantity = 1
+                    }
+                ]
+            }
+        };
+
+        var schedule = new SubscriptionSchedule
+        {
+            Status = SubscriptionScheduleStatus.Active,
+            Phases =
+            [
+                new SubscriptionSchedulePhase { StartDate = DateTime.UtcNow.AddDays(-30) },
+                new SubscriptionSchedulePhase
+                {
+                    StartDate = DateTime.UtcNow.AddDays(10),
+                    Items =
+                    [
+                        new SubscriptionSchedulePhaseItem
+                        {
+                            Price = new Price { UnitAmount = 4788, ProductId = "prod_families", Nickname = "Families" }
+                        }
+                    ],
+                    Discounts =
+                    [
+                        new SubscriptionSchedulePhaseDiscount
+                        {
+                            Coupon = new Coupon { Id = CouponIDs.Milestone3SubscriptionDiscount, PercentOff = 25m }
+                        }
+                    ]
+                }
+            ]
+        };
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionAsync(subscriber.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionScheduleAsync("sub_sched_test123", Arg.Any<SubscriptionScheduleGetOptions>())
+            .Returns(schedule);
+
+        // Act
+        var result = await sutProvider.Sut.GetSubscriptionAsync(subscriber);
+
+        // Assert — prices overridden with Phase 2 values
+        var item = Assert.Single(result.Subscription!.Items);
+        Assert.Equal(47.88m, item.Amount);
+
+        // Assert — discount overridden with Phase 2 discount
+        Assert.NotNull(result.CustomerDiscount);
+        Assert.Equal(CouponIDs.Milestone3SubscriptionDiscount, result.CustomerDiscount.Id);
+        Assert.Equal(25m, result.CustomerDiscount.PercentOff);
+        Assert.True(result.CustomerDiscount.Active);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetSubscriptionAsync_WithActiveSchedule_NoPhase2Discount_KeepsOriginalDiscount(
+        SutProvider<StripePaymentService> sutProvider,
+        User subscriber)
+    {
+        // Arrange
+        subscriber.Gateway = GatewayType.Stripe;
+        subscriber.GatewayCustomerId = "cus_test123";
+        subscriber.GatewaySubscriptionId = "sub_test123";
+
+        var subscription = new Subscription
+        {
+            Id = "sub_test123",
+            Status = "active",
+            CollectionMethod = "charge_automatically",
+            ScheduleId = "sub_sched_test123",
+            Customer = new Customer
+            {
+                Discount = new Discount
+                {
+                    Coupon = new Coupon { Id = "existing-coupon", PercentOff = 10m },
+                    End = null
+                }
+            },
+            Discounts = new List<Discount>(),
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Plan = new Plan { ProductId = "prod_families", Nickname = "Families 2025", Amount = 4000, Interval = "year" },
+                        Quantity = 1
+                    }
+                ]
+            }
+        };
+
+        var schedule = new SubscriptionSchedule
+        {
+            Status = SubscriptionScheduleStatus.Active,
+            Phases =
+            [
+                new SubscriptionSchedulePhase { StartDate = DateTime.UtcNow.AddDays(-30) },
+                new SubscriptionSchedulePhase
+                {
+                    StartDate = DateTime.UtcNow.AddDays(10),
+                    Items =
+                    [
+                        new SubscriptionSchedulePhaseItem
+                        {
+                            Price = new Price { UnitAmount = 4788, ProductId = "prod_families", Nickname = "Families" }
+                        }
+                    ],
+                    Discounts = new List<SubscriptionSchedulePhaseDiscount>()
+                }
+            ]
+        };
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionAsync(subscriber.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionScheduleAsync("sub_sched_test123", Arg.Any<SubscriptionScheduleGetOptions>())
+            .Returns(schedule);
+
+        // Act
+        var result = await sutProvider.Sut.GetSubscriptionAsync(subscriber);
+
+        // Assert — price overridden
+        var item = Assert.Single(result.Subscription!.Items);
+        Assert.Equal(47.88m, item.Amount);
+
+        // Assert — original discount preserved (Phase 2 has no discount)
+        Assert.NotNull(result.CustomerDiscount);
+        Assert.Equal("existing-coupon", result.CustomerDiscount.Id);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetSubscriptionAsync_WithNoSchedule_DoesNotFetchSchedule(
+        SutProvider<StripePaymentService> sutProvider,
+        User subscriber)
+    {
+        // Arrange
+        subscriber.Gateway = GatewayType.Stripe;
+        subscriber.GatewayCustomerId = "cus_test123";
+        subscriber.GatewaySubscriptionId = "sub_test123";
+
+        var subscription = new Subscription
+        {
+            Id = "sub_test123",
+            Status = "active",
+            CollectionMethod = "charge_automatically",
+            ScheduleId = null,
+            Customer = new Customer { Discount = null },
+            Discounts = new List<Discount>(),
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Plan = new Plan { ProductId = "prod_families", Amount = 1200, Interval = "year" },
+                        Quantity = 1
+                    }
+                ]
+            }
+        };
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionAsync(subscriber.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        // Act
+        var result = await sutProvider.Sut.GetSubscriptionAsync(subscriber);
+
+        // Assert — original price preserved
+        var item = Assert.Single(result.Subscription!.Items);
+        Assert.Equal(12.00m, item.Amount);
+
+        // Assert — no schedule fetch
+        await sutProvider.GetDependency<IStripeAdapter>()
+            .DidNotReceive()
+            .GetSubscriptionScheduleAsync(Arg.Any<string>(), Arg.Any<SubscriptionScheduleGetOptions>());
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetSubscriptionAsync_ScheduleFetchFails_GracefullyFallsBack(
+        SutProvider<StripePaymentService> sutProvider,
+        User subscriber)
+    {
+        // Arrange
+        subscriber.Gateway = GatewayType.Stripe;
+        subscriber.GatewayCustomerId = "cus_test123";
+        subscriber.GatewaySubscriptionId = "sub_test123";
+
+        var subscription = new Subscription
+        {
+            Id = "sub_test123",
+            Status = "active",
+            CollectionMethod = "charge_automatically",
+            ScheduleId = "sub_sched_test123",
+            Customer = new Customer { Discount = null },
+            Discounts = new List<Discount>(),
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Plan = new Plan { ProductId = "prod_families", Amount = 1200, Interval = "year" },
+                        Quantity = 1
+                    }
+                ]
+            }
+        };
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionAsync(subscriber.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionScheduleAsync("sub_sched_test123", Arg.Any<SubscriptionScheduleGetOptions>())
+            .ThrowsAsync(new StripeException("Schedule not found"));
+
+        // Act
+        var result = await sutProvider.Sut.GetSubscriptionAsync(subscriber);
+
+        // Assert — original data preserved despite schedule fetch failure
+        var item = Assert.Single(result.Subscription!.Items);
+        Assert.Equal(12.00m, item.Amount);
+        Assert.Null(result.CustomerDiscount);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetSubscriptionAsync_ScheduleNotActive_DoesNotOverride(
+        SutProvider<StripePaymentService> sutProvider,
+        User subscriber)
+    {
+        // Arrange
+        subscriber.Gateway = GatewayType.Stripe;
+        subscriber.GatewayCustomerId = "cus_test123";
+        subscriber.GatewaySubscriptionId = "sub_test123";
+
+        var subscription = new Subscription
+        {
+            Id = "sub_test123",
+            Status = "active",
+            CollectionMethod = "charge_automatically",
+            ScheduleId = "sub_sched_test123",
+            Customer = new Customer { Discount = null },
+            Discounts = new List<Discount>(),
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Plan = new Plan { ProductId = "prod_families", Amount = 1200, Interval = "year" },
+                        Quantity = 1
+                    }
+                ]
+            }
+        };
+
+        var schedule = new SubscriptionSchedule
+        {
+            Status = SubscriptionScheduleStatus.Canceled,
+            Phases =
+            [
+                new SubscriptionSchedulePhase { StartDate = DateTime.UtcNow.AddDays(-30) },
+                new SubscriptionSchedulePhase
+                {
+                    StartDate = DateTime.UtcNow.AddDays(10),
+                    Items =
+                    [
+                        new SubscriptionSchedulePhaseItem
+                        {
+                            Price = new Price { UnitAmount = 4788, ProductId = "prod_families" }
+                        }
+                    ]
+                }
+            ]
+        };
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionAsync(subscriber.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionScheduleAsync("sub_sched_test123", Arg.Any<SubscriptionScheduleGetOptions>())
+            .Returns(schedule);
+
+        // Act
+        var result = await sutProvider.Sut.GetSubscriptionAsync(subscriber);
+
+        // Assert — original price preserved
+        var item = Assert.Single(result.Subscription!.Items);
+        Assert.Equal(12.00m, item.Amount);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetSubscriptionAsync_Phase2AlreadyStarted_DoesNotOverride(
+        SutProvider<StripePaymentService> sutProvider,
+        User subscriber)
+    {
+        // Arrange
+        subscriber.Gateway = GatewayType.Stripe;
+        subscriber.GatewayCustomerId = "cus_test123";
+        subscriber.GatewaySubscriptionId = "sub_test123";
+
+        var subscription = new Subscription
+        {
+            Id = "sub_test123",
+            Status = "active",
+            CollectionMethod = "charge_automatically",
+            ScheduleId = "sub_sched_test123",
+            Customer = new Customer { Discount = null },
+            Discounts = new List<Discount>(),
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Plan = new Plan { ProductId = "prod_families", Amount = 1200, Interval = "year" },
+                        Quantity = 1
+                    }
+                ]
+            }
+        };
+
+        var schedule = new SubscriptionSchedule
+        {
+            Status = SubscriptionScheduleStatus.Active,
+            Phases =
+            [
+                new SubscriptionSchedulePhase { StartDate = DateTime.UtcNow.AddDays(-60) },
+                new SubscriptionSchedulePhase
+                {
+                    StartDate = DateTime.UtcNow.AddDays(-5),
+                    Items =
+                    [
+                        new SubscriptionSchedulePhaseItem
+                        {
+                            Price = new Price { UnitAmount = 4788, ProductId = "prod_families" }
+                        }
+                    ],
+                    Discounts =
+                    [
+                        new SubscriptionSchedulePhaseDiscount
+                        {
+                            Coupon = new Coupon { Id = CouponIDs.Milestone3SubscriptionDiscount, PercentOff = 25m }
+                        }
+                    ]
+                }
+            ]
+        };
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionAsync(subscriber.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionScheduleAsync("sub_sched_test123", Arg.Any<SubscriptionScheduleGetOptions>())
+            .Returns(schedule);
+
+        // Act
+        var result = await sutProvider.Sut.GetSubscriptionAsync(subscriber);
+
+        // Assert — original price preserved, Phase 2 already started so no override
+        var item = Assert.Single(result.Subscription!.Items);
+        Assert.Equal(12.00m, item.Amount);
+        Assert.Null(result.CustomerDiscount);
     }
 
     #region AdjustSubscription — CompleteSubscriptionUpdate tax exempt alignment


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34679

## 📔 Objective

During Phase 1 of a subscription schedule (the 15-day window before Families renewal), the Admin Console's Billing > Subscription page was showing the old plan price (2019 or 2025) and no discount. Stripe had the correct Phase 2 data, but `StripePaymentService.GetSubscriptionAsync()` never consulted the subscription schedule.

This PR adds schedule-aware logic to `GetSubscriptionAsync()` that overlays Phase 2 prices and discounts onto the `SubscriptionInfo` response when an active subscription schedule exists. This follows the same pattern already used for Premium individual subscriptions in `GetBitwardenSubscriptionQuery.GetSchedulePhase2DiscountAsync()`.

**Changes:**
- Added `ApplySchedulePhase2DataAsync()` to `StripePaymentService` — fetches the subscription schedule, matches Phase 2 items by product ID, and overrides line item amounts and discount
- Added `BillingCustomerDiscount(Coupon)` constructor to `SubscriptionInfo` for schedule phase discounts (which expose a Coupon, not a full Discount wrapper)
- 6 unit tests covering: happy path with discount, no Phase 2 discount, no schedule, schedule fetch failure, inactive schedule, and Phase 2 already started

No client-side changes needed — the existing response model fields already carry the correct data once populated with Phase 2 values.

## 📸 Screenshots

[Families subscription in phase 2](https://dashboard.stripe.com/acct_19smIXIGBnsLynRr/test/subscriptions/sub_1TJG7rIGBnsLynRr5FjWc37P)

<img width="960" height="323" alt="image" src="https://github.com/user-attachments/assets/b890d785-2fcd-4e97-8801-1a321fd2c64d" />
