### PR TITLE
[PM-35263] Admin Portal: Add checkbox for the InviteLinks ability

### DIFF
--- a/src/Admin/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Admin/AdminConsole/Controllers/OrganizationsController.cs
@@ -571,6 +571,7 @@ public class OrganizationsController : Controller
             organization.UseDisableSmAdsForUsers = model.UseDisableSmAdsForUsers;
             organization.UsePhishingBlocker = model.UsePhishingBlocker;
             organization.UseMyItems = model.UseMyItems;
+            organization.UseInviteLinks = model.UseInviteLinks;
 
             //secrets
             organization.SmSeats = model.SmSeats;

--- a/src/Admin/AdminConsole/Models/OrganizationEditModel.cs
+++ b/src/Admin/AdminConsole/Models/OrganizationEditModel.cs
@@ -110,6 +110,7 @@ public class OrganizationEditModel : OrganizationViewModel, IValidatableObject
         UseDisableSmAdsForUsers = org.UseDisableSmAdsForUsers;
         UsePhishingBlocker = org.UsePhishingBlocker;
         UseMyItems = org.UseMyItems;
+        UseInviteLinks = org.UseInviteLinks;
         ExemptFromBillingAutomation = org.ExemptFromBillingAutomation;
 
         _plans = plans;
@@ -206,6 +207,8 @@ public class OrganizationEditModel : OrganizationViewModel, IValidatableObject
     public bool UseAutomaticUserConfirmation { get; set; }
     [Display(Name = "Create My Items for organization ownership")]
     public bool UseMyItems { get; set; }
+    [Display(Name = "Invite Links")]
+    public bool UseInviteLinks { get; set; }
     [Display(Name = "Exempt From Billing Automation")]
     public bool ExemptFromBillingAutomation { get; set; }
     /**
@@ -243,6 +246,7 @@ public class OrganizationEditModel : OrganizationViewModel, IValidatableObject
                     UsersGetPremium = p.UsersGetPremium,
                     HasCustomPermissions = p.HasCustomPermissions,
                     HasMyItems = p.HasMyItems,
+                    HasInviteLinks = p.HasInviteLinks,
                     UpgradeSortOrder = p.UpgradeSortOrder,
                     DisplaySortOrder = p.DisplaySortOrder,
                     LegacyYear = p.LegacyYear,
@@ -343,6 +347,7 @@ public class OrganizationEditModel : OrganizationViewModel, IValidatableObject
         existingOrganization.UseDisableSmAdsForUsers = UseDisableSmAdsForUsers;
         existingOrganization.UsePhishingBlocker = UsePhishingBlocker;
         existingOrganization.UseMyItems = UseMyItems;
+        existingOrganization.UseInviteLinks = UseInviteLinks;
         existingOrganization.ExemptFromBillingAutomation = ExemptFromBillingAutomation;
         return existingOrganization;
     }

--- a/src/Admin/AdminConsole/Views/Shared/_OrganizationForm.cshtml
+++ b/src/Admin/AdminConsole/Views/Shared/_OrganizationForm.cshtml
@@ -164,6 +164,10 @@
                     <input type="checkbox" class="form-check-input" asp-for="UseAutomaticUserConfirmation" disabled='@(canEditPlan ? null : "disabled")'>
                     <label class="form-check-label" asp-for="UseAutomaticUserConfirmation"></label>
                 </div>
+                <div class="form-check">
+                    <input type="checkbox" class="form-check-input" asp-for="UseInviteLinks" disabled='@(canEditPlan ? null : "disabled")'>
+                    <label class="form-check-label" asp-for="UseInviteLinks"></label>
+                </div>
             </div>
             <div class="col-3">
                 <h3>Password Manager</h3>

--- a/src/Admin/AdminConsole/Views/Shared/_OrganizationFormScripts.cshtml
+++ b/src/Admin/AdminConsole/Views/Shared/_OrganizationFormScripts.cshtml
@@ -75,6 +75,7 @@
         document.getElementById('@(nameof(Model.UseEvents))').checked = plan.hasEvents;
         document.getElementById('@(nameof(Model.UseResetPassword))').checked = plan.hasResetPassword;
         document.getElementById('@(nameof(Model.UseCustomPermissions))').checked = plan.hasCustomPermissions;
+        document.getElementById('@(nameof(Model.UseInviteLinks))').checked = plan.hasInviteLinks;
         // use key connector is intentionally omitted
 
         // Password Manager features


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35263

## 📔 Objective

Add the `UseInviteLinks` checkbox to the Admin Portal organization edit form, allowing staff to manually enable or disable invite links per organization.

## 📸 Screenshots

<img width="408" height="522" alt="image" src="https://github.com/user-attachments/assets/3bbc931b-ad70-44ea-825d-e86609ade742" />

