### PR TITLE
[PM-36250] Add option to load certificate from file path

### DIFF
--- a/src/Core/Billing/Services/Implementations/LicensingService.cs
+++ b/src/Core/Billing/Services/Implementations/LicensingService.cs
@@ -94,6 +94,10 @@ public class LicensingService : ILicensingService
                 _verificationCertificates.Add(devCert);
             }
         }
+        else if (CoreHelpers.SettingHasValue(_globalSettings.LicenseCertificatePath) && CoreHelpers.SettingHasValue(_globalSettings.LicenseCertificatePassword))
+        {
+            _creationCertificate = CoreHelpers.GetCertificate(_globalSettings.LicenseCertificatePath, _globalSettings.LicenseCertificatePassword);
+        }
         else if (CoreHelpers.SettingHasValue(_globalSettings.Storage?.ConnectionString) &&
             CoreHelpers.SettingHasValue(_globalSettings.LicenseCertificatePassword))
         {

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -37,6 +37,7 @@ public class GlobalSettings : IGlobalSettings
         set => _mailTemplateDirectory = value;
     }
     public string LicenseCertificatePassword { get; set; }
+    public string LicenseCertificatePath { get; set; }
     public virtual string PushRelayBaseUri { get; set; }
     public virtual string InternalIdentityKey { get; set; }
     public virtual string OidcIdentityClientKey { get; set; }

--- a/src/Core/Settings/IGlobalSettings.cs
+++ b/src/Core/Settings/IGlobalSettings.cs
@@ -13,6 +13,7 @@ public interface IGlobalSettings
     bool EnableCloudCommunication { get; set; }
     string LicenseDirectory { get; set; }
     string LicenseCertificatePassword { get; set; }
+    string LicenseCertificatePath { get; set; }
     int OrganizationInviteExpirationHours { get; set; }
     bool DisableUserRegistration { get; set; }
     bool EnableNewDeviceVerification { get; set; }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-36250

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The current contributing docs prescribe loading the licensing certificate as a root certificate into the OS keychain. This gives everyone with the root certificate - all bitwarden employees - the ability to spoof, intercept and tamper with all TLS traffic of all everyone who has this trusted root certificate in their keychain.

Instead of loading it into the keychain as a root certificate, this PR adds the ability to load it from a file, only for the specific scope of the `bitwarden/server` application, entirely eliminating this risk.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
