### PR TITLE
[PM-34390] - Fixing Group/Provider User

### DIFF
--- a/src/Api/AdminConsole/Authorization/Organizations/Requirements/PermissionRequirements.cs
+++ b/src/Api/AdminConsole/Authorization/Organizations/Requirements/PermissionRequirements.cs
@@ -9,3 +9,4 @@ public class ManagePoliciesRequirement() : BasePermissionRequirement(p => p.Mana
 public class ManageScimRequirement() : BasePermissionRequirement(p => p.ManageScim);
 public class ManageSsoRequirement() : BasePermissionRequirement(p => p.ManageSso);
 public class ManageUsersRequirement() : BasePermissionRequirement(p => p.ManageUsers);
+public class ManageUsersOrGroupsRequirement() : BasePermissionRequirement(p => p.ManageUsers || p.ManageGroups);

--- a/src/Api/AdminConsole/Controllers/GroupsController.cs
+++ b/src/Api/AdminConsole/Controllers/GroupsController.cs
@@ -1,13 +1,13 @@
 ﻿// FIXME: Update this file to be null safe and then delete the line below
 #nullable disable
 
+using Bit.Api.AdminConsole.Authorization;
+using Bit.Api.AdminConsole.Authorization.Requirements;
 using Bit.Api.AdminConsole.Models.Request;
 using Bit.Api.AdminConsole.Models.Response;
 using Bit.Api.Models.Response;
 using Bit.Api.Vault.AuthorizationHandlers.Collections;
-using Bit.Core.AdminConsole.OrganizationFeatures.Groups.Authorization;
 using Bit.Core.AdminConsole.OrganizationFeatures.Groups.Interfaces;
-using Bit.Core.AdminConsole.OrganizationFeatures.Shared.Authorization;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.AdminConsole.Services;
 using Bit.Core.Context;
@@ -33,7 +33,6 @@ public class GroupsController : Controller
     private readonly IAuthorizationService _authorizationService;
     private readonly IApplicationCacheService _applicationCacheService;
     private readonly IUserService _userService;
-    private readonly IFeatureService _featureService;
     private readonly IOrganizationUserRepository _organizationUserRepository;
     private readonly ICollectionRepository _collectionRepository;
 
@@ -48,7 +47,6 @@ public class GroupsController : Controller
         IAuthorizationService authorizationService,
         IApplicationCacheService applicationCacheService,
         IUserService userService,
-        IFeatureService featureService,
         IOrganizationUserRepository organizationUserRepository,
         ICollectionRepository collectionRepository)
     {
@@ -62,16 +60,16 @@ public class GroupsController : Controller
         _authorizationService = authorizationService;
         _applicationCacheService = applicationCacheService;
         _userService = userService;
-        _featureService = featureService;
         _organizationUserRepository = organizationUserRepository;
         _collectionRepository = collectionRepository;
     }
 
     [HttpGet("{id}")]
-    public async Task<GroupResponseModel> Get(string orgId, string id)
+    [Authorize<ManageGroupsRequirement>]
+    public async Task<GroupResponseModel> Get(Guid orgId, Guid id)
     {
-        var group = await _groupRepository.GetByIdAsync(new Guid(id));
-        if (group == null || !await _currentContext.ManageGroups(group.OrganizationId))
+        var group = await _groupRepository.GetByIdAsync(id);
+        if (group == null || group.OrganizationId != orgId)
         {
             throw new NotFoundException();
         }
@@ -80,10 +78,11 @@ public class GroupsController : Controller
     }
 
     [HttpGet("{id}/details")]
-    public async Task<GroupDetailsResponseModel> GetDetails(string orgId, string id)
+    [Authorize<ManageGroupsRequirement>]
+    public async Task<GroupDetailsResponseModel> GetDetails(Guid orgId, Guid id)
     {
-        var groupDetails = await _groupRepository.GetByIdWithCollectionsAsync(new Guid(id));
-        if (groupDetails?.Item1 == null || !await _currentContext.ManageGroups(groupDetails.Item1.OrganizationId))
+        var groupDetails = await _groupRepository.GetByIdWithCollectionsAsync(id);
+        if (groupDetails?.Item1 == null || groupDetails.Item1.OrganizationId != orgId)
         {
             throw new NotFoundException();
         }
@@ -92,56 +91,41 @@ public class GroupsController : Controller
     }
 
     [HttpGet("")]
+    [Authorize<MemberOrProviderRequirement>]
     public async Task<ListResponseModel<GroupResponseModel>> GetOrganizationGroups(Guid orgId)
     {
-        var authResult = await _authorizationService.AuthorizeAsync(User, new OrganizationScope(orgId), GroupOperations.ReadAll);
-        if (!authResult.Succeeded)
-        {
-            throw new NotFoundException();
-        }
-
         var groups = await _groupRepository.GetManyByOrganizationIdAsync(orgId);
         var responses = groups.Select(g => new GroupResponseModel(g));
         return new ListResponseModel<GroupResponseModel>(responses);
     }
 
     [HttpGet("details")]
+    [Authorize<ManageUsersOrGroupsRequirement>]
     public async Task<ListResponseModel<GroupDetailsResponseModel>> GetOrganizationGroupDetails(Guid orgId)
     {
-        var authResult = await _authorizationService.AuthorizeAsync(User, new OrganizationScope(orgId), GroupOperations.ReadAllDetails);
-
-        if (!authResult.Succeeded)
-        {
-            throw new NotFoundException();
-        }
-
         var groups = await _groupRepository.GetManyWithCollectionsByOrganizationIdAsync(orgId);
         var responses = groups.Select(g => new GroupDetailsResponseModel(g.Item1, g.Item2));
         return new ListResponseModel<GroupDetailsResponseModel>(responses);
     }
 
     [HttpGet("{id}/users")]
-    public async Task<IEnumerable<Guid>> GetUsers(string orgId, string id)
+    [Authorize<ManageGroupsRequirement>]
+    public async Task<IEnumerable<Guid>> GetUsers(Guid orgId, Guid id)
     {
-        var idGuid = new Guid(id);
-        var group = await _groupRepository.GetByIdAsync(idGuid);
-        if (group == null || !await _currentContext.ManageGroups(group.OrganizationId))
+        var group = await _groupRepository.GetByIdAsync(id);
+        if (group == null || group.OrganizationId != orgId)
         {
             throw new NotFoundException();
         }
 
-        var groupIds = await _groupRepository.GetManyUserIdsByIdAsync(idGuid);
+        var groupIds = await _groupRepository.GetManyUserIdsByIdAsync(id);
         return groupIds;
     }
 
     [HttpPost("")]
+    [Authorize<ManageGroupsRequirement>]
     public async Task<GroupResponseModel> Post(Guid orgId, [FromBody] GroupRequestModel model)
     {
-        if (!await _currentContext.ManageGroups(orgId))
-        {
-            throw new NotFoundException();
-        }
-
         // Check the user has permission to grant access to the collections for the new group
         if (model.Collections?.Any() == true)
         {
@@ -163,13 +147,9 @@ public class GroupsController : Controller
     }
 
     [HttpPut("{id}")]
+    [Authorize<ManageGroupsRequirement>]
     public async Task<GroupResponseModel> Put(Guid orgId, Guid id, [FromBody] GroupRequestModel model)
     {
-        if (!await _currentContext.ManageGroups(orgId))
-        {
-            throw new NotFoundException();
-        }
-
         var (group, currentAccess) = await _groupRepository.GetByIdWithCollectionsAsync(id);
         if (group == null || group.OrganizationId != orgId)
         {
@@ -238,16 +218,18 @@ public class GroupsController : Controller
 
     [HttpPost("{id}")]
     [Obsolete("This endpoint is deprecated. Use PUT method instead")]
+    [Authorize<ManageGroupsRequirement>]
     public async Task<GroupResponseModel> PostPut(Guid orgId, Guid id, [FromBody] GroupRequestModel model)
     {
         return await Put(orgId, id, model);
     }
 
     [HttpDelete("{id}")]
-    public async Task Delete(string orgId, string id)
+    [Authorize<ManageGroupsRequirement>]
+    public async Task Delete(Guid orgId, Guid id)
     {
-        var group = await _groupRepository.GetByIdAsync(new Guid(id));
-        if (group == null || !await _currentContext.ManageGroups(group.OrganizationId))
+        var group = await _groupRepository.GetByIdAsync(id);
+        if (group == null || group.OrganizationId != orgId)
         {
             throw new NotFoundException();
         }
@@ -257,19 +239,21 @@ public class GroupsController : Controller
 
     [HttpPost("{id}/delete")]
     [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
-    public async Task PostDelete(string orgId, string id)
+    [Authorize<ManageGroupsRequirement>]
+    public async Task PostDelete(Guid orgId, Guid id)
     {
         await Delete(orgId, id);
     }
 
     [HttpDelete("")]
-    public async Task BulkDelete([FromBody] GroupBulkRequestModel model)
+    [Authorize<ManageGroupsRequirement>]
+    public async Task BulkDelete(Guid orgId, [FromBody] GroupBulkRequestModel model)
     {
         var groups = await _groupRepository.GetManyByManyIds(model.Ids);
 
         foreach (var group in groups)
         {
-            if (!await _currentContext.ManageGroups(group.OrganizationId))
+            if (group.OrganizationId != orgId)
             {
                 throw new NotFoundException();
             }
@@ -280,26 +264,29 @@ public class GroupsController : Controller
 
     [HttpPost("delete")]
     [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
-    public async Task PostBulkDelete([FromBody] GroupBulkRequestModel model)
+    [Authorize<ManageGroupsRequirement>]
+    public async Task PostBulkDelete(Guid orgId, [FromBody] GroupBulkRequestModel model)
     {
-        await BulkDelete(model);
+        await BulkDelete(orgId, model);
     }
 
     [HttpDelete("{id}/user/{orgUserId}")]
-    public async Task DeleteUser(string orgId, string id, string orgUserId)
+    [Authorize<ManageGroupsRequirement>]
+    public async Task DeleteUser(Guid orgId, Guid id, Guid orgUserId)
     {
-        var group = await _groupRepository.GetByIdAsync(new Guid(id));
-        if (group == null || !await _currentContext.ManageGroups(group.OrganizationId))
+        var group = await _groupRepository.GetByIdAsync(id);
+        if (group == null || group.OrganizationId != orgId)
         {
             throw new NotFoundException();
         }
 
-        await _groupService.DeleteUserAsync(group, new Guid(orgUserId));
+        await _groupService.DeleteUserAsync(group, orgUserId);
     }
 
     [HttpPost("{id}/delete-user/{orgUserId}")]
     [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
-    public async Task PostDeleteUser(string orgId, string id, string orgUserId)
+    [Authorize<ManageGroupsRequirement>]
+    public async Task PostDeleteUser(Guid orgId, Guid id, Guid orgUserId)
     {
         await DeleteUser(orgId, id, orgUserId);
     }

--- a/src/Api/AdminConsole/Controllers/ProviderUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/ProviderUsersController.cs
@@ -40,7 +40,8 @@ public class ProviderUsersController : Controller
     public async Task<ProviderUserResponseModel> Get(Guid providerId, Guid id)
     {
         var providerUser = await _providerUserRepository.GetByIdAsync(id);
-        if (providerUser == null || !_currentContext.ProviderManageUsers(providerUser.ProviderId))
+        if (providerUser == null || providerUser.ProviderId != providerId ||
+            !_currentContext.ProviderManageUsers(providerUser.ProviderId))
         {
             throw new NotFoundException();
         }

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/GroupsControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/GroupsControllerTests.cs
@@ -1,0 +1,476 @@
+﻿using System.Net;
+using Bit.Api.AdminConsole.Models.Request;
+using Bit.Api.IntegrationTest.Factories;
+using Bit.Api.IntegrationTest.Helpers;
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Enums.Provider;
+using Bit.Core.Billing.Enums;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data;
+using Xunit;
+
+namespace Bit.Api.IntegrationTest.AdminConsole.Controllers;
+
+public class GroupsControllerTests : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
+{
+    private readonly HttpClient _client;
+    private readonly ApiApplicationFactory _factory;
+    private readonly LoginHelper _loginHelper;
+
+    private string _ownerEmail = null!;
+    private Organization _organization = null!;
+    private Group _group = null!;
+
+    public GroupsControllerTests(ApiApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+        _loginHelper = new LoginHelper(_factory, _client);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _ownerEmail = $"integration-test{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(_ownerEmail);
+
+        (_organization, _) = await OrganizationTestHelpers.SignUpAsync(
+            _factory,
+            plan: PlanType.EnterpriseAnnually,
+            ownerEmail: _ownerEmail,
+            passwordManagerSeats: 10,
+            paymentMethod: PaymentMethodType.Card);
+
+        _group = await OrganizationTestHelpers.CreateGroup(_factory, _organization.Id);
+    }
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Get_AsOwner_ReturnsSuccess()
+    {
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups/{_group.Id}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_AsAdmin_ReturnsSuccess()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.Admin);
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups/{_group.Id}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_AsCustomWithManageGroups_ReturnsSuccess()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.Custom,
+            permissions: new Permissions { ManageGroups = true });
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups/{_group.Id}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_AsCustomWithoutManageGroups_ReturnsForbidden()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.Custom,
+            permissions: new Permissions { ManageGroups = false });
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups/{_group.Id}");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_AsUser_ReturnsForbidden()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.User);
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups/{_group.Id}");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_AsProviderUser_ReturnsSuccess()
+    {
+        var email = await CreateProviderUserForOrganizationAsync();
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups/{_group.Id}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_NotAMember_ReturnsForbidden()
+    {
+        var email = $"integration-test{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(email);
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups/{_group.Id}");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetOrganizationGroups_AsOwner_ReturnsSuccess()
+    {
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetOrganizationGroups_AsUser_ReturnsSuccess()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.User);
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetOrganizationGroups_AsProviderUser_ReturnsSuccess()
+    {
+        var email = await CreateProviderUserForOrganizationAsync();
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetOrganizationGroups_NotAMember_ReturnsForbidden()
+    {
+        var email = $"integration-test{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(email);
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetOrganizationGroupDetails_AsOwner_ReturnsSuccess()
+    {
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups/details");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetOrganizationGroupDetails_AsAdmin_ReturnsSuccess()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.Admin);
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups/details");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetOrganizationGroupDetails_AsCustomWithManageGroups_ReturnsSuccess()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.Custom,
+            permissions: new Permissions { ManageGroups = true });
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups/details");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetOrganizationGroupDetails_AsCustomWithManageUsers_ReturnsSuccess()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.Custom,
+            permissions: new Permissions { ManageUsers = true });
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups/details");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetOrganizationGroupDetails_AsCustomWithoutManageUsersOrGroups_ReturnsForbidden()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.Custom,
+            permissions: new Permissions { ManageUsers = false, ManageGroups = false });
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups/details");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetOrganizationGroupDetails_AsUser_ReturnsForbidden()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.User);
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups/details");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetOrganizationGroupDetails_AsProviderUser_ReturnsSuccess()
+    {
+        var email = await CreateProviderUserForOrganizationAsync();
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups/details");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetUsers_AsOwner_ReturnsSuccess()
+    {
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups/{_group.Id}/users");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetUsers_AsUser_ReturnsForbidden()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.User);
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups/{_group.Id}/users");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetUsers_AsCustomWithManageGroups_ReturnsSuccess()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.Custom,
+            permissions: new Permissions { ManageGroups = true });
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.GetAsync($"/organizations/{_organization.Id}/groups/{_group.Id}/users");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_AsOwner_ReturnsSuccess()
+    {
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var request = new GroupRequestModel { Name = "New Group" };
+        var response = await _client.PostAsJsonAsync($"/organizations/{_organization.Id}/groups", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_AsAdmin_ReturnsSuccess()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.Admin);
+        await _loginHelper.LoginAsync(email);
+
+        var request = new GroupRequestModel { Name = "New Group" };
+        var response = await _client.PostAsJsonAsync($"/organizations/{_organization.Id}/groups", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_AsUser_ReturnsForbidden()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.User);
+        await _loginHelper.LoginAsync(email);
+
+        var request = new GroupRequestModel { Name = "New Group" };
+        var response = await _client.PostAsJsonAsync($"/organizations/{_organization.Id}/groups", request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_AsCustomWithManageGroups_ReturnsSuccess()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.Custom,
+            permissions: new Permissions { ManageGroups = true });
+        await _loginHelper.LoginAsync(email);
+
+        var request = new GroupRequestModel { Name = "New Group" };
+        var response = await _client.PostAsJsonAsync($"/organizations/{_organization.Id}/groups", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_AsCustomWithoutManageGroups_ReturnsForbidden()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.Custom,
+            permissions: new Permissions { ManageGroups = false });
+        await _loginHelper.LoginAsync(email);
+
+        var request = new GroupRequestModel { Name = "New Group" };
+        var response = await _client.PostAsJsonAsync($"/organizations/{_organization.Id}/groups", request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_AsOwner_ReturnsSuccess()
+    {
+        await _loginHelper.LoginAsync(_ownerEmail);
+        var group = await OrganizationTestHelpers.CreateGroup(_factory, _organization.Id);
+
+        var response = await _client.DeleteAsync($"/organizations/{_organization.Id}/groups/{group.Id}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_AsUser_ReturnsForbidden()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.User);
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.DeleteAsync($"/organizations/{_organization.Id}/groups/{_group.Id}");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_AsCustomWithManageGroups_ReturnsSuccess()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.Custom,
+            permissions: new Permissions { ManageGroups = true });
+        await _loginHelper.LoginAsync(email);
+        var group = await OrganizationTestHelpers.CreateGroup(_factory, _organization.Id);
+
+        var response = await _client.DeleteAsync($"/organizations/{_organization.Id}/groups/{group.Id}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task BulkDelete_AsOwner_IsAuthorized()
+    {
+        await _loginHelper.LoginAsync(_ownerEmail);
+        var group = await OrganizationTestHelpers.CreateGroup(_factory, _organization.Id);
+
+        var request = new GroupBulkRequestModel { Ids = [group.Id] };
+        var response = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Delete,
+            $"/organizations/{_organization.Id}/groups")
+        {
+            Content = JsonContent.Create(request)
+        });
+
+        // Assert authorization passes (not Forbidden/Unauthorized)
+        Assert.NotEqual(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.NotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task BulkDelete_AsUser_ReturnsForbidden()
+    {
+        var (email, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.User);
+        await _loginHelper.LoginAsync(email);
+
+        var request = new GroupBulkRequestModel { Ids = [_group.Id] };
+        var response = await _client.SendAsync(new HttpRequestMessage(HttpMethod.Delete,
+            $"/organizations/{_organization.Id}/groups")
+        {
+            Content = JsonContent.Create(request)
+        });
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteUser_AsUser_ReturnsForbidden()
+    {
+        var (email, orgUser) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.User);
+        await _loginHelper.LoginAsync(email);
+
+        var response = await _client.DeleteAsync(
+            $"/organizations/{_organization.Id}/groups/{_group.Id}/user/{orgUser.Id}");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteUser_AsOwner_GroupNotFound_ReturnsNotFound()
+    {
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var response = await _client.DeleteAsync(
+            $"/organizations/{_organization.Id}/groups/{Guid.NewGuid()}/user/{Guid.NewGuid()}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Creates a provider linked to the test organization and returns a provider user's credentials.
+    /// </summary>
+    private async Task<string> CreateProviderUserForOrganizationAsync()
+    {
+        var email = $"integration-test{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(email);
+
+        var provider = await ProviderTestHelpers.CreateProviderAndLinkToOrganizationAsync(
+            _factory, _organization.Id, ProviderType.Msp);
+
+        await ProviderTestHelpers.CreateProviderUserAsync(
+            _factory, provider.Id, email, ProviderUserType.ServiceUser);
+
+        return email;
+    }
+}

--- a/test/Api.Test/AdminConsole/Controllers/AdminConsoleControllersAuthorizationTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/AdminConsoleControllersAuthorizationTests.cs
@@ -13,7 +13,6 @@ public class AdminConsoleControllersAuthorizationTests
     /// </summary>
     private static readonly HashSet<Type> _controllersNotYetMigrated =
     [
-        typeof(GroupsController),
         typeof(OrganizationAuthRequestsController),
         typeof(OrganizationConnectionsController),
         typeof(OrganizationDomainController),

--- a/test/Api.Test/AdminConsole/Controllers/GroupsControllerPutTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/GroupsControllerPutTests.cs
@@ -6,7 +6,6 @@ using Bit.Api.Vault.AuthorizationHandlers.Collections;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.OrganizationFeatures.Groups.Interfaces;
 using Bit.Core.AdminConsole.Repositories;
-using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Data;
@@ -46,7 +45,6 @@ public class GroupsControllerPutTests
 
         var response = await sutProvider.Sut.Put(organization.Id, group.Id, groupRequestModel);
 
-        await sutProvider.GetDependency<ICurrentContext>().Received(1).ManageGroups(organization.Id);
         await sutProvider.GetDependency<IUpdateGroupCommand>().Received(1).UpdateGroupAsync(
             Arg.Is<Group>(g =>
                 g.OrganizationId == organization.Id && g.Name == groupRequestModel.Name),
@@ -103,7 +101,6 @@ public class GroupsControllerPutTests
 
         var response = await sutProvider.Sut.Put(organization.Id, group.Id, groupRequestModel);
 
-        await sutProvider.GetDependency<ICurrentContext>().Received(1).ManageGroups(organization.Id);
         await sutProvider.GetDependency<IUpdateGroupCommand>().Received(1).UpdateGroupAsync(
             Arg.Is<Group>(g =>
                 g.OrganizationId == organization.Id && g.Name == groupRequestModel.Name),
@@ -155,7 +152,6 @@ public class GroupsControllerPutTests
 
         var response = await sutProvider.Sut.Put(organization.Id, group.Id, groupRequestModel);
 
-        await sutProvider.GetDependency<ICurrentContext>().Received(1).ManageGroups(organization.Id);
         await sutProvider.GetDependency<IUpdateGroupCommand>().Received(1).UpdateGroupAsync(
             Arg.Is<Group>(g =>
                 g.OrganizationId == organization.Id && g.Name == groupRequestModel.Name),
@@ -224,7 +220,6 @@ public class GroupsControllerPutTests
         var response = await sutProvider.Sut.Put(organization.Id, group.Id, groupRequestModel);
 
         // Expect all collection access (modified and unmodified) to be saved
-        await sutProvider.GetDependency<ICurrentContext>().Received(1).ManageGroups(organization.Id);
         await sutProvider.GetDependency<IUpdateGroupCommand>().Received(1).UpdateGroupAsync(
             Arg.Is<Group>(g =>
                 g.OrganizationId == organization.Id && g.Name == groupRequestModel.Name),
@@ -299,7 +294,6 @@ public class GroupsControllerPutTests
         // Arrange user
         // If no savingUser provided, they're not an org user, just return a random guid
         sutProvider.GetDependency<IUserService>().GetProperUserId(Arg.Any<ClaimsPrincipal>()).Returns(savingUser?.UserId ?? CoreHelpers.GenerateComb());
-        sutProvider.GetDependency<ICurrentContext>().ManageGroups(orgId).Returns(true);
 
         // Arrange repositories
         sutProvider.GetDependency<IGroupRepository>().GetManyUserIdsByIdAsync(group.Id).Returns(currentGroupUsers ?? []);

--- a/test/Api.Test/AdminConsole/Controllers/GroupsControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/GroupsControllerTests.cs
@@ -4,7 +4,8 @@ using Bit.Api.AdminConsole.Models.Request;
 using Bit.Api.Vault.AuthorizationHandlers.Collections;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.OrganizationFeatures.Groups.Interfaces;
-using Bit.Core.Context;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.AdminConsole.Services;
 using Bit.Core.Entities;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Data;
@@ -15,6 +16,7 @@ using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using Microsoft.AspNetCore.Authorization;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using Xunit;
 
 namespace Bit.Api.Test.AdminConsole.Controllers;
@@ -23,6 +25,217 @@ namespace Bit.Api.Test.AdminConsole.Controllers;
 [SutProviderCustomize]
 public class GroupsControllerTests
 {
+    // --- Get ---
+
+    [Theory]
+    [BitAutoData]
+    public async Task Get_GroupNotFound_ThrowsNotFound(Guid orgId, Guid id,
+        SutProvider<GroupsController> sutProvider)
+    {
+        sutProvider.GetDependency<IGroupRepository>().GetByIdAsync(id).ReturnsNull();
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.Get(orgId, id));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Get_OrgIdMismatch_ThrowsNotFound(Guid orgId, Group group,
+        SutProvider<GroupsController> sutProvider)
+    {
+        // group.OrganizationId will be auto-generated and won't match orgId
+        sutProvider.GetDependency<IGroupRepository>().GetByIdAsync(group.Id).Returns(group);
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.Get(orgId, group.Id));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Get_Success(Group group, SutProvider<GroupsController> sutProvider)
+    {
+        sutProvider.GetDependency<IGroupRepository>().GetByIdAsync(group.Id).Returns(group);
+
+        var result = await sutProvider.Sut.Get(group.OrganizationId, group.Id);
+
+        Assert.Equal(group.Id, result.Id);
+        Assert.Equal(group.OrganizationId, result.OrganizationId);
+    }
+
+    // --- GetDetails ---
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetDetails_GroupNotFound_ThrowsNotFound(Guid orgId, Guid id,
+        SutProvider<GroupsController> sutProvider)
+    {
+        sutProvider.GetDependency<IGroupRepository>().GetByIdWithCollectionsAsync(id)
+            .Returns((Tuple<Group, ICollection<CollectionAccessSelection>>)null);
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.GetDetails(orgId, id));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetDetails_OrgIdMismatch_ThrowsNotFound(Guid orgId, Group group,
+        ICollection<CollectionAccessSelection> collections, SutProvider<GroupsController> sutProvider)
+    {
+        sutProvider.GetDependency<IGroupRepository>().GetByIdWithCollectionsAsync(group.Id)
+            .Returns(new Tuple<Group, ICollection<CollectionAccessSelection>>(group, collections));
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.GetDetails(orgId, group.Id));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetDetails_Success(Group group, ICollection<CollectionAccessSelection> collections,
+        SutProvider<GroupsController> sutProvider)
+    {
+        sutProvider.GetDependency<IGroupRepository>().GetByIdWithCollectionsAsync(group.Id)
+            .Returns(new Tuple<Group, ICollection<CollectionAccessSelection>>(group, collections));
+
+        var result = await sutProvider.Sut.GetDetails(group.OrganizationId, group.Id);
+
+        Assert.Equal(group.Id, result.Id);
+        Assert.Equal(group.OrganizationId, result.OrganizationId);
+    }
+
+    // --- GetUsers ---
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetUsers_GroupNotFound_ThrowsNotFound(Guid orgId, Guid id,
+        SutProvider<GroupsController> sutProvider)
+    {
+        sutProvider.GetDependency<IGroupRepository>().GetByIdAsync(id).ReturnsNull();
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.GetUsers(orgId, id));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetUsers_OrgIdMismatch_ThrowsNotFound(Guid orgId, Group group,
+        SutProvider<GroupsController> sutProvider)
+    {
+        sutProvider.GetDependency<IGroupRepository>().GetByIdAsync(group.Id).Returns(group);
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.GetUsers(orgId, group.Id));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetUsers_Success(Group group, ICollection<Guid> userIds,
+        SutProvider<GroupsController> sutProvider)
+    {
+        sutProvider.GetDependency<IGroupRepository>().GetByIdAsync(group.Id).Returns(group);
+        sutProvider.GetDependency<IGroupRepository>().GetManyUserIdsByIdAsync(group.Id).Returns(userIds);
+
+        var result = await sutProvider.Sut.GetUsers(group.OrganizationId, group.Id);
+
+        Assert.Equal(userIds, result);
+    }
+
+    // --- Delete ---
+
+    [Theory]
+    [BitAutoData]
+    public async Task Delete_GroupNotFound_ThrowsNotFound(Guid orgId, Guid id,
+        SutProvider<GroupsController> sutProvider)
+    {
+        sutProvider.GetDependency<IGroupRepository>().GetByIdAsync(id).ReturnsNull();
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.Delete(orgId, id));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Delete_OrgIdMismatch_ThrowsNotFound(Guid orgId, Group group,
+        SutProvider<GroupsController> sutProvider)
+    {
+        sutProvider.GetDependency<IGroupRepository>().GetByIdAsync(group.Id).Returns(group);
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.Delete(orgId, group.Id));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Delete_Success(Group group, SutProvider<GroupsController> sutProvider)
+    {
+        sutProvider.GetDependency<IGroupRepository>().GetByIdAsync(group.Id).Returns(group);
+
+        await sutProvider.Sut.Delete(group.OrganizationId, group.Id);
+
+        await sutProvider.GetDependency<IDeleteGroupCommand>().Received(1).DeleteAsync(group);
+    }
+
+    // --- DeleteUser ---
+
+    [Theory]
+    [BitAutoData]
+    public async Task DeleteUser_GroupNotFound_ThrowsNotFound(Guid orgId, Guid id, Guid orgUserId,
+        SutProvider<GroupsController> sutProvider)
+    {
+        sutProvider.GetDependency<IGroupRepository>().GetByIdAsync(id).ReturnsNull();
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.DeleteUser(orgId, id, orgUserId));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task DeleteUser_OrgIdMismatch_ThrowsNotFound(Guid orgId, Group group, Guid orgUserId,
+        SutProvider<GroupsController> sutProvider)
+    {
+        sutProvider.GetDependency<IGroupRepository>().GetByIdAsync(group.Id).Returns(group);
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.DeleteUser(orgId, group.Id, orgUserId));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task DeleteUser_Success(Group group, Guid orgUserId,
+        SutProvider<GroupsController> sutProvider)
+    {
+        sutProvider.GetDependency<IGroupRepository>().GetByIdAsync(group.Id).Returns(group);
+
+        await sutProvider.Sut.DeleteUser(group.OrganizationId, group.Id, orgUserId);
+
+        await sutProvider.GetDependency<IGroupService>().Received(1).DeleteUserAsync(group, orgUserId);
+    }
+
+    // --- BulkDelete ---
+
+    [Theory]
+    [BitAutoData]
+    public async Task BulkDelete_OrgIdMismatch_ThrowsNotFound(Guid orgId,
+        SutProvider<GroupsController> sutProvider)
+    {
+        var groups = new List<Group>
+        {
+            new() { Id = Guid.NewGuid(), OrganizationId = Guid.NewGuid() }
+        };
+        var model = new GroupBulkRequestModel { Ids = groups.Select(g => g.Id) };
+        sutProvider.GetDependency<IGroupRepository>().GetManyByManyIds(model.Ids).Returns(groups);
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.BulkDelete(orgId, model));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task BulkDelete_Success(Guid orgId, SutProvider<GroupsController> sutProvider)
+    {
+        var groups = new List<Group>
+        {
+            new() { Id = Guid.NewGuid(), OrganizationId = orgId },
+            new() { Id = Guid.NewGuid(), OrganizationId = orgId }
+        };
+        var model = new GroupBulkRequestModel { Ids = groups.Select(g => g.Id) };
+        sutProvider.GetDependency<IGroupRepository>().GetManyByManyIds(model.Ids).Returns(groups);
+
+        await sutProvider.Sut.BulkDelete(orgId, model);
+
+        await sutProvider.GetDependency<IDeleteGroupCommand>().Received(1).DeleteManyAsync(groups);
+    }
+
+    // --- Post (existing tests) ---
+
     [Theory]
     [BitAutoData]
     public async Task Post_AuthorizedToGiveAccessToCollections_Success(Organization organization,
@@ -39,14 +252,12 @@ public class GroupsControllerTests
              .Returns(AuthorizationResult.Success());
 
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
-        sutProvider.GetDependency<ICurrentContext>().ManageGroups(organization.Id).Returns(true);
 
         var response = await sutProvider.Sut.Post(organization.Id, groupRequestModel);
 
         var requestModelCollectionIds = groupRequestModel.Collections.Select(c => c.Id).ToHashSet();
 
         // Assert that it checked permissions
-        await sutProvider.GetDependency<ICurrentContext>().Received(1).ManageGroups(organization.Id);
         await sutProvider.GetDependency<IAuthorizationService>()
             .Received(1)
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(),
@@ -76,7 +287,6 @@ public class GroupsControllerTests
             new OrganizationAbility { Id = organization.Id, AllowAdminAccessToAllCollectionItems = false });
 
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
-        sutProvider.GetDependency<ICurrentContext>().ManageGroups(organization.Id).Returns(true);
 
         var requestModelCollectionIds = groupRequestModel.Collections.Select(c => c.Id).ToHashSet();
         sutProvider.GetDependency<IAuthorizationService>()

--- a/test/Api.Test/AdminConsole/Controllers/GroupsControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/GroupsControllerTests.cs
@@ -25,7 +25,6 @@ namespace Bit.Api.Test.AdminConsole.Controllers;
 [SutProviderCustomize]
 public class GroupsControllerTests
 {
-    // --- Get ---
 
     [Theory]
     [BitAutoData]
@@ -42,7 +41,7 @@ public class GroupsControllerTests
     public async Task Get_OrgIdMismatch_ThrowsNotFound(Guid orgId, Group group,
         SutProvider<GroupsController> sutProvider)
     {
-        // group.OrganizationId will be auto-generated and won't match orgId
+        group.OrganizationId = Guid.NewGuid();
         sutProvider.GetDependency<IGroupRepository>().GetByIdAsync(group.Id).Returns(group);
 
         await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.Get(orgId, group.Id));
@@ -59,8 +58,6 @@ public class GroupsControllerTests
         Assert.Equal(group.Id, result.Id);
         Assert.Equal(group.OrganizationId, result.OrganizationId);
     }
-
-    // --- GetDetails ---
 
     [Theory]
     [BitAutoData]
@@ -98,8 +95,6 @@ public class GroupsControllerTests
         Assert.Equal(group.OrganizationId, result.OrganizationId);
     }
 
-    // --- GetUsers ---
-
     [Theory]
     [BitAutoData]
     public async Task GetUsers_GroupNotFound_ThrowsNotFound(Guid orgId, Guid id,
@@ -133,8 +128,6 @@ public class GroupsControllerTests
         Assert.Equal(userIds, result);
     }
 
-    // --- Delete ---
-
     [Theory]
     [BitAutoData]
     public async Task Delete_GroupNotFound_ThrowsNotFound(Guid orgId, Guid id,
@@ -165,8 +158,6 @@ public class GroupsControllerTests
 
         await sutProvider.GetDependency<IDeleteGroupCommand>().Received(1).DeleteAsync(group);
     }
-
-    // --- DeleteUser ---
 
     [Theory]
     [BitAutoData]
@@ -200,8 +191,6 @@ public class GroupsControllerTests
         await sutProvider.GetDependency<IGroupService>().Received(1).DeleteUserAsync(group, orgUserId);
     }
 
-    // --- BulkDelete ---
-
     [Theory]
     [BitAutoData]
     public async Task BulkDelete_OrgIdMismatch_ThrowsNotFound(Guid orgId,
@@ -233,8 +222,6 @@ public class GroupsControllerTests
 
         await sutProvider.GetDependency<IDeleteGroupCommand>().Received(1).DeleteManyAsync(groups);
     }
-
-    // --- Post (existing tests) ---
 
     [Theory]
     [BitAutoData]

--- a/test/Api.Test/AdminConsole/Controllers/ProviderUsersControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/ProviderUsersControllerTests.cs
@@ -1,0 +1,65 @@
+﻿using Bit.Api.AdminConsole.Controllers;
+using Bit.Core.AdminConsole.Entities.Provider;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Context;
+using Bit.Core.Exceptions;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
+using NSubstitute.ReturnsExtensions;
+using Xunit;
+
+namespace Bit.Api.Test.AdminConsole.Controllers;
+
+[ControllerCustomize(typeof(ProviderUsersController))]
+[SutProviderCustomize]
+public class ProviderUsersControllerTests
+{
+    [Theory]
+    [BitAutoData]
+    public async Task Get_ProviderUserNotFound_ThrowsNotFound(Guid providerId, Guid id,
+        SutProvider<ProviderUsersController> sutProvider)
+    {
+        sutProvider.GetDependency<IProviderUserRepository>().GetByIdAsync(id).ReturnsNull();
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.Get(providerId, id));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Get_ProviderIdMismatch_ThrowsNotFound(Guid providerId, ProviderUser providerUser,
+        SutProvider<ProviderUsersController> sutProvider)
+    {
+        sutProvider.GetDependency<IProviderUserRepository>().GetByIdAsync(providerUser.Id).Returns(providerUser);
+        sutProvider.GetDependency<ICurrentContext>().ProviderManageUsers(providerUser.ProviderId).Returns(true);
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.Get(providerId, providerUser.Id));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Get_NoPermission_ThrowsNotFound(ProviderUser providerUser,
+        SutProvider<ProviderUsersController> sutProvider)
+    {
+        sutProvider.GetDependency<IProviderUserRepository>().GetByIdAsync(providerUser.Id).Returns(providerUser);
+        sutProvider.GetDependency<ICurrentContext>().ProviderManageUsers(providerUser.ProviderId).Returns(false);
+
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            sutProvider.Sut.Get(providerUser.ProviderId, providerUser.Id));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Get_Success(ProviderUser providerUser,
+        SutProvider<ProviderUsersController> sutProvider)
+    {
+        // Permissions must be valid JSON for ProviderUserResponseModel constructor
+        providerUser.Permissions = null;
+        sutProvider.GetDependency<IProviderUserRepository>().GetByIdAsync(providerUser.Id).Returns(providerUser);
+        sutProvider.GetDependency<ICurrentContext>().ProviderManageUsers(providerUser.ProviderId).Returns(true);
+
+        var result = await sutProvider.Sut.Get(providerUser.ProviderId, providerUser.Id);
+
+        Assert.Equal(providerUser.Id, result.Id);
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking
[PM-34390](https://bitwarden.atlassian.net/browse/PM-34390)

## 📔 Objective
GroupsController — Migrated all endpoints to declarative [Authorize<...>] attributes 
- GET /organizations/{orgId}/groups/{id} 
- GET /organizations/{orgId}/groups/{id}/details 
- GET /organizations/{orgId}/groups/{id}/users 
- DELETE /organizations/{orgId}/groups/{id} 
- DELETE /organizations/{orgId}/groups/{id}/user/{orgUserId}
- DELETE /organizations/{orgId}/groups (bulk)
- POST, PUT, and list endpoints also moved to declarative auth attributes for consistency

ProviderUsersController — GET /providers/{providerId}/users/{id} now checks providerUser.ProviderId != providerId before returning.

Other:
- Added ManageUsersOrGroupsRequirement to preserve the existing OR logic on the group details list endpoint (ManageUsers || ManageGroups)
- Removed unused IFeatureService from GroupsController
- Changed string route params to Guid for type safety
- Removed GroupsController from the not-yet-migrated authorization test list


[PM-34390]: https://bitwarden.atlassian.net/browse/PM-34390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ