### PR TITLE
[PM-36185] Change where Setup container looks for openssl config

### DIFF
--- a/util/Setup/CertBuilder.cs
+++ b/util/Setup/CertBuilder.cs
@@ -44,7 +44,7 @@ public class CertBuilder
                     _context.Config.Ssl = true;
                     _context.Install.Trusted = false;
                     _context.Install.SelfSignedCert = true;
-                    var opensslConfig = File.ReadAllText("/usr/lib/ssl/openssl.cnf") +
+                    var opensslConfig = File.ReadAllText("/etc/ssl/openssl.cnf") +
                         $"\n[SAN]\nsubjectAltName=DNS:{_context.Install.Domain}\nbasicConstraints=CA:true";
                     var opensslConfigPath = Path.GetTempFileName();
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-36185](https://bitwarden.atlassian.net/browse/PM-36185)

## 📔 Objective

Fix an exception when the Setup container cannot find `/usr/lib/ssl/openssl.cnf`. On Debian and Ubuntu, that path is a symlink to `/etc/ssl/openssl.cnf`. Alpine/Fedora/Arch either only have `/etc/ssl/openssl.cnf` or symlink that to `/etc/pki/tls/openssl.cnf`. The `/usr/lib/ssl/openssl.cnf` path does not exist on those systems.


[PM-36185]: https://bitwarden.atlassian.net/browse/PM-36185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ