### PR TITLE
[PM-34389] Add refresh endpoint for organization invite links

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationInviteLinksController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationInviteLinksController.cs
@@ -17,7 +17,8 @@ public class OrganizationInviteLinksController(
     ICreateOrganizationInviteLinkCommand createOrganizationInviteLinkCommand,
     IGetOrganizationInviteLinkQuery getOrganizationInviteLinkQuery,
     IUpdateOrganizationInviteLinkCommand updateOrganizationInviteLinkCommand,
-    IDeleteOrganizationInviteLinkCommand deleteOrganizationInviteLinkCommand)
+    IDeleteOrganizationInviteLinkCommand deleteOrganizationInviteLinkCommand,
+    IRefreshOrganizationInviteLinkCommand refreshOrganizationInviteLinkCommand)
     : BaseAdminConsoleController
 {
     [HttpGet("")]
@@ -60,5 +61,16 @@ public class OrganizationInviteLinksController(
     {
         var result = await deleteOrganizationInviteLinkCommand.DeleteAsync(orgId);
         return Handle(result);
+    }
+
+    [HttpPost("refresh")]
+    [Authorize<ManageUsersRequirement>]
+    public async Task<IResult> Refresh(Guid orgId, [FromBody] RefreshOrganizationInviteLinkRequestModel model)
+    {
+        var result = await refreshOrganizationInviteLinkCommand.RefreshAsync(
+            model.ToCommandRequest(orgId));
+
+        return Handle(result, link =>
+            TypedResults.Ok(new OrganizationInviteLinkResponseModel(link)));
     }
 }

--- a/src/Api/AdminConsole/Models/Request/Organizations/RefreshOrganizationInviteLinkRequestModel.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/RefreshOrganizationInviteLinkRequestModel.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
+using Bit.Core.Utilities;
+
+namespace Bit.Api.AdminConsole.Models.Request.Organizations;
+
+public class RefreshOrganizationInviteLinkRequestModel
+{
+    /// <summary>
+    /// The invite key encrypted with the organization key.
+    /// </summary>
+    [Required]
+    [EncryptedString]
+    public required string EncryptedInviteKey { get; set; }
+
+    /// <summary>
+    /// The organization key encrypted for the invite link. Currently unused; will be populated in a future stage.
+    /// </summary>
+    [EncryptedString]
+    public string? EncryptedOrgKey { get; set; }
+
+    public RefreshOrganizationInviteLinkRequest ToCommandRequest(Guid organizationId) => new()
+    {
+        OrganizationId = organizationId,
+        EncryptedInviteKey = EncryptedInviteKey,
+        EncryptedOrgKey = EncryptedOrgKey,
+    };
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Errors.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Errors.cs
@@ -13,6 +13,3 @@ public record InviteLinkNotAvailable()
 
 public record InviteLinkNotFound()
     : NotFoundError("Invite link not found.");
-
-public record InviteLinkEncryptedKeyRequired()
-    : BadRequestError("An encrypted invite key is required.");

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Errors.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Errors.cs
@@ -13,3 +13,6 @@ public record InviteLinkNotAvailable()
 
 public record InviteLinkNotFound()
     : NotFoundError("Invite link not found.");
+
+public record InviteLinkEncryptedKeyRequired()
+    : BadRequestError("An encrypted invite key is required.");

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Interfaces/IRefreshOrganizationInviteLinkCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Interfaces/IRefreshOrganizationInviteLinkCommand.cs
@@ -6,14 +6,9 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
 public interface IRefreshOrganizationInviteLinkCommand
 {
     /// <summary>
-    /// Refreshes the invite link for the specified organization by replacing the existing link
-    /// with a new one (new <c>Id</c>, <c>Code</c>, and <c>EncryptedInviteKey</c>). The existing
-    /// <c>AllowedDomains</c> carry over. The previous link's URL stops working immediately.
+    /// Replaces the invite link for the specified organization with a new one. The existing allowed domains carry over.
     /// </summary>
-    /// <param name="request">The organization id and the new encrypted invite key.</param>
-    /// <returns>
-    /// The new <see cref="OrganizationInviteLink"/>, or an error if the invite link feature is
-    /// not available for the organization or no existing invite link is found.
-    /// </returns>
+    /// <param name="request">The organization ID and the encryption keys.</param>
+    /// <returns>The new <see cref="OrganizationInviteLink"/>, or an error if the feature is unavailable or no existing link is found.</returns>
     Task<CommandResult<OrganizationInviteLink>> RefreshAsync(RefreshOrganizationInviteLinkRequest request);
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Interfaces/IRefreshOrganizationInviteLinkCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Interfaces/IRefreshOrganizationInviteLinkCommand.cs
@@ -1,0 +1,19 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Utilities.v2.Results;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
+
+public interface IRefreshOrganizationInviteLinkCommand
+{
+    /// <summary>
+    /// Refreshes the invite link for the specified organization by replacing the existing link
+    /// with a new one (new <c>Id</c>, <c>Code</c>, and <c>EncryptedInviteKey</c>). The existing
+    /// <c>AllowedDomains</c> carry over. The previous link's URL stops working immediately.
+    /// </summary>
+    /// <param name="request">The organization id and the new encrypted invite key.</param>
+    /// <returns>
+    /// The new <see cref="OrganizationInviteLink"/>, or an error if the invite link feature is
+    /// not available for the organization or no existing invite link is found.
+    /// </returns>
+    Task<CommandResult<OrganizationInviteLink>> RefreshAsync(RefreshOrganizationInviteLinkRequest request);
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/RefreshOrganizationInviteLinkCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/RefreshOrganizationInviteLinkCommand.cs
@@ -1,0 +1,52 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.AdminConsole.Utilities.v2.Results;
+using Bit.Core.Services;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
+
+public class RefreshOrganizationInviteLinkCommand(
+    IOrganizationInviteLinkRepository organizationInviteLinkRepository,
+    IApplicationCacheService applicationCacheService,
+    TimeProvider timeProvider)
+    : IRefreshOrganizationInviteLinkCommand
+{
+    public async Task<CommandResult<OrganizationInviteLink>> RefreshAsync(
+        RefreshOrganizationInviteLinkRequest request)
+    {
+        if (!await OrganizationHasInviteLinksAbilityAsync(request.OrganizationId))
+        {
+            return new InviteLinkNotAvailable();
+        }
+
+        var existing = await organizationInviteLinkRepository.GetByOrganizationIdAsync(request.OrganizationId);
+        if (existing is null)
+        {
+            return new InviteLinkNotFound();
+        }
+
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        var newLink = new OrganizationInviteLink
+        {
+            OrganizationId = existing.OrganizationId,
+            AllowedDomains = existing.AllowedDomains,
+            EncryptedInviteKey = request.EncryptedInviteKey,
+            EncryptedOrgKey = request.EncryptedOrgKey,
+            CreationDate = now,
+            RevisionDate = now,
+        };
+        newLink.SetNewId();
+
+        await organizationInviteLinkRepository.DeleteAsync(existing);
+        await organizationInviteLinkRepository.CreateAsync(newLink);
+
+        return newLink;
+    }
+
+    private async Task<bool> OrganizationHasInviteLinksAbilityAsync(Guid organizationId)
+    {
+        var ability = await applicationCacheService.GetOrganizationAbilityAsync(organizationId);
+        return ability is not null && ability.UseInviteLinks;
+    }
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/RefreshOrganizationInviteLinkCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/RefreshOrganizationInviteLinkCommand.cs
@@ -38,8 +38,7 @@ public class RefreshOrganizationInviteLinkCommand(
         };
         newLink.SetNewId();
 
-        await organizationInviteLinkRepository.DeleteAsync(existing);
-        await organizationInviteLinkRepository.CreateAsync(newLink);
+        await organizationInviteLinkRepository.RefreshAsync(existing, newLink);
 
         return newLink;
     }

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/RefreshOrganizationInviteLinkRequest.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/RefreshOrganizationInviteLinkRequest.cs
@@ -1,0 +1,12 @@
+﻿namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
+
+public record RefreshOrganizationInviteLinkRequest
+{
+    public required Guid OrganizationId { get; init; }
+    public required string EncryptedInviteKey { get; init; }
+
+    /// <summary>
+    /// The organization key encrypted for the invite link. Currently unused; will be populated in a future stage.
+    /// </summary>
+    public string? EncryptedOrgKey { get; init; }
+}

--- a/src/Core/AdminConsole/Repositories/IOrganizationInviteLinkRepository.cs
+++ b/src/Core/AdminConsole/Repositories/IOrganizationInviteLinkRepository.cs
@@ -18,4 +18,11 @@ public interface IOrganizationInviteLinkRepository : IRepository<OrganizationInv
     /// <param name="organizationId">The ID of the organization.</param>
     /// <returns>The organization invite link if found, otherwise null.</returns>
     Task<OrganizationInviteLink?> GetByOrganizationIdAsync(Guid organizationId);
+
+    /// <summary>
+    /// Atomically deletes <paramref name="oldLink"/> and inserts <paramref name="newLink"/> in a single transaction.
+    /// If the transaction fails (e.g. constraint violation on the insert), the delete is rolled back so the
+    /// organization is never left without an invite link mid-operation.
+    /// </summary>
+    Task RefreshAsync(OrganizationInviteLink oldLink, OrganizationInviteLink newLink);
 }

--- a/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
+++ b/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
@@ -197,6 +197,7 @@ public static class OrganizationServiceCollectionExtensions
         services.TryAddScoped<IGetOrganizationInviteLinkQuery, GetOrganizationInviteLinkQuery>();
         services.TryAddScoped<IUpdateOrganizationInviteLinkCommand, UpdateOrganizationInviteLinkCommand>();
         services.TryAddScoped<IDeleteOrganizationInviteLinkCommand, DeleteOrganizationInviteLinkCommand>();
+        services.TryAddScoped<IRefreshOrganizationInviteLinkCommand, RefreshOrganizationInviteLinkCommand>();
     }
 
     private static void AddOrganizationDomainCommandsQueries(this IServiceCollection services)

--- a/src/Infrastructure.Dapper/AdminConsole/Repositories/OrganizationInviteLinkRepository.cs
+++ b/src/Infrastructure.Dapper/AdminConsole/Repositories/OrganizationInviteLinkRepository.cs
@@ -38,4 +38,42 @@ public class OrganizationInviteLinkRepository
             commandType: CommandType.StoredProcedure);
         return results.SingleOrDefault();
     }
+
+    public async Task RefreshAsync(OrganizationInviteLink oldLink, OrganizationInviteLink newLink)
+    {
+        await using var connection = new SqlConnection(ConnectionString);
+        await connection.OpenAsync();
+        await using var transaction = await connection.BeginTransactionAsync();
+        try
+        {
+            await connection.ExecuteAsync(
+                $"[{Schema}].[{Table}_DeleteById]",
+                new { Id = oldLink.Id },
+                transaction: transaction,
+                commandType: CommandType.StoredProcedure);
+
+            await connection.ExecuteAsync(
+                $"[{Schema}].[{Table}_Create]",
+                new
+                {
+                    newLink.Id,
+                    newLink.Code,
+                    newLink.OrganizationId,
+                    newLink.AllowedDomains,
+                    newLink.EncryptedInviteKey,
+                    newLink.EncryptedOrgKey,
+                    newLink.CreationDate,
+                    newLink.RevisionDate,
+                },
+                transaction: transaction,
+                commandType: CommandType.StoredProcedure);
+
+            await transaction.CommitAsync();
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
+    }
 }

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationInviteLinkRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationInviteLinkRepository.cs
@@ -36,4 +36,22 @@ public class OrganizationInviteLinkRepository
             .FirstOrDefaultAsync(e => e.OrganizationId == organizationId);
         return Mapper.Map<AdminConsoleEntities.OrganizationInviteLink>(result);
     }
+
+    public async Task RefreshAsync(
+        AdminConsoleEntities.OrganizationInviteLink oldLink,
+        AdminConsoleEntities.OrganizationInviteLink newLink)
+    {
+        using var scope = ServiceScopeFactory.CreateScope();
+        var dbContext = GetDatabaseContext(scope);
+        await using var transaction = await dbContext.Database.BeginTransactionAsync();
+
+        await dbContext.OrganizationInviteLinks
+            .Where(e => e.Id == oldLink.Id)
+            .ExecuteDeleteAsync();
+
+        var efNew = Mapper.Map<OrganizationInviteLink>(newLink);
+        await dbContext.OrganizationInviteLinks.AddAsync(efNew);
+        await dbContext.SaveChangesAsync();
+        await transaction.CommitAsync();
+    }
 }

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
@@ -171,4 +171,40 @@ public class OrganizationInviteLinksControllerTests : IClassFixture<ApiApplicati
         var getResponse = await _client.GetAsync($"/organizations/{_organization.Id}/invite-link");
         Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
     }
+
+    [Fact]
+    public async Task Refresh_AsOwner_ReplacesLink()
+    {
+        var createRequest = new CreateOrganizationInviteLinkRequestModel
+        {
+            AllowedDomains = ["acme.com", "example.com"],
+            EncryptedInviteKey = _validEncryptedKey,
+        };
+        var createResponse = await _client.PostAsJsonAsync(
+            $"/organizations/{_organization.Id}/invite-link", createRequest);
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+        var original = await createResponse.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
+        Assert.NotNull(original);
+
+        var refreshRequest = new RefreshOrganizationInviteLinkRequestModel
+        {
+            EncryptedInviteKey = _validEncryptedKey,
+        };
+        var refreshResponse = await _client.PostAsJsonAsync(
+            $"/organizations/{_organization.Id}/invite-link/refresh", refreshRequest);
+
+        Assert.Equal(HttpStatusCode.OK, refreshResponse.StatusCode);
+        var refreshed = await refreshResponse.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
+        Assert.NotNull(refreshed);
+        Assert.NotEqual(original.Id, refreshed.Id);
+        Assert.NotEqual(original.Code, refreshed.Code);
+        Assert.Equal(original.AllowedDomains, refreshed.AllowedDomains);
+        Assert.Equal(_organization.Id, refreshed.OrganizationId);
+
+        var getResponse = await _client.GetAsync($"/organizations/{_organization.Id}/invite-link");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        var current = await getResponse.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
+        Assert.NotNull(current);
+        Assert.Equal(refreshed.Id, current.Id);
+    }
 }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/RefreshOrganizationInviteLinkCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/RefreshOrganizationInviteLinkCommandTests.cs
@@ -1,0 +1,121 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Models.Data.Organizations;
+using Bit.Core.Services;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.InviteLinks;
+
+[SutProviderCustomize]
+public class RefreshOrganizationInviteLinkCommandTests
+{
+    [Theory, BitAutoData]
+    public async Task RefreshAsync_WithValidInput_Success(
+        Guid organizationId,
+        OrganizationInviteLink existingLink,
+        SutProvider<RefreshOrganizationInviteLinkCommand> sutProvider)
+    {
+        existingLink.OrganizationId = organizationId;
+        existingLink.SetAllowedDomains(["acme.com", "example.com"]);
+
+        SetupAbility(sutProvider, organizationId);
+        sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .GetByOrganizationIdAsync(organizationId)
+            .Returns(existingLink);
+
+        var request = new RefreshOrganizationInviteLinkRequest
+        {
+            OrganizationId = organizationId,
+            EncryptedInviteKey = "new-encrypted-key-value",
+        };
+
+        var result = await sutProvider.Sut.RefreshAsync(request);
+
+        Assert.True(result.IsSuccess);
+        var link = result.AsSuccess;
+        Assert.Equal(organizationId, link.OrganizationId);
+        Assert.NotEqual(Guid.Empty, link.Id);
+        Assert.NotEqual(existingLink.Id, link.Id);
+        Assert.NotEqual(existingLink.Code, link.Code);
+        Assert.Equal(request.EncryptedInviteKey, link.EncryptedInviteKey);
+        Assert.Equal(existingLink.AllowedDomains, link.AllowedDomains);
+        Assert.Contains("acme.com", link.GetAllowedDomains());
+        Assert.Contains("example.com", link.GetAllowedDomains());
+
+        await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .Received(1)
+            .DeleteAsync(existingLink);
+        await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .Received(1)
+            .CreateAsync(link);
+    }
+
+    [Theory, BitAutoData]
+    public async Task RefreshAsync_WithNoExistingLink_ReturnsNotFoundError(
+        Guid organizationId,
+        SutProvider<RefreshOrganizationInviteLinkCommand> sutProvider)
+    {
+        SetupAbility(sutProvider, organizationId);
+        sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .GetByOrganizationIdAsync(organizationId)
+            .Returns((OrganizationInviteLink?)null);
+
+        var request = new RefreshOrganizationInviteLinkRequest
+        {
+            OrganizationId = organizationId,
+            EncryptedInviteKey = "some-encrypted-key",
+        };
+
+        var result = await sutProvider.Sut.RefreshAsync(request);
+
+        Assert.True(result.IsError);
+        Assert.IsType<InviteLinkNotFound>(result.AsError);
+
+        await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .DeleteAsync(default!);
+        await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .CreateAsync(default!);
+    }
+
+    [Theory, BitAutoData]
+    public async Task RefreshAsync_WithoutUseInviteLinksAbility_ReturnsBadRequestError(
+        Guid organizationId,
+        SutProvider<RefreshOrganizationInviteLinkCommand> sutProvider)
+    {
+        SetupAbility(sutProvider, organizationId, useInviteLinks: false);
+
+        var request = new RefreshOrganizationInviteLinkRequest
+        {
+            OrganizationId = organizationId,
+            EncryptedInviteKey = "some-encrypted-key",
+        };
+
+        var result = await sutProvider.Sut.RefreshAsync(request);
+
+        Assert.True(result.IsError);
+        Assert.IsType<InviteLinkNotAvailable>(result.AsError);
+
+        await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .DeleteAsync(default!);
+        await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .CreateAsync(default!);
+    }
+
+    private static void SetupAbility(
+        SutProvider<RefreshOrganizationInviteLinkCommand> sutProvider,
+        Guid organizationId,
+        bool useInviteLinks = true)
+    {
+        sutProvider.GetDependency<IApplicationCacheService>()
+            .GetOrganizationAbilityAsync(organizationId)
+            .Returns(new OrganizationAbility { UseInviteLinks = useInviteLinks });
+    }
+}

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/RefreshOrganizationInviteLinkCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/RefreshOrganizationInviteLinkCommandTests.cs
@@ -48,10 +48,7 @@ public class RefreshOrganizationInviteLinkCommandTests
 
         await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
             .Received(1)
-            .DeleteAsync(existingLink);
-        await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
-            .Received(1)
-            .CreateAsync(link);
+            .RefreshAsync(existingLink, link);
     }
 
     [Theory, BitAutoData]
@@ -77,10 +74,7 @@ public class RefreshOrganizationInviteLinkCommandTests
 
         await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
             .DidNotReceiveWithAnyArgs()
-            .DeleteAsync(default!);
-        await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
-            .DidNotReceiveWithAnyArgs()
-            .CreateAsync(default!);
+            .RefreshAsync(default!, default!);
     }
 
     [Theory, BitAutoData]
@@ -103,10 +97,7 @@ public class RefreshOrganizationInviteLinkCommandTests
 
         await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
             .DidNotReceiveWithAnyArgs()
-            .DeleteAsync(default!);
-        await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
-            .DidNotReceiveWithAnyArgs()
-            .CreateAsync(default!);
+            .RefreshAsync(default!, default!);
     }
 
     private static void SetupAbility(

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationInviteLinkRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationInviteLinkRepositoryTests.cs
@@ -152,4 +152,63 @@ public class OrganizationInviteLinkRepositoryTests
         var result = await repository.GetByIdAsync(link.Id);
         Assert.Null(result);
     }
+
+    [Theory, DatabaseData]
+    public async Task RefreshAsync_ReplacesLink(
+        IOrganizationInviteLinkRepository repository,
+        IOrganizationRepository organizationRepository)
+    {
+        var organization = await organizationRepository.CreateTestOrganizationAsync();
+        var oldLink = await repository.CreateTestOrganizationInviteLinkAsync(organization);
+
+        var newLink = new OrganizationInviteLink
+        {
+            Code = Guid.NewGuid(),
+            OrganizationId = organization.Id,
+            AllowedDomains = oldLink.AllowedDomains,
+            EncryptedInviteKey = "new-encrypted-key",
+            CreationDate = DateTime.UtcNow,
+            RevisionDate = DateTime.UtcNow,
+        };
+        newLink.SetNewId();
+
+        await repository.RefreshAsync(oldLink, newLink);
+
+        Assert.Null(await repository.GetByIdAsync(oldLink.Id));
+        var current = await repository.GetByOrganizationIdAsync(organization.Id);
+        Assert.NotNull(current);
+        Assert.Equal(newLink.Id, current.Id);
+        Assert.Equal(newLink.Code, current.Code);
+        Assert.Equal(newLink.EncryptedInviteKey, current.EncryptedInviteKey);
+    }
+
+    [Theory, DatabaseData]
+    public async Task RefreshAsync_WhenInsertViolatesUniqueCode_RollsBackDelete(
+        IOrganizationInviteLinkRepository repository,
+        IOrganizationRepository organizationRepository)
+    {
+        var org1 = await organizationRepository.CreateTestOrganizationAsync(identifier: "org1");
+        var org2 = await organizationRepository.CreateTestOrganizationAsync(identifier: "org2");
+
+        var org1Link = await repository.CreateTestOrganizationInviteLinkAsync(org1);
+        var org2Link = await repository.CreateTestOrganizationInviteLinkAsync(org2);
+
+        var conflictingLink = new OrganizationInviteLink
+        {
+            Code = org2Link.Code,
+            OrganizationId = org1.Id,
+            AllowedDomains = org1Link.AllowedDomains,
+            EncryptedInviteKey = "new-encrypted-key",
+            CreationDate = DateTime.UtcNow,
+            RevisionDate = DateTime.UtcNow,
+        };
+        conflictingLink.SetNewId();
+
+        await Assert.ThrowsAnyAsync<Exception>(
+            () => repository.RefreshAsync(org1Link, conflictingLink));
+
+        var surviving = await repository.GetByIdAsync(org1Link.Id);
+        Assert.NotNull(surviving);
+        Assert.Equal(org1Link.Id, surviving.Id);
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34389

## 📔 Objective

Adds `POST /organizations/{orgId}/invite-link/refresh` that replaces an existing invite link with a new one (new ID, code, and encryption key) while preserving the allowed domains.

[Clients PR](https://github.com/bitwarden/clients/pull/20522).
