### PR TITLE
[PM-34823] Remove missed uses of PolicyRequirements flag

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/v2/AdminRecoverAccountCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/v2/AdminRecoverAccountCommand.cs
@@ -1,10 +1,8 @@
-﻿using Bit.Core.AdminConsole.Enums;
-using Bit.Core.AdminConsole.Models.Data;
+﻿using Bit.Core.AdminConsole.Models.Data;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interfaces;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Requests;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
-using Bit.Core.AdminConsole.Services;
 using Bit.Core.AdminConsole.Utilities.v2.Results;
 using Bit.Core.Auth.UserFeatures.TwoFactorAuth;
 using Bit.Core.Entities;
@@ -26,9 +24,7 @@ public class AdminRecoverAccountCommand(
     IPushNotificationService pushNotificationService,
     IUserService userService,
     IResetUserTwoFactorCommand resetUserTwoFactorCommand,
-    IFeatureService featureService,
     IPolicyRequirementQuery policyRequirementQuery,
-    IPolicyService policyService,
     IRevokeNonCompliantOrganizationUserCommand revokeNonCompliantOrganizationUserCommand,
     TimeProvider timeProvider) : IAdminRecoverAccountCommand
 {
@@ -110,49 +106,29 @@ public class AdminRecoverAccountCommand(
 
     private async Task CheckPoliciesOnTwoFactorRemovalAsync(User user)
     {
-        if (featureService.IsEnabled(FeatureFlagKeys.PolicyRequirements))
+        var requirement = await policyRequirementQuery.GetAsync<RequireTwoFactorPolicyRequirement>(user.Id);
+        if (!requirement.OrganizationsRequiringTwoFactor.Any())
         {
-            var requirement = await policyRequirementQuery.GetAsync<RequireTwoFactorPolicyRequirement>(user.Id);
-            if (!requirement.OrganizationsRequiringTwoFactor.Any())
-            {
-                return;
-            }
-
-            var organizationIds = requirement.OrganizationsRequiringTwoFactor.Select(o => o.OrganizationId).ToList();
-            var organizations = await organizationRepository.GetManyByIdsAsync(organizationIds);
-            var organizationLookup = organizations.ToDictionary(org => org.Id);
-
-            var revokeOrgUserTasks = requirement.OrganizationsRequiringTwoFactor
-                .Where(o => organizationLookup.ContainsKey(o.OrganizationId))
-                .Select(async o =>
-                {
-                    var organization = organizationLookup[o.OrganizationId];
-                    await revokeNonCompliantOrganizationUserCommand.RevokeNonCompliantOrganizationUsersAsync(
-                        new RevokeOrganizationUsersRequest(
-                            o.OrganizationId,
-                            [new OrganizationUserUserDetails { Id = o.OrganizationUserId, OrganizationId = o.OrganizationId }],
-                            new SystemUser(EventSystemUser.TwoFactorDisabled)));
-                    await mailService.SendOrganizationUserRevokedForTwoFactorPolicyEmailAsync(organization.DisplayName(), user.Email);
-                }).ToArray();
-
-            await Task.WhenAll(revokeOrgUserTasks);
-
             return;
         }
 
-        var twoFactorPolicies = await policyService.GetPoliciesApplicableToUserAsync(user.Id, PolicyType.TwoFactorAuthentication);
+        var organizationIds = requirement.OrganizationsRequiringTwoFactor.Select(o => o.OrganizationId).ToList();
+        var organizations = await organizationRepository.GetManyByIdsAsync(organizationIds);
+        var organizationLookup = organizations.ToDictionary(org => org.Id);
 
-        var legacyRevokeOrgUserTasks = twoFactorPolicies.Select(async p =>
-        {
-            var organization = await organizationRepository.GetByIdAsync(p.OrganizationId);
-            await revokeNonCompliantOrganizationUserCommand.RevokeNonCompliantOrganizationUsersAsync(
-                new RevokeOrganizationUsersRequest(
-                    p.OrganizationId,
-                    [new OrganizationUserUserDetails { Id = p.OrganizationUserId, OrganizationId = p.OrganizationId }],
-                    new SystemUser(EventSystemUser.TwoFactorDisabled)));
-            await mailService.SendOrganizationUserRevokedForTwoFactorPolicyEmailAsync(organization!.DisplayName(), user.Email);
-        }).ToArray();
+        var revokeOrgUserTasks = requirement.OrganizationsRequiringTwoFactor
+            .Where(o => organizationLookup.ContainsKey(o.OrganizationId))
+            .Select(async o =>
+            {
+                var organization = organizationLookup[o.OrganizationId];
+                await revokeNonCompliantOrganizationUserCommand.RevokeNonCompliantOrganizationUsersAsync(
+                    new RevokeOrganizationUsersRequest(
+                        o.OrganizationId,
+                        [new OrganizationUserUserDetails { Id = o.OrganizationUserId, OrganizationId = o.OrganizationId }],
+                        new SystemUser(EventSystemUser.TwoFactorDisabled)));
+                await mailService.SendOrganizationUserRevokedForTwoFactorPolicyEmailAsync(organization.DisplayName(), user.Email);
+            }).ToArray();
 
-        await Task.WhenAll(legacyRevokeOrgUserTasks);
+        await Task.WhenAll(revokeOrgUserTasks);
     }
 }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/AccountRecovery/v2/AdminRecoverAccountCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/AccountRecovery/v2/AdminRecoverAccountCommandTests.cs
@@ -1,5 +1,7 @@
 ﻿using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery.v2;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
 using Bit.Core.AdminConsole.Utilities.v2.Validation;
 using Bit.Core.Auth.UserFeatures.TwoFactorAuth;
 using Bit.Core.Entities;
@@ -32,6 +34,7 @@ public class AdminRecoverAccountCommandTests
         SetupOrganization(sutProvider, organization);
         SetupUser(sutProvider, user, organizationUser);
         SetupSuccessfulPasswordUpdate(sutProvider, user, newMasterPassword);
+        SetupPolicy(sutProvider, user);
 
         var request = CreateRequest(organization.Id, organizationUser,
             resetMasterPassword: true, resetTwoFactor: false,
@@ -84,6 +87,7 @@ public class AdminRecoverAccountCommandTests
         // Arrange
         SetupOrganization(sutProvider, organization);
         SetupUser(sutProvider, user, organizationUser);
+        SetupPolicy(sutProvider, user);
 
         var request = CreateRequest(organization.Id, organizationUser,
             resetMasterPassword: false, resetTwoFactor: true);
@@ -134,6 +138,7 @@ public class AdminRecoverAccountCommandTests
         SetupOrganization(sutProvider, organization);
         SetupUser(sutProvider, user, organizationUser);
         SetupSuccessfulPasswordUpdate(sutProvider, user, newMasterPassword);
+        SetupPolicy(sutProvider, user);
 
         var request = CreateRequest(organization.Id, organizationUser,
             resetMasterPassword: true, resetTwoFactor: true,
@@ -191,6 +196,7 @@ public class AdminRecoverAccountCommandTests
         // Arrange
         SetupOrganization(sutProvider, organization);
         SetupUser(sutProvider, user, organizationUser);
+        SetupPolicy(sutProvider, user);
 
         var failedResult = IdentityResult.Failed(new IdentityError { Description = "Password update failed" });
         sutProvider.GetDependency<IUserService>()
@@ -298,5 +304,13 @@ public class AdminRecoverAccountCommandTests
         sutProvider.GetDependency<IUserService>()
             .UpdatePasswordHash(user, newMasterPassword)
             .Returns(IdentityResult.Success);
+    }
+
+    private static void SetupPolicy(SutProvider<AdminRecoverAccountCommand> sutProvider, User user)
+    {
+        // 2FA policy does not apply
+        sutProvider.GetDependency<IPolicyRequirementQuery>()
+            .GetAsync<RequireTwoFactorPolicyRequirement>(user.Id)
+            .Returns(new RequireTwoFactorPolicyRequirement([]));
     }
 }

--- a/test/Core.Test/Tools/Services/NonAnonymousSendCommandTests.cs
+++ b/test/Core.Test/Tools/Services/NonAnonymousSendCommandTests.cs
@@ -3,7 +3,6 @@ using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Exceptions;
 using Bit.Core.Platform.Push;
-using Bit.Core.Services;
 using Bit.Core.Test.AutoFixture.CurrentContextFixtures;
 using Bit.Core.Test.Tools.AutoFixture.SendFixtures;
 using Bit.Core.Tools.Entities;
@@ -30,7 +29,6 @@ public class NonAnonymousSendCommandTests
     private readonly ISendFileStorageService _sendFileStorageService;
     private readonly IPushNotificationService _pushNotificationService;
     private readonly ISendValidationService _sendValidationService;
-    private readonly IFeatureService _featureService;
     private readonly ICurrentContext _currentContext;
     private readonly ISendCoreHelperService _sendCoreHelperService;
     private readonly NonAnonymousSendCommand _nonAnonymousSendCommand;
@@ -42,7 +40,6 @@ public class NonAnonymousSendCommandTests
         _sendRepository = Substitute.For<ISendRepository>();
         _sendFileStorageService = Substitute.For<ISendFileStorageService>();
         _pushNotificationService = Substitute.For<IPushNotificationService>();
-        _featureService = Substitute.For<IFeatureService>();
         _sendValidationService = Substitute.For<ISendValidationService>();
         _currentContext = Substitute.For<ICurrentContext>();
         _sendCoreHelperService = Substitute.For<ISendCoreHelperService>();
@@ -291,9 +288,6 @@ public class NonAnonymousSendCommandTests
         _currentContext.ClientId.Returns("test-client");
         _currentContext.ClientVersion.Returns(Version.Parse("1.0.0"));
 
-        // Enable feature flag for policy requirements (vNext path)
-        _featureService.IsEnabled(FeatureFlagKeys.PolicyRequirements).Returns(true);
-
         // Act
         await _nonAnonymousSendCommand.SaveSendAsync(send);
 
@@ -331,9 +325,6 @@ public class NonAnonymousSendCommandTests
             UserId = userId,
             HideEmail = true
         };
-
-        // Enable feature flag for policy requirements (vNext path)
-        _featureService.IsEnabled(FeatureFlagKeys.PolicyRequirements).Returns(true);
 
         // Configure validation service to throw when DisableHideEmail policy applies in vNext implementation
         _sendValidationService.ValidateUserCanSaveAsync(userId, send)
@@ -374,9 +365,6 @@ public class NonAnonymousSendCommandTests
 
         var initialDate = DateTime.UtcNow.AddMinutes(-5);
         send.RevisionDate = initialDate;
-
-        // Enable feature flag for policy requirements (vNext path)
-        _featureService.IsEnabled(FeatureFlagKeys.PolicyRequirements).Returns(true);
 
         // Configure validation service to allow saves when HideEmail is false
         _sendValidationService.ValidateUserCanSaveAsync(userId, send).Returns(Task.CompletedTask);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-34823

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We have removed the `PolicyRequirements` feature flag for all uses except for the `RequireSso` policy. One other use crept back in in the v2 `AdminRecoverAccountCommand`, and there were other references not cleaned up in some Tools tests (already removed from the sut). This PR removes those erroneous uses in advance of us turning on the feature flag next regression cycle.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
