### PR TITLE
BRE-1004 - Add write packages permission

### DIFF
--- a/.github/workflows/build_target.yml
+++ b/.github/workflows/build_target.yml
@@ -25,7 +25,8 @@ jobs:
     secrets: inherit
 
     permissions:
-      contents: read
       actions: read
+      contents: read
       id-token: write
+      packages: write
       security-events: write


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
- [BRE-1004](https://bitwarden.atlassian.net/browse/BRE-1004?atlOrigin=eyJpIjoiOTJmZGJmNmUzNDliNDFkOWJhM2RjY2ViNzQ3NTFkNTYiLCJwIjoiaiJ9)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The `build_target.yml` workflow will fail to call the `build.yml` workflow without the `packages: write` permission.


[BRE-1004]: https://bitwarden.atlassian.net/browse/BRE-1004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ