### PR TITLE
fix(change-email): [PM-34742] Change Email Sets Salt

### DIFF
--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -414,6 +414,10 @@ public class UserService : UserManager<User>, IUserService
         user.Key = key;
         user.Email = newEmail;
         user.EmailVerified = true;
+
+        // We need this to backfill the salt for now to keep the email and salt always in sync.
+        user.MasterPasswordSalt = newEmail;
+
         user.RevisionDate = user.AccountRevisionDate = now;
         user.LastEmailChangeDate = now;
         await _userRepository.ReplaceAsync(user);

--- a/src/Identity/Controllers/AccountsController.cs
+++ b/src/Identity/Controllers/AccountsController.cs
@@ -233,8 +233,9 @@ public class AccountsController : Controller
         if (kdfInformation == null)
         {
             kdfInformation = GetDefaultKdf(model.Email);
+            return new PasswordPreloginResponseModel(kdfInformation, model.Email);
         }
-        return new PasswordPreloginResponseModel(kdfInformation, model.Email);
+        return new PasswordPreloginResponseModel(kdfInformation, kdfInformation.MasterPasswordSalt);
     }
 
     [HttpGet("webauthn/assertion-options")]

--- a/test/Api.IntegrationTest/Controllers/AccountsControllerTest.cs
+++ b/test/Api.IntegrationTest/Controllers/AccountsControllerTest.cs
@@ -949,6 +949,7 @@ public class AccountsControllerTest : IClassFixture<ApiApplicationFactory>, IAsy
         Assert.Equal(_masterKeyWrappedUserKey, updatedUser.Key);
         Assert.Equal(PasswordVerificationResult.Success,
             _passwordHasher.VerifyHashedPassword(updatedUser, updatedUser.MasterPassword!, _newMasterPasswordHash));
+        Assert.Equal(newEmail, updatedUser.MasterPasswordSalt);
     }
 
     [Fact]

--- a/test/Identity.Test/Controllers/AccountsControllerTests.cs
+++ b/test/Identity.Test/Controllers/AccountsControllerTests.cs
@@ -125,12 +125,14 @@ public class AccountsControllerTests : IDisposable
     public async Task PostPasswordPrelogin_WhenUserExists_ReturnsNewFieldsAlignedWithLegacy_Argon2()
     {
         var email = "user@example.com";
+        var storedSalt = "stored-master-password-salt";
         var userKdfInfo = new UserKdfInformation
         {
             Kdf = KdfType.Argon2id,
             KdfIterations = AuthConstants.ARGON2_ITERATIONS.Default,
             KdfMemory = AuthConstants.ARGON2_MEMORY.Default,
-            KdfParallelism = AuthConstants.ARGON2_PARALLELISM.Default
+            KdfParallelism = AuthConstants.ARGON2_PARALLELISM.Default,
+            MasterPasswordSalt = storedSalt
         };
         _userRepository.GetKdfInformationByEmailAsync(Arg.Any<string>()).Returns(userKdfInfo);
 
@@ -149,8 +151,24 @@ public class AccountsControllerTests : IDisposable
         Assert.Equal(response.KdfMemory, response.KdfSettings!.Memory);
         Assert.Equal(response.KdfParallelism, response.KdfSettings!.Parallelism);
 
-        // Salt is set to the input email during migration
-        Assert.Equal(email, response.Salt);
+        // Salt comes from the stored MasterPasswordSalt on the user record, not the request email
+        Assert.Equal(storedSalt, response.Salt);
+    }
+
+    [Fact]
+    public async Task PostPasswordPrelogin_WhenUserExists_WithNullMasterPasswordSalt_ReturnsNullSalt()
+    {
+        var userKdfInfo = new UserKdfInformation
+        {
+            Kdf = KdfType.PBKDF2_SHA256,
+            KdfIterations = AuthConstants.PBKDF2_ITERATIONS.Default,
+            MasterPasswordSalt = null
+        };
+        _userRepository.GetKdfInformationByEmailAsync(Arg.Any<string>()).Returns(userKdfInfo);
+
+        var response = await _sut.PostPasswordPrelogin(new PasswordPreloginRequestModel { Email = "user@example.com" });
+
+        Assert.Null(response.Salt);
     }
 
     [Fact]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34742

## 📔 Objective

1. Fix the bug where changing email is not setting the salt
2. Have the prelogin properly reference what is in the database
3. Added new tests

## 📸 Screenshots


https://github.com/user-attachments/assets/f811eaab-edcd-41a9-b4b1-f33783406a23

User record after the video:

```
Email | MasterPasswordSalt
123@u.u | 123@u.u
```