### PR TITLE
[PM-34255] - SCIM Api Key Fix

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationsController.cs
@@ -407,17 +407,14 @@ public class OrganizationsController : Controller
             throw new UnauthorizedAccessException();
         }
 
-        if (model.Type != OrganizationApiKeyType.Scim
-            && !await _userService.VerifySecretAsync(user, model.Secret))
+        if (!await _userService.VerifySecretAsync(user, model.Secret))
         {
             await Task.Delay(2000);
             throw new BadRequestException("MasterPasswordHash", "Invalid password.");
         }
-        else
-        {
-            var response = new ApiKeyResponseModel(organizationApiKey);
-            return response;
-        }
+
+        var response = new ApiKeyResponseModel(organizationApiKey);
+        return response;
     }
 
     [HttpGet("{id}/api-key-information/{type?}")]
@@ -460,18 +457,15 @@ public class OrganizationsController : Controller
             throw new UnauthorizedAccessException();
         }
 
-        if (model.Type != OrganizationApiKeyType.Scim
-            && !await _userService.VerifySecretAsync(user, model.Secret))
+        if (!await _userService.VerifySecretAsync(user, model.Secret))
         {
             await Task.Delay(2000);
             throw new BadRequestException("MasterPasswordHash", "Invalid password.");
         }
-        else
-        {
-            await _rotateOrganizationApiKeyCommand.RotateApiKeyAsync(organizationApiKey);
-            var response = new ApiKeyResponseModel(organizationApiKey);
-            return response;
-        }
+
+        await _rotateOrganizationApiKeyCommand.RotateApiKeyAsync(organizationApiKey);
+        var response = new ApiKeyResponseModel(organizationApiKey);
+        return response;
     }
 
     private async Task<bool> HasApiKeyAccessAsync(Guid orgId, OrganizationApiKeyType? type)

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationsControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationsControllerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Security.Claims;
 using Bit.Api.AdminConsole.Controllers;
+using Bit.Api.AdminConsole.Models.Request.Organizations;
 using Bit.Api.Auth.Models.Request.Accounts;
 using Bit.Api.Models.Request.Organizations;
 using Bit.Core;
@@ -8,6 +9,7 @@ using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.AdminConsole.Models.Business;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
+using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationApiKeys.Interfaces;
 using Bit.Core.AdminConsole.OrganizationFeatures.Organizations.Interfaces;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interfaces;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
@@ -256,5 +258,114 @@ public class OrganizationsControllerTests
                     s.LimitCollectionDeletion == model.LimitCollectionDeletion &&
                     s.LimitItemDeletion == model.LimitItemDeletion &&
                     s.AllowAdminAccessToAllCollectionItems == model.AllowAdminAccessToAllCollectionItems));
+    }
+
+    [Theory, BitAutoData]
+    public async Task ApiKey_ScimType_InvalidSecret_ThrowsBadRequest(
+        SutProvider<OrganizationsController> sutProvider,
+        Organization organization,
+        OrganizationApiKey organizationApiKey,
+        User user)
+    {
+        organization.PlanType = PlanType.EnterpriseAnnually;
+        var model = new OrganizationApiKeyRequestModel
+        {
+            Type = OrganizationApiKeyType.Scim,
+            MasterPasswordHash = "invalid-hash"
+        };
+
+        sutProvider.GetDependency<ICurrentContext>().ManageScim(organization.Id).Returns(true);
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
+        sutProvider.GetDependency<IGetOrganizationApiKeyQuery>()
+            .GetOrganizationApiKeyAsync(organization.Id, OrganizationApiKeyType.Scim)
+            .Returns(organizationApiKey);
+
+        var userService = sutProvider.GetDependency<IUserService>();
+        userService.GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
+        userService.VerifySecretAsync(user, model.Secret).Returns(false);
+
+        await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.ApiKey(organization.Id.ToString(), model));
+    }
+
+    [Theory, BitAutoData]
+    public async Task ApiKey_ScimType_ValidSecret_ReturnsApiKey(
+        SutProvider<OrganizationsController> sutProvider,
+        Organization organization,
+        OrganizationApiKey organizationApiKey,
+        User user)
+    {
+        organization.PlanType = PlanType.EnterpriseAnnually;
+        var model = new OrganizationApiKeyRequestModel
+        {
+            Type = OrganizationApiKeyType.Scim,
+            MasterPasswordHash = "valid-hash"
+        };
+
+        sutProvider.GetDependency<ICurrentContext>().ManageScim(organization.Id).Returns(true);
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
+        sutProvider.GetDependency<IGetOrganizationApiKeyQuery>()
+            .GetOrganizationApiKeyAsync(organization.Id, OrganizationApiKeyType.Scim)
+            .Returns(organizationApiKey);
+        var userService = sutProvider.GetDependency<IUserService>();
+        userService.GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
+        userService.VerifySecretAsync(user, model.Secret).Returns(true);
+
+        var result = await sutProvider.Sut.ApiKey(organization.Id.ToString(), model);
+
+        Assert.Equal(organizationApiKey.ApiKey, result.ApiKey);
+    }
+
+    [Theory, BitAutoData]
+    public async Task RotateApiKey_ScimType_InvalidSecret_ThrowsBadRequest(
+        SutProvider<OrganizationsController> sutProvider,
+        Organization organization,
+        OrganizationApiKey organizationApiKey,
+        User user)
+    {
+        var model = new OrganizationApiKeyRequestModel
+        {
+            Type = OrganizationApiKeyType.Scim,
+            MasterPasswordHash = "invalid-hash"
+        };
+
+        sutProvider.GetDependency<ICurrentContext>().ManageScim(organization.Id).Returns(true);
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
+        sutProvider.GetDependency<IGetOrganizationApiKeyQuery>()
+            .GetOrganizationApiKeyAsync(organization.Id, OrganizationApiKeyType.Scim)
+            .Returns(organizationApiKey);
+        var userService = sutProvider.GetDependency<IUserService>();
+        userService.GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
+        userService.VerifySecretAsync(user, model.Secret).Returns(false);
+
+        await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.RotateApiKey(organization.Id.ToString(), model));
+    }
+
+    [Theory, BitAutoData]
+    public async Task RotateApiKey_ScimType_ValidSecret_ReturnsApiKey(
+        SutProvider<OrganizationsController> sutProvider,
+        Organization organization,
+        OrganizationApiKey organizationApiKey,
+        User user)
+    {
+        var model = new OrganizationApiKeyRequestModel
+        {
+            Type = OrganizationApiKeyType.Scim,
+            MasterPasswordHash = "valid-hash"
+        };
+
+        sutProvider.GetDependency<ICurrentContext>().ManageScim(organization.Id).Returns(true);
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
+        sutProvider.GetDependency<IGetOrganizationApiKeyQuery>()
+            .GetOrganizationApiKeyAsync(organization.Id, OrganizationApiKeyType.Scim)
+            .Returns(organizationApiKey);
+        var userService = sutProvider.GetDependency<IUserService>();
+        userService.GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
+        userService.VerifySecretAsync(user, model.Secret).Returns(true);
+
+        var result = await sutProvider.Sut.RotateApiKey(organization.Id.ToString(), model);
+
+        Assert.Equal(organizationApiKey.ApiKey, result.ApiKey);
     }
 }


### PR DESCRIPTION
🎟 Tracking

https://bitwarden.atlassian.net/browse/PM-34255

📔 Objective

Fix a security vulnerability where the SCIM API key retrieval (POST /organizations/{id}/api-key) and rotation (POST /organizations/{id}/rotate-api-key) endpoints skip master password verification due to a
boolean short-circuit bypass.

The condition model.Type != OrganizationApiKeyType.Scim && !await _userService.VerifySecretAsync(user, model.Secret) evaluates to false immediately when the type is SCIM, causing VerifySecretAsync to never
be called. This allows SCIM API keys to be retrieved or rotated without verifying the caller's master password.

Fix: Remove the model.Type != OrganizationApiKeyType.Scim guard so that VerifySecretAsync is called for all API key types, including SCIM.

Client side changes to check for MP [here](https://github.com/bitwarden/clients/pull/20036)

Changes:
- OrganizationsController.cs — Removed the SCIM type exception from password verification in both ApiKey and RotateApiKey methods
- OrganizationsControllerTests.cs — Added 4 unit tests covering SCIM-type requests with valid and invalid secrets for both endpoints   