### PR TITLE
Add passkey and password history to a subset of seeded credentials

### DIFF
--- a/test/SeederApi.IntegrationTest/CipherComposerTests.cs
+++ b/test/SeederApi.IntegrationTest/CipherComposerTests.cs
@@ -1,0 +1,121 @@
+﻿using Bit.Seeder.Data.Distributions;
+using Bit.Seeder.Data.Enums;
+using Bit.Seeder.Data.Static;
+using Bit.Seeder.Factories;
+using Xunit;
+
+namespace Bit.SeederApi.IntegrationTest;
+
+public class CipherComposerTests
+{
+    [Fact]
+    public void BuildPasswordHistory_IsDeterministic()
+    {
+        var first = CipherComposer.BuildPasswordHistory(42, 3, 1000, PasswordDistributions.Realistic);
+        var second = CipherComposer.BuildPasswordHistory(42, 3, 1000, PasswordDistributions.Realistic);
+
+        Assert.Equal(first.Count, second.Count);
+        for (var i = 0; i < first.Count; i++)
+        {
+            Assert.Equal(first[i].Password, second[i].Password);
+        }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(5)]
+    public void BuildPasswordHistory_ReturnsRequestedEntryCount(int entryCount)
+    {
+        var history = CipherComposer.BuildPasswordHistory(10, entryCount, 1000, PasswordDistributions.Realistic);
+
+        Assert.Equal(entryCount, history.Count);
+    }
+
+    [Fact]
+    public void BuildPasswordHistory_EntriesWithinSameHistoryVary()
+    {
+        // Multiple entries on the same cipher should walk to different pool positions so the history is not
+        // a string of identical passwords.
+        var history = CipherComposer.BuildPasswordHistory(7, 3, 1000, PasswordDistributions.Realistic);
+
+        Assert.Equal(3, history.Select(e => e.Password).Distinct().Count());
+    }
+
+    [Fact]
+    public void BuildPasswordHistory_HistoricalPasswordsAreMostlyDistinctFromCurrent()
+    {
+        // The offset is designed to walk away from the current password's pool position. Within the same strength
+        // bucket, modular collisions are still possible (priorIndex % poolSize == index % poolSize)
+        const int total = 1000;
+        const int entryCount = 3;
+        var collisions = 0;
+        var totalChecks = 0;
+
+        for (var index = 0; index < total; index++)
+        {
+            var currentPassword = Passwords.GetPassword(index, total, PasswordDistributions.Realistic);
+            var history = CipherComposer.BuildPasswordHistory(index, entryCount, total, PasswordDistributions.Realistic);
+            foreach (var entry in history)
+            {
+                totalChecks++;
+                if (entry.Password == currentPassword)
+                {
+                    collisions++;
+                }
+            }
+        }
+
+        Assert.True(collisions < totalChecks * 0.05,
+            $"Expected fewer than 5% historical-vs-current collisions; got {collisions}/{totalChecks}.");
+    }
+
+    [Fact]
+    public void BuildPasswordHistory_RespectsDistribution()
+    {
+        // priorIndex is constrained to [0, total), so historicals should span all five strength buckets
+        const int total = 1000;
+        const int entryCount = 3;
+        var bucketsSeen = new HashSet<PasswordStrength>();
+
+        for (var index = 0; index < total; index++)
+        {
+            var history = CipherComposer.BuildPasswordHistory(index, entryCount, total, PasswordDistributions.Realistic);
+            foreach (var entry in history)
+            {
+                bucketsSeen.Add(ClassifyStrength(entry.Password));
+            }
+        }
+
+        Assert.Equal(5, bucketsSeen.Count);
+    }
+
+    [Fact]
+    public void BuildPasswordHistory_ZeroEntryCount_ReturnsEmptyList()
+    {
+        var history = CipherComposer.BuildPasswordHistory(10, 0, 1000, PasswordDistributions.Realistic);
+
+        Assert.Empty(history);
+    }
+
+    [Fact]
+    public void BuildPasswordHistory_ZeroTotal_DoesNotThrow()
+    {
+        var history = CipherComposer.BuildPasswordHistory(0, 1, 0, PasswordDistributions.Realistic);
+
+        Assert.Single(history);
+        Assert.False(string.IsNullOrEmpty(history[0].Password));
+    }
+
+    private static PasswordStrength ClassifyStrength(string password)
+    {
+        if (Array.IndexOf(Passwords.VeryWeak, password) >= 0) return PasswordStrength.VeryWeak;
+        if (Array.IndexOf(Passwords.Weak, password) >= 0) return PasswordStrength.Weak;
+        if (Array.IndexOf(Passwords.Fair, password) >= 0) return PasswordStrength.Fair;
+        if (Array.IndexOf(Passwords.Strong, password) >= 0) return PasswordStrength.Strong;
+        if (Array.IndexOf(Passwords.VeryStrong, password) >= 0) return PasswordStrength.VeryStrong;
+        throw new InvalidOperationException($"Password '{password}' not found in any strength bucket.");
+    }
+}

--- a/test/SeederApi.IntegrationTest/EncryptPropertyAttributeTests.cs
+++ b/test/SeederApi.IntegrationTest/EncryptPropertyAttributeTests.cs
@@ -15,11 +15,12 @@ public sealed class EncryptPropertyAttributeTests
         // 3 login (username, password, totp)
         // 2 loginUri[*] (uri, uriChecksum)
         // 12 Fido2Credential (everything but discoverable)
+        // 1 passwordHistory[*].password
         // 6 card
         // 18 identity
         // 3 sshKey
         // 2 fields[*] (name, value)
-        Assert.Equal(48, paths.Length);
+        Assert.Equal(49, paths.Length);
     }
 
     [Fact]

--- a/test/SeederApi.IntegrationTest/RustSdkCipherTests.cs
+++ b/test/SeederApi.IntegrationTest/RustSdkCipherTests.cs
@@ -469,7 +469,7 @@ public sealed class RustSdkCipherTests
                 Password = "CurrentP@ss!",
                 Fido2Credentials =
                 [
-                    LoginCipherSeeder.CreateFido2Credential("example.com", "user@example.com")
+                    LoginCipherSeeder.CreateFido2Credential("example.com", "Example", "user@example.com")
                 ],
                 PasswordHistory =
                 [
@@ -507,6 +507,7 @@ public sealed class RustSdkCipherTests
 
         var fido2 = login.GetProperty("fido2Credentials")[0];
         Assert.Equal("example.com", RustSdkService.DecryptString(fido2.GetProperty("rpId").GetString()!, orgKeys.Key));
+        Assert.Equal("Example", RustSdkService.DecryptString(fido2.GetProperty("rpName").GetString()!, orgKeys.Key));
         Assert.Equal("user@example.com", RustSdkService.DecryptString(fido2.GetProperty("userName").GetString()!, orgKeys.Key));
         Assert.StartsWith("2.", fido2.GetProperty("keyValue").GetString());
     }
@@ -543,7 +544,7 @@ public sealed class RustSdkCipherTests
                 ],
                 Fido2Credentials =
                 [
-                    LoginCipherSeeder.CreateFido2Credential("example.com", "user@example.com")
+                    LoginCipherSeeder.CreateFido2Credential("example.com", "Example", "user@example.com")
                 ]
             }
         });

--- a/test/SeederApi.IntegrationTest/RustSdkCipherTests.cs
+++ b/test/SeederApi.IntegrationTest/RustSdkCipherTests.cs
@@ -455,6 +455,114 @@ public sealed class RustSdkCipherTests
     }
 
     [Fact]
+    public void EncryptFields_Fido2AndPasswordHistory_Roundtrip()
+    {
+        var orgKeys = RustSdkService.GenerateOrganizationKeys();
+
+        var cipher = new CipherViewDto
+        {
+            Name = "Login With Passkey",
+            Type = CipherTypes.Login,
+            Login = new LoginViewDto
+            {
+                Username = "user@example.com",
+                Password = "CurrentP@ss!",
+                Fido2Credentials =
+                [
+                    LoginCipherSeeder.CreateFido2Credential("example.com", "user@example.com")
+                ],
+                PasswordHistory =
+                [
+                    new PasswordHistoryViewDto
+                    {
+                        Password = "PreviousP@ss1!",
+                        LastUsedDate = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+                    },
+                    new PasswordHistoryViewDto
+                    {
+                        Password = "PreviousP@ss2!",
+                        LastUsedDate = new DateTime(2025, 2, 1, 0, 0, 0, DateTimeKind.Utc)
+                    }
+                ]
+            }
+        };
+
+        var json = JsonSerializer.Serialize(cipher, _sdkJsonOptions);
+        var fieldPathsJson = JsonSerializer.Serialize(EncryptPropertyAttribute.GetFieldPaths<CipherViewDto>());
+        var encryptedJson = RustSdkService.EncryptFields(json, fieldPathsJson, orgKeys.Key);
+
+        Assert.DoesNotContain("PreviousP@ss1!", encryptedJson);
+        Assert.DoesNotContain("PreviousP@ss2!", encryptedJson);
+
+        using var doc = JsonDocument.Parse(encryptedJson);
+        var login = doc.RootElement.GetProperty("login");
+
+        var history = login.GetProperty("passwordHistory");
+        Assert.Equal(2, history.GetArrayLength());
+        Assert.Equal("PreviousP@ss1!", RustSdkService.DecryptString(history[0].GetProperty("password").GetString()!, orgKeys.Key));
+        Assert.Equal("PreviousP@ss2!", RustSdkService.DecryptString(history[1].GetProperty("password").GetString()!, orgKeys.Key));
+
+        // LastUsedDate is metadata and should remain in plaintext.
+        Assert.Equal("2025-01-01T00:00:00Z", history[0].GetProperty("lastUsedDate").GetString());
+
+        var fido2 = login.GetProperty("fido2Credentials")[0];
+        Assert.Equal("example.com", RustSdkService.DecryptString(fido2.GetProperty("rpId").GetString()!, orgKeys.Key));
+        Assert.Equal("user@example.com", RustSdkService.DecryptString(fido2.GetProperty("userName").GetString()!, orgKeys.Key));
+        Assert.StartsWith("2.", fido2.GetProperty("keyValue").GetString());
+    }
+
+    [Fact]
+    public void EncryptPropertyAttribute_GetFieldPaths_IncludesFido2AndPasswordHistory()
+    {
+        var paths = EncryptPropertyAttribute.GetFieldPaths<CipherViewDto>();
+
+        Assert.Contains("login.passwordHistory[*].password", paths);
+        Assert.Contains("login.fido2Credentials[*].keyValue", paths);
+        Assert.Contains("login.fido2Credentials[*].userName", paths);
+        Assert.Contains("login.fido2Credentials[*].credentialId", paths);
+    }
+
+    [Fact]
+    public void CipherSeeder_WithPasswordHistory_PopulatesEncryptedCipherLoginData()
+    {
+        var orgKeys = RustSdkService.GenerateOrganizationKeys();
+
+        var cipher = LoginCipherSeeder.Create(new CipherSeed
+        {
+            Type = CipherType.Login,
+            Name = "Login With History",
+            EncryptionKey = orgKeys.Key,
+            OrganizationId = Guid.NewGuid(),
+            Login = new LoginViewDto
+            {
+                Username = "user@example.com",
+                Password = "CurrentP@ss!",
+                PasswordHistory =
+                [
+                    new PasswordHistoryViewDto { Password = "OldOne", LastUsedDate = DateTime.UtcNow.AddDays(-7) }
+                ],
+                Fido2Credentials =
+                [
+                    LoginCipherSeeder.CreateFido2Credential("example.com", "user@example.com")
+                ]
+            }
+        });
+
+        var loginData = JsonSerializer.Deserialize<CipherLoginData>(cipher.Data);
+        Assert.NotNull(loginData);
+        Assert.NotNull(loginData.PasswordHistory);
+        Assert.NotNull(loginData.Fido2Credentials);
+
+        var historyEntries = loginData.PasswordHistory.ToList();
+        Assert.Single(historyEntries);
+        Assert.StartsWith("2.", historyEntries[0].Password);
+        Assert.DoesNotContain("OldOne", cipher.Data);
+
+        Assert.Single(loginData.Fido2Credentials);
+        Assert.StartsWith("2.", loginData.Fido2Credentials[0].KeyValue);
+    }
+
+    [Fact]
     public void CipherSeeder_SshKeyCipher_ProducesServerCompatibleFormat()
     {
         var orgKeys = RustSdkService.GenerateOrganizationKeys();

--- a/util/Seeder/Factories/CipherComposer.cs
+++ b/util/Seeder/Factories/CipherComposer.cs
@@ -49,6 +49,17 @@ internal static class CipherComposer
     {
         var company = companies[index % companies.Length];
         var uri = $"https://{company.Domain}";
+        var username = generator.Username.GenerateByIndex(index, totalHint: generator.CipherCount, domain: company.Domain);
+
+        // ~20% of logins get a FIDO2 passkey; ~40% get a 1-3 entry password history. Deterministic by index.
+        var fido2Credentials = index % 5 == 0
+            ? new List<Fido2CredentialViewDto> { LoginCipherSeeder.CreateFido2Credential(company.Name, username) }
+            : null;
+
+        var passwordHistory = index % 5 < 2
+            ? BuildPasswordHistory(index, 1 + (index % 3), generator.CipherCount, passwordDistribution)
+            : null;
+
         return LoginCipherSeeder.Create(new CipherSeed
         {
             Type = CipherType.Login,
@@ -59,11 +70,33 @@ internal static class CipherComposer
             Reprompt = reprompt,
             Login = new LoginViewDto
             {
-                Username = generator.Username.GenerateByIndex(index, totalHint: generator.CipherCount, domain: company.Domain),
+                Username = username,
                 Password = Passwords.GetPassword(index, generator.CipherCount, passwordDistribution),
-                Uris = [new LoginUriViewDto { Uri = uri }]
+                Uris = [new LoginUriViewDto { Uri = uri }],
+                Fido2Credentials = fido2Credentials,
+                PasswordHistory = passwordHistory
             }
         });
+    }
+
+    private static List<PasswordHistoryViewDto> BuildPasswordHistory(
+        int index,
+        int entryCount,
+        int total,
+        Distribution<PasswordStrength> passwordDistribution)
+    {
+        var history = new List<PasswordHistoryViewDto>(entryCount);
+        for (var k = 1; k <= entryCount; k++)
+        {
+            // Offset back into the password pool so prior entries are deterministic and distinct from the current password.
+            var priorIndex = Math.Abs(index - (k * 7919));
+            history.Add(new PasswordHistoryViewDto
+            {
+                Password = Passwords.GetPassword(priorIndex, total, passwordDistribution),
+                LastUsedDate = DateTime.UtcNow.AddDays(-7 * k)
+            });
+        }
+        return history;
     }
 
     private static Cipher ComposeCard(

--- a/util/Seeder/Factories/CipherComposer.cs
+++ b/util/Seeder/Factories/CipherComposer.cs
@@ -53,7 +53,7 @@ internal static class CipherComposer
 
         // ~20% of logins get a FIDO2 passkey; ~40% get a 1-3 entry password history. Deterministic by index.
         var fido2Credentials = index % 5 == 0
-            ? new List<Fido2CredentialViewDto> { LoginCipherSeeder.CreateFido2Credential(company.Name, username) }
+            ? new List<Fido2CredentialViewDto> { LoginCipherSeeder.CreateFido2Credential(company.Domain, company.Name, username) }
             : null;
 
         var passwordHistory = index % 5 < 2
@@ -79,7 +79,7 @@ internal static class CipherComposer
         });
     }
 
-    private static List<PasswordHistoryViewDto> BuildPasswordHistory(
+    internal static List<PasswordHistoryViewDto> BuildPasswordHistory(
         int index,
         int entryCount,
         int total,
@@ -88,8 +88,24 @@ internal static class CipherComposer
         var history = new List<PasswordHistoryViewDto>(entryCount);
         for (var k = 1; k <= entryCount; k++)
         {
-            // Offset back into the password pool so prior entries are deterministic and distinct from the current password.
-            var priorIndex = Math.Abs(index - (k * 7919));
+            // Walk to a deterministic prior position in the pool. The offset must stay in [0, total) so
+            // Distribution.Select lands in a real bucket (otherwise every historical password collapses into the
+            // strongest tier), and must be non-zero so priorIndex != index — i.e. the prior password is genuinely
+            // distinct from the current one. 7919 is prime; multiplying by k varies offsets across entries.
+            int priorIndex;
+            if (total <= 1)
+            {
+                priorIndex = 0;
+            }
+            else
+            {
+                var offset = (k * 7919) % total;
+                if (offset == 0)
+                {
+                    offset = 1;
+                }
+                priorIndex = (index + offset) % total;
+            }
             history.Add(new PasswordHistoryViewDto
             {
                 Password = Passwords.GetPassword(priorIndex, total, passwordDistribution),

--- a/util/Seeder/Factories/LoginCipherSeeder.cs
+++ b/util/Seeder/Factories/LoginCipherSeeder.cs
@@ -27,7 +27,7 @@ internal static class LoginCipherSeeder
         return CipherEncryption.CreateEntity(encrypted, encrypted.ToLoginData(), CipherType.Login, options.OrganizationId, options.UserId);
     }
 
-    internal static Fido2CredentialViewDto CreateFido2Credential(string rpName, string userName)
+    internal static Fido2CredentialViewDto CreateFido2Credential(string rpId, string rpName, string userName)
     {
         // Generate ECDSA P-256 private key in PKCS#8 format
         using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
@@ -44,7 +44,7 @@ internal static class LoginCipherSeeder
             CredentialId = JsonSerializer.Serialize(Guid.NewGuid()),
             KeyValue = keyValue,
             Counter = "0",
-            RpId = rpName,
+            RpId = rpId,
             RpName = rpName,
             UserHandle = userHandle,
             UserName = userName,

--- a/util/Seeder/Models/CipherViewDto.cs
+++ b/util/Seeder/Models/CipherViewDto.cs
@@ -93,6 +93,19 @@ public class LoginViewDto
 
     [JsonPropertyName("fido2Credentials")]
     public List<Fido2CredentialViewDto>? Fido2Credentials { get; set; }
+
+    [JsonPropertyName("passwordHistory")]
+    public List<PasswordHistoryViewDto>? PasswordHistory { get; set; }
+}
+
+public class PasswordHistoryViewDto
+{
+    [EncryptProperty]
+    [JsonPropertyName("password")]
+    public required string Password { get; set; }
+
+    [JsonPropertyName("lastUsedDate")]
+    public DateTime LastUsedDate { get; set; } = DateTime.UtcNow;
 }
 
 public class Fido2CredentialViewDto

--- a/util/Seeder/Models/EncryptedCipherDto.cs
+++ b/util/Seeder/Models/EncryptedCipherDto.cs
@@ -93,6 +93,18 @@ public class EncryptedLoginDto
 
     [JsonPropertyName("fido2Credentials")]
     public List<EncryptedFido2CredentialDto>? Fido2Credentials { get; set; }
+
+    [JsonPropertyName("passwordHistory")]
+    public List<EncryptedPasswordHistoryDto>? PasswordHistory { get; set; }
+}
+
+public class EncryptedPasswordHistoryDto
+{
+    [JsonPropertyName("password")]
+    public required string Password { get; set; }
+
+    [JsonPropertyName("lastUsedDate")]
+    public DateTime LastUsedDate { get; set; }
 }
 
 public class EncryptedLoginUriDto

--- a/util/Seeder/Models/EncryptedCipherDtoExtensions.cs
+++ b/util/Seeder/Models/EncryptedCipherDtoExtensions.cs
@@ -36,6 +36,11 @@ internal static class EncryptedCipherDtoExtensions
             Discoverable = f.Discoverable,
             CreationDate = f.CreationDate
         }).ToArray(),
+        PasswordHistory = e.Login?.PasswordHistory?.Select(p => new CipherPasswordHistoryData
+        {
+            Password = p.Password,
+            LastUsedDate = p.LastUsedDate
+        }).ToArray(),
         Fields = e.ToFields()
     };
 

--- a/util/Seeder/Scenes/UserLoginCipherScene.cs
+++ b/util/Seeder/Scenes/UserLoginCipherScene.cs
@@ -40,6 +40,7 @@ public class UserLoginCipherScene(IUserRepository userRepository, ICipherReposit
 
     public class PasskeyRequest
     {
+        public required string RpId { get; set; }
         public required string RpName { get; set; }
         public required string UserName { get; set; }
     }
@@ -70,7 +71,7 @@ public class UserLoginCipherScene(IUserRepository userRepository, ICipherReposit
                 Password = request.Password,
                 Totp = request.Totp,
                 Uris = string.IsNullOrEmpty(request.Uri) ? null : [new LoginUriViewDto { Uri = request.Uri }],
-                Fido2Credentials = request.Passkeys?.Select(p => LoginCipherSeeder.CreateFido2Credential(p.RpName, p.UserName)).ToList()
+                Fido2Credentials = request.Passkeys?.Select(p => LoginCipherSeeder.CreateFido2Credential(p.RpId, p.RpName, p.UserName)).ToList()
             },
             Fields = request.Fields?.Select(f => new FieldViewDto
             {


### PR DESCRIPTION
## 🎟️ Tracking

Inspired by work performed as part of [PM-18786](https://bitwarden.atlassian.net/browse/PM-18786).

## 📔 Objective

This PR adds `fido2Credentials` and `passwordHistory` objects to a subset of seeded login ciphers in order to better resemble a real-world vault. A single passkey is added to ~20% of logins and password history (1-3 iterations) is added to ~40% of logins. 


[PM-18786]: https://bitwarden.atlassian.net/browse/PM-18786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ