### PR TITLE
[PM-37651] Handle SocketException in admin login when mail server DNS fails

### DIFF
--- a/src/Admin/Auth/Controllers/LoginController.cs
+++ b/src/Admin/Auth/Controllers/LoginController.cs
@@ -1,6 +1,7 @@
 ﻿// FIXME: Update this file to be null safe and then delete the line below
 #nullable disable
 
+using System.Net.Sockets;
 using Bit.Admin.Auth.IdentityServer;
 using Bit.Admin.Auth.Models;
 using Microsoft.AspNetCore.Identity;
@@ -11,11 +12,14 @@ namespace Bit.Admin.Auth.Controllers;
 public class LoginController : Controller
 {
     private readonly PasswordlessSignInManager<IdentityUser> _signInManager;
+    private readonly ILogger<LoginController> _logger;
 
     public LoginController(
-        PasswordlessSignInManager<IdentityUser> signInManager)
+        PasswordlessSignInManager<IdentityUser> signInManager,
+        ILogger<LoginController> logger)
     {
         _signInManager = signInManager;
+        _logger = logger;
     }
 
     public IActionResult Index(string returnUrl = null, int? error = null, int? success = null,
@@ -40,11 +44,22 @@ public class LoginController : Controller
     {
         if (ModelState.IsValid)
         {
-            await _signInManager.PasswordlessSignInAsync(model.Email, model.ReturnUrl);
-            return RedirectToAction("Index", new
+            try
             {
-                success = 3
-            });
+                await _signInManager.PasswordlessSignInAsync(model.Email, model.ReturnUrl);
+                return RedirectToAction("Index", new
+                {
+                    success = 3
+                });
+            }
+            catch (SocketException ex)
+            {
+                _logger.LogError(ex, "Failed to send login email due to mail server connection error");
+                return RedirectToAction("Index", new
+                {
+                    error = 5
+                });
+            }
         }
 
         return View(model);
@@ -89,6 +104,7 @@ public class LoginController : Controller
             3 => "If a valid admin user with this email address exists, " +
                 "we've sent you an email with a secure link to log in.",
             4 => "Access denied. Please log in.",
+            5 => "There was a problem sending the login email. Please check your mail server configuration.",
             _ => null,
         };
     }


### PR DESCRIPTION
## 🎟️ Tracking

Fixes #6792

## 📔 Objective

After a server migration, the mail server hostname in my self-hosted Bitwarden changed. When I tried to access the admin panel at `/admin/`, entering my email resulted in a redirect to `/login/` with a 404 error instead of any useful feedback.

Looking at the logs, a `SocketException` with "Name does not resolve" was being thrown from MailKit when it tried to connect to the non-existent SMTP host. This exception propagated all the way up from `PasswordlessSignInAsync` through `LoginController.Index`, eventually hitting the error handler in an unexpected way.

The fix wraps the passwordless sign-in call in a try-catch for `SocketException`, logs the error for debugging, and redirects back to the login page with a clear message: "There was a problem sending the login email. Please check your mail server configuration."

This way, admins with misconfigured mail servers get actionable feedback instead of a cryptic 404.
