### PR TITLE
[PM-35235] Make PUT Policy identical to PUT Policy/VNext

### DIFF
--- a/src/Api/AdminConsole/Controllers/PoliciesController.cs
+++ b/src/Api/AdminConsole/Controllers/PoliciesController.cs
@@ -134,9 +134,13 @@ public class PoliciesController : Controller
 
     [HttpPut("{type}")]
     [Authorize<ManagePoliciesRequirement>]
-    public async Task<PolicyResponseModel> Put(Guid orgId, PolicyType type, [FromBody] PolicyRequestModel model)
+    public async Task<PolicyResponseModel> Put(Guid orgId, PolicyType type, [FromBody] SavePolicyRequest model)
     {
-        return await PutVNext(orgId, type, new SavePolicyRequest { Policy = model });
+        var savePolicyRequest = await model.ToSavePolicyModelAsync(orgId, type, _currentContext);
+
+        var policy = await _savePolicyCommand.SaveAsync(savePolicyRequest);
+
+        return new PolicyResponseModel(policy);
     }
 
     [HttpPut("{type}/vnext")]

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/PoliciesControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/PoliciesControllerTests.cs
@@ -215,13 +215,16 @@ public class PoliciesControllerTests : IClassFixture<ApiApplicationFactory>, IAs
     {
         // Arrange
         var policyType = PolicyType.MasterPassword;
-        var request = new PolicyRequestModel
+        var request = new SavePolicyRequest
         {
-            Enabled = true,
-            Data = new Dictionary<string, object>
+            Policy = new PolicyRequestModel
             {
-                { "minLength", "not a number" }, // Wrong type - should be int
-                { "requireUpper", true }
+                Enabled = true,
+                Data = new Dictionary<string, object>
+                {
+                    { "minLength", "not a number" }, // Wrong type - should be int
+                    { "requireUpper", true }
+                }
             }
         };
 
@@ -240,12 +243,15 @@ public class PoliciesControllerTests : IClassFixture<ApiApplicationFactory>, IAs
     {
         // Arrange
         var policyType = PolicyType.SendOptions;
-        var request = new PolicyRequestModel
+        var request = new SavePolicyRequest
         {
-            Enabled = true,
-            Data = new Dictionary<string, object>
+            Policy = new PolicyRequestModel
             {
-                { "disableHideEmail", "not a boolean" } // Wrong type - should be bool
+                Enabled = true,
+                Data = new Dictionary<string, object>
+                {
+                    { "disableHideEmail", "not a boolean" } // Wrong type - should be bool
+                }
             }
         };
 
@@ -262,12 +268,15 @@ public class PoliciesControllerTests : IClassFixture<ApiApplicationFactory>, IAs
     {
         // Arrange
         var policyType = PolicyType.ResetPassword;
-        var request = new PolicyRequestModel
+        var request = new SavePolicyRequest
         {
-            Enabled = true,
-            Data = new Dictionary<string, object>
+            Policy = new PolicyRequestModel
             {
-                { "autoEnrollEnabled", 123 } // Wrong type - should be bool
+                Enabled = true,
+                Data = new Dictionary<string, object>
+                {
+                    { "autoEnrollEnabled", 123 } // Wrong type - should be bool
+                }
             }
         };
 
@@ -362,10 +371,13 @@ public class PoliciesControllerTests : IClassFixture<ApiApplicationFactory>, IAs
     {
         // Arrange
         var policyType = PolicyType.SingleOrg;
-        var request = new PolicyRequestModel
+        var request = new SavePolicyRequest
         {
-            Enabled = true,
-            Data = null
+            Policy = new PolicyRequestModel
+            {
+                Enabled = true,
+                Data = null
+            }
         };
 
         // Act
@@ -404,12 +416,15 @@ public class PoliciesControllerTests : IClassFixture<ApiApplicationFactory>, IAs
     {
         // Arrange
         var policyType = PolicyType.MasterPassword;
-        var request = new PolicyRequestModel
+        var request = new SavePolicyRequest
         {
-            Enabled = true,
-            Data = new Dictionary<string, object>
+            Policy = new PolicyRequestModel
             {
-                { "minLength", 129 }
+                Enabled = true,
+                Data = new Dictionary<string, object>
+                {
+                    { "minLength", 129 }
+                }
             }
         };
 
@@ -426,12 +441,15 @@ public class PoliciesControllerTests : IClassFixture<ApiApplicationFactory>, IAs
     {
         // Arrange
         var policyType = PolicyType.MasterPassword;
-        var request = new PolicyRequestModel
+        var request = new SavePolicyRequest
         {
-            Enabled = true,
-            Data = new Dictionary<string, object>
+            Policy = new PolicyRequestModel
             {
-                { "minComplexity", 5 }
+                Enabled = true,
+                Data = new Dictionary<string, object>
+                {
+                    { "minComplexity", 5 }
+                }
             }
         };
 
@@ -562,10 +580,13 @@ public class PoliciesControllerTests : IClassFixture<ApiApplicationFactory>, IAs
         // Re-authenticate as the owner of Org A
         await _loginHelper.LoginAsync(_ownerEmail);
 
-        var request = new PolicyRequestModel
+        var request = new SavePolicyRequest
         {
-            Enabled = true,
-            Data = null
+            Policy = new PolicyRequestModel
+            {
+                Enabled = true,
+                Data = null
+            }
         };
 
         // Act - Enable Single Org policy on Org A

--- a/test/Api.Test/AdminConsole/Controllers/PoliciesControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/PoliciesControllerTests.cs
@@ -414,7 +414,7 @@ public class PoliciesControllerTests
             .Returns(policy);
 
         // Act
-        var result = await sutProvider.Sut.Put(orgId, policy.Type, model.Policy);
+        var result = await sutProvider.Sut.Put(orgId, policy.Type, model);
 
         // Assert
         await sutProvider.GetDependency<ISavePolicyCommand>()


### PR DESCRIPTION
## 🎟️ Tracking
[PM-35235](https://bitwarden.atlassian.net/browse/PM-35235)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
A prior PR #7130 did not fully address the underlying need of ensuring the old endpoint was accepting the same request body AND performing all of the new actions. As-is, we can not repoint our clients to the non-VNext endpoint, because the request model differs.

This PR finalizes the transition server-side by ensuring the endpoint fully matches the VNext one (except the route), so we can point clients to the non-vNext-route.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->


[PM-35235]: https://bitwarden.atlassian.net/browse/PM-35235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ