### PR TITLE
[PM-37230] remove FF logic from new send endpoints

### DIFF
--- a/src/Api/Tools/Controllers/SendsController.cs
+++ b/src/Api/Tools/Controllers/SendsController.cs
@@ -240,13 +240,6 @@ public class SendsController : Controller
             throw new BadRequestException("Could not locate send");
         }
 
-        /* This guard can be removed once feature flag is retired*/
-        var sendEmailOtpEnabled = _featureService.IsEnabled(FeatureFlagKeys.SendEmailOTP);
-        if (!sendEmailOtpEnabled && send.AuthType == AuthType.Email && send.Emails is not null)
-        {
-            throw new NotFoundException();
-        }
-
         if (!INonAnonymousSendCommand.SendCanBeAccessed(send))
         {
             throw new NotFoundException();
@@ -286,13 +279,6 @@ public class SendsController : Controller
         if (send == null)
         {
             throw new BadRequestException("Could not locate send");
-        }
-
-        /* This guard can be removed once feature flag is retired*/
-        var sendEmailOtpEnabled = _featureService.IsEnabled(FeatureFlagKeys.SendEmailOTP);
-        if (!sendEmailOtpEnabled && send.AuthType == AuthType.Email && send.Emails is not null)
-        {
-            throw new NotFoundException();
         }
 
         var (url, result) = await _nonAnonymousSendCommand.GetSendFileDownloadUrlAsync(send, fileId);

--- a/test/Api.Test/Tools/Controllers/SendsControllerTests.cs
+++ b/test/Api.Test/Tools/Controllers/SendsControllerTests.cs
@@ -7,7 +7,6 @@ using Bit.Api.Tools.Controllers;
 using Bit.Api.Tools.Models;
 using Bit.Api.Tools.Models.Request;
 using Bit.Api.Tools.Models.Response;
-using Bit.Core;
 using Bit.Core.Billing.Premium.Queries;
 using Bit.Core.Entities;
 using Bit.Core.Exceptions;
@@ -875,33 +874,6 @@ public class SendsControllerTests : IDisposable
     }
 
     [Theory, AutoData]
-    public async Task AccessUsingAuth_WithEmailProtectedSend_WithFfDisabled_ReturnsUnauthorizedResult(Guid sendId, User creator)
-    {
-        var send = new Send
-        {
-            Id = sendId,
-            UserId = creator.Id,
-            Type = SendType.Text,
-            Data = JsonSerializer.Serialize(new SendTextData("Test", "Notes", "Text", false)),
-            HideEmail = false,
-            DeletionDate = DateTime.UtcNow.AddDays(7),
-            ExpirationDate = null,
-            Disabled = false,
-            AccessCount = 0,
-            AuthType = AuthType.Email,
-            Emails = "test@example.com",
-            MaxAccessCount = null
-        };
-        var user = CreateUserWithSendIdClaim(sendId);
-        _sut.ControllerContext = CreateControllerContextWithUser(user);
-        _sendRepository.GetByIdAsync(sendId).Returns(send);
-        _userService.GetUserByIdAsync(creator.Id).Returns(creator);
-        _featureService.IsEnabled(FeatureFlagKeys.SendEmailOTP).Returns(false);
-
-        await Assert.ThrowsAsync<NotFoundException>(() => _sut.AccessUsingAuth());
-    }
-
-    [Theory, AutoData]
     public async Task AccessUsingAuth_WithHideEmail_DoesNotIncludeCreatorIdentifier(Guid sendId, User creator)
     {
         var send = new Send
@@ -1142,33 +1114,6 @@ public class SendsControllerTests : IDisposable
         Assert.Equal(expectedUrl, response.Url);
         await _sendRepository.Received(1).GetByIdAsync(sendId);
         await _nonAnonymousSendCommand.Received(1).GetSendFileDownloadUrlAsync(send, fileId);
-    }
-
-    [Theory, AutoData]
-    public async Task GetSendFileDownloadDataUsingAuth_WithEmailProtectedSend_WithFfDisabled_ReturnsUnauthorizedResult(
-        Guid sendId, string fileId, string expectedUrl)
-    {
-        var fileData = new SendFileData("Test File", "Notes", "document.pdf") { Id = fileId, Size = 2048 };
-        var send = new Send
-        {
-            Id = sendId,
-            Type = SendType.File,
-            Data = JsonSerializer.Serialize(fileData),
-            DeletionDate = DateTime.UtcNow.AddDays(7),
-            ExpirationDate = null,
-            Disabled = false,
-            AccessCount = 0,
-            AuthType = AuthType.Email,
-            Emails = "test@example.com",
-            MaxAccessCount = null
-        };
-        var user = CreateUserWithSendIdClaim(sendId);
-        _sut.ControllerContext = CreateControllerContextWithUser(user);
-        _sendRepository.GetByIdAsync(sendId).Returns(send);
-        _sendFileStorageService.GetSendFileDownloadUrlAsync(send, fileId).Returns(expectedUrl);
-        _featureService.IsEnabled(FeatureFlagKeys.SendEmailOTP).Returns(false);
-
-        await Assert.ThrowsAsync<NotFoundException>(() => _sut.GetSendFileDownloadDataUsingAuth(fileId));
     }
 
     [Theory, AutoData]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37230

## 📔 Objective

We want to remove the email verification feature flag logic from the new Send Access endpoints so that the server no longer requires the email verification feature flag to be enabled for the email verification feature to work on cloud and self-hosted environments