### PR TITLE
Add release yml to rc

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,34 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: "💙 Community Highlight"
+      labels:
+        - community-pr
+    - title: ":shipit: Feature Development"
+      labels:
+        - t:feature
+        - t:feature-app
+        - t:feature-tool
+        - t:new-feature
+        - t:enhancement
+    - title: "❗ Breaking Changes"
+      labels:
+        - t:breaking-change
+    - title: "🐛 Bug fixes"
+      labels:
+        - t:bugfix
+    - title: "⚙️ Maintenance"
+      labels:
+        - t:tech-debt
+        - t:ci
+        - t:docs
+        - t:misc
+    - title: "📦 Dependency Updates"
+      labels:
+        - major-updates
+        - t:deps
+    - title: "🎨 Other"
+      labels:
+        - "*"


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Adds the release.yml template introduced with #7362, without the workflow updates to `rc`. This enables @bitwarden/dept-bre to generate release notes from the draft release page.
