### PR TITLE
PM-36416 - Implement master password reprompt seeding

### DIFF
--- a/util/Seeder/Factories/CardCipherSeeder.cs
+++ b/util/Seeder/Factories/CardCipherSeeder.cs
@@ -16,7 +16,8 @@ internal static class CardCipherSeeder
             Notes = options.Notes,
             Type = CipherTypes.Card,
             Card = options.Card,
-            Fields = options.Fields
+            Fields = options.Fields,
+            Reprompt = (int)options.Reprompt
         };
 
         var encrypted = CipherEncryption.Encrypt(cipherView, options.EncryptionKey!);

--- a/util/Seeder/Factories/CipherComposer.cs
+++ b/util/Seeder/Factories/CipherComposer.cs
@@ -23,15 +23,16 @@ internal static class CipherComposer
         GeneratorContext generator,
         Distribution<PasswordStrength> passwordDistribution,
         Guid? organizationId = null,
-        Guid? userId = null)
+        Guid? userId = null,
+        CipherRepromptType reprompt = CipherRepromptType.None)
     {
         return cipherType switch
         {
-            CipherType.Login => ComposeLogin(index, encryptionKey, companies, generator, passwordDistribution, organizationId, userId),
-            CipherType.Card => ComposeCard(index, encryptionKey, generator, organizationId, userId),
-            CipherType.Identity => ComposeIdentity(index, encryptionKey, generator, organizationId, userId),
-            CipherType.SecureNote => ComposeSecureNote(index, encryptionKey, generator, organizationId, userId),
-            CipherType.SSHKey => ComposeSshKey(index, encryptionKey, organizationId, userId),
+            CipherType.Login => ComposeLogin(index, encryptionKey, companies, generator, passwordDistribution, organizationId, userId, reprompt),
+            CipherType.Card => ComposeCard(index, encryptionKey, generator, organizationId, userId, reprompt),
+            CipherType.Identity => ComposeIdentity(index, encryptionKey, generator, organizationId, userId, reprompt),
+            CipherType.SecureNote => ComposeSecureNote(index, encryptionKey, generator, organizationId, userId, reprompt),
+            CipherType.SSHKey => ComposeSshKey(index, encryptionKey, organizationId, userId, reprompt),
             _ => throw new ArgumentException($"Unsupported cipher type: {cipherType}")
         };
     }
@@ -43,7 +44,8 @@ internal static class CipherComposer
         GeneratorContext generator,
         Distribution<PasswordStrength> passwordDistribution,
         Guid? organizationId = null,
-        Guid? userId = null)
+        Guid? userId = null,
+        CipherRepromptType reprompt = CipherRepromptType.None)
     {
         var company = companies[index % companies.Length];
         var uri = $"https://{company.Domain}";
@@ -54,6 +56,7 @@ internal static class CipherComposer
             EncryptionKey = encryptionKey,
             OrganizationId = organizationId,
             UserId = userId,
+            Reprompt = reprompt,
             Login = new LoginViewDto
             {
                 Username = generator.Username.GenerateByIndex(index, totalHint: generator.CipherCount, domain: company.Domain),
@@ -68,7 +71,8 @@ internal static class CipherComposer
         string encryptionKey,
         GeneratorContext generator,
         Guid? organizationId = null,
-        Guid? userId = null)
+        Guid? userId = null,
+        CipherRepromptType reprompt = CipherRepromptType.None)
     {
         var card = generator.Card.GenerateByIndex(index);
         return CardCipherSeeder.Create(new CipherSeed
@@ -78,6 +82,7 @@ internal static class CipherComposer
             EncryptionKey = encryptionKey,
             OrganizationId = organizationId,
             UserId = userId,
+            Reprompt = reprompt,
             Card = card
         });
     }
@@ -87,7 +92,8 @@ internal static class CipherComposer
         string encryptionKey,
         GeneratorContext generator,
         Guid? organizationId = null,
-        Guid? userId = null)
+        Guid? userId = null,
+        CipherRepromptType reprompt = CipherRepromptType.None)
     {
         var identity = generator.Identity.GenerateByIndex(index);
         var name = $"{identity.FirstName} {identity.LastName}";
@@ -102,6 +108,7 @@ internal static class CipherComposer
             EncryptionKey = encryptionKey,
             OrganizationId = organizationId,
             UserId = userId,
+            Reprompt = reprompt,
             Identity = identity
         });
     }
@@ -111,7 +118,8 @@ internal static class CipherComposer
         string encryptionKey,
         GeneratorContext generator,
         Guid? organizationId = null,
-        Guid? userId = null)
+        Guid? userId = null,
+        CipherRepromptType reprompt = CipherRepromptType.None)
     {
         var (name, notes) = generator.SecureNote.GenerateByIndex(index);
         return SecureNoteCipherSeeder.Create(new CipherSeed
@@ -121,7 +129,8 @@ internal static class CipherComposer
             Notes = notes,
             EncryptionKey = encryptionKey,
             OrganizationId = organizationId,
-            UserId = userId
+            UserId = userId,
+            Reprompt = reprompt
         });
     }
 
@@ -129,7 +138,8 @@ internal static class CipherComposer
         int index,
         string encryptionKey,
         Guid? organizationId = null,
-        Guid? userId = null)
+        Guid? userId = null,
+        CipherRepromptType reprompt = CipherRepromptType.None)
     {
         var sshKey = SshKeyDataGenerator.GenerateByIndex(index);
         return SshKeyCipherSeeder.Create(new CipherSeed
@@ -139,6 +149,7 @@ internal static class CipherComposer
             EncryptionKey = encryptionKey,
             OrganizationId = organizationId,
             UserId = userId,
+            Reprompt = reprompt,
             SshKey = sshKey
         });
     }

--- a/util/Seeder/Factories/IdentityCipherSeeder.cs
+++ b/util/Seeder/Factories/IdentityCipherSeeder.cs
@@ -16,7 +16,8 @@ internal static class IdentityCipherSeeder
             Notes = options.Notes,
             Type = CipherTypes.Identity,
             Identity = options.Identity,
-            Fields = options.Fields
+            Fields = options.Fields,
+            Reprompt = (int)options.Reprompt
         };
 
         var encrypted = CipherEncryption.Encrypt(cipherView, options.EncryptionKey!);

--- a/util/Seeder/Factories/LoginCipherSeeder.cs
+++ b/util/Seeder/Factories/LoginCipherSeeder.cs
@@ -19,7 +19,8 @@ internal static class LoginCipherSeeder
             Notes = options.Notes,
             Type = CipherTypes.Login,
             Login = options.Login,
-            Fields = options.Fields
+            Fields = options.Fields,
+            Reprompt = (int)options.Reprompt
         };
 
         var encrypted = CipherEncryption.Encrypt(cipherView, options.EncryptionKey!);

--- a/util/Seeder/Factories/SecureNoteCipherSeeder.cs
+++ b/util/Seeder/Factories/SecureNoteCipherSeeder.cs
@@ -16,7 +16,8 @@ internal static class SecureNoteCipherSeeder
             Notes = options.Notes,
             Type = CipherTypes.SecureNote,
             SecureNote = options.SecureNote ?? new SecureNoteViewDto { Type = 0 },
-            Fields = options.Fields
+            Fields = options.Fields,
+            Reprompt = (int)options.Reprompt
         };
 
         var encrypted = CipherEncryption.Encrypt(cipherView, options.EncryptionKey!);

--- a/util/Seeder/Factories/SshKeyCipherSeeder.cs
+++ b/util/Seeder/Factories/SshKeyCipherSeeder.cs
@@ -16,7 +16,8 @@ internal static class SshKeyCipherSeeder
             Notes = options.Notes,
             Type = CipherTypes.SshKey,
             SshKey = options.SshKey,
-            Fields = options.Fields
+            Fields = options.Fields,
+            Reprompt = (int)options.Reprompt
         };
 
         var encrypted = CipherEncryption.Encrypt(cipherView, options.EncryptionKey!);

--- a/util/Seeder/Models/SeedPreset.cs
+++ b/util/Seeder/Models/SeedPreset.cs
@@ -60,11 +60,13 @@ internal record SeedPresetCiphers
     public string? Fixture { get; init; }
     public int Count { get; init; }
     public bool AssignFolders { get; init; }
+    public int RepromptEveryNthCipher { get; init; }
 }
 
 internal record SeedPresetPersonalCiphers
 {
     public int CountPerUser { get; init; }
+    public int RepromptEveryNthCipher { get; init; }
 }
 
 internal record SeedCollectionAssignment

--- a/util/Seeder/Pipeline/BulkCommitter.cs
+++ b/util/Seeder/Pipeline/BulkCommitter.cs
@@ -3,6 +3,7 @@ using Bit.Infrastructure.EntityFramework.Repositories;
 using LinqToDB.Data;
 using LinqToDB.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using EfCipher = Bit.Infrastructure.EntityFramework.Vault.Models.Cipher;
 using EfCollection = Bit.Infrastructure.EntityFramework.AdminConsole.Models.Collection;
 using EfCollectionGroup = Bit.Infrastructure.EntityFramework.AdminConsole.Models.CollectionGroup;
 using EfCollectionUser = Bit.Infrastructure.EntityFramework.AdminConsole.Models.CollectionUser;
@@ -22,7 +23,8 @@ namespace Bit.Seeder.Pipeline;
 /// <remarks>
 /// Entities are committed in foreign-key-safe order (Organizations → OrgApiKeys → Users → OrgUsers → … → Folders → Ciphers).
 /// Most Core entities require AutoMapper conversion to their EF counterparts before insert;
-/// a few (Cipher, CollectionCipher) share the same type across layers and copy directly.
+/// a few (CollectionCipher) share the same type across layers and copy directly.
+/// Cipher uses a seeder-internal <see cref="CipherBulkRow"/> projection — see <see cref="BulkInsertCiphers"/>.
 /// Each list is cleared after insert so the context is ready for the next pipeline run.
 ///
 /// CollectionUser and CollectionGroup require an explicit table name in BulkCopyOptions because
@@ -58,7 +60,7 @@ internal sealed class BulkCommitter(DatabaseContext db, IMapper mapper)
 
         MapCopyAndClear<Core.Vault.Entities.Folder, EfFolder>(context.Folders);
 
-        CopyAndClear(context.Ciphers);
+        BulkInsertCiphers(context.Ciphers);
 
         CopyAndClear(context.CollectionCiphers);
     }
@@ -113,5 +115,80 @@ internal sealed class BulkCommitter(DatabaseContext db, IMapper mapper)
 
         db.BulkCopy(entities);
         entities.Clear();
+    }
+
+    /// <summary>
+    /// Bulk-inserts ciphers via a <see cref="CipherBulkRow"/> projection so the
+    /// <c>Reprompt</c> column survives BulkCopy. LinqToDB's bulk path drops <c>CipherRepromptType?</c>
+    /// on the EF model; projecting to <c>byte?</c> avoids the value-converter pipeline.
+    /// Keep <see cref="CipherBulkRow"/> in sync with the <c>dbo.Cipher</c> schema.
+    /// </summary>
+    private void BulkInsertCiphers(List<Core.Vault.Entities.Cipher> ciphers)
+    {
+        if (ciphers.Count is 0)
+        {
+            return;
+        }
+
+        var tableName = GetTableName<EfCipher>();
+        var rows = ciphers.Select(c => new CipherBulkRow
+        {
+            Id = c.Id,
+            UserId = c.UserId,
+            OrganizationId = c.OrganizationId,
+            Type = (short)c.Type,
+            Data = c.Data,
+            Favorites = c.Favorites,
+            Folders = c.Folders,
+            Attachments = c.Attachments,
+            CreationDate = c.CreationDate,
+            RevisionDate = c.RevisionDate,
+            DeletedDate = c.DeletedDate,
+            Archives = c.Archives,
+            Reprompt = c.Reprompt.HasValue ? (byte)c.Reprompt.Value : null,
+            Key = c.Key,
+        });
+
+        var options = tableName is not null
+            ? new BulkCopyOptions { TableName = tableName }
+            : new BulkCopyOptions();
+
+        db.BulkCopy(options, rows);
+        ciphers.Clear();
+    }
+
+    /// <summary>
+    /// Seeder-internal projection of <c>dbo.Cipher</c> with primitive column types.
+    /// Property names match DB column names exactly so LinqToDB maps them by convention.
+    /// </summary>
+    private sealed class CipherBulkRow
+    {
+        public Guid Id { get; init; }
+
+        public Guid? UserId { get; init; }
+
+        public Guid? OrganizationId { get; init; }
+
+        public short Type { get; init; }
+
+        public string? Data { get; init; }
+
+        public string? Favorites { get; init; }
+
+        public string? Folders { get; init; }
+
+        public string? Attachments { get; init; }
+
+        public DateTime CreationDate { get; init; }
+
+        public DateTime RevisionDate { get; init; }
+
+        public DateTime? DeletedDate { get; init; }
+
+        public string? Archives { get; init; }
+
+        public byte? Reprompt { get; init; }
+
+        public string? Key { get; init; }
     }
 }

--- a/util/Seeder/Pipeline/PresetLoader.cs
+++ b/util/Seeder/Pipeline/PresetLoader.cs
@@ -67,7 +67,7 @@ internal static class PresetLoader
         }
         else if (preset.Ciphers is { Count: > 0 })
         {
-            builder.AddPersonalCiphers(preset.Ciphers.Count);
+            builder.AddPersonalCiphers(preset.Ciphers.Count, repromptEveryNthCipher: preset.Ciphers.RepromptEveryNthCipher);
         }
 
         if (preset.FolderAssignments is { Count: > 0 })
@@ -168,7 +168,7 @@ internal static class PresetLoader
         }
         else if (preset.Ciphers is not null && preset.Ciphers.Count > 0)
         {
-            builder.AddCiphers(preset.Ciphers.Count, assignFolders: preset.Ciphers.AssignFolders, density: density);
+            builder.AddCiphers(preset.Ciphers.Count, assignFolders: preset.Ciphers.AssignFolders, density: density, repromptEveryNthCipher: preset.Ciphers.RepromptEveryNthCipher);
         }
 
         if (hasCollectionAssignments)
@@ -188,7 +188,7 @@ internal static class PresetLoader
 
         if (preset.PersonalCiphers is not null && preset.PersonalCiphers.CountPerUser > 0)
         {
-            builder.AddPersonalCiphers(preset.PersonalCiphers.CountPerUser, density: density);
+            builder.AddPersonalCiphers(preset.PersonalCiphers.CountPerUser, density: density, repromptEveryNthCipher: preset.PersonalCiphers.RepromptEveryNthCipher);
         }
         else if (density?.PersonalCipherDistribution is not null)
         {

--- a/util/Seeder/Pipeline/RecipeBuilderExtensions.cs
+++ b/util/Seeder/Pipeline/RecipeBuilderExtensions.cs
@@ -316,6 +316,7 @@ public static class RecipeBuilderExtensions
     /// <param name="pwDist">Distribution of password strengths. Uses realistic defaults if null.</param>
     /// <param name="assignFolders">When true, assigns ciphers to user folders round-robin.</param>
     /// <param name="density">Optional density profile for cipher-to-collection assignment control</param>
+    /// <param name="repromptEveryNthCipher">When &gt; 0, sets Reprompt=Password on every Nth generated cipher. 0 disables.</param>
     /// <returns>The builder for fluent chaining</returns>
     /// <exception cref="InvalidOperationException">Thrown when UseCiphers() was already called</exception>
     public static RecipeBuilder AddCiphers(
@@ -324,7 +325,8 @@ public static class RecipeBuilderExtensions
         Distribution<CipherType>? typeDist = null,
         Distribution<PasswordStrength>? pwDist = null,
         bool assignFolders = false,
-        DensityProfile? density = null)
+        DensityProfile? density = null,
+        int repromptEveryNthCipher = 0)
     {
         if (builder.HasFixtureCiphers)
         {
@@ -337,7 +339,7 @@ public static class RecipeBuilderExtensions
         {
             builder.HasCipherFolderAssignment = true;
         }
-        builder.AddStep(_ => new GenerateCiphersStep(count, typeDist, pwDist, assignFolders, density));
+        builder.AddStep(_ => new GenerateCiphersStep(count, typeDist, pwDist, assignFolders, density, repromptEveryNthCipher));
         return builder;
     }
 
@@ -427,13 +429,15 @@ public static class RecipeBuilderExtensions
     /// <param name="typeDist">Distribution of cipher types. Uses realistic defaults if null.</param>
     /// <param name="pwDist">Distribution of password strengths. Uses realistic defaults if null.</param>
     /// <param name="density">Optional density profile for per-user personal cipher count distribution</param>
+    /// <param name="repromptEveryNthCipher">When &gt; 0, sets Reprompt=Password on every Nth generated personal cipher. 0 disables.</param>
     /// <returns>The builder for fluent chaining</returns>
     /// <exception cref="InvalidOperationException">Thrown when no users exist</exception>
     public static RecipeBuilder AddPersonalCiphers(
         this RecipeBuilder builder, int countPerUser,
         Distribution<CipherType>? typeDist = null,
         Distribution<PasswordStrength>? pwDist = null,
-        DensityProfile? density = null)
+        DensityProfile? density = null,
+        int repromptEveryNthCipher = 0)
     {
         if (!builder.HasRosterUsers && !builder.HasGeneratedUsers && !builder.HasIndividualUser)
         {
@@ -442,7 +446,7 @@ public static class RecipeBuilderExtensions
         }
 
         builder.HasPersonalCiphers = true;
-        builder.AddStep(_ => new GeneratePersonalCiphersStep(countPerUser, typeDist, pwDist, density));
+        builder.AddStep(_ => new GeneratePersonalCiphersStep(countPerUser, typeDist, pwDist, density, repromptEveryNthCipher));
         return builder;
     }
 

--- a/util/Seeder/Scenes/UserCardCipherScene.cs
+++ b/util/Seeder/Scenes/UserCardCipherScene.cs
@@ -24,6 +24,7 @@ public class UserCardCipherScene(IUserRepository userRepository, ICipherReposito
         public required string ExpYear { get; set; }
         public required string Code { get; set; }
         public string? Notes { get; set; }
+        public bool Reprompt { get; set; }
     }
 
     public class Result
@@ -56,6 +57,10 @@ public class UserCardCipherScene(IUserRepository userRepository, ICipherReposito
             UserId = request.UserId,
             Card = card
         });
+        if (request.Reprompt)
+        {
+            cipher.Reprompt = CipherRepromptType.Password;
+        }
 
         await cipherRepository.CreateAsync(cipher);
 

--- a/util/Seeder/Scenes/UserIdentityCipherScene.cs
+++ b/util/Seeder/Scenes/UserIdentityCipherScene.cs
@@ -23,6 +23,7 @@ public class UserIdentityCipherScene(IUserRepository userRepository, ICipherRepo
         public string? MiddleName { get; set; }
         public string? LastName { get; set; }
         public string? Notes { get; set; }
+        public bool Reprompt { get; set; }
     }
 
     public class Result
@@ -54,6 +55,10 @@ public class UserIdentityCipherScene(IUserRepository userRepository, ICipherRepo
             UserId = request.UserId,
             Identity = identity
         });
+        if (request.Reprompt)
+        {
+            cipher.Reprompt = CipherRepromptType.Password;
+        }
 
         await cipherRepository.CreateAsync(cipher);
 

--- a/util/Seeder/Scenes/UserSecureNoteCipherScene.cs
+++ b/util/Seeder/Scenes/UserSecureNoteCipherScene.cs
@@ -19,6 +19,7 @@ public class UserSecureNoteCipherScene(IUserRepository userRepository, ICipherRe
         [Required]
         public required string Name { get; set; }
         public string? Notes { get; set; }
+        public bool Reprompt { get; set; }
     }
 
     public class Result
@@ -42,6 +43,10 @@ public class UserSecureNoteCipherScene(IUserRepository userRepository, ICipherRe
             EncryptionKey = request.UserKeyB64,
             UserId = request.UserId
         });
+        if (request.Reprompt)
+        {
+            cipher.Reprompt = CipherRepromptType.Password;
+        }
 
         await cipherRepository.CreateAsync(cipher);
 

--- a/util/Seeder/Seeds/docs/presets.md
+++ b/util/Seeder/Seeds/docs/presets.md
@@ -2,6 +2,14 @@
 
 Complete catalog of all seeder presets, organized by purpose. Use `--mangle` to avoid collisions with existing data.
 
+## Cipher generation knobs
+
+These options apply to any preset that uses generated (count-based) ciphers — QA, Scale, and Individual alike. Add them to the `"ciphers"` or `"personalCiphers"` block in the preset JSON. Schema reference: `Seeds/schemas/preset.schema.json`.
+
+| Knob                     | Type    | Default | Description                                                                                                                                                                                                                     |
+| ------------------------ | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `repromptEveryNthCipher` | integer | 0       | Set `Reprompt=Password` on every Nth generated cipher. `0` = disabled. Example: `5` flags ciphers at indices 0, 5, 10, … ≈ 20% reprompt rate. **SQL Server only** — non-SQL-Server providers log a warning and skip the column. |
+
 ## Features
 
 Test specific Bitwarden features. Fixture-based data for deterministic results.
@@ -26,14 +34,14 @@ Known users, groups, collections, and permissions you can point a client to.
 dotnet run -- preset --name qa.{name} --mangle
 ```
 
-| Preset                            | Org Fixture         | Roster                 | Ciphers                | Use Case                                    |
-| --------------------------------- | ------------------- | ---------------------- | ---------------------- | ------------------------------------------- |
-| enterprise-basic                  | redwood-analytics   | enterprise-basic       | enterprise-basic       | Standard enterprise org                     |
-| collection-permissions-enterprise | cobalt-logistics    | collection-permissions | collection-permissions | Permission edge cases                       |
-| dunder-mifflin-enterprise-full    | dunder-mifflin      | dunder-mifflin         | autofill-testing       | Large handcrafted org                       |
-| families-basic                    | adams-family        | family                 | 150 generated          | Families plan with personal vaults          |
-| stark-free-basic                  | stark-industries    | 1 generated user       | autofill-testing       | Free plan personal vault                    |
-| zero-knowledge-labs-enterprise    | zero-knowledge-labs | zero-knowledge-labs    | zero-knowledge-labs    | Full ZKL org with named folders + favorites |
+| Preset                            | Org Fixture         | Roster                 | Ciphers                | Use Case                                      |
+| --------------------------------- | ------------------- | ---------------------- | ---------------------- | --------------------------------------------- |
+| enterprise-basic                  | redwood-analytics   | enterprise-basic       | enterprise-basic       | Standard enterprise org                       |
+| collection-permissions-enterprise | cobalt-logistics    | collection-permissions | collection-permissions | Permission edge cases                         |
+| dunder-mifflin-enterprise-full    | dunder-mifflin      | dunder-mifflin         | autofill-testing       | Large handcrafted org                         |
+| families-basic                    | adams-family        | family                 | 150 generated          | Families plan with personal vaults + reprompt |
+| stark-free-basic                  | stark-industries    | 1 generated user       | autofill-testing       | Free plan personal vault                      |
+| zero-knowledge-labs-enterprise    | zero-knowledge-labs | zero-knowledge-labs    | zero-knowledge-labs    | Full ZKL org with named folders + favorites   |
 
 `families-basic` and `stark-free-basic` mix fixtures with generated data (ciphers and personal ciphers).
 
@@ -76,10 +84,10 @@ Individual user accounts with no organization. Useful for testing personal vault
 dotnet run -- preset --name individual.{name} --mangle
 ```
 
-| Preset        | Account Type | Folders                              | Ciphers                      | Assignments              |
-| ------------- | ------------ | ------------------------------------ | ---------------------------- | ------------------------ |
-| free          | Free         | —                                    | 0                            | —                        |
-| premium       | Premium (1GB)| —                                    | 0                            | —                        |
+| Preset  | Account Type  | Folders | Ciphers | Assignments |
+| ------- | ------------- | ------- | ------- | ----------- |
+| free    | Free          | —       | 0       | —           |
+| premium | Premium (1GB) | —       | 0       | —           |
 
 `free` and `premium` create accounts with no vault data — useful for testing account setup flows. Cipher count is set to 0 (TBD).
 

--- a/util/Seeder/Seeds/docs/presets.md
+++ b/util/Seeder/Seeds/docs/presets.md
@@ -6,9 +6,9 @@ Complete catalog of all seeder presets, organized by purpose. Use `--mangle` to 
 
 These options apply to any preset that uses generated (count-based) ciphers — QA, Scale, and Individual alike. Add them to the `"ciphers"` or `"personalCiphers"` block in the preset JSON. Schema reference: `Seeds/schemas/preset.schema.json`.
 
-| Knob                     | Type    | Default | Description                                                                                                                                                                                                                     |
-| ------------------------ | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `repromptEveryNthCipher` | integer | 0       | Set `Reprompt=Password` on every Nth generated cipher. `0` = disabled. Example: `5` flags ciphers at indices 0, 5, 10, … ≈ 20% reprompt rate. **SQL Server only** — non-SQL-Server providers log a warning and skip the column. |
+| Knob                     | Type    | Default | Description                                                                                                                                   |
+| ------------------------ | ------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `repromptEveryNthCipher` | integer | 0       | Set `Reprompt=Password` on every Nth generated cipher. `0` = disabled. Example: `5` flags ciphers at indices 0, 5, 10, … ≈ 20% reprompt rate. |
 
 ## Features
 

--- a/util/Seeder/Seeds/fixtures/presets/qa/families-basic.json
+++ b/util/Seeder/Seeds/fixtures/presets/qa/families-basic.json
@@ -11,9 +11,11 @@
   "folders": true,
   "ciphers": {
     "count": 150,
-    "assignFolders": true
+    "assignFolders": true,
+    "repromptEveryNthCipher": 10
   },
   "personalCiphers": {
-    "countPerUser": 65
+    "countPerUser": 65,
+    "repromptEveryNthCipher": 5
   }
 }

--- a/util/Seeder/Seeds/schemas/preset.schema.json
+++ b/util/Seeder/Seeds/schemas/preset.schema.json
@@ -156,6 +156,12 @@
           "type": "boolean",
           "default": false,
           "description": "When true, assigns generated ciphers to user folders round-robin. Requires 'folders' to be true."
+        },
+        "repromptEveryNthCipher": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "description": "Set Reprompt=Password on every Nth generated cipher. 0 = disabled."
         }
       }
     },
@@ -168,6 +174,12 @@
           "type": "integer",
           "minimum": 1,
           "description": "Number of personal ciphers to generate per user."
+        },
+        "repromptEveryNthCipher": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "description": "Set Reprompt=Password on every Nth generated personal cipher. 0 = disabled."
         }
       },
       "required": ["countPerUser"]

--- a/util/Seeder/Steps/GenerateCiphersStep.cs
+++ b/util/Seeder/Steps/GenerateCiphersStep.cs
@@ -27,7 +27,8 @@ internal sealed class GenerateCiphersStep(
     Distribution<CipherType>? typeDist = null,
     Distribution<PasswordStrength>? pwDist = null,
     bool assignFolders = false,
-    DensityProfile? density = null) : IStep
+    DensityProfile? density = null,
+    int repromptEveryNthCipher = 0) : IStep
 {
     private readonly DensityProfile? _density = density;
 
@@ -57,7 +58,10 @@ internal sealed class GenerateCiphersStep(
         for (var i = 0; i < count; i++)
         {
             var cipherType = typeDistribution.Select(i, count);
-            var cipher = CipherComposer.Compose(i, cipherType, orgKey, companies, generator, passwordDistribution, organizationId: orgId);
+            var reprompt = repromptEveryNthCipher > 0 && i % repromptEveryNthCipher == 0
+                ? CipherRepromptType.Password
+                : CipherRepromptType.None;
+            var cipher = CipherComposer.Compose(i, cipherType, orgKey, companies, generator, passwordDistribution, organizationId: orgId, reprompt: reprompt);
 
             if (userDigests is { Count: > 0 } && userFolderIds is not null)
             {

--- a/util/Seeder/Steps/GeneratePersonalCiphersStep.cs
+++ b/util/Seeder/Steps/GeneratePersonalCiphersStep.cs
@@ -22,7 +22,8 @@ internal sealed class GeneratePersonalCiphersStep(
     int countPerUser,
     Distribution<CipherType>? typeDist = null,
     Distribution<PasswordStrength>? pwDist = null,
-    DensityProfile? density = null) : IStep
+    DensityProfile? density = null,
+    int repromptEveryNthCipher = 0) : IStep
 {
     public void Execute(SeederContext context)
     {
@@ -78,7 +79,10 @@ internal sealed class GeneratePersonalCiphersStep(
             {
                 var globalIndex = baseOffset + i;
                 var cipherType = typeDistribution.Select(globalIndex, expectedTotal);
-                var cipher = CipherComposer.Compose(globalIndex, cipherType, userDigest.SymmetricKey, companies, generator, passwordDistribution, userId: userDigest.UserId);
+                var reprompt = repromptEveryNthCipher > 0 && globalIndex % repromptEveryNthCipher == 0
+                    ? CipherRepromptType.Password
+                    : CipherRepromptType.None;
+                var cipher = CipherComposer.Compose(globalIndex, cipherType, userDigest.SymmetricKey, companies, generator, passwordDistribution, userId: userDigest.UserId, reprompt: reprompt);
 
                 CipherComposer.AssignFolder(cipher, userDigest.UserId, i, userFolderIds);
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-36416 - SeederDB: Allow item creation with Master Password reprompt flag enabled ](https://bitwarden.atlassian.net/browse/PM-36416)

## 📔 Objective

Ensure that we are able to set the master password re-prompt flag via the Seeder. 
We are now able to set it via the SeederAPI and via presets via the SeederUtility. 

