### PR TITLE
Bumped version to 2026.4.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
 
-    <Version>2026.4.1</Version>
+    <Version>2026.4.2</Version>
 
     <RootNamespace>Bit.$(MSBuildProjectName)</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## 🎟️ Tracking

N/A — manual version bump in support of the upcoming hotfix release from `v2026.4.1`.

## 📔 Objective

Manually applying the version bump that the `Repository management` workflow's `bump_version` job would have produced. The workflow's direct push to `main` is currently blocked by the `required_status_checks` repository ruleset (requires *Run tests* and *Lint*), so this PR exists to route the same change through the standard PR flow.

Bumps `Directory.Build.props` from `2026.4.1` → `2026.4.2`. The same bump will be cherry-picked onto `hotfix-rc` after merge.