### PR TITLE
Add scenario docs for Seeder adoption and trim CLI reference

### DIFF
--- a/util/Seeder/CLAUDE.md
+++ b/util/Seeder/CLAUDE.md
@@ -159,6 +159,7 @@ Developer-facing documentation in `Seeds/docs/scenarios/`. Each file maps an eng
 
 - When adding a new preset, check if an existing scenario should reference it as a variation
 - When adding a new command or flag, check if it enables a new scenario or changes an existing one
+- When CLI flags, commands, or preset names change, scan all `*.md` files under `Seeds/` and `SeederUtility/` for stale references
 - Scenario files follow the template in `Seeds/docs/scenarios/README.md`
 - Never duplicate CLI flag documentation — link to `SeederUtility/README.md`
 - Never duplicate preset catalog details — link to `Seeds/docs/presets.md`

--- a/util/Seeder/CLAUDE.md
+++ b/util/Seeder/CLAUDE.md
@@ -124,11 +124,13 @@ The Seeder uses the Rust SDK via FFI because it must behave like a real Bitwarde
 ## Data Flow
 
 ### Pipeline path (fixture → entity)
+
 ```
 SeedVaultItem → CipherSeed.FromSeedItem() → CipherSeed → {Type}CipherSeeder.Create(options) → CipherViewDto → encrypt_fields (Rust FFI) → EncryptedCipherDto → EncryptedCipherDtoExtensions → Server Cipher Entity
 ```
 
 ### Core encryption (shared by all paths)
+
 ```
 CipherViewDto → JSON + [EncryptProperty] field paths → encrypt_fields (Rust FFI, bitwarden_crypto) → EncryptedCipherDto → EncryptedCipherDtoExtensions → Server Cipher Entity
 ```
@@ -148,6 +150,25 @@ Same domain = same seed = reproducible data:
 ```csharp
 var seed = options.Seed ?? DeriveStableSeed(options.Domain);
 ```
+
+## Scenarios
+
+Developer-facing documentation in `Seeds/docs/scenarios/`. Each file maps an engineering problem to a Seeder command.
+
+**Maintenance rules:**
+
+- When adding a new preset, check if an existing scenario should reference it as a variation
+- When adding a new command or flag, check if it enables a new scenario or changes an existing one
+- Scenario files follow the template in `Seeds/docs/scenarios/README.md`
+- Never duplicate CLI flag documentation — link to `SeederUtility/README.md`
+- Never duplicate preset catalog details — link to `Seeds/docs/presets.md`
+- Scenarios describe _why_ (the problem). READMEs describe _how_ (the tool). Keep the split clean.
+
+**File relationships:**
+
+- `SeederUtility/README.md` → CLI reference (commands, flags, examples) → links to scenarios
+- `Seeds/docs/presets.md` → what exists (the catalog) → scenarios link back to it
+- `Seeds/docs/scenarios/` → why you'd use it (problem → command)
 
 ## Security Reminders
 

--- a/util/Seeder/Seeds/docs/scenarios/README.md
+++ b/util/Seeder/Seeds/docs/scenarios/README.md
@@ -1,0 +1,64 @@
+# Seeder Scenarios
+
+Not sure what to run? Start here. Each scenario starts with a problem and ends with a command.
+
+**The Seeder writes directly to your database. Only run it against local development databases.**
+
+All commands run from `util/SeederUtility/`. All seeded users use password `asdfasdfasdf` (override with `--password`). Use `--mangle` for test isolation (randomizes IDs and emails so repeated runs don't collide).
+
+For CLI flag details, see the [SeederUtility reference](../../../../SeederUtility/README.md). For the full preset catalog, see [presets.md](../presets.md).
+
+## Scenarios
+
+| Scenario                                    | Problem                                                        | Command type   |
+| ------------------------------------------- | -------------------------------------------------------------- | -------------- |
+| [Fresh database](fresh-database.md)         | I need a working database with realistic data                  | `preset`       |
+| [Permission testing](permission-testing.md) | I'm building a feature that touches collections or permissions | `preset`       |
+| [Scale testing](scale-testing.md)           | Will my code survive at 250 / 1,000 / 5,000+ users?            | `preset`       |
+| [Bug reproduction](bug-reproduction.md)     | I need to reproduce a customer's org shape                     | `organization` |
+
+## Contributing a Scenario
+
+If you solved a problem with the Seeder that isn't listed here, add it. One file per scenario.
+
+1. Copy the template below into a new file in this folder (kebab-case name)
+2. Fill it in
+3. Add a row to the table above
+4. Open a PR
+
+### Template
+
+```markdown
+# [Problem as a question]
+
+> One-sentence pain statement.
+
+## Quick start
+
+\`\`\`bash
+dotnet run -- <your command here>
+\`\`\`
+
+## What you get
+
+What's in the database after this runs. Entity counts, login credentials, notable structure.
+
+## Who this is for
+
+Engineers who feel this pain.
+
+## Variations
+
+Other flags or presets worth trying for this problem.
+```
+
+## Field Test Feedback
+
+Tried the Seeder and have feedback? We want to hear it:
+
+- What did you try?
+- What worked?
+- What was confusing or missing?
+- What scenario do you wish existed?
+
+Open an issue or start a thread in Slack.

--- a/util/Seeder/Seeds/docs/scenarios/bug-reproduction.md
+++ b/util/Seeder/Seeds/docs/scenarios/bug-reproduction.md
@@ -1,0 +1,30 @@
+# I need to reproduce a customer's org shape
+
+> Bug report says "200 users, 800 collections, 8 groups." Can't repro locally.
+
+## Quick start
+
+```bash
+dotnet run -- organization -n BugRepro -d repro.example -u 200 -c 800 -g 8 --mangle
+```
+
+> Only run the Seeder against local development databases. Use fictional domains and round numbers — do not replicate exact customer details.
+
+Tweak the numbers to match the customer's profile. The `organization` command gives you full control over user count (`-u`), cipher count (`-c`), group count (`-g`), org structure (`-o`), region, and plan type.
+
+## What you get
+
+An org approximating the customer's shape with encrypted vault data, group memberships, and collection assignments. The owner email is printed in the CLI output — log in with password `asdfasdfasdf`.
+
+## Who this is for
+
+Any engineer reproducing a customer-reported issue.
+
+## Variations
+
+| Scenario                                   | Command                                                               |
+| ------------------------------------------ | --------------------------------------------------------------------- |
+| Match a specific plan type                 | Add `--plan-type teams-annually` or `--plan-type enterprise-annually` |
+| No vault data (just users + org structure) | Omit `-c` — e.g., `-n BugRepro -d repro.example -u 200 -g 8`          |
+| Specific org structure                     | Add `-o Traditional`, `-o Spotify`, or `-o Modern`                    |
+| Production-realistic auth for e2e          | Add `--kdf-iterations 600000`                                         |

--- a/util/Seeder/Seeds/docs/scenarios/bug-reproduction.md
+++ b/util/Seeder/Seeds/docs/scenarios/bug-reproduction.md
@@ -8,8 +8,6 @@
 dotnet run -- organization -n BugRepro -d repro.example -u 200 -c 500 --collections 800 -g 8 --mangle
 ```
 
-> Only run the Seeder against local development databases. Use fictional domains and round numbers — do not replicate exact customer details.
-
 Tweak the numbers to match the customer's profile. The `organization` command gives you full control over user count (`-u`), cipher count (`-c`), group count (`-g`), org structure (`-o`), region, and plan type.
 
 ## What you get

--- a/util/Seeder/Seeds/docs/scenarios/bug-reproduction.md
+++ b/util/Seeder/Seeds/docs/scenarios/bug-reproduction.md
@@ -5,7 +5,7 @@
 ## Quick start
 
 ```bash
-dotnet run -- organization -n BugRepro -d repro.example -u 200 -c 800 -g 8 --mangle
+dotnet run -- organization -n BugRepro -d repro.example -u 200 -collections 800 -g 8 --mangle
 ```
 
 > Only run the Seeder against local development databases. Use fictional domains and round numbers — do not replicate exact customer details.

--- a/util/Seeder/Seeds/docs/scenarios/bug-reproduction.md
+++ b/util/Seeder/Seeds/docs/scenarios/bug-reproduction.md
@@ -5,7 +5,7 @@
 ## Quick start
 
 ```bash
-dotnet run -- organization -n BugRepro -d repro.example -u 200 -collections 800 -g 8 --mangle
+dotnet run -- organization -n BugRepro -d repro.example -u 200 -c 500 --collections 800 -g 8 --mangle
 ```
 
 > Only run the Seeder against local development databases. Use fictional domains and round numbers — do not replicate exact customer details.

--- a/util/Seeder/Seeds/docs/scenarios/fresh-database.md
+++ b/util/Seeder/Seeds/docs/scenarios/fresh-database.md
@@ -1,0 +1,26 @@
+# I need a working database with realistic data
+
+> Just wiped my DB, new to the team, or starting fresh. I need something to log into.
+
+## Quick start
+
+```bash
+dotnet run -- preset --name qa.enterprise-basic --mangle
+```
+
+## What you get
+
+A standard enterprise org with known users, groups, collections, and encrypted vault items. The owner email is printed in the CLI output — log in with password `asdfasdfasdf`.
+
+## Who this is for
+
+New hires, anyone who just reset their environment, anyone who wants a clean baseline.
+
+## Variations
+
+| Scenario                         | Command                                                                                       |
+| -------------------------------- | --------------------------------------------------------------------------------------------- |
+| Larger org (58 users, 14 groups) | `dotnet run -- preset --name qa.dunder-mifflin-enterprise-full --mangle`                      |
+| Families plan                    | `dotnet run -- preset --name qa.families-basic --mangle`                                      |
+| Free plan personal vault         | `dotnet run -- preset --name qa.stark-free-basic --mangle`                                    |
+| Just a user, no org              | `dotnet run -- individual --subscription premium --first-name Jane --last-name Smith --vault` |

--- a/util/Seeder/Seeds/docs/scenarios/permission-testing.md
+++ b/util/Seeder/Seeds/docs/scenarios/permission-testing.md
@@ -1,0 +1,27 @@
+# I'm building a feature that touches collections or permissions
+
+> Setting up permission edge cases manually is tedious and error-prone. I need readOnly, hidePasswords, and manage combos already wired up.
+
+## Quick start
+
+```bash
+dotnet run -- preset --name qa.collection-permissions-enterprise --mangle
+```
+
+## What you get
+
+An enterprise org with collections pre-configured to cover permission edge cases — combinations of readOnly, hidePasswords, and manage assigned both directly to users and through groups. Owner email is printed in the CLI output, password `asdfasdfasdf`.
+
+This isn't random data. The test data was hand-crafted to exercise the permission paths that break in production.
+
+## Who this is for
+
+Engineers working on collection access, permission inheritance, or group-based authorization.
+
+## Variations
+
+| Scenario                                           | Command                                                                  |
+| -------------------------------------------------- | ------------------------------------------------------------------------ |
+| Full enterprise org with named folders + favorites | `dotnet run -- preset --name qa.zero-knowledge-labs-enterprise --mangle` |
+| Large org (58 users) with groups and collections   | `dotnet run -- preset --name qa.dunder-mifflin-enterprise-full --mangle` |
+| Scale with high permission density (2,500 users)   | `dotnet run -- preset --name scale.lg-highperm-tyrell-corp --mangle`     |

--- a/util/Seeder/Seeds/docs/scenarios/scale-testing.md
+++ b/util/Seeder/Seeds/docs/scenarios/scale-testing.md
@@ -1,0 +1,40 @@
+# Will my code survive at 250 / 1,000 / 5,000+ users?
+
+> "I think this will scale, but I have no way to verify."
+
+## Quick start
+
+Pick the tier that matches your concern:
+
+```bash
+# 250 users, 50 groups, 500 collections, 5K ciphers
+dotnet run -- preset --name scale.md-balanced-sterling-cooper --mangle
+
+# 1,000 users, 100 groups, 2K collections, 10K ciphers
+dotnet run -- preset --name scale.lg-balanced-wayne-enterprises --mangle
+
+# 5,000 users, 500 groups, 1.2K collections, 15K ciphers
+dotnet run -- preset --name scale.xl-highperm-weyland-yutani --mangle
+```
+
+## What you get
+
+These presets go beyond row counts. They model realistic group sizes (a few large groups, many small ones), varied permission types (readOnly, manage, hidePasswords), unassigned ciphers, and items belonging to multiple collections. The data shape mirrors real enterprise customers.
+
+This is the difference between "25K users with 5 groups" (useless) and "250 users with 50 groups across 500 collections where group sizes vary realistically" (the bug finder).
+
+The owner email is printed in the CLI output — log in with password `asdfasdfasdf`.
+
+## Who this is for
+
+Anyone touching queries, list views, API endpoints, or anything that multiplies across users, groups, and collections.
+
+## Variations
+
+The full scale catalog is in [presets.md](../presets.md#scale). Other shapes worth knowing:
+
+| Shape                                        | Preset                                  | Why                                            |
+| -------------------------------------------- | --------------------------------------- | ---------------------------------------------- |
+| Collection-heavy (800 collections, 8 groups) | `scale.md-highcollection-umbrella-corp` | Few groups managing many collections              |
+| High permission density                      | `scale.lg-highperm-tyrell-corp`         | 2,500 users with heavily skewed permissions       |
+| Mega corp, many collections                  | `scale.xl-broad-initech`                | 10K users, 12K collections, most ciphers unassigned |

--- a/util/SeederUtility/README.md
+++ b/util/SeederUtility/README.md
@@ -2,6 +2,8 @@
 
 A CLI wrapper around the Seeder library for generating test data in a Bitwarden database.
 
+**Not sure what to run?** See [Scenarios](../Seeder/Seeds/docs/scenarios/README.md) — problem-oriented guides that map common tasks to commands.
+
 ## Getting Started
 
 Build and run from the `util/SeederUtility` directory:
@@ -20,63 +22,31 @@ dotnet run -- <command> [options]
 Full control over the org shape via CLI flags — user count, domain, structure, region, density, and plan type. Reach for this when you need flexibility the preset catalog doesn't offer, including orgs with no vault data (every preset includes ciphers).
 
 ```bash
+# Small org with vault data
+dotnet run -- organization -n SmallOrg -d small.example -u 3 -c 10 -g 5 -o Traditional --mangle
+
 # Users only — no vault data
 dotnet run -- organization -n MyOrgNoCiphers -u 100 -d myorg-no-ciphers.example
 
-# 10,000 users for load testing
-dotnet run -- organization -n LargeOrgNoCiphers -u 10000 -d large-org-no-ciphers.example
-
-# With vault data (ciphers, groups, collections)
-dotnet run -- organization -n SmallOrg -d small.example -u 3 -c 10 -g 5 -o Traditional -m
-
-# Mid-size Traditional org with realistic status mix
-dotnet run -- organization -n MidOrg -d mid.example -u 50 -c 1000 -g 15 -o Traditional -m
-
-# Large Modern org
-dotnet run -- organization -n LargeOrg -d large.example -u 500 -c 10000 -g 85 -o Modern -m
-
-# Stress test — massive Spotify-style org
-dotnet run -- organization -n StressOrg -d stress.example -u 8000 -c 100000 -g 125 -o Spotify -m
-
-# Regional data variants
-dotnet run -- organization -n EuropeOrg -d europe.example -u 10 -c 100 -g 5 --region Europe
-dotnet run -- organization -n ApacOrg -d apac.example -u 17 -c 600 -g 12 --region AsiaPacific
-
-# With ID mangling for test isolation
-dotnet run -- organization -n IsolatedOrg -d isolated.example -u 5 -c 25 -g 4 -o Spotify --mangle
-
 # With custom password and plan type
-dotnet run -- organization -n CustomPwOrg -d custom-password-05.example -u 10 -c 100 -g 3 --password "MyTestPassword1" --plan-type teams-annually
-
-# Free plan org
-dotnet run -- organization -n FreeOrg -d free.example -u 1 -c 10 -g 1 --plan-type free
-
-# Teams plan org
-dotnet run -- organization -n TeamsOrg -d teams.example -u 20 -c 200 -g 5 --plan-type teams-annually
-
-# Production-realistic KDF iterations (600k) for e2e auth testing
-dotnet run -- organization -n E2eOrg -d e2e.example -u 5 -c 25 --kdf-iterations 600000 --mangle
+dotnet run -- organization -n CustomOrg -d custom.example -u 10 -c 100 -g 3 --password "MyTestPassword1" --plan-type teams-annually
 ```
+
+Additional flags include `--region`, `--kdf-iterations`, and `--plan-type`. Run `dotnet run -- organization --help` for the full list.
 
 ### `individual` - Seed an Individual User
 
 Full control over the user via CLI flags — subscription tier, identity, and optional vault data. Reach for this when you need a named user with a predictable email or a personal vault with generated items; the individual presets create bare accounts with no vault data.
 
 ```bash
-# Named user — predictable email (john.doe@individual.example), no mangling needed
+# Named user — predictable email (john.doe@individual.example)
 dotnet run -- individual --subscription free --first-name John --last-name Doe
 
 # Premium named user with personal vault (~75 ciphers, 5 folders)
 dotnet run -- individual --subscription premium --first-name Jane --last-name Smith --vault
 
-# Random name — mangling auto-enabled (no names = random Faker identity)
+# Random name — mangling auto-enabled
 dotnet run -- individual --subscription premium --vault
-
-# With custom password
-dotnet run -- individual --subscription free --first-name John --last-name Doe --vault --password "MyTestPassword1"
-
-# Production-realistic KDF iterations for e2e auth testing
-dotnet run -- individual --subscription premium --first-name Test --last-name User --kdf-iterations 600000
 ```
 
 ### `preset` - Fixture-Based Seeding
@@ -84,31 +54,17 @@ dotnet run -- individual --subscription premium --first-name Test --last-name Us
 Loads a named configuration from the embedded catalog. Presets are curated JSON fixtures with specific users, groups, collections, and cipher relationships — the same data every time. Reach for this when you need a known, reproducible scenario rather than generated data.
 
 ```bash
-# List available presets and fixtures
+# List available presets
 dotnet run -- preset --list
 
-# Load the Dunder Mifflin preset (58 users, 14 groups, 15 collections, ciphers)
-dotnet run -- preset --name qa.dunder-mifflin-enterprise-full
-
-# Zero Knowledge Labs — 429 users, named folders, favorites
-dotnet run -- preset --name qa.zero-knowledge-labs-enterprise --mangle
-
-# Load with ID mangling for test isolation
-dotnet run -- preset --name qa.dunder-mifflin-enterprise-full --mangle
-
-dotnet run -- preset --name qa.stark-free-basic --mangle
+# QA preset with known users and relationships
+dotnet run -- preset --name qa.enterprise-basic --mangle
 
 # Scale preset for performance testing
-dotnet run -- preset --name scale.xs-central-perk --mangle
+dotnet run -- preset --name scale.md-balanced-sterling-cooper --mangle
 
-dotnet run -- preset --name qa.dunder-mifflin-enterprise-full --password "MyTestPassword1" --mangle
-
-# Override KDF iterations for a preset (overrides preset's kdfIterations value)
-dotnet run -- preset --name qa.enterprise-basic --kdf-iterations 600000 --mangle
-
-# Seed a free individual user
-dotnet run -- preset --name individual.free --mangle
-
-# Seed a premium individual user
+# Individual user preset
 dotnet run -- preset --name individual.premium --mangle
 ```
+
+For the full preset catalog, see [presets.md](../Seeder/Seeds/docs/presets.md).


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33964](https://bitwarden.atlassian.net/browse/PM-33964)
[PM-31013](https://bitwarden.atlassian.net/browse/PM-31013)

## 📔 Objective

Continues the effort of keeping Seeder knowledge close-to-code. We already have good documentation on creating, adjusting, and testing presets — but lack a "Getting Started" guide for consuming them. This PR fills that gap and establishes a pattern where individuals and teams can contribute their own "when you need to do X, reach for Y" scenarios over time.

When peer reviewing, it's likely best to start with `util/Seeder/Seeds/docs/scenarios/README.md` and `util/SeederUtility/README.md`. Then, follow the example scenarios. 


[PM-33964]: https://bitwarden.atlassian.net/browse/PM-33964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-31013]: https://bitwarden.atlassian.net/browse/PM-31013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ