### PR TITLE
[PM-36568] Disable Pushed Authorization Request endpoint in Identity and SSO

### DIFF
--- a/bitwarden_license/src/Sso/Utilities/ServiceCollectionExtensions.cs
+++ b/bitwarden_license/src/Sso/Utilities/ServiceCollectionExtensions.cs
@@ -53,6 +53,7 @@ public static class ServiceCollectionExtensions
             .AddIdentityServer(options =>
             {
                 options.LicenseKey = globalSettings.IdentityServer.LicenseKey;
+                options.Endpoints.EnablePushedAuthorizationEndpoint = false;
                 options.IssuerUri = $"{issuerUri.Scheme}://{issuerUri.Host}";
                 if (env.IsDevelopment())
                 {

--- a/bitwarden_license/test/Sso.IntegrationTest/openid-configuration.json
+++ b/bitwarden_license/test/Sso.IntegrationTest/openid-configuration.json
@@ -10,8 +10,6 @@
   "introspection_endpoint": "http://localhost:51822/connect/introspect",
   "device_authorization_endpoint": "http://localhost:51822/connect/deviceauthorization",
   "backchannel_authentication_endpoint": "http://localhost:51822/connect/ciba",
-  "pushed_authorization_request_endpoint": "http://localhost:51822/connect/par",
-  "require_pushed_authorization_requests": false,
   "frontchannel_logout_supported": true,
   "frontchannel_logout_session_supported": true,
   "backchannel_logout_supported": true,
@@ -64,10 +62,18 @@
     "client_secret_basic",
     "client_secret_post"
   ],
-  "id_token_signing_alg_values_supported": ["RS256"],
-  "userinfo_signing_alg_values_supported": ["RS256"],
-  "introspection_signing_alg_values_supported": ["RS256"],
-  "subject_types_supported": ["public"],
+  "id_token_signing_alg_values_supported": [
+    "RS256"
+  ],
+  "userinfo_signing_alg_values_supported": [
+    "RS256"
+  ],
+  "introspection_signing_alg_values_supported": [
+    "RS256"
+  ],
+  "subject_types_supported": [
+    "public"
+  ],
   "code_challenge_methods_supported": [
     "plain",
     "S256"
@@ -91,7 +97,9 @@
     "select_account"
   ],
   "authorization_response_iss_parameter_supported": true,
-  "backchannel_token_delivery_modes_supported": ["poll"],
+  "backchannel_token_delivery_modes_supported": [
+    "poll"
+  ],
   "backchannel_user_code_parameter_supported": true,
   "dpop_signing_alg_values_supported": [
     "RS256",

--- a/bitwarden_license/test/Sso.IntegrationTest/openid-configuration.json
+++ b/bitwarden_license/test/Sso.IntegrationTest/openid-configuration.json
@@ -14,11 +14,7 @@
   "frontchannel_logout_session_supported": true,
   "backchannel_logout_supported": true,
   "backchannel_logout_session_supported": true,
-  "scopes_supported": [
-    "openid",
-    "profile",
-    "offline_access"
-  ],
+  "scopes_supported": ["openid", "profile", "offline_access"],
   "claims_supported": [
     "sub",
     "name",
@@ -53,31 +49,16 @@
     "code token",
     "code id_token token"
   ],
-  "response_modes_supported": [
-    "form_post",
-    "query",
-    "fragment"
-  ],
+  "response_modes_supported": ["form_post", "query", "fragment"],
   "token_endpoint_auth_methods_supported": [
     "client_secret_basic",
     "client_secret_post"
   ],
-  "id_token_signing_alg_values_supported": [
-    "RS256"
-  ],
-  "userinfo_signing_alg_values_supported": [
-    "RS256"
-  ],
-  "introspection_signing_alg_values_supported": [
-    "RS256"
-  ],
-  "subject_types_supported": [
-    "public"
-  ],
-  "code_challenge_methods_supported": [
-    "plain",
-    "S256"
-  ],
+  "id_token_signing_alg_values_supported": ["RS256"],
+  "userinfo_signing_alg_values_supported": ["RS256"],
+  "introspection_signing_alg_values_supported": ["RS256"],
+  "subject_types_supported": ["public"],
+  "code_challenge_methods_supported": ["plain", "S256"],
   "request_parameter_supported": true,
   "request_object_signing_alg_values_supported": [
     "RS256",
@@ -90,16 +71,9 @@
     "ES384",
     "ES512"
   ],
-  "prompt_values_supported": [
-    "none",
-    "login",
-    "consent",
-    "select_account"
-  ],
+  "prompt_values_supported": ["none", "login", "consent", "select_account"],
   "authorization_response_iss_parameter_supported": true,
-  "backchannel_token_delivery_modes_supported": [
-    "poll"
-  ],
+  "backchannel_token_delivery_modes_supported": ["poll"],
   "backchannel_user_code_parameter_supported": true,
   "dpop_signing_alg_values_supported": [
     "RS256",

--- a/src/Identity/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Identity/Utilities/ServiceCollectionExtensions.cs
@@ -43,6 +43,7 @@ public static class ServiceCollectionExtensions
                 options.Endpoints.EnableUserInfoEndpoint = false;
                 options.Endpoints.EnableCheckSessionEndpoint = false;
                 options.Endpoints.EnableTokenRevocationEndpoint = false;
+                options.Endpoints.EnablePushedAuthorizationEndpoint = false;
                 options.IssuerUri = $"{issuerUri.Scheme}://{issuerUri.Host}";
                 options.Caching.ClientStoreExpiration = new TimeSpan(0, 5, 0);
                 if (env.IsDevelopment())

--- a/test/Identity.IntegrationTest/openid-configuration.json
+++ b/test/Identity.IntegrationTest/openid-configuration.json
@@ -5,8 +5,6 @@
   "token_endpoint": "http://localhost:33656/connect/token",
   "device_authorization_endpoint": "http://localhost:33656/connect/deviceauthorization",
   "backchannel_authentication_endpoint": "http://localhost:33656/connect/ciba",
-  "pushed_authorization_request_endpoint": "http://localhost:33656/connect/par",
-  "require_pushed_authorization_requests": false,
   "scopes_supported": [
     "api",
     "api.push",
@@ -57,14 +55,25 @@
     "code token",
     "code id_token token"
   ],
-  "response_modes_supported": ["form_post", "query", "fragment"],
+  "response_modes_supported": [
+    "form_post",
+    "query",
+    "fragment"
+  ],
   "token_endpoint_auth_methods_supported": [
     "client_secret_basic",
     "client_secret_post"
   ],
-  "id_token_signing_alg_values_supported": ["RS256"],
-  "subject_types_supported": ["public"],
-  "code_challenge_methods_supported": ["plain", "S256"],
+  "id_token_signing_alg_values_supported": [
+    "RS256"
+  ],
+  "subject_types_supported": [
+    "public"
+  ],
+  "code_challenge_methods_supported": [
+    "plain",
+    "S256"
+  ],
   "request_parameter_supported": true,
   "request_object_signing_alg_values_supported": [
     "RS256",
@@ -77,9 +86,16 @@
     "ES384",
     "ES512"
   ],
-  "prompt_values_supported": ["none", "login", "consent", "select_account"],
+  "prompt_values_supported": [
+    "none",
+    "login",
+    "consent",
+    "select_account"
+  ],
   "authorization_response_iss_parameter_supported": true,
-  "backchannel_token_delivery_modes_supported": ["poll"],
+  "backchannel_token_delivery_modes_supported": [
+    "poll"
+  ],
   "backchannel_user_code_parameter_supported": true,
   "dpop_signing_alg_values_supported": [
     "RS256",

--- a/test/Identity.IntegrationTest/openid-configuration.json
+++ b/test/Identity.IntegrationTest/openid-configuration.json
@@ -55,25 +55,14 @@
     "code token",
     "code id_token token"
   ],
-  "response_modes_supported": [
-    "form_post",
-    "query",
-    "fragment"
-  ],
+  "response_modes_supported": ["form_post", "query", "fragment"],
   "token_endpoint_auth_methods_supported": [
     "client_secret_basic",
     "client_secret_post"
   ],
-  "id_token_signing_alg_values_supported": [
-    "RS256"
-  ],
-  "subject_types_supported": [
-    "public"
-  ],
-  "code_challenge_methods_supported": [
-    "plain",
-    "S256"
-  ],
+  "id_token_signing_alg_values_supported": ["RS256"],
+  "subject_types_supported": ["public"],
+  "code_challenge_methods_supported": ["plain", "S256"],
   "request_parameter_supported": true,
   "request_object_signing_alg_values_supported": [
     "RS256",
@@ -86,16 +75,9 @@
     "ES384",
     "ES512"
   ],
-  "prompt_values_supported": [
-    "none",
-    "login",
-    "consent",
-    "select_account"
-  ],
+  "prompt_values_supported": ["none", "login", "consent", "select_account"],
   "authorization_response_iss_parameter_supported": true,
-  "backchannel_token_delivery_modes_supported": [
-    "poll"
-  ],
+  "backchannel_token_delivery_modes_supported": ["poll"],
   "backchannel_user_code_parameter_supported": true,
   "dpop_signing_alg_values_supported": [
     "RS256",


### PR DESCRIPTION
## 🎟️ Tracking

[PM-36568](https://bitwarden.atlassian.net/browse/PM-36568)

## 📔 Objective

Explicitly disable the Pushed Authorization Request (PAR) endpoint on both the Identity and SSO IdentityServer hosts. Duende advertises `/connect/par` by default in its discovery document, but neither service uses or requires PAR. Turning the endpoint off removes the unused surface and prevents the endpoint from showing up in the well-known configuration.

Changes:
- `src/Identity/Utilities/ServiceCollectionExtensions.cs` — set `options.Endpoints.EnablePushedAuthorizationEndpoint = false`.
- `bitwarden_license/src/Sso/Utilities/ServiceCollectionExtensions.cs` — same.
- Updated the integration test `openid-configuration.json` snapshots for Identity and SSO to drop the PAR-related fields.

## 📸 Screenshots

https://github.com/user-attachments/assets/9e320963-54b9-4e57-9297-fc6459997061

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Contributing docs, code comments)
- Updated any reference files (e.g., `desktop_native/core/spec.json` for sdk-internal updates)

## 🦮 Reviewer guidelines

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes

[PM-36568]: https://bitwarden.atlassian.net/browse/PM-36568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ