### PR TITLE
[PM-35656] Add Events for New Item Types

### DIFF
--- a/src/Core/Dirt/Enums/EventType.cs
+++ b/src/Core/Dirt/Enums/EventType.cs
@@ -43,6 +43,12 @@ public enum EventType : int
     Cipher_ClientToggledLicenseNumberVisible = 1124,
     Cipher_ClientCopiedPassportNumber = 1125,
     Cipher_ClientToggledPassportNumberVisible = 1126,
+    Cipher_ClientCopiedSwiftCode = 1127,
+    Cipher_ClientToggledSwiftCodeVisible = 1128,
+    Cipher_ClientCopiedIban = 1129,
+    Cipher_ClientToggledIbanVisible = 1130,
+    Cipher_ClientCopiedNationalIdentificationNumber = 1131,
+    Cipher_ClientToggledNationalIdentificationNumberVisible = 1132,
 
     Collection_Created = 1300,
     Collection_Updated = 1301,

--- a/src/Events/Controllers/CollectController.cs
+++ b/src/Events/Controllers/CollectController.cs
@@ -89,6 +89,16 @@ public class CollectController : Controller
                 case EventType.Cipher_ClientCopiedBankAccountPin:
                 case EventType.Cipher_ClientToggledBankAccountNumberVisible:
                 case EventType.Cipher_ClientToggledBankAccountPinVisible:
+                case EventType.Cipher_ClientCopiedLicenseNumber:
+                case EventType.Cipher_ClientToggledLicenseNumberVisible:
+                case EventType.Cipher_ClientCopiedPassportNumber:
+                case EventType.Cipher_ClientToggledPassportNumberVisible:
+                case EventType.Cipher_ClientCopiedSwiftCode:
+                case EventType.Cipher_ClientToggledSwiftCodeVisible:
+                case EventType.Cipher_ClientCopiedIban:
+                case EventType.Cipher_ClientToggledIbanVisible:
+                case EventType.Cipher_ClientCopiedNationalIdentificationNumber:
+                case EventType.Cipher_ClientToggledNationalIdentificationNumberVisible:
                 case EventType.Cipher_ClientViewed:
                     if (!eventModel.CipherId.HasValue)
                     {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-35656](https://bitwarden.atlassian.net/browse/PM-35656)

## 📔 Objective

After the initial changes were in for new item types, additional fields were made hidden and/or copyable. To match existing patterns, these scenarios need events for organizations. Adding the missing fields here:
- Bank Account
  - `IBAN`
  - `SWIFT`
- Passport
  - `NationalIdentificationNumber`   


Initial addition PRs:
- https://github.com/bitwarden/server/pull/7512
- https://github.com/bitwarden/server/pull/7112

## 📸 Screenshots

N/A


[PM-35656]: https://bitwarden.atlassian.net/browse/PM-35656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ