### PR TITLE
chore: remove leftover implied reference to create default location ff

### DIFF
--- a/test/Api.IntegrationTest/AdminConsole/Controllers/PoliciesControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/PoliciesControllerTests.cs
@@ -13,7 +13,6 @@ using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Repositories;
 using Bit.Test.Common.Helpers;
-using NSubstitute;
 using Xunit;
 
 namespace Bit.Api.IntegrationTest.AdminConsole.Controllers;

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/PoliciesControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/PoliciesControllerTests.cs
@@ -30,12 +30,6 @@ public class PoliciesControllerTests : IClassFixture<ApiApplicationFactory>, IAs
     public PoliciesControllerTests(ApiApplicationFactory factory)
     {
         _factory = factory;
-        _factory.SubstituteService<Core.Services.IFeatureService>(featureService =>
-        {
-            featureService
-                .IsEnabled("pm-19467-create-default-location")
-                .Returns(true);
-        });
         _client = factory.CreateClient();
         _loginHelper = new LoginHelper(_factory, _client);
     }


### PR DESCRIPTION
## 📔 Objective

> Removed indirect reference to create-default-location feature flag that doesn't exist anymore

