### PR TITLE
PM-34680 serialize values to prevent injection

### DIFF
--- a/src/Core/Dirt/Utilities/IntegrationTemplateProcessor.cs
+++ b/src/Core/Dirt/Utilities/IntegrationTemplateProcessor.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace Bit.Core.Dirt.Utilities;
 
@@ -24,7 +25,8 @@ public static partial class IntegrationTemplateProcessor
                 return match.Value;  // Return unknown keys as keys - i.e. #Key#
             }
 
-            return property.GetValue(values)?.ToString() ?? string.Empty;
+            var value = property.GetValue(values)?.ToString() ?? string.Empty;
+            return JsonSerializer.Serialize(value).Trim('"'); // Escape value and remove surrounding quotes
         });
     }
 

--- a/test/Core.Test/Dirt/Utilities/IntegrationTemplateProcessorTests.cs
+++ b/test/Core.Test/Dirt/Utilities/IntegrationTemplateProcessorTests.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using System.Text.Json;
 using Bit.Core.Dirt.Utilities;
 using Bit.Core.Models.Data;
 using Bit.Test.Common.AutoFixture.Attributes;
@@ -78,6 +79,16 @@ public class IntegrationTemplateProcessorTests
         var expectedEmpty = "";
 
         Assert.Equal(expectedEmpty, IntegrationTemplateProcessor.ReplaceTokens(emptyTemplate, eventMessage));
+    }
+
+    [Theory, BitAutoData]
+    public void ReplaceTokens_JsonInjection_ReturnsJsonEscapedString(EventMessage eventMessage)
+    {
+        var template = "Event #Type# and UserName #UserId#.";
+        var expected = $"Event {JsonSerializer.Serialize(eventMessage.Type.ToString()).Trim('"')} and UserName {JsonSerializer.Serialize(eventMessage.UserId).Trim('"')}.";
+        var result = IntegrationTemplateProcessor.ReplaceTokens(template, eventMessage);
+
+        Assert.Equal(expected, result);
     }
 
     [Theory]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34680

## 📔 Objective

Serialize the value of Event Tag to prevent injected tags from being processed


## 📸 Screenshots

<img width="2020" height="938" alt="image" src="https://github.com/user-attachments/assets/63f67108-6b98-48ab-9549-31d12fe4b11a" />
