### PR TITLE
[PM-37740] Add missing container configuration to aspire

### DIFF
--- a/AppHost/AppHost.cs
+++ b/AppHost/AppHost.cs
@@ -9,14 +9,16 @@ builder.ConfigureMigrations()
     .WaitForCompletion(secretsSetup);
 var azurite = builder.ConfigureAzurite();
 var mail = builder.ConfigureMailCatcher();
-var (_, api, billing, _, _) = builder.ConfigureServices(db, secretsSetup, mail, azurite);
+builder.ConfigureRedis();
+builder.ConfigureIdp();
+var services = builder.ConfigureServices(db, secretsSetup, mail, azurite);
 
 #if ENABLE_NODEJS_COMMUNITY_PLUGIN
-builder.ConfigureWebFrontend(api);
+builder.ConfigureWebFrontend(services["api"]);
 #endif
 
 #if ENABLE_NGROK_COMMUNITY_PLUGIN
-builder.ConfigureNgrok((billing, "http"));
+builder.ConfigureNgrok((services["billing"], "http"));
 #endif
 
 builder.Build().Run();

--- a/AppHost/AppHost.csproj
+++ b/AppHost/AppHost.csproj
@@ -34,7 +34,12 @@
     <ProjectReference Include="..\src\Admin\Admin.csproj"/>
     <ProjectReference Include="..\src\Api\Api.csproj"/>
     <ProjectReference Include="..\src\Billing\Billing.csproj"/>
+    <ProjectReference Include="..\src\Events\Events.csproj"/>
+    <ProjectReference Include="..\src\EventsProcessor\EventsProcessor.csproj"/>
+    <ProjectReference Include="..\src\Icons\Icons.csproj"/>
     <ProjectReference Include="..\src\Identity\Identity.csproj"/>
     <ProjectReference Include="..\src\Notifications\Notifications.csproj"/>
+    <ProjectReference Include="..\bitwarden_license\src\Scim\Scim.csproj"/>
+    <ProjectReference Include="..\bitwarden_license\src\Sso\Sso.csproj"/>
   </ItemGroup>
 </Project>

--- a/AppHost/BuilderExtensions.cs
+++ b/AppHost/BuilderExtensions.cs
@@ -130,8 +130,8 @@ public static class BuilderExtensions
     }
 
     /// <summary>
-    /// Configures and initializes the essential services required for the distributed application,
-    /// including project-specific services such as admin, API, billing, identity, and notifications.
+    /// Configures and initializes the Bitwarden project services required for the distributed
+    /// application, keyed by service name.
     /// </summary>
     /// <param name="builder">The distributed application builder used to configure resources and services.</param>
     /// <param name="db">The SQL Server database resource builder.</param>

--- a/AppHost/BuilderExtensions.cs
+++ b/AppHost/BuilderExtensions.cs
@@ -83,10 +83,7 @@ public static class BuilderExtensions
 
     public static IResourceBuilder<ContainerResource> ConfigureMailCatcher(this IDistributedApplicationBuilder builder)
     {
-        var image = builder.Required("MailCatcher:Image");
-        var imageParts = image.Split(':');
-        var imageName = imageParts[0];
-        var imageTag = imageParts.Length > 1 ? imageParts[1] : "latest";
+        var (imageName, imageTag) = builder.GetImageParts("MailCatcher:Image");
 
         if (!int.TryParse(builder.Required("MailCatcher:SmtpPort"), out var smtpPort))
             throw new InvalidOperationException("Invalid value for MailCatcher:SmtpPort.");
@@ -100,6 +97,38 @@ public static class BuilderExtensions
             .WithHttpEndpoint(port: webPort, name: "web", targetPort: webPort);
     }
 
+    public static IResourceBuilder<ContainerResource> ConfigureRedis(this IDistributedApplicationBuilder builder)
+    {
+        var (imageName, imageTag) = builder.GetImageParts("Redis:Image");
+
+        if (!int.TryParse(builder.Required("Redis:Port"), out var port))
+            throw new InvalidOperationException("Invalid value for Redis:Port.");
+
+        return builder
+            .AddContainer("redis", imageName, imageTag)
+            .WithLifetime(ContainerLifetime.Persistent)
+            .WithEndpoint(port: port, name: "tcp", targetPort: 6379)
+            .WithVolume("redis_data", "/data")
+            .WithArgs("redis-server", "--appendonly", "yes");
+    }
+
+    public static IResourceBuilder<ContainerResource> ConfigureIdp(this IDistributedApplicationBuilder builder)
+    {
+        var (imageName, imageTag) = builder.GetImageParts("Idp:Image");
+
+        if (!int.TryParse(builder.Required("Idp:Port"), out var port))
+            throw new InvalidOperationException("Invalid value for Idp:Port.");
+
+        return builder
+            .AddContainer("idp", imageName, imageTag)
+            .WithHttpEndpoint(port: port, name: "http", targetPort: 8080)
+            .WithEnvironment("SIMPLESAMLPHP_SP_ENTITY_ID", builder.Required("Idp:SpEntityId"))
+            .WithEnvironment("SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE", builder.Required("Idp:SpAcsUrl"))
+            .WithBindMount($"{builder.Required("WorkingDirectory")}/authsources.php",
+                "/var/www/simplesamlphp/config/authsources.php")
+            .WithExplicitStart();
+    }
+
     /// <summary>
     /// Configures and initializes the essential services required for the distributed application,
     /// including project-specific services such as admin, API, billing, identity, and notifications.
@@ -109,36 +138,35 @@ public static class BuilderExtensions
     /// <param name="secretsSetup">The executable resource builder for configuring secrets.</param>
     /// <param name="mail">The container resource builder for setting up the mail service.</param>
     /// <param name="azurite">The Azure Storage resource builder used to configure Azurite storage services.</param>
-    /// <returns>A tuple containing the configured resource builders for each project service.</returns>
-    public static (
-        IResourceBuilder<ProjectResource> Admin,
-        IResourceBuilder<ProjectResource> Api,
-        IResourceBuilder<ProjectResource> Billing,
-        IResourceBuilder<ProjectResource> Identity,
-        IResourceBuilder<ProjectResource> Notifications
-        ) ConfigureServices(
-            this IDistributedApplicationBuilder builder,
-            IResourceBuilder<SqlServerDatabaseResource> db,
-            IResourceBuilder<ExecutableResource> secretsSetup,
-            IResourceBuilder<ContainerResource> mail,
-            IResourceBuilder<AzureStorageResource> azurite)
+    /// <returns>A dictionary of configured project resource builders keyed by service name.</returns>
+    public static IReadOnlyDictionary<string, IResourceBuilder<ProjectResource>> ConfigureServices(
+        this IDistributedApplicationBuilder builder,
+        IResourceBuilder<SqlServerDatabaseResource> db,
+        IResourceBuilder<ExecutableResource> secretsSetup,
+        IResourceBuilder<ContainerResource> mail,
+        IResourceBuilder<AzureStorageResource> azurite)
     {
-        var admin = builder.AddBitwardenService<Projects.Admin>(db, secretsSetup, mail, "admin");
-        var api = builder.AddBitwardenService<Projects.Api>(db, secretsSetup, mail, "api")
-            .WaitFor(azurite);
-        var billing = builder.AddBitwardenService<Projects.Billing>(db, secretsSetup, mail, "billing");
-        var identity = builder.AddBitwardenService<Projects.Identity>(db, secretsSetup, mail, "identity");
-        var notifications = builder.AddBitwardenService<Projects.Notifications>(db, secretsSetup, mail, "notifications")
-            .WaitFor(azurite);
-        builder.ConfigureAdditionalProjects(new Dictionary<string, IResourceBuilder<ProjectResource>>
+        var services = new Dictionary<string, IResourceBuilder<ProjectResource>>
         {
-            ["admin"] = admin,
-            ["api"] = api,
-            ["billing"] = billing,
-            ["identity"] = identity,
-            ["notifications"] = notifications
-        });
-        return (admin, api, billing, identity, notifications);
+            ["admin"] = builder.AddBitwardenService<Projects.Admin>(db, secretsSetup, mail, "admin"),
+            ["api"] = builder.AddBitwardenService<Projects.Api>(db, secretsSetup, mail, "api")
+                .WaitFor(azurite),
+            ["billing"] = builder.AddBitwardenService<Projects.Billing>(db, secretsSetup, mail, "billing"),
+            ["events"] = builder.AddBitwardenService<Projects.Events>(db, secretsSetup, mail, "events")
+                .WaitFor(azurite),
+            ["eventsProcessor"] = builder
+                .AddBitwardenService<Projects.EventsProcessor>(db, secretsSetup, mail, "eventsProcessor")
+                .WaitFor(azurite),
+            ["icons"] = builder.AddBitwardenService<Projects.Icons>(db, secretsSetup, mail, "icons"),
+            ["identity"] = builder.AddBitwardenService<Projects.Identity>(db, secretsSetup, mail, "identity"),
+            ["notifications"] = builder
+                .AddBitwardenService<Projects.Notifications>(db, secretsSetup, mail, "notifications")
+                .WaitFor(azurite),
+            ["scim"] = builder.AddBitwardenService<Projects.Scim>(db, secretsSetup, mail, "scim"),
+            ["sso"] = builder.AddBitwardenService<Projects.Sso>(db, secretsSetup, mail, "sso")
+        };
+        builder.ConfigureAdditionalProjects(services);
+        return services;
     }
 
     /// <summary>
@@ -187,7 +215,7 @@ public static class BuilderExtensions
             .WaitFor(db)
             .WaitForCompletion(secretsSetup);
 
-        if (name is "admin" or "identity" or "billing")
+        if (name is "admin" or "identity" or "billing" or "sso")
             service.WithReference(mail.GetEndpoint("smtp"));
 
         return service;
@@ -209,6 +237,16 @@ public static class BuilderExtensions
     /// <exception cref="InvalidOperationException"></exception>
     private static string Required(this IDistributedApplicationBuilder builder, string key) =>
         builder.Configuration[key] ?? throw new InvalidOperationException($"Missing required configuration: {key}");
+
+    /// <summary>
+    /// Reads an image reference from configuration in <c>name[:tag]</c> form and returns its components,
+    /// defaulting the tag to <c>latest</c> when not specified.
+    /// </summary>
+    private static (string Name, string Tag) GetImageParts(this IDistributedApplicationBuilder builder, string key)
+    {
+        var parts = builder.Required(key).Split(':');
+        return (parts[0], parts.Length > 1 ? parts[1] : "latest");
+    }
 
     /// <summary>
     /// Determines if the application is running in self-hosted mode.

--- a/AppHost/README.md
+++ b/AppHost/README.md
@@ -1,15 +1,15 @@
 # Aspire AppHost
 
-.NET Aspire orchestrates the entire Bitwarden server local development environment — SQL Server,
-Azure Storage (Azurite), MailCatcher, and all five application services — from a single command,
-replacing the manual docker-compose workflow.
+.NET Aspire orchestrates the entire Bitwarden server local development environment — supporting
+infrastructure and the Bitwarden application services — from a single command, replacing the
+manual docker-compose workflow.
 
 ## Prerequisites
 
 | Requirement            | Notes                                                                                                                            |
 |------------------------|----------------------------------------------------------------------------------------------------------------------------------|
 | .NET SDK 10            | Required by Aspire                                                                                                               |
-| Docker Desktop         | Runs SQL Server, Azurite, and MailCatcher containers                                                                             |
+| Docker Desktop         | Runs the supporting infrastructure containers                                                                                    |
 | PowerShell (`pwsh`)    | Used by migration and secrets scripts                                                                                            |
 | Completed server setup | `dev/secrets.json` must exist — follow the [setup guide](https://contributing.bitwarden.com/getting-started/server/guide/) first |
 
@@ -33,11 +33,18 @@ the services wait for the database and secrets setup to finish before launching.
 | `azurite`           | Azure Storage emulator    | Blob :10000 · Queue :10001 · Table :10002                                 |
 | `azurite-setup`     | Executable                | Runs `dev/setup_azurite.ps1` after Azurite is ready                       |
 | `mailcatcher`       | Container                 | SMTP :10250 · Web UI :1080                                                |
+| `redis`             | Container                 | Redis with AOF persistence, port 6379                                     |
+| `idp`               | SimpleSAMLphp container   | SAML IdP for SSO testing (**explicit start** from the dashboard)          |
 | `admin`             | .NET project              | Admin portal                                                              |
 | `api`               | .NET project              | Main API (waits for Azurite)                                              |
 | `billing`           | .NET project              | Billing service                                                           |
+| `events`            | .NET project              | Events service (waits for Azurite)                                        |
+| `eventsProcessor`   | .NET project              | Events processor (waits for Azurite)                                      |
+| `icons`             | .NET project              | Icons service                                                             |
 | `identity`          | .NET project              | Identity / auth service                                                   |
 | `notifications`     | .NET project              | Notifications service (waits for Azurite)                                 |
+| `scim`              | .NET project              | SCIM provisioning service                                                 |
+| `sso`               | .NET project              | SSO service                                                               |
 
 ## Configuration
 

--- a/AppHost/appsettings.Development.json
+++ b/AppHost/appsettings.Development.json
@@ -18,11 +18,26 @@
     "billing": {
       "BasePort": 44519
     },
+    "events": {
+      "BasePort": 46273
+    },
+    "eventsProcessor": {
+      "BasePort": 54103
+    },
+    "icons": {
+      "BasePort": 50024
+    },
     "identity": {
       "BasePort": 33656
     },
     "notifications": {
       "BasePort": 61840
+    },
+    "scim": {
+      "BasePort": 44559
+    },
+    "sso": {
+      "BasePort": 51822
     }
   },
   "AdditionalProjects": {},
@@ -43,6 +58,16 @@
     "Image": "sj26/mailcatcher:latest",
     "SmtpPort": 10250,
     "WebPort": 1080
+  },
+  "Redis": {
+    "Image": "redis:alpine",
+    "Port": 6379
+  },
+  "Idp": {
+    "Image": "kenchan0130/simplesamlphp:1.19.8",
+    "Port": 8090,
+    "SpEntityId": "http://localhost:51822/saml2/yourOrgIdHere",
+    "SpAcsUrl": "http://localhost:51822/saml2/yourOrgIdHere/Acs"
   },
   "WebFrontend": {
     "Port": 8080,

--- a/dev/.env.example
+++ b/dev/.env.example
@@ -15,7 +15,7 @@ MARIADB_ROOT_PASSWORD=SET_A_PASSWORD_HERE_123
 
 # IdP configuration
 # Complete using the values from the Manage SSO page in the web vault
-IDP_SP_ENTITY_ID=http://localhost:51822/saml2
+IDP_SP_ENTITY_ID=http://localhost:51822/saml2/yourOrgIdHere
 IDP_SP_ACS_URL=http://localhost:51822/saml2/yourOrgIdHere/Acs
 
 # Optional reverse proxy configuration


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-37740
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Adds the remaining Bitwarden services and supporting containers to the Aspire AppHost so the full server stack (matching dev/docker-compose.yml) can be run via Aspire.

**Project resources added**
  - Events, EventsProcessor, Icons, Scim, Sso

**Container resources added**
  - redis (persistent lifetime, append-only volume) for distributed caching
  - idp (SimpleSAMLphp, explicit start) for local SSO testing, with authsources.php bind-mounted from WorkingDirectory

**Other changes**
- Wires Sso into the mail-catcher reference list alongside admin/identity/billing
- ConfigureServices now returns IReadOnlyDictionary<string, IResourceBuilder<ProjectResource>> instead of a fixed 5-tuple, so adding services no longer breaks the call site
- Extracts repeated name[:tag] image parsing into a GetImageParts helper
- Adds BasePort entries for the new services and Redis/Idp config blocks in appsettings.Development.json

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
