### PR TITLE
Fix EF UserRepository batched UpdateUserData transactional behavior

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/UserRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/UserRepository.cs
@@ -14,6 +14,13 @@ namespace Bit.Infrastructure.EntityFramework.Repositories;
 
 public class UserRepository : Repository<Core.Entities.User, User, Guid>, IUserRepository
 {
+    // Carries the DbContext that owns the active UpdateUserData batch transaction so
+    // that delegates returned by SetMasterPassword/SetKeyConnectorUserKey/etc. can
+    // write through the same connection that owns the transaction. Without this, each
+    // delegate would open its own scope and SaveChangesAsync would auto-commit
+    // outside the outer transaction (see issue #7566).
+    private readonly AsyncLocal<DatabaseContext?> _activeBatchDbContext = new();
+
     public UserRepository(IServiceScopeFactory serviceScopeFactory, IMapper mapper)
         : base(serviceScopeFactory, mapper, (DatabaseContext context) => context.Users)
     { }
@@ -287,63 +294,77 @@ public class UserRepository : Repository<Core.Entities.User, User, Guid>, IUserR
 
         await using var transaction = await dbContext.Database.BeginTransactionAsync();
 
-        // Update user
-        var userEntity = await dbContext.Users.FindAsync(userId);
-        if (userEntity == null)
+        var previousBatchDbContext = _activeBatchDbContext.Value;
+        _activeBatchDbContext.Value = dbContext;
+        try
         {
-            throw new ArgumentException("User not found", nameof(userId));
-        }
-
-        // Update public key encryption key pair
-        var timestamp = DateTime.UtcNow;
-
-        userEntity.RevisionDate = timestamp;
-        userEntity.AccountRevisionDate = timestamp;
-
-        // V1 + V2 user crypto changes
-        userEntity.PublicKey = accountKeysData.PublicKeyEncryptionKeyPairData.PublicKey;
-        userEntity.PrivateKey = accountKeysData.PublicKeyEncryptionKeyPairData.WrappedPrivateKey;
-
-        userEntity.SecurityState = accountKeysData.SecurityStateData!.SecurityState;
-        userEntity.SecurityVersion = accountKeysData.SecurityStateData.SecurityVersion;
-        userEntity.SignedPublicKey = accountKeysData.PublicKeyEncryptionKeyPairData.SignedPublicKey;
-
-        // Replace existing key-pair if it exists
-        var existingKeyPair = await dbContext.UserSignatureKeyPairs
-            .FirstOrDefaultAsync(x => x.UserId == userId);
-        if (existingKeyPair != null)
-        {
-            existingKeyPair.SignatureAlgorithm = accountKeysData.SignatureKeyPairData!.SignatureAlgorithm;
-            existingKeyPair.SigningKey = accountKeysData.SignatureKeyPairData.WrappedSigningKey;
-            existingKeyPair.VerifyingKey = accountKeysData.SignatureKeyPairData.VerifyingKey;
-            existingKeyPair.RevisionDate = timestamp;
-        }
-        else
-        {
-            var newKeyPair = new UserSignatureKeyPair
+            // Update user
+            var userEntity = await dbContext.Users.FindAsync(userId);
+            if (userEntity == null)
             {
-                UserId = userId,
-                SignatureAlgorithm = accountKeysData.SignatureKeyPairData!.SignatureAlgorithm,
-                SigningKey = accountKeysData.SignatureKeyPairData.WrappedSigningKey,
-                VerifyingKey = accountKeysData.SignatureKeyPairData.VerifyingKey,
-                CreationDate = timestamp,
-                RevisionDate = timestamp
-            };
-            newKeyPair.SetNewId();
-            await dbContext.UserSignatureKeyPairs.AddAsync(newKeyPair);
-        }
-
-        await dbContext.SaveChangesAsync();
-
-        // Update additional user data within the same transaction
-        if (updateUserDataActions != null)
-        {
-            foreach (var action in updateUserDataActions)
-            {
-                await action();
+                throw new ArgumentException("User not found", nameof(userId));
             }
+
+            // Update public key encryption key pair
+            var timestamp = DateTime.UtcNow;
+
+            userEntity.RevisionDate = timestamp;
+            userEntity.AccountRevisionDate = timestamp;
+
+            // V1 + V2 user crypto changes
+            userEntity.PublicKey = accountKeysData.PublicKeyEncryptionKeyPairData.PublicKey;
+            userEntity.PrivateKey = accountKeysData.PublicKeyEncryptionKeyPairData.WrappedPrivateKey;
+
+            userEntity.SecurityState = accountKeysData.SecurityStateData!.SecurityState;
+            userEntity.SecurityVersion = accountKeysData.SecurityStateData.SecurityVersion;
+            userEntity.SignedPublicKey = accountKeysData.PublicKeyEncryptionKeyPairData.SignedPublicKey;
+
+            // Replace existing key-pair if it exists
+            var existingKeyPair = await dbContext.UserSignatureKeyPairs
+                .FirstOrDefaultAsync(x => x.UserId == userId);
+            if (existingKeyPair != null)
+            {
+                existingKeyPair.SignatureAlgorithm = accountKeysData.SignatureKeyPairData!.SignatureAlgorithm;
+                existingKeyPair.SigningKey = accountKeysData.SignatureKeyPairData.WrappedSigningKey;
+                existingKeyPair.VerifyingKey = accountKeysData.SignatureKeyPairData.VerifyingKey;
+                existingKeyPair.RevisionDate = timestamp;
+            }
+            else
+            {
+                var newKeyPair = new UserSignatureKeyPair
+                {
+                    UserId = userId,
+                    SignatureAlgorithm = accountKeysData.SignatureKeyPairData!.SignatureAlgorithm,
+                    SigningKey = accountKeysData.SignatureKeyPairData.WrappedSigningKey,
+                    VerifyingKey = accountKeysData.SignatureKeyPairData.VerifyingKey,
+                    CreationDate = timestamp,
+                    RevisionDate = timestamp
+                };
+                newKeyPair.SetNewId();
+                await dbContext.UserSignatureKeyPairs.AddAsync(newKeyPair);
+            }
+
+            await dbContext.SaveChangesAsync();
+
+            // Update additional user data within the same transaction
+            if (updateUserDataActions != null)
+            {
+                foreach (var action in updateUserDataActions)
+                {
+                    await action();
+                }
+            }
+            await transaction.CommitAsync();
         }
-        await transaction.CommitAsync();
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
+        finally
+        {
+            _activeBatchDbContext.Value = previousBatchDbContext;
+        }
     }
 
     public async Task<IEnumerable<Core.Entities.User>> GetManyAsync(IEnumerable<Guid> ids)
@@ -510,11 +531,8 @@ public class UserRepository : Repository<Core.Entities.User, User, Guid>, IUserR
 
     public UpdateUserData SetKeyConnectorUserKey(Guid userId, string keyConnectorWrappedUserKey)
     {
-        return async (_, _) =>
+        return (_, _) => RunUserDataActionAsync(async dbContext =>
         {
-            using var scope = ServiceScopeFactory.CreateScope();
-            var dbContext = GetDatabaseContext(scope);
-
             var userEntity = await dbContext.Users.FindAsync(userId);
             if (userEntity == null)
             {
@@ -534,17 +552,14 @@ public class UserRepository : Repository<Core.Entities.User, User, Guid>, IUserR
             userEntity.AccountRevisionDate = timestamp;
 
             await dbContext.SaveChangesAsync();
-        };
+        });
     }
 
     public UpdateUserData SetMasterPassword(Guid userId, MasterPasswordUnlockData masterPasswordUnlockData,
         string serverSideHashedMasterPasswordAuthenticationHash, string? masterPasswordHint)
     {
-        return async (_, _) =>
+        return (_, _) => RunUserDataActionAsync(async dbContext =>
         {
-            using var scope = ServiceScopeFactory.CreateScope();
-            var dbContext = GetDatabaseContext(scope);
-
             var userEntity = await dbContext.Users.FindAsync(userId);
             if (userEntity == null)
             {
@@ -568,7 +583,7 @@ public class UserRepository : Repository<Core.Entities.User, User, Guid>, IUserR
             // is persisted.
             // userEntity.LastPasswordChangeDate = timestamp; This needs adding in PM-34905
             await dbContext.SaveChangesAsync();
-        };
+        });
     }
 
     public async Task UpdateUserDataAsync(IEnumerable<UpdateUserData> updateUserDataActions)
@@ -578,21 +593,32 @@ public class UserRepository : Repository<Core.Entities.User, User, Guid>, IUserR
 
         await using var transaction = await dbContext.Database.BeginTransactionAsync();
 
-        foreach (var action in updateUserDataActions)
+        var previousBatchDbContext = _activeBatchDbContext.Value;
+        _activeBatchDbContext.Value = dbContext;
+        try
         {
-            await action();
-        }
+            foreach (var action in updateUserDataActions)
+            {
+                await action();
+            }
 
-        await transaction.CommitAsync();
+            await transaction.CommitAsync();
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
+        finally
+        {
+            _activeBatchDbContext.Value = previousBatchDbContext;
+        }
     }
 
     public UpdateUserData UpdateMasterPasswordUnlockData(Guid userId, RegisterFinishData registerFinishData)
     {
-        return async (_, _) =>
+        return (_, _) => RunUserDataActionAsync(async dbContext =>
         {
-            using var scope = ServiceScopeFactory.CreateScope();
-            var dbContext = GetDatabaseContext(scope);
-
             var userEntity = await dbContext.Users.FindAsync(userId) ?? throw new ArgumentException("User not found", nameof(userId));
             var timestamp = DateTime.UtcNow;
 
@@ -606,7 +632,25 @@ public class UserRepository : Repository<Core.Entities.User, User, Guid>, IUserR
             userEntity.AccountRevisionDate = timestamp;
 
             await dbContext.SaveChangesAsync();
-        };
+        });
+    }
+
+    // If a batch transaction is active (UpdateUserDataAsync or
+    // SetV2AccountCryptographicStateAsync), reuse its DbContext so the write joins
+    // the open transaction. Otherwise fall back to a fresh scope so the delegate
+    // can also be invoked standalone.
+    private async Task RunUserDataActionAsync(Func<DatabaseContext, Task> work)
+    {
+        var batchDbContext = _activeBatchDbContext.Value;
+        if (batchDbContext != null)
+        {
+            await work(batchDbContext);
+            return;
+        }
+
+        using var scope = ServiceScopeFactory.CreateScope();
+        var dbContext = GetDatabaseContext(scope);
+        await work(dbContext);
     }
 
     private static void MigrateDefaultUserCollectionsToShared(DatabaseContext dbContext, IEnumerable<Guid> userIds)

--- a/test/Infrastructure.IntegrationTest/Repositories/UserRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/Repositories/UserRepositoryTests.cs
@@ -671,6 +671,52 @@ public class UserRepositoryTests
         Assert.Equal(originalEmail.ToLowerInvariant().Trim(), updatedUser.MasterPasswordSalt);
     }
 
+    // Regression test for issue #7566. The IUserRepository contract states that
+    // every action passed to UpdateUserDataAsync executes inside a single transaction;
+    // a partial commit could otherwise leave a user with a new master-password hash
+    // but an old master-key-wrapped user key, which would lock them out of their vault.
+    [Theory, DatabaseData]
+    public async Task UpdateUserDataAsync_WhenSubsequentActionThrows_RollsBackPriorWrites(
+        IUserRepository userRepository)
+    {
+        // Arrange
+        var user = await userRepository.CreateTestUserAsync();
+        Assert.Null(user.MasterPassword);
+        Assert.Null(user.Key);
+
+        var unlockData = new MasterPasswordUnlockData
+        {
+            Kdf = new KdfSettings
+            {
+                KdfType = KdfType.Argon2id,
+                Iterations = AuthConstants.ARGON2_ITERATIONS.Default,
+                Memory = AuthConstants.ARGON2_MEMORY.Default,
+                Parallelism = AuthConstants.ARGON2_PARALLELISM.Default
+            },
+            MasterKeyWrappedUserKey = "should-not-persist-wrapped-key",
+            Salt = "should-not-persist-salt"
+        };
+
+        var setMasterPasswordAction = userRepository.SetMasterPassword(
+            user.Id, unlockData, "should-not-persist-hash", "should-not-persist-hint");
+
+        UpdateUserData faultingAction = (_, _) =>
+            throw new InvalidOperationException("Forced batch failure for rollback test.");
+
+        // Act
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => userRepository.UpdateUserDataAsync([setMasterPasswordAction, faultingAction]));
+
+        // Assert: the prior delegate's write was rolled back; the user is still in
+        // its initial state.
+        var reloaded = await userRepository.GetByIdAsync(user.Id);
+        Assert.NotNull(reloaded);
+        Assert.Null(reloaded.MasterPassword);
+        Assert.Null(reloaded.MasterPasswordHint);
+        Assert.Null(reloaded.Key);
+        Assert.Null(reloaded.MasterPasswordSalt);
+    }
+
     [Theory, DatabaseData]
     public async Task UpdateUserKeyAndEncryptedDataV2Async_UpdatesAllUserFields(IUserRepository userRepository)
     {


### PR DESCRIPTION
## 🎟️ Tracking

Resolves [#7566](https://github.com/bitwarden/server/issues/7566).

## 📔 Objective

Fixes a transactional-correctness bug on the EF code path of `UserRepository`. `UpdateUserDataAsync` and `SetV2AccountCryptographicStateAsync` opened a transaction on a `DatabaseContext` resolved from one `IServiceScope`, but each `UpdateUserData` delegate (`SetMasterPassword`, `SetKeyConnectorUserKey`, `UpdateMasterPasswordUnlockData`) opened its own scope and resolved its own `DatabaseContext`. Each `SaveChangesAsync` therefore auto-committed on a different connection from the one that owned the outer transaction, and the absence of a `try`/`catch` around the action loop meant a mid-batch throw left earlier delegates' writes durably committed. For master-password / KDF / Key Connector mutations this could leave a user with mismatched cryptographic state (e.g. a new master-password hash without the matching master-key-wrapped user key), locking them out of their vault until manual database reconciliation. Self-hosted EF deployments (Postgres / MySQL / SQLite, plus EF-mode MSSQL) were exposed; cloud (MSSQL/Dapper) was not — see issue #7566 for the full mechanism.

The fix flows the active batch `DatabaseContext` into each delegate via an `AsyncLocal<DatabaseContext?>` on the EF `UserRepository`, so all writes in a batch share the connection that owns the open transaction. The `UpdateUserData` delegate signature is preserved (no public-API change). Both methods now wrap their action loops in `try`/`catch` with explicit `RollbackAsync()` on failure. When no batch is active, delegates fall back to a fresh scope, preserving the standalone-invocation path used by existing test helpers. The Dapper `UserRepository` was already correct and is unchanged.

### Test plan

- New integration test `UpdateUserDataAsync_WhenSubsequentActionThrows_RollsBackPriorWrites` batches `[SetMasterPassword, throwing-delegate]`, asserts the call throws, then re-reads the user and asserts the prior delegate's write was rolled back. Runs against every configured `[DatabaseData]` provider — proves the fix on EF backends and regression-protects Dapper.
- All 66 existing unit tests under `Core.Test` for the consumer commands (`MasterPasswordServiceTests`, `TdeSetPasswordCommandTests`, `FinishSsoJitProvisionMasterPasswordCommandTests`, `SetKeyConnectorKeyCommandTests`) continue to pass — confirming the `IUserRepository` contract relied on by production callers is unchanged.

### Out of scope

- Removing `Microsoft.Data.SqlClient.SqlConnection?` / `SqlTransaction?` from the public `UpdateUserData` delegate in `IUserRepository`. That's an API-shape change discussed as a follow-up in the original issue.
- The same transactional-boundary fix for the `UpdateEncryptedDataForKeyRotation` delegate path in `UpdateUserKeyAndEncryptedDataAsync` / `UpdateUserKeyAndEncryptedDataV2Async` — separate delegate type with its own callers.

## 📸 Screenshots

N/A — backend correctness fix.
