### PR TITLE
[PM-35150] Make `Setup` testable and add test for install

### DIFF
--- a/bitwarden-server.sln
+++ b/bitwarden-server.sln
@@ -147,6 +147,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sso.IntegrationTest", "bitw
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Server.IntegrationTest", "test\Server.IntegrationTest\Server.IntegrationTest.csproj", "{E75E1F10-BC6F-4EB1-BA75-D897C45AEA0D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Setup.Test", "test\Setup.Test\Setup.Test.csproj", "{5A3AB73D-F0E8-4DC6-B072-0D3B394621ED}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -379,6 +381,10 @@ Global
 		{E75E1F10-BC6F-4EB1-BA75-D897C45AEA0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E75E1F10-BC6F-4EB1-BA75-D897C45AEA0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E75E1F10-BC6F-4EB1-BA75-D897C45AEA0D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A3AB73D-F0E8-4DC6-B072-0D3B394621ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A3AB73D-F0E8-4DC6-B072-0D3B394621ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A3AB73D-F0E8-4DC6-B072-0D3B394621ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A3AB73D-F0E8-4DC6-B072-0D3B394621ED}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -440,6 +446,7 @@ Global
 		{7D98784C-C253-43FB-9873-25B65C6250D6} = {287CFF34-BBDB-4BC4-AF88-1E19A5A4679B}
 		{FFB09376-595B-6F93-36F0-70CAE90AFECB} = {287CFF34-BBDB-4BC4-AF88-1E19A5A4679B}
 		{E75E1F10-BC6F-4EB1-BA75-D897C45AEA0D} = {DD5BD056-4AAE-43EF-BBD2-0B569B8DA84F}
+		{5A3AB73D-F0E8-4DC6-B072-0D3B394621ED} = {DD5BD056-4AAE-43EF-BBD2-0B569B8DA84F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E01CBF68-2E20-425F-9EDB-E0A6510CA92F}

--- a/test/Setup.Test/ProgramTests.cs
+++ b/test/Setup.Test/ProgramTests.cs
@@ -1,0 +1,124 @@
+﻿using System.Net;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Bit.Setup;
+using NSubstitute;
+using RichardSzalay.MockHttp;
+
+namespace Setup.Test;
+
+public class ProgramTests
+{
+    [Fact(Explicit = true)]
+    public async Task Install_Works()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var installationId = $"{Guid.NewGuid()}";
+            var testApp = Substitute.For<Application>();
+            testApp.RootDirectory.Returns(tempDir.FullName);
+            testApp
+                .ReadInput(Arg.Any<string>())
+                .Returns(c =>
+                {
+                    var prompt = c.Arg<string>();
+                    return prompt switch
+                    {
+                        "Enter your installation id (get at https://bitwarden.com/host)" => installationId,
+                        "Enter your installation key" => "test-key",
+                        "Enter your region (US/EU) [US]" => "",
+                        _ => throw new NotImplementedException($"Prompt not configured: {prompt}"),
+                    };
+                });
+            testApp
+                .ReadQuestion(Arg.Any<string>())
+                .Returns(c =>
+                {
+                    var prompt = c.Arg<string>();
+                    return prompt switch
+                    {
+                        "Do you have a SSL certificate to use?" => false,
+                        "Do you want to generate a self-signed SSL certificate?" => true,
+                        _ => throw new NotImplementedException(prompt),
+                    };
+                });
+
+            var mockHandler = new MockHttpMessageHandler();
+
+            mockHandler
+                .Expect(HttpMethod.Get, $"https://api.bitwarden.com/installations/{installationId}")
+                .Respond(HttpStatusCode.OK, JsonContent.Create(new { enabled = true, }));
+
+            testApp
+                .GetHttpClient()
+                .Returns(mockHandler.ToHttpClient());
+
+            Program.MainCore([
+                "-install", "1",
+                "-domain", "example.com",
+                "-letsencrypt", "n",
+                "-os", "lin",
+                "-corev", "test-version-does-not-exist",
+                "-webv", "test-version-does-not-exist",
+                "-dbname", "test-db",
+                "-keyconnectorv", "test-version-does-not-exist",
+            ], testApp);
+
+            // Assert SSL certificate details
+            var baseDir = Path.Join(tempDir.FullName, "ssl", "self", "example.com");
+            var certFile = new FileInfo(Path.Join(baseDir, "certificate.crt"));
+            Assert.True(certFile.Exists);
+            var cert = new X509Certificate2(certFile.FullName);
+
+            var hundredYearsFromNow = DateTime.UtcNow.AddDays(36500);
+
+            Assert.InRange(cert.NotAfter, hundredYearsFromNow.AddMinutes(-1), hundredYearsFromNow.AddMinutes(1));
+
+            Assert.Equal("sha256RSA", cert.SignatureAlgorithm.FriendlyName);
+
+            var names = cert.SubjectName.EnumerateRelativeDistinguishedNames().ToList();
+
+            Assert.Equal(6, names.Count);
+
+            Assert.Contains(names, n => n.GetSingleElementType().FriendlyName == "C" && n.GetSingleElementValue() == "US");
+            Assert.Contains(names, n => n.GetSingleElementType().FriendlyName == "S" && n.GetSingleElementValue() == "California");
+            Assert.Contains(names, n => n.GetSingleElementType().FriendlyName == "L" && n.GetSingleElementValue() == "Santa Barbara");
+            Assert.Contains(names, n => n.GetSingleElementType().FriendlyName == "O" && n.GetSingleElementValue() == "Bitwarden Inc.");
+            Assert.Contains(names, n => n.GetSingleElementType().FriendlyName == "OU" && n.GetSingleElementValue() == "Bitwarden");
+            Assert.Contains(names, n => n.GetSingleElementType().FriendlyName == "CN" && n.GetSingleElementValue() == "example.com");
+
+            Assert.Equal(3, cert.Extensions.Count);
+            var san = Assert.Single(cert.Extensions.OfType<X509SubjectAlternativeNameExtension>());
+            var dns = Assert.Single(san.EnumerateDnsNames());
+            Assert.Equal("example.com", dns);
+            Assert.Empty(san.EnumerateIPAddresses());
+            Assert.False(san.Critical);
+
+            var basicConstraints = Assert.Single(cert.Extensions.OfType<X509BasicConstraintsExtension>());
+            Assert.True(basicConstraints.CertificateAuthority);
+            Assert.False(basicConstraints.HasPathLengthConstraint);
+            Assert.Equal(0, basicConstraints.PathLengthConstraint);
+            Assert.False(basicConstraints.Critical);
+
+            var subjectKeyIdentifier = Assert.Single(cert.Extensions.OfType<X509SubjectKeyIdentifierExtension>());
+            Assert.False(subjectKeyIdentifier.Critical);
+
+            // Validate that the private key can be imported in PEM format
+            using var rsa = RSA.Create();
+            rsa.ImportFromPem(
+                await File.ReadAllTextAsync(Path.Combine(baseDir, "private.key"), TestContext.Current.CancellationToken)
+            );
+
+            Assert.Equal(4096, rsa.KeySize);
+            Assert.Equal("RSA", rsa.KeyExchangeAlgorithm);
+
+            // Assert other things
+        }
+        finally
+        {
+            tempDir.Delete(true);
+        }
+    }
+}

--- a/test/Setup.Test/Setup.Test.csproj
+++ b/test/Setup.Test/Setup.Test.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Setup.Test</RootNamespace>
+    <TargetFramework>net8.0</TargetFramework>
+    <!--
+    This template uses native xUnit.net command line options when using 'dotnet run' and
+    VSTest by default when using 'dotnet test'. For more information on how to enable support
+    for Microsoft Testing Platform, please visit:
+      https://xunit.net/docs/getting-started/v3/microsoft-testing-platform
+    -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
+    <PackageReference Include="Kralizek.AutoFixture.Extensions.MockHttp" Version="2.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\util\Setup\Setup.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Setup.Test/xunit.runner.json
+++ b/test/Setup.Test/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}

--- a/util/Setup/AppIdBuilder.cs
+++ b/util/Setup/AppIdBuilder.cs
@@ -21,9 +21,9 @@ public class AppIdBuilder
 
         // Needed for backwards compatability with migrated U2F tokens.
         Helpers.WriteLine(_context, "Building FIDO U2F app id.");
-        Directory.CreateDirectory("/bitwarden/web/");
+        Directory.CreateDirectory($"{_context.App.RootDirectory}/web/");
         var template = Helpers.ReadTemplate("AppId");
-        using (var sw = File.CreateText("/bitwarden/web/app-id.json"))
+        using (var sw = File.CreateText($"{_context.App.RootDirectory}/web/app-id.json"))
         {
             sw.Write(template(model));
         }

--- a/util/Setup/CertBuilder.cs
+++ b/util/Setup/CertBuilder.cs
@@ -29,17 +29,17 @@ public class CertBuilder
 
             if (!skipSSL)
             {
-                _context.Config.Ssl = Helpers.ReadQuestion("Do you have a SSL certificate to use?");
+                _context.Config.Ssl = _context.App.ReadQuestion("Do you have a SSL certificate to use?");
                 if (_context.Config.Ssl)
                 {
-                    Directory.CreateDirectory($"/bitwarden/ssl/{_context.Install.Domain}/");
+                    Directory.CreateDirectory($"{_context.App.RootDirectory}/ssl/{_context.Install.Domain}/");
                     var message = "Make sure 'certificate.crt' and 'private.key' are provided in the \n" +
                                   "appropriate directory before running 'start' (see docs for info).";
                     Helpers.ShowBanner(_context, "NOTE", message);
                 }
-                else if (Helpers.ReadQuestion("Do you want to generate a self-signed SSL certificate?"))
+                else if (_context.App.ReadQuestion("Do you want to generate a self-signed SSL certificate?"))
                 {
-                    Directory.CreateDirectory($"/bitwarden/ssl/self/{_context.Install.Domain}/");
+                    Directory.CreateDirectory($"{_context.App.RootDirectory}/ssl/self/{_context.Install.Domain}/");
                     Helpers.WriteLine(_context, "Generating self signed SSL certificate.");
                     _context.Config.Ssl = true;
                     _context.Install.Trusted = false;
@@ -58,22 +58,22 @@ public class CertBuilder
         {
             _context.Install.Trusted = true;
             _context.Install.DiffieHellman = true;
-            Directory.CreateDirectory($"/bitwarden/letsencrypt/live/{_context.Install.Domain}/");
+            Directory.CreateDirectory($"{_context.App.RootDirectory}/letsencrypt/live/{_context.Install.Domain}/");
             Helpers.Exec($"openssl dhparam -out " +
-                $"/bitwarden/letsencrypt/live/{_context.Install.Domain}/dhparam.pem 2048");
+                $"{_context.App.RootDirectory}/letsencrypt/live/{_context.Install.Domain}/dhparam.pem 2048");
         }
         else if (_context.Config.Ssl && !_context.Install.SelfSignedCert)
         {
-            _context.Install.Trusted = Helpers.ReadQuestion("Is this a trusted SSL certificate " +
+            _context.Install.Trusted = _context.App.ReadQuestion("Is this a trusted SSL certificate " +
                 "(requires ca.crt, see docs)?");
         }
 
         Helpers.WriteLine(_context, "Generating key for IdentityServer.");
         _context.Install.IdentityCertPassword = Helpers.SecureRandomString(32, alpha: true, numeric: true);
-        Directory.CreateDirectory("/bitwarden/identity/");
+        Directory.CreateDirectory($"{_context.App.RootDirectory}/identity/");
         Helpers.Exec("openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout identity.key " +
             "-out identity.crt -subj \"/CN=Bitwarden IdentityServer\" -days 36500");
-        Helpers.Exec("openssl pkcs12 -export -out /bitwarden/identity/identity.pfx -inkey identity.key " +
+        Helpers.Exec($"openssl pkcs12 -export -out {_context.App.RootDirectory}/identity/identity.pfx -inkey identity.key " +
             $"-in identity.crt -passout pass:{_context.Install.IdentityCertPassword}");
 
         Helpers.WriteLine(_context);
@@ -97,14 +97,14 @@ public class CertBuilder
 
     public void BuildForUpdater()
     {
-        if (_context.Config.EnableKeyConnector && !File.Exists("/bitwarden/key-connector/bwkc.pfx"))
+        if (_context.Config.EnableKeyConnector && !File.Exists($"{_context.App.RootDirectory}/key-connector/bwkc.pfx"))
         {
-            Directory.CreateDirectory("/bitwarden/key-connector/");
-            var keyConnectorCertPassword = Helpers.GetValueFromEnvFile("key-connector",
+            Directory.CreateDirectory($"{_context.App.RootDirectory}/key-connector/");
+            var keyConnectorCertPassword = Helpers.GetValueFromEnvFile(_context.App, "key-connector",
                 "keyConnectorSettings__certificate__filesystemPassword");
             Helpers.Exec("openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout bwkc.key " +
                          "-out bwkc.crt -subj \"/CN=Bitwarden Key Connector\" -days 36500");
-            Helpers.Exec("openssl pkcs12 -export -out /bitwarden/key-connector/bwkc.pfx -inkey bwkc.key " +
+            Helpers.Exec($"openssl pkcs12 -export -out {_context.App.RootDirectory}/key-connector/bwkc.pfx -inkey bwkc.key " +
                          $"-in bwkc.crt -passout pass:{keyConnectorCertPassword}");
         }
     }

--- a/util/Setup/Context.cs
+++ b/util/Setup/Context.cs
@@ -9,7 +9,7 @@ namespace Bit.Setup;
 
 public class Context
 {
-    private const string ConfigPath = "/bitwarden/config.yml";
+    private string ConfigPath => $"{App.RootDirectory}/config.yml";
 
     // These track of old CSP default values to correct.
     // Do not change these values.
@@ -45,6 +45,8 @@ public class Context
         Jan2023ContentSecurityPolicy
     };
 
+    public required Application App { get; init; }
+
     public string[] Args { get; set; }
     public bool Quiet { get; set; }
     public bool Stub { get; set; }
@@ -69,7 +71,7 @@ public class Context
             Helpers.WriteLine(this, "No existing `config.yml` detected. Let's generate one.");
 
             // Looks like updating from older version. Try to create config file.
-            var url = Helpers.GetValueFromEnvFile("global", "globalSettings__baseServiceUri__vault");
+            var url = Helpers.GetValueFromEnvFile(App, "global", "globalSettings__baseServiceUri__vault");
             if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
             {
                 Helpers.WriteLine(this, "Unable to determine existing installation url.");
@@ -77,10 +79,10 @@ public class Context
             }
             Config.Url = url;
 
-            var push = Helpers.GetValueFromEnvFile("global", "globalSettings__pushRelayBaseUri");
+            var push = Helpers.GetValueFromEnvFile(App, "global", "globalSettings__pushRelayBaseUri");
             Config.PushNotifications = push != "REPLACE";
 
-            var composeFile = "/bitwarden/docker/docker-compose.yml";
+            var composeFile = $"{App.RootDirectory}/docker/docker-compose.yml";
             if (File.Exists(composeFile))
             {
                 var fileLines = File.ReadAllLines(composeFile);
@@ -118,7 +120,7 @@ public class Context
                 }
             }
 
-            var nginxFile = "/bitwarden/nginx/default.conf";
+            var nginxFile = $"{App.RootDirectory}/nginx/default.conf";
             if (File.Exists(nginxFile))
             {
                 var confContent = File.ReadAllText(nginxFile);
@@ -177,7 +179,7 @@ public class Context
             .WithEmissionPhaseObjectGraphVisitor(args => new CommentsObjectGraphVisitor(args.InnerVisitor))
             .Build();
         var yaml = serializer.Serialize(Config);
-        Directory.CreateDirectory("/bitwarden/");
+        Directory.CreateDirectory($"{App.RootDirectory}/");
         using (var sw = File.CreateText(ConfigPath))
         {
             sw.Write(yaml);

--- a/util/Setup/DockerComposeBuilder.cs
+++ b/util/Setup/DockerComposeBuilder.cs
@@ -22,7 +22,7 @@ public class DockerComposeBuilder
 
     private void Build()
     {
-        Directory.CreateDirectory("/bitwarden/docker/");
+        Directory.CreateDirectory($"{_context.App.RootDirectory}/docker/");
         Helpers.WriteLine(_context, "Building docker-compose.yml.");
         if (!_context.Config.GenerateComposeConfig)
         {
@@ -32,7 +32,7 @@ public class DockerComposeBuilder
 
         var template = Helpers.ReadTemplate("DockerCompose");
         var model = new TemplateModel(_context);
-        using (var sw = File.CreateText("/bitwarden/docker/docker-compose.yml"))
+        using (var sw = File.CreateText($"{_context.App.RootDirectory}/docker/docker-compose.yml"))
         {
             sw.Write(template(model));
         }

--- a/util/Setup/EnvironmentFileBuilder.cs
+++ b/util/Setup/EnvironmentFileBuilder.cs
@@ -35,7 +35,7 @@ public class EnvironmentFileBuilder
 
     public void BuildForInstaller()
     {
-        Directory.CreateDirectory("/bitwarden/env/");
+        Directory.CreateDirectory($"{_context.App.RootDirectory}/env/");
         Init();
         Build();
     }
@@ -43,9 +43,9 @@ public class EnvironmentFileBuilder
     public void BuildForUpdater()
     {
         Init();
-        LoadExistingValues(_globalOverrideValues, "/bitwarden/env/global.override.env");
-        LoadExistingValues(_mssqlOverrideValues, "/bitwarden/env/mssql.override.env");
-        LoadExistingValues(_keyConnectorOverrideValues, "/bitwarden/env/key-connector.override.env");
+        LoadExistingValues(_globalOverrideValues, $"{_context.App.RootDirectory}/env/global.override.env");
+        LoadExistingValues(_mssqlOverrideValues, $"{_context.App.RootDirectory}/env/mssql.override.env");
+        LoadExistingValues(_keyConnectorOverrideValues, $"{_context.App.RootDirectory}/env/key-connector.override.env");
 
         if (_context.Config.PushNotifications &&
             _globalOverrideValues.ContainsKey("globalSettings__pushRelayBaseUri") &&
@@ -173,47 +173,47 @@ public class EnvironmentFileBuilder
         var template = Helpers.ReadTemplate("EnvironmentFile");
 
         Helpers.WriteLine(_context, "Building docker environment files.");
-        Directory.CreateDirectory("/bitwarden/docker/");
-        using (var sw = File.CreateText("/bitwarden/docker/global.env"))
+        Directory.CreateDirectory($"{_context.App.RootDirectory}/docker/");
+        using (var sw = File.CreateText($"{_context.App.RootDirectory}/docker/global.env"))
         {
             sw.Write(template(new TemplateModel(_globalValues)));
         }
-        Helpers.Exec("chmod 600 /bitwarden/docker/global.env");
+        Helpers.Exec($"chmod 600 {_context.App.RootDirectory}/docker/global.env");
 
-        using (var sw = File.CreateText("/bitwarden/docker/mssql.env"))
+        using (var sw = File.CreateText($"{_context.App.RootDirectory}/docker/mssql.env"))
         {
             sw.Write(template(new TemplateModel(_mssqlValues)));
         }
-        Helpers.Exec("chmod 600 /bitwarden/docker/mssql.env");
+        Helpers.Exec($"chmod 600 {_context.App.RootDirectory}/docker/mssql.env");
 
         Helpers.WriteLine(_context, "Building docker environment override files.");
-        Directory.CreateDirectory("/bitwarden/env/");
-        using (var sw = File.CreateText("/bitwarden/env/global.override.env"))
+        Directory.CreateDirectory($"{_context.App.RootDirectory}/env/");
+        using (var sw = File.CreateText($"{_context.App.RootDirectory}/env/global.override.env"))
         {
             sw.Write(template(new TemplateModel(_globalOverrideValues)));
         }
-        Helpers.Exec("chmod 600 /bitwarden/env/global.override.env");
+        Helpers.Exec($"chmod 600 {_context.App.RootDirectory}/env/global.override.env");
 
-        using (var sw = File.CreateText("/bitwarden/env/mssql.override.env"))
+        using (var sw = File.CreateText($"{_context.App.RootDirectory}/env/mssql.override.env"))
         {
             sw.Write(template(new TemplateModel(_mssqlOverrideValues)));
         }
-        Helpers.Exec("chmod 600 /bitwarden/env/mssql.override.env");
+        Helpers.Exec($"chmod 600 {_context.App.RootDirectory}/env/mssql.override.env");
 
         if (_context.Config.EnableKeyConnector)
         {
-            using (var sw = File.CreateText("/bitwarden/env/key-connector.override.env"))
+            using (var sw = File.CreateText($"{_context.App.RootDirectory}/env/key-connector.override.env"))
             {
                 sw.Write(template(new TemplateModel(_keyConnectorOverrideValues)));
             }
 
-            Helpers.Exec("chmod 600 /bitwarden/env/key-connector.override.env");
+            Helpers.Exec($"chmod 600 {_context.App.RootDirectory}/env/key-connector.override.env");
         }
 
         // Empty uid env file. Only used on Linux hosts.
-        if (!File.Exists("/bitwarden/env/uid.env"))
+        if (!File.Exists($"{_context.App.RootDirectory}/env/uid.env"))
         {
-            using (var sw = File.CreateText("/bitwarden/env/uid.env")) { }
+            using (var sw = File.CreateText($"{_context.App.RootDirectory}/env/uid.env")) { }
         }
     }
 

--- a/util/Setup/Helpers.cs
+++ b/util/Setup/Helpers.cs
@@ -93,14 +93,14 @@ public static class Helpers
         return characters;
     }
 
-    public static string GetValueFromEnvFile(string envFile, string key)
+    public static string GetValueFromEnvFile(Application config, string envFile, string key)
     {
-        if (!File.Exists($"/bitwarden/env/{envFile}.override.env"))
+        if (!File.Exists($"{config.RootDirectory}/env/{envFile}.override.env"))
         {
             return null;
         }
 
-        var lines = File.ReadAllLines($"/bitwarden/env/{envFile}.override.env");
+        var lines = File.ReadAllLines($"{config.RootDirectory}/env/{envFile}.override.env");
         foreach (var line in lines)
         {
             if (line.StartsWith($"{key}="))

--- a/util/Setup/NginxConfigBuilder.cs
+++ b/util/Setup/NginxConfigBuilder.cs
@@ -5,7 +5,7 @@ namespace Bit.Setup;
 
 public class NginxConfigBuilder
 {
-    private const string ConfFile = "/bitwarden/nginx/default.conf";
+    private string ConfFile => $"{_context.App.RootDirectory}/nginx/default.conf";
 
     private const string DefaultContentSecurityPolicy = "default-src 'self'; " +
         "script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; " +
@@ -55,7 +55,7 @@ public class NginxConfigBuilder
 
     private void Build(TemplateModel model)
     {
-        Directory.CreateDirectory("/bitwarden/nginx/");
+        Directory.CreateDirectory($"{_context.App.RootDirectory}/nginx/");
         Helpers.WriteLine(_context, "Building nginx config.");
         if (!_context.Config.GenerateNginxConfig)
         {

--- a/util/Setup/Program.cs
+++ b/util/Setup/Program.cs
@@ -153,7 +153,7 @@ public class Program
         Console.WriteLine(string.Empty);
     }
 
-    private static void Update(Application config)
+    private static void Update(Application application)
     {
         // This portion of code checks for multiple certs in the Identity.pfx PKCS12 bag.  If found, it generates
         // a new cert and bag to replace the old Identity.pfx.  This fixes an issue that came up as a result of

--- a/util/Setup/Program.cs
+++ b/util/Setup/Program.cs
@@ -8,16 +8,34 @@ using Bit.Setup.Enums;
 
 namespace Bit.Setup;
 
+public class Application
+{
+    public virtual string RootDirectory => "/bitwarden";
+    public virtual bool ReadQuestion(string prompt) => Helpers.ReadQuestion(prompt);
+    public virtual string ReadInput(string prompt) => Helpers.ReadInput(prompt);
+    public virtual HttpClient GetHttpClient()
+    {
+        return new HttpClient();
+    }
+}
+
 public class Program
 {
     private static Context _context;
 
     public static void Main(string[] args)
     {
+        MainCore(args, new Application());
+    }
+
+    // internal for testing
+    internal static void MainCore(string[] args, Application application)
+    {
         CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
 
         _context = new Context
         {
+            App = application,
             Args = args
         };
 
@@ -52,11 +70,11 @@ public class Program
 
         if (_context.Parameters.ContainsKey("install"))
         {
-            Install();
+            Install(application);
         }
         else if (_context.Parameters.ContainsKey("update"))
         {
-            Update();
+            Update(application);
         }
         else if (_context.Parameters.ContainsKey("printenv"))
         {
@@ -68,7 +86,7 @@ public class Program
         }
     }
 
-    private static void Install()
+    private static void Install(Application application)
     {
         if (_context.Parameters.TryGetValue("letsencrypt", out var sslManagedLetsEncrypt))
         {
@@ -89,7 +107,7 @@ public class Program
             _context.Install.InstallationId = Guid.Empty;
             _context.Install.InstallationKey = "SECRET_INSTALLATION_KEY";
         }
-        else if (!ValidateInstallation())
+        else if (!ValidateInstallation(application))
         {
             return;
         }
@@ -135,24 +153,24 @@ public class Program
         Console.WriteLine(string.Empty);
     }
 
-    private static void Update()
+    private static void Update(Application config)
     {
         // This portion of code checks for multiple certs in the Identity.pfx PKCS12 bag.  If found, it generates
         // a new cert and bag to replace the old Identity.pfx.  This fixes an issue that came up as a result of
         // moving the project to .NET 5.
-        _context.Install.IdentityCertPassword = Helpers.GetValueFromEnvFile("global", "globalSettings__identityServer__certificatePassword");
-        var certCountString = Helpers.Exec("openssl pkcs12 -nokeys -info -in /bitwarden/identity/identity.pfx " +
+        _context.Install.IdentityCertPassword = Helpers.GetValueFromEnvFile(_context.App, "global", "globalSettings__identityServer__certificatePassword");
+        var certCountString = Helpers.Exec($"openssl pkcs12 -nokeys -info -in {config.RootDirectory}/identity/identity.pfx " +
             $"-passin pass:{_context.Install.IdentityCertPassword} 2> /dev/null | grep -c \"\\-----BEGIN CERTIFICATE----\"", true);
         if (int.TryParse(certCountString, out var certCount) && certCount > 1)
         {
             // Extract key from identity.pfx
-            Helpers.Exec("openssl pkcs12 -in /bitwarden/identity/identity.pfx -nocerts -nodes -out identity.key " +
+            Helpers.Exec($"openssl pkcs12 -in {config.RootDirectory}/identity/identity.pfx -nocerts -nodes -out identity.key " +
                 $"-passin pass:{_context.Install.IdentityCertPassword} > /dev/null 2>&1");
             // Extract certificate from identity.pfx
-            Helpers.Exec("openssl pkcs12 -in /bitwarden/identity/identity.pfx -clcerts -nokeys -out identity.crt " +
+            Helpers.Exec($"openssl pkcs12 -in {config.RootDirectory}/identity/identity.pfx -clcerts -nokeys -out identity.crt " +
                 $"-passin pass:{_context.Install.IdentityCertPassword} > /dev/null 2>&1");
             // Create new PKCS12 bag with certificate and key
-            Helpers.Exec("openssl pkcs12 -export -out /bitwarden/identity/identity.pfx -inkey identity.key " +
+            Helpers.Exec($"openssl pkcs12 -export -out {config.RootDirectory}/identity/identity.pfx -inkey identity.key " +
                 $"-in identity.crt -passout pass:{_context.Install.IdentityCertPassword} > /dev/null 2>&1");
         }
 
@@ -190,7 +208,7 @@ public class Program
 
     private static void PrepareAndMigrateDatabase()
     {
-        var vaultConnectionString = Helpers.GetValueFromEnvFile("global",
+        var vaultConnectionString = Helpers.GetValueFromEnvFile(_context.App, "global",
             "globalSettings__sqlServer__connectionString");
         var migrator = new DbMigrator(vaultConnectionString);
 
@@ -203,7 +221,7 @@ public class Program
         migrator.MigrateMsSqlDatabaseWithRetries(enableLogging, true, MigratorConstants.TransitionMigrationsFolderName);
     }
 
-    private static bool ValidateInstallation()
+    private static bool ValidateInstallation(Application application)
     {
         var installationId = string.Empty;
         var installationKey = string.Empty;
@@ -216,11 +234,11 @@ public class Program
         else
         {
             var prompt = "Enter your installation id (get at https://bitwarden.com/host)";
-            installationId = Helpers.ReadInput(prompt);
+            installationId = application.ReadInput(prompt);
             while (string.IsNullOrEmpty(installationId))
             {
                 Helpers.WriteError("Invalid input for installation id. Please try again.");
-                installationId = Helpers.ReadInput(prompt);
+                installationId = application.ReadInput(prompt);
             }
         }
 
@@ -237,11 +255,11 @@ public class Program
         else
         {
             var prompt = "Enter your installation key";
-            installationKey = Helpers.ReadInput(prompt);
+            installationKey = application.ReadInput(prompt);
             while (string.IsNullOrEmpty(installationKey))
             {
                 Helpers.WriteError("Invalid input for installation key. Please try again.");
-                installationKey = Helpers.ReadInput(prompt);
+                installationKey = application.ReadInput(prompt);
             }
         }
 
@@ -252,13 +270,13 @@ public class Program
         else
         {
             var prompt = "Enter your region (US/EU) [US]";
-            var region = Helpers.ReadInput(prompt);
+            var region = application.ReadInput(prompt);
             if (string.IsNullOrEmpty(region)) region = "US";
 
             while (!Enum.TryParse(region, out cloudRegion))
             {
                 Helpers.WriteError("Invalid input for region. Please try again.");
-                region = Helpers.ReadInput(prompt);
+                region = application.ReadInput(prompt);
                 if (string.IsNullOrEmpty(region)) region = "US";
             }
         }
@@ -287,7 +305,7 @@ public class Program
                 url = $"{installationUrl}/installations/";
             }
 
-            var response = new HttpClient().GetAsync(url + _context.Install.InstallationId).GetAwaiter().GetResult();
+            var response = _context.App.GetHttpClient().GetAsync(url + _context.Install.InstallationId).GetAwaiter().GetResult();
 
             if (!response.IsSuccessStatusCode)
             {

--- a/util/Setup/Program.cs
+++ b/util/Setup/Program.cs
@@ -159,18 +159,18 @@ public class Program
         // a new cert and bag to replace the old Identity.pfx.  This fixes an issue that came up as a result of
         // moving the project to .NET 5.
         _context.Install.IdentityCertPassword = Helpers.GetValueFromEnvFile(_context.App, "global", "globalSettings__identityServer__certificatePassword");
-        var certCountString = Helpers.Exec($"openssl pkcs12 -nokeys -info -in {config.RootDirectory}/identity/identity.pfx " +
+        var certCountString = Helpers.Exec($"openssl pkcs12 -nokeys -info -in {application.RootDirectory}/identity/identity.pfx " +
             $"-passin pass:{_context.Install.IdentityCertPassword} 2> /dev/null | grep -c \"\\-----BEGIN CERTIFICATE----\"", true);
         if (int.TryParse(certCountString, out var certCount) && certCount > 1)
         {
             // Extract key from identity.pfx
-            Helpers.Exec($"openssl pkcs12 -in {config.RootDirectory}/identity/identity.pfx -nocerts -nodes -out identity.key " +
+            Helpers.Exec($"openssl pkcs12 -in {application.RootDirectory}/identity/identity.pfx -nocerts -nodes -out identity.key " +
                 $"-passin pass:{_context.Install.IdentityCertPassword} > /dev/null 2>&1");
             // Extract certificate from identity.pfx
-            Helpers.Exec($"openssl pkcs12 -in {config.RootDirectory}/identity/identity.pfx -clcerts -nokeys -out identity.crt " +
+            Helpers.Exec($"openssl pkcs12 -in {application.RootDirectory}/identity/identity.pfx -clcerts -nokeys -out identity.crt " +
                 $"-passin pass:{_context.Install.IdentityCertPassword} > /dev/null 2>&1");
             // Create new PKCS12 bag with certificate and key
-            Helpers.Exec($"openssl pkcs12 -export -out {config.RootDirectory}/identity/identity.pfx -inkey identity.key " +
+            Helpers.Exec($"openssl pkcs12 -export -out {application.RootDirectory}/identity/identity.pfx -inkey identity.key " +
                 $"-in identity.crt -passout pass:{_context.Install.IdentityCertPassword} > /dev/null 2>&1");
         }
 

--- a/util/Setup/Setup.csproj
+++ b/util/Setup/Setup.csproj
@@ -21,4 +21,8 @@
     <ProjectReference Include="..\Migrator\Migrator.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Setup.Test" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-35150

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This makes the `Setup` project much more testable. It is an explicit test because the test currently requires openssl and bash which will not work on all development environments. It makes it possible to invoke the program with a custom root directory so that you can save things into a temp directory. This makes it possible to run multiple tests in parallel without worrying about them clobbering each other. It also allows the ability to respond to prompts through mocking instead of dealing with stdin. Right now you still can't assert on logs at all since all tests will go to the same stdout and be unreliable. Making that mockable could be a good next step but for now you just need to assert on the files it creates which is the most important outcome of this utility. 

The one test that I wrote to prove this working is for the install process and I make a lot of assertions about the cert that we generate for TLS. This is because we may soon be switching that code to use managed C# API's instead of using the `openssl` CLI utility. There are still a lot of file assertions that could be made from the `-install` path but I left this short of that. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
