### PR TITLE
[PM-37649] Fix admin panel web vault version fetch error handling

### DIFF
--- a/src/Admin/Controllers/HomeController.cs
+++ b/src/Admin/Controllers/HomeController.cs
@@ -77,20 +77,36 @@ public class HomeController : Controller
         try
         {
             var response = await _httpClientFactory.CreateClient().GetAsync(requestUri, cancellationToken);
-            if (response.IsSuccessStatusCode)
+            if (!response.IsSuccessStatusCode)
             {
-                using var jsonDocument = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(cancellationToken), cancellationToken: cancellationToken);
-                var root = jsonDocument.RootElement;
-                return new JsonResult(root.GetProperty("version").GetString());
+                _logger.LogWarning("Non-success status code {StatusCode} from {RequestUri}", (int)response.StatusCode, requestUri);
+                return new JsonResult("Unable to fetch installed version") { StatusCode = StatusCodes.Status500InternalServerError };
             }
+
+            using var jsonDocument = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(cancellationToken), cancellationToken: cancellationToken);
+            var root = jsonDocument.RootElement;
+            return new JsonResult(root.GetProperty("version").GetString());
         }
         catch (HttpRequestException e)
         {
             _logger.LogError(e, "Error encountered while sending GET request to {RequestUri}", requestUri);
             return new JsonResult("Unable to fetch installed version") { StatusCode = StatusCodes.Status500InternalServerError };
         }
-
-        return new JsonResult("-");
+        catch (TaskCanceledException e) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogError(e, "Request to {RequestUri} timed out", requestUri);
+            return new JsonResult("Unable to fetch installed version") { StatusCode = StatusCodes.Status500InternalServerError };
+        }
+        catch (System.Text.Json.JsonException e)
+        {
+            _logger.LogError(e, "Failed to parse JSON response from {RequestUri}", requestUri);
+            return new JsonResult("Unable to fetch installed version") { StatusCode = StatusCodes.Status500InternalServerError };
+        }
+        catch (KeyNotFoundException e)
+        {
+            _logger.LogError(e, "Response from {RequestUri} missing 'version' property", requestUri);
+            return new JsonResult("Unable to fetch installed version") { StatusCode = StatusCodes.Status500InternalServerError };
+        }
     }
 
     private class LatestVersions


### PR DESCRIPTION
Fixes #7142

The admin panel shows "Unable to fetch installed version" for the Web Vault version when running behind a reverse proxy. The `GetInstalledWebVersion` method only catches `HttpRequestException`, but proxies can cause other failure modes.

The fix adds handling for:
- **Timeouts**: `TaskCanceledException` when the request takes too long (common behind slow proxies)
- **Invalid JSON**: `JsonException` when the response isn't valid JSON
- **Missing property**: `KeyNotFoundException` when the response lacks a "version" field
- **Non-success status**: Now logs a warning and returns a proper error instead of silently returning "-"

All error paths now consistently return "Unable to fetch installed version" with a 500 status code, and each scenario is logged for debugging.
