### PR TITLE
[PM-34773] Fix storage addition during active Phase 2 of schedule

### DIFF
--- a/src/Core/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommand.cs
+++ b/src/Core/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommand.cs
@@ -128,15 +128,20 @@ public class UpdateOrganizationSubscriptionCommand(
                 CommandName, activeSchedule.Id, subscription.Id);
 
             var phase1 = activeSchedule.Phases[0];
+            var now = subscription.TestClock?.FrozenTime ?? DateTime.UtcNow;
 
             /* This applies the change set's price IDs (which are Phase 1 / current-plan prices)
-             * to both phases. This works because storage prices are uniform across the Families
-             * migration. If storage prices ever differ between phases, both this command and
-             * UpdatePremiumStorageCommand would need plan-aware price resolution (e.g. matching
+             * to all active phases. This works because storage prices are uniform across the
+             * Families migration. If storage prices ever differ between phases, both this command
+             * and UpdatePremiumStorageCommand would need plan-aware price resolution (e.g. matching
              * Phase 2's seat price to determine the correct storage price). */
-            var phases = new List<SubscriptionSchedulePhaseOptions>
+            var phases = new List<SubscriptionSchedulePhaseOptions>();
+
+            // Stripe rejects schedule updates that include phases whose end_date is in the past.
+            // A phase ending at exactly `now` has effectively ended (strict > is intentional).
+            if (phase1.EndDate > now)
             {
-                new()
+                phases.Add(new SubscriptionSchedulePhaseOptions
                 {
                     StartDate = phase1.StartDate,
                     EndDate = phase1.EndDate,
@@ -144,8 +149,16 @@ public class UpdateOrganizationSubscriptionCommand(
                     Discounts = phase1.Discounts?.Select(d =>
                         new SubscriptionSchedulePhaseDiscountOptions { Coupon = d.CouponId }).ToList(),
                     ProrationBehavior = phase1.ProrationBehavior
-                }
-            };
+                });
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "{Command}: Phase 1 has already ended (EndDate: {EndDate}), updating only active phase(s)",
+                    CommandName, phase1.EndDate);
+            }
+
+            var phase1Ended = phase1.EndDate <= now;
 
             if (activeSchedule.Phases.Count >= 2)
             {
@@ -155,10 +168,22 @@ public class UpdateOrganizationSubscriptionCommand(
                     StartDate = phase2.StartDate,
                     EndDate = phase2.EndDate,
                     Items = ApplyChangesToPhaseItems(phase2.Items, changeSet.Changes),
-                    Discounts = phase2.Discounts?.Select(d =>
-                        new SubscriptionSchedulePhaseDiscountOptions { Coupon = d.CouponId }).ToList(),
+                    // When Phase 2 is already active, its one-time migration discount has been
+                    // applied and consumed. Re-including it would cause Stripe to re-apply it.
+                    Discounts = phase1Ended
+                        ? []
+                        : phase2.Discounts?.Select(d =>
+                            new SubscriptionSchedulePhaseDiscountOptions { Coupon = d.CouponId }).ToList(),
                     ProrationBehavior = phase2.ProrationBehavior
                 });
+            }
+
+            if (phases.Count == 0)
+            {
+                _logger.LogWarning(
+                    "{Command}: Schedule ({ScheduleId}) has no updatable phases remaining",
+                    CommandName, activeSchedule.Id);
+                return DefaultConflict;
             }
 
             /* Note: the schedule phase API does not support PendingInvoiceItemInterval. For annual
@@ -226,7 +251,7 @@ public class UpdateOrganizationSubscriptionCommand(
         {
             return await stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId, new SubscriptionGetOptions
             {
-                Expand = ["customer"]
+                Expand = ["customer", "test_clock"]
             });
         }
         catch (StripeException stripeException) when (stripeException.StripeError?.Code == ErrorCodes.ResourceMissing)

--- a/src/Core/Billing/Premium/Commands/UpdatePremiumStorageCommand.cs
+++ b/src/Core/Billing/Premium/Commands/UpdatePremiumStorageCommand.cs
@@ -39,6 +39,9 @@ public class UpdatePremiumStorageCommand(
 {
     private readonly ILogger<UpdatePremiumStorageCommand> _logger = logger;
 
+    protected override Conflict DefaultConflict =>
+        new("We had a problem updating your subscription. Please contact support for assistance.");
+
     public Task<BillingCommandResult<None>> Run(User user, short additionalStorageGb) => HandleAsync<None>(async () =>
     {
         if (user is not { Premium: true, GatewaySubscriptionId: not null and not "" })
@@ -55,7 +58,7 @@ public class UpdatePremiumStorageCommand(
         var premiumPlans = await pricingClient.ListPremiumPlans();
         var subscription = await stripeAdapter.GetSubscriptionAsync(user.GatewaySubscriptionId, new SubscriptionGetOptions
         {
-            Expand = ["customer"]
+            Expand = ["customer", "test_clock"]
         });
 
         // Find the password manager subscription item (seat, not storage) and match it to a plan
@@ -160,15 +163,20 @@ public class UpdatePremiumStorageCommand(
                 CommandName, activeSchedule.Id, subscription.Id);
 
             var phase1 = activeSchedule.Phases[0];
+            var now = subscription.TestClock?.FrozenTime ?? DateTime.UtcNow;
 
             // Storage prices are uniform across the Premium migration, so we use the same price
-            // for both phases. If storage prices ever differ between phases, this would need
-            // plan-aware price resolution (e.g. matching Phase 2's seat price to a plan).
+            // for all active phases. If storage prices ever differ between phases, this would
+            // need plan-aware price resolution (e.g. matching Phase 2's seat price to a plan).
             var storagePriceId = premiumPlan.Storage.StripePriceId;
 
-            var phases = new List<SubscriptionSchedulePhaseOptions>
+            var phases = new List<SubscriptionSchedulePhaseOptions>();
+
+            // Stripe rejects schedule updates that include phases whose end_date is in the past.
+            // A phase ending at exactly `now` has effectively ended (strict > is intentional).
+            if (phase1.EndDate > now)
             {
-                new()
+                phases.Add(new SubscriptionSchedulePhaseOptions
                 {
                     StartDate = phase1.StartDate,
                     EndDate = phase1.EndDate,
@@ -176,8 +184,16 @@ public class UpdatePremiumStorageCommand(
                     Discounts = phase1.Discounts?.Select(d =>
                         new SubscriptionSchedulePhaseDiscountOptions { Coupon = d.CouponId }).ToList(),
                     ProrationBehavior = phase1.ProrationBehavior
-                }
-            };
+                });
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "{Command}: Phase 1 has already ended (EndDate: {EndDate}), updating only active phase(s)",
+                    CommandName, phase1.EndDate);
+            }
+
+            var phase1Ended = phase1.EndDate <= now;
 
             if (activeSchedule.Phases.Count >= 2)
             {
@@ -187,10 +203,22 @@ public class UpdatePremiumStorageCommand(
                     StartDate = phase2.StartDate,
                     EndDate = phase2.EndDate,
                     Items = BuildPhaseItemsWithStorage(phase2.Items, storagePriceId, additionalStorageGb),
-                    Discounts = phase2.Discounts?.Select(d =>
-                        new SubscriptionSchedulePhaseDiscountOptions { Coupon = d.CouponId }).ToList(),
+                    // When Phase 2 is already active, its one-time migration discount has been
+                    // applied and consumed. Re-including it would cause Stripe to re-apply it.
+                    Discounts = phase1Ended
+                        ? []
+                        : phase2.Discounts?.Select(d =>
+                            new SubscriptionSchedulePhaseDiscountOptions { Coupon = d.CouponId }).ToList(),
                     ProrationBehavior = phase2.ProrationBehavior
                 });
+            }
+
+            if (phases.Count == 0)
+            {
+                _logger.LogWarning(
+                    "{Command}: Schedule ({ScheduleId}) has no updatable phases remaining",
+                    CommandName, activeSchedule.Id);
+                return DefaultConflict;
             }
 
             await stripeAdapter.UpdateSubscriptionScheduleAsync(activeSchedule.Id,

--- a/test/Core.Test/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommandTests.cs
+++ b/test/Core.Test/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommandTests.cs
@@ -1134,6 +1134,76 @@ public class UpdateOrganizationSubscriptionCommandTests
         await _stripeAdapter.DidNotReceive().UpdateSubscriptionAsync(Arg.Any<string>(), Arg.Any<SubscriptionUpdateOptions>());
     }
 
+    [Fact]
+    public async Task Run_AddItem_WithSchedule_Phase2Active_UpdatesOnlyPhase2()
+    {
+        var organization = CreateOrganization();
+        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
+
+        SetupGetSubscription(organization, subscription);
+
+        var schedule = CreateMockSchedule(
+            subscription.Id,
+            [("price_seats", 5)],
+            [("price_seats_new", 5)],
+            phase2Active: true);
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
+
+        var changeSet = new OrganizationSubscriptionChangeSet
+        {
+            Changes = [new AddItem("price_storage", 3)]
+        };
+
+        var result = await _command.Run(organization, changeSet);
+
+        Assert.True(result.Success);
+
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            schedule.Id,
+            Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
+                opts.Phases.Count == 1 &&
+                opts.Phases[0].Items.Any(i => i.Price == "price_seats_new" && i.Quantity == 5) &&
+                opts.Phases[0].Items.Any(i => i.Price == "price_storage" && i.Quantity == 3) &&
+                opts.Phases[0].Discounts != null && opts.Phases[0].Discounts.Count == 0));
+
+        await _stripeAdapter.DidNotReceive().UpdateSubscriptionAsync(Arg.Any<string>(), Arg.Any<SubscriptionUpdateOptions>());
+    }
+
+    [Fact]
+    public async Task Run_UpdateItemQuantity_Zero_WithSchedule_Phase2Active_RemovesFromPhase2()
+    {
+        var organization = CreateOrganization();
+        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5), ("price_storage", "si_2", 3)]);
+
+        SetupGetSubscription(organization, subscription);
+
+        var schedule = CreateMockSchedule(
+            subscription.Id,
+            [("price_seats", 5), ("price_storage", 3)],
+            [("price_seats_new", 5), ("price_storage", 3)],
+            phase2Active: true);
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
+
+        var changeSet = new OrganizationSubscriptionChangeSet
+        {
+            Changes = [new UpdateItemQuantity("price_storage", 0)]
+        };
+
+        var result = await _command.Run(organization, changeSet);
+
+        Assert.True(result.Success);
+
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            schedule.Id,
+            Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
+                opts.Phases.Count == 1 &&
+                opts.Phases[0].Items.All(i => i.Price != "price_storage")));
+
+        await _stripeAdapter.DidNotReceive().UpdateSubscriptionAsync(Arg.Any<string>(), Arg.Any<SubscriptionUpdateOptions>());
+    }
+
     private static Organization CreateOrganization() => new()
     {
         Id = Guid.NewGuid(),
@@ -1191,14 +1261,18 @@ public class UpdateOrganizationSubscriptionCommandTests
     private static SubscriptionSchedule CreateMockSchedule(
         string subscriptionId,
         (string priceId, long quantity)[] phase1Items,
-        (string priceId, long quantity)[]? phase2Items = null)
+        (string priceId, long quantity)[]? phase2Items = null,
+        bool phase2Active = false)
     {
+        var phase1Start = phase2Active ? DateTime.UtcNow.AddYears(-1) : DateTime.UtcNow;
+        var phase1End = phase2Active ? DateTime.UtcNow.AddDays(-1) : DateTime.UtcNow.AddYears(1);
+
         var phases = new List<SubscriptionSchedulePhase>
         {
             new()
             {
-                StartDate = DateTime.UtcNow,
-                EndDate = DateTime.UtcNow.AddYears(1),
+                StartDate = phase1Start,
+                EndDate = phase1End,
                 Items = phase1Items.Select(i =>
                     new SubscriptionSchedulePhaseItem { PriceId = i.priceId, Quantity = i.quantity }).ToList(),
                 ProrationBehavior = ProrationBehavior.None
@@ -1209,7 +1283,7 @@ public class UpdateOrganizationSubscriptionCommandTests
         {
             phases.Add(new SubscriptionSchedulePhase
             {
-                StartDate = DateTime.UtcNow.AddYears(1),
+                StartDate = phase1End,
                 Items = phase2Items.Select(i =>
                     new SubscriptionSchedulePhaseItem { PriceId = i.priceId, Quantity = i.quantity }).ToList(),
                 ProrationBehavior = ProrationBehavior.None

--- a/test/Core.Test/Billing/Premium/Commands/UpdatePremiumStorageCommandTests.cs
+++ b/test/Core.Test/Billing/Premium/Commands/UpdatePremiumStorageCommandTests.cs
@@ -740,11 +740,72 @@ public class UpdatePremiumStorageCommandTests
         await _userService.Received(1).SaveUserAsync(Arg.Is<User>(u => u.MaxStorageGb == 10));
     }
 
+    [Theory, BitAutoData]
+    public async Task Run_IncreaseStorage_WithSchedule_Phase2Active_UpdatesOnlyPhase2(User user)
+    {
+        user.Premium = true;
+        user.MaxStorageGb = 5;
+        user.Storage = 2L * 1024 * 1024 * 1024;
+        user.GatewaySubscriptionId = "sub_123";
+
+        var subscription = CreateMockSubscription("sub_123", 4);
+        _stripeAdapter.GetSubscriptionAsync("sub_123", Arg.Any<SubscriptionGetOptions>()).Returns(subscription);
+
+        var schedule = CreateMockSchedule("sub_123", hasStorage: true, storageQuantity: 4, phase2Active: true);
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
+
+        var result = await _command.Run(user, 9);
+
+        Assert.True(result.IsT0);
+
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            schedule.Id,
+            Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
+                opts.Phases.Count == 1 &&
+                opts.Phases[0].Items.Any(i => i.Price == "price_premium_new" && i.Quantity == 1) &&
+                opts.Phases[0].Items.Any(i => i.Price == "price_storage" && i.Quantity == 9) &&
+                opts.Phases[0].Discounts != null && opts.Phases[0].Discounts.Count == 0));
+
+        await _stripeAdapter.DidNotReceive().UpdateSubscriptionAsync(Arg.Any<string>(), Arg.Any<SubscriptionUpdateOptions>());
+        await _userService.Received(1).SaveUserAsync(Arg.Is<User>(u => u.MaxStorageGb == 10));
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_RemoveStorage_WithSchedule_Phase2Active_RemovesFromPhase2(User user)
+    {
+        user.Premium = true;
+        user.MaxStorageGb = 10;
+        user.Storage = 500L * 1024 * 1024;
+        user.GatewaySubscriptionId = "sub_123";
+
+        var subscription = CreateMockSubscription("sub_123", 9);
+        _stripeAdapter.GetSubscriptionAsync("sub_123", Arg.Any<SubscriptionGetOptions>()).Returns(subscription);
+
+        var schedule = CreateMockSchedule("sub_123", hasStorage: true, storageQuantity: 9, phase2Active: true);
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
+
+        var result = await _command.Run(user, 0);
+
+        Assert.True(result.IsT0);
+
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            schedule.Id,
+            Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
+                opts.Phases.Count == 1 &&
+                opts.Phases[0].Items.All(i => i.Price != "price_storage")));
+
+        await _stripeAdapter.DidNotReceive().UpdateSubscriptionAsync(Arg.Any<string>(), Arg.Any<SubscriptionUpdateOptions>());
+        await _userService.Received(1).SaveUserAsync(Arg.Is<User>(u => u.MaxStorageGb == 1));
+    }
+
     private static SubscriptionSchedule CreateMockSchedule(
         string subscriptionId,
         bool hasStorage,
         int storageQuantity = 0,
-        bool singlePhase = false)
+        bool singlePhase = false,
+        bool phase2Active = false)
     {
         var phase1Items = new List<SubscriptionSchedulePhaseItem>
         {
@@ -756,12 +817,15 @@ public class UpdatePremiumStorageCommandTests
             phase1Items.Add(new SubscriptionSchedulePhaseItem { PriceId = "price_storage", Quantity = storageQuantity });
         }
 
+        var phase1Start = phase2Active ? DateTime.UtcNow.AddYears(-1) : DateTime.UtcNow;
+        var phase1End = phase2Active ? DateTime.UtcNow.AddDays(-1) : DateTime.UtcNow.AddYears(1);
+
         var phases = new List<SubscriptionSchedulePhase>
         {
             new()
             {
-                StartDate = DateTime.UtcNow,
-                EndDate = DateTime.UtcNow.AddYears(1),
+                StartDate = phase1Start,
+                EndDate = phase1End,
                 Items = phase1Items,
                 ProrationBehavior = ProrationBehavior.None
             }
@@ -781,7 +845,7 @@ public class UpdatePremiumStorageCommandTests
 
             phases.Add(new SubscriptionSchedulePhase
             {
-                StartDate = DateTime.UtcNow.AddYears(1),
+                StartDate = phase1End,
                 Items = phase2Items,
                 Discounts =
                 [


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34773

## 📔 Objective

Fixes a 500 error when adding or removing storage for Premium users or Families organizations whose subscription schedule has transitioned to Phase 2 (the migrated price is active).

The schedule-aware storage commands (introduced in PM-33898) reconstructed both schedule phases when updating storage. After Phase 2 activates, Phase 1's dates are in the past and Stripe rejects updates to ended phases. This PR:

- Skips Phase 1 when its `EndDate` has passed, sending only the active phase(s) to Stripe
- Strips the one-time migration discount from Phase 2 when it is already active, preventing Stripe from re-applying a consumed coupon
- Guards against degenerate schedule states where no updatable phases remain
- Uses `subscription.TestClock.FrozenTime` for accurate phase-ended detection in test clock environments

## 📸 Screenshots


https://github.com/user-attachments/assets/56a3d9b0-c2f8-45e2-8cf2-de564b9cd478

