### PR TITLE
[PM-35909] Preserve existing discounts during price migration

### DIFF
--- a/src/Billing/Services/Implementations/UpcomingInvoiceHandler.cs
+++ b/src/Billing/Services/Implementations/UpcomingInvoiceHandler.cs
@@ -48,9 +48,12 @@ public class UpcomingInvoiceHandler(
     {
         var invoice = await stripeEventService.GetInvoice(parsedEvent);
 
+        // "subscriptions.data.discounts" is required by IPriceIncreaseScheduler.Schedule
+        // to preserve pre-existing subscription-level discounts when constructing Phase 2.
+        // See PM-35909.
         var customer =
             await stripeAdapter.GetCustomerAsync(invoice.CustomerId,
-                new CustomerGetOptions { Expand = ["subscriptions", "subscriptions.data.test_clock", "tax", "tax_ids"] });
+                new CustomerGetOptions { Expand = ["subscriptions", "subscriptions.data.discounts", "subscriptions.data.test_clock", "tax", "tax_ids"] });
 
         var subscription = customer.Subscriptions.FirstOrDefault();
 

--- a/src/Core/Billing/Extensions/DiscountExtensions.cs
+++ b/src/Core/Billing/Extensions/DiscountExtensions.cs
@@ -7,6 +7,9 @@ public static class DiscountExtensions
     public static bool AppliesTo(this Discount discount, SubscriptionItem subscriptionItem)
         => discount.Coupon.AppliesTo.Products.Contains(subscriptionItem.Price.Product.Id);
 
+    public static bool AppliesTo(this Coupon coupon, SubscriptionItem subscriptionItem)
+        => coupon.AppliesTo?.Products?.Contains(subscriptionItem.Price.Product.Id) ?? false;
+
     public static bool IsValid(this Discount? discount)
         => discount?.Coupon?.Valid ?? false;
 }

--- a/src/Core/Billing/Pricing/PriceIncreaseScheduler.cs
+++ b/src/Core/Billing/Pricing/PriceIncreaseScheduler.cs
@@ -172,6 +172,19 @@ public class PriceIncreaseScheduler(
             return null;
         }
 
+        // Detect callers who fetched the subscription without expanding "discounts".
+        // Stripe.NET deserializes the unexpanded ID-array form as a list of null entries,
+        // which would silently drop pre-existing discounts from Phase 2 (the bug PM-35909 fixed).
+        if (subscription.Discounts is { Count: > 0 } && subscription.Discounts.Any(d => d == null))
+        {
+            logger.LogError(
+                "Subscription ({SubscriptionId}) was loaded without expanding 'discounts'; " +
+                "{Count} pre-existing discount(s) would be silently dropped from Phase 2. " +
+                "Caller must include \"discounts\" in the Stripe Expand list.",
+                subscription.Id, subscription.DiscountIds?.Count ?? 0);
+            return null;
+        }
+
         try
         {
             SubscriberId subscriberId = subscription;
@@ -190,7 +203,7 @@ public class PriceIncreaseScheduler(
         catch (Exception ex)
         {
             logger.LogError(ex,
-                "Failed to resolve subscriber type for subscription ({SubscriptionId}), cannot determine price migration path",
+                "Failed to resolve Phase 2 options for subscription ({SubscriptionId}), cannot determine price migration path",
                 subscription.Id);
             return null;
         }
@@ -244,12 +257,21 @@ public class PriceIncreaseScheduler(
             return null;
         }
 
+        var discounts = subscription.Discounts?
+            .Select(d => new SubscriptionSchedulePhaseDiscountOptions { Coupon = d.Coupon.Id })
+            .ToList() ?? [];
+
+        discounts.Add(new SubscriptionSchedulePhaseDiscountOptions
+        {
+            Coupon = CouponIDs.Milestone2SubscriptionDiscount
+        });
+
         return new SubscriptionSchedulePhaseOptions
         {
             StartDate = startDate,
             EndDate = startDate.Value.AddYears(1),
             Items = items,
-            Discounts = [new() { Coupon = CouponIDs.Milestone2SubscriptionDiscount }],
+            Discounts = discounts,
             ProrationBehavior = ProrationBehavior.None
         };
     }
@@ -291,12 +313,17 @@ public class PriceIncreaseScheduler(
             });
         }
 
-        var discounts = oldPlan.Type == PlanType.FamiliesAnnually2019
-            ? new List<SubscriptionSchedulePhaseDiscountOptions>
+        var discounts = subscription.Discounts?
+            .Select(d => new SubscriptionSchedulePhaseDiscountOptions { Coupon = d.Coupon.Id })
+            .ToList() ?? [];
+
+        if (oldPlan.Type == PlanType.FamiliesAnnually2019)
+        {
+            discounts.Add(new SubscriptionSchedulePhaseDiscountOptions
             {
-                new() { Coupon = CouponIDs.Milestone3SubscriptionDiscount }
-            }
-            : null;
+                Coupon = CouponIDs.Milestone3SubscriptionDiscount
+            });
+        }
 
         var startDate = subscription.GetCurrentPeriodEnd();
         if (startDate == null)
@@ -312,7 +339,7 @@ public class PriceIncreaseScheduler(
             StartDate = startDate,
             EndDate = startDate.Value.AddYears(1),
             Items = items,
-            Discounts = discounts,
+            Discounts = discounts.Count > 0 ? discounts : null,
             ProrationBehavior = ProrationBehavior.None
         };
     }

--- a/src/Core/Billing/Subscriptions/Commands/ReinstateSubscriptionCommand.cs
+++ b/src/Core/Billing/Subscriptions/Commands/ReinstateSubscriptionCommand.cs
@@ -28,7 +28,9 @@ public class ReinstateSubscriptionCommand(
 
     public Task<BillingCommandResult<None>> Run(ISubscriber subscriber) => HandleAsync<None>(async () =>
     {
-        var subscription = await stripeAdapter.GetSubscriptionAsync(subscriber.GatewaySubscriptionId);
+        var subscription = await stripeAdapter.GetSubscriptionAsync(
+            subscriber.GatewaySubscriptionId,
+            new SubscriptionGetOptions { Expand = ["discounts"] });
 
         if (subscription is not
             {

--- a/src/Core/Billing/Subscriptions/Queries/GetBitwardenSubscriptionQuery.cs
+++ b/src/Core/Billing/Subscriptions/Queries/GetBitwardenSubscriptionQuery.cs
@@ -107,11 +107,8 @@ public class GetBitwardenSubscriptionQuery(
         var additionalStorageItem = subscription.Items.FirstOrDefault(item =>
             plans.Any(plan => plan.Storage.StripePriceId == item.Price.Id));
 
-        var (cartLevelDiscount, productLevelDiscounts) = GetStripeDiscounts(subscription);
-
-        var (scheduleDiscount, scheduleCouponId) = cartLevelDiscount == null
-            ? await GetSchedulePhase2DiscountAsync(subscription)
-            : (null, (string?)null);
+        var coupons = await GetRelevantCouponsAsync(subscription);
+        var (cartLevelCoupon, productLevelCoupons) = PartitionCouponsByScope(coupons);
 
         var availablePlan = plans.First(plan => plan.Available);
         var onCurrentPricing = passwordManagerSeatsItem.Price.Id == availablePlan.Seat.StripePriceId;
@@ -127,7 +124,9 @@ public class GetBitwardenSubscriptionQuery(
         else
         {
             seatCost = availablePlan.Seat.Price;
-            estimatedTax = await EstimatePremiumTaxAsync(subscription, plans, availablePlan, scheduleCouponId);
+            estimatedTax = await EstimatePremiumTaxAsync(
+                subscription, plans, availablePlan,
+                [.. coupons.Select(c => c.Id)]);
         }
 
         var passwordManagerSeats = new CartItem
@@ -135,7 +134,7 @@ public class GetBitwardenSubscriptionQuery(
             TranslationKey = "premiumMembership",
             Quantity = passwordManagerSeatsItem.Quantity,
             Cost = seatCost,
-            Discount = productLevelDiscounts.FirstOrDefault(discount => discount.AppliesTo(passwordManagerSeatsItem)) ?? scheduleDiscount
+            Discount = productLevelCoupons.FirstOrDefault(coupon => coupon.AppliesTo(passwordManagerSeatsItem))
         };
 
         var additionalStorage = additionalStorageItem != null
@@ -144,7 +143,7 @@ public class GetBitwardenSubscriptionQuery(
                 TranslationKey = "additionalStorageGB",
                 Quantity = additionalStorageItem.Quantity,
                 Cost = GetCost(additionalStorageItem),
-                Discount = productLevelDiscounts.FirstOrDefault(discount => discount.AppliesTo(additionalStorageItem))
+                Discount = productLevelCoupons.FirstOrDefault(coupon => coupon.AppliesTo(additionalStorageItem))
             }
             : null;
 
@@ -156,18 +155,16 @@ public class GetBitwardenSubscriptionQuery(
                 AdditionalStorage = additionalStorage
             },
             Cadence = PlanCadenceType.Annually,
-            Discount = cartLevelDiscount,
+            Discount = cartLevelCoupon,
             EstimatedTax = estimatedTax
         };
     }
-
-    #region Utilities
 
     private async Task<decimal> EstimatePremiumTaxAsync(
         Subscription subscription,
         List<PremiumPlan>? plans = null,
         PremiumPlan? availablePlan = null,
-        string? couponId = null)
+        List<string>? couponIds = null)
     {
         try
         {
@@ -185,7 +182,7 @@ public class GetBitwardenSubscriptionQuery(
 
                 options.SubscriptionDetails = new InvoiceSubscriptionDetailsOptions
                 {
-                    Items = subscription.Items.Select(item =>
+                    Items = [.. subscription.Items.Select(item =>
                     {
                         var isSeatItem = plans.Any(plan => plan.Seat.StripePriceId == item.Price.Id);
 
@@ -194,12 +191,12 @@ public class GetBitwardenSubscriptionQuery(
                             Price = isSeatItem ? availablePlan.Seat.StripePriceId : item.Price.Id,
                             Quantity = item.Quantity
                         };
-                    }).ToList()
+                    })]
                 };
 
-                if (couponId != null)
+                if (couponIds is { Count: > 0 })
                 {
-                    options.Discounts = [new InvoiceDiscountOptions { Coupon = couponId }];
+                    options.Discounts = [.. couponIds.Select(id => new InvoiceDiscountOptions { Coupon = id })];
                 }
             }
             else
@@ -223,30 +220,52 @@ public class GetBitwardenSubscriptionQuery(
             item => (item.Price.UnitAmountDecimal ?? 0) / 100M,
             taxes => taxes.Sum(invoiceTotalTax => invoiceTotalTax.Amount) / 100M);
 
-    private static (Discount? CartLevel, List<Discount> ProductLevel) GetStripeDiscounts(
-        Subscription subscription)
+    /// <summary>
+    /// Returns the coupons relevant to the subscription's upcoming invoice. When a subscription
+    /// schedule is attached, Phase 2's discounts are the source of truth (they reflect the
+    /// upcoming-renewal state, including any preserved current discounts plus migration coupons).
+    /// Otherwise the subscription's current discounts are used. Customer-level discounts apply
+    /// independently of the schedule and are always included.
+    /// </summary>
+    private async Task<List<Coupon>> GetRelevantCouponsAsync(Subscription subscription)
     {
-        var discounts = new List<Discount>();
+        var coupons = new List<Coupon>();
 
         if (subscription.Customer.Discount.IsValid())
         {
-            discounts.Add(subscription.Customer.Discount);
+            coupons.Add(subscription.Customer.Discount.Coupon);
         }
 
-        discounts.AddRange(subscription.Discounts.Where(discount => discount.IsValid()));
-
-        var cartLevel = new List<Discount>();
-        var productLevel = new List<Discount>();
-
-        foreach (var discount in discounts)
+        if (!string.IsNullOrEmpty(subscription.ScheduleId))
         {
-            switch (discount)
+            coupons.AddRange(await GetSchedulePhase2CouponsAsync(subscription));
+        }
+        else
+        {
+            coupons.AddRange((subscription.Discounts ?? [])
+                .Where(d => d.IsValid())
+                .Select(d => d.Coupon));
+        }
+
+        return coupons;
+    }
+
+    private static (Coupon? CartLevel, List<Coupon> ProductLevel) PartitionCouponsByScope(
+        IEnumerable<Coupon> coupons)
+    {
+        var cartLevel = new List<Coupon>();
+        var productLevel = new List<Coupon>();
+
+        foreach (var coupon in coupons)
+        {
+            switch (coupon)
             {
-                case { Coupon.AppliesTo.Products: null or { Count: 0 } }:
-                    cartLevel.Add(discount);
+                case { AppliesTo.Products: null or { Count: 0 } }:
+                case { AppliesTo: null }:
+                    cartLevel.Add(coupon);
                     break;
-                case { Coupon.AppliesTo.Products.Count: > 0 }:
-                    productLevel.Add(discount);
+                case { AppliesTo.Products.Count: > 0 }:
+                    productLevel.Add(coupon);
                     break;
             }
         }
@@ -254,24 +273,19 @@ public class GetBitwardenSubscriptionQuery(
         return (cartLevel.FirstOrDefault(), productLevel);
     }
 
-    private async Task<(BitwardenDiscount? Discount, string? CouponId)> GetSchedulePhase2DiscountAsync(Subscription subscription)
+    private async Task<List<Coupon>> GetSchedulePhase2CouponsAsync(Subscription subscription)
     {
-        if (string.IsNullOrEmpty(subscription.ScheduleId))
-        {
-            return (null, null);
-        }
-
         try
         {
             var schedule = await stripeAdapter.GetSubscriptionScheduleAsync(subscription.ScheduleId,
                 new SubscriptionScheduleGetOptions
                 {
-                    Expand = ["phases.discounts.coupon"]
+                    Expand = ["phases.discounts.coupon.applies_to"]
                 });
 
             if (schedule.Status != SubscriptionScheduleStatus.Active || schedule.Phases.Count < 2)
             {
-                return (null, null);
+                return [];
             }
 
             var phase2 = schedule.Phases[1];
@@ -282,18 +296,23 @@ public class GetBitwardenSubscriptionQuery(
                 logger.LogInformation(
                     "Schedule phase 2 for subscription schedule ({ScheduleID}) has already started, skipping discount display",
                     subscription.ScheduleId);
-                return (null, null);
+                return [];
             }
 
-            var discount = phase2.Discounts?.FirstOrDefault();
-            return (discount?.Coupon, discount?.CouponId);
+            return phase2.Discounts?
+                .Where(d => d?.Coupon?.Valid == true)
+                .Select(d => d.Coupon)
+                .ToList() ?? [];
         }
         catch (StripeException stripeException)
         {
+            // Rethrow rather than soft-fail. The schedule's coupons feed both the discount display
+            // and the tax-preview's `options.Discounts` list — silently dropping them would inflate
+            // the tax estimate the user sees against the new pricing without any error signal.
             logger.LogError(stripeException,
                 "Failed to retrieve subscription schedule ({ScheduleID}) for discount resolution",
                 subscription.ScheduleId);
-            return (null, null);
+            throw;
         }
     }
 
@@ -318,6 +337,4 @@ public class GetBitwardenSubscriptionQuery(
             return null;
         }
     }
-
-    #endregion
 }

--- a/test/Core.Test/Billing/Pricing/PriceIncreaseSchedulerTests.cs
+++ b/test/Core.Test/Billing/Pricing/PriceIncreaseSchedulerTests.cs
@@ -101,9 +101,59 @@ public class PriceIncreaseSchedulerTests
             Arg.Is<SubscriptionScheduleUpdateOptions>(o =>
                 o.Phases.Count == 2 &&
                 o.Phases[1].Items.Any(i => i.Price == "premium-new-seat" && i.Quantity == 1) &&
+                o.Phases[1].Discounts.Count == 1 &&
                 o.Phases[1].Discounts.Any(d => d.Coupon == CouponIDs.Milestone2SubscriptionDiscount) &&
                 o.Phases[1].EndDate != null &&
                 o.EndBehavior == SubscriptionScheduleEndBehavior.Release));
+    }
+
+    [Fact]
+    public async Task Schedule_PremiumSubscriptionWithExistingDiscount_PreservesDiscountAndAppendsMilestone2()
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal).Returns(true);
+
+        var oldPremium = new PremiumPlan
+        {
+            Name = "Premium (Old)",
+            Available = false,
+            Seat = new Purchasable { StripePriceId = "premium-old-seat", Price = 10, Provided = 1 },
+            Storage = new Purchasable { StripePriceId = "premium-old-storage", Price = 4, Provided = 1 }
+        };
+
+        var newPremium = new PremiumPlan
+        {
+            Name = "Premium",
+            Available = true,
+            Seat = new Purchasable { StripePriceId = "premium-new-seat", Price = 15, Provided = 1 },
+            Storage = new Purchasable { StripePriceId = "premium-new-storage", Price = 4, Provided = 1 }
+        };
+
+        _pricingClient.ListPremiumPlans().Returns([oldPremium, newPremium]);
+
+        var subscription = CreateSubscription("sub_1", "cus_1",
+            CreateSubscriptionItem("premium-old-seat", 1));
+        subscription.Discounts =
+        [
+            new Discount { Coupon = new Coupon { Id = "existing-grandfather-discount" } }
+        ];
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [] });
+
+        _stripeAdapter.CreateSubscriptionScheduleAsync(Arg.Any<SubscriptionScheduleCreateOptions>())
+            .Returns(CreateScheduleWithPhase("sched_1", "sub_1"));
+
+        var sut = CreateSut();
+
+        await sut.Schedule(subscription);
+
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            "sched_1",
+            Arg.Is<SubscriptionScheduleUpdateOptions>(o =>
+                o.Phases.Count == 2 &&
+                o.Phases[1].Discounts.Count == 2 &&
+                o.Phases[1].Discounts[0].Coupon == "existing-grandfather-discount" &&
+                o.Phases[1].Discounts[1].Coupon == CouponIDs.Milestone2SubscriptionDiscount));
     }
 
     [Fact]
@@ -188,9 +238,52 @@ public class PriceIncreaseSchedulerTests
             Arg.Is<SubscriptionScheduleUpdateOptions>(o =>
                 o.Phases.Count == 2 &&
                 o.Phases[1].Items.Any(i => i.Price == familiesTarget.PasswordManager.StripePlanId && i.Quantity == 1) &&
+                o.Phases[1].Discounts.Count == 1 &&
                 o.Phases[1].Discounts.Any(d => d.Coupon == CouponIDs.Milestone3SubscriptionDiscount) &&
                 o.Phases[1].EndDate != null &&
                 o.EndBehavior == SubscriptionScheduleEndBehavior.Release));
+    }
+
+    [Fact]
+    public async Task Schedule_Families2019SubscriptionWithExistingDiscount_PreservesDiscountAndAppendsMilestone3()
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal).Returns(true);
+
+        _pricingClient.ListPremiumPlans().Returns([]);
+
+        var families2019 = MockPlans.Get(PlanType.FamiliesAnnually2019);
+        var families2025 = MockPlans.Get(PlanType.FamiliesAnnually2025);
+        var familiesTarget = MockPlans.Get(PlanType.FamiliesAnnually);
+
+        _pricingClient.GetPlanOrThrow(PlanType.FamiliesAnnually2019).Returns(families2019);
+        _pricingClient.GetPlanOrThrow(PlanType.FamiliesAnnually2025).Returns(families2025);
+        _pricingClient.GetPlanOrThrow(PlanType.FamiliesAnnually).Returns(familiesTarget);
+
+        var orgMetadata = new Dictionary<string, string> { { "organizationId", Guid.NewGuid().ToString() } };
+        var subscription = CreateSubscription("sub_1", "cus_1", orgMetadata,
+            CreateSubscriptionItem(families2019.PasswordManager.StripePlanId, 1));
+        subscription.Discounts =
+        [
+            new Discount { Coupon = new Coupon { Id = "existing-partner-discount" } }
+        ];
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [] });
+
+        _stripeAdapter.CreateSubscriptionScheduleAsync(Arg.Any<SubscriptionScheduleCreateOptions>())
+            .Returns(CreateScheduleWithPhase("sched_1", "sub_1"));
+
+        var sut = CreateSut();
+
+        await sut.Schedule(subscription);
+
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            "sched_1",
+            Arg.Is<SubscriptionScheduleUpdateOptions>(o =>
+                o.Phases.Count == 2 &&
+                o.Phases[1].Discounts.Count == 2 &&
+                o.Phases[1].Discounts[0].Coupon == "existing-partner-discount" &&
+                o.Phases[1].Discounts[1].Coupon == CouponIDs.Milestone3SubscriptionDiscount));
     }
 
     [Fact]
@@ -232,6 +325,48 @@ public class PriceIncreaseSchedulerTests
                 o.Phases[1].Discounts == null &&
                 o.Phases[1].EndDate != null &&
                 o.EndBehavior == SubscriptionScheduleEndBehavior.Release));
+    }
+
+    [Fact]
+    public async Task Schedule_Families2025SubscriptionWithExistingDiscount_PreservesDiscountWithoutMilestone()
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal).Returns(true);
+
+        _pricingClient.ListPremiumPlans().Returns([]);
+
+        var families2019 = MockPlans.Get(PlanType.FamiliesAnnually2019);
+        var families2025 = MockPlans.Get(PlanType.FamiliesAnnually2025);
+        var familiesTarget = MockPlans.Get(PlanType.FamiliesAnnually);
+
+        _pricingClient.GetPlanOrThrow(PlanType.FamiliesAnnually2019).Returns(families2019);
+        _pricingClient.GetPlanOrThrow(PlanType.FamiliesAnnually2025).Returns(families2025);
+        _pricingClient.GetPlanOrThrow(PlanType.FamiliesAnnually).Returns(familiesTarget);
+
+        var orgMetadata = new Dictionary<string, string> { { "organizationId", Guid.NewGuid().ToString() } };
+        var subscription = CreateSubscription("sub_1", "cus_1", orgMetadata,
+            CreateSubscriptionItem(families2025.PasswordManager.StripePlanId, 1));
+        subscription.Discounts =
+        [
+            new Discount { Coupon = new Coupon { Id = "existing-retention-discount" } }
+        ];
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [] });
+
+        _stripeAdapter.CreateSubscriptionScheduleAsync(Arg.Any<SubscriptionScheduleCreateOptions>())
+            .Returns(CreateScheduleWithPhase("sched_1", "sub_1"));
+
+        var sut = CreateSut();
+
+        await sut.Schedule(subscription);
+
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            "sched_1",
+            Arg.Is<SubscriptionScheduleUpdateOptions>(o =>
+                o.Phases.Count == 2 &&
+                o.Phases[1].Discounts != null &&
+                o.Phases[1].Discounts.Count == 1 &&
+                o.Phases[1].Discounts[0].Coupon == "existing-retention-discount"));
     }
 
     [Fact]
@@ -434,6 +569,36 @@ public class PriceIncreaseSchedulerTests
     }
 
     [Fact]
+    public async Task ResolvePhase2Async_SubscriptionLoadedWithoutDiscountsExpand_ReturnsNullAndDoesNotResolve()
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal).Returns(true);
+
+        // Construct the subscription via the same JSON path Stripe.NET uses on API responses.
+        // Verified empirically against Stripe.net 48.5.0: when "discounts" is not in the request's Expand list,
+        // the SDK populates DiscountIds with the IDs and Discounts with a same-length list of null entries.
+        // Direct assignment of `[null]` to subscription.Discounts is rejected by the SDK setter, so this is the
+        // only way to reproduce the state in a unit test.
+        const string unexpandedJson = """
+            {
+              "id": "sub_1",
+              "object": "subscription",
+              "customer": "cus_1",
+              "metadata": { "userId": "00000000-0000-0000-0000-000000000001" },
+              "discounts": ["di_abc"]
+            }
+            """;
+        var subscription = Newtonsoft.Json.JsonConvert.DeserializeObject<Subscription>(unexpandedJson)!;
+
+        var sut = CreateSut();
+
+        var result = await sut.ResolvePhase2Async(subscription);
+
+        Assert.Null(result);
+        await _pricingClient.DidNotReceiveWithAnyArgs().ListPremiumPlans();
+        await _pricingClient.DidNotReceiveWithAnyArgs().GetPlanOrThrow(Arg.Any<PlanType>());
+    }
+
+    [Fact]
     public async Task ResolvePhase2Async_PremiumSubscription_ReturnsPhase2WithDiscount()
     {
         _featureService.IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal).Returns(true);
@@ -475,6 +640,94 @@ public class PriceIncreaseSchedulerTests
         Assert.Equal(CouponIDs.Milestone2SubscriptionDiscount, result.Discounts[0].Coupon);
         Assert.Equal(ProrationBehavior.None, result.ProrationBehavior);
         Assert.Equal(currentPeriodEnd.AddYears(1), (DateTime)result.EndDate);
+    }
+
+    [Fact]
+    public async Task ResolvePhase2Async_PremiumSubscriptionWithExistingDiscount_PreservesAndAppendsMilestone2()
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal).Returns(true);
+
+        var oldPremium = new PremiumPlan
+        {
+            Name = "Premium (Old)",
+            Available = false,
+            Seat = new Purchasable { StripePriceId = "premium-old-seat", Price = 10, Provided = 1 },
+            Storage = new Purchasable { StripePriceId = "premium-old-storage", Price = 4, Provided = 1 }
+        };
+
+        var newPremium = new PremiumPlan
+        {
+            Name = "Premium",
+            Available = true,
+            Seat = new Purchasable { StripePriceId = "premium-new-seat", Price = 15, Provided = 1 },
+            Storage = new Purchasable { StripePriceId = "premium-new-storage", Price = 4, Provided = 1 }
+        };
+
+        _pricingClient.ListPremiumPlans().Returns([oldPremium, newPremium]);
+
+        var currentPeriodEnd = DateTime.UtcNow.AddMonths(1);
+        var subscription = CreateSubscription("sub_1", "cus_1",
+            CreateSubscriptionItem("premium-old-seat", 1));
+        subscription.Items.Data[0].CurrentPeriodEnd = currentPeriodEnd;
+        subscription.Discounts =
+        [
+            new Discount { Coupon = new Coupon { Id = "existing-grandfather-discount" } }
+        ];
+
+        var sut = CreateSut();
+
+        var result = await sut.ResolvePhase2Async(subscription);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Discounts);
+        Assert.Equal(2, result.Discounts.Count);
+        Assert.Equal("existing-grandfather-discount", result.Discounts[0].Coupon);
+        Assert.Equal(CouponIDs.Milestone2SubscriptionDiscount, result.Discounts[1].Coupon);
+    }
+
+    [Fact]
+    public async Task ResolvePhase2Async_PremiumSubscriptionWithMultipleExistingDiscounts_PreservesAllAndAppendsMilestone2()
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal).Returns(true);
+
+        var oldPremium = new PremiumPlan
+        {
+            Name = "Premium (Old)",
+            Available = false,
+            Seat = new Purchasable { StripePriceId = "premium-old-seat", Price = 10, Provided = 1 },
+            Storage = new Purchasable { StripePriceId = "premium-old-storage", Price = 4, Provided = 1 }
+        };
+
+        var newPremium = new PremiumPlan
+        {
+            Name = "Premium",
+            Available = true,
+            Seat = new Purchasable { StripePriceId = "premium-new-seat", Price = 15, Provided = 1 },
+            Storage = new Purchasable { StripePriceId = "premium-new-storage", Price = 4, Provided = 1 }
+        };
+
+        _pricingClient.ListPremiumPlans().Returns([oldPremium, newPremium]);
+
+        var currentPeriodEnd = DateTime.UtcNow.AddMonths(1);
+        var subscription = CreateSubscription("sub_1", "cus_1",
+            CreateSubscriptionItem("premium-old-seat", 1));
+        subscription.Items.Data[0].CurrentPeriodEnd = currentPeriodEnd;
+        subscription.Discounts =
+        [
+            new Discount { Coupon = new Coupon { Id = "existing-grandfather-discount" } },
+            new Discount { Coupon = new Coupon { Id = "existing-nfr-discount" } }
+        ];
+
+        var sut = CreateSut();
+
+        var result = await sut.ResolvePhase2Async(subscription);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Discounts);
+        Assert.Equal(3, result.Discounts.Count);
+        Assert.Equal("existing-grandfather-discount", result.Discounts[0].Coupon);
+        Assert.Equal("existing-nfr-discount", result.Discounts[1].Coupon);
+        Assert.Equal(CouponIDs.Milestone2SubscriptionDiscount, result.Discounts[2].Coupon);
     }
 
     [Fact]
@@ -558,6 +811,42 @@ public class PriceIncreaseSchedulerTests
     }
 
     [Fact]
+    public async Task ResolvePhase2Async_Families2019SubscriptionWithExistingDiscount_PreservesAndAppendsMilestone3()
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal).Returns(true);
+
+        _pricingClient.ListPremiumPlans().Returns([]);
+
+        var families2019 = MockPlans.Get(PlanType.FamiliesAnnually2019);
+        var families2025 = MockPlans.Get(PlanType.FamiliesAnnually2025);
+        var familiesTarget = MockPlans.Get(PlanType.FamiliesAnnually);
+
+        _pricingClient.GetPlanOrThrow(PlanType.FamiliesAnnually2019).Returns(families2019);
+        _pricingClient.GetPlanOrThrow(PlanType.FamiliesAnnually2025).Returns(families2025);
+        _pricingClient.GetPlanOrThrow(PlanType.FamiliesAnnually).Returns(familiesTarget);
+
+        var currentPeriodEnd = DateTime.UtcNow.AddYears(1);
+        var orgMetadata = new Dictionary<string, string> { { "organizationId", Guid.NewGuid().ToString() } };
+        var subscription = CreateSubscription("sub_1", "cus_1", orgMetadata,
+            CreateSubscriptionItem(families2019.PasswordManager.StripePlanId, 1));
+        subscription.Items.Data[0].CurrentPeriodEnd = currentPeriodEnd;
+        subscription.Discounts =
+        [
+            new Discount { Coupon = new Coupon { Id = "existing-partner-discount" } }
+        ];
+
+        var sut = CreateSut();
+
+        var result = await sut.ResolvePhase2Async(subscription);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Discounts);
+        Assert.Equal(2, result.Discounts.Count);
+        Assert.Equal("existing-partner-discount", result.Discounts[0].Coupon);
+        Assert.Equal(CouponIDs.Milestone3SubscriptionDiscount, result.Discounts[1].Coupon);
+    }
+
+    [Fact]
     public async Task ResolvePhase2Async_Families2025Subscription_ReturnsPhase2WithoutDiscount()
     {
         _featureService.IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal).Returns(true);
@@ -589,6 +878,41 @@ public class PriceIncreaseSchedulerTests
         Assert.Equal(1, result.Items[0].Quantity);
         Assert.Null(result.Discounts);
         Assert.Equal(ProrationBehavior.None, result.ProrationBehavior);
+    }
+
+    [Fact]
+    public async Task ResolvePhase2Async_Families2025SubscriptionWithExistingDiscount_PreservesDiscountWithoutMilestone()
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.PM32645_DeferPriceMigrationToRenewal).Returns(true);
+
+        _pricingClient.ListPremiumPlans().Returns([]);
+
+        var families2019 = MockPlans.Get(PlanType.FamiliesAnnually2019);
+        var families2025 = MockPlans.Get(PlanType.FamiliesAnnually2025);
+        var familiesTarget = MockPlans.Get(PlanType.FamiliesAnnually);
+
+        _pricingClient.GetPlanOrThrow(PlanType.FamiliesAnnually2019).Returns(families2019);
+        _pricingClient.GetPlanOrThrow(PlanType.FamiliesAnnually2025).Returns(families2025);
+        _pricingClient.GetPlanOrThrow(PlanType.FamiliesAnnually).Returns(familiesTarget);
+
+        var currentPeriodEnd = DateTime.UtcNow.AddYears(1);
+        var orgMetadata = new Dictionary<string, string> { { "organizationId", Guid.NewGuid().ToString() } };
+        var subscription = CreateSubscription("sub_1", "cus_1", orgMetadata,
+            CreateSubscriptionItem(families2025.PasswordManager.StripePlanId, 1));
+        subscription.Items.Data[0].CurrentPeriodEnd = currentPeriodEnd;
+        subscription.Discounts =
+        [
+            new Discount { Coupon = new Coupon { Id = "existing-retention-discount" } }
+        ];
+
+        var sut = CreateSut();
+
+        var result = await sut.ResolvePhase2Async(subscription);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Discounts);
+        Assert.Single(result.Discounts);
+        Assert.Equal("existing-retention-discount", result.Discounts[0].Coupon);
     }
 
     [Fact]

--- a/test/Core.Test/Billing/Subscriptions/Commands/ReinstateSubscriptionCommandTests.cs
+++ b/test/Core.Test/Billing/Subscriptions/Commands/ReinstateSubscriptionCommandTests.cs
@@ -29,7 +29,7 @@ public class ReinstateSubscriptionCommandTests
     {
         var user = new User { GatewaySubscriptionId = "sub_1" };
 
-        _stripeAdapter.GetSubscriptionAsync("sub_1")
+        _stripeAdapter.GetSubscriptionAsync("sub_1", Arg.Any<SubscriptionGetOptions>())
             .Returns(new Subscription { Status = SubscriptionStatus.Active, CancelAt = null });
 
         var result = await _command.Run(user);
@@ -43,7 +43,7 @@ public class ReinstateSubscriptionCommandTests
     {
         var user = new User { GatewaySubscriptionId = "sub_1" };
 
-        _stripeAdapter.GetSubscriptionAsync("sub_1")
+        _stripeAdapter.GetSubscriptionAsync("sub_1", Arg.Any<SubscriptionGetOptions>())
             .Returns(new Subscription
             {
                 Id = "sub_1",
@@ -67,7 +67,7 @@ public class ReinstateSubscriptionCommandTests
     {
         var user = new User { GatewaySubscriptionId = "sub_1" };
 
-        _stripeAdapter.GetSubscriptionAsync("sub_1")
+        _stripeAdapter.GetSubscriptionAsync("sub_1", Arg.Any<SubscriptionGetOptions>())
             .Returns(new Subscription
             {
                 Id = "sub_1",
@@ -94,7 +94,7 @@ public class ReinstateSubscriptionCommandTests
     {
         var user = new User { GatewaySubscriptionId = "sub_1" };
 
-        _stripeAdapter.GetSubscriptionAsync("sub_1")
+        _stripeAdapter.GetSubscriptionAsync("sub_1", Arg.Any<SubscriptionGetOptions>())
             .Returns(new Subscription
             {
                 Id = "sub_1",
@@ -121,4 +121,18 @@ public class ReinstateSubscriptionCommandTests
         await _priceIncreaseScheduler.Received(1).Schedule(Arg.Any<Subscription>());
     }
 
+    [Fact]
+    public async Task Run_FetchesSubscriptionWithDiscountsExpanded()
+    {
+        var user = new User { GatewaySubscriptionId = "sub_1" };
+
+        _stripeAdapter.GetSubscriptionAsync("sub_1", Arg.Any<SubscriptionGetOptions>())
+            .Returns(new Subscription { Status = SubscriptionStatus.Active, CancelAt = null });
+
+        await _command.Run(user);
+
+        await _stripeAdapter.Received(1).GetSubscriptionAsync(
+            "sub_1",
+            Arg.Is<SubscriptionGetOptions>(o => o.Expand != null && o.Expand.Contains("discounts")));
+    }
 }

--- a/test/Core.Test/Billing/Subscriptions/Queries/GetBitwardenSubscriptionQueryTests.cs
+++ b/test/Core.Test/Billing/Subscriptions/Queries/GetBitwardenSubscriptionQueryTests.cs
@@ -581,7 +581,7 @@ public class GetBitwardenSubscriptionQueryTests
     }
 
     [Fact]
-    public async Task Run_WithSchedulePhase2Discount_IncludesDiscountOnSeats()
+    public async Task Run_WithSchedulePhase2CartLevelDiscount_IncludesDiscountOnCart()
     {
         var user = CreateUser();
         var subscription = CreateSubscription(SubscriptionStatus.Active);
@@ -600,34 +600,41 @@ public class GetBitwardenSubscriptionQueryTests
         var result = await _query.Run(user);
 
         Assert.NotNull(result);
-        Assert.Null(result.Cart.Discount);
-        Assert.NotNull(result.Cart.PasswordManager.Seats.Discount);
-        Assert.Equal(BitwardenDiscountType.PercentOff, result.Cart.PasswordManager.Seats.Discount.Type);
-        Assert.Equal(30, result.Cart.PasswordManager.Seats.Discount.Value);
+        // A Phase 2 coupon with no AppliesTo restriction is cart-level, so it surfaces on Cart.Discount.
+        Assert.NotNull(result.Cart.Discount);
+        Assert.Equal(BitwardenDiscountType.PercentOff, result.Cart.Discount.Type);
+        Assert.Equal(30, result.Cart.Discount.Value);
+        Assert.Null(result.Cart.PasswordManager.Seats.Discount);
     }
 
     [Fact]
-    public async Task Run_WithCartLevelDiscountAndScheduleDiscount_PrefersCartLevelDiscount()
+    public async Task Run_WithCustomerLevelDiscountAndSchedulePhase2_BothFlowThrough_CustomerLevelWinsCart()
     {
         var user = CreateUser();
         var subscription = CreateSubscription(SubscriptionStatus.Active);
         subscription.Customer.Discount = CreateDiscount(discountType: "cart");
         subscription.ScheduleId = "sub_sched_test";
         var premiumPlans = CreatePremiumPlans();
+        var schedule = CreateSubscriptionSchedule(percentOff: 30);
 
         _stripeAdapter.GetSubscriptionAsync(user.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
             .Returns(subscription);
         _pricingClient.ListPremiumPlans().Returns(premiumPlans);
         _stripeAdapter.CreateInvoicePreviewAsync(Arg.Any<InvoiceCreatePreviewOptions>())
             .Returns(CreateInvoicePreview());
+        _stripeAdapter.GetSubscriptionScheduleAsync("sub_sched_test", Arg.Any<SubscriptionScheduleGetOptions>())
+            .Returns(schedule);
 
         var result = await _query.Run(user);
 
         Assert.NotNull(result);
+        // Customer-level discount is added to the coupon list before Phase 2's coupons, so it
+        // wins the singular Cart.Discount slot. The Phase 2 coupon still flows into the tax
+        // estimate via the coupon-id list.
         Assert.NotNull(result.Cart.Discount);
         Assert.Equal(20, result.Cart.Discount.Value);
-        await _stripeAdapter.DidNotReceive()
-            .GetSubscriptionScheduleAsync(Arg.Any<string>(), Arg.Any<SubscriptionScheduleGetOptions>());
+        await _stripeAdapter.Received(1)
+            .GetSubscriptionScheduleAsync("sub_sched_test", Arg.Any<SubscriptionScheduleGetOptions>());
     }
 
     [Fact]
@@ -655,7 +662,7 @@ public class GetBitwardenSubscriptionQueryTests
     }
 
     [Fact]
-    public async Task Run_WithScheduleStripeException_ReturnsNoDiscount()
+    public async Task Run_WithScheduleStripeException_Rethrows()
     {
         var user = CreateUser();
         var subscription = CreateSubscription(SubscriptionStatus.Active);
@@ -670,15 +677,13 @@ public class GetBitwardenSubscriptionQueryTests
         _stripeAdapter.GetSubscriptionScheduleAsync("sub_sched_test", Arg.Any<SubscriptionScheduleGetOptions>())
             .ThrowsAsync(new StripeException());
 
-        var result = await _query.Run(user);
-
-        Assert.NotNull(result);
-        Assert.Null(result.Cart.Discount);
-        Assert.Null(result.Cart.PasswordManager.Seats.Discount);
+        // Schedule fetch failure now propagates because Phase 2 coupons drive both display and
+        // tax-preview accuracy — silently dropping them would inflate the user-facing tax estimate.
+        await Assert.ThrowsAsync<StripeException>(() => _query.Run(user));
     }
 
     [Fact]
-    public async Task Run_WithSchedulePhase2AmountOffDiscount_IncludesAmountOffDiscountOnSeats()
+    public async Task Run_WithSchedulePhase2AmountOffDiscount_IncludesAmountOffDiscountOnCart()
     {
         var user = CreateUser();
         var subscription = CreateSubscription(SubscriptionStatus.Active);
@@ -697,10 +702,41 @@ public class GetBitwardenSubscriptionQueryTests
         var result = await _query.Run(user);
 
         Assert.NotNull(result);
+        Assert.NotNull(result.Cart.Discount);
+        Assert.Equal(BitwardenDiscountType.AmountOff, result.Cart.Discount.Type);
+        Assert.Equal(500, result.Cart.Discount.Value);
+        Assert.Null(result.Cart.PasswordManager.Seats.Discount);
+    }
+
+    [Fact]
+    public async Task Run_WithSchedulePhase2ProductLevelCoupon_IncludesDiscountOnSeat()
+    {
+        var user = CreateUser();
+        var subscription = CreateSubscription(SubscriptionStatus.Active);
+        subscription.ScheduleId = "sub_sched_test";
+        var premiumPlans = CreatePremiumPlans();
+        var schedule = CreateSubscriptionSchedule(
+            percentOff: 25,
+            couponId: "phase2-seat-coupon",
+            appliesToProductId: "prod_premium_seat");
+
+        _stripeAdapter.GetSubscriptionAsync(user.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+        _pricingClient.ListPremiumPlans().Returns(premiumPlans);
+        _stripeAdapter.CreateInvoicePreviewAsync(Arg.Any<InvoiceCreatePreviewOptions>())
+            .Returns(CreateInvoicePreview());
+        _stripeAdapter.GetSubscriptionScheduleAsync("sub_sched_test", Arg.Any<SubscriptionScheduleGetOptions>())
+            .Returns(schedule);
+
+        var result = await _query.Run(user);
+
+        Assert.NotNull(result);
+        // A Phase 2 coupon scoped to the seat product partitions to product-level and surfaces on
+        // the seat line item, not on Cart.Discount.
         Assert.Null(result.Cart.Discount);
         Assert.NotNull(result.Cart.PasswordManager.Seats.Discount);
-        Assert.Equal(BitwardenDiscountType.AmountOff, result.Cart.PasswordManager.Seats.Discount.Type);
-        Assert.Equal(500, result.Cart.PasswordManager.Seats.Discount.Value);
+        Assert.Equal(BitwardenDiscountType.PercentOff, result.Cart.PasswordManager.Seats.Discount.Type);
+        Assert.Equal(25, result.Cart.PasswordManager.Seats.Discount.Value);
     }
 
     [Fact]
@@ -777,6 +813,39 @@ public class GetBitwardenSubscriptionQueryTests
                 opts.Discounts != null &&
                 opts.Discounts.Count == 1 &&
                 opts.Discounts[0].Coupon == "milestone-2c"));
+    }
+
+    [Fact]
+    public async Task Run_UserOnLegacyPricing_WithCustomerLevelDiscountAndScheduleDiscount_IncludesAllCouponIdsInTaxPreview()
+    {
+        var user = CreateUser();
+        var subscription = CreateSubscription(SubscriptionStatus.Active, legacyPricing: true);
+        subscription.Customer.Discount = CreateDiscount(discountType: "cart");
+        subscription.Customer.Discount.Coupon.Id = "customer-coupon";
+        subscription.ScheduleId = "sub_sched_test";
+        var premiumPlans = CreatePremiumPlans();
+        var schedule = CreateSubscriptionSchedule(percentOff: 30, couponId: "milestone-2c");
+
+        _stripeAdapter.GetSubscriptionAsync(user.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+        _pricingClient.ListPremiumPlans().Returns(premiumPlans);
+        _stripeAdapter.CreateInvoicePreviewAsync(Arg.Any<InvoiceCreatePreviewOptions>())
+            .Returns(CreateInvoicePreview(totalTax: 150));
+        _stripeAdapter.GetSubscriptionScheduleAsync("sub_sched_test", Arg.Any<SubscriptionScheduleGetOptions>())
+            .Returns(schedule);
+
+        await _query.Run(user);
+
+        // Both the customer-level coupon and the Phase 2 schedule coupon must be passed to the
+        // tax-preview override so the estimate matches the actual upcoming-renewal invoice.
+        await _stripeAdapter.Received(1).CreateInvoicePreviewAsync(
+            Arg.Is<InvoiceCreatePreviewOptions>(opts =>
+                opts.Subscription == null &&
+                opts.SubscriptionDetails != null &&
+                opts.Discounts != null &&
+                opts.Discounts.Count == 2 &&
+                opts.Discounts.Any(d => d.Coupon == "customer-coupon") &&
+                opts.Discounts.Any(d => d.Coupon == "milestone-2c")));
     }
 
     [Fact]
@@ -1010,7 +1079,8 @@ public class GetBitwardenSubscriptionQueryTests
         long? amountOff = null,
         string status = StripeConstants.SubscriptionScheduleStatus.Active,
         bool validCoupon = true,
-        string? couponId = null,
+        string couponId = "phase2-coupon",
+        string? appliesToProductId = null,
         DateTime? phase2StartDate = null)
     {
         var phases = new List<SubscriptionSchedulePhase>
@@ -1026,7 +1096,16 @@ public class GetBitwardenSubscriptionQueryTests
                     new()
                     {
                         CouponId = couponId,
-                        Coupon = new Coupon { Id = couponId, Valid = validCoupon, PercentOff = percentOff, AmountOff = amountOff }
+                        Coupon = new Coupon
+                        {
+                            Id = couponId,
+                            Valid = validCoupon,
+                            PercentOff = percentOff,
+                            AmountOff = amountOff,
+                            AppliesTo = appliesToProductId != null
+                                ? new CouponAppliesTo { Products = [appliesToProductId] }
+                                : null
+                        }
                     }
                 }
                 : new List<SubscriptionSchedulePhaseDiscount>();


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35909

## 📔 Objective

Fixes a silent regression introduced by PM-32645's deferred-price-migration scheduler. When a Premium or Families subscription with a pre-existing subscription-level discount (a coupon attached to `Subscription.Discounts`) went through the migration schedule, the discount was silently dropped at Phase 2 activation. Phase 1 preserved discounts correctly, so the bug only fired at renewal — invisible during the ~15-day window between schedule creation and Phase 2 going live, and invisible to our logs and Stripe's. Affected populations: Premium 2019, Families 2019, and Families 2025 customers migrated since ~Q1 2026 with grandfather/partner/NFR/retention coupons.

**The fix:**
- `PriceIncreaseScheduler.ResolvePhase2For{Premium,Families}Async` now reads `subscription.Discounts` and concatenates the migration's Milestone coupon onto that list, rather than replacing with only the Milestone. Premium always appends Milestone2; Families 2019 appends Milestone3; Families 2025 appends nothing (and collapses an empty list to `null` to preserve the historical Stripe-API contract). Existing-discount-first ordering keeps the customer's pre-existing discount as the primary.
- `UpcomingInvoiceHandler` adds `subscriptions.data.discounts` to the customer expand list so `subscription.Discounts` is actually populated for the production webhook path. Without this, the scheduler fix would be a silent no-op for the bug's primary trigger. Added a load-bearing comment citing PM-35909 to discourage future cleanup.
- `ReinstateSubscriptionCommand` adds `Expand = ["discounts"]` to its subscription fetch. This was a third Schedule() call site introduced by PM-34565 (#7535) shortly before this PR; without the expand, the bug regressed silently on the reinstate path (or worse, NRE'd).
- `ResolvePhase2Async` now refuses to construct Phase 2 when handed a subscription whose `Discounts` collection contains null entries — the empirically-confirmed Stripe.NET shape for an unexpanded `discounts` field. Surfaces expand-list misuse as a loud `LogError` with the dropped-discount count, instead of regressing to the pre-fix silent-drop behavior. Defends against future call sites that forget the expand.

**Test changes:**
- Strengthened existing scheduler tests with `Discounts.Count == 1` assertions for the no-existing-discount cases.
- Added 7 new tests covering Premium / Families 2019 / Families 2025 with one or more pre-existing discounts in both `Schedule_*` (integration) and `ResolvePhase2Async_*` (unit) flavors, plus a regression test for the unexpanded-subscription guard.
- Added `Run_FetchesSubscriptionWithDiscountsExpanded` to `ReinstateSubscriptionCommandTests` to pin the new expand option.

## Follow-up: `GetBitwardenSubscriptionQuery` discount-source refactor

Once `PriceIncreaseScheduler` correctly populates Phase 2 with `[existing-discounts..., Milestone]`, several assumptions in `GetBitwardenSubscriptionQuery` no longer hold:
- The pre-fix code only fetched the schedule when `cartLevelDiscount == null`, gating on the (now-broken) assumption that "current discount and scheduled discount are mutually exclusive."
- It surfaced the schedule's discount as a fallback on the seat line item via `?? scheduleDiscount`, only correct because Phase 2 used to contain only the cart-level Milestone.
- The tax-preview override-mode took a single `couponId`, which silently under-reports tax savings now that Phase 2 may contain multiple coupons that all apply at renewal.

**Refactor:**
- Adopt a single source-of-truth rule: when a schedule is attached, Phase 2's discounts are the source for subscription-level coupons (Phase 2 reflects the upcoming-renewal state, including preserved current discounts plus migration coupons). Otherwise `subscription.Discounts` is the source. Customer-level discounts (`subscription.Customer.Discount`) are always included.
- Project both sources to `Stripe.Coupon` and partition by `Coupon.AppliesTo.Products` via a new `PartitionCouponsByScope` helper (renamed from `GetStripeDiscounts`). Cart-level coupons land on `Cart.Discount`; product-level land on the matching `CartItem.Discount`.
- Remove the seat-fallback `?? scheduleDiscount` — cart-level Phase 2 coupons (e.g. the migration Milestone) now surface on `Cart.Discount` directly, where they belong.
- `EstimatePremiumTaxAsync` parameter changes from `string? couponId` to `List<string>? couponIds` so the override-mode tax preview includes every coupon that will apply at renewal.
- Update the schedule expand list from `phases.discounts.coupon` to `phases.discounts.coupon.applies_to` so the partition logic can read `Coupon.AppliesTo.Products`.
- `GetSchedulePhase2CouponsAsync` no longer swallows `StripeException` — it logs and rethrows. Pre-refactor, soft-failing only suppressed a display badge; post-refactor the same swallow would silently corrupt the tax estimate (Phase 2 coupons feed both the discount display *and* `options.Discounts` for the invoice preview), so failure must propagate.
- New `Coupon.AppliesTo(SubscriptionItem)` extension in `DiscountExtensions.cs` mirrors the existing `Discount.AppliesTo` for the partitioned coupon list.

**Behavior change worth flagging for review:** a customer in the migration window with no current cart-level discount used to see the Milestone displayed on the seat line; now they see it as `Cart.Discount`. Visually different, semantically correct.

**Follow-up tests:**
- Renamed `Run_WithSchedulePhase2Discount_IncludesDiscountOnSeats` → `_IncludesDiscountOnCart` and `Run_WithSchedulePhase2AmountOffDiscount_IncludesAmountOffDiscountOnSeats` → `_OnCart` to reflect the new placement.
- New `Run_WithSchedulePhase2ProductLevelCoupon_IncludesDiscountOnSeat` — verifies a Phase 2 coupon with `AppliesTo.Products` populated lands on `Seats.Discount`, exercising the previously-uncovered partition path.
- New `Run_UserOnLegacyPricing_WithCustomerLevelDiscountAndScheduleDiscount_IncludesAllCouponIdsInTaxPreview` — verifies both customer-level and Phase 2 coupon IDs flow into `options.Discounts` (asserts `Count == 2`), the multi-coupon tax-preview path that didn't previously have coverage.
- `Run_WithScheduleStripeException_ReturnsNoDiscount` → `_Rethrows` — schedule fetch failure now propagates instead of soft-failing.
- Test fixture cleanup: `CreateSubscriptionSchedule` parameter `couponId` defaults to `"phase2-coupon"` directly (was a runtime sentinel), and gains an `appliesToProductId` parameter for product-scoped coupons.

## Concerns / follow-ups (not in this PR)

- **`StripePaymentService.ApplySchedulePhase2DataAsync:789`** has the same `phase2.Discounts?.FirstOrDefault()` pattern that PM-35909 fixed in `PriceIncreaseScheduler`. Post-fix, Phase 2 may contain multiple discounts; `FirstOrDefault()` will return whichever Stripe lists first, which is no longer guaranteed to be the migration coupon. The schedule-fetch + status/phase/start-date guard preamble is duplicated between this method and the new `GetSchedulePhase2CouponsAsync`. A future PR should fix the bug there and extract the shared preamble into a helper.
- Multi-discount support on `Cart.Discount` / `CartItem.Discount` — currently single-valued, with a separate Jira ticket tracking the multi-discount surface. This PR keeps the singular contract; the source-of-truth rule lays the groundwork without changing the public shape.

## Out of scope (per ticket, file separately)
- Detection script for already-affected customers since PM-32645 went live.
- Remediation script to re-attach silently-dropped discounts on already-migrated subscriptions.
