### PR TITLE
[PM-34828] Fix BW lite sqlite bulk import failure for org imports

### DIFF
--- a/src/Infrastructure.EntityFramework/Dirt/Repositories/EventRepository.cs
+++ b/src/Infrastructure.EntityFramework/Dirt/Repositories/EventRepository.cs
@@ -48,6 +48,7 @@ public class EventRepository : Repository<Core.Entities.Event, Event, Guid>, IEv
             var tableEvents = entities.Select(e => e as Core.Entities.Event ?? new Core.Entities.Event(e));
             var entityEvents = Mapper.Map<List<Event>>(tableEvents);
             entityEvents.ForEach(e => e.SetNewId());
+            // SQLite does not support LinqToDB BulkCopy; use EF Core directly instead
             if (dbContext.Database.IsSqlite())
             {
                 await dbContext.AddRangeAsync(entityEvents);

--- a/src/Infrastructure.EntityFramework/Dirt/Repositories/EventRepository.cs
+++ b/src/Infrastructure.EntityFramework/Dirt/Repositories/EventRepository.cs
@@ -48,7 +48,15 @@ public class EventRepository : Repository<Core.Entities.Event, Event, Guid>, IEv
             var tableEvents = entities.Select(e => e as Core.Entities.Event ?? new Core.Entities.Event(e));
             var entityEvents = Mapper.Map<List<Event>>(tableEvents);
             entityEvents.ForEach(e => e.SetNewId());
-            await dbContext.BulkCopyAsync(entityEvents);
+            if (dbContext.Database.IsSqlite())
+            {
+                await dbContext.AddRangeAsync(entityEvents);
+                await dbContext.SaveChangesAsync();
+            }
+            else
+            {
+                await dbContext.BulkCopyAsync(entityEvents);
+            }
         }
     }
 

--- a/src/Infrastructure.EntityFramework/Dirt/Repositories/EventRepository.cs
+++ b/src/Infrastructure.EntityFramework/Dirt/Repositories/EventRepository.cs
@@ -57,6 +57,7 @@ public class EventRepository : Repository<Core.Entities.Event, Event, Guid>, IEv
             else
             {
                 await dbContext.BulkCopyAsync(entityEvents);
+                await dbContext.SaveChangesAsync();
             }
         }
     }

--- a/src/Infrastructure.EntityFramework/Vault/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.EntityFramework/Vault/Repositories/CipherRepository.cs
@@ -160,6 +160,7 @@ public class CipherRepository : Repository<Core.Vault.Entities.Cipher, Cipher, G
             var dbContext = GetDatabaseContext(scope);
             var folderEntities = Mapper.Map<List<Folder>>(folders);
             var cipherEntities = Mapper.Map<List<Cipher>>(ciphers);
+            // SQLite does not support LinqToDB BulkCopy; use EF Core directly instead
             if (dbContext.Database.IsSqlite())
             {
                 await dbContext.AddRangeAsync(folderEntities);
@@ -189,6 +190,7 @@ public class CipherRepository : Repository<Core.Vault.Entities.Cipher, Cipher, G
         {
             var dbContext = GetDatabaseContext(scope);
             var cipherEntities = Mapper.Map<List<Cipher>>(ciphers);
+            // SQLite does not support LinqToDB BulkCopy; use EF Core directly instead
             if (dbContext.Database.IsSqlite())
             {
                 await dbContext.AddRangeAsync(cipherEntities);

--- a/src/Infrastructure.EntityFramework/Vault/Repositories/CipherRepository.cs
+++ b/src/Infrastructure.EntityFramework/Vault/Repositories/CipherRepository.cs
@@ -159,9 +159,17 @@ public class CipherRepository : Repository<Core.Vault.Entities.Cipher, Cipher, G
         {
             var dbContext = GetDatabaseContext(scope);
             var folderEntities = Mapper.Map<List<Folder>>(folders);
-            await dbContext.BulkCopyAsync(base.DefaultBulkCopyOptions, folderEntities);
             var cipherEntities = Mapper.Map<List<Cipher>>(ciphers);
-            await dbContext.BulkCopyAsync(base.DefaultBulkCopyOptions, cipherEntities);
+            if (dbContext.Database.IsSqlite())
+            {
+                await dbContext.AddRangeAsync(folderEntities);
+                await dbContext.AddRangeAsync(cipherEntities);
+            }
+            else
+            {
+                await dbContext.BulkCopyAsync(base.DefaultBulkCopyOptions, folderEntities);
+                await dbContext.BulkCopyAsync(base.DefaultBulkCopyOptions, cipherEntities);
+            }
             await dbContext.UserBumpAccountRevisionDateAsync(userId);
 
             await dbContext.SaveChangesAsync();
@@ -181,24 +189,43 @@ public class CipherRepository : Repository<Core.Vault.Entities.Cipher, Cipher, G
         {
             var dbContext = GetDatabaseContext(scope);
             var cipherEntities = Mapper.Map<List<Cipher>>(ciphers);
-            await dbContext.BulkCopyAsync(base.DefaultBulkCopyOptions, cipherEntities);
-
-            if (collections.Any())
+            if (dbContext.Database.IsSqlite())
             {
-                var collectionEntities = Mapper.Map<List<Collection>>(collections);
-                await dbContext.BulkCopyAsync(base.DefaultBulkCopyOptions, collectionEntities);
+                await dbContext.AddRangeAsync(cipherEntities);
+                if (collections.Any())
+                {
+                    await dbContext.AddRangeAsync(Mapper.Map<List<Collection>>(collections));
+                }
+                if (collectionCiphers.Any())
+                {
+                    await dbContext.AddRangeAsync(Mapper.Map<List<CollectionCipher>>(collectionCiphers));
+                }
+                if (collectionUsers.Any())
+                {
+                    await dbContext.AddRangeAsync(Mapper.Map<List<CollectionUser>>(collectionUsers));
+                }
             }
-
-            if (collectionCiphers.Any())
+            else
             {
-                var collectionCipherEntities = Mapper.Map<List<CollectionCipher>>(collectionCiphers);
-                await dbContext.BulkCopyAsync(base.DefaultBulkCopyOptions, collectionCipherEntities);
-            }
+                await dbContext.BulkCopyAsync(base.DefaultBulkCopyOptions, cipherEntities);
 
-            if (collectionUsers.Any())
-            {
-                var collectionUserEntities = Mapper.Map<List<CollectionUser>>(collectionUsers);
-                await dbContext.BulkCopyAsync(base.DefaultBulkCopyOptions, collectionUserEntities);
+                if (collections.Any())
+                {
+                    var collectionEntities = Mapper.Map<List<Collection>>(collections);
+                    await dbContext.BulkCopyAsync(base.DefaultBulkCopyOptions, collectionEntities);
+                }
+
+                if (collectionCiphers.Any())
+                {
+                    var collectionCipherEntities = Mapper.Map<List<CollectionCipher>>(collectionCiphers);
+                    await dbContext.BulkCopyAsync(base.DefaultBulkCopyOptions, collectionCipherEntities);
+                }
+
+                if (collectionUsers.Any())
+                {
+                    var collectionUserEntities = Mapper.Map<List<CollectionUser>>(collectionUsers);
+                    await dbContext.BulkCopyAsync(base.DefaultBulkCopyOptions, collectionUserEntities);
+                }
             }
 
             await dbContext.UserBumpAccountRevisionDateByOrganizationIdAsync(ciphers.First().OrganizationId.Value);


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-34828
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Fixes a 500 error when logging in with an org account and when importing a vault on SQLite environments.

### Cause
`EventRepository.CreateManyAsync` and two cases of `CipherRepository.CreateAsync` call
  LinqToDB's BulkCopyAsync. When called against a SQLite context, LinqToDB auto-detects which SQLite
  adapter to use by checking for `System.Data.SQLite.dll` or `Microsoft.Data.Sqlite.dll` on disk. Since the
  server publishes as a single-file bundle (PublishSingleFile=true), managed DLLs are embedded in the
  executable and not present on disk ([example](https://github.com/bitwarden/server/blob/main/src/Identity/Dockerfile#L33)).

This surfaced after a change in the build process for the Bitwarden Lite container, which now pulls directly from our existing built containers. 
https://github.com/bitwarden/self-host/commit/08922d41f4f40be9432869b340444a3eb924367e


### Changes in this PR
Added IsSqlite() guards to three methods to route SQLite through EF Core's AddRangeAsync/SaveChangesAsync instead of LinqToDB's BulkCopyAsync:
- EventRepository.CreateManyAsync
- CipherRepository.CreateAsync(userId, ciphers, folders) — personal vault import with folders
- CipherRepository.CreateAsync(ciphers, collections, collectionCiphers, collectionUsers) — org vault import with collections


<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
