### PR TITLE
[PM-35066] - remove legacy collections endpoint

### DIFF
--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -759,33 +759,6 @@ public class CiphersController : Controller
         return await PutShare(id, model);
     }
 
-    [HttpPut("{id}/collections")]
-    public async Task<CipherDetailsResponseModel> PutCollections(Guid id, [FromBody] CipherCollectionsRequestModel model)
-    {
-        var user = await _userService.GetUserByPrincipalAsync(User);
-        var cipher = await GetByIdAsync(id, user.Id);
-        if (cipher == null || !cipher.OrganizationId.HasValue ||
-            !await _currentContext.OrganizationUser(cipher.OrganizationId.Value))
-        {
-            throw new NotFoundException();
-        }
-
-        await _cipherService.SaveCollectionsAsync(cipher,
-            model.CollectionIds.Select(c => new Guid(c)), user.Id, false);
-
-        var updatedCipher = await GetByIdAsync(id, user.Id);
-        var collectionCiphers = await _collectionCipherRepository.GetManyByUserIdCipherIdAsync(user.Id, id);
-
-        return new CipherDetailsResponseModel(updatedCipher, user, await GetOrganizationAbilityAsync(updatedCipher), _globalSettings, collectionCiphers);
-    }
-
-    [HttpPost("{id}/collections")]
-    [Obsolete("This endpoint is deprecated. Use PUT method instead.")]
-    public async Task<CipherDetailsResponseModel> PostCollections(Guid id, [FromBody] CipherCollectionsRequestModel model)
-    {
-        return await PutCollections(id, model);
-    }
-
     [HttpPut("{id}/collections_v2")]
     public async Task<OptionalCipherDetailsResponseModel> PutCollections_vNext(Guid id, [FromBody] CipherCollectionsRequestModel model)
     {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35066

## 📔 Objective

Removes the legacy v1 `PUT /api/ciphers/{id}/collections` endpoint and its `POST` alias `POST /api/ciphers/{id}/collections` from `CiphersController`.

These endpoints were identified as still reachable during investigation of [VULN-514](https://bitwarden.atlassian.net/browse/VULN-514). While the vulnerability itself was not deemed a security issue, the endpoints were flagged for removal. They are superseded by the v2 endpoint `PUT /api/ciphers/{id}/collections_v2` (`PutCollections_vNext`), which remains intact.

[VULN-514]: https://bitwarden.atlassian.net/browse/VULN-514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ