### PR TITLE
[PM-35243] Exclude 'other' cancel survey reason for Teams/Enterprise

### DIFF
--- a/src/Core/Billing/Services/Implementations/SubscriberService.cs
+++ b/src/Core/Billing/Services/Implementations/SubscriberService.cs
@@ -66,6 +66,12 @@ public class SubscriberService(
             "unused"
         ];
 
+        if (subscriber is Organization { PlanType: var planType } &&
+            planType.IsBusinessProductTierType())
+        {
+            validCancellationReasons.Remove("other");
+        }
+
         // Build once from survey — null when survey is absent (system-initiated cancellation)
         var cancellationDetails = offboardingSurveyResponse != null
             ? new SubscriptionCancellationDetailsOptions

--- a/test/Core.Test/Billing/Services/SubscriberServiceTests.cs
+++ b/test/Core.Test/Billing/Services/SubscriberServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.Billing.Constants;
+using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Models;
 using Bit.Core.Billing.Pricing;
 using Bit.Core.Billing.Services;
@@ -554,6 +555,166 @@ public class SubscriberServiceTests
 
         await stripeAdapter.Received(1).UpdateSubscriptionAsync(subscriptionId,
             Arg.Is<SubscriptionUpdateOptions>(o => o.CancelAtPeriodEnd == true));
+    }
+
+    [Theory, BitAutoData]
+    public async Task CancelSubscription_TeamsOrg_OtherReason_FeedbackIsNull(
+        Organization organization,
+        SutProvider<SubscriberService> sutProvider)
+    {
+        organization.PlanType = PlanType.TeamsAnnually;
+
+        const string subscriptionId = "subscription_id";
+
+        var subscription = new Subscription
+        {
+            Id = subscriptionId,
+            Status = "active",
+            Metadata = new Dictionary<string, string>
+            {
+                { "organizationId", "organization_id" }
+            }
+        };
+
+        var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
+        stripeAdapter
+            .GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        var offboardingSurveyResponse = new OffboardingSurveyResponse
+        {
+            UserId = Guid.NewGuid(),
+            Reason = "other",
+            Feedback = "Some feedback"
+        };
+
+        await sutProvider.Sut.CancelSubscription(organization, true, offboardingSurveyResponse);
+
+        await stripeAdapter
+            .Received(1)
+            .CancelSubscriptionAsync(subscriptionId, Arg.Is<SubscriptionCancelOptions>(options =>
+                options.CancellationDetails.Comment == "Some feedback" &&
+                options.CancellationDetails.Feedback == null));
+    }
+
+    [Theory, BitAutoData]
+    public async Task CancelSubscription_EnterpriseOrg_OtherReason_FeedbackIsNull(
+        Organization organization,
+        SutProvider<SubscriberService> sutProvider)
+    {
+        organization.PlanType = PlanType.EnterpriseAnnually;
+
+        const string subscriptionId = "subscription_id";
+
+        var subscription = new Subscription
+        {
+            Id = subscriptionId,
+            Status = "active",
+            Metadata = new Dictionary<string, string>
+            {
+                { "organizationId", "organization_id" }
+            }
+        };
+
+        var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
+        stripeAdapter
+            .GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        var offboardingSurveyResponse = new OffboardingSurveyResponse
+        {
+            UserId = Guid.NewGuid(),
+            Reason = "other",
+            Feedback = "Some feedback"
+        };
+
+        await sutProvider.Sut.CancelSubscription(organization, true, offboardingSurveyResponse);
+
+        await stripeAdapter
+            .Received(1)
+            .CancelSubscriptionAsync(subscriptionId, Arg.Is<SubscriptionCancelOptions>(options =>
+                options.CancellationDetails.Comment == "Some feedback" &&
+                options.CancellationDetails.Feedback == null));
+    }
+
+    [Theory, BitAutoData]
+    public async Task CancelSubscription_TeamsOrg_ValidReason_FeedbackIsPreserved(
+        Organization organization,
+        SutProvider<SubscriberService> sutProvider)
+    {
+        organization.PlanType = PlanType.TeamsAnnually;
+
+        const string subscriptionId = "subscription_id";
+
+        var subscription = new Subscription
+        {
+            Id = subscriptionId,
+            Status = "active",
+            Metadata = new Dictionary<string, string>
+            {
+                { "organizationId", "organization_id" }
+            }
+        };
+
+        var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
+        stripeAdapter
+            .GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        var offboardingSurveyResponse = new OffboardingSurveyResponse
+        {
+            UserId = Guid.NewGuid(),
+            Reason = "missing_features",
+            Feedback = "Some feedback"
+        };
+
+        await sutProvider.Sut.CancelSubscription(organization, true, offboardingSurveyResponse);
+
+        await stripeAdapter
+            .Received(1)
+            .CancelSubscriptionAsync(subscriptionId, Arg.Is<SubscriptionCancelOptions>(options =>
+                options.CancellationDetails.Comment == "Some feedback" &&
+                options.CancellationDetails.Feedback == "missing_features"));
+    }
+
+    [Theory, BitAutoData]
+    public async Task CancelSubscription_FamiliesOrg_OtherReason_FeedbackIsPreserved(
+        Organization organization,
+        SutProvider<SubscriberService> sutProvider)
+    {
+        organization.PlanType = PlanType.FamiliesAnnually;
+
+        const string subscriptionId = "subscription_id";
+
+        var subscription = new Subscription
+        {
+            Id = subscriptionId,
+            Status = "active",
+            Metadata = new Dictionary<string, string>
+            {
+                { "organizationId", "organization_id" }
+            }
+        };
+
+        var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
+        stripeAdapter
+            .GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        var offboardingSurveyResponse = new OffboardingSurveyResponse
+        {
+            UserId = Guid.NewGuid(),
+            Reason = "other",
+            Feedback = "Some feedback"
+        };
+
+        await sutProvider.Sut.CancelSubscription(organization, true, offboardingSurveyResponse);
+
+        await stripeAdapter
+            .Received(1)
+            .CancelSubscriptionAsync(subscriptionId, Arg.Is<SubscriptionCancelOptions>(options =>
+                options.CancellationDetails.Comment == "Some feedback" &&
+                options.CancellationDetails.Feedback == "other"));
     }
 
     #endregion


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35243

## 📔 Objective

Adds plan-aware validation to `SubscriberService.CancelSubscription` so that "other" is excluded from valid cancellation survey reasons when the subscriber is a Teams, Enterprise, or Teams Starter organization. This is defense-in-depth for PM-35243, which updates the cancel survey options shown to business-tier customers. The existing behavior — invalid reasons silently become `null` feedback to Stripe — is preserved. Uses the existing `IsBusinessProductTierType()` extension to identify business plans.

## 📸 Screenshots

N/A — no UI changes in this repo.