### PR TITLE
[PM-35306] Fix password change not working when using the unlock and authentication data models

### DIFF
--- a/src/Api/Auth/Models/Request/Accounts/PasswordRequestModel.cs
+++ b/src/Api/Auth/Models/Request/Accounts/PasswordRequestModel.cs
@@ -1,7 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.KeyManagement.Models.Api.Request;
-using Bit.Core.Utilities;
-
 
 namespace Bit.Api.Auth.Models.Request.Accounts;
 
@@ -21,27 +19,33 @@ public class PasswordRequestModel : SecretVerificationRequestModel
 
     public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
-        // validate the secrets for the base class first
         foreach (var result in base.Validate(validationContext))
         {
             yield return result;
         }
 
-        // Enforce: if one is provided, both must be provided. Neither is also acceptable
-        // for backward compatibility with clients that don't yet send these fields.
-        if (AuthenticationData != null && UnlockData != null)
-        {
-            foreach (var validationResult in KdfSettingsValidator.ValidateAuthenticationAndUnlockData(
-                AuthenticationData.ToData(), UnlockData.ToData()))
-            {
-                yield return validationResult;
-            }
-        }
-        else if (AuthenticationData != null || UnlockData != null)
+        // Either both must be present or none should be present
+        if ((AuthenticationData == null) != (UnlockData == null))
         {
             yield return new ValidationResult(
                 "AuthenticationData and UnlockData must be provided.",
                 [nameof(AuthenticationData), nameof(UnlockData)]);
+        }
+        if (AuthenticationData != null && UnlockData != null)
+        {
+            if (!AuthenticationData.HasSameKdfConfiguration(UnlockData))
+            {
+                yield return new ValidationResult(
+                    "AuthenticationData and UnlockData must have the same KDF configuration.",
+                    [nameof(AuthenticationData), nameof(UnlockData)]);
+            }
+
+            if (!AuthenticationData.Salt.Equals(UnlockData.Salt))
+            {
+                yield return new ValidationResult(
+                    "AuthenticationData and UnlockData must have the same salt.",
+                    [nameof(AuthenticationData), nameof(UnlockData)]);
+            }
         }
     }
 }

--- a/src/Core/KeyManagement/Kdf/Implementations/ChangeKdfCommand.cs
+++ b/src/Core/KeyManagement/Kdf/Implementations/ChangeKdfCommand.cs
@@ -51,7 +51,7 @@ public class ChangeKdfCommand : IChangeKdfCommand
         // Currently KDF settings are not saved separately for authentication and unlock and must therefore be equal
         if (!authenticationData.Kdf.Equals(unlockData.Kdf))
         {
-            throw new BadRequestException("KDF settings must be equal for authentication and unlock.");
+            throw new BadRequestException("AuthenticationData and UnlockData must have the same KDF configuration.");
         }
 
         var validationErrors = KdfSettingsValidator.Validate(unlockData.Kdf);

--- a/src/Core/KeyManagement/Models/Api/Request/KdfRequestModel.cs
+++ b/src/Core/KeyManagement/Models/Api/Request/KdfRequestModel.cs
@@ -1,11 +1,10 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Bit.Core.Enums;
 using Bit.Core.KeyManagement.Models.Data;
-using Bit.Core.Utilities;
 
 namespace Bit.Core.KeyManagement.Models.Api.Request;
 
-public class KdfRequestModel : IValidatableObject
+public class KdfRequestModel
 {
     [Required]
     public required KdfType KdfType { get; init; }
@@ -23,11 +22,5 @@ public class KdfRequestModel : IValidatableObject
             Memory = Memory,
             Parallelism = Parallelism
         };
-    }
-
-    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-    {
-        // Generic per-request KDF validation for any request model embedding KdfRequestModel
-        return KdfSettingsValidator.Validate(ToData());
     }
 }

--- a/src/Core/KeyManagement/Models/Api/Request/MasterPasswordAuthenticationDataRequestModel.cs
+++ b/src/Core/KeyManagement/Models/Api/Request/MasterPasswordAuthenticationDataRequestModel.cs
@@ -25,4 +25,17 @@ public class MasterPasswordAuthenticationDataRequestModel
             Salt = Salt
         };
     }
+
+    public bool HasSameKdfConfiguration(MasterPasswordUnlockDataRequestModel unlockData)
+    {
+        if (unlockData == null)
+        {
+            return false;
+        }
+
+        return Kdf.KdfType == unlockData.Kdf.KdfType
+            && Kdf.Iterations == unlockData.Kdf.Iterations
+            && Kdf.Memory == unlockData.Kdf.Memory
+            && Kdf.Parallelism == unlockData.Kdf.Parallelism;
+    }
 }

--- a/src/Core/KeyManagement/Models/Api/Request/MasterPasswordAuthenticationDataRequestModel.cs
+++ b/src/Core/KeyManagement/Models/Api/Request/MasterPasswordAuthenticationDataRequestModel.cs
@@ -33,9 +33,6 @@ public class MasterPasswordAuthenticationDataRequestModel
             return false;
         }
 
-        return Kdf.KdfType == unlockData.Kdf.KdfType
-            && Kdf.Iterations == unlockData.Kdf.Iterations
-            && Kdf.Memory == unlockData.Kdf.Memory
-            && Kdf.Parallelism == unlockData.Kdf.Parallelism;
+        return Kdf.ToData().Equals(unlockData.Kdf.ToData());
     }
 }

--- a/src/Core/Utilities/KdfSettingsValidator.cs
+++ b/src/Core/Utilities/KdfSettingsValidator.cs
@@ -8,7 +8,9 @@ public static class KdfSettingsValidator
 {
     /// <summary>
     /// Validates that authentication and unlock data have matching KDF settings and salts,
-    /// then validates the KDF settings themselves.
+    /// then validates the KDF settings themselves. This should be used when setting
+    /// the KDF settings. This should NOT be used when merely changing settings affected
+    /// by the kdf settings (email-salt, password, key-rotation).
     /// </summary>
     public static IEnumerable<ValidationResult> ValidateAuthenticationAndUnlockData(
         MasterPasswordAuthenticationData authentication,
@@ -18,7 +20,7 @@ public static class KdfSettingsValidator
         if (!authentication.Kdf.Equals(unlock.Kdf))
         {
             yield return new ValidationResult(
-                "KDF settings must be equal for authentication and unlock.",
+                "AuthenticationData and UnlockData must have the same KDF configuration.",
                 [nameof(authentication.Kdf)]);
             // KDF settings diverge; remaining validation is not meaningful
             yield break;

--- a/test/Api.IntegrationTest/Controllers/AccountsControllerTest.cs
+++ b/test/Api.IntegrationTest/Controllers/AccountsControllerTest.cs
@@ -382,7 +382,7 @@ public class AccountsControllerTest : IClassFixture<ApiApplicationFactory>, IAsy
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         var content = await response.Content.ReadAsStringAsync();
-        Assert.Contains("The model state is invalid", content);
+        Assert.Contains("KDF settings are invalid.", content);
     }
 
     [Fact]

--- a/test/Api.IntegrationTest/Controllers/AccountsControllerTest.cs
+++ b/test/Api.IntegrationTest/Controllers/AccountsControllerTest.cs
@@ -307,7 +307,7 @@ public class AccountsControllerTest : IClassFixture<ApiApplicationFactory>, IAsy
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         var content = await response.Content.ReadAsStringAsync();
-        Assert.Contains("Invalid master password salt.", content);
+        Assert.Contains("AuthenticationData and UnlockData must have the same salt.", content);
     }
 
     [Fact]
@@ -333,7 +333,7 @@ public class AccountsControllerTest : IClassFixture<ApiApplicationFactory>, IAsy
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         var content = await response.Content.ReadAsStringAsync();
-        Assert.Contains("Invalid master password salt.", content);
+        Assert.Contains("AuthenticationData and UnlockData must have the same salt.", content);
     }
 
     [Fact]
@@ -359,7 +359,7 @@ public class AccountsControllerTest : IClassFixture<ApiApplicationFactory>, IAsy
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         var content = await response.Content.ReadAsStringAsync();
-        Assert.Contains("KDF settings must be equal for authentication and unlock.", content);
+        Assert.Contains("AuthenticationData and UnlockData must have the same KDF configuration.", content);
     }
 
     [Theory]

--- a/test/Api.Test/Auth/Models/Request/Accounts/PasswordRequestModelTests.cs
+++ b/test/Api.Test/Auth/Models/Request/Accounts/PasswordRequestModelTests.cs
@@ -160,7 +160,7 @@ public class PasswordRequestModelTests
     public void Validate_WhenBothAuthAndUnlockPresent_WithBelowMinimumKdf_NoError()
     {
         // Regression guard: legacy users with sub-minimum KDF settings must be able to change
-        // their master password. KDF strength is enforced only on /accounts/kdf (ChangeKdfCommand).
+        // their master password. KDF strength is enforced in the commands for registration / kdf change
         var kdf = new KdfRequestModel
         {
             KdfType = KdfType.PBKDF2_SHA256,

--- a/test/Api.Test/Auth/Models/Request/Accounts/PasswordRequestModelTests.cs
+++ b/test/Api.Test/Auth/Models/Request/Accounts/PasswordRequestModelTests.cs
@@ -118,10 +118,7 @@ public class PasswordRequestModelTests
 
         var result = model.Validate(new ValidationContext(model)).ToList();
 
-        Assert.Contains(result, r =>
-            r.ErrorMessage == "AuthenticationData and UnlockData must have the same salt." &&
-            r.MemberNames.Contains(nameof(PasswordRequestModel.AuthenticationData)) &&
-            r.MemberNames.Contains(nameof(PasswordRequestModel.UnlockData)));
+        Assert.Contains(result, r => r.ErrorMessage == "AuthenticationData and UnlockData must have the same salt.");
     }
 
     [Fact]

--- a/test/Api.Test/Auth/Models/Request/Accounts/PasswordRequestModelTests.cs
+++ b/test/Api.Test/Auth/Models/Request/Accounts/PasswordRequestModelTests.cs
@@ -82,10 +82,7 @@ public class PasswordRequestModelTests
 
         var result = model.Validate(new ValidationContext(model)).ToList();
 
-        Assert.Contains(result, r =>
-            r.ErrorMessage == "AuthenticationData and UnlockData must have the same KDF configuration." &&
-            r.MemberNames.Contains(nameof(PasswordRequestModel.AuthenticationData)) &&
-            r.MemberNames.Contains(nameof(PasswordRequestModel.UnlockData)));
+        Assert.Contains(result, r => r.ErrorMessage == "AuthenticationData and UnlockData must have the same KDF configuration.");
     }
 
     [Fact]

--- a/test/Api.Test/Auth/Models/Request/Accounts/PasswordRequestModelTests.cs
+++ b/test/Api.Test/Auth/Models/Request/Accounts/PasswordRequestModelTests.cs
@@ -52,7 +52,7 @@ public class PasswordRequestModelTests
     [Fact]
     public void Validate_WhenBothAuthAndUnlockPresent_WithMismatchedKdf_ReturnsError()
     {
-        // Arrange
+        // Request model enforces matching KDF settings between AuthenticationData and UnlockData.
         var model = new PasswordRequestModel
         {
             MasterPasswordHash = "masterPasswordHash",
@@ -73,24 +73,24 @@ public class PasswordRequestModelTests
                 Kdf = new KdfRequestModel
                 {
                     KdfType = KdfType.PBKDF2_SHA256,
-                    Iterations = 650000 // Different iterations
+                    Iterations = 650000
                 },
                 MasterKeyWrappedUserKey = "wrappedKey",
                 Salt = "salt"
             }
         };
 
-        // Act
         var result = model.Validate(new ValidationContext(model)).ToList();
 
-        // Assert
-        Assert.Contains(result, r => r.ErrorMessage != null && r.ErrorMessage.Contains("KDF settings must be equal"));
+        Assert.Contains(result, r =>
+            r.ErrorMessage == "AuthenticationData and UnlockData must have the same KDF configuration." &&
+            r.MemberNames.Contains(nameof(PasswordRequestModel.AuthenticationData)) &&
+            r.MemberNames.Contains(nameof(PasswordRequestModel.UnlockData)));
     }
 
     [Fact]
     public void Validate_WhenBothAuthAndUnlockPresent_WithMismatchedSalt_ReturnsError()
     {
-        // Arrange
         var kdf = new KdfRequestModel
         {
             KdfType = KdfType.PBKDF2_SHA256,
@@ -112,25 +112,65 @@ public class PasswordRequestModelTests
             {
                 Kdf = kdf,
                 MasterKeyWrappedUserKey = "wrappedKey",
-                Salt = "salt2" // Different salt
+                Salt = "salt2"
             }
         };
 
-        // Act
         var result = model.Validate(new ValidationContext(model)).ToList();
 
-        // Assert
-        Assert.Contains(result, r => r.ErrorMessage != null && r.ErrorMessage.Contains("Invalid master password salt."));
+        Assert.Contains(result, r =>
+            r.ErrorMessage == "AuthenticationData and UnlockData must have the same salt." &&
+            r.MemberNames.Contains(nameof(PasswordRequestModel.AuthenticationData)) &&
+            r.MemberNames.Contains(nameof(PasswordRequestModel.UnlockData)));
     }
 
     [Fact]
-    public void Validate_WhenBothAuthAndUnlockPresent_WithInvalidKdf_ReturnsError()
+    public void Validate_WhenBothAuthAndUnlockPresent_WithMismatchedKdfAndSalt_ReturnsBothErrors()
     {
-        // Arrange
+        var model = new PasswordRequestModel
+        {
+            MasterPasswordHash = "masterPasswordHash",
+            NewMasterPasswordHash = "newHash",
+            Key = "key",
+            AuthenticationData = new MasterPasswordAuthenticationDataRequestModel
+            {
+                Kdf = new KdfRequestModel
+                {
+                    KdfType = KdfType.PBKDF2_SHA256,
+                    Iterations = 600000
+                },
+                MasterPasswordAuthenticationHash = "authHash",
+                Salt = "salt1"
+            },
+            UnlockData = new MasterPasswordUnlockDataRequestModel
+            {
+                Kdf = new KdfRequestModel
+                {
+                    KdfType = KdfType.Argon2id,
+                    Iterations = 3,
+                    Memory = 64,
+                    Parallelism = 4
+                },
+                MasterKeyWrappedUserKey = "wrappedKey",
+                Salt = "salt2"
+            }
+        };
+
+        var result = model.Validate(new ValidationContext(model)).ToList();
+
+        Assert.Contains(result, r => r.ErrorMessage == "AuthenticationData and UnlockData must have the same KDF configuration.");
+        Assert.Contains(result, r => r.ErrorMessage == "AuthenticationData and UnlockData must have the same salt.");
+    }
+
+    [Fact]
+    public void Validate_WhenBothAuthAndUnlockPresent_WithBelowMinimumKdf_NoError()
+    {
+        // Regression guard: legacy users with sub-minimum KDF settings must be able to change
+        // their master password. KDF strength is enforced only on /accounts/kdf (ChangeKdfCommand).
         var kdf = new KdfRequestModel
         {
             KdfType = KdfType.PBKDF2_SHA256,
-            Iterations = 1 // Too low
+            Iterations = 1
         };
 
         var model = new PasswordRequestModel
@@ -152,11 +192,9 @@ public class PasswordRequestModelTests
             }
         };
 
-        // Act
         var result = model.Validate(new ValidationContext(model)).ToList();
 
-        // Assert
-        Assert.Contains(result, r => r.ErrorMessage != null && r.ErrorMessage.Contains("KDF iterations must be between"));
+        Assert.DoesNotContain(result, r => r.ErrorMessage != null && r.ErrorMessage.Contains("KDF iterations must be between"));
     }
 
     [Fact]

--- a/test/Api.Test/Auth/Models/Request/Accounts/SetInitialPasswordRequestModelTests.cs
+++ b/test/Api.Test/Auth/Models/Request/Accounts/SetInitialPasswordRequestModelTests.cs
@@ -95,7 +95,7 @@ public class SetInitialPasswordRequestModelTests
 
         // Assert
         Assert.Single(result);
-        Assert.Contains("KDF settings must be equal", result[0].ErrorMessage);
+        Assert.Contains("AuthenticationData and UnlockData must have the same KDF configuration", result[0].ErrorMessage);
         var memberNames = result[0].MemberNames.ToList();
         Assert.Single(memberNames);
         Assert.Contains("Kdf", memberNames);

--- a/test/Api.Test/Utilities/KdfSettingsValidatorTests.cs
+++ b/test/Api.Test/Utilities/KdfSettingsValidatorTests.cs
@@ -76,7 +76,7 @@ public class KdfSettingsValidatorTests
         var results = KdfSettingsValidator.ValidateAuthenticationAndUnlockData(authentication, unlock).ToList();
 
         Assert.Single(results);
-        Assert.Equal("KDF settings must be equal for authentication and unlock.", results[0].ErrorMessage);
+        Assert.Equal("AuthenticationData and UnlockData must have the same KDF configuration.", results[0].ErrorMessage);
     }
 
     [Fact]

--- a/test/Core.Test/Auth/Models/Api/Request/Accounts/RegisterFinishRequestModelTests.cs
+++ b/test/Core.Test/Auth/Models/Api/Request/Accounts/RegisterFinishRequestModelTests.cs
@@ -381,7 +381,7 @@ public class RegisterFinishRequestModelTests
 
         var results = Validate(model);
 
-        Assert.Contains(results, r => r.ErrorMessage == "KDF settings must be equal for authentication and unlock.");
+        Assert.Contains(results, r => r.ErrorMessage == "AuthenticationData and UnlockData must have the same KDF configuration.");
     }
 
     [Fact]

--- a/test/Identity.Test/Controllers/AccountsControllerTests.cs
+++ b/test/Identity.Test/Controllers/AccountsControllerTests.cs
@@ -955,7 +955,7 @@ public class AccountsControllerTests : IDisposable
 
         // Assert mismatched auth/unlock KDF settings are rejected
         Assert.Single(results);
-        Assert.Equal("KDF settings must be equal for authentication and unlock.", results[0].ErrorMessage);
+        Assert.Equal("AuthenticationData and UnlockData must have the same KDF configuration.", results[0].ErrorMessage);
     }
 
     [Theory, BitAutoData]


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-35306

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Currently, the KDF request model validates the KDF parameters to be in the acceptable range for KDF changes and new accounts. However, this validation is re-used during password changes, which is incorrect. This prevents users from changing their password until they upgrade their KDF settings.

This PR removes the validation on the request model directly. Validation still happens in the commands that should validate (registration, change KDF).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
