### PR TITLE
[PM-36421] Add xmldoc to Admin Console entities

### DIFF
--- a/src/Core/AdminConsole/Entities/Collection.cs
+++ b/src/Core/AdminConsole/Entities/Collection.cs
@@ -2,22 +2,54 @@
 using Bit.Core.Enums;
 using Bit.Core.Utilities;
 
-#nullable enable
-
 namespace Bit.Core.Entities;
 
+/// <summary>
+/// A named grouping of vault items within an organization, used to share items with members and groups.
+/// Access is granted to individual members via <see cref="CollectionUser"/> and to groups via <see cref="CollectionGroup"/>.
+/// </summary>
 public class Collection : ITableObject<Guid>
 {
+    /// <summary>
+    /// A unique identifier for the collection.
+    /// </summary>
     public Guid Id { get; set; }
+    /// <summary>
+    /// The ID of the <see cref="Bit.Core.AdminConsole.Entities.Organization"/> that owns this collection.
+    /// </summary>
     public Guid OrganizationId { get; set; }
+    /// <summary>
+    /// The name of the collection, stored encrypted.
+    /// </summary>
     public string Name { get; set; } = null!;
+    /// <summary>
+    /// An ID used to associate this collection with a record in external services.
+    /// </summary>
     [MaxLength(300)]
     public string? ExternalId { get; set; }
+    /// <summary>
+    /// The date the collection was created.
+    /// </summary>
     public DateTime CreationDate { get; set; } = DateTime.UtcNow;
+    /// <summary>
+    /// The date the collection was last updated.
+    /// </summary>
     public DateTime RevisionDate { get; set; } = DateTime.UtcNow;
+    /// <summary>
+    /// The type of collection, indicating how it was created and how it behaves.
+    /// </summary>
     public CollectionType Type { get; set; } = CollectionType.SharedCollection;
+    /// <summary>
+    /// Used as the name for the collection if this is a <see cref="CollectionType.DefaultUserCollection"/>
+    /// of a user who is no longer a member of the organization. In this case, it stores the user's
+    /// email address so that it is identifiable by an admin (rather than being called "My Items" for an
+    /// unknown user). Unencrypted.
+    /// </summary>
     public string? DefaultUserCollectionEmail { get; set; }
 
+    /// <summary>
+    /// Initializes <see cref="Id"/> to a new COMB GUID.
+    /// </summary>
     public void SetNewId()
     {
         Id = CoreHelpers.GenerateComb();

--- a/src/Core/AdminConsole/Entities/CollectionGroup.cs
+++ b/src/Core/AdminConsole/Entities/CollectionGroup.cs
@@ -1,12 +1,30 @@
 ﻿namespace Bit.Core.Entities;
 
-#nullable enable
-
+/// <summary>
+/// A join record that grants a <see cref="Bit.Core.AdminConsole.Entities.Group"/> access to a <see cref="Collection"/>
+/// with specific permissions. Direct user access is represented separately by <see cref="CollectionUser"/>.
+/// </summary>
 public class CollectionGroup
 {
+    /// <summary>
+    /// The ID of the <see cref="Collection"/> the group has access to.
+    /// </summary>
     public Guid CollectionId { get; set; }
+    /// <summary>
+    /// The ID of the <see cref="Bit.Core.AdminConsole.Entities.Group"/> that has access to the collection.
+    /// </summary>
     public Guid GroupId { get; set; }
+    /// <summary>
+    /// If true, group members can view items in the collection but cannot create, edit, or delete them.
+    /// </summary>
     public bool ReadOnly { get; set; }
+    /// <summary>
+    /// If true, group members cannot see password and TOTP fields for items in the collection.
+    /// </summary>
     public bool HidePasswords { get; set; }
+    /// <summary>
+    /// If true, group members can manage the collection itself — including renaming it,
+    /// deleting it, and assigning access for other users and groups.
+    /// </summary>
     public bool Manage { get; set; }
 }

--- a/src/Core/AdminConsole/Entities/CollectionUser.cs
+++ b/src/Core/AdminConsole/Entities/CollectionUser.cs
@@ -1,12 +1,30 @@
 ﻿namespace Bit.Core.Entities;
 
-#nullable enable
-
+/// <summary>
+/// A join record that grants an <see cref="OrganizationUser"/> direct access to a <see cref="Collection"/>
+/// with specific permissions. Access via group membership is represented separately by <see cref="CollectionGroup"/>.
+/// </summary>
 public class CollectionUser
 {
+    /// <summary>
+    /// The ID of the <see cref="Collection"/> the organization user has access to.
+    /// </summary>
     public Guid CollectionId { get; set; }
+    /// <summary>
+    /// The ID of the <see cref="OrganizationUser"/> who has access to the collection.
+    /// </summary>
     public Guid OrganizationUserId { get; set; }
+    /// <summary>
+    /// If true, the user can view items in the collection but cannot create, edit, or delete them.
+    /// </summary>
     public bool ReadOnly { get; set; }
+    /// <summary>
+    /// If true, the user cannot see password and TOTP fields for items in the collection.
+    /// </summary>
     public bool HidePasswords { get; set; }
+    /// <summary>
+    /// If true, the user can manage the collection itself — including renaming it,
+    /// deleting it, and assigning access for other users and groups.
+    /// </summary>
     public bool Manage { get; set; }
 }

--- a/src/Core/AdminConsole/Entities/Group.cs
+++ b/src/Core/AdminConsole/Entities/Group.cs
@@ -3,21 +3,46 @@ using Bit.Core.Entities;
 using Bit.Core.Models;
 using Bit.Core.Utilities;
 
-#nullable enable
-
 namespace Bit.Core.AdminConsole.Entities;
 
+/// <summary>
+/// A named group of organization members, used to grant <see cref="Collection"/> access
+/// to multiple members at once via <see cref="CollectionGroup"/> associations.
+/// Members are associated with groups via <see cref="GroupUser"/>.
+/// </summary>
 public class Group : ITableObject<Guid>, IExternal
 {
+    /// <summary>
+    /// A unique identifier for the group.
+    /// </summary>
     public Guid Id { get; set; }
+    /// <summary>
+    /// The ID of the <see cref="Organization"/> that owns this group.
+    /// </summary>
     public Guid OrganizationId { get; set; }
+    /// <summary>
+    /// The name of the group. Unencrypted.
+    /// </summary>
     [MaxLength(100)]
     public string Name { get; set; } = null!;
+    /// <summary>
+    /// An ID used to associate this group with a record in an external directory service.
+    /// Used by Directory Connector and SCIM.
+    /// </summary>
     [MaxLength(300)]
     public string? ExternalId { get; set; }
+    /// <summary>
+    /// The date the group was created.
+    /// </summary>
     public DateTime CreationDate { get; internal set; } = DateTime.UtcNow;
+    /// <summary>
+    /// The date the group was last updated.
+    /// </summary>
     public DateTime RevisionDate { get; set; } = DateTime.UtcNow;
 
+    /// <summary>
+    /// Initializes <see cref="Id"/> to a new COMB GUID.
+    /// </summary>
     public void SetNewId()
     {
         Id = CoreHelpers.GenerateComb();

--- a/src/Core/AdminConsole/Entities/GroupUser.cs
+++ b/src/Core/AdminConsole/Entities/GroupUser.cs
@@ -1,9 +1,17 @@
 ﻿namespace Bit.Core.AdminConsole.Entities;
 
-#nullable enable
-
+/// <summary>
+/// A join record linking an <see cref="Bit.Core.Entities.OrganizationUser"/> to a <see cref="Group"/>,
+/// indicating that the organization user is a member of that group.
+/// </summary>
 public class GroupUser
 {
+    /// <summary>
+    /// The ID of the <see cref="Group"/> the organization user belongs to.
+    /// </summary>
     public Guid GroupId { get; set; }
+    /// <summary>
+    /// The ID of the <see cref="Bit.Core.Entities.OrganizationUser"/> that is a member of the group.
+    /// </summary>
     public Guid OrganizationUserId { get; set; }
 }

--- a/src/Core/AdminConsole/Entities/Organization.cs
+++ b/src/Core/AdminConsole/Entities/Organization.cs
@@ -14,11 +14,21 @@ using Bit.Core.Utilities;
 
 namespace Bit.Core.AdminConsole.Entities;
 
+/// <summary>
+/// An organization is an entity that allows users to share vault items and
+/// manage billing, access control, and other enterprise features depending on the plan.
+/// </summary>
 public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable
 {
     private Dictionary<TwoFactorProviderType, TwoFactorProvider>? _twoFactorProviders;
 
+    /// <summary>
+    /// A unique identifier for the organization.
+    /// </summary>
     public Guid Id { get; set; }
+    /// <summary>
+    /// A unique, human-readable identifier used to specify the organization during SSO login.
+    /// </summary>
     [MaxLength(50)]
     public string? Identifier { get; set; }
     /// <summary>
@@ -32,62 +42,217 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable
     [MaxLength(50)]
     [Obsolete("This property has been deprecated. Use the 'Name' property instead.")]
     public string? BusinessName { get; set; }
+    /// <summary>
+    /// The first line of the organization's business address.
+    /// </summary>
     [MaxLength(50)]
     public string? BusinessAddress1 { get; set; }
+    /// <summary>
+    /// The second line of the organization's business address.
+    /// </summary>
     [MaxLength(50)]
     public string? BusinessAddress2 { get; set; }
+    /// <summary>
+    /// The third line of the organization's business address.
+    /// </summary>
     [MaxLength(50)]
     public string? BusinessAddress3 { get; set; }
+    /// <summary>
+    /// The two-letter ISO country code of the organization's business address.
+    /// </summary>
     [MaxLength(2)]
     public string? BusinessCountry { get; set; }
+    /// <summary>
+    /// The organization's tax identification number.
+    /// </summary>
     [MaxLength(30)]
     public string? BusinessTaxNumber { get; set; }
+    /// <summary>
+    /// The billing email address for the organization.
+    /// </summary>
     [MaxLength(256)]
     public string BillingEmail { get; set; } = null!;
+    /// <summary>
+    /// The name of the plan the organization is subscribed to.
+    /// It is unclear why this is stored and what it is used for - do not use it.
+    /// Use the <see cref="PlanType"/> instead.
+    /// </summary>
     [MaxLength(50)]
     public string Plan { get; set; } = null!;
+    /// <summary>
+    /// The type of plan the organization is subscribed to.
+    /// </summary>
     public PlanType PlanType { get; set; }
+    /// <summary>
+    /// The number of user seats included in the organization's subscription. NULL if the plan has no seat limit.
+    /// </summary>
     public int? Seats { get; set; }
+    /// <summary>
+    /// The maximum number of collections the organization can create. NULL if the plan has no collection limit.
+    /// </summary>
     public short? MaxCollections { get; set; }
+    /// <summary>
+    /// If true, the organization has access to the Policies feature.
+    /// </summary>
     public bool UsePolicies { get; set; }
+    /// <summary>
+    /// If true, the organization has access to the SSO (Single Sign-On) feature.
+    /// </summary>
     public bool UseSso { get; set; }
+    /// <summary>
+    /// If true, the organization has access to the Key Connector feature, which allows SSO without master passwords.
+    /// </summary>
     public bool UseKeyConnector { get; set; }
+    /// <summary>
+    /// If true, the organization has access to the SCIM (System for Cross-domain Identity Management) feature.
+    /// This is used for automatic user provisioning.
+    /// </summary>
     public bool UseScim { get; set; }
+    /// <summary>
+    /// If true, the organization has access to the Groups feature.
+    /// </summary>
     public bool UseGroups { get; set; }
+    /// <summary>
+    /// If true, the organization can use Directory Connector.
+    /// This is a standalone app used for automatic user provisioning.
+    /// </summary>
     public bool UseDirectory { get; set; }
+    /// <summary>
+    /// If true, the organization has access to the event logs feature.
+    /// </summary>
     public bool UseEvents { get; set; }
+    /// <summary>
+    /// If true, the organization has access to the TOTP feature for vault items.
+    /// </summary>
     public bool UseTotp { get; set; }
+    /// <summary>
+    /// If true, the organization has access to organization-level two-factor authentication.
+    /// </summary>
     public bool Use2fa { get; set; }
+    /// <summary>
+    /// If true, the organization has access to the public API.
+    /// </summary>
     public bool UseApi { get; set; }
+    /// <summary>
+    /// If true, the organization has access to the account recovery (admin password reset) feature.
+    /// </summary>
     public bool UseResetPassword { get; set; }
+    /// <summary>
+    /// If true, the organization is subscribed to the Secrets Manager product.
+    /// </summary>
     public bool UseSecretsManager { get; set; }
+    /// <summary>
+    /// If true, the organization can export a license file which is used to create the organization on
+    /// a self-hosted instance. It does not indicate whether this organization is self-hosted.
+    /// </summary>
     public bool SelfHost { get; set; }
+    /// <summary>
+    /// If true, all members of the organization are granted premium features.
+    /// </summary>
     public bool UsersGetPremium { get; set; }
+    /// <summary>
+    /// If true, the organization has access to custom user roles with fine-grained permissions.
+    /// </summary>
     public bool UseCustomPermissions { get; set; }
+    /// <summary>
+    /// The number of bytes of file attachment storage the organization has used.
+    /// </summary>
     public long? Storage { get; set; }
+    /// <summary>
+    /// The maximum number of gigabytes of file attachment storage available to the organization.
+    /// </summary>
     public short? MaxStorageGb { get; set; }
+    /// <summary>
+    /// The payment gateway used for billing.
+    /// </summary>
     public GatewayType? Gateway { get; set; }
+    /// <summary>
+    /// The organization's customer ID in the payment gateway.
+    /// </summary>
     [MaxLength(50)]
     public string? GatewayCustomerId { get; set; }
+    /// <summary>
+    /// The organization's subscription ID in the payment gateway.
+    /// </summary>
     [MaxLength(50)]
     public string? GatewaySubscriptionId { get; set; }
+    /// <summary>
+    /// A JSON blob of reference data, e.g. the signup source.
+    /// </summary>
     public string? ReferenceData { get; set; }
+    /// <summary>
+    /// If true, the organization is active. If false, the organization is disabled and access to its
+    /// vault and features are restricted.
+    /// </summary>
     public bool Enabled { get; set; } = true;
+    /// <summary>
+    /// The license key for the organization. Used by self-hosted instances to validate the license.
+    /// </summary>
     [MaxLength(100)]
     public string? LicenseKey { get; set; }
+    /// <summary>
+    /// The organization's asymmetric public key, used to enrol members in account recovery.
+    /// </summary>
     public string? PublicKey { get; set; }
+    /// <summary>
+    /// The organization's asymmetric private key, encrypted with the organization's symmetric key.
+    /// </summary>
     public string? PrivateKey { get; set; }
+    /// <summary>
+    /// A JSON blob of the organization's two-factor authentication provider configurations.
+    /// Use <see cref="GetTwoFactorProviders"/> and <see cref="SetTwoFactorProviders"/> to read and write this field.
+    /// </summary>
     public string? TwoFactorProviders { get; set; }
+    /// <summary>
+    /// The date the organization's license expires. NULL if the license does not expire.
+    /// </summary>
     public DateTime? ExpirationDate { get; set; }
+    /// <summary>
+    /// The date the organization was created.
+    /// </summary>
     public DateTime CreationDate { get; set; } = DateTime.UtcNow;
+    /// <summary>
+    /// The date the organization was last updated.
+    /// </summary>
     public DateTime RevisionDate { get; set; } = DateTime.UtcNow;
+    /// <summary>
+    /// The maximum number of seats the organization can autoscale to. NULL if autoscaling is not limited.
+    /// </summary>
     public int? MaxAutoscaleSeats { get; set; } = null;
+    /// <summary>
+    /// The date the organization's owners were last notified that the organization had autoscaled.
+    /// NULL if owners have not been notified.
+    /// </summary>
     public DateTime? OwnersNotifiedOfAutoscaling { get; set; } = null;
+    /// <summary>
+    /// The current status of the organization, representing its lifecycle state.
+    /// </summary>
     public OrganizationStatusType Status { get; set; }
+    /// <summary>
+    /// If true, the organization has access to the Password Manager product.
+    /// This is intended for future use if we separate Password Manager from Secrets Manager (and other products).
+    /// For now, all organizations and users implicitly have access to Password Manager.
+    /// </summary>
     public bool UsePasswordManager { get; set; }
+    /// <summary>
+    /// The number of Secrets Manager seats included in the organization's subscription.
+    /// NULL if the organization does not have access to Secrets Manager.
+    /// </summary>
     public int? SmSeats { get; set; }
+    /// <summary>
+    /// The number of Secrets Manager machine accounts (service accounts) included in the organization's subscription.
+    /// NULL if the organization does not have access to Secrets Manager.
+    /// </summary>
     public int? SmServiceAccounts { get; set; }
+    /// <summary>
+    /// The maximum number of Secrets Manager seats the organization can autoscale to.
+    /// NULL if autoscaling is not limited.
+    /// </summary>
     public int? MaxAutoscaleSmSeats { get; set; }
+    /// <summary>
+    /// The maximum number of Secrets Manager machine accounts the organization can autoscale to.
+    /// NULL if autoscaling is not limited.
+    /// </summary>
     public int? MaxAutoscaleSmServiceAccounts { get; set; }
     /// <summary>
     /// If set to true, only owners, admins, and some custom users can create and delete collections.
@@ -95,6 +260,10 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable
     /// they have Can Manage permissions for.
     /// </summary>
     public bool LimitCollectionCreation { get; set; }
+    /// <summary>
+    /// If set to true, only owners, admins, and some custom users can delete collections.
+    /// If set to false, any member can delete a collection that they have Can Manage permissions for.
+    /// </summary>
     public bool LimitCollectionDeletion { get; set; }
 
     /// <summary>
@@ -110,12 +279,13 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable
     public bool LimitItemDeletion { get; set; }
 
     /// <summary>
-    /// Risk Insights is a reporting feature that provides insights into the security of an organization's vault.
+    /// If true, the organization can use the Risk Insights feature. Thisis a reporting feature that provides
+    /// insights into the security of an organization.
     /// </summary>
     public bool UseRiskInsights { get; set; }
 
     /// <summary>
-    /// If true, the organization can claim domains, which unlocks additional enterprise features
+    /// If true, the organization can claim domains, which unlocks additional enterprise features.
     /// </summary>
     public bool UseOrganizationDomains { get; set; }
 
@@ -125,12 +295,14 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable
     public bool UseAdminSponsoredFamilies { get; set; }
 
     /// <summary>
-    /// If set to true, organization needs their seat count synced with their subscription
+    /// If set to true, organization needs their seat count synced with their subscription.
     /// </summary>
     public bool SyncSeats { get; set; }
 
     /// <summary>
-    /// If set to true,  user accounts created within the organization are automatically confirmed without requiring additional verification steps.
+    /// If set to true, the organization can use the automatic user confirmation feature.
+    /// This automatically confirms users in the Accepted state without requiring manual admin intervention.
+    /// There are significant security risks to this and access is manually controlled by our internal teams.
     /// </summary>
     public bool UseAutomaticUserConfirmation { get; set; }
 
@@ -140,7 +312,7 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable
     public bool UseDisableSmAdsForUsers { get; set; }
 
     /// <summary>
-    /// If set to true, the organization has phishing protection enabled.
+    /// If set to true, the organization can use the phishing blocker feature.
     /// </summary>
     public bool UsePhishingBlocker { get; set; }
 
@@ -151,17 +323,19 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable
     public bool UseMyItems { get; set; }
 
     /// <summary>
-    /// If set to true, the organization can generate invite links to invite users to the organization.
-    /// This is an Enterprise-only feature.
+    /// If set to true, the organization can generate reusable sharable invite links to invite users to the organization.
     /// </summary>
     public bool UseInviteLinks { get; set; }
 
     /// <summary>
-    /// When set to <see langword="true"/>, the organization is excluded from automated billing
+    /// When set to true, the organization is excluded from automated billing
     /// lifecycle operations such as subscription cancellation and disabling for non-payment.
     /// </summary>
     public bool ExemptFromBillingAutomation { get; set; }
 
+    /// <summary>
+    /// Initializes <see cref="Id"/> to a new COMB GUID.
+    /// </summary>
     public void SetNewId()
     {
         if (Id == default(Guid))
@@ -188,55 +362,72 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable
         return WebUtility.HtmlDecode(BusinessName);
     }
 
+    /// <inheritdoc/>
     public string? BillingEmailAddress()
     {
         return BillingEmail?.ToLowerInvariant()?.Trim();
     }
 
+    /// <inheritdoc/>
     public string? BillingName()
     {
         return DisplayBusinessName();
     }
 
+    /// <inheritdoc/>
     public string? SubscriberName()
     {
         return DisplayName();
     }
 
+    /// <inheritdoc/>
     public string BraintreeCustomerIdPrefix()
     {
         return "o";
     }
 
+    /// <inheritdoc/>
     public string BraintreeIdField()
     {
         return "organization_id";
     }
 
+    /// <inheritdoc/>
     public string BraintreeCloudRegionField()
     {
         return "region";
     }
 
+    /// <inheritdoc/>
     public string GatewayIdField()
     {
         return "organizationId";
     }
 
+    /// <inheritdoc/>
     public bool IsOrganization() => true;
 
+    /// <inheritdoc/>
     public bool IsUser()
     {
         return false;
     }
 
+    /// <inheritdoc/>
     public string SubscriberType()
     {
         return "Organization";
     }
 
+    /// <summary>
+    /// Returns true if the organization's license has expired.
+    /// </summary>
     public bool IsExpired() => ExpirationDate.HasValue && ExpirationDate.Value <= DateTime.UtcNow;
 
+    /// <summary>
+    /// Returns the number of bytes of file attachment storage remaining for the organization,
+    /// based on <see cref="MaxStorageGb"/>. Returns 0 if no storage limit is set.
+    /// </summary>
     public long StorageBytesRemaining()
     {
         if (!MaxStorageGb.HasValue)
@@ -247,6 +438,10 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable
         return StorageBytesRemaining(MaxStorageGb.Value);
     }
 
+    /// <summary>
+    /// Returns the number of bytes of file attachment storage remaining for the organization,
+    /// given the specified maximum storage in gigabytes.
+    /// </summary>
     public long StorageBytesRemaining(short maxStorageGb)
     {
         var maxStorageBytes = maxStorageGb * 1073741824L;
@@ -258,6 +453,10 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable
         return maxStorageBytes - Storage.Value;
     }
 
+    /// <summary>
+    /// Deserializes <see cref="TwoFactorProviders"/> into a dictionary of two-factor provider configurations.
+    /// Returns null if no providers are configured or if the JSON is invalid.
+    /// </summary>
     public Dictionary<TwoFactorProviderType, TwoFactorProvider>? GetTwoFactorProviders()
     {
         if (string.IsNullOrWhiteSpace(TwoFactorProviders))
@@ -282,6 +481,10 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable
         }
     }
 
+    /// <summary>
+    /// Serializes the given two-factor provider configurations and stores them in <see cref="TwoFactorProviders"/>.
+    /// Clears the field if the dictionary is empty.
+    /// </summary>
     public void SetTwoFactorProviders(Dictionary<TwoFactorProviderType, TwoFactorProvider> providers)
     {
         if (!providers.Any())
@@ -295,6 +498,9 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable
         _twoFactorProviders = providers;
     }
 
+    /// <summary>
+    /// Returns true if the specified two-factor provider is configured and enabled for the organization.
+    /// </summary>
     public bool TwoFactorProviderIsEnabled(TwoFactorProviderType provider)
     {
         var providers = GetTwoFactorProviders();
@@ -306,6 +512,9 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable
         return twoFactorProvider.Enabled && Use2fa;
     }
 
+    /// <summary>
+    /// Returns true if the organization has any two-factor provider configured and enabled.
+    /// </summary>
     public bool TwoFactorIsEnabled()
     {
         var providers = GetTwoFactorProviders();
@@ -317,12 +526,18 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable
         return providers.Any(p => (p.Value?.Enabled ?? false) && Use2fa);
     }
 
+    /// <summary>
+    /// Returns the configuration for the specified two-factor provider, or null if it is not configured.
+    /// </summary>
     public TwoFactorProvider? GetTwoFactorProvider(TwoFactorProviderType provider)
     {
         var providers = GetTwoFactorProviders();
         return providers?.GetValueOrDefault(provider);
     }
 
+    /// <summary>
+    /// Updates the organization's properties from a self-hosted license file.
+    /// </summary>
     public void UpdateFromLicense(OrganizationLicense license, IFeatureService featureService)
     {
         // The following properties are intentionally excluded from being updated:

--- a/src/Core/AdminConsole/Entities/Organization.cs
+++ b/src/Core/AdminConsole/Entities/Organization.cs
@@ -279,7 +279,7 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable
     public bool LimitItemDeletion { get; set; }
 
     /// <summary>
-    /// If true, the organization can use the Risk Insights feature. Thisis a reporting feature that provides
+    /// If true, the organization can use the Risk Insights feature. This is a reporting feature that provides
     /// insights into the security of an organization.
     /// </summary>
     public bool UseRiskInsights { get; set; }

--- a/src/Core/AdminConsole/Entities/OrganizationInviteLink.cs
+++ b/src/Core/AdminConsole/Entities/OrganizationInviteLink.cs
@@ -4,29 +4,72 @@ using Bit.Core.Utilities;
 
 namespace Bit.Core.AdminConsole.Entities;
 
+/// <summary>
+/// A shareable link that allows users to join an organization without a per-email address invitation.
+/// </summary>
 public class OrganizationInviteLink : ITableObject<Guid>
 {
+    /// <summary>
+    /// A unique identifier for the invite link.
+    /// </summary>
     public Guid Id { get; set; }
     /// <summary>
-    /// A random, publicly shareable code used to identify the invite link.
+    /// A random, secret code embedded in the invite link to ensure it cannot be guessed.
+    /// </summary>
+    /// <remarks>
     /// Uses <see cref="Guid.NewGuid"/> rather than a sequential/comb GUID because this is not
     /// a table identifier and therefore does not need index-friendly ordering. A comb GUID's embedded
     /// timestamp would also make the code partially predictable.
-    /// </summary>
+    /// </remarks>
     public Guid Code { get; set; } = Guid.NewGuid();
+    /// <summary>
+    /// The ID of the <see cref="Organization"/> this invite link belongs to.
+    /// </summary>
     public Guid OrganizationId { get; set; }
+    /// <summary>
+    /// A JSON-serialized list of email domains that are permitted to use this invite link.
+    /// Use <see cref="GetAllowedDomains"/> and <see cref="SetAllowedDomains"/> to read and write this field.
+    /// </summary>
     public string AllowedDomains { get; set; } = null!;
+    /// <summary>
+    /// The invite link key encrypted with the organization's symmetric key.
+    /// </summary>
+    /// <remarks>
+    /// This is decrypted client-side and used to reconstruct the invite link for display to the admin.
+    /// </remarks>
     public string EncryptedInviteKey { get; set; } = null!;
+    /// <summary>
+    /// The organization's symmetric key, encrypted with the invite link key.
+    /// </summary>
+    /// <remarks>
+    /// This is used to support automatic confirmation of invited users by allowing a user who clicks the link
+    /// to decrypt a copy of the organization symmetric key.
+    /// </remarks>
     public string? EncryptedOrgKey { get; set; }
+    /// <summary>
+    /// The date the invite link was created.
+    /// </summary>
     public DateTime CreationDate { get; set; } = DateTime.UtcNow;
+    /// <summary>
+    /// The date the invite link was last updated.
+    /// </summary>
     public DateTime RevisionDate { get; set; } = DateTime.UtcNow;
 
+    /// <summary>
+    /// Deserializes <see cref="AllowedDomains"/> into a list of domain strings.
+    /// </summary>
     public IEnumerable<string> GetAllowedDomains() =>
         JsonSerializer.Deserialize<IEnumerable<string>>(AllowedDomains) ?? [];
 
+    /// <summary>
+    /// Serializes the given domains and stores them in <see cref="AllowedDomains"/>.
+    /// </summary>
     public void SetAllowedDomains(IEnumerable<string> domains) =>
         AllowedDomains = JsonSerializer.Serialize(domains);
 
+    /// <summary>
+    /// Initializes <see cref="Id"/> to a new COMB GUID.
+    /// </summary>
     public void SetNewId()
     {
         if (Id == default)

--- a/src/Core/AdminConsole/Entities/Policy.cs
+++ b/src/Core/AdminConsole/Entities/Policy.cs
@@ -1,32 +1,72 @@
 ﻿using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
 using Bit.Core.Entities;
 using Bit.Core.Utilities;
 
-#nullable enable
-
 namespace Bit.Core.AdminConsole.Entities;
 
+/// <summary>
+/// An organization policy of a given <see cref="PolicyType"/>, optionally with additional
+/// configuration data. Policies enforce rules on members of the organization or change organization behavior.
+/// </summary>
+/// <remarks>
+/// The policy domain has various business rules to determine whether a policy should be enforced against a user.
+/// You should not read the Policy object directly to decide this. Instead, see <see cref="IPolicyRequirementQuery"/>.
+/// </remarks>
 public class Policy : ITableObject<Guid>
 {
+    /// <summary>
+    /// A unique identifier for the policy.
+    /// </summary>
     public Guid Id { get; set; }
+    /// <summary>
+    /// The ID of the <see cref="Organization"/> this policy belongs to.
+    /// </summary>
     public Guid OrganizationId { get; set; }
+    /// <summary>
+    /// The type of policy, which determines its description and behavior.
+    /// </summary>
     public PolicyType Type { get; set; }
+    /// <summary>
+    /// Optional JSON configuration for the policy. The shape of the data depends on the
+    /// <see cref="Type"/>. Use <see cref="GetDataModel{T}"/> and <see cref="SetDataModel{T}"/>
+    /// to read and write this field.
+    /// </summary>
     public string? Data { get; set; }
+    /// <summary>
+    /// If true, the policy is turned on and may be enforced (subject to other business rules such as
+    /// exemptions or plan limitations). If false, the policy exists and may be configured but has no effect.
+    /// </summary>
     public bool Enabled { get; set; }
+    /// <summary>
+    /// The date the policy was created.
+    /// </summary>
     public DateTime CreationDate { get; internal set; } = DateTime.UtcNow;
+    /// <summary>
+    /// The date the policy was last updated.
+    /// </summary>
     public DateTime RevisionDate { get; internal set; } = DateTime.UtcNow;
 
+    /// <summary>
+    /// Initializes <see cref="Id"/> to a new COMB GUID.
+    /// </summary>
     public void SetNewId()
     {
         Id = CoreHelpers.GenerateComb();
     }
 
+    /// <summary>
+    /// Deserializes <see cref="Data"/> into the specified <see cref="IPolicyDataModel"/> type.
+    /// </summary>
     public T GetDataModel<T>() where T : IPolicyDataModel, new()
     {
         return CoreHelpers.LoadClassFromJsonData<T>(Data);
     }
 
+    /// <summary>
+    /// Serializes the specified <see cref="IPolicyDataModel"/> and stores it in <see cref="Data"/>.
+    /// </summary>
     public void SetDataModel<T>(T dataModel) where T : IPolicyDataModel, new()
     {
         Data = CoreHelpers.ClassToJsonData(dataModel);

--- a/src/Core/AdminConsole/Entities/Provider/Provider.cs
+++ b/src/Core/AdminConsole/Entities/Provider/Provider.cs
@@ -5,12 +5,21 @@ using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Utilities;
 
-#nullable enable
-
 namespace Bit.Core.AdminConsole.Entities.Provider;
 
+/// <summary>
+/// An entity that can manage multiple client organizations on behalf of their owners - for example, an IT
+/// services business.
+/// </summary>
+/// <remarks>
+/// Members are associated with the provider via <see cref="ProviderUser"/> and client organizations via
+/// <see cref="ProviderOrganization"/>. There are different types as providers as described in <see cref="ProviderType"/>.
+/// </remarks>
 public class Provider : ITableObject<Guid>, ISubscriber
 {
+    /// <summary>
+    /// A unique identifier for the provider.
+    /// </summary>
     public Guid Id { get; set; }
     /// <summary>
     /// This value is HTML encoded. For display purposes use the method DisplayName() instead.
@@ -20,46 +29,110 @@ public class Provider : ITableObject<Guid>, ISubscriber
     /// This value is HTML encoded. For display purposes use the method DisplayBusinessName() instead.
     /// </summary>
     public string? BusinessName { get; set; }
+    /// <summary>
+    /// The first line of the provider's business address.
+    /// </summary>
     public string? BusinessAddress1 { get; set; }
+    /// <summary>
+    /// The second line of the provider's business address.
+    /// </summary>
     public string? BusinessAddress2 { get; set; }
+    /// <summary>
+    /// The third line of the provider's business address.
+    /// </summary>
     public string? BusinessAddress3 { get; set; }
+    /// <summary>
+    /// The two-letter ISO country code of the provider's business address.
+    /// </summary>
     public string? BusinessCountry { get; set; }
+    /// <summary>
+    /// The provider's tax identification number.
+    /// </summary>
     public string? BusinessTaxNumber { get; set; }
+    /// <summary>
+    /// The billing email address for the provider.
+    /// </summary>
     public string? BillingEmail { get; set; }
+    /// <summary>
+    /// The billing phone number for the provider.
+    /// </summary>
     public string? BillingPhone { get; set; }
+    /// <summary>
+    /// The current status of the provider, representing its lifecycle state.
+    /// </summary>
     public ProviderStatusType Status { get; set; }
+    /// <summary>
+    /// If true, event logging is enabled for the provider.
+    /// </summary>
     public bool UseEvents { get; set; }
+    /// <summary>
+    /// The type of provider, which determines its capabilities and billing model.
+    /// </summary>
     public ProviderType Type { get; set; }
+    /// <summary>
+    /// If true, the provider is active. If false, the provider and its managed organizations are disabled.
+    /// </summary>
     public bool Enabled { get; set; } = true;
+    /// <summary>
+    /// The date the provider was created.
+    /// </summary>
     public DateTime CreationDate { get; internal set; } = DateTime.UtcNow;
+    /// <summary>
+    /// The date the provider was last updated.
+    /// </summary>
     public DateTime RevisionDate { get; internal set; } = DateTime.UtcNow;
+    /// <summary>
+    /// The payment gateway used for billing.
+    /// </summary>
     public GatewayType? Gateway { get; set; }
+    /// <summary>
+    /// The provider's customer ID in the payment gateway.
+    /// </summary>
     [MaxLength(50)]
     public string? GatewayCustomerId { get; set; }
+    /// <summary>
+    /// The provider's subscription ID in the payment gateway.
+    /// </summary>
     [MaxLength(50)]
     public string? GatewaySubscriptionId { get; set; }
+    /// <summary>
+    /// A discount ID applied to the provider's subscription in the payment gateway.
+    /// </summary>
     public string? DiscountId { get; set; }
 
+    /// <inheritdoc/>
     public string? BillingEmailAddress() => BillingEmail?.ToLowerInvariant().Trim();
 
+    /// <inheritdoc/>
     public string? BillingName() => DisplayBusinessName();
 
+    /// <inheritdoc/>
     public string? SubscriberName() => DisplayName();
 
+    /// <inheritdoc/>
     public string BraintreeCustomerIdPrefix() => "p";
 
+    /// <inheritdoc/>
     public string BraintreeIdField() => "provider_id";
 
+    /// <inheritdoc/>
     public string BraintreeCloudRegionField() => "region";
 
+    /// <inheritdoc/>
     public bool IsOrganization() => false;
 
+    /// <inheritdoc/>
     public bool IsUser() => false;
 
+    /// <inheritdoc/>
     public string SubscriberType() => "Provider";
 
+    /// <inheritdoc/>
     public bool IsExpired() => false;
 
+    /// <summary>
+    /// Initializes <see cref="Id"/> to a new COMB GUID.
+    /// </summary>
     public void SetNewId()
     {
         if (Id == default)

--- a/src/Core/AdminConsole/Entities/Provider/ProviderOrganization.cs
+++ b/src/Core/AdminConsole/Entities/Provider/ProviderOrganization.cs
@@ -1,20 +1,46 @@
 ﻿using Bit.Core.Entities;
 using Bit.Core.Utilities;
 
-#nullable enable
-
 namespace Bit.Core.AdminConsole.Entities.Provider;
 
+/// <summary>
+/// A join record linking a <see cref="Provider"/> to a client <see cref="Bit.Core.AdminConsole.Entities.Organization"/>
+/// that it manages.
+/// </summary>
 public class ProviderOrganization : ITableObject<Guid>
 {
+    /// <summary>
+    /// A unique identifier for the provider-organization relationship.
+    /// </summary>
     public Guid Id { get; set; }
+    /// <summary>
+    /// The ID of the <see cref="Provider"/> that manages the organization.
+    /// </summary>
     public Guid ProviderId { get; set; }
+    /// <summary>
+    /// The ID of the <see cref="Bit.Core.AdminConsole.Entities.Organization"/> being managed.
+    /// </summary>
     public Guid OrganizationId { get; set; }
+    /// <summary>
+    /// The organization's symmetric key, encrypted with the provider's symmetric key.
+    /// </summary>
     public string? Key { get; set; }
+    /// <summary>
+    /// A JSON blob of provider-specific configuration for this organization.
+    /// </summary>
     public string? Settings { get; set; }
+    /// <summary>
+    /// The date the provider-organization relationship was created.
+    /// </summary>
     public DateTime CreationDate { get; internal set; } = DateTime.UtcNow;
+    /// <summary>
+    /// The date the provider-organization relationship was last updated.
+    /// </summary>
     public DateTime RevisionDate { get; internal set; } = DateTime.UtcNow;
 
+    /// <summary>
+    /// Initializes <see cref="Id"/> to a new COMB GUID.
+    /// </summary>
     public void SetNewId()
     {
         if (Id == default)

--- a/src/Core/AdminConsole/Entities/Provider/ProviderUser.cs
+++ b/src/Core/AdminConsole/Entities/Provider/ProviderUser.cs
@@ -2,23 +2,62 @@
 using Bit.Core.Entities;
 using Bit.Core.Utilities;
 
-#nullable enable
-
 namespace Bit.Core.AdminConsole.Entities.Provider;
 
+/// <summary>
+/// Represents a user's membership in a <see cref="Provider"/>, including their role and status.
+/// Analogous to <see cref="Bit.Core.Entities.OrganizationUser"/> for organizations.
+/// </summary>
 public class ProviderUser : ITableObject<Guid>
 {
+    /// <summary>
+    /// A unique identifier for the provider user.
+    /// </summary>
     public Guid Id { get; set; }
+    /// <summary>
+    /// The ID of the <see cref="Provider"/> the user is a member of.
+    /// </summary>
     public Guid ProviderId { get; set; }
+    /// <summary>
+    /// The ID of the <see cref="Bit.Core.Entities.User"/> that is the member. NULL if the Status
+    /// is Invited, because the invitation has not yet been linked to a specific user account.
+    /// </summary>
     public Guid? UserId { get; set; }
+    /// <summary>
+    /// The email address of the invited user. NULL once the invitation has been accepted and the
+    /// provider user is linked to a <see cref="Bit.Core.Entities.User"/>.
+    /// </summary>
     public string? Email { get; set; }
+    /// <summary>
+    /// The provider's symmetric key, encrypted with the user's symmetric key. NULL if the user
+    /// has not yet confirmed their membership.
+    /// </summary>
     public string? Key { get; set; }
+    /// <summary>
+    /// The current status of the provider user, representing their progress in joining the provider.
+    /// </summary>
     public ProviderUserStatusType Status { get; set; }
+    /// <summary>
+    /// The user's role within the provider.
+    /// </summary>
     public ProviderUserType Type { get; set; }
+    /// <summary>
+    /// A JSON blob of permissions for the provider user.
+    /// Currently unused as custom permissions are not implemented for providers.
+    /// </summary>
     public string? Permissions { get; set; }
+    /// <summary>
+    /// The date the provider user was created.
+    /// </summary>
     public DateTime CreationDate { get; set; } = DateTime.UtcNow;
+    /// <summary>
+    /// The date the provider user was last updated.
+    /// </summary>
     public DateTime RevisionDate { get; set; } = DateTime.UtcNow;
 
+    /// <summary>
+    /// Initializes <see cref="Id"/> to a new COMB GUID.
+    /// </summary>
     public void SetNewId()
     {
         if (Id == default)

--- a/src/Core/AdminConsole/Enums/CollectionType.cs
+++ b/src/Core/AdminConsole/Enums/CollectionType.cs
@@ -1,7 +1,17 @@
 ﻿namespace Bit.Core.Enums;
 
+/// <summary>
+/// Represents the type of a <see cref="Bit.Core.Entities.Collection"/>, indicating how it was created and how it behaves.
+/// </summary>
 public enum CollectionType
 {
+    /// <summary>
+    /// A standard collection shared among organization members.
+    /// </summary>
     SharedCollection = 0,
+    /// <summary>
+    /// A personal "My Items" collection created for a specific organization member when the
+    /// Organization Data Ownership policy is enabled.
+    /// </summary>
     DefaultUserCollection = 1,
 }

--- a/src/Core/AdminConsole/Models/Data/CollectionAccessDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/CollectionAccessDetails.cs
@@ -3,9 +3,18 @@
 
 namespace Bit.Core.Models.Data;
 
+/// <summary>
+/// Access configuration for a collection, including all assigned groups and users and their permission levels.
+/// </summary>
 public class CollectionAccessDetails
 {
+    /// <summary>
+    /// The groups that have been assigned to this collection, including each group's permission level.
+    /// </summary>
     public IEnumerable<CollectionAccessSelection> Groups { get; set; }
+    /// <summary>
+    /// The organization users that have been directly assigned to this collection, including each user's permission level.
+    /// </summary>
     public IEnumerable<CollectionAccessSelection> Users { get; set; }
 }
 

--- a/src/Core/AdminConsole/Models/Data/CollectionAccessSelection.cs
+++ b/src/Core/AdminConsole/Models/Data/CollectionAccessSelection.cs
@@ -1,9 +1,27 @@
 ﻿namespace Bit.Core.Models.Data;
 
+/// <summary>
+/// Represents a user's or group's access to a collection, including their permission level.
+/// </summary>
 public class CollectionAccessSelection
 {
+    /// <summary>
+    /// The ID of the user (<see cref="Bit.Core.Entities.OrganizationUser"/>) or group
+    /// (<see cref="Bit.Core.AdminConsole.Entities.Group"/>) being granted access.
+    /// This is ambiguous without further context.
+    /// </summary>
     public Guid Id { get; set; }
+    /// <summary>
+    /// If true, the user or group can view items in the collection but cannot create, edit, or delete them.
+    /// </summary>
     public bool ReadOnly { get; set; }
+    /// <summary>
+    /// If true, the user or group cannot see password and TOTP fields for items in the collection.
+    /// </summary>
     public bool HidePasswords { get; set; }
+    /// <summary>
+    /// If true, the user or group can manage the collection itself — including renaming it,
+    /// deleting it, and assigning access for other users and groups.
+    /// </summary>
     public bool Manage { get; set; }
 }

--- a/src/Core/AdminConsole/Models/Data/CollectionAdminDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/CollectionAdminDetails.cs
@@ -7,7 +7,13 @@ namespace Bit.Core.Models.Data;
 /// </summary>
 public class CollectionAdminDetails : CollectionDetails
 {
+    /// <summary>
+    /// The groups that have been assigned to this collection, including each group's permission level.
+    /// </summary>
     public IEnumerable<CollectionAccessSelection> Groups { get; set; } = [];
+    /// <summary>
+    /// The organization users that have been directly assigned to this collection, including each user's permission level.
+    /// </summary>
     public IEnumerable<CollectionAccessSelection> Users { get; set; } = [];
 
     /// <summary>

--- a/src/Core/AdminConsole/Models/Data/CollectionDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/CollectionDetails.cs
@@ -3,11 +3,22 @@
 namespace Bit.Core.Models.Data;
 
 /// <summary>
-/// Collection information that includes permission details for a particular user
+/// Collection information that includes permission details for a particular user.
+/// The user ID is not recorded and should be clear from the context (usually the current authenticated user).
 /// </summary>
 public class CollectionDetails : Collection
 {
+    /// <summary>
+    /// If true, the user can view items in the collection but cannot create, edit, or delete them.
+    /// </summary>
     public bool ReadOnly { get; set; }
+    /// <summary>
+    /// If true, the user cannot see password and TOTP fields for items in the collection.
+    /// </summary>
     public bool HidePasswords { get; set; }
+    /// <summary>
+    /// If true, the user can manage the collection itself — including renaming it,
+    /// deleting it, and assigning access for other users and groups.
+    /// </summary>
     public bool Manage { get; set; }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-36421

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add xmldoc to AC Team entity models. This is a chore and some of it is rote, but there's useful and important stuff in there - e.g. how collection access assignments work, that the organization `Identifier` is the SSO identifier, what the collection management settings do.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
