### PR TITLE
test(accounts-controller): Move tests under Auth/ directories for CODEOWNERS.

### DIFF
--- a/test/Api.IntegrationTest/Auth/Controllers/AccountsControllerTest.cs
+++ b/test/Api.IntegrationTest/Auth/Controllers/AccountsControllerTest.cs
@@ -30,7 +30,7 @@ using NSubstitute;
 using Xunit;
 using static Bit.Core.KeyManagement.Enums.SignatureAlgorithm;
 
-namespace Bit.Api.IntegrationTest.Controllers;
+namespace Bit.Api.IntegrationTest.Auth.Controllers;
 
 public class AccountsControllerTest : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
 {

--- a/test/Api.IntegrationTest/Auth/Controllers/EmergencyAccessControllerTest.cs
+++ b/test/Api.IntegrationTest/Auth/Controllers/EmergencyAccessControllerTest.cs
@@ -17,7 +17,7 @@ using Bit.Core.Tokens;
 using Microsoft.AspNetCore.Identity;
 using Xunit;
 
-namespace Bit.Api.IntegrationTest.Controllers;
+namespace Bit.Api.IntegrationTest.Auth.Controllers;
 
 public class EmergencyAccessControllerTest : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
 {

--- a/test/Api.IntegrationTest/Auth/Controllers/TwoFactorControllerTest.cs
+++ b/test/Api.IntegrationTest/Auth/Controllers/TwoFactorControllerTest.cs
@@ -10,7 +10,7 @@ using Bit.Core.Repositories;
 using Bit.Core.Tokens;
 using Xunit;
 
-namespace Bit.Api.IntegrationTest.Controllers;
+namespace Bit.Api.IntegrationTest.Auth.Controllers;
 
 public class TwoFactorControllerTest : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
 {

--- a/test/Identity.Test/Auth/Controllers/AccountsControllerTests.cs
+++ b/test/Identity.Test/Auth/Controllers/AccountsControllerTests.cs
@@ -25,7 +25,7 @@ using NSubstitute.ReturnsExtensions;
 using Xunit;
 using SignatureKeyPairRequestModelCustomizeAttribute = Bit.Test.Common.AutoFixture.SignatureKeyPairRequestModelCustomizeAttribute;
 
-namespace Bit.Identity.Test.Controllers;
+namespace Bit.Identity.Test.Auth.Controllers;
 
 public class AccountsControllerTests : IDisposable
 {


### PR DESCRIPTION
## 🎟️ Tracking

N/A — surfaced as a follow-up hygiene item during [PM-35393](https://bitwarden.atlassian.net/browse/PM-35393).

## 📔 Objective

Several Auth-owned controllers had integration/unit tests sitting outside any `Auth/` path segment, so CODEOWNERS' `**/Auth` rule (`@bitwarden/team-auth-dev`) never matched them — changes to these tests didn't trigger the required team review.

This moves the remaining unowned tests under `Auth/`, matching the convention already used by sibling domains (`AdminConsole/`, `Billing/`, `KeyManagement/`, etc.) and by the unit tests in `test/Api.Test/Auth/Controllers/`, which already fully cover these same controllers:

- `AccountsControllerTest.cs` (`Api.IntegrationTest`)
- `AccountsControllerTests.cs` (`Identity.Test`)
- `EmergencyAccessControllerTest.cs` (`Api.IntegrationTest`)
- `TwoFactorControllerTest.cs` (`Api.IntegrationTest`)

No behavior change — namespace-only rename + directory move to pick up `**/Auth` CODEOWNERS ownership automatically. Verified no other code references the old namespaces, and build + full test suites pass for both moved integration tests.

[PM-35393]: https://bitwarden.atlassian.net/browse/PM-35393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ