### PR TITLE
chore: ignore C# Dev Kit lscache and dump files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,9 @@ bitwarden_license/src/Sso/wwwroot/assets
 .github/test/build.secrets
 **/CoverageOutput/
 .idea/*
+*.lscache
+*.dmp
+*.dump
 **/**.swp
 .mono
 src/Core/MailTemplates/Mjml/out


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Add *.lscache, *.dmp, and *.dump to .gitignore following the pattern now enshrined in [dotnet runtime](https://github.com/dotnet/runtime/pull/126718) and tracked in [vscode-dotnettools issue 2952](https://github.com/microsoft/vscode-dotnettools/issues/2952).

*.lscache files are generated by the [C# Dev Kit language server](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) and appear as untracked noise in any developer's working tree. *.dmp and *.dump files are .NET memory dump artifacts that can be large and may contain sensitive in-process data.