### PR TITLE
[PM-34728] Use top-level ProrationBehavior on schedule updates

### DIFF
--- a/src/Core/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommand.cs
+++ b/src/Core/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommand.cs
@@ -109,11 +109,11 @@ public class UpdateOrganizationSubscriptionCommand(
         var activeSchedule = schedules.Data.FirstOrDefault(s =>
             s.Status == SubscriptionScheduleStatus.Active && s.SubscriptionId == subscription.Id);
 
-        // An active schedule here means PriceIncreaseScheduler created a schedule to defer a
-        // Families price migration to renewal. A 2-phase schedule is the standard migration
-        // state; a 1-phase schedule means the subscription was cancelled (end-of-period) while
-        // a schedule was attached (PM-33897). Either way, we update via the schedule to avoid
-        // conflicting with Stripe's schedule ownership of the subscription.
+        /* An active schedule here means PriceIncreaseScheduler created a schedule to defer a
+         * Families price migration to renewal. A 2-phase schedule is the standard migration
+         * state; a 1-phase schedule means the subscription was cancelled (end-of-period) while
+         * a schedule was attached (PM-33897). Either way, we update via the schedule to avoid
+         * conflicting with Stripe's schedule ownership of the subscription. */
         if (activeSchedule is { Phases.Count: > 0 })
         {
             if (activeSchedule.Phases.Count > 2)
@@ -129,11 +129,11 @@ public class UpdateOrganizationSubscriptionCommand(
 
             var phase1 = activeSchedule.Phases[0];
 
-            // This applies the change set's price IDs (which are Phase 1 / current-plan prices)
-            // to both phases. This works because storage prices are uniform across the Families
-            // migration. If storage prices ever differ between phases, both this command and
-            // UpdatePremiumStorageCommand would need plan-aware price resolution (e.g. matching
-            // Phase 2's seat price to determine the correct storage price).
+            /* This applies the change set's price IDs (which are Phase 1 / current-plan prices)
+             * to both phases. This works because storage prices are uniform across the Families
+             * migration. If storage prices ever differ between phases, both this command and
+             * UpdatePremiumStorageCommand would need plan-aware price resolution (e.g. matching
+             * Phase 2's seat price to determine the correct storage price). */
             var phases = new List<SubscriptionSchedulePhaseOptions>
             {
                 new()
@@ -143,7 +143,7 @@ public class UpdateOrganizationSubscriptionCommand(
                     Items = ApplyChangesToPhaseItems(phase1.Items, changeSet.Changes),
                     Discounts = phase1.Discounts?.Select(d =>
                         new SubscriptionSchedulePhaseDiscountOptions { Coupon = d.CouponId }).ToList(),
-                    ProrationBehavior = prorationBehavior
+                    ProrationBehavior = phase1.ProrationBehavior
                 }
             };
 
@@ -161,20 +161,22 @@ public class UpdateOrganizationSubscriptionCommand(
                 });
             }
 
-            // Note: the schedule phase API does not support PendingInvoiceItemInterval. For annual
-            // subscribers, the non-schedule path invoices prorations monthly. Here, prorations
-            // remain pending until the next invoice (~15 days, when the schedule was created on
-            // invoice.upcoming). Accepted trade-off for the migration window.
+            /* Note: the schedule phase API does not support PendingInvoiceItemInterval. For annual
+             * subscribers, the non-schedule path invoices prorations monthly. When the top-level
+             * ProrationBehavior is AlwaysInvoice (structural changes), Stripe invoices immediately.
+             * When it is CreateProrations (non-structural changes), prorations remain pending until
+             * the next invoice (~15 days). Accepted trade-off for the migration window. */
             await stripeAdapter.UpdateSubscriptionScheduleAsync(activeSchedule.Id,
                 new SubscriptionScheduleUpdateOptions
                 {
                     EndBehavior = activeSchedule.EndBehavior,
-                    Phases = phases
+                    Phases = phases,
+                    ProrationBehavior = prorationBehavior
                 });
 
-            // Note: this returns the pre-update subscription. The schedule update modified the
-            // subscription via Stripe, but we don't re-fetch it. Callers currently only check
-            // success/failure. If a caller ever needs the post-update state, re-fetch here.
+            /* Note: this returns the pre-update subscription. The schedule update modified the
+             * subscription via Stripe, but we don't re-fetch it. Callers currently only check
+             * success/failure. If a caller ever needs the post-update state, re-fetch here. */
             return subscription;
         }
 
@@ -324,10 +326,10 @@ public class UpdateOrganizationSubscriptionCommand(
         IList<SubscriptionSchedulePhaseItem> phaseItems,
         IReadOnlyList<OrganizationSubscriptionChange> changes)
     {
-        // Note: when a change targets a price ID not present in this phase (e.g. Phase 2 has
-        // migrated prices), the change is silently skipped. This is safe because subscription-
-        // level validation (ValidateItemAddition, ValidateItemPriceChange, etc.) already ran
-        // before this method is called.
+        /* Note: when a change targets a price ID not present in this phase (e.g. Phase 2 has
+         * migrated prices), the change is silently skipped. This is safe because subscription-
+         * level validation (ValidateItemAddition, ValidateItemPriceChange, etc.) already ran
+         * before this method is called. */
         var items = phaseItems
             .Select(i => new SubscriptionSchedulePhaseItemOptions { Price = i.PriceId, Quantity = i.Quantity })
             .ToList();

--- a/src/Core/Billing/Premium/Commands/UpdatePremiumStorageCommand.cs
+++ b/src/Core/Billing/Premium/Commands/UpdatePremiumStorageCommand.cs
@@ -175,9 +175,7 @@ public class UpdatePremiumStorageCommand(
                     Items = BuildPhaseItemsWithStorage(phase1.Items, storagePriceId, additionalStorageGb),
                     Discounts = phase1.Discounts?.Select(d =>
                         new SubscriptionSchedulePhaseDiscountOptions { Coupon = d.CouponId }).ToList(),
-                    ProrationBehavior = usingPayPal
-                        ? ProrationBehavior.CreateProrations
-                        : ProrationBehavior.AlwaysInvoice
+                    ProrationBehavior = phase1.ProrationBehavior
                 }
             };
 
@@ -199,7 +197,10 @@ public class UpdatePremiumStorageCommand(
                 new SubscriptionScheduleUpdateOptions
                 {
                     EndBehavior = activeSchedule.EndBehavior,
-                    Phases = phases
+                    Phases = phases,
+                    ProrationBehavior = usingPayPal
+                        ? ProrationBehavior.CreateProrations
+                        : ProrationBehavior.AlwaysInvoice
                 });
         }
         else

--- a/test/Core.Test/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommandTests.cs
+++ b/test/Core.Test/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommandTests.cs
@@ -993,9 +993,10 @@ public class UpdateOrganizationSubscriptionCommandTests
         await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
             schedule.Id,
             Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
+                opts.ProrationBehavior == ProrationBehavior.CreateProrations &&
                 opts.EndBehavior == SubscriptionScheduleEndBehavior.Release &&
                 opts.Phases.Count == 2 &&
-                opts.Phases[0].ProrationBehavior == ProrationBehavior.CreateProrations &&
+                opts.Phases[0].ProrationBehavior == ProrationBehavior.None &&
                 opts.Phases[0].Items.Any(i => i.Price == "price_storage" && i.Quantity == 3) &&
                 opts.Phases[0].Items.Any(i => i.Price == "price_seats" && i.Quantity == 5) &&
                 opts.Phases[1].ProrationBehavior == ProrationBehavior.None &&

--- a/test/Core.Test/Billing/Premium/Commands/UpdatePremiumStorageCommandTests.cs
+++ b/test/Core.Test/Billing/Premium/Commands/UpdatePremiumStorageCommandTests.cs
@@ -569,8 +569,9 @@ public class UpdatePremiumStorageCommandTests
         await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
             schedule.Id,
             Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
+                opts.ProrationBehavior == "always_invoice" &&
                 opts.Phases.Count == 2 &&
-                opts.Phases[0].ProrationBehavior == "always_invoice" &&
+                opts.Phases[0].ProrationBehavior == "none" &&
                 opts.Phases[0].Items.Any(i => i.Price == "price_storage" && i.Quantity == 9) &&
                 opts.Phases[1].Items.Any(i => i.Price == "price_storage" && i.Quantity == 9)));
 
@@ -696,7 +697,8 @@ public class UpdatePremiumStorageCommandTests
         await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
             schedule.Id,
             Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
-                opts.Phases[0].ProrationBehavior == "create_prorations" &&
+                opts.ProrationBehavior == "create_prorations" &&
+                opts.Phases[0].ProrationBehavior == "none" &&
                 opts.Phases[0].Items.Any(i => i.Price == "price_storage" && i.Quantity == 9) &&
                 opts.Phases[1].Items.Any(i => i.Price == "price_storage" && i.Quantity == 9)));
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34728

## 📔 Objective

When a subscription has an active schedule (created by `PriceIncreaseScheduler` for the Premium/Families price migration), storage adjustments update the schedule's phase items via `UpdateSubscriptionScheduleAsync`. The per-phase `proration_behavior` parameter only controls phase-transition prorations — not mid-phase modifications. This caused storage prorations to become pending invoice items deferred to the next billing event rather than being charged immediately.

For cancelled subscriptions (1-phase schedule with `EndBehavior=Cancel`), this meant the user was billed after their service had already ended.

The fix sets the **top-level** `ProrationBehavior` on `SubscriptionScheduleUpdateOptions`, which controls mid-phase modification proration behavior. This makes Stripe handle schedule-path prorations identically to direct subscription updates:
- Card users (`AlwaysInvoice`): Stripe creates and charges a proration invoice immediately
- PayPal users (`CreateProrations`): pending items are collected by the existing manual invoice flow

Also preserves Phase 1's original per-phase `ProrationBehavior` (from the schedule) instead of overwriting it — consistent with how Phase 2 was already handled.

Applied to both `UpdatePremiumStorageCommand` and `UpdateOrganizationSubscriptionCommand`.

[Subscription with immediately invoiced storage update and subscription schedule attached](https://dashboard.stripe.com/acct_19smIXIGBnsLynRr/test/subscriptions/sub_1TJfCwIGBnsLynRreoHMybEn).