### PR TITLE
[PM-34848] Add authorization to PreviewInvoiceController org endpoints

### DIFF
--- a/src/Api/Billing/Controllers/PreviewInvoiceController.cs
+++ b/src/Api/Billing/Controllers/PreviewInvoiceController.cs
@@ -1,5 +1,7 @@
-﻿using Bit.Api.Billing.Attributes;
+﻿using Bit.Api.AdminConsole.Authorization;
+using Bit.Api.Billing.Attributes;
 using Bit.Api.Billing.Models.Requests.PreviewInvoice;
+using Bit.Api.Billing.Models.Requirements;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.Billing.Organizations.Commands;
 using Bit.Core.Billing.Premium.Commands;
@@ -28,6 +30,7 @@ public class PreviewInvoiceController(
         return Handle(result.Map(pair => new { pair.Tax, pair.Total }));
     }
 
+    [Authorize<ManageOrganizationBillingRequirement>]
     [HttpPost("organizations/{organizationId:guid}/subscription/plan-change")]
     [InjectOrganization]
     public async Task<IResult> PreviewOrganizationSubscriptionPlanChangeTaxAsync(
@@ -39,6 +42,7 @@ public class PreviewInvoiceController(
         return Handle(result.Map(pair => new { pair.Tax, pair.Total }));
     }
 
+    [Authorize<ManageOrganizationBillingRequirement>]
     [HttpPut("organizations/{organizationId:guid}/subscription/update")]
     [InjectOrganization]
     public async Task<IResult> PreviewOrganizationSubscriptionUpdateTaxAsync(

--- a/test/Api.IntegrationTest/Billing/Controllers/PreviewInvoiceControllerTests.cs
+++ b/test/Api.IntegrationTest/Billing/Controllers/PreviewInvoiceControllerTests.cs
@@ -1,0 +1,244 @@
+using System.Net;
+using System.Net.Http.Json;
+using Bit.Api.IntegrationTest.Factories;
+using Bit.Api.IntegrationTest.Helpers;
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.Billing.Enums;
+using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data;
+using Xunit;
+
+namespace Bit.Api.IntegrationTest.Billing.Controllers;
+
+/// <summary>
+/// Integration tests for PreviewInvoiceController, focusing on the organization-scoped
+/// endpoints that take an organizationId in the route.
+///
+/// Reproduces VULN-501 (PM-34848): the [InjectOrganization] action filter loads an
+/// Organization from the route but performs no membership/role check, so any
+/// authenticated user could probe billing data for any organization.
+/// </summary>
+public class PreviewInvoiceControllerTests : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
+{
+    private readonly HttpClient _client;
+    private readonly ApiApplicationFactory _factory;
+    private readonly LoginHelper _loginHelper;
+
+    private Organization _organization = null!;
+    private OrganizationUser _ownerOrgUser = null!;
+    private string _ownerEmail = null!;
+
+    public PreviewInvoiceControllerTests(ApiApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = _factory.CreateClient();
+        _loginHelper = new LoginHelper(_factory, _client);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _ownerEmail = $"preview-invoice-owner-{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(_ownerEmail);
+
+        (_organization, _ownerOrgUser) = await OrganizationTestHelpers.SignUpAsync(
+            _factory,
+            plan: PlanType.Free,
+            ownerEmail: _ownerEmail);
+    }
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        return Task.CompletedTask;
+    }
+
+    #region plan-change authorization tests
+
+    /// <summary>
+    /// Reproduces VULN-501: a fully-unrelated authenticated user calls the plan-change
+    /// preview endpoint with a victim org's id. Authorization must reject the request
+    /// before [InjectOrganization] loads the org or the command reaches Stripe.
+    /// </summary>
+    [Fact]
+    public async Task PreviewPlanChangeTax_AsNonMember_ReturnsForbidden()
+    {
+        var attackerEmail = $"preview-invoice-attacker-{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(attackerEmail);
+        await _loginHelper.LoginAsync(attackerEmail);
+
+        var response = await _client.PostAsJsonAsync(
+            $"billing/preview-invoice/organizations/{_organization.Id}/subscription/plan-change",
+            BuildPlanChangePayload());
+
+        Assert.True(
+            response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized,
+            $"Expected 401 or 403 but got {(int)response.StatusCode} {response.StatusCode}. " +
+            "Non-org-members must not be able to preview plan-change tax for an org they don't belong to.");
+    }
+
+    /// <summary>
+    /// Cross-org variant: attacker owns their own org but is not a member of the victim's org.
+    /// Owning a different org must not grant access to the victim's billing data.
+    /// </summary>
+    [Fact]
+    public async Task PreviewPlanChangeTax_AsOwnerOfDifferentOrg_ReturnsForbidden()
+    {
+        var attackerEmail = $"preview-invoice-other-owner-{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(attackerEmail);
+        await OrganizationTestHelpers.SignUpAsync(
+            _factory,
+            plan: PlanType.Free,
+            ownerEmail: attackerEmail,
+            name: "Attacker Org",
+            billingEmail: attackerEmail);
+
+        await _loginHelper.LoginAsync(attackerEmail);
+
+        var response = await _client.PostAsJsonAsync(
+            $"billing/preview-invoice/organizations/{_organization.Id}/subscription/plan-change",
+            BuildPlanChangePayload());
+
+        Assert.True(
+            response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized,
+            $"Expected 401 or 403 but got {(int)response.StatusCode} {response.StatusCode}. " +
+            "Being an owner of a different org must not grant access to another org's billing data.");
+    }
+
+    /// <summary>
+    /// A plain User of the org (not Owner, not Provider) is below the
+    /// ManageOrganizationBillingRequirement bar and must be rejected.
+    /// </summary>
+    [Fact]
+    public async Task PreviewPlanChangeTax_AsRegularMember_ReturnsForbidden()
+    {
+        var (memberEmail, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.User,
+            permissions: new Permissions());
+        await _loginHelper.LoginAsync(memberEmail);
+
+        var response = await _client.PostAsJsonAsync(
+            $"billing/preview-invoice/organizations/{_organization.Id}/subscription/plan-change",
+            BuildPlanChangePayload());
+
+        Assert.True(
+            response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized,
+            $"Expected 401 or 403 but got {(int)response.StatusCode} {response.StatusCode}. " +
+            "Regular org members must not be able to preview plan-change tax.");
+    }
+
+    /// <summary>
+    /// Positive test: the org Owner satisfies the requirement and must pass authorization.
+    /// The downstream call may fail (Stripe is not wired up in integration tests),
+    /// but the response must NOT be 401/403.
+    /// </summary>
+    [Fact]
+    public async Task PreviewPlanChangeTax_AsOwner_IsNotForbidden()
+    {
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var response = await _client.PostAsJsonAsync(
+            $"billing/preview-invoice/organizations/{_organization.Id}/subscription/plan-change",
+            BuildPlanChangePayload());
+
+        Assert.True(
+            response.StatusCode is not HttpStatusCode.Forbidden and not HttpStatusCode.Unauthorized,
+            $"Expected to pass authorization but got {(int)response.StatusCode} {response.StatusCode}.");
+    }
+
+    #endregion
+
+    #region update authorization tests
+
+    /// <summary>
+    /// Reproduces the second half of VULN-501: the subscription/update preview endpoint
+    /// is called by a non-member. Even though the endpoint itself returns BadRequest for
+    /// orgs without an active Stripe subscription, that response leaks subscription
+    /// status — authorization must reject the request first.
+    /// </summary>
+    [Fact]
+    public async Task PreviewSubscriptionUpdateTax_AsNonMember_ReturnsForbidden()
+    {
+        var attackerEmail = $"preview-update-attacker-{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(attackerEmail);
+        await _loginHelper.LoginAsync(attackerEmail);
+
+        var response = await _client.PutAsJsonAsync(
+            $"billing/preview-invoice/organizations/{_organization.Id}/subscription/update",
+            BuildUpdatePayload());
+
+        Assert.True(
+            response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized,
+            $"Expected 401 or 403 but got {(int)response.StatusCode} {response.StatusCode}. " +
+            "Non-org-members must not be able to preview subscription updates for an org they don't belong to.");
+    }
+
+    [Fact]
+    public async Task PreviewSubscriptionUpdateTax_AsOwnerOfDifferentOrg_ReturnsForbidden()
+    {
+        var attackerEmail = $"preview-update-other-owner-{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(attackerEmail);
+        await OrganizationTestHelpers.SignUpAsync(
+            _factory,
+            plan: PlanType.Free,
+            ownerEmail: attackerEmail,
+            name: "Attacker Org 2",
+            billingEmail: attackerEmail);
+
+        await _loginHelper.LoginAsync(attackerEmail);
+
+        var response = await _client.PutAsJsonAsync(
+            $"billing/preview-invoice/organizations/{_organization.Id}/subscription/update",
+            BuildUpdatePayload());
+
+        Assert.True(
+            response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized,
+            $"Expected 401 or 403 but got {(int)response.StatusCode} {response.StatusCode}. " +
+            "Being an owner of a different org must not grant access to another org's billing data.");
+    }
+
+    [Fact]
+    public async Task PreviewSubscriptionUpdateTax_AsRegularMember_ReturnsForbidden()
+    {
+        var (memberEmail, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.User,
+            permissions: new Permissions());
+        await _loginHelper.LoginAsync(memberEmail);
+
+        var response = await _client.PutAsJsonAsync(
+            $"billing/preview-invoice/organizations/{_organization.Id}/subscription/update",
+            BuildUpdatePayload());
+
+        Assert.True(
+            response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized,
+            $"Expected 401 or 403 but got {(int)response.StatusCode} {response.StatusCode}. " +
+            "Regular org members must not be able to preview subscription updates.");
+    }
+
+    [Fact]
+    public async Task PreviewSubscriptionUpdateTax_AsOwner_IsNotForbidden()
+    {
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var response = await _client.PutAsJsonAsync(
+            $"billing/preview-invoice/organizations/{_organization.Id}/subscription/update",
+            BuildUpdatePayload());
+
+        Assert.True(
+            response.StatusCode is not HttpStatusCode.Forbidden and not HttpStatusCode.Unauthorized,
+            $"Expected to pass authorization but got {(int)response.StatusCode} {response.StatusCode}.");
+    }
+
+    #endregion
+
+    private static object BuildPlanChangePayload() => new
+    {
+        plan = new { tier = "Teams", cadence = "Annually" },
+        billingAddress = new { country = "US", postalCode = "10001" }
+    };
+
+    private static object BuildUpdatePayload() => new
+    {
+        update = new { passwordManager = new { seats = 10 } }
+    };
+}

--- a/test/Api.IntegrationTest/Billing/Controllers/PreviewInvoiceControllerTests.cs
+++ b/test/Api.IntegrationTest/Billing/Controllers/PreviewInvoiceControllerTests.cs
@@ -1,5 +1,4 @@
-using System.Net;
-using System.Net.Http.Json;
+﻿using System.Net;
 using Bit.Api.IntegrationTest.Factories;
 using Bit.Api.IntegrationTest.Helpers;
 using Bit.Core.AdminConsole.Entities;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34848

## 📔 Objective

Two organization-scoped endpoints on `PreviewInvoiceController` (`POST .../subscription/plan-change` and `PUT .../subscription/update`) had `[InjectOrganization]` but no authorization check. The action filter only loads the org from the route, so any authenticated user could call these endpoints with an arbitrary `organizationId` and have the server make Stripe API calls against the victim org's subscription, leaking tax/total amounts and subscription status.

Adds `[Authorize<ManageOrganizationBillingRequirement>]` to both endpoints, matching the pattern already in `OrganizationBillingVNextController`. Owners and Provider users continue to work; everyone else now gets 403.

Integration tests in `PreviewInvoiceControllerTests.cs` cover non-member, owner-of-different-org, regular-member, and Owner across both endpoints. The non-member tests fail against the pre-fix code and pass after the fix.