### PR TITLE
Auth/PM-37621 - Fix Device.LastActivityDate surfacing legacy NULL rows as DateTime.UtcNow

### DIFF
--- a/src/Api/Models/Request/DeviceRequestModels.cs
+++ b/src/Api/Models/Request/DeviceRequestModels.cs
@@ -26,7 +26,9 @@ public class DeviceRequestModel
     {
         return ToDevice(new Device
         {
-            UserId = userId == null ? default(Guid) : userId.Value
+            UserId = userId == null ? default(Guid) : userId.Value,
+            // Device creation counts as first activity.
+            LastActivityDate = DateTime.UtcNow,
         });
     }
 

--- a/src/Core/Entities/Device.cs
+++ b/src/Core/Entities/Device.cs
@@ -47,7 +47,7 @@ public class Device : ITableObject<Guid>
     /// The last time this device was logged in on or had a token refresh. Null if the device has not
     /// authenticated since activity tracking was introduced.
     /// </summary>
-    public DateTime? LastActivityDate { get; internal set; } = DateTime.UtcNow;
+    public DateTime? LastActivityDate { get; set; }
 
     /// <summary>
     /// The version of the client software the device was last seen running. Populated from the

--- a/src/Identity/IdentityServer/RequestValidators/DeviceValidator.cs
+++ b/src/Identity/IdentityServer/RequestValidators/DeviceValidator.cs
@@ -245,6 +245,8 @@ public class DeviceValidator(
             Type = parsedDeviceType,
             PushToken = string.IsNullOrWhiteSpace(devicePushToken) ? null : devicePushToken,
             ClientVersion = clientVersion,
+            // Device creation counts as first activity.
+            LastActivityDate = DateTime.UtcNow,
         };
     }
 

--- a/test/Identity.Test/IdentityServer/DeviceValidatorTests.cs
+++ b/test/Identity.Test/IdentityServer/DeviceValidatorTests.cs
@@ -144,6 +144,7 @@ public class DeviceValidatorTests
     {
         // Arrange
         AddValidDeviceToRequest(request);
+        var beforeCall = DateTime.UtcNow;
 
         // Act
         var result = DeviceValidator.GetDeviceFromRequest(request, clientVersion: null);
@@ -154,6 +155,10 @@ public class DeviceValidatorTests
         Assert.Equal("DeviceName", result.Name);
         Assert.Equal(DeviceType.Android, result.Type);
         Assert.Equal("DevicePushToken", result.PushToken);
+        // Device creation counts as first activity — must be stamped at the construction site so
+        // legacy NULL rows still read back as null. 
+        Assert.NotNull(result.LastActivityDate);
+        Assert.InRange(result.LastActivityDate.Value, beforeCall, DateTime.UtcNow);
     }
 
     [Theory, BitAutoData]

--- a/test/Infrastructure.IntegrationTest/Auth/Repositories/DeviceRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/Auth/Repositories/DeviceRepositoryTests.cs
@@ -43,6 +43,8 @@ public class DeviceRepositoryTests
             Type = type,
             Identifier = identifier ?? Guid.NewGuid().ToString(),
             ClientVersion = clientVersion,
+            // Mirror production creation sites — device creation counts as first activity.
+            LastActivityDate = DateTime.UtcNow,
         });
     }
 
@@ -533,6 +535,34 @@ public class DeviceRepositoryTests
         Assert.NotNull(result.LastActivityDate);
         Assert.True(TruncateToSecond(result.LastActivityDate.Value) >= TruncateToSecond(beforeCreation),
             $"LastActivityDate {result.LastActivityDate:O} precedes beforeCreation {beforeCreation:O} at second-level precision.");
+    }
+
+    /// <summary>
+    /// Creates a device with an explicit null LastActivityDate and asserts the read path surfaces null verbatim.
+    /// </summary>
+    [DatabaseTheory]
+    [DatabaseData]
+    public async Task GetManyByUserIdWithDeviceAuth_NullLastActivityDateInDb_ReturnsNullNotDefaultAsync(
+        IDeviceRepository sutRepository,
+        IUserRepository userRepository)
+    {
+        // Arrange
+        var user = await CreateTestUserAsync(userRepository);
+        await sutRepository.CreateAsync(new Device
+        {
+            UserId = user.Id,
+            Name = "legacy-null-activity",
+            Type = DeviceType.ChromeBrowser,
+            Identifier = Guid.NewGuid().ToString(),
+            LastActivityDate = null,
+        });
+
+        // Act
+        var response = await sutRepository.GetManyByUserIdWithDeviceAuth(user.Id);
+
+        // Assert
+        var result = Assert.Single(response);
+        Assert.Null(result.LastActivityDate);
     }
 
     /// <summary>

--- a/util/Seeder/Factories/DeviceSeeder.cs
+++ b/util/Seeder/Factories/DeviceSeeder.cs
@@ -15,7 +15,9 @@ internal static class DeviceSeeder
             Type = deviceType,
             Name = deviceName,
             Identifier = identifier,
-            PushToken = pushToken
+            PushToken = pushToken,
+            // Mirror production creation sites — device creation counts as first activity.
+            LastActivityDate = DateTime.UtcNow,
         };
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-37621

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To fix an issue with where null `Device.LastActivityDate` values were coming out of the server as new `DateTime.UtcNow`

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/b9f3b075-e437-4f98-a8cb-0b19580c4ca3


