### PR TITLE
[PM-34427] Fix Users can edit and save sends with the hide email address option enabled

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/DisableSendSyncPolicyEvent.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/DisableSendSyncPolicyEvent.cs
@@ -4,7 +4,6 @@ using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.Models;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyUpdateEvents.Interfaces;
 using Bit.Core.AdminConsole.Repositories;
-using Bit.Core.Utilities;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyEventHandlers;
 
@@ -27,10 +26,11 @@ public class DisableSendSyncPolicyEvent(
         var organizationId = policyRequest.PolicyUpdate.OrganizationId;
 
         // Step 1: sync DisableSend.Enabled -> SendControlsPolicy.Data.DisableSend
+        // Leave Id as default(Guid) for new policies so UpsertAsync routes to CreateAsync;
+        // pre-assigning an Id causes UpsertAsync to attempt an UPDATE that silently affects 0 rows.
         var sendControlsPolicy = await policyRepository.GetByOrganizationIdTypeAsync(
             organizationId, PolicyType.SendControls) ?? new Policy
             {
-                Id = CoreHelpers.GenerateComb(),
                 OrganizationId = organizationId,
                 Type = PolicyType.SendControls,
             };

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/SendControlsSyncPolicyEvent.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/SendControlsSyncPolicyEvent.cs
@@ -47,12 +47,9 @@ public class SendControlsSyncPolicyEvent(
     {
         var existing = await policyRepository.GetByOrganizationIdTypeAsync(organizationId, type);
 
+        // Leave Id as default(Guid) for new policies so UpsertAsync routes to CreateAsync;
+        // pre-assigning an Id causes UpsertAsync to attempt an UPDATE that silently affects 0 rows.
         var policy = existing ?? new Policy { OrganizationId = organizationId, Type = type, };
-
-        if (existing == null)
-        {
-            policy.SetNewId();
-        }
 
         policy.Enabled = enabled;
         if (policyData != null)

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/SendOptionsSyncPolicyEvent.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/SendOptionsSyncPolicyEvent.cs
@@ -4,7 +4,6 @@ using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.Models;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyUpdateEvents.Interfaces;
 using Bit.Core.AdminConsole.Repositories;
-using Bit.Core.Utilities;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyEventHandlers;
 
@@ -27,10 +26,11 @@ public class SendOptionsSyncPolicyEvent(
         var organizationId = policyRequest.PolicyUpdate.OrganizationId;
 
         // Step 1: sync SendOptionsPolicy.Data.DisableHideEmail -> SendControlsPolicy.Data.DisableHideEmail
+        // Leave Id as default(Guid) for new policies so UpsertAsync routes to CreateAsync;
+        // pre-assigning an Id causes UpsertAsync to attempt an UPDATE that silently affects 0 rows.
         var sendControlsPolicy = await policyRepository.GetByOrganizationIdTypeAsync(
             organizationId, PolicyType.SendControls) ?? new Policy
             {
-                Id = CoreHelpers.GenerateComb(),
                 OrganizationId = organizationId,
                 Type = PolicyType.SendControls,
             };


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34427

## 📔 Objective

Existing Policy Sync logic (SendControls, SendOptions, and DisableSend sync events) was pre-assigning a valid GUID to new Policy entities before calling UpsertAsync, which routed to Policy_Update and silently affected 0 rows instead of inserting. 

The Id is now left as default(Guid) so UpsertAsync correctly routes to CreateAsync on first sync. Only first-time syncs were affected (when no legacy/target row existed yet), which is why this behavior appeared intermittent.