### PR TITLE
feat(kdf-settings-validator): Enforce salt cannot be empty string.

### DIFF
--- a/src/Core/KeyManagement/Models/Api/Request/MasterPasswordAuthenticationDataRequestModel.cs
+++ b/src/Core/KeyManagement/Models/Api/Request/MasterPasswordAuthenticationDataRequestModel.cs
@@ -12,7 +12,7 @@ public class MasterPasswordAuthenticationDataRequestModel
     public required KdfRequestModel Kdf { get; init; }
     [Required]
     public required string MasterPasswordAuthenticationHash { get; init; }
-    [Required]
+    [Required(AllowEmptyStrings = false)]
     [StringLength(256)]
     public required string Salt { get; init; }
 

--- a/src/Core/KeyManagement/Models/Api/Request/MasterPasswordUnlockDataRequestModel.cs
+++ b/src/Core/KeyManagement/Models/Api/Request/MasterPasswordUnlockDataRequestModel.cs
@@ -14,7 +14,7 @@ public class MasterPasswordUnlockDataRequestModel
     [Required]
     [EncryptedString]
     public required string MasterKeyWrappedUserKey { get; init; }
-    [Required]
+    [Required(AllowEmptyStrings = false)]
     [StringLength(256)]
     public required string Salt { get; init; }
 

--- a/src/Core/Utilities/KdfSettingsValidator.cs
+++ b/src/Core/Utilities/KdfSettingsValidator.cs
@@ -17,6 +17,22 @@ public static class KdfSettingsValidator
         MasterPasswordAuthenticationData authentication,
         MasterPasswordUnlockData unlock)
     {
+        if (string.IsNullOrEmpty(authentication.Salt))
+        {
+            yield return new ValidationResult(
+                "Master password salt must not be empty.",
+                [nameof(authentication.Salt)]);
+            yield break;
+        }
+
+        if (string.IsNullOrEmpty(unlock.Salt))
+        {
+            yield return new ValidationResult(
+                "Master password salt must not be empty.",
+                [nameof(unlock.Salt)]);
+            yield break;
+        }
+
         // Currently KDF settings are not saved separately for authentication and unlock and must therefore be equal
         if (!authentication.Kdf.Equals(unlock.Kdf))
         {
@@ -58,6 +74,22 @@ public static class KdfSettingsValidator
         MasterPasswordAuthenticationData authentication,
         MasterPasswordUnlockData unlock)
     {
+        if (string.IsNullOrEmpty(authentication.Salt))
+        {
+            yield return new ValidationResult(
+                "Master password salt must not be empty.",
+                [nameof(authentication.Salt)]);
+            yield break;
+        }
+
+        if (string.IsNullOrEmpty(unlock.Salt))
+        {
+            yield return new ValidationResult(
+                "Master password salt must not be empty.",
+                [nameof(unlock.Salt)]);
+            yield break;
+        }
+
         if (!authentication.Kdf.Equals(unlock.Kdf))
         {
             yield return new ValidationResult(

--- a/src/Core/Utilities/KdfSettingsValidator.cs
+++ b/src/Core/Utilities/KdfSettingsValidator.cs
@@ -17,7 +17,7 @@ public static class KdfSettingsValidator
         MasterPasswordAuthenticationData authentication,
         MasterPasswordUnlockData unlock)
     {
-        if (string.IsNullOrEmpty(authentication.Salt))
+        if (string.IsNullOrWhiteSpace(authentication.Salt))
         {
             yield return new ValidationResult(
                 "Master password salt must not be empty.",
@@ -25,7 +25,7 @@ public static class KdfSettingsValidator
             yield break;
         }
 
-        if (string.IsNullOrEmpty(unlock.Salt))
+        if (string.IsNullOrWhiteSpace(unlock.Salt))
         {
             yield return new ValidationResult(
                 "Master password salt must not be empty.",
@@ -74,7 +74,7 @@ public static class KdfSettingsValidator
         MasterPasswordAuthenticationData authentication,
         MasterPasswordUnlockData unlock)
     {
-        if (string.IsNullOrEmpty(authentication.Salt))
+        if (string.IsNullOrWhiteSpace(authentication.Salt))
         {
             yield return new ValidationResult(
                 "Master password salt must not be empty.",
@@ -82,7 +82,7 @@ public static class KdfSettingsValidator
             yield break;
         }
 
-        if (string.IsNullOrEmpty(unlock.Salt))
+        if (string.IsNullOrWhiteSpace(unlock.Salt))
         {
             yield return new ValidationResult(
                 "Master password salt must not be empty.",

--- a/test/Api.Test/Utilities/KdfSettingsValidatorTests.cs
+++ b/test/Api.Test/Utilities/KdfSettingsValidatorTests.cs
@@ -125,6 +125,50 @@ public class KdfSettingsValidatorTests
     }
 
     [Fact]
+    public void ValidateAuthenticationAndUnlockData_WhenAuthSaltIsEmpty_ReturnsSaltError()
+    {
+        var authentication = new MasterPasswordAuthenticationData
+        {
+            Kdf = new KdfSettings { KdfType = KdfType.PBKDF2_SHA256, Iterations = 600_000 },
+            MasterPasswordAuthenticationHash = "hash",
+            Salt = ""
+        };
+        var unlock = new MasterPasswordUnlockData
+        {
+            Kdf = new KdfSettings { KdfType = KdfType.PBKDF2_SHA256, Iterations = 600_000 },
+            MasterKeyWrappedUserKey = "wrapped",
+            Salt = "salt"
+        };
+
+        var results = KdfSettingsValidator.ValidateAuthenticationAndUnlockData(authentication, unlock).ToList();
+
+        Assert.Single(results);
+        Assert.Equal("Master password salt must not be empty.", results[0].ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateAuthenticationAndUnlockData_WhenUnlockSaltIsEmpty_ReturnsSaltError()
+    {
+        var authentication = new MasterPasswordAuthenticationData
+        {
+            Kdf = new KdfSettings { KdfType = KdfType.PBKDF2_SHA256, Iterations = 600_000 },
+            MasterPasswordAuthenticationHash = "hash",
+            Salt = "salt"
+        };
+        var unlock = new MasterPasswordUnlockData
+        {
+            Kdf = new KdfSettings { KdfType = KdfType.PBKDF2_SHA256, Iterations = 600_000 },
+            MasterKeyWrappedUserKey = "wrapped",
+            Salt = ""
+        };
+
+        var results = KdfSettingsValidator.ValidateAuthenticationAndUnlockData(authentication, unlock).ToList();
+
+        Assert.Single(results);
+        Assert.Equal("Master password salt must not be empty.", results[0].ErrorMessage);
+    }
+
+    [Fact]
     public void ValidateKdfAndSaltAgreement_WhenMatchingKdfAndSalt_ReturnsNoErrors()
     {
         var kdf = new KdfSettings { KdfType = KdfType.PBKDF2_SHA256, Iterations = 600_000 };
@@ -191,6 +235,50 @@ public class KdfSettingsValidatorTests
 
         Assert.Single(results);
         Assert.Equal("Invalid master password salt.", results[0].ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateKdfAndSaltAgreement_WhenAuthSaltIsEmpty_ReturnsSaltError()
+    {
+        var authentication = new MasterPasswordAuthenticationData
+        {
+            Kdf = new KdfSettings { KdfType = KdfType.PBKDF2_SHA256, Iterations = 600_000 },
+            MasterPasswordAuthenticationHash = "hash",
+            Salt = ""
+        };
+        var unlock = new MasterPasswordUnlockData
+        {
+            Kdf = new KdfSettings { KdfType = KdfType.PBKDF2_SHA256, Iterations = 600_000 },
+            MasterKeyWrappedUserKey = "wrapped",
+            Salt = "salt"
+        };
+
+        var results = KdfSettingsValidator.ValidateKdfAndSaltAgreement(authentication, unlock).ToList();
+
+        Assert.Single(results);
+        Assert.Equal("Master password salt must not be empty.", results[0].ErrorMessage);
+    }
+
+    [Fact]
+    public void ValidateKdfAndSaltAgreement_WhenUnlockSaltIsEmpty_ReturnsSaltError()
+    {
+        var authentication = new MasterPasswordAuthenticationData
+        {
+            Kdf = new KdfSettings { KdfType = KdfType.PBKDF2_SHA256, Iterations = 600_000 },
+            MasterPasswordAuthenticationHash = "hash",
+            Salt = "salt"
+        };
+        var unlock = new MasterPasswordUnlockData
+        {
+            Kdf = new KdfSettings { KdfType = KdfType.PBKDF2_SHA256, Iterations = 600_000 },
+            MasterKeyWrappedUserKey = "wrapped",
+            Salt = ""
+        };
+
+        var results = KdfSettingsValidator.ValidateKdfAndSaltAgreement(authentication, unlock).ToList();
+
+        Assert.Single(results);
+        Assert.Equal("Master password salt must not be empty.", results[0].ErrorMessage);
     }
 
     [Theory]

--- a/test/Api.Test/Utilities/KdfSettingsValidatorTests.cs
+++ b/test/Api.Test/Utilities/KdfSettingsValidatorTests.cs
@@ -124,14 +124,18 @@ public class KdfSettingsValidatorTests
         Assert.Contains("KDF iterations must be between", results[0].ErrorMessage);
     }
 
-    [Fact]
-    public void ValidateAuthenticationAndUnlockData_WhenAuthSaltIsEmpty_ReturnsSaltError()
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    public void ValidateAuthenticationAndUnlockData_WhenAuthSaltIsEmptyOrWhitespace_ReturnsSaltError(string salt)
     {
         var authentication = new MasterPasswordAuthenticationData
         {
             Kdf = new KdfSettings { KdfType = KdfType.PBKDF2_SHA256, Iterations = 600_000 },
             MasterPasswordAuthenticationHash = "hash",
-            Salt = ""
+            Salt = salt
         };
         var unlock = new MasterPasswordUnlockData
         {
@@ -146,8 +150,12 @@ public class KdfSettingsValidatorTests
         Assert.Equal("Master password salt must not be empty.", results[0].ErrorMessage);
     }
 
-    [Fact]
-    public void ValidateAuthenticationAndUnlockData_WhenUnlockSaltIsEmpty_ReturnsSaltError()
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    public void ValidateAuthenticationAndUnlockData_WhenUnlockSaltIsEmptyOrWhitespace_ReturnsSaltError(string salt)
     {
         var authentication = new MasterPasswordAuthenticationData
         {
@@ -159,7 +167,7 @@ public class KdfSettingsValidatorTests
         {
             Kdf = new KdfSettings { KdfType = KdfType.PBKDF2_SHA256, Iterations = 600_000 },
             MasterKeyWrappedUserKey = "wrapped",
-            Salt = ""
+            Salt = salt
         };
 
         var results = KdfSettingsValidator.ValidateAuthenticationAndUnlockData(authentication, unlock).ToList();
@@ -237,14 +245,18 @@ public class KdfSettingsValidatorTests
         Assert.Equal("Invalid master password salt.", results[0].ErrorMessage);
     }
 
-    [Fact]
-    public void ValidateKdfAndSaltAgreement_WhenAuthSaltIsEmpty_ReturnsSaltError()
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    public void ValidateKdfAndSaltAgreement_WhenAuthSaltIsEmptyOrWhitespace_ReturnsSaltError(string salt)
     {
         var authentication = new MasterPasswordAuthenticationData
         {
             Kdf = new KdfSettings { KdfType = KdfType.PBKDF2_SHA256, Iterations = 600_000 },
             MasterPasswordAuthenticationHash = "hash",
-            Salt = ""
+            Salt = salt
         };
         var unlock = new MasterPasswordUnlockData
         {
@@ -259,8 +271,12 @@ public class KdfSettingsValidatorTests
         Assert.Equal("Master password salt must not be empty.", results[0].ErrorMessage);
     }
 
-    [Fact]
-    public void ValidateKdfAndSaltAgreement_WhenUnlockSaltIsEmpty_ReturnsSaltError()
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    public void ValidateKdfAndSaltAgreement_WhenUnlockSaltIsEmptyOrWhitespace_ReturnsSaltError(string salt)
     {
         var authentication = new MasterPasswordAuthenticationData
         {
@@ -272,7 +288,7 @@ public class KdfSettingsValidatorTests
         {
             Kdf = new KdfSettings { KdfType = KdfType.PBKDF2_SHA256, Iterations = 600_000 },
             MasterKeyWrappedUserKey = "wrapped",
-            Salt = ""
+            Salt = salt
         };
 
         var results = KdfSettingsValidator.ValidateKdfAndSaltAgreement(authentication, unlock).ToList();


### PR DESCRIPTION
## 🎟️ Tracking

[PM-35393](https://bitwarden.atlassian.net/browse/PM-35393)

## 📔 Objective

`[Required]` attribution on `salt`-related fields enforces _by default_ that salt cannot be null, empty, or whitespace. However, this is a [configurable opinion](https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations.requiredattribute.allowemptystrings?view=netframework-4.8.1&viewFallbackFrom=net-10.0#system-componentmodel-dataannotations-requiredattribute-allowemptystrings). While it should probably not be configured to allow whitespace, because this is a critical path, reinforcement should be present to guard against configuration drift, which would otherwise be invisible to this logic.
`string.IsNullOrWhitespace` properly [captures all of these](https://learn.microsoft.com/en-us/dotnet/api/system.string.isnullorwhitespace?view=netframework-4.8.1&viewFallbackFrom=net-10.0#system-string-isnullorwhitespace(system-string)).

Tests have been added to support.

[PM-35393]: https://bitwarden.atlassian.net/browse/PM-35393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ