### PR TITLE
[PM-37727] Fix exceptions when serialzing blob-encrypted ciphers

### DIFF
--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -1645,7 +1645,7 @@ public class CiphersController : Controller
 
     private void ValidateClientVersionForFido2CredentialSupport(Cipher cipher)
     {
-        if (cipher.Type == Core.Vault.Enums.CipherType.Login)
+        if (cipher.Type == Core.Vault.Enums.CipherType.Login && !cipher.IsDataBlobEncrypted())
         {
             var loginData = JsonSerializer.Deserialize<CipherLoginData>(cipher.Data);
             if (loginData?.Fido2Credentials != null && _currentContext.ClientVersion < _fido2KeyCipherMinimumVersion)

--- a/src/Api/Vault/Models/Response/CipherResponseModel.cs
+++ b/src/Api/Vault/Models/Response/CipherResponseModel.cs
@@ -26,6 +26,19 @@ public class CipherMiniResponseModel : ResponseModel
         Id = cipher.Id;
         Type = cipher.Type;
         Data = cipher.Data;
+        RevisionDate = cipher.RevisionDate;
+        OrganizationId = cipher.OrganizationId;
+        Attachments = AttachmentResponseModel.FromCipher(cipher, globalSettings);
+        OrganizationUseTotp = orgUseTotp;
+        CreationDate = cipher.CreationDate;
+        DeletedDate = cipher.DeletedDate;
+        Reprompt = cipher.Reprompt.GetValueOrDefault(CipherRepromptType.None);
+        Key = cipher.Key;
+
+        if (cipher.IsDataBlobEncrypted())
+        {
+            return;
+        }
 
         CipherData cipherData;
         switch (cipher.Type)
@@ -78,14 +91,6 @@ public class CipherMiniResponseModel : ResponseModel
         Notes = cipherData.Notes;
         Fields = cipherData.Fields?.Select(f => new CipherFieldModel(f));
         PasswordHistory = cipherData.PasswordHistory?.Select(ph => new CipherPasswordHistoryModel(ph));
-        RevisionDate = cipher.RevisionDate;
-        OrganizationId = cipher.OrganizationId;
-        Attachments = AttachmentResponseModel.FromCipher(cipher, globalSettings);
-        OrganizationUseTotp = orgUseTotp;
-        CreationDate = cipher.CreationDate;
-        DeletedDate = cipher.DeletedDate;
-        Reprompt = cipher.Reprompt.GetValueOrDefault(CipherRepromptType.None);
-        Key = cipher.Key;
     }
 
     public Guid Id { get; set; }

--- a/src/Core/Vault/Entities/Cipher.cs
+++ b/src/Core/Vault/Entities/Cipher.cs
@@ -32,6 +32,17 @@ public class Cipher : ITableObject<Guid>, ICloneable
         Id = CoreHelpers.GenerateComb();
     }
 
+    public bool IsDataBlobEncrypted()
+    {
+        if (string.IsNullOrWhiteSpace(Data))
+        {
+            return false;
+        }
+
+        var span = Data.AsSpan().TrimStart();
+        return span.Length > 0 && span[0] != '{';
+    }
+
     public Dictionary<string, CipherAttachment.MetaData> GetAttachments()
     {
         if (string.IsNullOrWhiteSpace(Attachments))

--- a/test/Api.Test/Vault/Controllers/CiphersControllerTests.cs
+++ b/test/Api.Test/Vault/Controllers/CiphersControllerTests.cs
@@ -62,6 +62,49 @@ public class CiphersControllerTests
     }
 
     [Theory, BitAutoData]
+    public async Task Put_OpaqueLoginCipherWithOldClient_SkipsFido2VersionCheck(
+        User user,
+        SutProvider<CiphersController> sutProvider)
+    {
+        var cipherId = Guid.NewGuid();
+        var cipherDetails = new CipherDetails
+        {
+            Id = cipherId,
+            UserId = user.Id,
+            Type = CipherType.Login,
+            Data = "2.iv|ct|mac",
+            Edit = true,
+            ViewPassword = true,
+        };
+
+        sutProvider.GetDependency<IUserService>()
+            .GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>())
+            .Returns(user);
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetByIdAsync(cipherId, user.Id)
+            .Returns(cipherDetails);
+        sutProvider.GetDependency<ICurrentContext>()
+            .ClientVersion
+            .Returns(new Version(2022, 1, 0));
+
+        var model = new CipherRequestModel
+        {
+            Type = CipherType.Login,
+            Name = "2.name|encrypted",
+            Data = "2.iv|ct|mac",
+        };
+
+        var response = await sutProvider.Sut.Put(cipherId, model);
+
+        Assert.NotNull(response);
+        Assert.Equal("2.iv|ct|mac", response.Data);
+        Assert.Null(response.Login);
+        await sutProvider.GetDependency<ICipherService>()
+            .Received(1)
+            .SaveDetailsAsync(Arg.Any<CipherDetails>(), user.Id, Arg.Any<DateTime?>(), Arg.Any<IEnumerable<Guid>>());
+    }
+
+    [Theory, BitAutoData]
     public async Task PutPartialShouldThrowNotFoundExceptionWhenCipherDoesNotExist(User user, Guid folderId, SutProvider<CiphersController> sutProvider)
     {
         var isFavorite = true;

--- a/test/Api.Test/Vault/Models/Response/CipherResponseModelTests.cs
+++ b/test/Api.Test/Vault/Models/Response/CipherResponseModelTests.cs
@@ -269,4 +269,43 @@ public class CipherResponseModelTests
 
         Assert.Equal(serializedData, response.Data);
     }
+
+    [Theory]
+    [InlineData(CipherType.Login)]
+    [InlineData(CipherType.SecureNote)]
+    [InlineData(CipherType.Card)]
+    [InlineData(CipherType.Identity)]
+    [InlineData(CipherType.SSHKey)]
+    [InlineData(CipherType.BankAccount)]
+    [InlineData(CipherType.DriversLicense)]
+    [InlineData(CipherType.Passport)]
+    public void Constructor_OpaqueData_DoesNotThrowAndSkipsLegacyFields(CipherType type)
+    {
+        const string opaque = "2.iv|ct|mac";
+        var cipher = new Cipher
+        {
+            Id = Guid.NewGuid(),
+            Type = type,
+            Data = opaque,
+            RevisionDate = DateTime.UtcNow,
+            CreationDate = DateTime.UtcNow,
+        };
+
+        var response = new CipherMiniResponseModel(cipher, _globalSettings, false);
+
+        Assert.Equal(type, response.Type);
+        Assert.Equal(opaque, response.Data);
+        Assert.Null(response.Name);
+        Assert.Null(response.Notes);
+        Assert.Null(response.Login);
+        Assert.Null(response.SecureNote);
+        Assert.Null(response.Card);
+        Assert.Null(response.Identity);
+        Assert.Null(response.SSHKey);
+        Assert.Null(response.BankAccount);
+        Assert.Null(response.DriversLicense);
+        Assert.Null(response.Passport);
+        Assert.Null(response.Fields);
+        Assert.Null(response.PasswordHistory);
+    }
 }

--- a/test/Core.Test/Vault/Models/CipherTests.cs
+++ b/test/Core.Test/Vault/Models/CipherTests.cs
@@ -23,4 +23,26 @@ public class CipherTests
     {
         Assert.Equal(JsonSerializer.Serialize(cipher), JsonSerializer.Serialize(cipher.Clone()));
     }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("{\"Name\":\"x\"}")]
+    [InlineData("   { \"Name\": \"x\" }")]
+    public void IsDataBlobEncrypted_LegacyOrEmpty_ReturnsFalse(string? data)
+    {
+        var cipher = new Cipher { Data = data! };
+        Assert.False(cipher.IsDataBlobEncrypted());
+    }
+
+    [Theory]
+    [InlineData("2.iv|ct|mac")]
+    [InlineData("plain string")]
+    [InlineData("   2.iv|ct|mac")]
+    public void IsDataBlobEncrypted_OpaqueData_ReturnsTrue(string data)
+    {
+        var cipher = new Cipher { Data = data };
+        Assert.True(cipher.IsDataBlobEncrypted());
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37727

## 📔 Objective

When saving a blob-encrypted cipher from the client, the Server throws errors because it is expecting the JSON data for parsing. This adds a function call to see if a cipher is blob encrypted, and skip the ciphertype extractions if so.
