### PR TITLE
[PM-33875] Add Revocation Reasons

### DIFF
--- a/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
+++ b/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
@@ -106,7 +106,8 @@ public class UsersController : Controller
                 new RevokeOrganizationUsersRequest(
                     organizationId,
                     [id],
-                    new SystemUser(EventSystemUser.SCIM)));
+                    new SystemUser(EventSystemUser.SCIM),
+                    RevocationReason.Manual));
 
             var errors = results.Select(x => x.Result.Match(
                 y => $"{y.Message} for user {x.Id}",

--- a/bitwarden_license/src/Scim/Users/PatchUserCommand.cs
+++ b/bitwarden_license/src/Scim/Users/PatchUserCommand.cs
@@ -107,7 +107,7 @@ public class PatchUserCommand : IPatchUserCommand
         }
         else if (!active && orgUser.Status != OrganizationUserStatusType.Revoked)
         {
-            await _revokeOrganizationUserCommand.RevokeUserAsync(orgUser, EventSystemUser.SCIM);
+            await _revokeOrganizationUserCommand.RevokeUserAsync(orgUser, EventSystemUser.SCIM, RevocationReason.Manual);
             return true;
         }
         return false;

--- a/bitwarden_license/test/Scim.Test/Users/PatchUserCommandTests.cs
+++ b/bitwarden_license/test/Scim.Test/Users/PatchUserCommandTests.cs
@@ -102,7 +102,7 @@ public class PatchUserCommandTests
 
         await sutProvider.Sut.PatchUserAsync(organizationUser.OrganizationId, organizationUser.Id, scimPatchModel);
 
-        await sutProvider.GetDependency<IRevokeOrganizationUserCommand>().Received(1).RevokeUserAsync(organizationUser, EventSystemUser.SCIM);
+        await sutProvider.GetDependency<IRevokeOrganizationUserCommand>().Received(1).RevokeUserAsync(organizationUser, EventSystemUser.SCIM, RevocationReason.Manual);
     }
 
     [Theory]
@@ -130,7 +130,7 @@ public class PatchUserCommandTests
 
         await sutProvider.Sut.PatchUserAsync(organizationUser.OrganizationId, organizationUser.Id, scimPatchModel);
 
-        await sutProvider.GetDependency<IRevokeOrganizationUserCommand>().Received(1).RevokeUserAsync(organizationUser, EventSystemUser.SCIM);
+        await sutProvider.GetDependency<IRevokeOrganizationUserCommand>().Received(1).RevokeUserAsync(organizationUser, EventSystemUser.SCIM, RevocationReason.Manual);
     }
 
     [Theory]
@@ -150,7 +150,7 @@ public class PatchUserCommandTests
         await sutProvider.Sut.PatchUserAsync(organizationUser.OrganizationId, organizationUser.Id, scimPatchModel);
 
         await sutProvider.GetDependency<IRestoreOrganizationUserCommand>().DidNotReceiveWithAnyArgs().RestoreUserAsync(default, EventSystemUser.SCIM);
-        await sutProvider.GetDependency<IRevokeOrganizationUserCommand>().DidNotReceiveWithAnyArgs().RevokeUserAsync(default, EventSystemUser.SCIM);
+        await sutProvider.GetDependency<IRevokeOrganizationUserCommand>().DidNotReceiveWithAnyArgs().RevokeUserAsync(default, EventSystemUser.SCIM, default);
     }
 
     [Theory]
@@ -380,7 +380,7 @@ public class PatchUserCommandTests
 
         // Verify no restore or revoke operations were called
         await sutProvider.GetDependency<IRestoreOrganizationUserCommand>().DidNotReceiveWithAnyArgs().RestoreUserAsync(default, EventSystemUser.SCIM);
-        await sutProvider.GetDependency<IRevokeOrganizationUserCommand>().DidNotReceiveWithAnyArgs().RevokeUserAsync(default, EventSystemUser.SCIM);
+        await sutProvider.GetDependency<IRevokeOrganizationUserCommand>().DidNotReceiveWithAnyArgs().RevokeUserAsync(default, EventSystemUser.SCIM, default);
     }
 
     [Theory]
@@ -415,7 +415,7 @@ public class PatchUserCommandTests
         await sutProvider.Sut.PatchUserAsync(organizationUser.OrganizationId, organizationUser.Id, scimPatchModel);
 
         // Verify both operations were processed
-        await sutProvider.GetDependency<IRevokeOrganizationUserCommand>().Received(1).RevokeUserAsync(organizationUser, EventSystemUser.SCIM);
+        await sutProvider.GetDependency<IRevokeOrganizationUserCommand>().Received(1).RevokeUserAsync(organizationUser, EventSystemUser.SCIM, RevocationReason.Manual);
         await sutProvider.GetDependency<IOrganizationUserRepository>().Received(1).ReplaceAsync(
             Arg.Is<OrganizationUser>(ou => ou.ExternalId == newExternalId));
     }

--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -644,7 +644,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
     [Authorize<ManageUsersRequirement>]
     public async Task RevokeAsync(Guid orgId, Guid id)
     {
-        await RestoreOrRevokeUserAsync(orgId, id, _revokeOrganizationUserCommand.RevokeUserAsync);
+        await RestoreOrRevokeUserAsync(orgId, id, (orgUser, userId) => _revokeOrganizationUserCommand.RevokeUserAsync(orgUser, userId, RevocationReason.Manual));
     }
 
     [HttpPut("revoke-self")]
@@ -683,7 +683,8 @@ public class OrganizationUsersController : BaseAdminConsoleController
             new V2_RevokeOrganizationUserCommand.RevokeOrganizationUsersRequest(
                 orgId,
                 model.Ids.ToArray(),
-                new StandardUser(currentUserId.Value, await _currentContext.OrganizationOwner(orgId))));
+                new StandardUser(currentUserId.Value, await _currentContext.OrganizationOwner(orgId)),
+                RevocationReason.Manual));
 
         return new ListResponseModel<OrganizationUserBulkResponseModel>(results
             .Select(result => new OrganizationUserBulkResponseModel(result.Id,

--- a/src/Api/AdminConsole/Public/Controllers/MembersController.cs
+++ b/src/Api/AdminConsole/Public/Controllers/MembersController.cs
@@ -339,7 +339,8 @@ public class MembersController : Controller
         var request = new RevokeOrganizationUsersRequest(
             _currentContext.OrganizationId!.Value,
             [id],
-            new SystemUser(EventSystemUser.PublicApi)
+            new SystemUser(EventSystemUser.PublicApi),
+            RevocationReason.Manual
         );
 
         var results = await _revokeOrganizationUserCommandV2.RevokeUsersAsync(request);

--- a/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/v2/AdminRecoverAccountCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/v2/AdminRecoverAccountCommand.cs
@@ -125,7 +125,8 @@ public class AdminRecoverAccountCommand(
                     new RevokeOrganizationUsersRequest(
                         o.OrganizationId,
                         [new OrganizationUserUserDetails { Id = o.OrganizationUserId, OrganizationId = o.OrganizationId }],
-                        new SystemUser(EventSystemUser.TwoFactorDisabled)));
+                        new SystemUser(EventSystemUser.TwoFactorDisabled),
+                        RevocationReason.TwoFactorPolicyNonCompliance));
                 await mailService.SendOrganizationUserRevokedForTwoFactorPolicyEmailAsync(organization.DisplayName(), user.Email);
             }).ToArray();
 

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/Requests/RevokeOrganizationUserRequest.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/Requests/RevokeOrganizationUserRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Core.AdminConsole.Models.Data;
+using Bit.Core.Enums;
 using Bit.Core.Models.Data.Organizations.OrganizationUsers;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Requests;
@@ -6,8 +7,9 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Requests;
 public record RevokeOrganizationUsersRequest(
     Guid OrganizationId,
     IEnumerable<OrganizationUserUserDetails> OrganizationUsers,
-    IActingUser ActionPerformedBy)
+    IActingUser ActionPerformedBy,
+    RevocationReason RevocationReason)
 {
-    public RevokeOrganizationUsersRequest(Guid organizationId, OrganizationUserUserDetails organizationUser, IActingUser actionPerformedBy)
-        : this(organizationId, [organizationUser], actionPerformedBy) { }
+    public RevokeOrganizationUsersRequest(Guid organizationId, OrganizationUserUserDetails organizationUser, IActingUser actionPerformedBy, RevocationReason revocationReason)
+        : this(organizationId, [organizationUser], actionPerformedBy, revocationReason) { }
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeNonCompliantOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeNonCompliantOrganizationUserCommand.cs
@@ -30,33 +30,42 @@ public class RevokeNonCompliantOrganizationUserCommand(IOrganizationUserReposito
             return validationResult;
         }
 
-        await organizationUserRepository.RevokeManyAsync(request.OrganizationUsers.Select(x => x.Id));
+        await organizationUserRepository.RevokeManyAsync(request.OrganizationUsers.Select(x => x.Id), request.RevocationReason);
 
         var now = timeProvider.GetUtcNow();
+
+        var eventType = MapRevocationReasonToEventType(request.RevocationReason);
 
         switch (request.ActionPerformedBy)
         {
             case StandardUser:
                 await eventService.LogOrganizationUserEventsAsync(
-                    request.OrganizationUsers.Select(x => GetRevokedUserEventTuple(x, now)));
+                    request.OrganizationUsers.Select(x => GetRevokedUserEventTuple(x, eventType, now)));
                 break;
             case SystemUser { SystemUserType: not null } loggableSystem:
                 await eventService.LogOrganizationUserEventsAsync(
                     request.OrganizationUsers.Select(x =>
-                        GetRevokedUserEventBySystemUserTuple(x, loggableSystem.SystemUserType.Value, now)));
+                        GetRevokedUserEventBySystemUserTuple(x, eventType, loggableSystem.SystemUserType.Value, now)));
                 break;
         }
 
         return validationResult;
     }
 
+    private static EventType MapRevocationReasonToEventType(RevocationReason reason) => reason switch
+    {
+        RevocationReason.TwoFactorPolicyNonCompliance => EventType.OrganizationUser_Revoked_TwoFactorNonCompliance,
+        RevocationReason.SingleOrgPolicyNonCompliance => EventType.OrganizationUser_Revoked_SingleOrganizationNonCompliance,
+        _ => EventType.OrganizationUser_Revoked
+    };
+
     private static (OrganizationUserUserDetails organizationUser, EventType eventType, DateTime? time) GetRevokedUserEventTuple(
-        OrganizationUserUserDetails organizationUser, DateTimeOffset dateTimeOffset) =>
-        new(organizationUser, EventType.OrganizationUser_Revoked, dateTimeOffset.UtcDateTime);
+        OrganizationUserUserDetails organizationUser, EventType eventType, DateTimeOffset dateTimeOffset) =>
+        new(organizationUser, eventType, dateTimeOffset.UtcDateTime);
 
     private static (OrganizationUserUserDetails organizationUser, EventType eventType, EventSystemUser eventSystemUser, DateTime? time) GetRevokedUserEventBySystemUserTuple(
-        OrganizationUserUserDetails organizationUser, EventSystemUser systemUser, DateTimeOffset dateTimeOffset) => new(organizationUser,
-        EventType.OrganizationUser_Revoked, systemUser, dateTimeOffset.UtcDateTime);
+        OrganizationUserUserDetails organizationUser, EventType eventType, EventSystemUser systemUser, DateTimeOffset dateTimeOffset) => new(organizationUser,
+        eventType, systemUser, dateTimeOffset.UtcDateTime);
 
     private async Task<CommandResult> ValidateAsync(RevokeOrganizationUsersRequest request)
     {

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v1/IRevokeOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v1/IRevokeOrganizationUserCommand.cs
@@ -5,6 +5,6 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.RevokeUse
 
 public interface IRevokeOrganizationUserCommand
 {
-    Task RevokeUserAsync(OrganizationUser organizationUser, Guid? revokingUserId);
-    Task RevokeUserAsync(OrganizationUser organizationUser, EventSystemUser systemUser);
+    Task RevokeUserAsync(OrganizationUser organizationUser, Guid? revokingUserId, RevocationReason reason);
+    Task RevokeUserAsync(OrganizationUser organizationUser, EventSystemUser systemUser, RevocationReason reason);
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v1/RevokeOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v1/RevokeOrganizationUserCommand.cs
@@ -17,7 +17,7 @@ public class RevokeOrganizationUserCommand(
     IHasConfirmedOwnersExceptQuery hasConfirmedOwnersExceptQuery)
     : IRevokeOrganizationUserCommand
 {
-    public async Task RevokeUserAsync(OrganizationUser organizationUser, Guid? revokingUserId)
+    public async Task RevokeUserAsync(OrganizationUser organizationUser, Guid? revokingUserId, RevocationReason reason)
     {
         if (revokingUserId.HasValue && organizationUser.UserId == revokingUserId.Value)
         {
@@ -30,7 +30,7 @@ public class RevokeOrganizationUserCommand(
             throw new BadRequestException("Only owners can revoke other owners.");
         }
 
-        await RepositoryRevokeUserAsync(organizationUser);
+        await RepositoryRevokeUserAsync(organizationUser, reason);
         await eventService.LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_Revoked);
 
         if (organizationUser.UserId.HasValue)
@@ -40,9 +40,9 @@ public class RevokeOrganizationUserCommand(
     }
 
     public async Task RevokeUserAsync(OrganizationUser organizationUser,
-        EventSystemUser systemUser)
+        EventSystemUser systemUser, RevocationReason reason)
     {
-        await RepositoryRevokeUserAsync(organizationUser);
+        await RepositoryRevokeUserAsync(organizationUser, reason);
         await eventService.LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_Revoked,
             systemUser);
 
@@ -52,7 +52,7 @@ public class RevokeOrganizationUserCommand(
         }
     }
 
-    private async Task RepositoryRevokeUserAsync(OrganizationUser organizationUser)
+    private async Task RepositoryRevokeUserAsync(OrganizationUser organizationUser, RevocationReason reason)
     {
         if (organizationUser.Status == OrganizationUserStatusType.Revoked)
         {
@@ -65,7 +65,8 @@ public class RevokeOrganizationUserCommand(
             throw new BadRequestException("Organization must have at least one confirmed owner.");
         }
 
-        await organizationUserRepository.RevokeAsync(organizationUser.Id);
+        await organizationUserRepository.RevokeAsync(organizationUser.Id, reason);
         organizationUser.Status = OrganizationUserStatusType.Revoked;
+        organizationUser.RevocationReason = reason;
     }
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v2/RevokeOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v2/RevokeOrganizationUserCommand.cs
@@ -27,7 +27,7 @@ public class RevokeOrganizationUserCommand(
 
         var validUsers = results.Where(r => r.IsValid).Select(r => r.Request).ToList();
 
-        await RevokeValidUsersAsync(validUsers);
+        await RevokeValidUsersAsync(validUsers, request.RevocationReason);
 
         await Task.WhenAll(
             LogRevokedOrganizationUsersAsync(validUsers, request.PerformedBy),
@@ -53,17 +53,18 @@ public class RevokeOrganizationUserCommand(
         return new RevokeOrganizationUsersValidationRequest(
             request.OrganizationId,
             organizationUserToRevoke,
-            request.PerformedBy);
+            request.PerformedBy,
+            request.RevocationReason);
     }
 
-    private async Task RevokeValidUsersAsync(ICollection<OrganizationUser> validUsers)
+    private async Task RevokeValidUsersAsync(ICollection<OrganizationUser> validUsers, RevocationReason reason)
     {
         if (validUsers.Count == 0)
         {
             return;
         }
 
-        await organizationUserRepository.RevokeManyAsync(validUsers.Select(u => u.Id));
+        await organizationUserRepository.RevokeManyAsync(validUsers.Select(u => u.Id), reason);
     }
 
     private async Task LogRevokedOrganizationUsersAsync(

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v2/RevokeOrganizationUsersRequest.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v2/RevokeOrganizationUsersRequest.cs
@@ -1,18 +1,21 @@
 ﻿using Bit.Core.AdminConsole.Models.Data;
 using Bit.Core.Entities;
+using Bit.Core.Enums;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.RevokeUser.v2;
 
 public record RevokeOrganizationUsersRequest(
     Guid OrganizationId,
     ICollection<Guid> OrganizationUserIdsToRevoke,
-    IActingUser PerformedBy
+    IActingUser PerformedBy,
+    RevocationReason RevocationReason
 );
 
 public record RevokeOrganizationUsersValidationRequest(
     Guid OrganizationId,
     ICollection<OrganizationUser> OrganizationUsersToRevoke,
-    IActingUser PerformedBy
+    IActingUser PerformedBy,
+    RevocationReason RevocationReason
 )
 {
     public ICollection<Guid> OrganizationUserIdsToRevoke => OrganizationUsersToRevoke.Select(x => x.Id).ToArray();

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/SelfRevokeUser/SelfRevokeOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/SelfRevokeUser/SelfRevokeOrganizationUserCommand.cs
@@ -47,7 +47,7 @@ public class SelfRevokeOrganizationUserCommand(
             }
         }
 
-        await organizationUserRepository.RevokeAsync(organizationUser.Id);
+        await organizationUserRepository.RevokeAsync(organizationUser.Id, RevocationReason.OrganizationDataOwnershipPolicyNonCompliance);
         await eventService.LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_SelfRevoked);
         await pushNotificationService.PushSyncOrgKeysAsync(organizationUser.UserId!.Value);
 

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/SingleOrgPolicyEventHandler.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/SingleOrgPolicyEventHandler.cs
@@ -115,7 +115,10 @@ public class SingleOrgPolicyEventHandler : IPolicyValidationEvent, IOnPolicyPreU
                 uo.Status != OrganizationUserStatusType.Invited)).ToList();
 
         var commandResult = await _revokeNonCompliantOrganizationUserCommand.RevokeNonCompliantOrganizationUsersAsync(
-            new RevokeOrganizationUsersRequest(organizationId, usersToRevoke, performedBy));
+            new RevokeOrganizationUsersRequest(organizationId,
+                usersToRevoke,
+                performedBy,
+                RevocationReason.SingleOrgPolicyNonCompliance));
 
         if (commandResult.HasErrors)
         {

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/TwoFactorAuthenticationPolicyEventHandler.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/TwoFactorAuthenticationPolicyEventHandler.cs
@@ -97,7 +97,10 @@ public class TwoFactorAuthenticationPolicyEventHandler : IOnPolicyPreUpdateEvent
         }
 
         var commandResult = await _revokeNonCompliantOrganizationUserCommand.RevokeNonCompliantOrganizationUsersAsync(
-            new RevokeOrganizationUsersRequest(organizationId, nonCompliantUsers.Select(x => x.user), performedBy));
+            new RevokeOrganizationUsersRequest(organizationId,
+                nonCompliantUsers.Select(x => x.user),
+                performedBy,
+                RevocationReason.TwoFactorPolicyNonCompliance));
 
         if (commandResult.HasErrors)
         {

--- a/src/Core/AdminConsole/Repositories/IOrganizationUserRepository.cs
+++ b/src/Core/AdminConsole/Repositories/IOrganizationUserRepository.cs
@@ -66,7 +66,7 @@ public interface IOrganizationUserRepository : IRepository<OrganizationUser, Gui
     /// around <see cref="RevokeManyAsync"/> for single-user operations.
     /// </summary>
     /// <param name="id">The ID of the organization user to revoke.</param>
-    Task RevokeAsync(Guid id);
+    Task RevokeAsync(Guid id, RevocationReason reason);
     /// <summary>
     /// Restores access for a single revoked organization user. This is a convenience wrapper
     /// around <see cref="RestoreManyAsync"/> for single-user operations.
@@ -97,7 +97,7 @@ public interface IOrganizationUserRepository : IRepository<OrganizationUser, Gui
     /// </summary>
     /// <param name="organizationUserIds">The IDs of the organization users to revoke.</param>
     /// <param name="reason">The reason for revocation. May be null if the reason is not known.</param>
-    Task RevokeManyAsync(IEnumerable<Guid> organizationUserIds, RevocationReason? reason = null);
+    Task RevokeManyAsync(IEnumerable<Guid> organizationUserIds, RevocationReason reason);
     /// <summary>
     /// Restores access for one or more revoked organization users, clearing their
     /// <see cref="Core.Entities.OrganizationUser.RevocationReason"/>. Only affects users

--- a/src/Core/Dirt/Enums/EventType.cs
+++ b/src/Core/Dirt/Enums/EventType.cs
@@ -63,6 +63,8 @@ public enum EventType : int
     OrganizationUser_AutomaticallyConfirmed = 1517,
     OrganizationUser_SelfRevoked = 1518, // User self-revoked due to declining organization data ownership policy
     OrganizationUser_AdminResetTwoFactor = 1519,
+    OrganizationUser_Revoked_TwoFactorNonCompliance = 1520,
+    OrganizationUser_Revoked_SingleOrganizationNonCompliance = 1521,
 
     Organization_Updated = 1600,
     Organization_PurgedVault = 1601,

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -1097,7 +1097,8 @@ public class UserService : UserManager<User>, IUserService
                                 OrganizationId = o.OrganizationId
                             }
                         ],
-                        new SystemUser(EventSystemUser.TwoFactorDisabled)));
+                        new SystemUser(EventSystemUser.TwoFactorDisabled),
+                        RevocationReason.TwoFactorPolicyNonCompliance));
                 await _mailService.SendOrganizationUserRevokedForTwoFactorPolicyEmailAsync(organization.DisplayName(),
                     user.Email);
             }).ToArray();

--- a/src/Infrastructure.Dapper/AdminConsole/Repositories/OrganizationUserRepository.cs
+++ b/src/Infrastructure.Dapper/AdminConsole/Repositories/OrganizationUserRepository.cs
@@ -559,9 +559,9 @@ public class OrganizationUserRepository : Repository<OrganizationUser, Guid>, IO
         }
     }
 
-    public async Task RevokeAsync(Guid id)
+    public async Task RevokeAsync(Guid id, RevocationReason reason)
     {
-        await RevokeManyAsync([id]);
+        await RevokeManyAsync([id], reason);
     }
 
     public async Task RestoreAsync(Guid id, OrganizationUserStatusType status)
@@ -621,7 +621,7 @@ public class OrganizationUserRepository : Repository<OrganizationUser, Guid>, IO
         }
     }
 
-    public async Task RevokeManyAsync(IEnumerable<Guid> organizationUserIds, RevocationReason? reason = null)
+    public async Task RevokeManyAsync(IEnumerable<Guid> organizationUserIds, RevocationReason reason)
     {
         await using var connection = new SqlConnection(ConnectionString);
 

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationUserRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationUserRepository.cs
@@ -787,9 +787,9 @@ public class OrganizationUserRepository : Repository<Core.Entities.OrganizationU
         }
     }
 
-    public async Task RevokeAsync(Guid id)
+    public async Task RevokeAsync(Guid id, RevocationReason reason)
     {
-        await RevokeManyAsync([id]);
+        await RevokeManyAsync([id], reason);
     }
 
     public async Task RestoreAsync(Guid id, OrganizationUserStatusType status)
@@ -899,7 +899,7 @@ public class OrganizationUserRepository : Repository<Core.Entities.OrganizationU
         }
     }
 
-    public async Task RevokeManyAsync(IEnumerable<Guid> organizationUserIds, RevocationReason? reason = null)
+    public async Task RevokeManyAsync(IEnumerable<Guid> organizationUserIds, RevocationReason reason)
     {
         using var scope = ServiceScopeFactory.CreateScope();
 

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUserControllerBulkRevokeTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUserControllerBulkRevokeTests.cs
@@ -144,7 +144,7 @@ public class OrganizationUserControllerBulkRevokeTests : IClassFixture<ApiApplic
 
         var organizationUserRepository = _factory.GetService<IOrganizationUserRepository>();
 
-        await organizationUserRepository.RevokeAsync(orgUser.Id);
+        await organizationUserRepository.RevokeAsync(orgUser.Id, RevocationReason.Manual);
 
         var request = new OrganizationUserBulkRequestModel
         {
@@ -205,7 +205,7 @@ public class OrganizationUserControllerBulkRevokeTests : IClassFixture<ApiApplic
 
         var organizationUserRepository = _factory.GetService<IOrganizationUserRepository>();
 
-        await organizationUserRepository.RevokeAsync(alreadyRevokedOrgUser.Id);
+        await organizationUserRepository.RevokeAsync(alreadyRevokedOrgUser.Id, RevocationReason.Manual);
 
         var request = new OrganizationUserBulkRequestModel
         {

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeNonCompliantOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeNonCompliantOrganizationUserCommandTests.cs
@@ -20,7 +20,7 @@ public class RevokeNonCompliantOrganizationUserCommandTests
     public async Task RevokeNonCompliantOrganizationUsersAsync_GivenUnrecognizedUserType_WhenAttemptingToRevoke_ThenErrorShouldBeReturned(
             Guid organizationId, SutProvider<RevokeNonCompliantOrganizationUserCommand> sutProvider)
     {
-        var command = new RevokeOrganizationUsersRequest(organizationId, [], new InvalidUser());
+        var command = new RevokeOrganizationUsersRequest(organizationId, [], new InvalidUser(), RevocationReason.TwoFactorPolicyNonCompliance);
 
         var result = await sutProvider.Sut.RevokeNonCompliantOrganizationUsersAsync(command);
 
@@ -34,7 +34,7 @@ public class RevokeNonCompliantOrganizationUserCommandTests
             SutProvider<RevokeNonCompliantOrganizationUserCommand> sutProvider)
     {
         var command = new RevokeOrganizationUsersRequest(organizationId, revokingUser,
-            new StandardUser(revokingUser?.UserId ?? Guid.NewGuid(), true));
+            new StandardUser(revokingUser?.UserId ?? Guid.NewGuid(), true), RevocationReason.TwoFactorPolicyNonCompliance);
 
         var result = await sutProvider.Sut.RevokeNonCompliantOrganizationUsersAsync(command);
 
@@ -50,7 +50,7 @@ public class RevokeNonCompliantOrganizationUserCommandTests
         userFromAnotherOrg.OrganizationId = Guid.NewGuid();
 
         var command = new RevokeOrganizationUsersRequest(organizationId, userFromAnotherOrg,
-            new StandardUser(Guid.NewGuid(), true));
+            new StandardUser(Guid.NewGuid(), true), RevocationReason.TwoFactorPolicyNonCompliance);
 
         var result = await sutProvider.Sut.RevokeNonCompliantOrganizationUsersAsync(command);
 
@@ -66,7 +66,7 @@ public class RevokeNonCompliantOrganizationUserCommandTests
         userToRevoke.OrganizationId = organizationId;
 
         var command = new RevokeOrganizationUsersRequest(organizationId, userToRevoke,
-            new StandardUser(Guid.NewGuid(), true));
+            new StandardUser(Guid.NewGuid(), true), RevocationReason.TwoFactorPolicyNonCompliance);
 
         sutProvider.GetDependency<IHasConfirmedOwnersExceptQuery>()
             .HasConfirmedOwnersExceptAsync(organizationId, Arg.Any<IEnumerable<Guid>>())
@@ -87,7 +87,7 @@ public class RevokeNonCompliantOrganizationUserCommandTests
         userToRevoke.Type = OrganizationUserType.Owner;
 
         var command = new RevokeOrganizationUsersRequest(organizationId, userToRevoke,
-            new StandardUser(Guid.NewGuid(), false));
+            new StandardUser(Guid.NewGuid(), false), RevocationReason.TwoFactorPolicyNonCompliance);
 
         sutProvider.GetDependency<IHasConfirmedOwnersExceptQuery>()
             .HasConfirmedOwnersExceptAsync(organizationId, Arg.Any<IEnumerable<Guid>>())
@@ -108,7 +108,7 @@ public class RevokeNonCompliantOrganizationUserCommandTests
         userToRevoke.Status = OrganizationUserStatusType.Revoked;
 
         var command = new RevokeOrganizationUsersRequest(organizationId, userToRevoke,
-            new StandardUser(Guid.NewGuid(), true));
+            new StandardUser(Guid.NewGuid(), true), RevocationReason.TwoFactorPolicyNonCompliance);
 
         sutProvider.GetDependency<IHasConfirmedOwnersExceptQuery>()
             .HasConfirmedOwnersExceptAsync(organizationId, Arg.Any<IEnumerable<Guid>>())
@@ -131,7 +131,7 @@ public class RevokeNonCompliantOrganizationUserCommandTests
         revocableUsers[1].Status = OrganizationUserStatusType.Revoked;
 
         var command = new RevokeOrganizationUsersRequest(organizationId, revocableUsers,
-            new StandardUser(Guid.NewGuid(), false));
+            new StandardUser(Guid.NewGuid(), false), RevocationReason.TwoFactorPolicyNonCompliance);
 
         sutProvider.GetDependency<IHasConfirmedOwnersExceptQuery>()
             .HasConfirmedOwnersExceptAsync(organizationId, Arg.Any<IEnumerable<Guid>>())
@@ -152,7 +152,7 @@ public class RevokeNonCompliantOrganizationUserCommandTests
         userToRevoke.Type = OrganizationUserType.Admin;
 
         var command = new RevokeOrganizationUsersRequest(organizationId, userToRevoke,
-            new StandardUser(Guid.NewGuid(), false));
+            new StandardUser(Guid.NewGuid(), false), RevocationReason.TwoFactorPolicyNonCompliance);
 
         sutProvider.GetDependency<IHasConfirmedOwnersExceptQuery>()
             .HasConfirmedOwnersExceptAsync(organizationId, Arg.Any<IEnumerable<Guid>>())
@@ -162,7 +162,7 @@ public class RevokeNonCompliantOrganizationUserCommandTests
 
         await sutProvider.GetDependency<IOrganizationUserRepository>()
             .Received(1)
-            .RevokeManyAsync(Arg.Is<IEnumerable<Guid>>(x => x.Count() == 1 && x.Contains(userToRevoke.Id)), null);
+            .RevokeManyAsync(Arg.Is<IEnumerable<Guid>>(x => x.Count() == 1 && x.Contains(userToRevoke.Id)), RevocationReason.TwoFactorPolicyNonCompliance);
 
         Assert.True(result.Success);
 
@@ -172,7 +172,7 @@ public class RevokeNonCompliantOrganizationUserCommandTests
                 Arg.Is<IEnumerable<(OrganizationUserUserDetails organizationUser, EventType eventType, DateTime? time
                     )>>(
                     x => x.Any(y =>
-                        y.organizationUser.Id == userToRevoke.Id && y.eventType == EventType.OrganizationUser_Revoked)
+                        y.organizationUser.Id == userToRevoke.Id && y.eventType == EventType.OrganizationUser_Revoked_TwoFactorNonCompliance)
                 ));
     }
 

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeOrganizationUserCommandTests.cs
@@ -28,11 +28,11 @@ public class RevokeOrganizationUserCommandTests
     {
         RestoreRevokeUser_Setup(organization, owner, organizationUser, sutProvider);
 
-        await sutProvider.Sut.RevokeUserAsync(organizationUser, owner.Id);
+        await sutProvider.Sut.RevokeUserAsync(organizationUser, owner.Id, RevocationReason.Manual);
 
         await sutProvider.GetDependency<IOrganizationUserRepository>()
             .Received(1)
-            .RevokeAsync(organizationUser.Id);
+            .RevokeAsync(organizationUser.Id, RevocationReason.Manual);
         await sutProvider.GetDependency<IEventService>()
             .Received(1)
             .LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_Revoked);
@@ -50,11 +50,11 @@ public class RevokeOrganizationUserCommandTests
     {
         RestoreRevokeUser_Setup(organization, null, organizationUser, sutProvider);
 
-        await sutProvider.Sut.RevokeUserAsync(organizationUser, eventSystemUser);
+        await sutProvider.Sut.RevokeUserAsync(organizationUser, eventSystemUser, RevocationReason.Manual);
 
         await sutProvider.GetDependency<IOrganizationUserRepository>()
             .Received(1)
-            .RevokeAsync(organizationUser.Id);
+            .RevokeAsync(organizationUser.Id, RevocationReason.Manual);
         await sutProvider.GetDependency<IEventService>()
             .Received(1)
             .LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_Revoked, eventSystemUser);

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v2/RevokeOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v2/RevokeOrganizationUserCommandTests.cs
@@ -36,7 +36,8 @@ public class RevokeOrganizationUserCommandTests
         var request = new RevokeOrganizationUsersRequest(
             organizationId,
             [orgUser1.Id, orgUser2.Id],
-            actingUser);
+            actingUser,
+            RevocationReason.Manual);
 
         SetupRepositoryMocks(sutProvider, [orgUser1, orgUser2]);
         SetupValidatorMock(sutProvider, [
@@ -54,7 +55,7 @@ public class RevokeOrganizationUserCommandTests
         await sutProvider.GetDependency<IOrganizationUserRepository>()
             .Received(1)
             .RevokeManyAsync(Arg.Is<IEnumerable<Guid>>(ids =>
-                ids.Contains(orgUser1.Id) && ids.Contains(orgUser2.Id)), null);
+                ids.Contains(orgUser1.Id) && ids.Contains(orgUser2.Id)), RevocationReason.Manual);
 
         await sutProvider.GetDependency<IEventService>()
             .Received(1)
@@ -86,7 +87,8 @@ public class RevokeOrganizationUserCommandTests
         var request = new RevokeOrganizationUsersRequest(
             organizationId,
             [orgUser.Id],
-            actingUser);
+            actingUser,
+            RevocationReason.Manual);
 
         SetupRepositoryMocks(sutProvider, [orgUser]);
         SetupValidatorMock(sutProvider, [ValidationResultHelpers.Valid(orgUser)]);
@@ -118,7 +120,8 @@ public class RevokeOrganizationUserCommandTests
         var request = new RevokeOrganizationUsersRequest(
             organizationId,
             [orgUser1.Id, orgUser2.Id],
-            actingUser);
+            actingUser,
+            RevocationReason.Manual);
 
         SetupRepositoryMocks(sutProvider, [orgUser1, orgUser2]);
         SetupValidatorMock(sutProvider, [
@@ -141,7 +144,7 @@ public class RevokeOrganizationUserCommandTests
         await sutProvider.GetDependency<IOrganizationUserRepository>()
             .Received(1)
             .RevokeManyAsync(Arg.Is<IEnumerable<Guid>>(ids =>
-                ids.Count() == 1 && ids.Contains(orgUser2.Id)), null);
+                ids.Count() == 1 && ids.Contains(orgUser2.Id)), RevocationReason.Manual);
     }
 
     [Theory]
@@ -161,7 +164,8 @@ public class RevokeOrganizationUserCommandTests
         var request = new RevokeOrganizationUsersRequest(
             organizationId,
             [orgUser.Id],
-            actingUser);
+            actingUser,
+            RevocationReason.Manual);
 
         SetupRepositoryMocks(sutProvider, [orgUser]);
         SetupValidatorMock(sutProvider, [ValidationResultHelpers.Valid(orgUser)]);
@@ -205,7 +209,8 @@ public class RevokeOrganizationUserCommandTests
         var request = new RevokeOrganizationUsersRequest(
             organizationId,
             [orgUser.Id, userFromDifferentOrg.Id],
-            actingUser);
+            actingUser,
+            RevocationReason.Manual);
 
         SetupRepositoryMocks(sutProvider, [orgUser, userFromDifferentOrg]);
         SetupValidatorMock(sutProvider, [ValidationResultHelpers.Valid(orgUser)]);

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v2/RevokeOrganizationUsersValidatorTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v2/RevokeOrganizationUsersValidatorTests.cs
@@ -347,7 +347,8 @@ public class RevokeOrganizationUsersValidatorTests
         return new RevokeOrganizationUsersValidationRequest(
             organizationId,
             organizationUsers,
-            actingUser
+            actingUser,
+            RevocationReason.Manual
         );
     }
 }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/SelfRevokeUser/SelfRevokeOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/SelfRevokeUser/SelfRevokeOrganizationUserCommandTests.cs
@@ -68,7 +68,7 @@ public class SelfRevokeOrganizationUserCommandTests
 
         await sutProvider.GetDependency<IOrganizationUserRepository>()
             .Received(1)
-            .RevokeAsync(organizationUser.Id);
+            .RevokeAsync(organizationUser.Id, RevocationReason.OrganizationDataOwnershipPolicyNonCompliance);
 
         await sutProvider.GetDependency<IEventService>()
             .Received(1)
@@ -224,7 +224,7 @@ public class SelfRevokeOrganizationUserCommandTests
 
         await sutProvider.GetDependency<IOrganizationUserRepository>()
             .Received(1)
-            .RevokeAsync(organizationUser.Id);
+            .RevokeAsync(organizationUser.Id, RevocationReason.OrganizationDataOwnershipPolicyNonCompliance);
 
         await sutProvider.GetDependency<IEventService>()
             .Received(1)

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/OrganizationUserRevocationTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/OrganizationUserRevocationTests.cs
@@ -34,7 +34,7 @@ public class OrganizationUserRevocationTests
     }
 
     [Theory, DatabaseData]
-    public async Task RevokeManyAsync_WithNullReason_SetsStatusOnly(
+    public async Task RevokeManyAsync_WithManualReason_SetsStatusAndReason(
         IOrganizationUserRepository organizationUserRepository,
         IOrganizationRepository organizationRepository,
         IUserRepository userRepository)
@@ -45,12 +45,12 @@ public class OrganizationUserRevocationTests
         var orgUser = await organizationUserRepository.CreateConfirmedTestOrganizationUserAsync(organization, user);
 
         // Act
-        await organizationUserRepository.RevokeManyAsync([orgUser.Id]);
+        await organizationUserRepository.RevokeManyAsync([orgUser.Id], RevocationReason.Manual);
 
         // Assert
         var updated = await organizationUserRepository.GetByIdAsync(orgUser.Id);
         Assert.Equal(OrganizationUserStatusType.Revoked, updated!.Status);
-        Assert.Null(updated.RevocationReason);
+        Assert.Equal(RevocationReason.Manual, updated.RevocationReason);
     }
 
     [Theory, DatabaseData]


### PR DESCRIPTION
## 🎟️ Tracking
[PM-33875](https://bitwarden.atlassian.net/browse/PM-33875)

## 📔 Objective

> [!NOTE]
> This PR is stacked on top of #7432  

Following up on the addition of the schema, this PR now passes along revocation reasons from the various ingress points - controller endpoints, commands, repository methods, etc. Each place has some contextual information on why the user is being revoked, and it now passes those to the underlying repository methods for saving.

This PR also adds two new events for two revocation reasons that are not yet tracked - TwoFactoryRemoval and SingleOrgCompliance. 

RevocationReason was made **required** on the repository, as all future users should know why a user's being revoked.

| Reason | Call Sites |
  |---|---|
  | `Manual` | `OrganizationUsersController PUT /{id}/revoke` (single), `OrganizationUsersController PUT /revoke` (bulk), `MembersController POST /{id}/revoke` (public API), SCIM `UsersController PUT /{id}`, SCIM `PatchUserCommand PATCH /{id}` |
  | `TwoFactorPolicyNonCompliance` | `TwoFactorAuthenticationPolicyEventHandler` (policy enabled), `UserService` (user disables 2FA), `AdminRecoverAccountCommand` (admin resets 2FA) |
  | `SingleOrgPolicyNonCompliance` | `SingleOrgPolicyEventHandler` (policy enabled) |
  | `OrganizationDataOwnershipPolicyNonCompliance` | `SelfRevokeOrganizationUserCommand` (user declines data ownership transfer) |


[PM-33875]: https://bitwarden.atlassian.net/browse/PM-33875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ