### PR TITLE
[PM-13328] Move OrganizationCollectionManagementUpdateRequestModel to AC team

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationsController.cs
@@ -9,7 +9,6 @@ using Bit.Api.Auth.Models.Request.Accounts;
 using Bit.Api.Auth.Models.Request.Organizations;
 using Bit.Api.Auth.Models.Response.Organizations;
 using Bit.Api.Models.Request.Accounts;
-using Bit.Api.Models.Request.Organizations;
 using Bit.Api.Models.Response;
 using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Models.Business.Tokenables;

--- a/src/Api/AdminConsole/Models/Request/Organizations/OrganizationCollectionManagementUpdateRequestModel.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/OrganizationCollectionManagementUpdateRequestModel.cs
@@ -1,6 +1,6 @@
 ﻿using Bit.Core.AdminConsole.Models.Business;
 
-namespace Bit.Api.Models.Request.Organizations;
+namespace Bit.Api.AdminConsole.Models.Request.Organizations;
 
 public class OrganizationCollectionManagementUpdateRequestModel
 {

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationAbilityCacheTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationAbilityCacheTests.cs
@@ -1,8 +1,8 @@
 ﻿using System.Net;
+using Bit.Api.AdminConsole.Models.Request.Organizations;
 using Bit.Api.Auth.Models.Request.Accounts;
 using Bit.Api.IntegrationTest.Factories;
 using Bit.Api.IntegrationTest.Helpers;
-using Bit.Api.Models.Request.Organizations;
 using Bit.Core;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.Billing.Enums;

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationsControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationsControllerTests.cs
@@ -2,7 +2,6 @@
 using Bit.Api.AdminConsole.Controllers;
 using Bit.Api.AdminConsole.Models.Request.Organizations;
 using Bit.Api.Auth.Models.Request.Accounts;
-using Bit.Api.Models.Request.Organizations;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Enums.Provider;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13328

## 📔 Objective

Last of the codeowners cleanup on this ticket.

Move `OrganizationCollectionManagementUpdateRequestModel` into `Bit.Api.AdminConsole.Models.Request.Organizations` so it's covered by the AC team's CODEOWNERS rule. No behavior change.