### PR TITLE
Add data protection cert override to recommended dev settings

### DIFF
--- a/dev/secrets.json.example
+++ b/dev/secrets.json.example
@@ -28,6 +28,7 @@
     },
     "dataProtection": {
       "certificateThumbprint": "<your Data Protection certificate thumbprint with no spaces>"
+      "directory": "<full path to DataProtection-keys directory (default is /your/home/directory/.aspnet/DataProtection-keys)>"
     },
     "installation": {
       "id": "<your Installation Id>",


### PR DESCRIPTION
Adds recommended settings to fix an issue running self host-like dev instances after merge of #7430 , which are now defaulting to `/etc/bitwarden` for data protection persistence, rather than the default user directory.

Because this setting is used to default a large number of self host instances and multiple settings, the cleanest solution is to recommend setting this value back to the default value.
