### PR TITLE
Fix test clock awareness in schedule-aware cancellation

### DIFF
--- a/src/Core/Billing/Services/Implementations/SubscriberService.cs
+++ b/src/Core/Billing/Services/Implementations/SubscriberService.cs
@@ -42,7 +42,8 @@ public class SubscriberService(
         bool cancelImmediately,
         OffboardingSurveyResponse offboardingSurveyResponse = null)
     {
-        var subscription = await GetSubscriptionOrThrow(subscriber);
+        var subscription = await GetSubscriptionOrThrow(subscriber,
+            new SubscriptionGetOptions { Expand = ["test_clock"] });
 
         if (subscription.CanceledAt.HasValue ||
             subscription.Status == "canceled" ||
@@ -279,7 +280,9 @@ public class SubscriberService(
                     "{Service}: Active subscription schedule ({ScheduleId}) found for subscription ({SubscriptionId}), updating schedule phases",
                     GetType().Name, activeSchedule.Id, subscription.Id);
 
-                var phase1 = activeSchedule.Phases[0];
+                var now = subscription.TestClock?.FrozenTime ?? DateTime.UtcNow;
+                var currentPhase = activeSchedule.Phases.FirstOrDefault(p => p.EndDate > now)
+                    ?? activeSchedule.Phases[^1];
 
                 await stripeAdapter.UpdateSubscriptionScheduleAsync(activeSchedule.Id,
                     new SubscriptionScheduleUpdateOptions
@@ -289,15 +292,17 @@ public class SubscriberService(
                         [
                             new SubscriptionSchedulePhaseOptions
                             {
-                                StartDate = phase1.StartDate,
-                                EndDate = phase1.EndDate,
-                                Items = phase1.Items.Select(i => new SubscriptionSchedulePhaseItemOptions
+                                StartDate = currentPhase.StartDate,
+                                EndDate = currentPhase.EndDate,
+                                Items = currentPhase.Items.Select(i => new SubscriptionSchedulePhaseItemOptions
                                 {
                                     Price = i.PriceId,
                                     Quantity = i.Quantity
                                 }).ToList(),
-                                Discounts = phase1.Discounts?.Select(d =>
-                                    new SubscriptionSchedulePhaseDiscountOptions { Coupon = d.CouponId }).ToList(),
+                                Discounts = currentPhase.StartDate <= now
+                                    ? []
+                                    : currentPhase.Discounts?.Select(d =>
+                                        new SubscriptionSchedulePhaseDiscountOptions { Coupon = d.CouponId }).ToList(),
                                 ProrationBehavior = ProrationBehavior.None,
                                 Metadata = cancellingUserMetadata
                             }

--- a/test/Core.Test/Billing/Services/SubscriberServiceTests.cs
+++ b/test/Core.Test/Billing/Services/SubscriberServiceTests.cs
@@ -41,7 +41,7 @@ public class SubscriberServiceTests
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
 
         stripeAdapter
-            .GetSubscriptionAsync(organization.GatewaySubscriptionId)
+            .GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
             .Returns(subscription);
 
         await ThrowsBillingExceptionAsync(() =>
@@ -78,7 +78,7 @@ public class SubscriberServiceTests
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
 
         stripeAdapter
-            .GetSubscriptionAsync(organization.GatewaySubscriptionId)
+            .GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
             .Returns(subscription);
 
         var offboardingSurveyResponse = new OffboardingSurveyResponse
@@ -124,7 +124,7 @@ public class SubscriberServiceTests
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
 
         stripeAdapter
-            .GetSubscriptionAsync(organization.GatewaySubscriptionId)
+            .GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
             .Returns(subscription);
 
         var offboardingSurveyResponse = new OffboardingSurveyResponse
@@ -167,7 +167,7 @@ public class SubscriberServiceTests
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
 
         stripeAdapter
-            .GetSubscriptionAsync(organization.GatewaySubscriptionId)
+            .GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
             .Returns(subscription);
 
         var featureService = sutProvider.GetDependency<IFeatureService>();
@@ -213,7 +213,7 @@ public class SubscriberServiceTests
         };
 
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
-        stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId).Returns(subscription);
+        stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>()).Returns(subscription);
 
         await sutProvider.Sut.CancelSubscription(organization, cancelImmediately: true);
 
@@ -243,7 +243,7 @@ public class SubscriberServiceTests
         };
 
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
-        stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId).Returns(subscription);
+        stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>()).Returns(subscription);
 
         var featureService = sutProvider.GetDependency<IFeatureService>();
         featureService.IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal).Returns(false);
@@ -278,7 +278,7 @@ public class SubscriberServiceTests
         };
 
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
-        stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId).Returns(subscription);
+        stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>()).Returns(subscription);
         stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
             .Returns(new StripeList<SubscriptionSchedule>
             {
@@ -318,7 +318,7 @@ public class SubscriberServiceTests
         };
 
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
-        stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId).Returns(subscription);
+        stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>()).Returns(subscription);
 
         var featureService = sutProvider.GetDependency<IFeatureService>();
         featureService.IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal).Returns(false);
@@ -347,7 +347,7 @@ public class SubscriberServiceTests
         };
 
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
-        stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId).Returns(subscription);
+        stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>()).Returns(subscription);
         stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
             .Returns(new StripeList<SubscriptionSchedule> { Data = [] });
 
@@ -379,7 +379,7 @@ public class SubscriberServiceTests
         };
 
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
-        stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId).Returns(subscription);
+        stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>()).Returns(subscription);
         stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
             .Returns(new StripeList<SubscriptionSchedule>
             {
@@ -445,7 +445,7 @@ public class SubscriberServiceTests
         };
 
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
-        stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId).Returns(subscription);
+        stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>()).Returns(subscription);
         stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
             .Returns(new StripeList<SubscriptionSchedule>
             {
@@ -511,7 +511,7 @@ public class SubscriberServiceTests
         };
 
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
-        stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId).Returns(subscription);
+        stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>()).Returns(subscription);
         stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
             .Returns(new StripeList<SubscriptionSchedule> { Data = [] });
 
@@ -542,7 +542,7 @@ public class SubscriberServiceTests
         };
 
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
-        stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId).Returns(subscription);
+        stripeAdapter.GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>()).Returns(subscription);
 
         var featureService = sutProvider.GetDependency<IFeatureService>();
         featureService.IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal).Returns(false);
@@ -1028,7 +1028,7 @@ public class SubscriberServiceTests
         var subscription = new Subscription();
 
         sutProvider.GetDependency<IStripeAdapter>()
-            .GetSubscriptionAsync(organization.GatewaySubscriptionId)
+            .GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
             .Returns(subscription);
 
         var gotSubscription = await sutProvider.Sut.GetSubscription(organization);
@@ -1091,7 +1091,7 @@ public class SubscriberServiceTests
         var subscription = new Subscription();
 
         sutProvider.GetDependency<IStripeAdapter>()
-            .GetSubscriptionAsync(organization.GatewaySubscriptionId)
+            .GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
             .Returns(subscription);
 
         var gotSubscription = await sutProvider.Sut.GetSubscriptionOrThrow(organization);


### PR DESCRIPTION
## 🎟️ Tracking

No Jira ticket — test environment fix for Stripe test clock compatibility.

## 📔 Objective

Fixes `SubscriberService.CancelSubscriptionAtPeriodEndAsync` to correctly handle Stripe test clocks when updating schedule phases during cancellation.

The method hardcoded `activeSchedule.Phases[0]` as the phase to keep when cancelling at period end. When QA uses Stripe test clocks to advance past the Phase 1 → Phase 2 transition, Phase 0 has already ended in test-clock-simulated time, and Stripe rejects the update with "You can not update a phase that has already ended."

### Fix

- Expands `test_clock` on the subscription fetch in `CancelSubscription`
- Uses `subscription.TestClock?.FrozenTime ?? DateTime.UtcNow` to determine the current time
- Finds the current active phase (first with `EndDate > now`) instead of hardcoding index 0
- Clears consumed one-time discounts on already-active phases (same pattern as `UpdatePremiumStorageCommand`)

## 📸 Screenshots

N/A — no UI changes.