### PR TITLE
[PM-35234] Prevent appending duplicate org user in validator request

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptOrgUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptOrgUserCommand.cs
@@ -232,11 +232,15 @@ public class AcceptOrgUserCommand : IAcceptOrgUserCommand
         var policyRequirement = await _policyRequirementQuery.GetAsync<AutomaticUserConfirmationPolicyRequirement>(
             user.Id);
 
+        // Ensure that the user is not already in the list of organization users
+        if (!allOrgUsers.Any(x => x.OrganizationId == orgUser.OrganizationId && x.UserId == user.Id))
+        {
+            allOrgUsers.Add(orgUser);
+        }
+
         var error = (await _automaticUserConfirmationPolicyEnforcementValidator.IsCompliantAsync(
                 new AutomaticUserConfirmationPolicyEnforcementRequest(orgUser.OrganizationId,
-                    allOrgUsers
-                        .Where(u => u.OrganizationId != orgUser.OrganizationId && u.UserId != orgUser.UserId)
-                        .Append(orgUser),
+                    allOrgUsers,
                     user),
                 policyRequirement))
             .Match(

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptOrgUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptOrgUserCommand.cs
@@ -234,7 +234,9 @@ public class AcceptOrgUserCommand : IAcceptOrgUserCommand
 
         var error = (await _automaticUserConfirmationPolicyEnforcementValidator.IsCompliantAsync(
                 new AutomaticUserConfirmationPolicyEnforcementRequest(orgUser.OrganizationId,
-                    allOrgUsers.Append(orgUser),
+                    allOrgUsers
+                        .Where(u => u.OrganizationId != orgUser.OrganizationId && u.UserId != orgUser.UserId)
+                        .Append(orgUser),
                     user),
                 policyRequirement))
             .Match(

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptOrgUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptOrgUserCommandTests.cs
@@ -741,6 +741,49 @@ public class AcceptOrgUserCommandTests
 
     [Theory]
     [BitAutoData]
+    public async Task AcceptOrgUserAsync_WhenSsoPreProvisionedUserAlreadyInAllOrgUsers_DeduplicatesAndSucceeds(
+        SutProvider<AcceptOrgUserCommand> sutProvider,
+        User user, Organization org, OrganizationUser orgUser, OrganizationUserUserDetails adminUserDetails)
+    {
+        // Arrange
+        // Simulate SSO pre-provisioning: orgUser already has UserId set and is returned by GetManyByUserAsync,
+        // meaning allOrgUsers already contains orgUser before the Append call.
+        orgUser.UserId = user.Id;
+        orgUser.OrganizationId = org.Id;
+
+        SetupCommonAcceptOrgUserMocks(sutProvider, user, org, orgUser, adminUserDetails);
+
+        // GetManyByUserAsync returns the same orgUser (SSO pre-provisioned)
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetManyByUserAsync(user.Id)
+            .Returns(new List<OrganizationUser> { orgUser });
+
+        sutProvider.GetDependency<IPolicyRequirementQuery>()
+            .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
+            .Returns(new AutomaticUserConfirmationPolicyRequirement([new PolicyDetails { OrganizationId = org.Id }]));
+
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+            .IsCompliantAsync(
+                Arg.Is<AutomaticUserConfirmationPolicyEnforcementRequest>(r =>
+                    r.AllOrganizationUsers.Count == 1 &&
+                    r.AllOrganizationUsers.Single().Id == orgUser.Id),
+                Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
+            .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser], user)));
+
+        // Act - should not throw even though the same orgUser was in allOrgUsers
+        var result = await sutProvider.Sut.AcceptOrgUserAsync(orgUser, user, _userService);
+
+        // Assert
+        Assert.NotNull(result);
+        await sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+            .Received(1)
+            .IsCompliantAsync(
+                Arg.Is<AutomaticUserConfirmationPolicyEnforcementRequest>(r => r.AllOrganizationUsers.Count == 1),
+                Arg.Any<AutomaticUserConfirmationPolicyRequirement>());
+    }
+
+    [Theory]
+    [BitAutoData]
     public async Task AcceptOrgUserAsync_WithAutoConfirmPolicyEnabled_DeletesEmergencyAccess(
         SutProvider<AcceptOrgUserCommand> sutProvider,
         User user, Organization org, OrganizationUser orgUser, OrganizationUserUserDetails adminUserDetails)


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-35234
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
In the accept flow, we query for all possible org users related to the user accepting the invite (to enforce single org requirement) when auto confirm is enabled. However, at this stage an SSO user will have an org user already provisioned, so the query returns our user accepting the invite. The validator logic does not recognize this is the same user for the same organization and erroneously fails the single organization requirement validation step. 

This PR fixes that by ensuring the orgUser is not appended to the request if it is the same org user as the accepting user.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
