### PR TITLE
[PM-35250] Prevent Custom Users Removing Admins

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RemoveOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RemoveOrganizationUserCommand.cs
@@ -212,9 +212,11 @@ public class RemoveOrganizationUserCommand : IRemoveOrganizationUserCommand
         }
 
         var deletingUserIsOwner = false;
+        var deletingUserIsCustom = false;
         if (deletingUserId.HasValue)
         {
             deletingUserIsOwner = await _currentContext.OrganizationOwner(organizationId);
+            deletingUserIsCustom = await _currentContext.OrganizationCustom(organizationId);
         }
 
         var claimedStatus = deletingUserId.HasValue && eventSystemUser == null
@@ -233,6 +235,11 @@ public class RemoveOrganizationUserCommand : IRemoveOrganizationUserCommand
                 if (orgUser.Type == OrganizationUserType.Owner && deletingUserId.HasValue && !deletingUserIsOwner)
                 {
                     throw new BadRequestException(RemoveOwnerByNonOwnerErrorMessage);
+                }
+
+                if (orgUser.Type == OrganizationUserType.Admin && deletingUserIsCustom)
+                {
+                    throw new BadRequestException(RemoveAdminByCustomUserErrorMessage);
                 }
 
                 if (claimedStatus.TryGetValue(orgUser.Id, out var isClaimed) && isClaimed)

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RemoveOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RemoveOrganizationUserCommandTests.cs
@@ -515,6 +515,37 @@ public class RemoveOrganizationUserCommandTests
     }
 
     [Theory, BitAutoData]
+    public async Task RemoveUsers_WithDeletingUserId_CustomUserRemovesAdmin_ReturnsError(
+        [OrganizationUser(type: OrganizationUserType.Admin)] OrganizationUser orgUser,
+        [OrganizationUser(type: OrganizationUserType.Custom)] OrganizationUser deletingUser,
+        SutProvider<RemoveOrganizationUserCommand> sutProvider)
+    {
+        // Arrange
+        orgUser.OrganizationId = deletingUser.OrganizationId;
+        var organizationUsers = new[] { orgUser };
+        var organizationUserIds = organizationUsers.Select(u => u.Id);
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetManyAsync(default)
+            .ReturnsForAnyArgs(organizationUsers);
+        sutProvider.GetDependency<IHasConfirmedOwnersExceptQuery>()
+            .HasConfirmedOwnersExceptAsync(deletingUser.OrganizationId, Arg.Any<IEnumerable<Guid>>())
+            .Returns(true);
+        sutProvider.GetDependency<ICurrentContext>()
+            .OrganizationCustom(deletingUser.OrganizationId)
+            .Returns(true);
+
+        // Act
+        var result = await sutProvider.Sut.RemoveUsersAsync(deletingUser.OrganizationId, organizationUserIds, deletingUser.UserId);
+
+        // Assert
+        Assert.Contains(RemoveOrganizationUserCommand.RemoveAdminByCustomUserErrorMessage, result.First().ErrorMessage);
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .DeleteManyAsync(default);
+    }
+
+    [Theory, BitAutoData]
     public async Task RemoveUsers_WithDeletingUserId_RemovingClaimedUser_ThrowsException(
         [OrganizationUser(status: OrganizationUserStatusType.Confirmed, OrganizationUserType.User)] OrganizationUser orgUser,
         OrganizationUser deletingUser,


### PR DESCRIPTION
## 🎟️ Tracking
[PM-35250](https://bitwarden.atlassian.net/browse/PM-35250)

## 📔 Objective
Bulk user removal is implemented in a separate path than single user removal, and reimplements its own set of checks and validations. One of these checks was missing, causing a divergence in allowed behavior between single and bulk removal: whether or not a user with custom permissions was able to remove an admin user from the org.

This check has simply been reapplied, similar to the single-user path.

> [!NOTE]
> We have tech debt initiatives to consolidate validation and single->bulk operations, which prevents discrepancies like this in the first place. In due time.


[PM-35250]: https://bitwarden.atlassian.net/browse/PM-35250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ