### PR TITLE
PM-37478 temporarily disabling useRiskInsights access controll

### DIFF
--- a/src/Api/Dirt/Controllers/OrganizationReportsController.cs
+++ b/src/Api/Dirt/Controllers/OrganizationReportsController.cs
@@ -465,11 +465,15 @@ public class OrganizationReportsController : Controller
             throw new NotFoundException();
         }
 
-        var orgAbility = await _applicationCacheService.GetOrganizationAbilityAsync(organizationId);
-        if (orgAbility is null || !orgAbility.UseRiskInsights)
-        {
-            throw new BadRequestException("Your organization's plan does not support this feature.");
-        }
+        // TODO: Re-enable this access control in PM-37469
+        // Temporarily disabling this access control to allow for proper access control and billing
+        // setup to be done.
+        //
+        // var orgAbility = await _applicationCacheService.GetOrganizationAbilityAsync(organizationId);
+        // if (orgAbility is null || !orgAbility.UseRiskInsights)
+        // {
+        //     throw new BadRequestException("Your organization's plan does not support this feature.");
+        // }
     }
 
     private static void EnsureValidIds(Guid organizationId, Guid? reportId = null)

--- a/test/Api.Test/Dirt/OrganizationReportsControllerTests.cs
+++ b/test/Api.Test/Dirt/OrganizationReportsControllerTests.cs
@@ -11,7 +11,6 @@ using Bit.Core.Dirt.Reports.Services;
 using Bit.Core.Dirt.Repositories;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
-using Bit.Core.Models.Data.Organizations;
 using Bit.Core.Services;
 using Bit.Core.Utilities;
 using Bit.Test.Common.AutoFixture;
@@ -114,28 +113,29 @@ public class OrganizationReportControllerTests
             .GetLatestOrganizationReportAsync(Arg.Any<Guid>());
     }
 
-    [Theory, BitAutoData]
-    public async Task GetLatestOrganizationReportAsync_NoUseRiskInsights_ThrowsBadRequestException(
-        SutProvider<OrganizationReportsController> sutProvider,
-        Guid orgId)
-    {
-        // Arrange
-        sutProvider.GetDependency<ICurrentContext>()
-            .AccessReports(orgId)
-            .Returns(true);
-
-        sutProvider.GetDependency<IApplicationCacheService>()
-            .GetOrganizationAbilityAsync(orgId)
-            .Returns(new OrganizationAbility { UseRiskInsights = false });
-
-        // Act & Assert
-        await Assert.ThrowsAsync<BadRequestException>(() =>
-            sutProvider.Sut.GetLatestOrganizationReportAsync(orgId));
-
-        await sutProvider.GetDependency<IGetOrganizationReportQuery>()
-            .DidNotReceive()
-            .GetLatestOrganizationReportAsync(Arg.Any<Guid>());
-    }
+    // TODO: Re-enable in PM-37469 when UseRiskInsights access control is restored
+    // [Theory, BitAutoData]
+    // public async Task GetLatestOrganizationReportAsync_NoUseRiskInsights_ThrowsBadRequestException(
+    //     SutProvider<OrganizationReportsController> sutProvider,
+    //     Guid orgId)
+    // {
+    //     // Arrange
+    //     sutProvider.GetDependency<ICurrentContext>()
+    //         .AccessReports(orgId)
+    //         .Returns(true);
+    //
+    //     sutProvider.GetDependency<IApplicationCacheService>()
+    //         .GetOrganizationAbilityAsync(orgId)
+    //         .Returns(new OrganizationAbility { UseRiskInsights = false });
+    //
+    //     // Act & Assert
+    //     await Assert.ThrowsAsync<BadRequestException>(() =>
+    //         sutProvider.Sut.GetLatestOrganizationReportAsync(orgId));
+    //
+    //     await sutProvider.GetDependency<IGetOrganizationReportQuery>()
+    //         .DidNotReceive()
+    //         .GetLatestOrganizationReportAsync(Arg.Any<Guid>());
+    // }
 
     // CreateOrganizationReportAsync - V1 (flag off)
 
@@ -1411,9 +1411,10 @@ public class OrganizationReportControllerTests
             .AccessReports(orgId)
             .Returns(true);
 
-        sutProvider.GetDependency<IApplicationCacheService>()
-            .GetOrganizationAbilityAsync(orgId)
-            .Returns(new OrganizationAbility { UseRiskInsights = true });
+        // TODO: Re-enable in PM-37469 when UseRiskInsights access control is restored
+        // sutProvider.GetDependency<IApplicationCacheService>()
+        //     .GetOrganizationAbilityAsync(orgId)
+        //     .Returns(new OrganizationAbility { UseRiskInsights = true });
     }
 
     private static void SetupV2Authorization(
@@ -1428,8 +1429,9 @@ public class OrganizationReportControllerTests
             .AccessReports(orgId)
             .Returns(true);
 
-        sutProvider.GetDependency<IApplicationCacheService>()
-            .GetOrganizationAbilityAsync(orgId)
-            .Returns(new OrganizationAbility { UseRiskInsights = true });
+        // TODO: Re-enable in PM-37469 when UseRiskInsights access control is restored
+        // sutProvider.GetDependency<IApplicationCacheService>()
+        //     .GetOrganizationAbilityAsync(orgId)
+        //     .Returns(new OrganizationAbility { UseRiskInsights = true });
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37478](https://bitwarden.atlassian.net/browse/PM-37478)

## 📔 Objective

[PR #7228](https://github.com/bitwarden/server/pull/7228) added an orgAbility.UseRiskInsights check to AuthorizeAsync() on the V1 and V2 Access Intelligence endpoints. The check follows the correct pattern, but it should not have been added before the upstream Organization Ability work was completed (tracked by the parent Story — link TBD). The UseRiskInsights flag is not reliably 1 on Enterprise org rows, so the check now fails for affected Enterprise users.

Temporarily disable the check to restore production behavior while the parent Story's subtasks complete the org-ability work. The check will be re-enabled by a subtask under the parent Story once that work ships.


[PM-37478]: https://bitwarden.atlassian.net/browse/PM-37478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ