### PR TITLE
[PM-35257] Validate plan frequency tier

### DIFF
--- a/src/Api/Billing/Controllers/OrganizationBillingController.cs
+++ b/src/Api/Billing/Controllers/OrganizationBillingController.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Api.Billing.Models.Requests;
 using Bit.Api.Billing.Models.Responses;
+using Bit.Core.Billing.Extensions;
 using Bit.Core.Billing.Organizations.Services;
 using Bit.Core.Billing.Providers.Services;
 using Bit.Core.Billing.Services;
@@ -166,6 +167,11 @@ public class OrganizationBillingController(
         if (organization.PlanType == request.NewPlanType)
         {
             return Error.BadRequest("Organization is already on the requested plan frequency.");
+        }
+
+        if (organization.PlanType.GetProductTier() != request.NewPlanType.GetProductTier())
+        {
+            return Error.BadRequest("Plan frequency changes must stay within the same product tier.");
         }
 
         await organizationBillingService.UpdateSubscriptionPlanFrequency(

--- a/test/Api.Test/Billing/Controllers/OrganizationBillingControllerTests.cs
+++ b/test/Api.Test/Billing/Controllers/OrganizationBillingControllerTests.cs
@@ -1,8 +1,12 @@
 ﻿using Bit.Api.Billing.Controllers;
+using Bit.Api.Billing.Models.Requests;
 using Bit.Core.AdminConsole.Entities;
+using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Models;
+using Bit.Core.Billing.Organizations.Services;
 using Bit.Core.Billing.Services;
 using Bit.Core.Context;
+using Bit.Core.Models.Api;
 using Bit.Core.Repositories;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
@@ -65,5 +69,134 @@ public class OrganizationBillingControllerTests
         // Assert
         var okResult = Assert.IsType<Ok<BillingHistoryInfo>>(result);
         Assert.Equal(billingInfo, okResult.Value);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ChangePlanSubscriptionFrequencyAsync_Unauthorized_ReturnsUnauthorized(
+        Guid organizationId,
+        SutProvider<OrganizationBillingController> sutProvider)
+    {
+        // Arrange
+        var request = new ChangePlanFrequencyRequest { NewPlanType = PlanType.EnterpriseMonthly };
+        sutProvider.GetDependency<ICurrentContext>().EditSubscription(organizationId).Returns(false);
+
+        // Act
+        var result = await sutProvider.Sut.ChangePlanSubscriptionFrequencyAsync(organizationId, request);
+
+        // Assert
+        AssertUnauthorized(result);
+
+        await sutProvider.GetDependency<IOrganizationBillingService>()
+            .DidNotReceive()
+            .UpdateSubscriptionPlanFrequency(Arg.Any<Organization>(), Arg.Any<PlanType>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task ChangePlanSubscriptionFrequencyAsync_OrganizationNotFound_ReturnsNotFound(
+        Guid organizationId,
+        SutProvider<OrganizationBillingController> sutProvider)
+    {
+        // Arrange
+        var request = new ChangePlanFrequencyRequest { NewPlanType = PlanType.EnterpriseMonthly };
+        sutProvider.GetDependency<ICurrentContext>().EditSubscription(organizationId).Returns(true);
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organizationId).Returns((Organization)null);
+
+        // Act
+        var result = await sutProvider.Sut.ChangePlanSubscriptionFrequencyAsync(organizationId, request);
+
+        // Assert
+        AssertNotFound(result);
+
+        await sutProvider.GetDependency<IOrganizationBillingService>()
+            .DidNotReceive()
+            .UpdateSubscriptionPlanFrequency(Arg.Any<Organization>(), Arg.Any<PlanType>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task ChangePlanSubscriptionFrequencyAsync_SamePlan_ReturnsBadRequest(
+        Guid organizationId,
+        Organization organization,
+        SutProvider<OrganizationBillingController> sutProvider)
+    {
+        // Arrange
+        organization.PlanType = PlanType.EnterpriseAnnually;
+        var request = new ChangePlanFrequencyRequest { NewPlanType = PlanType.EnterpriseAnnually };
+
+        sutProvider.GetDependency<ICurrentContext>().EditSubscription(organizationId).Returns(true);
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organizationId).Returns(organization);
+
+        // Act
+        var result = await sutProvider.Sut.ChangePlanSubscriptionFrequencyAsync(organizationId, request);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequest<ErrorResponseModel>>(result);
+        Assert.Equal("Organization is already on the requested plan frequency.", badRequest.Value!.Message);
+
+        await sutProvider.GetDependency<IOrganizationBillingService>()
+            .DidNotReceive()
+            .UpdateSubscriptionPlanFrequency(Arg.Any<Organization>(), Arg.Any<PlanType>());
+    }
+
+    [Theory]
+    [BitAutoData(PlanType.EnterpriseAnnually, PlanType.Free)]
+    [BitAutoData(PlanType.EnterpriseAnnually, PlanType.TeamsAnnually)]
+    [BitAutoData(PlanType.EnterpriseAnnually, PlanType.TeamsMonthly)]
+    [BitAutoData(PlanType.TeamsAnnually, PlanType.Free)]
+    [BitAutoData(PlanType.TeamsAnnually, PlanType.EnterpriseAnnually)]
+    [BitAutoData(PlanType.FamiliesAnnually, PlanType.EnterpriseMonthly)]
+    public async Task ChangePlanSubscriptionFrequencyAsync_DifferentTier_ReturnsBadRequest(
+        PlanType currentPlan,
+        PlanType requestedPlan,
+        Guid organizationId,
+        Organization organization,
+        SutProvider<OrganizationBillingController> sutProvider)
+    {
+        // Arrange
+        organization.PlanType = currentPlan;
+        var request = new ChangePlanFrequencyRequest { NewPlanType = requestedPlan };
+
+        sutProvider.GetDependency<ICurrentContext>().EditSubscription(organizationId).Returns(true);
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organizationId).Returns(organization);
+
+        // Act
+        var result = await sutProvider.Sut.ChangePlanSubscriptionFrequencyAsync(organizationId, request);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequest<ErrorResponseModel>>(result);
+        Assert.Equal("Plan frequency changes must stay within the same product tier.", badRequest.Value!.Message);
+
+        await sutProvider.GetDependency<IOrganizationBillingService>()
+            .DidNotReceive()
+            .UpdateSubscriptionPlanFrequency(Arg.Any<Organization>(), Arg.Any<PlanType>());
+    }
+
+    [Theory]
+    [BitAutoData(PlanType.EnterpriseAnnually, PlanType.EnterpriseMonthly)]
+    [BitAutoData(PlanType.EnterpriseMonthly, PlanType.EnterpriseAnnually)]
+    [BitAutoData(PlanType.TeamsAnnually, PlanType.TeamsMonthly)]
+    [BitAutoData(PlanType.TeamsMonthly, PlanType.TeamsAnnually)]
+    public async Task ChangePlanSubscriptionFrequencyAsync_SameTierDifferentFrequency_ReturnsOk(
+        PlanType currentPlan,
+        PlanType requestedPlan,
+        Guid organizationId,
+        Organization organization,
+        SutProvider<OrganizationBillingController> sutProvider)
+    {
+        // Arrange
+        organization.PlanType = currentPlan;
+        var request = new ChangePlanFrequencyRequest { NewPlanType = requestedPlan };
+
+        sutProvider.GetDependency<ICurrentContext>().EditSubscription(organizationId).Returns(true);
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organizationId).Returns(organization);
+
+        // Act
+        var result = await sutProvider.Sut.ChangePlanSubscriptionFrequencyAsync(organizationId, request);
+
+        // Assert
+        Assert.IsType<Ok>(result);
+
+        await sutProvider.GetDependency<IOrganizationBillingService>()
+            .Received(1)
+            .UpdateSubscriptionPlanFrequency(organization, requestedPlan);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking
- [PM-35257](https://bitwarden.atlassian.net/browse/PM-35257) (originating: [VULN-531](https://bitwarden.atlassian.net/browse/VULN-531))

## 📔 Objective

`POST /billing/change-frequency` only checked that the requested `PlanType` differed from the current one — not that they were the same product tier. An owner could swap an Enterprise org to Free or Teams, desyncing `Organization.PlanType` from the feature booleans (which the server actually uses for entitlement). Verified live: Enterprise → Teams re-prices the Stripe subscription downward (PM seat \$72→\$48/yr, SM \$144→\$72/yr) while the org keeps SSO, SCIM, Policies, and Reset Password.

This PR adds a tier guard via the existing `PlanType.GetProductTier()` extension. Cross-tier requests now return `400` before any DB or Stripe write; within-tier Monthly↔Annually still works.

The reporter also suggested syncing feature booleans on each change and adding null-safety in the price-remap loop. Both become unreachable with the tier guard: within a tier every plan shares identical `Has*` flags (Monthly/Annually variants only differ on Stripe IDs), and the only plan with null `StripeSeatPlanId`s is Free — which can never be `oldPlan` here since Free→Free is already blocked by the same-plan check.

Unit tests cover unauthorized, not-found, same-plan, 6 cross-tier rejections, and 4 within-tier successes. Manually verified on a dev instance with a real Stripe test subscription.

[PM-35257]: https://bitwarden.atlassian.net/browse/PM-35257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VULN-531]: https://bitwarden.atlassian.net/browse/VULN-531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ