### PR TITLE
chore: ignore Roslyn .lscache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,9 @@ ipch/
 *.sdf
 *.cachefile
 
+# Roslyn / C# language server cache
+*.lscache
+
 # Visual Studio profiler
 *.psess
 *.vsp


### PR DESCRIPTION
## 🎟️ Tracking

N/A — repo hygiene.

## 📔 Objective

Adds `*.lscache` to the root `.gitignore`. These files are produced by the Roslyn / C# language server (e.g. when working in VS Code with the C# Dev Kit) and shouldn't be tracked.