### PR TITLE
[PM-34500] Fix Feature Flag pm-34500-strict-cipher-decryption name casing

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -287,7 +287,7 @@ public static class FeatureFlagKeys
     public const string PM29437_WelcomeDialogNoExtPrompt = "pm-29437-welcome-dialog-no-ext-prompt";
     public const string PM31948_OrgUserNotificationBanner = "pm-31948-org-user-notification-banner";
     public const string PM32009_NewItemTypes = "pm-32009-new-item-types";
-    public const string PM34500_StrictCipherDecryption = "PM-34500-strict-cipher-decryption";
+    public const string PM34500_StrictCipherDecryption = "pm-34500-strict-cipher-decryption";
     public const string PM28091_AddCopyAndQuickLaunchActions = "pm-28091-add-copy-and-quick-launch-actions";
 
     /* Innovation Team */


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34500

## 📔 Objective

The feature flag name was copied from Launch Darkly, but it turns out the actual key used is all lower-case. This fixes the feature flag key name so it comes back in the `/config` response.