### PR TITLE
[PM-25056] - Deadlock testing fix

### DIFF
--- a/test/Infrastructure.IntegrationTest/AdminConsole/OrganizationTestHelpers.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/OrganizationTestHelpers.cs
@@ -4,6 +4,8 @@ using Bit.Core.Billing.Enums;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Repositories;
+using Bit.Core.Utilities;
+using Microsoft.Data.SqlClient;
 
 namespace Bit.Infrastructure.IntegrationTest.AdminConsole;
 
@@ -16,7 +18,7 @@ public static class OrganizationTestHelpers
 {
     public static Task<User> CreateTestUserAsync(this IUserRepository userRepository, string identifier = "test")
     {
-        var id = Guid.NewGuid();
+        var id = CoreHelpers.GenerateComb();
         return userRepository.CreateAsync(new User
         {
             Id = id,
@@ -34,7 +36,7 @@ public static class OrganizationTestHelpers
         int? seatCount = null,
         string identifier = "test")
     {
-        var id = Guid.NewGuid();
+        var id = CoreHelpers.GenerateComb();
         return organizationRepository.CreateAsync(new Organization
         {
             Name = $"{identifier}-{id}",
@@ -180,6 +182,41 @@ public static class OrganizationTestHelpers
             OrganizationId = organization.Id,
             Name = $"{identifier} {Guid.NewGuid()}"
         });
+
+    /// <summary>
+    /// Deletes an organization with retry logic for SQL Server deadlocks (error 1205).
+    /// Use this instead of <see cref="IOrganizationRepository.DeleteAsync"/> in test cleanup
+    /// to avoid deadlocks when tests run in parallel.
+    /// </summary>
+    public static async Task SafeDeleteAsync(this IOrganizationRepository repo, Organization org, int maxRetries = 3)
+    {
+        for (var attempt = 0; ; attempt++)
+        {
+            try
+            {
+                await repo.DeleteAsync(org);
+                return;
+            }
+            catch (Exception ex) when (attempt < maxRetries && IsDeadlock(ex))
+            {
+                await Task.Delay(Random.Shared.Next(50, 200));
+            }
+        }
+    }
+
+    private static bool IsDeadlock(Exception ex)
+    {
+        var current = ex;
+        while (current != null)
+        {
+            if (current is SqlException { Number: 1205 })
+            {
+                return true;
+            }
+            current = current.InnerException;
+        }
+        return false;
+    }
 
     public static Task<OrganizationInviteLink> CreateTestOrganizationInviteLinkAsync(
         this IOrganizationInviteLinkRepository repository,

--- a/test/Infrastructure.IntegrationTest/AdminConsole/OrganizationTestHelpers.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/OrganizationTestHelpers.cs
@@ -5,8 +5,6 @@ using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Repositories;
 using Bit.Core.Utilities;
-using Microsoft.Data.SqlClient;
-
 namespace Bit.Infrastructure.IntegrationTest.AdminConsole;
 
 /// <summary>
@@ -182,41 +180,6 @@ public static class OrganizationTestHelpers
             OrganizationId = organization.Id,
             Name = $"{identifier} {Guid.NewGuid()}"
         });
-
-    /// <summary>
-    /// Deletes an organization with retry logic for SQL Server deadlocks (error 1205).
-    /// Use this instead of <see cref="IOrganizationRepository.DeleteAsync"/> in test cleanup
-    /// to avoid deadlocks when tests run in parallel.
-    /// </summary>
-    public static async Task SafeDeleteAsync(this IOrganizationRepository repo, Organization org, int maxRetries = 3)
-    {
-        for (var attempt = 0; ; attempt++)
-        {
-            try
-            {
-                await repo.DeleteAsync(org);
-                return;
-            }
-            catch (Exception ex) when (attempt < maxRetries && IsDeadlock(ex))
-            {
-                await Task.Delay(Random.Shared.Next(50, 200));
-            }
-        }
-    }
-
-    private static bool IsDeadlock(Exception ex)
-    {
-        var current = ex;
-        while (current != null)
-        {
-            if (current is SqlException { Number: 1205 })
-            {
-                return true;
-            }
-            current = current.InnerException;
-        }
-        return false;
-    }
 
     public static Task<OrganizationInviteLink> CreateTestOrganizationInviteLinkAsync(
         this IOrganizationInviteLinkRepository repository,

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/CollectionRepository/CollectionRepositoryCreateTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/CollectionRepository/CollectionRepositoryCreateTests.cs
@@ -61,13 +61,6 @@ public class CollectionRepositoryCreateTests
         Assert.Equal(2, users.Length);
         Assert.Single(users, u => u.Id == orgUser1.Id && u.Manage && !u.HidePasswords && u.ReadOnly);
         Assert.Single(users, u => u.Id == orgUser2.Id && !u.Manage && u.HidePasswords && !u.ReadOnly);
-
-        // Clean up data
-        await userRepository.DeleteAsync(user1);
-        await userRepository.DeleteAsync(user2);
-        await organizationRepository.SafeDeleteAsync(organization);
-        await groupRepository.DeleteManyAsync([group1.Id, group2.Id]);
-        await organizationUserRepository.DeleteManyAsync([orgUser1.Id, orgUser2.Id]);
     }
 
     /// <remarks>
@@ -98,8 +91,5 @@ public class CollectionRepositoryCreateTests
 
         Assert.Empty(actualAccess.Groups);
         Assert.Empty(actualAccess.Users);
-
-        // Clean up
-        await organizationRepository.SafeDeleteAsync(organization);
     }
 }

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/CollectionRepository/CollectionRepositoryCreateTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/CollectionRepository/CollectionRepositoryCreateTests.cs
@@ -65,7 +65,7 @@ public class CollectionRepositoryCreateTests
         // Clean up data
         await userRepository.DeleteAsync(user1);
         await userRepository.DeleteAsync(user2);
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await groupRepository.DeleteManyAsync([group1.Id, group2.Id]);
         await organizationUserRepository.DeleteManyAsync([orgUser1.Id, orgUser2.Id]);
     }
@@ -100,6 +100,6 @@ public class CollectionRepositoryCreateTests
         Assert.Empty(actualAccess.Users);
 
         // Clean up
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
     }
 }

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/CollectionRepository/CollectionRepositoryReplaceTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/CollectionRepository/CollectionRepositoryReplaceTests.cs
@@ -92,7 +92,7 @@ public class CollectionRepositoryReplaceTests
         await userRepository.DeleteAsync(user1);
         await userRepository.DeleteAsync(user2);
         await userRepository.DeleteAsync(user3);
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
     }
 
     /// <remarks>
@@ -144,7 +144,7 @@ public class CollectionRepositoryReplaceTests
 
         // Clean up
         await userRepository.DeleteAsync(user);
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
     }
 
     [Theory, DatabaseData]
@@ -209,6 +209,6 @@ public class CollectionRepositoryReplaceTests
         // Clean up data
         await userRepository.DeleteAsync(user1);
         await userRepository.DeleteAsync(user2);
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
     }
 }

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/CollectionRepository/CollectionRepositoryReplaceTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/CollectionRepository/CollectionRepositoryReplaceTests.cs
@@ -87,12 +87,6 @@ public class CollectionRepositoryReplaceTests
         Assert.Equal(2, users.Length);
         Assert.Single(users, u => u.Id == orgUser2.Id && !u.Manage && !u.HidePasswords && u.ReadOnly);
         Assert.Single(users, u => u.Id == orgUser3.Id && u.Manage && !u.HidePasswords && u.ReadOnly);
-
-        // Clean up data
-        await userRepository.DeleteAsync(user1);
-        await userRepository.DeleteAsync(user2);
-        await userRepository.DeleteAsync(user3);
-        await organizationRepository.SafeDeleteAsync(organization);
     }
 
     /// <remarks>
@@ -141,10 +135,6 @@ public class CollectionRepositoryReplaceTests
 
         Assert.Empty(actualAccess.Groups);
         Assert.Empty(actualAccess.Users);
-
-        // Clean up
-        await userRepository.DeleteAsync(user);
-        await organizationRepository.SafeDeleteAsync(organization);
     }
 
     [Theory, DatabaseData]
@@ -205,10 +195,5 @@ public class CollectionRepositoryReplaceTests
         Assert.Equal(2, users.Length);
         Assert.Single(users, u => u.Id == orgUser1.Id && u.Manage && !u.HidePasswords && u.ReadOnly);
         Assert.Single(users, u => u.Id == orgUser2.Id && !u.Manage && u.HidePasswords && !u.ReadOnly);
-
-        // Clean up data
-        await userRepository.DeleteAsync(user1);
-        await userRepository.DeleteAsync(user2);
-        await organizationRepository.SafeDeleteAsync(organization);
     }
 }

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/CollectionRepository/CreateDefaultCollectionsSharedTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/CollectionRepository/CreateDefaultCollectionsSharedTests.cs
@@ -147,7 +147,7 @@ public static class CreateDefaultCollectionsSharedTests
         Organization organization,
         IEnumerable<OrganizationUser> organizationUsers)
     {
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
 
         await userRepository.DeleteManyAsync(
             organizationUsers

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/CollectionRepository/CreateDefaultCollectionsSharedTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/CollectionRepository/CreateDefaultCollectionsSharedTests.cs
@@ -35,8 +35,6 @@ public static class CreateDefaultCollectionsSharedTests
 
         // Assert
         await AssertAllUsersHaveOneDefaultCollectionAsync(collectionRepository, resultOrganizationUsers, organization.Id);
-
-        await CleanupAsync(organizationRepository, userRepository, organization, resultOrganizationUsers);
     }
 
     public static async Task CreatesForNewUsersOnly_AndIgnoresExistingUsers(
@@ -72,8 +70,6 @@ public static class CreateDefaultCollectionsSharedTests
 
         // Assert
         await AssertAllUsersHaveOneDefaultCollectionAsync(collectionRepository, affectedOrgUsers, organization.Id);
-
-        await CleanupAsync(organizationRepository, userRepository, organization, affectedOrgUsers);
     }
 
     public static async Task IgnoresAllExistingUsers(
@@ -101,8 +97,6 @@ public static class CreateDefaultCollectionsSharedTests
 
         // Assert - Original collections should remain unchanged, still only one per user
         await AssertAllUsersHaveOneDefaultCollectionAsync(collectionRepository, resultOrganizationUsers, organization.Id);
-
-        await CleanupAsync(organizationRepository, userRepository, organization, resultOrganizationUsers);
     }
 
     private static async Task CreateUsersWithExistingDefaultCollectionsAsync(
@@ -140,19 +134,5 @@ public static class CreateDefaultCollectionsSharedTests
         var orgUser = await organizationUserRepository.CreateTestOrganizationUserAsync(organization, user);
 
         return orgUser;
-    }
-
-    private static async Task CleanupAsync(IOrganizationRepository organizationRepository,
-        IUserRepository userRepository,
-        Organization organization,
-        IEnumerable<OrganizationUser> organizationUsers)
-    {
-        await organizationRepository.SafeDeleteAsync(organization);
-
-        await userRepository.DeleteManyAsync(
-            organizationUsers
-                .Where(organizationUser => organizationUser.UserId != null)
-                .Select(organizationUser => new User() { Id = organizationUser.UserId.Value })
-        );
     }
 }

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationRepositoryTests.cs
@@ -36,10 +36,6 @@ public class OrganizationRepositoryTests
         Assert.Equal(2, result.Count);
         Assert.Contains(result, org => org.Id == organization1.Id);
         Assert.Contains(result, org => org.Id == organization2.Id);
-
-        // Clean up
-        await organizationRepository.SafeDeleteAsync(organization1);
-        await organizationRepository.SafeDeleteAsync(organization2);
     }
 
     [Theory, DatabaseData]
@@ -212,9 +208,6 @@ public class OrganizationRepositoryTests
         Assert.Equal(organization.Id, updateResult.Id);
         Assert.True(updateResult.SyncSeats);
         Assert.Equal(requestDate.ToString("yyyy-MM-dd HH:mm:ss"), updateResult.RevisionDate.ToString("yyyy-MM-dd HH:mm:ss"));
-
-        // Annul
-        await sutRepository.SafeDeleteAsync(organization);
     }
 
     [DatabaseData, Theory]
@@ -237,9 +230,6 @@ public class OrganizationRepositoryTests
         Assert.Equal(organization.Id, updateResult.Id);
         Assert.True(updateResult.SyncSeats);
         Assert.Equal(requestDate.ToString("yyyy-MM-dd HH:mm:ss"), updateResult.RevisionDate.ToString("yyyy-MM-dd HH:mm:ss"));
-
-        // Annul
-        await sutRepository.SafeDeleteAsync(organization);
     }
 
     [DatabaseData, Theory]
@@ -260,9 +250,6 @@ public class OrganizationRepositoryTests
         Assert.Equal(organization.Id, updateResult.Id);
         Assert.True(updateResult.SyncSeats);
         Assert.Equal(requestDate.ToString("yyyy-MM-dd HH:mm:ss"), updateResult.RevisionDate.ToString("yyyy-MM-dd HH:mm:ss"));
-
-        // Annul
-        await sutRepository.SafeDeleteAsync(organization);
     }
 
     [DatabaseData, Theory]
@@ -281,9 +268,6 @@ public class OrganizationRepositoryTests
         // Assert
         var result = (await sutRepository.GetOrganizationsForSubscriptionSyncAsync()).ToArray();
         Assert.Null(result.FirstOrDefault(x => x.Id == organization.Id));
-
-        // Annul
-        await sutRepository.SafeDeleteAsync(organization);
     }
 
     [DatabaseTheory, DatabaseData]
@@ -400,9 +384,6 @@ public class OrganizationRepositoryTests
         Assert.Equal(organization.UseDisableSmAdsForUsers, result.UseDisableSmAdsForUsers);
         Assert.Equal(organization.UsePhishingBlocker, result.UsePhishingBlocker);
         Assert.Equal(organization.UseMyItems, result.UseMyItems);
-
-        // Clean up
-        await organizationRepository.SafeDeleteAsync(organization);
     }
 
     [Theory, DatabaseData]

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationRepositoryTests.cs
@@ -38,8 +38,8 @@ public class OrganizationRepositoryTests
         Assert.Contains(result, org => org.Id == organization2.Id);
 
         // Clean up
-        await organizationRepository.DeleteAsync(organization1);
-        await organizationRepository.DeleteAsync(organization2);
+        await organizationRepository.SafeDeleteAsync(organization1);
+        await organizationRepository.SafeDeleteAsync(organization2);
     }
 
     [Theory, DatabaseData]
@@ -214,7 +214,7 @@ public class OrganizationRepositoryTests
         Assert.Equal(requestDate.ToString("yyyy-MM-dd HH:mm:ss"), updateResult.RevisionDate.ToString("yyyy-MM-dd HH:mm:ss"));
 
         // Annul
-        await sutRepository.DeleteAsync(organization);
+        await sutRepository.SafeDeleteAsync(organization);
     }
 
     [DatabaseData, Theory]
@@ -239,7 +239,7 @@ public class OrganizationRepositoryTests
         Assert.Equal(requestDate.ToString("yyyy-MM-dd HH:mm:ss"), updateResult.RevisionDate.ToString("yyyy-MM-dd HH:mm:ss"));
 
         // Annul
-        await sutRepository.DeleteAsync(organization);
+        await sutRepository.SafeDeleteAsync(organization);
     }
 
     [DatabaseData, Theory]
@@ -262,7 +262,7 @@ public class OrganizationRepositoryTests
         Assert.Equal(requestDate.ToString("yyyy-MM-dd HH:mm:ss"), updateResult.RevisionDate.ToString("yyyy-MM-dd HH:mm:ss"));
 
         // Annul
-        await sutRepository.DeleteAsync(organization);
+        await sutRepository.SafeDeleteAsync(organization);
     }
 
     [DatabaseData, Theory]
@@ -283,7 +283,7 @@ public class OrganizationRepositoryTests
         Assert.Null(result.FirstOrDefault(x => x.Id == organization.Id));
 
         // Annul
-        await sutRepository.DeleteAsync(organization);
+        await sutRepository.SafeDeleteAsync(organization);
     }
 
     [DatabaseTheory, DatabaseData]
@@ -402,7 +402,7 @@ public class OrganizationRepositoryTests
         Assert.Equal(organization.UseMyItems, result.UseMyItems);
 
         // Clean up
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
     }
 
     [Theory, DatabaseData]

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/GetManyConfirmedAcceptedDetailsByUserAsyncTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/GetManyConfirmedAcceptedDetailsByUserAsyncTests.cs
@@ -28,7 +28,7 @@ public class GetManyConfirmedAcceptedDetailsByUserAsyncTests
         Assert.Equal(OrganizationUserStatusType.Confirmed, result.Status);
 
         // Annul
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteAsync(user);
     }
 
@@ -54,7 +54,7 @@ public class GetManyConfirmedAcceptedDetailsByUserAsyncTests
         Assert.Equal(OrganizationUserStatusType.Accepted, result.Status);
 
         // Annul
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteAsync(user);
     }
 
@@ -82,8 +82,8 @@ public class GetManyConfirmedAcceptedDetailsByUserAsyncTests
         Assert.Contains(results, r => r.OrganizationId == acceptedOrg.Id && r.Status == OrganizationUserStatusType.Accepted);
 
         // Annul
-        await organizationRepository.DeleteAsync(confirmedOrg);
-        await organizationRepository.DeleteAsync(acceptedOrg);
+        await organizationRepository.SafeDeleteAsync(confirmedOrg);
+        await organizationRepository.SafeDeleteAsync(acceptedOrg);
         await userRepository.DeleteAsync(user);
     }
 
@@ -105,7 +105,7 @@ public class GetManyConfirmedAcceptedDetailsByUserAsyncTests
         Assert.DoesNotContain(results, r => r.OrganizationId == organization.Id);
 
         // Annul
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteAsync(user);
     }
 
@@ -127,7 +127,7 @@ public class GetManyConfirmedAcceptedDetailsByUserAsyncTests
         Assert.DoesNotContain(results, r => r.OrganizationId == organization.Id);
 
         // Annul
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteAsync(user);
     }
 
@@ -151,7 +151,7 @@ public class GetManyConfirmedAcceptedDetailsByUserAsyncTests
         Assert.DoesNotContain(results, r => r.OrganizationId == organization.Id);
 
         // Annul
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteManyAsync([targetUser, otherUser]);
     }
 }

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/GetManyConfirmedAcceptedDetailsByUserAsyncTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/GetManyConfirmedAcceptedDetailsByUserAsyncTests.cs
@@ -26,10 +26,6 @@ public class GetManyConfirmedAcceptedDetailsByUserAsyncTests
         Assert.Equal(organization.Id, result.OrganizationId);
         Assert.Equal(user.Id, result.UserId);
         Assert.Equal(OrganizationUserStatusType.Confirmed, result.Status);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory, DatabaseData]
@@ -52,10 +48,6 @@ public class GetManyConfirmedAcceptedDetailsByUserAsyncTests
         Assert.Equal(organization.Id, result.OrganizationId);
         Assert.Equal(user.Id, result.UserId);
         Assert.Equal(OrganizationUserStatusType.Accepted, result.Status);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory, DatabaseData]
@@ -80,11 +72,6 @@ public class GetManyConfirmedAcceptedDetailsByUserAsyncTests
         Assert.Equal(2, results.Count);
         Assert.Contains(results, r => r.OrganizationId == confirmedOrg.Id && r.Status == OrganizationUserStatusType.Confirmed);
         Assert.Contains(results, r => r.OrganizationId == acceptedOrg.Id && r.Status == OrganizationUserStatusType.Accepted);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(confirmedOrg);
-        await organizationRepository.SafeDeleteAsync(acceptedOrg);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory, DatabaseData]
@@ -103,10 +90,6 @@ public class GetManyConfirmedAcceptedDetailsByUserAsyncTests
 
         // Assert
         Assert.DoesNotContain(results, r => r.OrganizationId == organization.Id);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory, DatabaseData]
@@ -125,10 +108,6 @@ public class GetManyConfirmedAcceptedDetailsByUserAsyncTests
 
         // Assert
         Assert.DoesNotContain(results, r => r.OrganizationId == organization.Id);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory, DatabaseData]
@@ -149,9 +128,5 @@ public class GetManyConfirmedAcceptedDetailsByUserAsyncTests
 
         // Assert
         Assert.DoesNotContain(results, r => r.OrganizationId == organization.Id);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteManyAsync([targetUser, otherUser]);
     }
 }

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/OrganizationUserRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/OrganizationUserRepositoryTests.cs
@@ -1393,10 +1393,6 @@ public class OrganizationUserRepositoryTests
         Assert.NotNull(updatedUser);
         Assert.Equal(OrganizationUserStatusType.Confirmed, updatedUser.Status);
         Assert.Equal(key, updatedUser.Key);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory, DatabaseData]
@@ -1426,10 +1422,6 @@ public class OrganizationUserRepositoryTests
         var unchangedUser = await organizationUserRepository.GetByIdAsync(orgUser.Id);
         Assert.NotNull(unchangedUser);
         Assert.Equal(OrganizationUserStatusType.Confirmed, unchangedUser.Status);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory, DatabaseData]
@@ -1460,10 +1452,6 @@ public class OrganizationUserRepositoryTests
         var finalUser = await organizationUserRepository.GetByIdAsync(orgUser.Id);
         Assert.NotNull(finalUser);
         Assert.Equal(OrganizationUserStatusType.Confirmed, finalUser.Status);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory, DatabaseData]

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/OrganizationUserRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/OrganizationUserRepositoryTests.cs
@@ -1395,7 +1395,7 @@ public class OrganizationUserRepositoryTests
         Assert.Equal(key, updatedUser.Key);
 
         // Annul
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteAsync(user);
     }
 
@@ -1428,7 +1428,7 @@ public class OrganizationUserRepositoryTests
         Assert.Equal(OrganizationUserStatusType.Confirmed, unchangedUser.Status);
 
         // Annul
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteAsync(user);
     }
 
@@ -1462,7 +1462,7 @@ public class OrganizationUserRepositoryTests
         Assert.Equal(OrganizationUserStatusType.Confirmed, finalUser.Status);
 
         // Annul
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteAsync(user);
     }
 

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetManyConfirmedAcceptedByUserIdAsyncTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetManyConfirmedAcceptedByUserIdAsyncTests.cs
@@ -33,10 +33,6 @@ public class GetManyConfirmedAcceptedByUserIdAsyncTests
 
         // Assert
         Assert.Contains(results, p => p.Id == policy.Id);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory, DatabaseData]
@@ -62,10 +58,6 @@ public class GetManyConfirmedAcceptedByUserIdAsyncTests
 
         // Assert
         Assert.Contains(results, p => p.Id == policy.Id);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory, DatabaseData]
@@ -102,11 +94,6 @@ public class GetManyConfirmedAcceptedByUserIdAsyncTests
         // Assert
         Assert.Contains(results, p => p.Id == confirmedPolicy.Id);
         Assert.Contains(results, p => p.Id == acceptedPolicy.Id);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(confirmedOrg);
-        await organizationRepository.SafeDeleteAsync(acceptedOrg);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory, DatabaseData]
@@ -139,10 +126,6 @@ public class GetManyConfirmedAcceptedByUserIdAsyncTests
 
         // Assert
         Assert.DoesNotContain(results, p => p.Id == policy.Id);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory, DatabaseData]
@@ -168,10 +151,6 @@ public class GetManyConfirmedAcceptedByUserIdAsyncTests
 
         // Assert
         Assert.DoesNotContain(results, p => p.Id == policy.Id);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory, DatabaseData]
@@ -199,9 +178,5 @@ public class GetManyConfirmedAcceptedByUserIdAsyncTests
 
         // Assert
         Assert.DoesNotContain(results, p => p.Id == policy.Id);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteManyAsync([targetUser, otherUser]);
     }
 }

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetManyConfirmedAcceptedByUserIdAsyncTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetManyConfirmedAcceptedByUserIdAsyncTests.cs
@@ -35,7 +35,7 @@ public class GetManyConfirmedAcceptedByUserIdAsyncTests
         Assert.Contains(results, p => p.Id == policy.Id);
 
         // Annul
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteAsync(user);
     }
 
@@ -64,7 +64,7 @@ public class GetManyConfirmedAcceptedByUserIdAsyncTests
         Assert.Contains(results, p => p.Id == policy.Id);
 
         // Annul
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteAsync(user);
     }
 
@@ -104,8 +104,8 @@ public class GetManyConfirmedAcceptedByUserIdAsyncTests
         Assert.Contains(results, p => p.Id == acceptedPolicy.Id);
 
         // Annul
-        await organizationRepository.DeleteAsync(confirmedOrg);
-        await organizationRepository.DeleteAsync(acceptedOrg);
+        await organizationRepository.SafeDeleteAsync(confirmedOrg);
+        await organizationRepository.SafeDeleteAsync(acceptedOrg);
         await userRepository.DeleteAsync(user);
     }
 
@@ -141,7 +141,7 @@ public class GetManyConfirmedAcceptedByUserIdAsyncTests
         Assert.DoesNotContain(results, p => p.Id == policy.Id);
 
         // Annul
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteAsync(user);
     }
 
@@ -170,7 +170,7 @@ public class GetManyConfirmedAcceptedByUserIdAsyncTests
         Assert.DoesNotContain(results, p => p.Id == policy.Id);
 
         // Annul
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteAsync(user);
     }
 
@@ -201,7 +201,7 @@ public class GetManyConfirmedAcceptedByUserIdAsyncTests
         Assert.DoesNotContain(results, p => p.Id == policy.Id);
 
         // Annul
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteManyAsync([targetUser, otherUser]);
     }
 }

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetPolicyDetailsByOrganizationIdAsyncTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetPolicyDetailsByOrganizationIdAsyncTests.cs
@@ -40,10 +40,6 @@ public class GetPolicyDetailsByOrganizationIdAsyncTests
 
         Assert.True(results.Single().IsProvider);
 
-        // Annul
-        await organizationRepository.SafeDeleteAsync(new Organization { Id = userOrgConnectedDirectly.OrganizationId });
-        await userRepository.DeleteAsync(user);
-
         async Task ArrangeProvider()
         {
             var provider = await providerRepository.CreateAsync(new Provider
@@ -90,11 +86,6 @@ public class GetPolicyDetailsByOrganizationIdAsyncTests
         Assert.Contains(results, result => result.OrganizationUserId == userOrgConnectedDirectly.Id
                                            && result.OrganizationId == userOrgConnectedDirectly.OrganizationId);
         Assert.DoesNotContain(results, result => result.OrganizationId == notConnectedOrg.Id);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(new Organization { Id = userOrgConnectedDirectly.OrganizationId });
-        await organizationRepository.SafeDeleteAsync(notConnectedOrg);
-        await userRepository.DeleteAsync(user);
     }
 
     [DatabaseTheory, DatabaseData]
@@ -124,10 +115,6 @@ public class GetPolicyDetailsByOrganizationIdAsyncTests
                                            && result.PolicyType == inputPolicyType);
 
         Assert.DoesNotContain(results, result => result.PolicyType == notInputPolicyType);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(new Organization { Id = orgUser.OrganizationId });
-        await userRepository.DeleteAsync(user);
     }
 
 
@@ -156,12 +143,6 @@ public class GetPolicyDetailsByOrganizationIdAsyncTests
         Assert.Equal(expectedCount, results.Count);
 
         AssertPolicyDetailUserConnections(results, userOrgConnectedDirectly, userOrgConnectedByEmail, userOrgConnectedByUserId);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(new Organization() { Id = userOrgConnectedDirectly.OrganizationId });
-        await organizationRepository.SafeDeleteAsync(new Organization() { Id = userOrgConnectedByEmail.OrganizationId });
-        await organizationRepository.SafeDeleteAsync(new Organization() { Id = userOrgConnectedByUserId.OrganizationId });
-        await userRepository.DeleteAsync(user);
     }
 
     [DatabaseTheory, DatabaseData]
@@ -186,12 +167,6 @@ public class GetPolicyDetailsByOrganizationIdAsyncTests
 
         // Assert
         AssertPolicyDetailUserConnections(results, userOrgConnectedDirectly, userOrgConnectedByEmail, userOrgConnectedByUserId);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(new Organization() { Id = userOrgConnectedDirectly.OrganizationId });
-        await organizationRepository.SafeDeleteAsync(new Organization() { Id = userOrgConnectedByEmail.OrganizationId });
-        await organizationRepository.SafeDeleteAsync(new Organization() { Id = userOrgConnectedByUserId.OrganizationId });
-        await userRepository.DeleteAsync(user);
     }
 
     [DatabaseTheory, DatabaseData]
@@ -225,10 +200,6 @@ public class GetPolicyDetailsByOrganizationIdAsyncTests
         Assert.Contains(results, result => result.OrganizationUserId == orgUser2.Id
                                            && result.UserId == orgUser2.UserId
                                            && result.OrganizationId == orgUser2.OrganizationId);
-
-        // Annul
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteManyAsync([user1, user2]);
     }
 
 

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetPolicyDetailsByOrganizationIdAsyncTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetPolicyDetailsByOrganizationIdAsyncTests.cs
@@ -41,7 +41,7 @@ public class GetPolicyDetailsByOrganizationIdAsyncTests
         Assert.True(results.Single().IsProvider);
 
         // Annul
-        await organizationRepository.DeleteAsync(new Organization { Id = userOrgConnectedDirectly.OrganizationId });
+        await organizationRepository.SafeDeleteAsync(new Organization { Id = userOrgConnectedDirectly.OrganizationId });
         await userRepository.DeleteAsync(user);
 
         async Task ArrangeProvider()
@@ -92,8 +92,8 @@ public class GetPolicyDetailsByOrganizationIdAsyncTests
         Assert.DoesNotContain(results, result => result.OrganizationId == notConnectedOrg.Id);
 
         // Annul
-        await organizationRepository.DeleteAsync(new Organization { Id = userOrgConnectedDirectly.OrganizationId });
-        await organizationRepository.DeleteAsync(notConnectedOrg);
+        await organizationRepository.SafeDeleteAsync(new Organization { Id = userOrgConnectedDirectly.OrganizationId });
+        await organizationRepository.SafeDeleteAsync(notConnectedOrg);
         await userRepository.DeleteAsync(user);
     }
 
@@ -126,7 +126,7 @@ public class GetPolicyDetailsByOrganizationIdAsyncTests
         Assert.DoesNotContain(results, result => result.PolicyType == notInputPolicyType);
 
         // Annul
-        await organizationRepository.DeleteAsync(new Organization { Id = orgUser.OrganizationId });
+        await organizationRepository.SafeDeleteAsync(new Organization { Id = orgUser.OrganizationId });
         await userRepository.DeleteAsync(user);
     }
 
@@ -158,9 +158,9 @@ public class GetPolicyDetailsByOrganizationIdAsyncTests
         AssertPolicyDetailUserConnections(results, userOrgConnectedDirectly, userOrgConnectedByEmail, userOrgConnectedByUserId);
 
         // Annul
-        await organizationRepository.DeleteAsync(new Organization() { Id = userOrgConnectedDirectly.OrganizationId });
-        await organizationRepository.DeleteAsync(new Organization() { Id = userOrgConnectedByEmail.OrganizationId });
-        await organizationRepository.DeleteAsync(new Organization() { Id = userOrgConnectedByUserId.OrganizationId });
+        await organizationRepository.SafeDeleteAsync(new Organization() { Id = userOrgConnectedDirectly.OrganizationId });
+        await organizationRepository.SafeDeleteAsync(new Organization() { Id = userOrgConnectedByEmail.OrganizationId });
+        await organizationRepository.SafeDeleteAsync(new Organization() { Id = userOrgConnectedByUserId.OrganizationId });
         await userRepository.DeleteAsync(user);
     }
 
@@ -188,9 +188,9 @@ public class GetPolicyDetailsByOrganizationIdAsyncTests
         AssertPolicyDetailUserConnections(results, userOrgConnectedDirectly, userOrgConnectedByEmail, userOrgConnectedByUserId);
 
         // Annul
-        await organizationRepository.DeleteAsync(new Organization() { Id = userOrgConnectedDirectly.OrganizationId });
-        await organizationRepository.DeleteAsync(new Organization() { Id = userOrgConnectedByEmail.OrganizationId });
-        await organizationRepository.DeleteAsync(new Organization() { Id = userOrgConnectedByUserId.OrganizationId });
+        await organizationRepository.SafeDeleteAsync(new Organization() { Id = userOrgConnectedDirectly.OrganizationId });
+        await organizationRepository.SafeDeleteAsync(new Organization() { Id = userOrgConnectedByEmail.OrganizationId });
+        await organizationRepository.SafeDeleteAsync(new Organization() { Id = userOrgConnectedByUserId.OrganizationId });
         await userRepository.DeleteAsync(user);
     }
 
@@ -227,7 +227,7 @@ public class GetPolicyDetailsByOrganizationIdAsyncTests
                                            && result.OrganizationId == orgUser2.OrganizationId);
 
         // Annul
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteManyAsync([user1, user2]);
     }
 

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetPolicyDetailsByUserIdAndPolicyTypeTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetPolicyDetailsByUserIdAndPolicyTypeTests.cs
@@ -59,7 +59,7 @@ public class GetPolicyDetailsByUserIdAndPolicyTypeTests
         Assert.False(result.IsProvider);
 
         // Cleanup
-        await organizationRepository.DeleteAsync(org);
+        await organizationRepository.SafeDeleteAsync(org);
         await userRepository.DeleteAsync(user);
     }
 
@@ -99,7 +99,7 @@ public class GetPolicyDetailsByUserIdAndPolicyTypeTests
         Assert.False(result.IsProvider);
 
         // Cleanup
-        await organizationRepository.DeleteAsync(org);
+        await organizationRepository.SafeDeleteAsync(org);
         await userRepository.DeleteAsync(user);
     }
 
@@ -137,7 +137,7 @@ public class GetPolicyDetailsByUserIdAndPolicyTypeTests
         Assert.False(result.IsProvider);
 
         // Cleanup
-        await organizationRepository.DeleteAsync(org);
+        await organizationRepository.SafeDeleteAsync(org);
         await userRepository.DeleteAsync(user);
     }
 
@@ -188,8 +188,8 @@ public class GetPolicyDetailsByUserIdAndPolicyTypeTests
         Assert.Equal(PolicyType.SingleOrg, result2.PolicyType);
 
         // Cleanup
-        await organizationRepository.DeleteAsync(org1);
-        await organizationRepository.DeleteAsync(org2);
+        await organizationRepository.SafeDeleteAsync(org1);
+        await organizationRepository.SafeDeleteAsync(org2);
         await userRepository.DeleteAsync(user);
     }
 
@@ -238,7 +238,7 @@ public class GetPolicyDetailsByUserIdAndPolicyTypeTests
         Assert.Equal(PolicyType.TwoFactorAuthentication, result.PolicyType);
 
         // Cleanup
-        await organizationRepository.DeleteAsync(org);
+        await organizationRepository.SafeDeleteAsync(org);
         await userRepository.DeleteAsync(user);
     }
 
@@ -272,7 +272,7 @@ public class GetPolicyDetailsByUserIdAndPolicyTypeTests
         Assert.Empty(results);
 
         // Cleanup
-        await organizationRepository.DeleteAsync(org);
+        await organizationRepository.SafeDeleteAsync(org);
         await userRepository.DeleteAsync(user);
     }
 
@@ -321,7 +321,7 @@ public class GetPolicyDetailsByUserIdAndPolicyTypeTests
         Assert.Empty(results);
 
         // Cleanup
-        await organizationRepository.DeleteAsync(org);
+        await organizationRepository.SafeDeleteAsync(org);
         await userRepository.DeleteAsync(user);
     }
 
@@ -370,7 +370,7 @@ public class GetPolicyDetailsByUserIdAndPolicyTypeTests
         Assert.Empty(results);
 
         // Cleanup
-        await organizationRepository.DeleteAsync(org);
+        await organizationRepository.SafeDeleteAsync(org);
         await userRepository.DeleteAsync(user);
     }
 
@@ -436,7 +436,7 @@ public class GetPolicyDetailsByUserIdAndPolicyTypeTests
         Assert.Equal(org.Id, result.OrganizationId);
 
         // Cleanup
-        await organizationRepository.DeleteAsync(org);
+        await organizationRepository.SafeDeleteAsync(org);
         await userRepository.DeleteAsync(user);
     }
 

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetPolicyDetailsByUserIdAndPolicyTypeTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetPolicyDetailsByUserIdAndPolicyTypeTests.cs
@@ -58,9 +58,6 @@ public class GetPolicyDetailsByUserIdAndPolicyTypeTests
         Assert.Equal(customPermissions, result.OrganizationUserPermissionsData);
         Assert.False(result.IsProvider);
 
-        // Cleanup
-        await organizationRepository.SafeDeleteAsync(org);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory]
@@ -98,9 +95,6 @@ public class GetPolicyDetailsByUserIdAndPolicyTypeTests
         Assert.Equal(OrganizationUserStatusType.Accepted, result.OrganizationUserStatus);
         Assert.False(result.IsProvider);
 
-        // Cleanup
-        await organizationRepository.SafeDeleteAsync(org);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory]
@@ -136,9 +130,6 @@ public class GetPolicyDetailsByUserIdAndPolicyTypeTests
         Assert.Equal(OrganizationUserStatusType.Invited, result.OrganizationUserStatus);
         Assert.False(result.IsProvider);
 
-        // Cleanup
-        await organizationRepository.SafeDeleteAsync(org);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory]
@@ -186,11 +177,6 @@ public class GetPolicyDetailsByUserIdAndPolicyTypeTests
         var result2 = resultsList.First(r => r.OrganizationId == org2.Id);
         Assert.Equal(orgUser2.Id, result2.OrganizationUserId);
         Assert.Equal(PolicyType.SingleOrg, result2.PolicyType);
-
-        // Cleanup
-        await organizationRepository.SafeDeleteAsync(org1);
-        await organizationRepository.SafeDeleteAsync(org2);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory]
@@ -237,9 +223,6 @@ public class GetPolicyDetailsByUserIdAndPolicyTypeTests
         var result = Assert.Single(resultsList);
         Assert.Equal(PolicyType.TwoFactorAuthentication, result.PolicyType);
 
-        // Cleanup
-        await organizationRepository.SafeDeleteAsync(org);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory]
@@ -271,9 +254,6 @@ public class GetPolicyDetailsByUserIdAndPolicyTypeTests
         // Assert
         Assert.Empty(results);
 
-        // Cleanup
-        await organizationRepository.SafeDeleteAsync(org);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory]
@@ -320,9 +300,6 @@ public class GetPolicyDetailsByUserIdAndPolicyTypeTests
         // Assert
         Assert.Empty(results);
 
-        // Cleanup
-        await organizationRepository.SafeDeleteAsync(org);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory]
@@ -369,9 +346,6 @@ public class GetPolicyDetailsByUserIdAndPolicyTypeTests
         // Assert
         Assert.Empty(results);
 
-        // Cleanup
-        await organizationRepository.SafeDeleteAsync(org);
-        await userRepository.DeleteAsync(user);
     }
 
     [Theory]
@@ -435,9 +409,6 @@ public class GetPolicyDetailsByUserIdAndPolicyTypeTests
         Assert.True(result.IsProvider);
         Assert.Equal(org.Id, result.OrganizationId);
 
-        // Cleanup
-        await organizationRepository.SafeDeleteAsync(org);
-        await userRepository.DeleteAsync(user);
     }
 
     private static async Task<Organization> CreateEnterpriseOrgAsync(IOrganizationRepository orgRepo)

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetPolicyDetailsByUserIdsAndPolicyTypeTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetPolicyDetailsByUserIdsAndPolicyTypeTests.cs
@@ -62,9 +62,6 @@ public class GetPolicyDetailsByUserIdsAndPolicyTypeTests
         Assert.Equal(PolicyType.TwoFactorAuthentication, result2.PolicyType);
         Assert.Equal(policy.Data, result2.PolicyData);
         Assert.Equal(OrganizationUserStatusType.Confirmed, result2.OrganizationUserStatus);
-
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteManyAsync([user1, user2]);
     }
 
     [Theory]
@@ -114,9 +111,6 @@ public class GetPolicyDetailsByUserIdsAndPolicyTypeTests
         Assert.Equal(organization.Id, result2.OrganizationId);
         Assert.Equal(PolicyType.MasterPassword, result2.PolicyType);
         Assert.Equal(OrganizationUserStatusType.Invited, result2.OrganizationUserStatus);
-
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteManyAsync([user1, user2]);
     }
 
     [Theory]
@@ -178,9 +172,6 @@ public class GetPolicyDetailsByUserIdsAndPolicyTypeTests
         Assert.True(result.IsProvider);
         Assert.Equal(user.Id, result.UserId);
         Assert.Equal(organization.Id, result.OrganizationId);
-
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteManyAsync([user]);
     }
 
     [Theory]
@@ -212,9 +203,6 @@ public class GetPolicyDetailsByUserIdsAndPolicyTypeTests
         var resultsList = results.ToList();
         Assert.Single(resultsList);
         Assert.All(resultsList, r => Assert.Equal(PolicyType.TwoFactorAuthentication, r.PolicyType));
-
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteManyAsync([user]);
     }
 
     [Theory]
@@ -246,8 +234,6 @@ public class GetPolicyDetailsByUserIdsAndPolicyTypeTests
 
         // Assert
         Assert.Empty(results);
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteManyAsync([user]);
     }
 
     [Theory]
@@ -289,9 +275,6 @@ public class GetPolicyDetailsByUserIdsAndPolicyTypeTests
 
         // Assert
         Assert.Empty(results);
-
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteManyAsync([user]);
     }
 
     [Theory]
@@ -333,9 +316,6 @@ public class GetPolicyDetailsByUserIdsAndPolicyTypeTests
 
         // Assert
         Assert.Empty(results);
-
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteManyAsync([user]);
     }
 
     [Theory]

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetPolicyDetailsByUserIdsAndPolicyTypeTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetPolicyDetailsByUserIdsAndPolicyTypeTests.cs
@@ -63,7 +63,7 @@ public class GetPolicyDetailsByUserIdsAndPolicyTypeTests
         Assert.Equal(policy.Data, result2.PolicyData);
         Assert.Equal(OrganizationUserStatusType.Confirmed, result2.OrganizationUserStatus);
 
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteManyAsync([user1, user2]);
     }
 
@@ -115,7 +115,7 @@ public class GetPolicyDetailsByUserIdsAndPolicyTypeTests
         Assert.Equal(PolicyType.MasterPassword, result2.PolicyType);
         Assert.Equal(OrganizationUserStatusType.Invited, result2.OrganizationUserStatus);
 
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteManyAsync([user1, user2]);
     }
 
@@ -179,7 +179,7 @@ public class GetPolicyDetailsByUserIdsAndPolicyTypeTests
         Assert.Equal(user.Id, result.UserId);
         Assert.Equal(organization.Id, result.OrganizationId);
 
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteManyAsync([user]);
     }
 
@@ -213,7 +213,7 @@ public class GetPolicyDetailsByUserIdsAndPolicyTypeTests
         Assert.Single(resultsList);
         Assert.All(resultsList, r => Assert.Equal(PolicyType.TwoFactorAuthentication, r.PolicyType));
 
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteManyAsync([user]);
     }
 
@@ -246,7 +246,7 @@ public class GetPolicyDetailsByUserIdsAndPolicyTypeTests
 
         // Assert
         Assert.Empty(results);
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteManyAsync([user]);
     }
 
@@ -290,7 +290,7 @@ public class GetPolicyDetailsByUserIdsAndPolicyTypeTests
         // Assert
         Assert.Empty(results);
 
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteManyAsync([user]);
     }
 
@@ -334,7 +334,7 @@ public class GetPolicyDetailsByUserIdsAndPolicyTypeTests
         // Assert
         Assert.Empty(results);
 
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteManyAsync([user]);
     }
 

--- a/test/Infrastructure.IntegrationTest/Vault/Repositories/CipherRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/Vault/Repositories/CipherRepositoryTests.cs
@@ -13,7 +13,6 @@ using Bit.Core.Vault.Entities;
 using Bit.Core.Vault.Enums;
 using Bit.Core.Vault.Models.Data;
 using Bit.Core.Vault.Repositories;
-using Bit.Infrastructure.IntegrationTest.AdminConsole;
 using Xunit;
 using CipherType = Bit.Core.Vault.Enums.CipherType;
 
@@ -627,12 +626,6 @@ public class CipherRepositoryTests
         var deletableCipher = ciphers.SingleOrDefault(x => x.Id == cipher.Id);
         Assert.NotNull(deletableCipher);
         Assert.True(deletableCipher.Manage);
-
-        // Annul
-        await cipherRepository.DeleteAsync(cipher);
-        await organizationUserRepository.DeleteAsync(orgUser);
-        await organizationRepository.SafeDeleteAsync(organization);
-        await userRepository.DeleteAsync(user);
     }
 
     private async Task<(User user, Organization org, OrganizationUser orgUser)> CreateTestUserAndOrganization(

--- a/test/Infrastructure.IntegrationTest/Vault/Repositories/CipherRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/Vault/Repositories/CipherRepositoryTests.cs
@@ -13,6 +13,7 @@ using Bit.Core.Vault.Entities;
 using Bit.Core.Vault.Enums;
 using Bit.Core.Vault.Models.Data;
 using Bit.Core.Vault.Repositories;
+using Bit.Infrastructure.IntegrationTest.AdminConsole;
 using Xunit;
 using CipherType = Bit.Core.Vault.Enums.CipherType;
 
@@ -630,7 +631,7 @@ public class CipherRepositoryTests
         // Annul
         await cipherRepository.DeleteAsync(cipher);
         await organizationUserRepository.DeleteAsync(orgUser);
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
         await userRepository.DeleteAsync(user);
     }
 

--- a/test/Infrastructure.IntegrationTest/Vault/Repositories/CollectionCipherRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/Vault/Repositories/CollectionCipherRepositoryTests.cs
@@ -6,6 +6,7 @@ using Bit.Core.Repositories;
 using Bit.Core.Vault.Entities;
 using Bit.Core.Vault.Enums;
 using Bit.Core.Vault.Repositories;
+using Bit.Infrastructure.IntegrationTest.AdminConsole;
 using Xunit;
 
 namespace Bit.Infrastructure.IntegrationTest.Vault.Repositories;
@@ -79,6 +80,6 @@ public class CollectionCipherRepositoryTests
         await cipherRepository.DeleteAsync(defaultCipher);
         await collectionRepository.DeleteAsync(sharedCollection);
         await collectionRepository.DeleteAsync(defaultUserCollection);
-        await organizationRepository.DeleteAsync(organization);
+        await organizationRepository.SafeDeleteAsync(organization);
     }
 }

--- a/test/Infrastructure.IntegrationTest/Vault/Repositories/CollectionCipherRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/Vault/Repositories/CollectionCipherRepositoryTests.cs
@@ -6,7 +6,6 @@ using Bit.Core.Repositories;
 using Bit.Core.Vault.Entities;
 using Bit.Core.Vault.Enums;
 using Bit.Core.Vault.Repositories;
-using Bit.Infrastructure.IntegrationTest.AdminConsole;
 using Xunit;
 
 namespace Bit.Infrastructure.IntegrationTest.Vault.Repositories;
@@ -74,12 +73,5 @@ public class CollectionCipherRepositoryTests
         Assert.Single(result);
         Assert.Equal(sharedCollection.Id, result.First().CollectionId);
         Assert.DoesNotContain(result, cc => cc.CollectionId == defaultUserCollection.Id);
-
-        // Cleanup
-        await cipherRepository.DeleteAsync(sharedCipher);
-        await cipherRepository.DeleteAsync(defaultCipher);
-        await collectionRepository.DeleteAsync(sharedCollection);
-        await collectionRepository.DeleteAsync(defaultUserCollection);
-        await organizationRepository.SafeDeleteAsync(organization);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking
[PM-25056](https://bitwarden.atlassian.net/browse/PM-25056)

## 📔 Objective
This identified the root cause for the testing framework deadlock. 

When tests are being run in parallel, tests that called `OrganizationRepo.DeleteAsync` would call the giant sproc that would go across all the other tables to clean up related data. Each opened up its own transaction and would lock tables. This caused the intermittent deadlocks across the different tests as they were all locking and trying to delete records in the same tables.


[PM-25056]: https://bitwarden.atlassian.net/browse/PM-25056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ