### PR TITLE
Add seed script for local development

### DIFF
--- a/dev/.gitignore
+++ b/dev/.gitignore
@@ -19,3 +19,5 @@ signingkey.jwk
 # Reverse Proxy Conifg
 reverse-proxy.conf
 *.crt
+
+seeds.local.json

--- a/dev/seed.ps1
+++ b/dev/seed.ps1
@@ -1,0 +1,77 @@
+#!/usr/bin/env pwsh
+# Runs SeederUtility for each entry defined in seeds.json (and optionally seeds.local.json).
+# Usage: ./seed.ps1 [-DryRun]
+
+param(
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+
+$globalSeedsPath = Join-Path $PSScriptRoot "seeds.json"
+$localSeedsPath  = Join-Path $PSScriptRoot "seeds.local.json"
+$seederProject   = Join-Path $PSScriptRoot ".." "util" "SeederUtility"
+
+$seeds = @(Get-Content $globalSeedsPath -Raw | ConvertFrom-Json)
+
+if (Test-Path $localSeedsPath) {
+    $seeds += @(Get-Content $localSeedsPath -Raw | ConvertFrom-Json)
+}
+
+function ConvertTo-KebabCase {
+    param([string]$Name)
+    return ($Name -creplace '(?<=[a-z])([A-Z])', '-$1').ToLower()
+}
+
+function Build-CliArgs {
+    param($ArgsObject)
+    $parts = @()
+    foreach ($prop in $ArgsObject.PSObject.Properties) {
+        $flag  = ConvertTo-KebabCase $prop.Name
+        $value = $prop.Value
+        if ($null -eq $value) {
+            continue
+        } elseif ($value -is [bool]) {
+            if ($value) {
+                $parts += "--$flag"
+            }
+        } else {
+            $parts += "--$flag"
+            $parts += "$value"
+        }
+    }
+    return ,$parts
+}
+
+$total = $seeds.Count
+
+if ($total -eq 0) {
+    Write-Host "No seeds configured." -ForegroundColor Yellow
+    exit 0
+}
+
+for ($i = 0; $i -lt $total; $i++) {
+    $seed    = $seeds[$i]
+    $label   = if ($seed.label) { $seed.label } else { "$($seed.command) #$($i + 1)" }
+    $command = $seed.command
+    $cliArgs = Build-CliArgs $seed.args
+
+    Write-Host ""
+    Write-Host "[$($i + 1)/$total] $label" -ForegroundColor Cyan
+    Write-Host "  dotnet run --project $seederProject -- $command $($cliArgs -join ' ')" -ForegroundColor DarkGray
+
+    if (-not $DryRun) {
+        dotnet run --project $seederProject -- $command @cliArgs
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Seed '$label' failed with exit code $LASTEXITCODE."
+            exit $LASTEXITCODE
+        }
+    }
+}
+
+Write-Host ""
+if ($DryRun) {
+    Write-Host "Dry run complete. $total seed(s) would be executed." -ForegroundColor Yellow
+} else {
+    Write-Host "All $total seed(s) completed successfully." -ForegroundColor Green
+}

--- a/dev/seed.ps1
+++ b/dev/seed.ps1
@@ -63,7 +63,7 @@ for ($i = 0; $i -lt $total; $i++) {
     if (-not $DryRun) {
         dotnet run --project $seederProject -- $command @cliArgs
         if ($LASTEXITCODE -ne 0) {
-            Write-Error "Seed '$label' failed with exit code $LASTEXITCODE."
+            [Console]::Error.WriteLine("Seed '$label' failed with exit code $LASTEXITCODE.")
             exit $LASTEXITCODE
         }
     }

--- a/dev/seeds.json
+++ b/dev/seeds.json
@@ -1,0 +1,29 @@
+[
+  {
+    "label": "Jane Doe Free (individual, free)",
+    "command": "individual",
+    "args": {
+      "subscription": "free",
+      "firstName": "Jane",
+      "lastName": "Doe",
+      "email": "jane@bitwarden.pw"
+    }
+  },
+  {
+    "label": "John Doe (individual, premium)",
+    "command": "individual",
+    "args": {
+      "subscription": "premium",
+      "firstName": "John",
+      "lastName": "Doe",
+      "email": "john@bitwarden.pw"
+    }
+  },
+  {
+    "label": "Enterprise Basic (qa.enterprise-basic preset)",
+    "command": "preset",
+    "args": {
+      "name": "qa.enterprise-basic"
+    }
+  }
+]

--- a/dev/seeds.json
+++ b/dev/seeds.json
@@ -6,7 +6,7 @@
       "subscription": "free",
       "firstName": "Jane",
       "lastName": "Doe",
-      "email": "jane@bitwarden.pw"
+      "email": "jane@bw.test"
     }
   },
   {
@@ -16,7 +16,7 @@
       "subscription": "premium",
       "firstName": "John",
       "lastName": "Doe",
-      "email": "john@bitwarden.pw"
+      "email": "john@bw.test"
     }
   },
   {

--- a/util/Seeder/Options/IndividualUserOptions.cs
+++ b/util/Seeder/Options/IndividualUserOptions.cs
@@ -18,6 +18,11 @@ public record IndividualUserOptions
     public string? LastName { get; init; }
 
     /// <summary>
+    /// Optional email.
+    /// </summary>
+    public string? Email { get; init; }
+
+    /// <summary>
     /// Whether the user has a premium subscription (enables 1 GB storage).
     /// </summary>
     public bool Premium { get; init; }

--- a/util/Seeder/Pipeline/RecipeOrchestrator.cs
+++ b/util/Seeder/Pipeline/RecipeOrchestrator.cs
@@ -96,7 +96,7 @@ internal sealed class RecipeOrchestrator(SeederDependencies deps)
     {
         var firstName = options.FirstName ?? new Bogus.Faker().Name.FirstName();
         var lastName = options.LastName ?? new Bogus.Faker().Name.LastName();
-        var email = $"{firstName}.{lastName}@individual.example".ToLowerInvariant();
+        var email = options.Email ?? $"{firstName}.{lastName}@individual.example".ToLowerInvariant();
 
         var premium = options.Premium;
         var maxStorageGb = premium ? (short)1 : (short)0;

--- a/util/SeederUtility/Commands/IndividualArgs.cs
+++ b/util/SeederUtility/Commands/IndividualArgs.cs
@@ -18,6 +18,9 @@ public class IndividualArgs : IArgumentModel
     [Option("last-name", Description = "Last name for the user (generates predictable email)")]
     public string? LastName { get; set; }
 
+    [Option("email", Description = "Email for the user")]
+    public string? Email { get; set; }
+
     [Option("vault", Description = "Generate ~75 personal ciphers and folders")]
     public bool Vault { get; set; } = false;
 
@@ -62,6 +65,7 @@ public class IndividualArgs : IArgumentModel
     {
         FirstName = FirstName,
         LastName = LastName,
+        Email = Email,
         Premium = string.Equals(Subscription, "premium", StringComparison.OrdinalIgnoreCase),
         GenerateVault = Vault,
         Password = Password,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

 Introduces a repeatable, declarative way to seed a local dev environment via the existing `SeederUtility`.                                                                                                        
   
  - **`dev/seed.ps1`** — new script that reads `dev/seeds.json` (and optional, gitignored `dev/seeds.local.json` for per-developer overrides), converts each entry's `args` from camelCase to kebab-case CLI flags, 
  and invokes `dotnet run --project util/SeederUtility` once per seed. Supports `-DryRun` to preview the commands without executing. Fails fast on non-zero exit codes.
  - **`dev/seeds.json`** — default seed set (two individual users + the `qa.enterprise-basic` preset) so new contributors get a consistent baseline dataset.                                                        
  - **`dev/.gitignore`** — ignores `seeds.local.json` so per-developer overrides don't leak into the repo.                                                                                                          
  - **`IndividualUserOptions` / `IndividualArgs` / `RecipeOrchestrator`** — adds an optional `--email` flag to the `individual` command, falling back to the existing `firstName.lastName@individual.example`       
  pattern when omitted. This lets `seeds.json` pin deterministic emails (e.g. `jane@bitwarden.pw`) instead of relying on the generated default.      

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
