### PR TITLE
chore: remove bulk reinvite and org accept init flags

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -159,8 +159,6 @@ public static class FeatureFlagKeys
     public const string PolicyRequirements = "pm-14439-policy-requirements";
     public const string ScimInviteUserOptimization = "pm-16811-optimize-invite-user-flow-to-fail-fast";
     public const string AutomaticConfirmUsers = "pm-19934-auto-confirm-organization-users";
-    public const string BulkReinviteUI = "pm-28416-bulk-reinvite-ux-improvements";
-    public const string RefactorOrgAcceptInit = "pm-33082-refactor-org-accept-init";
     public const string AdminResetTwoFactor = "pm-15489-reset-two-factor-account-recovery";
     public const string PublicMembersInviteRefactor = "pm-33398-refactor-members-invite-org-users-command";
     public const string GenerateInviteLink = "pm-32497-generate-invite-link";


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33087
https://bitwarden.atlassian.net/browse/PM-28420

## 📔 Objective

> Bad merge conflict resolutions or updates to the `Constants.cs` file that are outdated when merged to main keep causing flags to get added back in. Remove `pm-28416-bulk-reinvite-ux-improvements` and `pm-33082-refactor-org-accept-init` again.