### PR TITLE
[PM-36560] Create Send event logs

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -268,6 +268,7 @@ public static class FeatureFlagKeys
     public const string SendEmailOTP = "pm-19051-send-email-verification";
     public const string SendControls = "pm-31885-send-controls";
     public const string SdkSendsApi = "pm-30110-sdk-sends-api";
+    public const string SendEventLogging = "pm-36560-send-event-logging";
 
     /* Vault Team */
     public const string CipherKeyEncryption = "cipher-key-encryption";

--- a/src/Core/Dirt/Enums/EventType.cs
+++ b/src/Core/Dirt/Enums/EventType.cs
@@ -141,5 +141,10 @@ public enum EventType : int
     PhishingBlocker_SiteExited = 2401,
     PhishingBlocker_Bypassed = 2402,
 
-
+    Send_Created_Text = 2500,
+    Send_Created_Text_WithEmailVerification = 2501,
+    Send_Created_Text_WithPasswordProtection = 2502,
+    Send_Created_File = 2503,
+    Send_Created_File_WithEmailVerification = 2504,
+    Send_Created_File_WithPasswordProtection = 2505,
 }

--- a/src/Core/Tools/SendFeatures/Commands/NonAnonymousSendCommand.cs
+++ b/src/Core/Tools/SendFeatures/Commands/NonAnonymousSendCommand.cs
@@ -2,8 +2,10 @@
 #nullable disable
 
 using System.Text.Json;
+using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Platform.Push;
+using Bit.Core.Services;
 using Bit.Core.Tools.Entities;
 using Bit.Core.Tools.Enums;
 using Bit.Core.Tools.Models.Data;
@@ -22,6 +24,8 @@ public class NonAnonymousSendCommand : INonAnonymousSendCommand
     private readonly IPushNotificationService _pushNotificationService;
     private readonly ISendValidationService _sendValidationService;
     private readonly ISendCoreHelperService _sendCoreHelperService;
+    private readonly IEventService _eventService;
+    private readonly IFeatureService _featureService;
     private readonly ILogger<NonAnonymousSendCommand> _logger;
 
     public NonAnonymousSendCommand(ISendRepository sendRepository,
@@ -29,6 +33,8 @@ public class NonAnonymousSendCommand : INonAnonymousSendCommand
         IPushNotificationService pushNotificationService,
         ISendValidationService sendValidationService,
         ISendCoreHelperService sendCoreHelperService,
+        IEventService eventService,
+        IFeatureService featureService,
         ILogger<NonAnonymousSendCommand> logger)
     {
         _sendRepository = sendRepository;
@@ -36,6 +42,8 @@ public class NonAnonymousSendCommand : INonAnonymousSendCommand
         _pushNotificationService = pushNotificationService;
         _sendValidationService = sendValidationService;
         _sendCoreHelperService = sendCoreHelperService;
+        _eventService = eventService;
+        _featureService = featureService;
         _logger = logger;
     }
 
@@ -48,6 +56,7 @@ public class NonAnonymousSendCommand : INonAnonymousSendCommand
         {
             await _sendRepository.CreateAsync(send);
             await _pushNotificationService.PushSyncSendCreateAsync(send);
+            await LogSendCreatedEventAsync(send);
         }
         else
         {
@@ -55,6 +64,32 @@ public class NonAnonymousSendCommand : INonAnonymousSendCommand
             await _sendRepository.UpsertAsync(send);
             await _pushNotificationService.PushSyncSendUpdateAsync(send);
         }
+    }
+
+    private async Task LogSendCreatedEventAsync(Send send)
+    {
+        if (!send.UserId.HasValue || !_featureService.IsEnabled(FeatureFlagKeys.SendEventLogging))
+        {
+            return;
+        }
+
+        await _eventService.LogUserEventAsync(send.UserId.Value, ResolveSendCreatedEventType(send));
+    }
+
+    private static EventType ResolveSendCreatedEventType(Send send)
+    {
+        // send.AuthType is populated by SendRequestModel.ToSendBase before SaveSendAsync runs
+        var authType = send.AuthType ?? AuthType.None;
+
+        return (send.Type, authType) switch
+        {
+            (SendType.Text, AuthType.Password) => EventType.Send_Created_Text_WithPasswordProtection,
+            (SendType.Text, AuthType.Email) => EventType.Send_Created_Text_WithEmailVerification,
+            (SendType.Text, _) => EventType.Send_Created_Text,
+            (SendType.File, AuthType.Password) => EventType.Send_Created_File_WithPasswordProtection,
+            (SendType.File, AuthType.Email) => EventType.Send_Created_File_WithEmailVerification,
+            _ => EventType.Send_Created_File,
+        };
     }
 
     public async Task<string> SaveFileSendAsync(Send send, SendFileData data, long fileLength)

--- a/test/Core.Test/Tools/Services/NonAnonymousSendCommandTests.cs
+++ b/test/Core.Test/Tools/Services/NonAnonymousSendCommandTests.cs
@@ -1,8 +1,10 @@
 ﻿using System.Text.Json;
 using Bit.Core.Context;
 using Bit.Core.Entities;
+using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Platform.Push;
+using Bit.Core.Services;
 using Bit.Core.Test.AutoFixture.CurrentContextFixtures;
 using Bit.Core.Test.Tools.AutoFixture.SendFixtures;
 using Bit.Core.Tools.Entities;
@@ -31,6 +33,8 @@ public class NonAnonymousSendCommandTests
     private readonly ISendValidationService _sendValidationService;
     private readonly ICurrentContext _currentContext;
     private readonly ISendCoreHelperService _sendCoreHelperService;
+    private readonly IEventService _eventService;
+    private readonly IFeatureService _featureService;
     private readonly NonAnonymousSendCommand _nonAnonymousSendCommand;
 
     private readonly ILogger<NonAnonymousSendCommand> _logger;
@@ -43,6 +47,8 @@ public class NonAnonymousSendCommandTests
         _sendValidationService = Substitute.For<ISendValidationService>();
         _currentContext = Substitute.For<ICurrentContext>();
         _sendCoreHelperService = Substitute.For<ISendCoreHelperService>();
+        _eventService = Substitute.For<IEventService>();
+        _featureService = Substitute.For<IFeatureService>();
         _logger = Substitute.For<ILogger<NonAnonymousSendCommand>>();
 
         _nonAnonymousSendCommand = new NonAnonymousSendCommand(
@@ -51,6 +57,8 @@ public class NonAnonymousSendCommandTests
             _pushNotificationService,
             _sendValidationService,
             _sendCoreHelperService,
+            _eventService,
+            _featureService,
             _logger
         );
     }
@@ -1435,5 +1443,98 @@ public class NonAnonymousSendCommandTests
         await _sendRepository.Received(1).DeleteAsync(send);
         await _pushNotificationService.Received(1).PushSyncSendDeleteAsync(send);
         Assert.Equal(new[] { "file", "db" }, callOrder);
+    }
+
+    public static IEnumerable<object[]> SendCreatedEventTypeData()
+    {
+        yield return new object[] { SendType.Text, AuthType.None, EventType.Send_Created_Text };
+        yield return new object[] { SendType.Text, AuthType.Email, EventType.Send_Created_Text_WithEmailVerification };
+        yield return new object[] { SendType.Text, AuthType.Password, EventType.Send_Created_Text_WithPasswordProtection };
+        yield return new object[] { SendType.File, AuthType.None, EventType.Send_Created_File };
+        yield return new object[] { SendType.File, AuthType.Email, EventType.Send_Created_File_WithEmailVerification };
+        yield return new object[] { SendType.File, AuthType.Password, EventType.Send_Created_File_WithPasswordProtection };
+    }
+
+    [Theory]
+    [MemberData(nameof(SendCreatedEventTypeData))]
+    public async Task SaveSendAsync_NewSend_FlagOn_LogsExpectedEventType(
+        SendType sendType, AuthType authType, EventType expectedEventType)
+    {
+        var userId = Guid.NewGuid();
+        var send = new Send
+        {
+            Id = default,
+            Type = sendType,
+            UserId = userId,
+            AuthType = authType,
+        };
+
+        _featureService.IsEnabled(FeatureFlagKeys.SendEventLogging).Returns(true);
+        _sendValidationService.ValidateUserCanSaveAsync(userId, send).Returns(Task.CompletedTask);
+
+        await _nonAnonymousSendCommand.SaveSendAsync(send);
+
+        await _sendRepository.Received(1).CreateAsync(send);
+        await _eventService.Received(1).LogUserEventAsync(userId, expectedEventType);
+    }
+
+    [Fact]
+    public async Task SaveSendAsync_NewSend_NullAuthType_LogsBaseSendCreatedEvent()
+    {
+        var userId = Guid.NewGuid();
+        var send = new Send
+        {
+            Id = default,
+            Type = SendType.Text,
+            UserId = userId,
+            AuthType = null,
+        };
+
+        _featureService.IsEnabled(FeatureFlagKeys.SendEventLogging).Returns(true);
+        _sendValidationService.ValidateUserCanSaveAsync(userId, send).Returns(Task.CompletedTask);
+
+        await _nonAnonymousSendCommand.SaveSendAsync(send);
+
+        await _eventService.Received(1).LogUserEventAsync(userId, EventType.Send_Created_Text);
+    }
+
+    [Fact]
+    public async Task SaveSendAsync_NewSend_FlagOff_DoesNotLogEvent()
+    {
+        var userId = Guid.NewGuid();
+        var send = new Send
+        {
+            Id = default,
+            Type = SendType.Text,
+            UserId = userId,
+        };
+
+        _featureService.IsEnabled(FeatureFlagKeys.SendEventLogging).Returns(false);
+        _sendValidationService.ValidateUserCanSaveAsync(userId, send).Returns(Task.CompletedTask);
+
+        await _nonAnonymousSendCommand.SaveSendAsync(send);
+
+        await _sendRepository.Received(1).CreateAsync(send);
+        await _eventService.DidNotReceiveWithAnyArgs().LogUserEventAsync(default, default);
+    }
+
+    [Fact]
+    public async Task SaveSendAsync_ExistingSend_FlagOn_DoesNotLogEvent()
+    {
+        var userId = Guid.NewGuid();
+        var send = new Send
+        {
+            Id = Guid.NewGuid(),
+            Type = SendType.Text,
+            UserId = userId,
+        };
+
+        _featureService.IsEnabled(FeatureFlagKeys.SendEventLogging).Returns(true);
+        _sendValidationService.ValidateUserCanSaveAsync(userId, send).Returns(Task.CompletedTask);
+
+        await _nonAnonymousSendCommand.SaveSendAsync(send);
+
+        await _sendRepository.Received(1).UpsertAsync(send);
+        await _eventService.DidNotReceiveWithAnyArgs().LogUserEventAsync(default, default);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36560

## 📔 Objective

This PR introduces some foundational logic used to log Send-related events. Currently, only Send creation events are being logged. See https://github.com/bitwarden/clients/pull/20567 for more details. 