### PR TITLE
[PM-34150] - RequireSSO Applies to Accepted

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyRequirements/RequireSsoPolicyRequirement.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyRequirements/RequireSsoPolicyRequirement.cs
@@ -1,7 +1,9 @@
-﻿using Bit.Core.AdminConsole.Enums;
+﻿using Bit.Core;
+using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
 using Bit.Core.Enums;
+using Bit.Core.Services;
 using Bit.Core.Settings;
 
 /// <summary>
@@ -29,32 +31,31 @@ public class RequireSsoPolicyRequirement : IPolicyRequirement
 }
 
 
-public class RequireSsoPolicyRequirementFactory : BasePolicyRequirementFactory<RequireSsoPolicyRequirement>
+public class RequireSsoPolicyRequirementFactory(GlobalSettings globalSettings, IFeatureService featureService)
+    : BasePolicyRequirementFactory<RequireSsoPolicyRequirement>
 {
-    private readonly GlobalSettings _globalSettings;
-
-    public RequireSsoPolicyRequirementFactory(GlobalSettings globalSettings)
-    {
-        _globalSettings = globalSettings;
-    }
 
     public override PolicyType PolicyType => PolicyType.RequireSso;
 
     protected override IEnumerable<OrganizationUserType> ExemptRoles =>
-        _globalSettings.Sso.EnforceSsoPolicyForAllUsers
+        globalSettings.Sso.EnforceSsoPolicyForAllUsers
             ? Array.Empty<OrganizationUserType>()
             : [OrganizationUserType.Owner, OrganizationUserType.Admin];
 
     public override RequireSsoPolicyRequirement Create(IEnumerable<PolicyDetails> policyDetails)
     {
         policyDetails = policyDetails.ToList();
+
+        var acceptedFeatureFlagEnabled = featureService.IsEnabled(FeatureFlagKeys.PoliciesInAcceptedState);
+
         var result = new RequireSsoPolicyRequirement
         {
             CanUsePasskeyLogin = !policyDetails.Any(p =>
                 p.OrganizationUserStatus is OrganizationUserStatusType.Accepted or OrganizationUserStatusType.Confirmed),
 
-            SsoRequired = policyDetails.Any(p =>
-                p.OrganizationUserStatus is OrganizationUserStatusType.Accepted or OrganizationUserStatusType.Confirmed)
+            SsoRequired = policyDetails.Any(p => !acceptedFeatureFlagEnabled
+                ? p.OrganizationUserStatus is OrganizationUserStatusType.Confirmed
+                : p.OrganizationUserStatus is OrganizationUserStatusType.Accepted or OrganizationUserStatusType.Confirmed)
         };
 
         return result;

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyRequirements/RequireSsoPolicyRequirement.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyRequirements/RequireSsoPolicyRequirement.cs
@@ -54,7 +54,7 @@ public class RequireSsoPolicyRequirementFactory : BasePolicyRequirementFactory<R
                 p.OrganizationUserStatus is OrganizationUserStatusType.Accepted or OrganizationUserStatusType.Confirmed),
 
             SsoRequired = policyDetails.Any(p =>
-                p.OrganizationUserStatus == OrganizationUserStatusType.Confirmed)
+                p.OrganizationUserStatus is OrganizationUserStatusType.Accepted or OrganizationUserStatusType.Confirmed)
         };
 
         return result;

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyRequirements/RequireSsoPolicyRequirementFactoryTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyRequirements/RequireSsoPolicyRequirementFactoryTests.cs
@@ -69,7 +69,6 @@ public class RequireSsoPolicyRequirementFactoryTests
     [Theory]
     [BitAutoData(OrganizationUserStatusType.Revoked)]
     [BitAutoData(OrganizationUserStatusType.Invited)]
-    [BitAutoData(OrganizationUserStatusType.Accepted)]
     public void SsoRequired_WithoutExemptStatus_ReturnsFalse(
         OrganizationUserStatusType userStatus,
         SutProvider<RequireSsoPolicyRequirementFactory> sutProvider)
@@ -86,8 +85,11 @@ public class RequireSsoPolicyRequirementFactoryTests
         Assert.False(actual.SsoRequired);
     }
 
-    [Theory, BitAutoData]
+    [Theory]
+    [BitAutoData(OrganizationUserStatusType.Accepted)]
+    [BitAutoData(OrganizationUserStatusType.Confirmed)]
     public void SsoRequired_WithExemptStatus_ReturnsTrue(
+        OrganizationUserStatusType userStatus,
         SutProvider<RequireSsoPolicyRequirementFactory> sutProvider)
     {
         var actual = sutProvider.Sut.Create(
@@ -95,7 +97,7 @@ public class RequireSsoPolicyRequirementFactoryTests
             new PolicyDetails
             {
                 PolicyType = PolicyType.RequireSso,
-                OrganizationUserStatus = OrganizationUserStatusType.Confirmed
+                OrganizationUserStatus = userStatus
             }
         ]);
 

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyRequirements/RequireSsoPolicyRequirementFactoryTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyRequirements/RequireSsoPolicyRequirementFactoryTests.cs
@@ -1,8 +1,10 @@
 ﻿using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
 using Bit.Core.Enums;
+using Bit.Core.Services;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
 using Xunit;
 
 namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
@@ -88,16 +90,60 @@ public class RequireSsoPolicyRequirementFactoryTests
     [Theory]
     [BitAutoData(OrganizationUserStatusType.Accepted)]
     [BitAutoData(OrganizationUserStatusType.Confirmed)]
-    public void SsoRequired_WithExemptStatus_ReturnsTrue(
+    public void SsoRequired_PoliciesInAcceptedStateEnabled_AcceptedOrConfirmed_ReturnsTrue(
         OrganizationUserStatusType userStatus,
         SutProvider<RequireSsoPolicyRequirementFactory> sutProvider)
     {
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PoliciesInAcceptedState)
+            .Returns(true);
+
         var actual = sutProvider.Sut.Create(
         [
             new PolicyDetails
             {
                 PolicyType = PolicyType.RequireSso,
                 OrganizationUserStatus = userStatus
+            }
+        ]);
+
+        Assert.True(actual.SsoRequired);
+    }
+
+    [Theory, BitAutoData]
+    public void SsoRequired_PoliciesInAcceptedStateDisabled_Accepted_ReturnsFalse(
+        SutProvider<RequireSsoPolicyRequirementFactory> sutProvider)
+    {
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PoliciesInAcceptedState)
+            .Returns(false);
+
+        var actual = sutProvider.Sut.Create(
+        [
+            new PolicyDetails
+            {
+                PolicyType = PolicyType.RequireSso,
+                OrganizationUserStatus = OrganizationUserStatusType.Accepted
+            }
+        ]);
+
+        Assert.False(actual.SsoRequired);
+    }
+
+    [Theory, BitAutoData]
+    public void SsoRequired_PoliciesInAcceptedStateDisabled_Confirmed_ReturnsTrue(
+        SutProvider<RequireSsoPolicyRequirementFactory> sutProvider)
+    {
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PoliciesInAcceptedState)
+            .Returns(false);
+
+        var actual = sutProvider.Sut.Create(
+        [
+            new PolicyDetails
+            {
+                PolicyType = PolicyType.RequireSso,
+                OrganizationUserStatus = OrganizationUserStatusType.Confirmed
             }
         ]);
 


### PR DESCRIPTION
## 🎟️ Tracking
[PM-34150](https://bitwarden.atlassian.net/browse/PM-34150)

## 📔 Objective
The `RequireSSO` field now applies when a user is in the Accepted or Confirmed State when the feature flag is active.


[PM-34150]: https://bitwarden.atlassian.net/browse/PM-34150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ