### PR TITLE
[PM-34388] Add organization invite link update endpoint

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationInviteLinksController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationInviteLinksController.cs
@@ -15,7 +15,8 @@ namespace Bit.Api.AdminConsole.Controllers;
 [RequireFeature(FeatureFlagKeys.GenerateInviteLink)]
 public class OrganizationInviteLinksController(
     ICreateOrganizationInviteLinkCommand createOrganizationInviteLinkCommand,
-    IGetOrganizationInviteLinkQuery getOrganizationInviteLinkQuery)
+    IGetOrganizationInviteLinkQuery getOrganizationInviteLinkQuery,
+    IUpdateOrganizationInviteLinkCommand updateOrganizationInviteLinkCommand)
     : BaseAdminConsoleController
 {
     [HttpGet("")]
@@ -39,5 +40,16 @@ public class OrganizationInviteLinksController(
             TypedResults.Created(
                 $"organizations/{orgId}/invite-link",
                 new OrganizationInviteLinkResponseModel(link)));
+    }
+
+    [HttpPut("")]
+    [Authorize<ManageUsersRequirement>]
+    public async Task<IResult> Update(Guid orgId, [FromBody] UpdateOrganizationInviteLinkRequestModel model)
+    {
+        var result = await updateOrganizationInviteLinkCommand.UpdateAsync(
+            model.ToCommandRequest(orgId));
+
+        return Handle(result, link =>
+            TypedResults.Ok(new OrganizationInviteLinkResponseModel(link)));
     }
 }

--- a/src/Api/AdminConsole/Models/Request/Organizations/UpdateOrganizationInviteLinkRequestModel.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/UpdateOrganizationInviteLinkRequestModel.cs
@@ -10,6 +10,7 @@ public class UpdateOrganizationInviteLinkRequestModel
     /// Email domains permitted to accept the invite link (e.g. <c>["acme.com"]</c>).
     /// </summary>
     [Required]
+    [MinLength(1)]
     [ValidateSequence<DomainNameValidatorAttribute>]
     public required IEnumerable<string> AllowedDomains { get; set; }
 

--- a/src/Api/AdminConsole/Models/Request/Organizations/UpdateOrganizationInviteLinkRequestModel.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/UpdateOrganizationInviteLinkRequestModel.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
+using Bit.Core.Utilities;
+
+namespace Bit.Api.AdminConsole.Models.Request.Organizations;
+
+public class UpdateOrganizationInviteLinkRequestModel
+{
+    /// <summary>
+    /// Email domains permitted to accept the invite link (e.g. <c>["acme.com"]</c>).
+    /// </summary>
+    [Required]
+    [ValidateSequence<DomainNameValidatorAttribute>]
+    public required IEnumerable<string> AllowedDomains { get; set; }
+
+    public UpdateOrganizationInviteLinkRequest ToCommandRequest(Guid organizationId) => new()
+    {
+        OrganizationId = organizationId,
+        AllowedDomains = AllowedDomains,
+    };
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/CreateOrganizationInviteLinkCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/CreateOrganizationInviteLinkCommand.cs
@@ -1,6 +1,7 @@
 ﻿using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
 using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.AdminConsole.Utilities;
 using Bit.Core.AdminConsole.Utilities.v2.Results;
 using Bit.Core.Services;
 
@@ -20,7 +21,7 @@ public class CreateOrganizationInviteLinkCommand(
             return new InviteLinkNotAvailable();
         }
 
-        var sanitizedDomains = SanitizeDomains(request.AllowedDomains);
+        var sanitizedDomains = InviteLinkDomainSanitizer.SanitizeDomains(request.AllowedDomains);
         if (sanitizedDomains.Count == 0)
         {
             return new InviteLinkDomainsRequired();
@@ -55,13 +56,4 @@ public class CreateOrganizationInviteLinkCommand(
         return ability is not null && ability.UseInviteLinks;
     }
 
-    /// <summary>
-    /// Normalizes domains to lowercase and removes blank entries.
-    /// </summary>
-    private static List<string> SanitizeDomains(IEnumerable<string>? domains) =>
-        domains?
-            .Select(d => d?.Trim().ToLowerInvariant())
-            .Where(d => !string.IsNullOrEmpty(d))
-            .Cast<string>()
-            .ToList() ?? [];
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Interfaces/IUpdateOrganizationInviteLinkCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Interfaces/IUpdateOrganizationInviteLinkCommand.cs
@@ -1,0 +1,14 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Utilities.v2.Results;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
+
+public interface IUpdateOrganizationInviteLinkCommand
+{
+    /// <summary>
+    /// Updates the allowed domains for the invite link of the specified organization.
+    /// </summary>
+    /// <param name="request">The details for the invite link update.</param>
+    /// <returns>The updated <see cref="OrganizationInviteLink"/>, or an error if validation fails or a link does not exist.</returns>
+    Task<CommandResult<OrganizationInviteLink>> UpdateAsync(UpdateOrganizationInviteLinkRequest request);
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/UpdateOrganizationInviteLinkCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/UpdateOrganizationInviteLinkCommand.cs
@@ -1,0 +1,49 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.AdminConsole.Utilities;
+using Bit.Core.AdminConsole.Utilities.v2.Results;
+using Bit.Core.Services;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
+
+public class UpdateOrganizationInviteLinkCommand(
+    IOrganizationInviteLinkRepository organizationInviteLinkRepository,
+    IApplicationCacheService applicationCacheService,
+    TimeProvider timeProvider)
+    : IUpdateOrganizationInviteLinkCommand
+{
+    public async Task<CommandResult<OrganizationInviteLink>> UpdateAsync(
+        UpdateOrganizationInviteLinkRequest request)
+    {
+        if (!await OrganizationHasInviteLinksAbilityAsync(request.OrganizationId))
+        {
+            return new InviteLinkNotAvailable();
+        }
+
+        var sanitizedDomains = InviteLinkDomainSanitizer.SanitizeDomains(request.AllowedDomains);
+        if (sanitizedDomains.Count == 0)
+        {
+            return new InviteLinkDomainsRequired();
+        }
+
+        var inviteLink = await organizationInviteLinkRepository.GetByOrganizationIdAsync(request.OrganizationId);
+        if (inviteLink is null)
+        {
+            return new InviteLinkNotFound();
+        }
+
+        inviteLink.SetAllowedDomains(sanitizedDomains);
+        inviteLink.RevisionDate = timeProvider.GetUtcNow().UtcDateTime;
+
+        await organizationInviteLinkRepository.ReplaceAsync(inviteLink);
+
+        return inviteLink;
+    }
+
+    private async Task<bool> OrganizationHasInviteLinksAbilityAsync(Guid organizationId)
+    {
+        var ability = await applicationCacheService.GetOrganizationAbilityAsync(organizationId);
+        return ability is not null && ability.UseInviteLinks;
+    }
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/UpdateOrganizationInviteLinkRequest.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/UpdateOrganizationInviteLinkRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
+
+public record UpdateOrganizationInviteLinkRequest
+{
+    public required Guid OrganizationId { get; init; }
+    public required IEnumerable<string> AllowedDomains { get; init; }
+}

--- a/src/Core/AdminConsole/Utilities/InviteLinkDomainSanitizer.cs
+++ b/src/Core/AdminConsole/Utilities/InviteLinkDomainSanitizer.cs
@@ -1,0 +1,14 @@
+﻿namespace Bit.Core.AdminConsole.Utilities;
+
+internal static class InviteLinkDomainSanitizer
+{
+    /// <summary>
+    /// Normalizes domains to lowercase and removes blank entries.
+    /// </summary>
+    internal static List<string> SanitizeDomains(IEnumerable<string>? domains) =>
+        domains?
+            .Select(d => d?.Trim().ToLowerInvariant())
+            .Where(d => !string.IsNullOrEmpty(d))
+            .Cast<string>()
+            .ToList() ?? [];
+}

--- a/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
+++ b/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
@@ -195,6 +195,7 @@ public static class OrganizationServiceCollectionExtensions
     {
         services.TryAddScoped<ICreateOrganizationInviteLinkCommand, CreateOrganizationInviteLinkCommand>();
         services.TryAddScoped<IGetOrganizationInviteLinkQuery, GetOrganizationInviteLinkQuery>();
+        services.TryAddScoped<IUpdateOrganizationInviteLinkCommand, UpdateOrganizationInviteLinkCommand>();
     }
 
     private static void AddOrganizationDomainCommandsQueries(this IServiceCollection services)

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
@@ -100,4 +100,51 @@ public class OrganizationInviteLinksControllerTests : IClassFixture<ApiApplicati
         var content = await getResponse.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
         AssertInviteLink(content, _organization);
     }
+
+    [Fact]
+    public async Task CreateThenUpdateThenGet_AsOwner_ReturnsCreatedAndOkAndOk()
+    {
+        var createRequest = new CreateOrganizationInviteLinkRequestModel
+        {
+            AllowedDomains = ["acme.com"],
+            EncryptedInviteKey = _validEncryptedKey,
+        };
+
+        var createResponse = await _client.PostAsJsonAsync(
+            $"/organizations/{_organization.Id}/invite-link", createRequest);
+
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+
+        var created = await createResponse.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
+        Assert.NotNull(created);
+
+        var updateRequest = new UpdateOrganizationInviteLinkRequestModel
+        {
+            AllowedDomains = ["example.com", "new.com"],
+        };
+
+        var updateResponse = await _client.PutAsJsonAsync(
+            $"/organizations/{_organization.Id}/invite-link", updateRequest);
+
+        Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
+
+        var updated = await updateResponse.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
+        Assert.NotNull(updated);
+        Assert.Equal(created.Id, updated.Id);
+        Assert.Equal(created.Code, updated.Code);
+        Assert.Equal(_organization.Id, updated.OrganizationId);
+        Assert.Equal(_validEncryptedKey, updated.EncryptedInviteKey);
+        Assert.Equal(["example.com", "new.com"], updated.AllowedDomains);
+
+        var getResponse = await _client.GetAsync($"/organizations/{_organization.Id}/invite-link");
+
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+
+        var content = await getResponse.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
+        Assert.NotNull(content);
+        Assert.Equal(created.Id, content.Id);
+        Assert.Equal(created.Code, content.Code);
+        Assert.Equal(_validEncryptedKey, content.EncryptedInviteKey);
+        Assert.Equal(["example.com", "new.com"], content.AllowedDomains);
+    }
 }

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
@@ -145,4 +145,75 @@ public class OrganizationInviteLinksControllerTests
         var badRequestResult = Assert.IsType<BadRequest<Bit.Core.Models.Api.ErrorResponseModel>>(result);
         Assert.NotNull(badRequestResult.Value);
     }
+
+    [Theory, BitAutoData]
+    public async Task Update_WithValidInput_ReturnsOk(
+        Guid orgId,
+        OrganizationInviteLink inviteLink,
+        SutProvider<OrganizationInviteLinksController> sutProvider)
+    {
+        inviteLink.OrganizationId = orgId;
+        inviteLink.AllowedDomains = "[\"acme.com\"]";
+
+        var model = new UpdateOrganizationInviteLinkRequestModel
+        {
+            AllowedDomains = ["acme.com"],
+        };
+
+        sutProvider.GetDependency<IUpdateOrganizationInviteLinkCommand>()
+            .UpdateAsync(Arg.Any<UpdateOrganizationInviteLinkRequest>())
+            .Returns(new CommandResult<OrganizationInviteLink>(inviteLink));
+
+        var result = await sutProvider.Sut.Update(orgId, model);
+
+        var okResult = Assert.IsType<Ok<OrganizationInviteLinkResponseModel>>(result);
+        Assert.NotNull(okResult.Value);
+        Assert.Equal(inviteLink.Id, okResult.Value.Id);
+        Assert.Equal(orgId, okResult.Value.OrganizationId);
+
+        await sutProvider.GetDependency<IUpdateOrganizationInviteLinkCommand>()
+            .Received(1)
+            .UpdateAsync(Arg.Is<UpdateOrganizationInviteLinkRequest>(r =>
+                r.OrganizationId == orgId));
+    }
+
+    [Theory, BitAutoData]
+    public async Task Update_WhenNoLinkExists_ReturnsNotFound(
+        Guid orgId,
+        SutProvider<OrganizationInviteLinksController> sutProvider)
+    {
+        var model = new UpdateOrganizationInviteLinkRequestModel
+        {
+            AllowedDomains = ["acme.com"],
+        };
+
+        sutProvider.GetDependency<IUpdateOrganizationInviteLinkCommand>()
+            .UpdateAsync(Arg.Any<UpdateOrganizationInviteLinkRequest>())
+            .Returns(new CommandResult<OrganizationInviteLink>(new InviteLinkNotFound()));
+
+        var result = await sutProvider.Sut.Update(orgId, model);
+
+        var notFoundResult = Assert.IsType<NotFound<Bit.Core.Models.Api.ErrorResponseModel>>(result);
+        Assert.NotNull(notFoundResult.Value);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Update_WithValidationError_Returns400(
+        Guid orgId,
+        SutProvider<OrganizationInviteLinksController> sutProvider)
+    {
+        var model = new UpdateOrganizationInviteLinkRequestModel
+        {
+            AllowedDomains = [],
+        };
+
+        sutProvider.GetDependency<IUpdateOrganizationInviteLinkCommand>()
+            .UpdateAsync(Arg.Any<UpdateOrganizationInviteLinkRequest>())
+            .Returns(new CommandResult<OrganizationInviteLink>(new InviteLinkDomainsRequired()));
+
+        var result = await sutProvider.Sut.Update(orgId, model);
+
+        var badRequestResult = Assert.IsType<BadRequest<Bit.Core.Models.Api.ErrorResponseModel>>(result);
+        Assert.NotNull(badRequestResult.Value);
+    }
 }

--- a/test/Api.Test/AdminConsole/Models/Request/Organizations/UpdateOrganizationInviteLinkRequestModelTests.cs
+++ b/test/Api.Test/AdminConsole/Models/Request/Organizations/UpdateOrganizationInviteLinkRequestModelTests.cs
@@ -1,0 +1,62 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Api.AdminConsole.Models.Request.Organizations;
+using Xunit;
+
+namespace Bit.Api.Test.AdminConsole.Models.Request.Organizations;
+
+public class UpdateOrganizationInviteLinkRequestModelTests
+{
+    [Fact]
+    public void Validate_WithValidModel_ReturnsNoErrors()
+    {
+        var model = new UpdateOrganizationInviteLinkRequestModel
+        {
+            AllowedDomains = ["acme.com"],
+        };
+
+        var results = Validate(model);
+
+        Assert.Empty(results);
+    }
+
+    [Theory]
+    [InlineData("not a domain")]
+    [InlineData("<script>alert(1)</script>")]
+    [InlineData("double..dot.com")]
+    [InlineData("-starts-with-hyphen.com")]
+    [InlineData(" acme.com ")]
+    public void Validate_WithInvalidDomainFormat_ReturnsError(string invalidDomain)
+    {
+        var model = new UpdateOrganizationInviteLinkRequestModel
+        {
+            AllowedDomains = [invalidDomain],
+        };
+
+        var results = Validate(model);
+
+        Assert.Single(results);
+        Assert.Contains(results, r => r.MemberNames.Contains(nameof(model.AllowedDomains)));
+    }
+
+    [Fact]
+    public void Validate_WithMixedValidAndInvalidDomains_ReturnsError()
+    {
+        var model = new UpdateOrganizationInviteLinkRequestModel
+        {
+            AllowedDomains = ["acme.com", "not a domain", "<script>"],
+        };
+
+        var results = Validate(model);
+
+        var error = Assert.Single(results);
+        Assert.Contains("'not a domain'", error.ErrorMessage);
+        Assert.Contains("'<script>'", error.ErrorMessage);
+    }
+
+    private static List<ValidationResult> Validate(UpdateOrganizationInviteLinkRequestModel model)
+    {
+        var results = new List<ValidationResult>();
+        Validator.TryValidateObject(model, new ValidationContext(model), results, true);
+        return results;
+    }
+}

--- a/test/Api.Test/AdminConsole/Models/Request/Organizations/UpdateOrganizationInviteLinkRequestModelTests.cs
+++ b/test/Api.Test/AdminConsole/Models/Request/Organizations/UpdateOrganizationInviteLinkRequestModelTests.cs
@@ -39,6 +39,20 @@ public class UpdateOrganizationInviteLinkRequestModelTests
     }
 
     [Fact]
+    public void Validate_WithEmptyAllowedDomains_ReturnsError()
+    {
+        var model = new UpdateOrganizationInviteLinkRequestModel
+        {
+            AllowedDomains = [],
+        };
+
+        var results = Validate(model);
+
+        Assert.Single(results);
+        Assert.Contains(results, r => r.MemberNames.Contains(nameof(model.AllowedDomains)));
+    }
+
+    [Fact]
     public void Validate_WithMixedValidAndInvalidDomains_ReturnsError()
     {
         var model = new UpdateOrganizationInviteLinkRequestModel

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/UpdateOrganizationInviteLinkCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/UpdateOrganizationInviteLinkCommandTests.cs
@@ -1,0 +1,184 @@
+﻿using System.Text.Json;
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.AdminConsole.Utilities.v2.Results;
+using Bit.Core.Models.Data.Organizations;
+using Bit.Core.Services;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.InviteLinks;
+
+[SutProviderCustomize]
+public class UpdateOrganizationInviteLinkCommandTests
+{
+    [Theory, BitAutoData]
+    public async Task UpdateAsync_WithValidInput_Success(
+        Guid organizationId,
+        SutProvider<UpdateOrganizationInviteLinkCommand> sutProvider)
+    {
+        SetupAbility(sutProvider, organizationId);
+
+        var originalCreationDate = DateTime.UtcNow.AddDays(-5);
+        var existingLink = new OrganizationInviteLink
+        {
+            Id = Guid.NewGuid(),
+            Code = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            EncryptedInviteKey = "encrypted-key",
+            EncryptedOrgKey = "encrypted-org-key",
+            CreationDate = originalCreationDate,
+            RevisionDate = originalCreationDate,
+        };
+        existingLink.SetAllowedDomains(["old.com"]);
+
+        sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .GetByOrganizationIdAsync(organizationId)
+            .Returns(existingLink);
+
+        var request = CreateRequest(organizationId, [" New.com ", "Example.COM", " "]);
+
+        var result = await sutProvider.Sut.UpdateAsync(request);
+
+        Assert.True(result.IsSuccess);
+        var link = result.AsSuccess;
+        Assert.Same(existingLink, link);
+        Assert.Equal(existingLink.Id, link.Id);
+        Assert.Equal(existingLink.Code, link.Code);
+        Assert.Equal("encrypted-key", link.EncryptedInviteKey);
+        Assert.Equal("encrypted-org-key", link.EncryptedOrgKey);
+        Assert.Equal(originalCreationDate, link.CreationDate);
+        Assert.True(link.RevisionDate > originalCreationDate);
+
+        var deserializedDomains = JsonSerializer.Deserialize<List<string>>(link.AllowedDomains);
+        Assert.NotNull(deserializedDomains);
+        Assert.Equal(["new.com", "example.com"], deserializedDomains);
+
+        await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .Received(1)
+            .ReplaceAsync(existingLink);
+    }
+
+    [Theory, BitAutoData]
+    public async Task UpdateAsync_WithNoExistingLink_ReturnsNotFoundError(
+        Guid organizationId,
+        SutProvider<UpdateOrganizationInviteLinkCommand> sutProvider)
+    {
+        SetupAbility(sutProvider, organizationId);
+        sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .GetByOrganizationIdAsync(organizationId)
+            .Returns((OrganizationInviteLink?)null);
+
+        var request = CreateRequest(organizationId, ["acme.com"]);
+
+        var result = await sutProvider.Sut.UpdateAsync(request);
+
+        Assert.True(result.IsError);
+        Assert.IsType<InviteLinkNotFound>(result.AsError);
+
+        await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .ReplaceAsync(default!);
+    }
+
+    [Theory, BitAutoData]
+    public async Task UpdateAsync_WithEmptyDomainsList_ReturnsBadRequestError(
+        Guid organizationId,
+        SutProvider<UpdateOrganizationInviteLinkCommand> sutProvider)
+    {
+        SetupAbility(sutProvider, organizationId);
+
+        var request = CreateRequest(organizationId, []);
+
+        var result = await sutProvider.Sut.UpdateAsync(request);
+
+        AssertDomainsRequired(result);
+    }
+
+    [Theory, BitAutoData]
+    public async Task UpdateAsync_WithWhitespaceOnlyDomains_ReturnsBadRequestError(
+        Guid organizationId,
+        SutProvider<UpdateOrganizationInviteLinkCommand> sutProvider)
+    {
+        SetupAbility(sutProvider, organizationId);
+
+        var request = CreateRequest(organizationId, [" ", ""]);
+
+        var result = await sutProvider.Sut.UpdateAsync(request);
+
+        AssertDomainsRequired(result);
+    }
+
+    [Theory, BitAutoData]
+    public async Task UpdateAsync_WithNullDomains_ReturnsBadRequestError(
+        Guid organizationId,
+        SutProvider<UpdateOrganizationInviteLinkCommand> sutProvider)
+    {
+        SetupAbility(sutProvider, organizationId);
+
+        var request = CreateRequest(organizationId, null);
+
+        var result = await sutProvider.Sut.UpdateAsync(request);
+
+        AssertDomainsRequired(result);
+    }
+
+    [Theory, BitAutoData]
+    public async Task UpdateAsync_WithoutUseInviteLinksAbility_ReturnsBadRequestError(
+        Guid organizationId,
+        SutProvider<UpdateOrganizationInviteLinkCommand> sutProvider)
+    {
+        SetupAbility(sutProvider, organizationId, useInviteLinks: false);
+
+        var request = CreateRequest(organizationId, ["acme.com"]);
+
+        var result = await sutProvider.Sut.UpdateAsync(request);
+
+        Assert.True(result.IsError);
+        Assert.IsType<InviteLinkNotAvailable>(result.AsError);
+    }
+
+    [Theory, BitAutoData]
+    public async Task UpdateAsync_WithNullAbility_ReturnsBadRequestError(
+        Guid organizationId,
+        SutProvider<UpdateOrganizationInviteLinkCommand> sutProvider)
+    {
+        sutProvider.GetDependency<IApplicationCacheService>()
+            .GetOrganizationAbilityAsync(organizationId)
+            .Returns((OrganizationAbility?)null);
+
+        var request = CreateRequest(organizationId, ["acme.com"]);
+
+        var result = await sutProvider.Sut.UpdateAsync(request);
+
+        Assert.True(result.IsError);
+        Assert.IsType<InviteLinkNotAvailable>(result.AsError);
+    }
+
+    private static void SetupAbility(
+        SutProvider<UpdateOrganizationInviteLinkCommand> sutProvider,
+        Guid organizationId,
+        bool useInviteLinks = true)
+    {
+        sutProvider.GetDependency<IApplicationCacheService>()
+            .GetOrganizationAbilityAsync(organizationId)
+            .Returns(new OrganizationAbility { UseInviteLinks = useInviteLinks });
+    }
+
+    private static UpdateOrganizationInviteLinkRequest CreateRequest(
+        Guid organizationId,
+        IEnumerable<string>? allowedDomains) => new()
+        {
+            OrganizationId = organizationId,
+            AllowedDomains = allowedDomains!,
+        };
+
+    private static void AssertDomainsRequired(CommandResult<OrganizationInviteLink> result)
+    {
+        Assert.True(result.IsError);
+        Assert.IsType<InviteLinkDomainsRequired>(result.AsError);
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34388

## 📔 Objective

Add `PUT /organizations/{orgId}/invite-link` to update an existing invite link’s allowed domains (requires at least one valid domain; returns 404 if missing), without changing the link’s code/key/url.

[Clients PR](https://github.com/bitwarden/clients/pull/20431).
