### PR TITLE
[PM-35401] Update exception handling in CreateAuthRequestAsync() and PostAdminRequest()

### DIFF
--- a/src/Api/Auth/Controllers/AuthRequestsController.cs
+++ b/src/Api/Auth/Controllers/AuthRequestsController.cs
@@ -91,6 +91,11 @@ public class AuthRequestsController(
     [HttpPost("admin-request")]
     public async Task<AuthRequestResponseModel> PostAdminRequest([FromBody] AuthRequestCreateRequestModel model)
     {
+        if (model.Type != AuthRequestType.AdminApproval)
+        {
+            throw new BadRequestException("Invalid AuthRequestType. Expected AdminApproval.");
+        }
+
         var authRequest = await _authRequestService.CreateAuthRequestAsync(model);
         var r = new AuthRequestResponseModel(authRequest, _globalSettings.BaseServiceUri.Vault);
         return r;

--- a/src/Core/Auth/Services/Implementations/AuthRequestService.cs
+++ b/src/Core/Auth/Services/Implementations/AuthRequestService.cs
@@ -113,6 +113,11 @@ public class AuthRequestService : IAuthRequestService
             throw new BadRequestException("User or known device not found.");
         }
 
+        if (_currentContext.UserId.HasValue && user!.Id != _currentContext.UserId.Value)
+        {
+            throw new BadRequestException("User or known device not found.");
+        }
+
         // AdminApproval requests require correlating the user and their organization
         if (model.Type == AuthRequestType.AdminApproval)
         {

--- a/src/Core/Auth/Services/Implementations/AuthRequestService.cs
+++ b/src/Core/Auth/Services/Implementations/AuthRequestService.cs
@@ -113,6 +113,7 @@ public class AuthRequestService : IAuthRequestService
             throw new BadRequestException("User or known device not found.");
         }
 
+        // Ensure authenticated user id matches target user (allows anon scenarios still)
         if (_currentContext.UserId.HasValue && user!.Id != _currentContext.UserId.Value)
         {
             throw new BadRequestException("User or known device not found.");

--- a/test/Api.Test/Auth/Controllers/AuthRequestsControllerTests.cs
+++ b/test/Api.Test/Auth/Controllers/AuthRequestsControllerTests.cs
@@ -231,8 +231,10 @@ public class AuthRequestsControllerTests
     {
         requestModel.Type = type;
 
-        await Assert.ThrowsAsync<BadRequestException>(
+        var exception = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.PostAdminRequest(requestModel));
+
+        Assert.Equal("Invalid AuthRequestType. Expected AdminApproval.", exception.Message);
 
         await sutProvider.GetDependency<IAuthRequestService>()
             .DidNotReceiveWithAnyArgs()

--- a/test/Api.Test/Auth/Controllers/AuthRequestsControllerTests.cs
+++ b/test/Api.Test/Auth/Controllers/AuthRequestsControllerTests.cs
@@ -208,7 +208,7 @@ public class AuthRequestsControllerTests
         // Arrange
         SetBaseServiceUri(sutProvider);
 
-        requestModel.Type = AuthRequestType.AuthenticateAndUnlock;
+        requestModel.Type = AuthRequestType.AdminApproval;
         sutProvider.GetDependency<IAuthRequestService>()
             .CreateAuthRequestAsync(requestModel)
             .Returns(authRequest);
@@ -219,6 +219,24 @@ public class AuthRequestsControllerTests
         // Assert
         Assert.NotNull(result);
         Assert.IsType<AuthRequestResponseModel>(result);
+    }
+
+    [Theory]
+    [BitAutoData(AuthRequestType.AuthenticateAndUnlock)]
+    [BitAutoData(AuthRequestType.Unlock)]
+    public async Task PostAdminRequest_NonAdminApprovalType_ThrowsBadRequest(
+        AuthRequestType type,
+        SutProvider<AuthRequestsController> sutProvider,
+        AuthRequestCreateRequestModel requestModel)
+    {
+        requestModel.Type = type;
+
+        await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.PostAdminRequest(requestModel));
+
+        await sutProvider.GetDependency<IAuthRequestService>()
+            .DidNotReceiveWithAnyArgs()
+            .CreateAuthRequestAsync(default!);
     }
 
     [Theory, BitAutoData]

--- a/test/Core.Test/Auth/Services/AuthRequestServiceTests.cs
+++ b/test/Core.Test/Auth/Services/AuthRequestServiceTests.cs
@@ -500,6 +500,8 @@ public class AuthRequestServiceTests
             .UserId
             .Returns(authenticatedUserId);
 
+        // Mock this as false so we pin the test failure to the userId mismatch guard rather than to the first
+        // identically-worded "User or known device not found." exception that could fire earlier.
         sutProvider.GetDependency<IGlobalSettings>()
             .PasswordlessAuth.KnownDevicesOnly
             .Returns(false);
@@ -507,6 +509,8 @@ public class AuthRequestServiceTests
         var exception = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.CreateAuthRequestAsync(createModel));
 
+        // For the AuthRequestType.AdminApproval test case, this assertion pins the test failure to the userId mismatch guard
+        // rather than to the "User does not belong to any organizations." exception, which is also of type BadRequestException.
         Assert.Equal("User or known device not found.", exception.Message);
 
         await sutProvider.GetDependency<IAuthRequestRepository>()

--- a/test/Core.Test/Auth/Services/AuthRequestServiceTests.cs
+++ b/test/Core.Test/Auth/Services/AuthRequestServiceTests.cs
@@ -474,6 +474,44 @@ public class AuthRequestServiceTests
             .LogWarning("There are no admin emails to send to.");
     }
 
+    [Theory]
+    [BitAutoData(AuthRequestType.AdminApproval)]
+    [BitAutoData(AuthRequestType.AuthenticateAndUnlock)]
+    [BitAutoData(AuthRequestType.Unlock)]
+    public async Task CreateAuthRequestAsync_AuthenticatedCallerUserIdMismatch_ThrowsBadRequest(
+        AuthRequestType type,
+        SutProvider<AuthRequestService> sutProvider,
+        AuthRequestCreateRequestModel createModel,
+        User user,
+        Guid authenticatedUserId)
+    {
+        createModel.Type = type;
+        createModel.Email = user.Email;
+
+        sutProvider.GetDependency<IUserRepository>()
+            .GetByEmailAsync(user.Email)
+            .Returns(user);
+
+        sutProvider.GetDependency<ICurrentContext>()
+            .DeviceType
+            .Returns(DeviceType.ChromeExtension);
+
+        sutProvider.GetDependency<ICurrentContext>()
+            .UserId
+            .Returns(authenticatedUserId);
+
+        sutProvider.GetDependency<IGlobalSettings>()
+            .PasswordlessAuth.KnownDevicesOnly
+            .Returns(false);
+
+        await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.CreateAuthRequestAsync(createModel));
+
+        await sutProvider.GetDependency<IAuthRequestRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .CreateAsync(default!);
+    }
+
     /// <summary>
     /// Story: When an <see cref="AuthRequest"> is approved we want to update it in the database so it cannot have
     /// it's status changed again and we want to push a notification to let the user know of the approval.

--- a/test/Core.Test/Auth/Services/AuthRequestServiceTests.cs
+++ b/test/Core.Test/Auth/Services/AuthRequestServiceTests.cs
@@ -504,8 +504,10 @@ public class AuthRequestServiceTests
             .PasswordlessAuth.KnownDevicesOnly
             .Returns(false);
 
-        await Assert.ThrowsAsync<BadRequestException>(
+        var exception = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.CreateAuthRequestAsync(createModel));
+
+        Assert.Equal("User or known device not found.", exception.Message);
 
         await sutProvider.GetDependency<IAuthRequestRepository>()
             .DidNotReceiveWithAnyArgs()


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35401

## 📔 Objective

Adds a `BadRequestException` case to `CreateAuthRequestAsync()` and `PostAdminRequest()`.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
