### PR TITLE
[PM-34774] Add GET endpoint for organization invite links

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationInviteLinksController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationInviteLinksController.cs
@@ -4,6 +4,7 @@ using Bit.Api.AdminConsole.Models.Request.Organizations;
 using Bit.Api.AdminConsole.Models.Response.Organizations;
 using Bit.Core;
 using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
+using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -14,9 +15,21 @@ namespace Bit.Api.AdminConsole.Controllers;
 [Authorize("Application")]
 [RequireFeature(FeatureFlagKeys.GenerateInviteLink)]
 public class OrganizationInviteLinksController(
-    ICreateOrganizationInviteLinkCommand createOrganizationInviteLinkCommand)
+    ICreateOrganizationInviteLinkCommand createOrganizationInviteLinkCommand,
+    IOrganizationInviteLinkRepository organizationInviteLinkRepository)
     : BaseAdminConsoleController
 {
+    [HttpGet("")]
+    [Authorize<ManageUsersRequirement>]
+    public async Task<IResult> Get(Guid orgId)
+    {
+        var link = await organizationInviteLinkRepository.GetByOrganizationIdAsync(orgId);
+
+        return link is null
+            ? TypedResults.NotFound()
+            : TypedResults.Ok(new OrganizationInviteLinkResponseModel(link));
+    }
+
     [HttpPost("")]
     [Authorize<ManageUsersRequirement>]
     public async Task<IResult> Create(Guid orgId, [FromBody] CreateOrganizationInviteLinkRequestModel model)

--- a/src/Api/AdminConsole/Controllers/OrganizationInviteLinksController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationInviteLinksController.cs
@@ -4,7 +4,6 @@ using Bit.Api.AdminConsole.Models.Request.Organizations;
 using Bit.Api.AdminConsole.Models.Response.Organizations;
 using Bit.Core;
 using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
-using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -16,18 +15,17 @@ namespace Bit.Api.AdminConsole.Controllers;
 [RequireFeature(FeatureFlagKeys.GenerateInviteLink)]
 public class OrganizationInviteLinksController(
     ICreateOrganizationInviteLinkCommand createOrganizationInviteLinkCommand,
-    IOrganizationInviteLinkRepository organizationInviteLinkRepository)
+    IGetOrganizationInviteLinkQuery getOrganizationInviteLinkQuery)
     : BaseAdminConsoleController
 {
     [HttpGet("")]
     [Authorize<ManageUsersRequirement>]
     public async Task<IResult> Get(Guid orgId)
     {
-        var link = await organizationInviteLinkRepository.GetByOrganizationIdAsync(orgId);
+        var result = await getOrganizationInviteLinkQuery.GetAsync(orgId);
 
-        return link is null
-            ? TypedResults.NotFound()
-            : TypedResults.Ok(new OrganizationInviteLinkResponseModel(link));
+        return Handle(result, link =>
+            TypedResults.Ok(new OrganizationInviteLinkResponseModel(link)));
     }
 
     [HttpPost("")]

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Errors.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Errors.cs
@@ -10,3 +10,6 @@ public record InviteLinkDomainsRequired()
 
 public record InviteLinkNotAvailable()
     : BadRequestError("Your organization's plan does not support invite links.");
+
+public record InviteLinkNotFound()
+    : NotFoundError("Invite link not found.");

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/GetOrganizationInviteLinkQuery.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/GetOrganizationInviteLinkQuery.cs
@@ -1,0 +1,35 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.AdminConsole.Utilities.v2.Results;
+using Bit.Core.Services;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
+
+public class GetOrganizationInviteLinkQuery(
+    IOrganizationInviteLinkRepository organizationInviteLinkRepository,
+    IApplicationCacheService applicationCacheService)
+    : IGetOrganizationInviteLinkQuery
+{
+    public async Task<CommandResult<OrganizationInviteLink>> GetAsync(Guid organizationId)
+    {
+        if (!await OrganizationHasInviteLinksAbilityAsync(organizationId))
+        {
+            return new InviteLinkNotAvailable();
+        }
+
+        var link = await organizationInviteLinkRepository.GetByOrganizationIdAsync(organizationId);
+        if (link is null)
+        {
+            return new InviteLinkNotFound();
+        }
+
+        return link;
+    }
+
+    private async Task<bool> OrganizationHasInviteLinksAbilityAsync(Guid organizationId)
+    {
+        var ability = await applicationCacheService.GetOrganizationAbilityAsync(organizationId);
+        return ability is not null && ability.UseInviteLinks;
+    }
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Interfaces/IGetOrganizationInviteLinkQuery.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Interfaces/IGetOrganizationInviteLinkQuery.cs
@@ -1,0 +1,17 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Utilities.v2.Results;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
+
+public interface IGetOrganizationInviteLinkQuery
+{
+    /// <summary>
+    /// Gets the invite link for the specified organization.
+    /// </summary>
+    /// <param name="organizationId">The organization to get the invite link for.</param>
+    /// <returns>
+    /// The <see cref="OrganizationInviteLink"/> if found and available, or an error if the invite link
+    /// feature is not available or no invite link exists.
+    /// </returns>
+    Task<CommandResult<OrganizationInviteLink>> GetAsync(Guid organizationId);
+}

--- a/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
+++ b/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
@@ -67,7 +67,7 @@ public static class OrganizationServiceCollectionExtensions
         services.AddOrganizationApiKeyCommandsQueries();
         services.AddOrganizationCollectionCommands();
         services.AddOrganizationGroupCommands();
-        services.AddOrganizationInviteLinkCommands();
+        services.AddOrganizationInviteLinkCommandsQueries();
         services.AddOrganizationDomainCommandsQueries();
         services.AddOrganizationSignUpCommands();
         services.AddOrganizationDeleteCommands();
@@ -191,7 +191,7 @@ public static class OrganizationServiceCollectionExtensions
         services.AddScoped<IUpdateGroupCommand, UpdateGroupCommand>();
     }
 
-    private static void AddOrganizationInviteLinkCommands(this IServiceCollection services)
+    private static void AddOrganizationInviteLinkCommandsQueries(this IServiceCollection services)
     {
         services.TryAddScoped<ICreateOrganizationInviteLinkCommand, CreateOrganizationInviteLinkCommand>();
     }

--- a/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
+++ b/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
@@ -194,6 +194,7 @@ public static class OrganizationServiceCollectionExtensions
     private static void AddOrganizationInviteLinkCommandsQueries(this IServiceCollection services)
     {
         services.TryAddScoped<ICreateOrganizationInviteLinkCommand, CreateOrganizationInviteLinkCommand>();
+        services.TryAddScoped<IGetOrganizationInviteLinkQuery, GetOrganizationInviteLinkQuery>();
     }
 
     private static void AddOrganizationDomainCommandsQueries(this IServiceCollection services)

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
@@ -5,9 +5,9 @@ using Bit.Api.IntegrationTest.Factories;
 using Bit.Api.IntegrationTest.Helpers;
 using Bit.Core;
 using Bit.Core.AdminConsole.Entities;
-using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Billing.Enums;
 using Bit.Core.Enums;
+using Bit.Core.Models.Data.Organizations;
 using Bit.Core.Services;
 using NSubstitute;
 using Xunit;
@@ -35,6 +35,12 @@ public class OrganizationInviteLinksControllerTests : IClassFixture<ApiApplicati
                 .IsEnabled(FeatureFlagKeys.GenerateInviteLink)
                 .Returns(true);
         });
+        _factory.SubstituteService<IApplicationCacheService>(cacheService =>
+        {
+            cacheService
+                .GetOrganizationAbilityAsync(Arg.Any<Guid>())
+                .Returns(new OrganizationAbility { UseInviteLinks = true });
+        });
         _client = factory.CreateClient();
         _loginHelper = new LoginHelper(_factory, _client);
     }
@@ -61,7 +67,7 @@ public class OrganizationInviteLinksControllerTests : IClassFixture<ApiApplicati
     }
 
     [Fact]
-    public async Task Create_AsOwner_ReturnsCreated()
+    public async Task CreateThenGet_AsOwner_ReturnsCreatedAndOk()
     {
         var request = new CreateOrganizationInviteLinkRequestModel
         {
@@ -69,22 +75,29 @@ public class OrganizationInviteLinksControllerTests : IClassFixture<ApiApplicati
             EncryptedInviteKey = _validEncryptedKey,
         };
 
-        var response = await _client.PostAsJsonAsync(
+        static void AssertInviteLink(OrganizationInviteLinkResponseModel? content, Organization organization)
+        {
+            Assert.NotNull(content);
+            Assert.NotEqual(Guid.Empty, content.Id);
+            Assert.NotEqual(Guid.Empty, content.Code);
+            Assert.Equal(organization.Id, content.OrganizationId);
+            Assert.Equal(["acme.com", "example.com"], content.AllowedDomains);
+            Assert.Equal(_validEncryptedKey, content.EncryptedInviteKey);
+        }
+
+        var createResponse = await _client.PostAsJsonAsync(
             $"/organizations/{_organization.Id}/invite-link", request);
 
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
 
-        var content = await response.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
-        Assert.NotNull(content);
-        Assert.NotEqual(Guid.Empty, content.Id);
-        Assert.NotEqual(Guid.Empty, content.Code);
-        Assert.Equal(_organization.Id, content.OrganizationId);
-        Assert.Equal(["acme.com", "example.com"], content.AllowedDomains);
-        Assert.Equal(_validEncryptedKey, content.EncryptedInviteKey);
+        var created = await createResponse.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
+        AssertInviteLink(created, _organization);
 
-        var repository = _factory.GetService<IOrganizationInviteLinkRepository>();
-        var persisted = await repository.GetByOrganizationIdAsync(_organization.Id);
-        Assert.NotNull(persisted);
-        Assert.Equal(content.Id, persisted.Id);
+        var getResponse = await _client.GetAsync($"/organizations/{_organization.Id}/invite-link");
+
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+
+        var content = await getResponse.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
+        AssertInviteLink(content, _organization);
     }
 }

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
@@ -5,7 +5,6 @@ using Bit.Api.IntegrationTest.Factories;
 using Bit.Api.IntegrationTest.Helpers;
 using Bit.Core;
 using Bit.Core.AdminConsole.Entities;
-using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Billing.Enums;
 using Bit.Core.Enums;
 using Bit.Core.Models.Data.Organizations;
@@ -68,7 +67,7 @@ public class OrganizationInviteLinksControllerTests : IClassFixture<ApiApplicati
     }
 
     [Fact]
-    public async Task Create_AsOwner_ReturnsCreated()
+    public async Task CreateThenGet_AsOwner_ReturnsCreatedAndOk()
     {
         var request = new CreateOrganizationInviteLinkRequestModel
         {
@@ -76,22 +75,29 @@ public class OrganizationInviteLinksControllerTests : IClassFixture<ApiApplicati
             EncryptedInviteKey = _validEncryptedKey,
         };
 
-        var response = await _client.PostAsJsonAsync(
+        static void AssertInviteLink(OrganizationInviteLinkResponseModel? content, Organization organization)
+        {
+            Assert.NotNull(content);
+            Assert.NotEqual(Guid.Empty, content.Id);
+            Assert.NotEqual(Guid.Empty, content.Code);
+            Assert.Equal(organization.Id, content.OrganizationId);
+            Assert.Equal(["acme.com", "example.com"], content.AllowedDomains);
+            Assert.Equal(_validEncryptedKey, content.EncryptedInviteKey);
+        }
+
+        var createResponse = await _client.PostAsJsonAsync(
             $"/organizations/{_organization.Id}/invite-link", request);
 
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
 
-        var content = await response.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
-        Assert.NotNull(content);
-        Assert.NotEqual(Guid.Empty, content.Id);
-        Assert.NotEqual(Guid.Empty, content.Code);
-        Assert.Equal(_organization.Id, content.OrganizationId);
-        Assert.Equal(["acme.com", "example.com"], content.AllowedDomains);
-        Assert.Equal(_validEncryptedKey, content.EncryptedInviteKey);
+        var created = await createResponse.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
+        AssertInviteLink(created, _organization);
 
-        var repository = _factory.GetService<IOrganizationInviteLinkRepository>();
-        var persisted = await repository.GetByOrganizationIdAsync(_organization.Id);
-        Assert.NotNull(persisted);
-        Assert.Equal(content.Id, persisted.Id);
+        var getResponse = await _client.GetAsync($"/organizations/{_organization.Id}/invite-link");
+
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+
+        var content = await getResponse.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
+        AssertInviteLink(content, _organization);
     }
 }

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
@@ -4,6 +4,7 @@ using Bit.Api.AdminConsole.Models.Response.Organizations;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
 using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
+using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.AdminConsole.Utilities.v2.Results;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
@@ -72,6 +73,40 @@ public class OrganizationInviteLinksControllerTests
 
         var jsonResult = Assert.IsType<JsonHttpResult<Bit.Core.Models.Api.ErrorResponseModel>>(result);
         Assert.Equal(StatusCodes.Status409Conflict, jsonResult.StatusCode);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Get_WhenLinkExists_ReturnsOkWithModel(
+        Guid orgId,
+        OrganizationInviteLink inviteLink,
+        SutProvider<OrganizationInviteLinksController> sutProvider)
+    {
+        inviteLink.OrganizationId = orgId;
+
+        sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .GetByOrganizationIdAsync(orgId)
+            .Returns(inviteLink);
+
+        var result = await sutProvider.Sut.Get(orgId);
+
+        var okResult = Assert.IsType<Ok<OrganizationInviteLinkResponseModel>>(result);
+        Assert.NotNull(okResult.Value);
+        Assert.Equal(inviteLink.Id, okResult.Value.Id);
+        Assert.Equal(orgId, okResult.Value.OrganizationId);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Get_WhenNoLinkExists_ReturnsNotFound(
+        Guid orgId,
+        SutProvider<OrganizationInviteLinksController> sutProvider)
+    {
+        sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .GetByOrganizationIdAsync(orgId)
+            .Returns((OrganizationInviteLink?)null);
+
+        var result = await sutProvider.Sut.Get(orgId);
+
+        Assert.IsType<NotFound>(result);
     }
 
     [Theory, BitAutoData]

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
@@ -4,7 +4,6 @@ using Bit.Api.AdminConsole.Models.Response.Organizations;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
 using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
-using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.AdminConsole.Utilities.v2.Results;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
@@ -83,9 +82,9 @@ public class OrganizationInviteLinksControllerTests
     {
         inviteLink.OrganizationId = orgId;
 
-        sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
-            .GetByOrganizationIdAsync(orgId)
-            .Returns(inviteLink);
+        sutProvider.GetDependency<IGetOrganizationInviteLinkQuery>()
+            .GetAsync(orgId)
+            .Returns(new CommandResult<OrganizationInviteLink>(inviteLink));
 
         var result = await sutProvider.Sut.Get(orgId);
 
@@ -100,13 +99,29 @@ public class OrganizationInviteLinksControllerTests
         Guid orgId,
         SutProvider<OrganizationInviteLinksController> sutProvider)
     {
-        sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
-            .GetByOrganizationIdAsync(orgId)
-            .Returns((OrganizationInviteLink?)null);
+        sutProvider.GetDependency<IGetOrganizationInviteLinkQuery>()
+            .GetAsync(orgId)
+            .Returns(new CommandResult<OrganizationInviteLink>(new InviteLinkNotFound()));
 
         var result = await sutProvider.Sut.Get(orgId);
 
-        Assert.IsType<NotFound>(result);
+        var notFoundResult = Assert.IsType<NotFound<Bit.Core.Models.Api.ErrorResponseModel>>(result);
+        Assert.NotNull(notFoundResult.Value);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Get_WhenInviteLinkNotAvailable_Returns400(
+        Guid orgId,
+        SutProvider<OrganizationInviteLinksController> sutProvider)
+    {
+        sutProvider.GetDependency<IGetOrganizationInviteLinkQuery>()
+            .GetAsync(orgId)
+            .Returns(new CommandResult<OrganizationInviteLink>(new InviteLinkNotAvailable()));
+
+        var result = await sutProvider.Sut.Get(orgId);
+
+        var badRequestResult = Assert.IsType<BadRequest<Bit.Core.Models.Api.ErrorResponseModel>>(result);
+        Assert.NotNull(badRequestResult.Value);
     }
 
     [Theory, BitAutoData]

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
@@ -81,6 +81,7 @@ public class OrganizationInviteLinksControllerTests
         SutProvider<OrganizationInviteLinksController> sutProvider)
     {
         inviteLink.OrganizationId = orgId;
+        inviteLink.AllowedDomains = "[\"acme.com\"]";
 
         sutProvider.GetDependency<IGetOrganizationInviteLinkQuery>()
             .GetAsync(orgId)

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/GetOrganizationInviteLinkQueryTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/GetOrganizationInviteLinkQueryTests.cs
@@ -1,0 +1,97 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Models.Data.Organizations;
+using Bit.Core.Services;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.InviteLinks;
+
+[SutProviderCustomize]
+public class GetOrganizationInviteLinkQueryTests
+{
+    [Theory, BitAutoData]
+    public async Task GetAsync_WithValidInput_Success(
+        Guid organizationId,
+        OrganizationInviteLink link,
+        SutProvider<GetOrganizationInviteLinkQuery> sutProvider)
+    {
+        SetupAbility(sutProvider, organizationId);
+        link.OrganizationId = organizationId;
+
+        sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .GetByOrganizationIdAsync(organizationId)
+            .Returns(link);
+
+        var result = await sutProvider.Sut.GetAsync(organizationId);
+
+        Assert.True(result.IsSuccess);
+        Assert.Same(link, result.AsSuccess);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetAsync_WhenNoLinkExists_ReturnsNotFoundError(
+        Guid organizationId,
+        SutProvider<GetOrganizationInviteLinkQuery> sutProvider)
+    {
+        SetupAbility(sutProvider, organizationId);
+
+        sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .GetByOrganizationIdAsync(organizationId)
+            .Returns((OrganizationInviteLink?)null);
+
+        var result = await sutProvider.Sut.GetAsync(organizationId);
+
+        Assert.True(result.IsError);
+        Assert.IsType<InviteLinkNotFound>(result.AsError);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetAsync_WithoutUseInviteLinksAbility_ReturnsBadRequestError(
+        Guid organizationId,
+        SutProvider<GetOrganizationInviteLinkQuery> sutProvider)
+    {
+        SetupAbility(sutProvider, organizationId, useInviteLinks: false);
+
+        var result = await sutProvider.Sut.GetAsync(organizationId);
+
+        Assert.True(result.IsError);
+        Assert.IsType<InviteLinkNotAvailable>(result.AsError);
+
+        await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .GetByOrganizationIdAsync(default);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetAsync_WithNullAbility_ReturnsBadRequestError(
+        Guid organizationId,
+        SutProvider<GetOrganizationInviteLinkQuery> sutProvider)
+    {
+        sutProvider.GetDependency<IApplicationCacheService>()
+            .GetOrganizationAbilityAsync(organizationId)
+            .Returns((OrganizationAbility?)null);
+
+        var result = await sutProvider.Sut.GetAsync(organizationId);
+
+        Assert.True(result.IsError);
+        Assert.IsType<InviteLinkNotAvailable>(result.AsError);
+
+        await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .GetByOrganizationIdAsync(default);
+    }
+
+    private static void SetupAbility(
+        SutProvider<GetOrganizationInviteLinkQuery> sutProvider,
+        Guid organizationId,
+        bool useInviteLinks = true)
+    {
+        sutProvider.GetDependency<IApplicationCacheService>()
+            .GetOrganizationAbilityAsync(organizationId)
+            .Returns(new OrganizationAbility { UseInviteLinks = useInviteLinks });
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34774

## 📔 Objective

Adds `GET /organizations/{orgId}/invite-link` to retrieve an organization's existing invite link. Returns 404 if none exists.
