### PR TITLE
[FIX] Image tag max length logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,13 +209,13 @@ jobs:
           if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
             SANITIZED_REPO_NAME=$(echo "$_GITHUB_PR_REPO_NAME" | sed "s/[^a-zA-Z0-9]/-/g") # Sanitize repo name to alphanumeric only
             IMAGE_TAG=$SANITIZED_REPO_NAME-$IMAGE_TAG # Add repo name to the tag
-            IMAGE_TAG=${IMAGE_TAG:0:128}  # Limit to 128 characters, as that's the max length for Docker image tags
           fi
 
           if [[ "$IMAGE_TAG" == "main" ]]; then
             IMAGE_TAG=dev
           fi
-
+          
+          IMAGE_TAG=${IMAGE_TAG:0:128} # Limit image tags to 128 chars
           echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
           echo "### :mega: Docker Image Tag: $IMAGE_TAG" >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
## 🎟️ Tracking
Failing [workflow](https://github.com/bitwarden/server/actions/runs/24041654615/job/70116013701?pr=7394)

## 📔 Objective
🐛 
The logic that truncated generated image tags to the maximum length of 128 characters was inside a conditional block, so it wasn't applied in all scenarios. Some tags were being generated that exceeded the max length allowed by GHCR. This PR moves that logic out of a conditional and places it directly before setting the job's output variable.
