### PR TITLE
[PM-37259] - Accepted User Sso Identifier

### DIFF
--- a/src/Core/Auth/Sso/UserSsoOrganizationIdentifierQuery.cs
+++ b/src/Core/Auth/Sso/UserSsoOrganizationIdentifierQuery.cs
@@ -19,7 +19,7 @@ public class UserSsoOrganizationIdentifierQuery(
 
         // we can only confidently return the correct SsoOrganizationIdentifier if there is exactly one Organization.
         // The user must also be in the Confirmed status.
-        var confirmedOrgUsers = organizationUsers.Where(ou => ou.Status == OrganizationUserStatusType.Confirmed);
+        var confirmedOrgUsers = organizationUsers.Where(ou => ou.Status is OrganizationUserStatusType.Confirmed or OrganizationUserStatusType.Accepted);
         if (confirmedOrgUsers.Count() != 1)
         {
             return null;

--- a/src/Core/Auth/Sso/UserSsoOrganizationIdentifierQuery.cs
+++ b/src/Core/Auth/Sso/UserSsoOrganizationIdentifierQuery.cs
@@ -1,11 +1,10 @@
-﻿using Bit.Core.Enums;
-using Bit.Core.Repositories;
+﻿using Bit.Core.Repositories;
 
 namespace Bit.Core.Auth.Sso;
 
 /// <summary>
 /// TODO : PM-28846 review data structures as they relate to this query
-/// Query to retrieve the SSO organization identifier that a user is a confirmed member of.
+/// Query to retrieve the SSO organization identifier that a user is a member of.
 /// </summary>
 public class UserSsoOrganizationIdentifierQuery(
     IOrganizationUserRepository _organizationUserRepository,
@@ -14,25 +13,15 @@ public class UserSsoOrganizationIdentifierQuery(
     /// <inheritdoc />
     public async Task<string?> GetSsoOrganizationIdentifierAsync(Guid userId)
     {
-        // Get all confirmed organization memberships for the user
         var organizationUsers = await _organizationUserRepository.GetManyByUserAsync(userId);
 
-        // we can only confidently return the correct SsoOrganizationIdentifier if there is exactly one Organization.
-        // The user must also be in the Confirmed status.
-        var confirmedOrgUsers = organizationUsers.Where(ou => ou.Status is OrganizationUserStatusType.Confirmed or OrganizationUserStatusType.Accepted);
-        if (confirmedOrgUsers.Count() != 1)
+        if (organizationUsers.Count != 1)
         {
             return null;
         }
 
-        var confirmedOrgUser = confirmedOrgUsers.Single();
-        var organization = await _organizationRepository.GetByIdAsync(confirmedOrgUser.OrganizationId);
+        var organization = await _organizationRepository.GetByIdAsync(organizationUsers.Single().OrganizationId);
 
-        if (organization == null)
-        {
-            return null;
-        }
-
-        return organization.Identifier;
+        return organization?.Identifier;
     }
 }

--- a/test/Core.Test/Auth/UserFeatures/Sso/UserSsoOrganizationIdentifierQueryTests.cs
+++ b/test/Core.Test/Auth/UserFeatures/Sso/UserSsoOrganizationIdentifierQueryTests.cs
@@ -100,80 +100,6 @@ public class UserSsoOrganizationIdentifierQueryTests
             .GetByIdAsync(Arg.Any<Guid>());
     }
 
-    [Theory]
-    [BitAutoData(OrganizationUserStatusType.Invited)]
-    [BitAutoData(OrganizationUserStatusType.Accepted)]
-    [BitAutoData(OrganizationUserStatusType.Revoked)]
-    public async Task GetSsoOrganizationIdentifierAsync_UserHasOnlyInvitedOrganization_ReturnsNull(
-        OrganizationUserStatusType status,
-        SutProvider<UserSsoOrganizationIdentifierQuery> sutProvider,
-        Guid userId,
-        OrganizationUser organizationUser)
-    {
-        // Arrange
-        organizationUser.UserId = userId;
-        organizationUser.Status = status;
-
-        sutProvider.GetDependency<IOrganizationUserRepository>()
-            .GetManyByUserAsync(userId)
-            .Returns([organizationUser]);
-
-        // Act
-        var result = await sutProvider.Sut.GetSsoOrganizationIdentifierAsync(userId);
-
-        // Assert
-        Assert.Null(result);
-        await sutProvider.GetDependency<IOrganizationUserRepository>()
-            .Received(1)
-            .GetManyByUserAsync(userId);
-        await sutProvider.GetDependency<IOrganizationRepository>()
-            .DidNotReceive()
-            .GetByIdAsync(Arg.Any<Guid>());
-    }
-
-    [Theory, BitAutoData]
-    public async Task GetSsoOrganizationIdentifierAsync_UserHasMixedStatusOrganizations_OnlyOneConfirmed_ReturnsIdentifier(
-        SutProvider<UserSsoOrganizationIdentifierQuery> sutProvider,
-        Guid userId,
-        Organization organization,
-        OrganizationUser confirmedOrgUser,
-        OrganizationUser invitedOrgUser,
-        OrganizationUser revokedOrgUser)
-    {
-        // Arrange
-        confirmedOrgUser.UserId = userId;
-        confirmedOrgUser.OrganizationId = organization.Id;
-        confirmedOrgUser.Status = OrganizationUserStatusType.Confirmed;
-
-        invitedOrgUser.UserId = userId;
-        invitedOrgUser.Status = OrganizationUserStatusType.Invited;
-
-        revokedOrgUser.UserId = userId;
-        revokedOrgUser.Status = OrganizationUserStatusType.Revoked;
-
-        organization.Identifier = "mixed-status-org";
-
-        sutProvider.GetDependency<IOrganizationUserRepository>()
-            .GetManyByUserAsync(userId)
-            .Returns(new[] { confirmedOrgUser, invitedOrgUser, revokedOrgUser });
-
-        sutProvider.GetDependency<IOrganizationRepository>()
-            .GetByIdAsync(organization.Id)
-            .Returns(organization);
-
-        // Act
-        var result = await sutProvider.Sut.GetSsoOrganizationIdentifierAsync(userId);
-
-        // Assert
-        Assert.Equal("mixed-status-org", result);
-        await sutProvider.GetDependency<IOrganizationUserRepository>()
-            .Received(1)
-            .GetManyByUserAsync(userId);
-        await sutProvider.GetDependency<IOrganizationRepository>()
-            .Received(1)
-            .GetByIdAsync(organization.Id);
-    }
-
     [Theory, BitAutoData]
     public async Task GetSsoOrganizationIdentifierAsync_OrganizationNotFound_ReturnsNull(
         SutProvider<UserSsoOrganizationIdentifierQuery> sutProvider,
@@ -239,37 +165,4 @@ public class UserSsoOrganizationIdentifierQueryTests
             .GetByIdAsync(organization.Id);
     }
 
-    [Theory, BitAutoData]
-    public async Task GetSsoOrganizationIdentifierAsync_OrganizationIdentifierIsEmpty_ReturnsEmpty(
-        SutProvider<UserSsoOrganizationIdentifierQuery> sutProvider,
-        Guid userId,
-        Organization organization,
-        OrganizationUser organizationUser)
-    {
-        // Arrange
-        organizationUser.UserId = userId;
-        organizationUser.OrganizationId = organization.Id;
-        organizationUser.Status = OrganizationUserStatusType.Confirmed;
-        organization.Identifier = string.Empty;
-
-        sutProvider.GetDependency<IOrganizationUserRepository>()
-            .GetManyByUserAsync(userId)
-            .Returns(new[] { organizationUser });
-
-        sutProvider.GetDependency<IOrganizationRepository>()
-            .GetByIdAsync(organization.Id)
-            .Returns(organization);
-
-        // Act
-        var result = await sutProvider.Sut.GetSsoOrganizationIdentifierAsync(userId);
-
-        // Assert
-        Assert.Equal(string.Empty, result);
-        await sutProvider.GetDependency<IOrganizationUserRepository>()
-            .Received(1)
-            .GetManyByUserAsync(userId);
-        await sutProvider.GetDependency<IOrganizationRepository>()
-            .Received(1)
-            .GetByIdAsync(organization.Id);
-    }
 }


### PR DESCRIPTION
## 🎟️ Tracking
[PM-37259](https://bitwarden.atlassian.net/browse/PM-37259)

## 📔 Objective
Currently, Accepted users do not get the org identifier when SSO is requried. This will allow them to be redirected.

## 📸 Screenshots
https://github.com/user-attachments/assets/f07c3af8-fa91-4e6e-8edf-2d87a964802a

[PM-37259]: https://bitwarden.atlassian.net/browse/PM-37259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ