### PR TITLE
[PM-35624] Fix EF GetCountByOnlyOwnerAsync

### DIFF
--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationUserRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationUserRepository.cs
@@ -326,9 +326,9 @@ public class OrganizationUserRepository : Repository<Core.Entities.OrganizationU
         {
             var dbContext = GetDatabaseContext(scope);
             return await dbContext.OrganizationUsers
-                .Where(ou => ou.Type == OrganizationUserType.Owner && ou.Status == OrganizationUserStatusType.Confirmed)
-                .GroupBy(ou => ou.OrganizationId)
-                .Where(g => g.Count() == 1 && g.Any(ou => ou.UserId == userId))
+                .Where(organizationUser => organizationUser.Type == OrganizationUserType.Owner && organizationUser.Status == OrganizationUserStatusType.Confirmed)
+                .GroupBy(organizationUser => organizationUser.OrganizationId)
+                .Where(grouping => grouping.Count() == 1 && grouping.Any(ou => ou.UserId == userId))
                 .CountAsync();
         }
     }

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationUserRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationUserRepository.cs
@@ -327,9 +327,8 @@ public class OrganizationUserRepository : Repository<Core.Entities.OrganizationU
             var dbContext = GetDatabaseContext(scope);
             return await dbContext.OrganizationUsers
                 .Where(ou => ou.Type == OrganizationUserType.Owner && ou.Status == OrganizationUserStatusType.Confirmed)
-                .GroupBy(ou => ou.UserId)
-                .Select(g => new { UserId = g.Key, ConfirmedOwnerCount = g.Count() })
-                .Where(oc => oc.UserId == userId && oc.ConfirmedOwnerCount == 1)
+                .GroupBy(ou => ou.OrganizationId)
+                .Where(g => g.Count() == 1 && g.Any(ou => ou.UserId == userId))
                 .CountAsync();
         }
     }

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/OrganizationUserRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/OrganizationUserRepositoryTests.cs
@@ -17,7 +17,180 @@ namespace Bit.Infrastructure.IntegrationTest.AdminConsole.Repositories.Organizat
 
 public class OrganizationUserRepositoryTests
 {
-    [DatabaseTheory, DatabaseData]
+    [Theory, DatabaseData]
+    public async Task GetCountByOnlyOwnerAsync_WhenUserIsNotInAnyOrg_ReturnsZero(
+        IOrganizationUserRepository organizationUserRepository,
+        IUserRepository userRepository)
+    {
+        // Arrange
+        var user = await userRepository.CreateTestUserAsync();
+
+        // Act
+        var count = await organizationUserRepository.GetCountByOnlyOwnerAsync(user.Id);
+
+        // Assert
+        Assert.Equal(0, count);
+    }
+
+    [Theory, DatabaseData]
+    public async Task GetCountByOnlyOwnerAsync_WhenUserIsSoleConfirmedOwner_ReturnsOne(
+        IOrganizationUserRepository organizationUserRepository,
+        IOrganizationRepository organizationRepository,
+        IUserRepository userRepository)
+    {
+        // Arrange
+        var user = await userRepository.CreateTestUserAsync();
+        var org = await organizationRepository.CreateTestOrganizationAsync();
+        await organizationUserRepository.CreateAsync(new OrganizationUser
+        {
+            OrganizationId = org.Id,
+            UserId = user.Id,
+            Status = OrganizationUserStatusType.Confirmed,
+            Type = OrganizationUserType.Owner,
+        });
+
+        // Act
+        var count = await organizationUserRepository.GetCountByOnlyOwnerAsync(user.Id);
+
+        // Assert
+        Assert.Equal(1, count);
+    }
+
+    [Theory, DatabaseData]
+    public async Task GetCountByOnlyOwnerAsync_WhenOrgHasMultipleConfirmedOwners_ReturnsZero(
+        IOrganizationUserRepository organizationUserRepository,
+        IOrganizationRepository organizationRepository,
+        IUserRepository userRepository)
+    {
+        // Arrange
+        var user = await userRepository.CreateTestUserAsync();
+        var otherUser = await userRepository.CreateTestUserAsync();
+        var org = await organizationRepository.CreateTestOrganizationAsync();
+        await organizationUserRepository.CreateAsync(new OrganizationUser
+        {
+            OrganizationId = org.Id,
+            UserId = user.Id,
+            Status = OrganizationUserStatusType.Confirmed,
+            Type = OrganizationUserType.Owner,
+        });
+        await organizationUserRepository.CreateAsync(new OrganizationUser
+        {
+            OrganizationId = org.Id,
+            UserId = otherUser.Id,
+            Status = OrganizationUserStatusType.Confirmed,
+            Type = OrganizationUserType.Owner,
+        });
+
+        // Act
+        var count = await organizationUserRepository.GetCountByOnlyOwnerAsync(user.Id);
+
+        // Assert
+        Assert.Equal(0, count);
+    }
+
+    [Theory, DatabaseData]
+    public async Task GetCountByOnlyOwnerAsync_WhenUserIsSoleOwnerInOneOrgAndSharedOwnerInAnother_ReturnsOne(
+        IOrganizationUserRepository organizationUserRepository,
+        IOrganizationRepository organizationRepository,
+        IUserRepository userRepository)
+    {
+        // Arrange
+        var user = await userRepository.CreateTestUserAsync();
+        var otherUser = await userRepository.CreateTestUserAsync();
+
+        // Org1: user is the sole confirmed owner
+        var org1 = await organizationRepository.CreateTestOrganizationAsync();
+        await organizationUserRepository.CreateAsync(new OrganizationUser
+        {
+            OrganizationId = org1.Id,
+            UserId = user.Id,
+            Status = OrganizationUserStatusType.Confirmed,
+            Type = OrganizationUserType.Owner,
+        });
+
+        // Org2: user shares ownership with another confirmed owner
+        var org2 = await organizationRepository.CreateTestOrganizationAsync();
+        await organizationUserRepository.CreateAsync(new OrganizationUser
+        {
+            OrganizationId = org2.Id,
+            UserId = user.Id,
+            Status = OrganizationUserStatusType.Confirmed,
+            Type = OrganizationUserType.Owner,
+        });
+        await organizationUserRepository.CreateAsync(new OrganizationUser
+        {
+            OrganizationId = org2.Id,
+            UserId = otherUser.Id,
+            Status = OrganizationUserStatusType.Confirmed,
+            Type = OrganizationUserType.Owner,
+        });
+
+        // Act
+        var count = await organizationUserRepository.GetCountByOnlyOwnerAsync(user.Id);
+
+        // Assert — only org1 qualifies; org2 is excluded because it has two owners
+        Assert.Equal(1, count);
+    }
+
+    [Theory, DatabaseData]
+    public async Task GetCountByOnlyOwnerAsync_WhenOwnerIsNotConfirmed_ReturnsZero(
+        IOrganizationUserRepository organizationUserRepository,
+        IOrganizationRepository organizationRepository,
+        IUserRepository userRepository)
+    {
+        // Arrange
+        var user = await userRepository.CreateTestUserAsync();
+        var org = await organizationRepository.CreateTestOrganizationAsync();
+        await organizationUserRepository.CreateAsync(new OrganizationUser
+        {
+            OrganizationId = org.Id,
+            UserId = user.Id,
+            Status = OrganizationUserStatusType.Invited,
+            Type = OrganizationUserType.Owner,
+        });
+
+        // Act
+        var count = await organizationUserRepository.GetCountByOnlyOwnerAsync(user.Id);
+
+        // Assert
+        Assert.Equal(0, count);
+    }
+
+    [Theory, DatabaseData]
+    public async Task GetCountByOnlyOwnerAsync_WhenUserIsSoleOwnerOfMultipleOrgs_ReturnsCorrectCount(
+        IOrganizationUserRepository organizationUserRepository,
+        IOrganizationRepository organizationRepository,
+        IUserRepository userRepository)
+    {
+        // Arrange
+        var user = await userRepository.CreateTestUserAsync();
+        var org1 = await organizationRepository.CreateTestOrganizationAsync();
+        var org2 = await organizationRepository.CreateTestOrganizationAsync();
+        await organizationUserRepository.CreateAsync(new OrganizationUser
+        {
+            OrganizationId = org1.Id,
+            UserId = user.Id,
+            Status = OrganizationUserStatusType.Confirmed,
+            Type = OrganizationUserType.Owner,
+        });
+        await organizationUserRepository.CreateAsync(new OrganizationUser
+        {
+            OrganizationId = org2.Id,
+            UserId = user.Id,
+            Status = OrganizationUserStatusType.Confirmed,
+            Type = OrganizationUserType.Owner,
+        });
+
+        // Act
+        var count = await organizationUserRepository.GetCountByOnlyOwnerAsync(user.Id);
+
+        // Assert
+        Assert.Equal(2, count);
+    }
+
+
+
+    [Theory, DatabaseData]
     public async Task DeleteAsync_Works(IUserRepository userRepository,
         IOrganizationRepository organizationRepository,
         IOrganizationUserRepository organizationUserRepository)
@@ -52,7 +225,7 @@ public class OrganizationUserRepositoryTests
         Assert.NotEqual(newUser.AccountRevisionDate, user.AccountRevisionDate);
     }
 
-    [DatabaseTheory, DatabaseData]
+    [Theory, DatabaseData]
     public async Task DeleteManyAsync_Migrates_UserDefaultCollection(IUserRepository userRepository,
         ICollectionRepository collectionRepository,
         IOrganizationRepository organizationRepository,
@@ -154,7 +327,7 @@ public class OrganizationUserRepositoryTests
         Assert.Equal(user2.Email, updatedCollection2.DefaultUserCollectionEmail);
     }
 
-    [DatabaseTheory, DatabaseData]
+    [Theory, DatabaseData]
     public async Task DeleteAsync_Migrates_UserDefaultCollection(IUserRepository userRepository,
         ICollectionRepository collectionRepository,
         IOrganizationRepository organizationRepository,
@@ -217,7 +390,7 @@ public class OrganizationUserRepositoryTests
     }
 
 
-    [DatabaseTheory, DatabaseData]
+    [Theory, DatabaseData]
     public async Task DeleteManyAsync_Works(IUserRepository userRepository,
         IOrganizationRepository organizationRepository,
         IOrganizationUserRepository organizationUserRepository)
@@ -276,7 +449,7 @@ public class OrganizationUserRepositoryTests
         Assert.NotEqual(updatedUser2.AccountRevisionDate, user2.AccountRevisionDate);
     }
 
-    [DatabaseTheory, DatabaseData]
+    [Theory, DatabaseData]
     public async Task GetManyAccountRecoveryDetailsByOrganizationUserAsync_Works(IUserRepository userRepository,
         IOrganizationRepository organizationRepository,
         IOrganizationUserRepository organizationUserRepository)
@@ -367,7 +540,7 @@ public class OrganizationUserRepositoryTests
             r.MasterPasswordSalt == "master-salt2");
     }
 
-    [DatabaseTheory, DatabaseData]
+    [Theory, DatabaseData]
     public async Task GetManyDetailsByOrganizationAsync_WithIncludeCollections_ExcludesDefaultCollections(
         IUserRepository userRepository,
         IOrganizationRepository organizationRepository,
@@ -448,7 +621,7 @@ public class OrganizationUserRepositoryTests
         Assert.DoesNotContain(orgUserWithCollections.Collections, c => c.Id == defaultCollection.Id);
     }
 
-    [DatabaseTheory, DatabaseData]
+    [Theory, DatabaseData]
     public async Task GetDetailsByIdWithSharedCollectionsAsync_ExcludesDefaultCollections(
         IUserRepository userRepository,
         IOrganizationRepository organizationRepository,
@@ -525,7 +698,7 @@ public class OrganizationUserRepositoryTests
         Assert.DoesNotContain(collections, c => c.Id == defaultCollection.Id);
     }
 
-    [DatabaseTheory, DatabaseData]
+    [Theory, DatabaseData]
     public async Task GetManyDetailsByUserAsync_Works(IUserRepository userRepository,
         IOrganizationRepository organizationRepository,
         IOrganizationUserRepository organizationUserRepository,
@@ -682,7 +855,7 @@ public class OrganizationUserRepositoryTests
         Assert.Null(orgWithoutSsoDetails.SsoConfig);
     }
 
-    [DatabaseTheory, DatabaseData]
+    [Theory, DatabaseData]
     public async Task CreateManyAsync_NoId_Works(IOrganizationRepository organizationRepository,
         IUserRepository userRepository,
         IOrganizationUserRepository organizationUserRepository)
@@ -716,7 +889,7 @@ public class OrganizationUserRepositoryTests
         Assert.Equal(createdOrgUserIds.ToHashSet(), readOrgUserIds.ToHashSet());
     }
 
-    [DatabaseTheory, DatabaseData]
+    [Theory, DatabaseData]
     public async Task CreateManyAsync_WithId_Works(IOrganizationRepository organizationRepository,
         IUserRepository userRepository,
         IOrganizationUserRepository organizationUserRepository)
@@ -751,7 +924,7 @@ public class OrganizationUserRepositoryTests
         Assert.Equal(createdOrgUserIds.ToHashSet(), readOrgUserIds.ToHashSet());
     }
 
-    [DatabaseTheory, DatabaseData]
+    [Theory, DatabaseData]
     public async Task CreateManyAsync_WithCollectionAndGroup_SaveSuccessfully(
         IOrganizationUserRepository organizationUserRepository,
         IOrganizationRepository organizationRepository,
@@ -942,7 +1115,7 @@ public class OrganizationUserRepositoryTests
         Assert.Equal(group3.Id, group3Database.First());
     }
 
-    [DatabaseTheory, DatabaseData]
+    [Theory, DatabaseData]
     public async Task GetManyDetailsByOrganizationAsync_vNext_WithoutGroupsAndCollections_ReturnsBasicUserDetails(
         IUserRepository userRepository,
         IOrganizationRepository organizationRepository,
@@ -1042,7 +1215,7 @@ public class OrganizationUserRepositoryTests
         Assert.Empty(user2Result.Collections);
     }
 
-    [DatabaseTheory, DatabaseData]
+    [Theory, DatabaseData]
     public async Task GetManyDetailsByOrganizationAsync_vNext_WithGroupsAndCollections_ReturnsUserDetailsWithBoth(
         IUserRepository userRepository,
         IOrganizationRepository organizationRepository,
@@ -1193,7 +1366,7 @@ public class OrganizationUserRepositoryTests
         Assert.DoesNotContain(user1Result.Collections, c => c.Id == defaultUserCollection.Id);
     }
 
-    [DatabaseTheory, DatabaseData]
+    [Theory, DatabaseData]
     public async Task DeleteAsync_WithNullEmail_DoesNotSetDefaultUserCollectionEmail(IUserRepository userRepository,
         ICollectionRepository collectionRepository,
         IOrganizationRepository organizationRepository,
@@ -1250,7 +1423,7 @@ public class OrganizationUserRepositoryTests
         Assert.Equal(user.Email, updatedCollection.DefaultUserCollectionEmail);
     }
 
-    [DatabaseTheory, DatabaseData]
+    [Theory, DatabaseData]
     public async Task DeleteAsync_WithEmptyEmail_DoesNotSetDefaultUserCollectionEmail(IUserRepository userRepository,
         ICollectionRepository collectionRepository,
         IOrganizationRepository organizationRepository,
@@ -1307,7 +1480,7 @@ public class OrganizationUserRepositoryTests
         Assert.Equal(user.Email, updatedCollection.DefaultUserCollectionEmail);
     }
 
-    [DatabaseTheory, DatabaseData]
+    [Theory, DatabaseData]
     public async Task ReplaceAsync_PreservesDefaultCollections_WhenUpdatingCollectionAccess(
         IUserRepository userRepository,
         IOrganizationRepository organizationRepository,
@@ -1478,7 +1651,7 @@ public class OrganizationUserRepositoryTests
         Assert.False(result);
     }
 
-    [DatabaseTheory, DatabaseData]
+    [Theory, DatabaseData]
     public async Task UpdateGroupsAsync_BumpsGroupRevisionDate(
         IGroupRepository groupRepository,
         IUserRepository userRepository,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35624

## 📔 Objective
1. Fix the EF query to mirror the stored procedure behavior.
2. Add unit tests to cover edge cases.

Added test cases
  1. A user with no org memberships at all.                                                                                                         
  2. A user who is the only confirmed owner of one org.
  3. A user who shares ownership with another confirmed owner in the same org.                                                                     
  4. A user who is the sole owner of one org but shares ownership in another org.
  5. A user who is an Owner but has only been invited, not confirmed.                                                                       
  6. A user who is the sole confirmed owner of two separate orgs.


## 📸 Screenshots

I ran a sanity check by executing the tests against the old code to confirm they fail, which validates that this change is the fix.

<img width="2678" height="1548" alt="image" src="https://github.com/user-attachments/assets/d6bf2540-30f2-4c3b-a768-93dca5aa460c" />
