### PR TITLE
[PM-36843] Skip relay push registration for non mobile clients

### DIFF
--- a/src/Core/Platform/PushRegistration/RelayPushRegistrationService.cs
+++ b/src/Core/Platform/PushRegistration/RelayPushRegistrationService.cs
@@ -28,6 +28,14 @@ public class RelayPushRegistrationService : BaseIdentityClientService, IPushRegi
     public async Task CreateOrUpdateRegistrationAsync(PushRegistrationData pushData, string deviceId, string userId,
         string identifier, DeviceType type, IEnumerable<string> organizationIds, Guid installationId)
     {
+        if (string.IsNullOrEmpty(pushData.Token))
+        {
+            // Self-host installations have no need to relay non-mobile push registration
+            // as even web push capable clients will use signalR based push notifications
+            // in self-host environments.
+            return;
+        }
+
         var requestModel = new PushRegistrationRequestModel
         {
             DeviceId = deviceId,

--- a/src/Core/Services/Implementations/BaseIdentityClientService.cs
+++ b/src/Core/Services/Implementations/BaseIdentityClientService.cs
@@ -1,9 +1,9 @@
-﻿// FIXME: Update this file to be null safe and then delete the line below
-#nullable disable
-
+﻿using System.Diagnostics;
+using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json;
 using Bit.Core.Utilities;
 using Microsoft.Extensions.Logging;
@@ -18,7 +18,7 @@ public abstract class BaseIdentityClientService : IDisposable
     private readonly string _identityClientSecret;
     protected readonly ILogger<BaseIdentityClientService> _logger;
 
-    private JsonDocument _decodedToken;
+    private JsonDocument? _decodedToken;
     private DateTime? _nextAuthAttempt = null;
 
     public BaseIdentityClientService(
@@ -47,15 +47,15 @@ public abstract class BaseIdentityClientService : IDisposable
 
     protected HttpClient Client { get; private set; }
     protected HttpClient IdentityClient { get; private set; }
-    protected string AccessToken { get; private set; }
+    protected string? AccessToken { get; private set; }
 
     protected Task SendAsync(HttpMethod method, string path) =>
-        SendAsync<object>(method, path, null);
+        SendAsync<object?>(method, path, null);
 
     protected Task SendAsync<TRequest>(HttpMethod method, string path, TRequest requestModel) =>
         SendAsync<TRequest, object>(method, path, requestModel, false);
 
-    protected async Task<TResult> SendAsync<TRequest, TResult>(HttpMethod method, string path,
+    protected async Task<TResult?> SendAsync<TRequest, TResult>(HttpMethod method, string path,
         TRequest requestModel, bool hasJsonResult)
     {
         var fullRequestPath = string.Concat(Client.BaseAddress, path);
@@ -63,10 +63,13 @@ public abstract class BaseIdentityClientService : IDisposable
         var tokenStateResponse = await HandleTokenStateAsync();
         if (!tokenStateResponse)
         {
-            _logger.LogError("Unable to send {method} request to {requestUri} because an access token was unable to be obtained",
+            _logger.LogError("Unable to send {Method} request to {RequestUri} because an access token was unable to be obtained",
                 method.Method, fullRequestPath);
             return default;
         }
+
+        // HandleTokenStateAsync should not return true when AccessToken is still null
+        Debug.Assert(AccessToken is not null);
 
         var message = new TokenHttpRequestMessage(requestModel, AccessToken)
         {
@@ -85,8 +88,9 @@ public abstract class BaseIdentityClientService : IDisposable
             }
             else
             {
-                _logger.LogError("Request to {url} is unsuccessful with status of {code}-{reason}",
-                    message.RequestUri.ToString(), response.StatusCode, response.ReasonPhrase);
+                var errorResponse = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+                _logger.LogError("Request to {Url} is unsuccessful with status of {Code}-{Reason}: {Message}",
+                    message.RequestUri.ToString(), response.StatusCode, response.ReasonPhrase, errorResponse);
             }
             return default;
         }
@@ -124,7 +128,7 @@ public abstract class BaseIdentityClientService : IDisposable
             })
         };
 
-        HttpResponseMessage response = null;
+        HttpResponseMessage? response = null;
         try
         {
             response = await IdentityClient.SendAsync(requestMessage);
@@ -172,13 +176,39 @@ public abstract class BaseIdentityClientService : IDisposable
             Headers.Add("Authorization", $"Bearer {token}");
         }
 
-        public TokenHttpRequestMessage(object requestObject, string token)
+        public TokenHttpRequestMessage(object? requestObject, string token)
             : this(token)
         {
             if (requestObject != null)
             {
                 Content = JsonContent.Create(requestObject);
             }
+        }
+    }
+    private class ErrorResponse
+    {
+        public string? Message { get; set; }
+        public Dictionary<string, string[]>? ValidationErrors { get; set; }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendLine(Message ?? "Unknown error");
+
+            if (ValidationErrors != null)
+            {
+                sb.AppendLine("Validation Errors:");
+
+                foreach (var (key, value) in ValidationErrors)
+                {
+                    sb.Append(CultureInfo.InvariantCulture, $"{key}: ");
+                    sb.AppendJoin(", ", value);
+                    sb.AppendLine();
+                }
+            }
+
+            return sb.ToString();
         }
     }
 

--- a/test/Api.IntegrationTest/Api.IntegrationTest.csproj
+++ b/test/Api.IntegrationTest/Api.IntegrationTest.csproj
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="[9.3.0]" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Api.IntegrationTest/Api.IntegrationTest.csproj
+++ b/test/Api.IntegrationTest/Api.IntegrationTest.csproj
@@ -16,6 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Api.IntegrationTest/Platform/RelayPushRegistrationServiceTests.cs
+++ b/test/Api.IntegrationTest/Platform/RelayPushRegistrationServiceTests.cs
@@ -1,0 +1,102 @@
+﻿using Bit.Api.IntegrationTest.Factories;
+using Bit.Core.Enums;
+using Bit.Core.Platform.Installations;
+using Bit.Core.Platform.Push;
+using Bit.Core.Platform.PushRegistration;
+using Bit.Core.Platform.PushRegistration.Internal;
+using Bit.Core.Settings;
+using Microsoft.Extensions.Logging.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Api.IntegrationTest.Platform;
+
+public class RelayPushRegistrationServiceTests
+{
+    private readonly FakeLogCollector _logCollector;
+    private readonly RelayPushRegistrationService _sut;
+
+    public RelayPushRegistrationServiceTests()
+    {
+        var cloudApi = new ApiApplicationFactory();
+        cloudApi.SubstituteService<IPushRegistrationService>(service => {});
+
+        var fakeInstallationId = Guid.NewGuid();
+
+        cloudApi.Identity.SubstituteService<IInstallationRepository>(service =>
+        {
+            service.GetByIdAsync(fakeInstallationId)
+                .Returns(new Installation
+                {
+                    Id = fakeInstallationId,
+                    Key = "test_key",
+                    Enabled = true,
+                });
+        });
+
+        var cloudApiHttpClient = cloudApi.CreateClient();
+        var cloudIdentityHttpClient = cloudApi.Identity.CreateClient();
+
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+
+        httpClientFactory.CreateClient("client")
+            .Returns(cloudApiHttpClient);
+
+        httpClientFactory.CreateClient("identity")
+            .Returns(cloudIdentityHttpClient);
+
+        var globalSettings = new GlobalSettings
+        {
+            PushRelayBaseUri = "http://api.localhost"
+        };
+        globalSettings.Installation.IdentityUri = "http://identity.localhost";
+        globalSettings.Installation.Id = fakeInstallationId;
+        globalSettings.Installation.Key = "test_key";
+
+        var logger = new FakeLogger<RelayPushRegistrationService>();
+
+        _logCollector = logger.Collector;
+
+        _sut = new RelayPushRegistrationService(
+            httpClientFactory,
+            globalSettings,
+            logger
+        );
+    }
+
+    [Fact]
+    public async Task BrowserExtensionData_ShouldNotLogIssues()
+    {
+        await _sut.CreateOrUpdateRegistrationAsync(
+            new PushRegistrationData("endpoint", "p256dh", "auth"),
+            deviceId: Guid.NewGuid().ToString(),
+            userId: Guid.NewGuid().ToString(),
+            identifier: Guid.NewGuid().ToString(),
+            DeviceType.ChromeExtension,
+            organizationIds: [Guid.NewGuid().ToString()],
+            installationId: Guid.NewGuid()
+        );
+
+        var logs = _logCollector.GetSnapshot();
+
+        Assert.DoesNotContain(logs, l => l.Level >= LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task MobileData_ShouldNotLogIssues()
+    {
+        await _sut.CreateOrUpdateRegistrationAsync(
+            new PushRegistrationData("PushToken"),
+            deviceId: Guid.NewGuid().ToString(),
+            userId: Guid.NewGuid().ToString(),
+            identifier: Guid.NewGuid().ToString(),
+            DeviceType.ChromeExtension,
+            organizationIds: [Guid.NewGuid().ToString()],
+            installationId: Guid.NewGuid()
+        );
+
+        var logs = _logCollector.GetSnapshot();
+
+        Assert.DoesNotContain(logs, l => l.Level >= LogLevel.Warning);
+    }
+}

--- a/test/Api.IntegrationTest/Platform/RelayPushRegistrationServiceTests.cs
+++ b/test/Api.IntegrationTest/Platform/RelayPushRegistrationServiceTests.cs
@@ -13,29 +13,31 @@ namespace Bit.Api.IntegrationTest.Platform;
 
 public class RelayPushRegistrationServiceTests
 {
+    private readonly ApiApplicationFactory _cloudApi;
+    private readonly Guid _fakeInstallationId;
     private readonly FakeLogCollector _logCollector;
     private readonly RelayPushRegistrationService _sut;
 
     public RelayPushRegistrationServiceTests()
     {
-        var cloudApi = new ApiApplicationFactory();
-        cloudApi.SubstituteService<IPushRegistrationService>(service => { });
+        _cloudApi = new ApiApplicationFactory();
+        _cloudApi.SubstituteService<IPushRegistrationService>(service => { });
 
-        var fakeInstallationId = Guid.NewGuid();
+        _fakeInstallationId = Guid.NewGuid();
 
-        cloudApi.Identity.SubstituteService<IInstallationRepository>(service =>
+        _cloudApi.Identity.SubstituteService<IInstallationRepository>(service =>
         {
-            service.GetByIdAsync(fakeInstallationId)
+            service.GetByIdAsync(_fakeInstallationId)
                 .Returns(new Installation
                 {
-                    Id = fakeInstallationId,
+                    Id = _fakeInstallationId,
                     Key = "test_key",
                     Enabled = true,
                 });
         });
 
-        var cloudApiHttpClient = cloudApi.CreateClient();
-        var cloudIdentityHttpClient = cloudApi.Identity.CreateClient();
+        var cloudApiHttpClient = _cloudApi.CreateClient();
+        var cloudIdentityHttpClient = _cloudApi.Identity.CreateClient();
 
         var httpClientFactory = Substitute.For<IHttpClientFactory>();
 
@@ -50,7 +52,7 @@ public class RelayPushRegistrationServiceTests
             PushRelayBaseUri = "http://api.localhost"
         };
         globalSettings.Installation.IdentityUri = "http://identity.localhost";
-        globalSettings.Installation.Id = fakeInstallationId;
+        globalSettings.Installation.Id = _fakeInstallationId;
         globalSettings.Installation.Key = "test_key";
 
         var logger = new FakeLogger<RelayPushRegistrationService>();
@@ -85,18 +87,39 @@ public class RelayPushRegistrationServiceTests
     [Fact]
     public async Task MobileData_ShouldNotLogIssues()
     {
+        var deviceId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var identifier = Guid.NewGuid();
+        var organizationId = Guid.NewGuid();
+        var installationId = Guid.NewGuid();
+
         await _sut.CreateOrUpdateRegistrationAsync(
             new PushRegistrationData("PushToken"),
-            deviceId: Guid.NewGuid().ToString(),
-            userId: Guid.NewGuid().ToString(),
-            identifier: Guid.NewGuid().ToString(),
-            DeviceType.ChromeExtension,
-            organizationIds: [Guid.NewGuid().ToString()],
-            installationId: Guid.NewGuid()
+            deviceId.ToString(),
+            userId.ToString(),
+            identifier.ToString(),
+            DeviceType.iOS,
+            [organizationId.ToString()],
+            installationId
         );
 
         var logs = _logCollector.GetSnapshot();
 
         Assert.DoesNotContain(logs, l => l.Level >= LogLevel.Warning);
+
+        // Mobile should also actually successfully make it to the cloud push registration service
+        // with all of its data prefixed with the self host installation id.
+        var mockPushRegistrationService = _cloudApi.GetService<IPushRegistrationService>();
+        await mockPushRegistrationService
+            .Received(1)
+            .CreateOrUpdateRegistrationAsync(
+                new PushRegistrationData("PushToken"),
+                deviceId: $"{_fakeInstallationId}_{deviceId}",
+                userId: $"{_fakeInstallationId}_{userId}",
+                identifier: $"{_fakeInstallationId}_{identifier}",
+                type: DeviceType.iOS,
+                Arg.Is<IEnumerable<string>>(v => v.Single() == $"{_fakeInstallationId}_{organizationId}"),
+                installationId
+            );
     }
 }

--- a/test/Api.IntegrationTest/Platform/RelayPushRegistrationServiceTests.cs
+++ b/test/Api.IntegrationTest/Platform/RelayPushRegistrationServiceTests.cs
@@ -19,7 +19,7 @@ public class RelayPushRegistrationServiceTests
     public RelayPushRegistrationServiceTests()
     {
         var cloudApi = new ApiApplicationFactory();
-        cloudApi.SubstituteService<IPushRegistrationService>(service => {});
+        cloudApi.SubstituteService<IPushRegistrationService>(service => { });
 
         var fakeInstallationId = Guid.NewGuid();
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-36843

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Skips relaying push registration for non-mobile clients since only mobile clients need to be registered in our cloud to get notifications. Browser extensions will continue to use SignalR on self-host.

Also I added additional details to the logs, for example the log that would be logged without the fix would have been:
```
Request to http://api.localhost/push/register is unsuccessful with status of BadRequest-Bad Request: The model state is invalid.
Validation Errors:
PushToken: The PushToken field is required.
```

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
