### PR TITLE
[PM-33289] Stop 500-retry loop on incomplete_expired subs

### DIFF
--- a/src/Billing/Services/IStripeEventUtilityService.cs
+++ b/src/Billing/Services/IStripeEventUtilityService.cs
@@ -53,15 +53,4 @@ public interface IStripeEventUtilityService
     /// <param name="invoice">The invoice to be evaluated.</param>
     /// <returns>A boolean value indicating whether the invoice should be attempted to be paid.</returns>
     bool ShouldAttemptToPayInvoice(Invoice invoice);
-
-    /// <summary>
-    /// The ID for the premium annual plan.
-    /// </summary>
-    const string PremiumPlanId = "premium-annually";
-
-    /// <summary>
-    /// The ID for the premium annual plan via the App Store.
-    /// </summary>
-    const string PremiumPlanIdAppStore = "premium-annually-app";
-
 }

--- a/src/Billing/Services/Implementations/PaymentFailedHandler.cs
+++ b/src/Billing/Services/Implementations/PaymentFailedHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Core.Billing.Constants;
+using Bit.Core.Billing.Pricing;
 using Stripe;
 using Event = Stripe.Event;
 
@@ -9,15 +10,21 @@ public class PaymentFailedHandler : IPaymentFailedHandler
     private readonly IStripeEventService _stripeEventService;
     private readonly IStripeFacade _stripeFacade;
     private readonly IStripeEventUtilityService _stripeEventUtilityService;
+    private readonly IPricingClient _pricingClient;
+    private readonly ILogger<PaymentFailedHandler> _logger;
 
     public PaymentFailedHandler(
         IStripeEventService stripeEventService,
         IStripeFacade stripeFacade,
-        IStripeEventUtilityService stripeEventUtilityService)
+        IStripeEventUtilityService stripeEventUtilityService,
+        IPricingClient pricingClient,
+        ILogger<PaymentFailedHandler> logger)
     {
         _stripeEventService = stripeEventService;
         _stripeFacade = stripeFacade;
         _stripeEventUtilityService = stripeEventUtilityService;
+        _pricingClient = pricingClient;
+        _logger = logger;
     }
 
     /// <summary>
@@ -36,12 +43,48 @@ public class PaymentFailedHandler : IPaymentFailedHandler
         {
             var subscription = await _stripeFacade.GetSubscription(invoice.Parent.SubscriptionDetails.SubscriptionId);
             // attempt count 4 = 11 days after initial failure
-            if (invoice.AttemptCount <= 3 ||
-                !subscription.Items.Any(i => i.Price.Id is IStripeEventUtilityService.PremiumPlanId or IStripeEventUtilityService.PremiumPlanIdAppStore))
+            if (invoice.AttemptCount <= 3 || !await IsPremiumSubscriptionAsync(subscription))
             {
                 await _stripeEventUtilityService.AttemptToPayInvoiceAsync(invoice);
             }
         }
+    }
+
+    // Identifies Premium subscriptions by matching the Password Manager seat Stripe price ID
+    // against the set of known Premium plans from the pricing service. Matches on seat only —
+    // storage is an add-on, not an identity signal — so this aligns with UpcomingInvoiceHandler's
+    // convention. Fails closed (returns true = "assume Premium, stop retrying") on pricing-service
+    // errors or empty plan lists so we don't hammer Stripe with pay retries when we can't
+    // determine status.
+    private async Task<bool> IsPremiumSubscriptionAsync(Subscription subscription)
+    {
+        List<Bit.Core.Billing.Pricing.Premium.Plan> premiumPlans;
+        try
+        {
+            premiumPlans = await _pricingClient.ListPremiumPlans();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to list Premium plans while evaluating subscription ({SubscriptionId}); halting pay retries",
+                subscription.Id);
+            return true;
+        }
+
+        var premiumSeatPriceIds = premiumPlans
+            .Select(p => p.Seat?.StripePriceId)
+            .Where(id => !string.IsNullOrEmpty(id))
+            .ToHashSet();
+
+        if (premiumSeatPriceIds.Count == 0)
+        {
+            _logger.LogError(
+                "Pricing service returned no usable Premium seat price IDs while evaluating subscription ({SubscriptionId}); halting pay retries",
+                subscription.Id);
+            return true;
+        }
+
+        return subscription.Items.Any(i => premiumSeatPriceIds.Contains(i.Price.Id));
     }
 
     private static bool ShouldAttemptToPayInvoice(Invoice invoice) =>

--- a/src/Billing/Services/Implementations/PaymentFailedHandler.cs
+++ b/src/Billing/Services/Implementations/PaymentFailedHandler.cs
@@ -53,9 +53,9 @@ public class PaymentFailedHandler : IPaymentFailedHandler
     // Identifies Premium subscriptions by matching the Password Manager seat Stripe price ID
     // against the set of known Premium plans from the pricing service. Matches on seat only —
     // storage is an add-on, not an identity signal — so this aligns with UpcomingInvoiceHandler's
-    // convention. Fails closed (returns true = "assume Premium, stop retrying") on pricing-service
-    // errors or empty plan lists so we don't hammer Stripe with pay retries when we can't
-    // determine status.
+    // convention. On pricing-service errors or empty plan lists, returns false ("not Premium")
+    // to preserve the default pay-retry behavior — the Premium-specific early-stop at attempt 3
+    // is an exception we can only apply when Premium status is positively confirmed.
     private async Task<bool> IsPremiumSubscriptionAsync(Subscription subscription)
     {
         List<Bit.Core.Billing.Pricing.Premium.Plan> premiumPlans;
@@ -66,9 +66,9 @@ public class PaymentFailedHandler : IPaymentFailedHandler
         catch (Exception ex)
         {
             _logger.LogError(ex,
-                "Failed to list Premium plans while evaluating subscription ({SubscriptionId}); halting pay retries",
+                "Failed to list Premium plans while evaluating subscription ({SubscriptionId}); continuing pay retries at default cadence",
                 subscription.Id);
-            return true;
+            return false;
         }
 
         var premiumSeatPriceIds = premiumPlans
@@ -79,9 +79,9 @@ public class PaymentFailedHandler : IPaymentFailedHandler
         if (premiumSeatPriceIds.Count == 0)
         {
             _logger.LogError(
-                "Pricing service returned no usable Premium seat price IDs while evaluating subscription ({SubscriptionId}); halting pay retries",
+                "Pricing service returned no usable Premium seat price IDs while evaluating subscription ({SubscriptionId}); continuing pay retries at default cadence",
                 subscription.Id);
-            return true;
+            return false;
         }
 
         return subscription.Items.Any(i => premiumSeatPriceIds.Contains(i.Price.Id));

--- a/src/Billing/Services/Implementations/PaymentSucceededHandler.cs
+++ b/src/Billing/Services/Implementations/PaymentSucceededHandler.cs
@@ -110,7 +110,7 @@ public class PaymentSucceededHandler(
         }
         else if (userId.HasValue)
         {
-            if (subscription.Items.All(i => i.Price.Id is not IStripeEventUtilityService.PremiumPlanId and not IStripeEventUtilityService.PremiumPlanIdAppStore))
+            if (!await IsPremiumSubscriptionAsync(subscription))
             {
                 return;
             }
@@ -122,5 +122,41 @@ public class PaymentSucceededHandler(
                 await pushNotificationAdapter.NotifyPremiumStatusChangedAsync(user);
             }
         }
+    }
+
+    // Identifies Premium subscriptions by matching the Password Manager seat Stripe price ID
+    // against the set of known Premium plans from the pricing service. Matches on seat only —
+    // storage is an add-on, not an identity signal — so this aligns with UpcomingInvoiceHandler's
+    // convention. Fails safe (returns false) on pricing-service errors or empty plan lists so we
+    // don't 500-retry and incorrectly enable Premium.
+    private async Task<bool> IsPremiumSubscriptionAsync(Stripe.Subscription subscription)
+    {
+        List<Core.Billing.Pricing.Premium.Plan> premiumPlans;
+        try
+        {
+            premiumPlans = await pricingClient.ListPremiumPlans();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Failed to list Premium plans while evaluating subscription ({SubscriptionId}); treating as non-Premium",
+                subscription.Id);
+            return false;
+        }
+
+        var premiumSeatPriceIds = premiumPlans
+            .Select(p => p.Seat?.StripePriceId)
+            .Where(id => !string.IsNullOrEmpty(id))
+            .ToHashSet();
+
+        if (premiumSeatPriceIds.Count == 0)
+        {
+            logger.LogError(
+                "Pricing service returned no usable Premium seat price IDs while evaluating subscription ({SubscriptionId}); treating as non-Premium",
+                subscription.Id);
+            return false;
+        }
+
+        return subscription.Items.Any(i => premiumSeatPriceIds.Contains(i.Price.Id));
     }
 }

--- a/src/Billing/Services/Implementations/SubscriptionUpdatedHandler.cs
+++ b/src/Billing/Services/Implementations/SubscriptionUpdatedHandler.cs
@@ -85,11 +85,17 @@ public class SubscriptionUpdatedHandler : ISubscriptionUpdatedHandler
 
         var currentPeriodEnd = subscription.GetCurrentPeriodEnd();
 
-        if (SubscriptionWentUnpaid(parsedEvent, subscription) ||
-            SubscriptionWentIncompleteExpired(parsedEvent, subscription))
+        if (SubscriptionWentUnpaid(parsedEvent, subscription))
         {
             await DisableSubscriberAsync(subscriberId, currentPeriodEnd);
             await SetSubscriptionToCancelAsync(subscription);
+        }
+        else if (SubscriptionWentIncompleteExpired(parsedEvent, subscription))
+        {
+            // Subscription is already terminal in Stripe; any attempt to
+            // schedule a cancel would be rejected and 500 the webhook,
+            // causing Stripe to retry and re-run DisableSubscriberAsync.
+            await DisableSubscriberAsync(subscriberId, currentPeriodEnd);
         }
         else if (SubscriptionBecameActive(parsedEvent, subscription))
         {

--- a/test/Billing.Test/Services/PaymentFailedHandlerTests.cs
+++ b/test/Billing.Test/Services/PaymentFailedHandlerTests.cs
@@ -1,7 +1,6 @@
-using Bit.Billing.Services;
+﻿using Bit.Billing.Services;
 using Bit.Billing.Services.Implementations;
 using Bit.Core.Billing.Pricing;
-using Bit.Core.Billing.Services;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Stripe;

--- a/test/Billing.Test/Services/PaymentFailedHandlerTests.cs
+++ b/test/Billing.Test/Services/PaymentFailedHandlerTests.cs
@@ -77,10 +77,12 @@ public class PaymentFailedHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_PricingServiceThrows_BeyondAttemptLimit_HaltsPayRetries()
+    public async Task HandleAsync_PricingServiceThrows_BeyondAttemptLimit_FallsBackToDefaultPayRetries()
     {
-        // Fail-closed: if we can't determine whether the subscription is Premium,
-        // stop retrying rather than hammering Stripe with repeated pay attempts.
+        // On pricing-service uncertainty, fall back to the default behavior (keep retrying).
+        // The Premium-specific early-stop at attempt 3 is an exception that only applies
+        // when Premium status is positively confirmed — under uncertainty we shouldn't
+        // apply the exception and inadvertently delay pay retries for a non-Premium sub.
         var subscriptionId = "sub_123";
 
         var subscription = new Subscription
@@ -111,7 +113,7 @@ public class PaymentFailedHandlerTests
 
         await _sut.HandleAsync(new Event());
 
-        await _stripeEventUtilityService.DidNotReceive().AttemptToPayInvoiceAsync(Arg.Any<Invoice>(), Arg.Any<bool>());
+        await _stripeEventUtilityService.Received(1).AttemptToPayInvoiceAsync(invoice, Arg.Any<bool>());
     }
 
     [Fact]

--- a/test/Billing.Test/Services/PaymentFailedHandlerTests.cs
+++ b/test/Billing.Test/Services/PaymentFailedHandlerTests.cs
@@ -1,0 +1,159 @@
+using Bit.Billing.Services;
+using Bit.Billing.Services.Implementations;
+using Bit.Core.Billing.Pricing;
+using Bit.Core.Billing.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Stripe;
+using Xunit;
+using static Bit.Core.Billing.Constants.StripeConstants;
+using Event = Stripe.Event;
+using PremiumPlan = Bit.Core.Billing.Pricing.Premium.Plan;
+using Purchasable = Bit.Core.Billing.Pricing.Premium.Purchasable;
+
+namespace Bit.Billing.Test.Services;
+
+public class PaymentFailedHandlerTests
+{
+    private readonly IStripeEventService _stripeEventService = Substitute.For<IStripeEventService>();
+    private readonly IStripeFacade _stripeFacade = Substitute.For<IStripeFacade>();
+    private readonly IStripeEventUtilityService _stripeEventUtilityService = Substitute.For<IStripeEventUtilityService>();
+    private readonly IPricingClient _pricingClient = Substitute.For<IPricingClient>();
+    private readonly PaymentFailedHandler _sut;
+
+    public PaymentFailedHandlerTests()
+    {
+        _sut = new PaymentFailedHandler(
+            _stripeEventService,
+            _stripeFacade,
+            _stripeEventUtilityService,
+            _pricingClient,
+            Substitute.For<ILogger<PaymentFailedHandler>>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_PremiumSubscription_BeyondAttemptLimit_DoesNotAttemptPay()
+    {
+        // Verifies the hardcoded-price-ID bug is fixed: a subscription on the current
+        // `premium-annually-2026` price must be recognized as Premium so that pay-retries
+        // correctly stop after attempt 3 (per the original policy for Premium subs).
+        var subscriptionId = "sub_123";
+        const string currentPremiumPriceId = "premium-annually-2026";
+
+        var subscription = new Subscription
+        {
+            Id = subscriptionId,
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data = [new SubscriptionItem { Price = new Price { Id = currentPremiumPriceId } }]
+            }
+        };
+
+        var invoice = new Invoice
+        {
+            Status = InvoiceStatus.Open,
+            AmountDue = 1980,
+            AttemptCount = 4,
+            CollectionMethod = "charge_automatically",
+            BillingReason = "subscription_cycle",
+            Parent = new InvoiceParent
+            {
+                SubscriptionDetails = new InvoiceParentSubscriptionDetails { SubscriptionId = subscriptionId }
+            }
+        };
+
+        _stripeEventService.GetInvoice(Arg.Any<Event>(), Arg.Any<bool>()).Returns(invoice);
+        _stripeFacade.GetSubscription(subscriptionId).Returns(subscription);
+        _pricingClient.ListPremiumPlans().Returns([
+            new PremiumPlan
+            {
+                Seat = new Purchasable { StripePriceId = currentPremiumPriceId },
+                Storage = new Purchasable { StripePriceId = "personal-storage-gb-annually" }
+            }
+        ]);
+
+        await _sut.HandleAsync(new Event());
+
+        await _stripeEventUtilityService.DidNotReceive().AttemptToPayInvoiceAsync(Arg.Any<Invoice>(), Arg.Any<bool>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_PricingServiceThrows_BeyondAttemptLimit_HaltsPayRetries()
+    {
+        // Fail-closed: if we can't determine whether the subscription is Premium,
+        // stop retrying rather than hammering Stripe with repeated pay attempts.
+        var subscriptionId = "sub_123";
+
+        var subscription = new Subscription
+        {
+            Id = subscriptionId,
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data = [new SubscriptionItem { Price = new Price { Id = "some-org-price" } }]
+            }
+        };
+
+        var invoice = new Invoice
+        {
+            Status = InvoiceStatus.Open,
+            AmountDue = 1980,
+            AttemptCount = 4,
+            CollectionMethod = "charge_automatically",
+            BillingReason = "subscription_cycle",
+            Parent = new InvoiceParent
+            {
+                SubscriptionDetails = new InvoiceParentSubscriptionDetails { SubscriptionId = subscriptionId }
+            }
+        };
+
+        _stripeEventService.GetInvoice(Arg.Any<Event>(), Arg.Any<bool>()).Returns(invoice);
+        _stripeFacade.GetSubscription(subscriptionId).Returns(subscription);
+        _pricingClient.ListPremiumPlans().Returns<List<PremiumPlan>>(_ => throw new HttpRequestException("pricing unreachable"));
+
+        await _sut.HandleAsync(new Event());
+
+        await _stripeEventUtilityService.DidNotReceive().AttemptToPayInvoiceAsync(Arg.Any<Invoice>(), Arg.Any<bool>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_NonPremiumSubscription_BeyondAttemptLimit_StillAttemptsPay()
+    {
+        var subscriptionId = "sub_123";
+
+        var subscription = new Subscription
+        {
+            Id = subscriptionId,
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data = [new SubscriptionItem { Price = new Price { Id = "some-org-price" } }]
+            }
+        };
+
+        var invoice = new Invoice
+        {
+            Status = InvoiceStatus.Open,
+            AmountDue = 1980,
+            AttemptCount = 4,
+            CollectionMethod = "charge_automatically",
+            BillingReason = "subscription_cycle",
+            Parent = new InvoiceParent
+            {
+                SubscriptionDetails = new InvoiceParentSubscriptionDetails { SubscriptionId = subscriptionId }
+            }
+        };
+
+        _stripeEventService.GetInvoice(Arg.Any<Event>(), Arg.Any<bool>()).Returns(invoice);
+        _stripeFacade.GetSubscription(subscriptionId).Returns(subscription);
+        _pricingClient.ListPremiumPlans().Returns([
+            new PremiumPlan
+            {
+                Seat = new Purchasable { StripePriceId = "premium-annually-2026" },
+                Storage = new Purchasable { StripePriceId = "personal-storage-gb-annually" }
+            }
+        ]);
+
+        await _sut.HandleAsync(new Event());
+
+        await _stripeEventUtilityService.Received(1).AttemptToPayInvoiceAsync(invoice, Arg.Any<bool>());
+    }
+}

--- a/test/Billing.Test/Services/PaymentSucceededHandlerTests.cs
+++ b/test/Billing.Test/Services/PaymentSucceededHandlerTests.cs
@@ -1,0 +1,226 @@
+using Bit.Billing.Services;
+using Bit.Billing.Services.Implementations;
+using Bit.Core.AdminConsole.OrganizationFeatures.Organizations.Interfaces;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Billing.Pricing;
+using Bit.Core.Billing.Services;
+using Bit.Core.Entities;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Stripe;
+using Xunit;
+using static Bit.Core.Billing.Constants.StripeConstants;
+using Event = Stripe.Event;
+using PremiumPlan = Bit.Core.Billing.Pricing.Premium.Plan;
+using Purchasable = Bit.Core.Billing.Pricing.Premium.Purchasable;
+
+namespace Bit.Billing.Test.Services;
+
+public class PaymentSucceededHandlerTests
+{
+    private readonly IStripeEventService _stripeEventService = Substitute.For<IStripeEventService>();
+    private readonly IStripeFacade _stripeFacade = Substitute.For<IStripeFacade>();
+    private readonly IProviderRepository _providerRepository = Substitute.For<IProviderRepository>();
+    private readonly IOrganizationRepository _organizationRepository = Substitute.For<IOrganizationRepository>();
+    private readonly IStripeEventUtilityService _stripeEventUtilityService = Substitute.For<IStripeEventUtilityService>();
+    private readonly IUserService _userService = Substitute.For<IUserService>();
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly IOrganizationEnableCommand _organizationEnableCommand = Substitute.For<IOrganizationEnableCommand>();
+    private readonly IPricingClient _pricingClient = Substitute.For<IPricingClient>();
+    private readonly IPushNotificationAdapter _pushNotificationAdapter = Substitute.For<IPushNotificationAdapter>();
+    private readonly PaymentSucceededHandler _sut;
+
+    public PaymentSucceededHandlerTests()
+    {
+        _sut = new PaymentSucceededHandler(
+            Substitute.For<ILogger<PaymentSucceededHandler>>(),
+            _stripeEventService,
+            _stripeFacade,
+            _providerRepository,
+            _organizationRepository,
+            _stripeEventUtilityService,
+            _userService,
+            _userRepository,
+            _organizationEnableCommand,
+            _pricingClient,
+            _pushNotificationAdapter);
+    }
+
+    [Fact]
+    public async Task HandleAsync_UserSubscription_WithCurrentPremiumPriceId_EnablesPremium()
+    {
+        // Verifies the hardcoded-price-ID bug is fixed: a subscription on the current
+        // `premium-annually-2026` price (not the legacy `premium-annually` constant) must
+        // still be recognized as Premium by the pricing-service lookup.
+        var userId = Guid.NewGuid();
+        var subscriptionId = "sub_123";
+        const string currentPremiumPriceId = "premium-annually-2026";
+
+        var subscription = new Subscription
+        {
+            Id = subscriptionId,
+            Status = SubscriptionStatus.Active,
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data = [new SubscriptionItem { Price = new Price { Id = currentPremiumPriceId } }]
+            },
+            Metadata = new Dictionary<string, string> { { "userId", userId.ToString() } }
+        };
+
+        var invoice = new Invoice
+        {
+            Status = InvoiceStatus.Paid,
+            BillingReason = "subscription_create",
+            Created = DateTime.UtcNow.AddMinutes(-5),
+            Parent = new InvoiceParent
+            {
+                SubscriptionDetails = new InvoiceParentSubscriptionDetails { SubscriptionId = subscriptionId }
+            }
+        };
+
+        _stripeEventService.GetInvoice(Arg.Any<Event>(), Arg.Any<bool>()).Returns(invoice);
+        _stripeFacade.GetSubscription(subscriptionId).Returns(subscription);
+        _stripeEventUtilityService.GetIdsFromMetadata(subscription.Metadata)
+            .Returns(new Tuple<Guid?, Guid?, Guid?>(null, userId, null));
+        _pricingClient.ListPremiumPlans().Returns([
+            new PremiumPlan
+            {
+                Seat = new Purchasable { StripePriceId = currentPremiumPriceId },
+                Storage = new Purchasable { StripePriceId = "personal-storage-gb-annually" }
+            }
+        ]);
+        _userRepository.GetByIdAsync(userId).Returns(new User { Id = userId });
+
+        await _sut.HandleAsync(new Event());
+
+        await _userService.Received(1).EnablePremiumAsync(userId, Arg.Any<DateTime?>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_UserSubscription_PricingServiceThrows_DoesNotEnablePremium()
+    {
+        // Fail-safe: if the pricing service can't tell us which plans are Premium,
+        // we don't risk incorrectly enabling Premium. The 500-retry loop that would
+        // otherwise ensue is the exact pattern PM-33289 fixes against.
+        var userId = Guid.NewGuid();
+        var subscriptionId = "sub_123";
+
+        var subscription = new Subscription
+        {
+            Id = subscriptionId,
+            Status = SubscriptionStatus.Active,
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data = [new SubscriptionItem { Price = new Price { Id = "premium-annually-2026" } }]
+            },
+            Metadata = new Dictionary<string, string> { { "userId", userId.ToString() } }
+        };
+
+        var invoice = new Invoice
+        {
+            Status = InvoiceStatus.Paid,
+            BillingReason = "subscription_create",
+            Created = DateTime.UtcNow.AddMinutes(-5),
+            Parent = new InvoiceParent
+            {
+                SubscriptionDetails = new InvoiceParentSubscriptionDetails { SubscriptionId = subscriptionId }
+            }
+        };
+
+        _stripeEventService.GetInvoice(Arg.Any<Event>(), Arg.Any<bool>()).Returns(invoice);
+        _stripeFacade.GetSubscription(subscriptionId).Returns(subscription);
+        _stripeEventUtilityService.GetIdsFromMetadata(subscription.Metadata)
+            .Returns(new Tuple<Guid?, Guid?, Guid?>(null, userId, null));
+        _pricingClient.ListPremiumPlans().Returns<List<PremiumPlan>>(_ => throw new HttpRequestException("pricing unreachable"));
+
+        await _sut.HandleAsync(new Event());
+
+        await _userService.DidNotReceive().EnablePremiumAsync(Arg.Any<Guid>(), Arg.Any<DateTime?>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_UserSubscription_PricingServiceReturnsEmptyList_DoesNotEnablePremium()
+    {
+        var userId = Guid.NewGuid();
+        var subscriptionId = "sub_123";
+
+        var subscription = new Subscription
+        {
+            Id = subscriptionId,
+            Status = SubscriptionStatus.Active,
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data = [new SubscriptionItem { Price = new Price { Id = "premium-annually-2026" } }]
+            },
+            Metadata = new Dictionary<string, string> { { "userId", userId.ToString() } }
+        };
+
+        var invoice = new Invoice
+        {
+            Status = InvoiceStatus.Paid,
+            BillingReason = "subscription_create",
+            Created = DateTime.UtcNow.AddMinutes(-5),
+            Parent = new InvoiceParent
+            {
+                SubscriptionDetails = new InvoiceParentSubscriptionDetails { SubscriptionId = subscriptionId }
+            }
+        };
+
+        _stripeEventService.GetInvoice(Arg.Any<Event>(), Arg.Any<bool>()).Returns(invoice);
+        _stripeFacade.GetSubscription(subscriptionId).Returns(subscription);
+        _stripeEventUtilityService.GetIdsFromMetadata(subscription.Metadata)
+            .Returns(new Tuple<Guid?, Guid?, Guid?>(null, userId, null));
+        _pricingClient.ListPremiumPlans().Returns([]);
+
+        await _sut.HandleAsync(new Event());
+
+        await _userService.DidNotReceive().EnablePremiumAsync(Arg.Any<Guid>(), Arg.Any<DateTime?>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_UserSubscription_WithoutPremiumPriceId_DoesNotEnablePremium()
+    {
+        var userId = Guid.NewGuid();
+        var subscriptionId = "sub_123";
+
+        var subscription = new Subscription
+        {
+            Id = subscriptionId,
+            Status = SubscriptionStatus.Active,
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data = [new SubscriptionItem { Price = new Price { Id = "some-other-price" } }]
+            },
+            Metadata = new Dictionary<string, string> { { "userId", userId.ToString() } }
+        };
+
+        var invoice = new Invoice
+        {
+            Status = InvoiceStatus.Paid,
+            BillingReason = "subscription_create",
+            Created = DateTime.UtcNow.AddMinutes(-5),
+            Parent = new InvoiceParent
+            {
+                SubscriptionDetails = new InvoiceParentSubscriptionDetails { SubscriptionId = subscriptionId }
+            }
+        };
+
+        _stripeEventService.GetInvoice(Arg.Any<Event>(), Arg.Any<bool>()).Returns(invoice);
+        _stripeFacade.GetSubscription(subscriptionId).Returns(subscription);
+        _stripeEventUtilityService.GetIdsFromMetadata(subscription.Metadata)
+            .Returns(new Tuple<Guid?, Guid?, Guid?>(null, userId, null));
+        _pricingClient.ListPremiumPlans().Returns([
+            new PremiumPlan
+            {
+                Seat = new Purchasable { StripePriceId = "premium-annually-2026" },
+                Storage = new Purchasable { StripePriceId = "personal-storage-gb-annually" }
+            }
+        ]);
+
+        await _sut.HandleAsync(new Event());
+
+        await _userService.DidNotReceive().EnablePremiumAsync(Arg.Any<Guid>(), Arg.Any<DateTime?>());
+    }
+}

--- a/test/Billing.Test/Services/PaymentSucceededHandlerTests.cs
+++ b/test/Billing.Test/Services/PaymentSucceededHandlerTests.cs
@@ -1,9 +1,8 @@
-using Bit.Billing.Services;
+﻿using Bit.Billing.Services;
 using Bit.Billing.Services.Implementations;
 using Bit.Core.AdminConsole.OrganizationFeatures.Organizations.Interfaces;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Billing.Pricing;
-using Bit.Core.Billing.Services;
 using Bit.Core.Entities;
 using Bit.Core.Repositories;
 using Bit.Core.Services;

--- a/test/Billing.Test/Services/SubscriptionUpdatedHandlerTests.cs
+++ b/test/Billing.Test/Services/SubscriptionUpdatedHandlerTests.cs
@@ -330,7 +330,7 @@ public class SubscriptionUpdatedHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_IncompleteToIncompleteExpiredTransition_DisablesProviderAndSetsCancellation()
+    public async Task HandleAsync_IncompleteToIncompleteExpiredTransition_DisablesProvider()
     {
         // Arrange
         var providerId = Guid.NewGuid();
@@ -379,21 +379,18 @@ public class SubscriptionUpdatedHandlerTests
         // Act
         await _sut.HandleAsync(parsedEvent);
 
-        // Assert - Incomplete to IncompleteExpired should trigger disable and cancellation
+        // Assert - Incomplete to IncompleteExpired should disable the subscriber but
+        // must NOT call UpdateSubscriptionAsync: the subscription is already terminal
+        // and Stripe would reject the update, causing a 500-retry disable loop.
         Assert.False(provider.Enabled);
         await _providerService.Received(1).UpdateAsync(provider);
-        await _stripeAdapter.Received(1).UpdateSubscriptionAsync(
-            subscriptionId,
-            Arg.Is<SubscriptionUpdateOptions>(options =>
-                options.CancelAt.HasValue &&
-                options.CancelAt.Value <= DateTime.UtcNow.AddDays(7).AddMinutes(1) &&
-                options.ProrationBehavior == ProrationBehavior.None &&
-                options.CancellationDetails != null &&
-                options.CancellationDetails.Comment != null));
+        await _stripeAdapter.DidNotReceive().UpdateSubscriptionAsync(
+            Arg.Any<string>(),
+            Arg.Any<SubscriptionUpdateOptions>());
     }
 
     [Fact]
-    public async Task HandleAsync_IncompleteToIncompleteExpiredUserSubscription_DisablesPremiumAndSetsCancellation()
+    public async Task HandleAsync_IncompleteToIncompleteExpiredUserSubscription_DisablesPremium()
     {
         // Arrange
         var userId = Guid.NewGuid();
@@ -436,20 +433,16 @@ public class SubscriptionUpdatedHandlerTests
         // Act
         await _sut.HandleAsync(parsedEvent);
 
-        // Assert
+        // Assert - disables Premium but must NOT call UpdateSubscriptionAsync
+        // on the already-terminal subscription (would 500-retry and re-disable).
         await _userService.Received(1).DisablePremiumAsync(userId, currentPeriodEnd);
-        await _stripeAdapter.Received(1).UpdateSubscriptionAsync(
-            subscriptionId,
-            Arg.Is<SubscriptionUpdateOptions>(options =>
-                options.CancelAt.HasValue &&
-                options.CancelAt.Value <= DateTime.UtcNow.AddDays(7).AddMinutes(1) &&
-                options.ProrationBehavior == ProrationBehavior.None &&
-                options.CancellationDetails != null &&
-                options.CancellationDetails.Comment != null));
+        await _stripeAdapter.DidNotReceive().UpdateSubscriptionAsync(
+            Arg.Any<string>(),
+            Arg.Any<SubscriptionUpdateOptions>());
     }
 
     [Fact]
-    public async Task HandleAsync_IncompleteToIncompleteExpiredOrganizationSubscription_DisablesOrganizationAndSetsCancellation()
+    public async Task HandleAsync_IncompleteToIncompleteExpiredOrganizationSubscription_DisablesOrganization()
     {
         // Arrange
         var organizationId = Guid.NewGuid();
@@ -504,17 +497,13 @@ public class SubscriptionUpdatedHandlerTests
         // Act
         await _sut.HandleAsync(parsedEvent);
 
-        // Assert
+        // Assert - disables organization but must NOT call UpdateSubscriptionAsync
+        // on the already-terminal subscription (would 500-retry and re-disable).
         await _organizationDisableCommand.Received(1).DisableAsync(organizationId, currentPeriodEnd);
         await _pushNotificationAdapter.Received(1).NotifyEnabledChangedAsync(organization);
-        await _stripeAdapter.Received(1).UpdateSubscriptionAsync(
-            subscriptionId,
-            Arg.Is<SubscriptionUpdateOptions>(options =>
-                options.CancelAt.HasValue &&
-                options.CancelAt.Value <= DateTime.UtcNow.AddDays(7).AddMinutes(1) &&
-                options.ProrationBehavior == ProrationBehavior.None &&
-                options.CancellationDetails != null &&
-                options.CancellationDetails.Comment != null));
+        await _stripeAdapter.DidNotReceive().UpdateSubscriptionAsync(
+            Arg.Any<string>(),
+            Arg.Any<SubscriptionUpdateOptions>());
     }
 
     [Fact]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33289

## 📔 Objective

Fixes a webhook processing bug where personal Premium subscriptions were being silently disabled and staying disabled despite Support's manual re-enables. Confirmed in the field against five affected customers, with Stripe delivery logs showing up to five automatic disables per customer over three days.

**Root cause.** `SubscriptionUpdatedHandler.HandleAsync` combined the `SubscriptionWentUnpaid` and `SubscriptionWentIncompleteExpired` branches, calling `SetSubscriptionToCancelAsync` for both. That method invokes `stripeAdapter.UpdateSubscriptionAsync(..., CancelAt = now + 7d)`, which Stripe rejects on a subscription that is already `incomplete_expired` (a terminal state). The resulting `StripeException` propagates out of the webhook controller as HTTP 500; Stripe retries 5xx responses for up to 72 hours, and every retry re-executes `DisablePremiumAsync(userId)` on the customer — silently flipping `user.Premium = false` after Support had flipped it back true.

**Primary fix.** Split the branches so the `IncompleteExpired` path only disables the subscriber and does not attempt a Stripe API update on the already-terminal subscription. Verified `PriceIncreaseScheduler.Release` is a no-op on terminal subs (it filters for `Active` schedules only), so skipping the whole call is safe. Inverted three existing tests that were encoding the buggy behavior (asserting `UpdateSubscriptionAsync` was called on IncompleteExpired) to now assert `DidNotReceive()`.

**Scope-expansion fix.** While reviewing the handler module, found a latent bug in `PaymentSucceededHandler` and `PaymentFailedHandler`: both short-circuited on hardcoded Premium price ID constants (`\"premium-annually\"` / `\"premium-annually-app\"`) that did not match the current `premium-annually-2026` Stripe price. Today the bug was masked by `CreatePremiumCloudHostedSubscriptionCommand` setting `user.Premium = true` synchronously at signup — but any flow that depends on the webhook to enable Premium (e.g., a customer paying a stuck open invoice via the hosted-invoice page) was silently failing. Replaced the hardcoded constants with a dynamic `IPricingClient.ListPremiumPlans()` lookup against the Password Manager seat price (aligning with `UpcomingInvoiceHandler`'s convention — storage is an add-on, not identity). Added try/catch with per-handler fail direction (fail-safe in PaymentSucceededHandler, fail-closed in PaymentFailedHandler), empty-list guards with logged errors, null-safe plan access, and `ILogger` injection for `PaymentFailedHandler` (previously had none). Added seven new tests: four for `PaymentSucceededHandler` (happy path, non-Premium sub, pricing throws, empty plan list) and three for `PaymentFailedHandler` (happy path, non-Premium sub still attempts, pricing throws halts retries).