### PR TITLE
[PM-36561] Send edit event logging 

### DIFF
--- a/src/Core/Dirt/Enums/EventType.cs
+++ b/src/Core/Dirt/Enums/EventType.cs
@@ -147,4 +147,6 @@ public enum EventType : int
     Send_Created_File = 2503,
     Send_Created_File_WithEmailVerification = 2504,
     Send_Created_File_WithPasswordProtection = 2505,
+    Send_Edited_Text = 2506,
+    Send_Edited_File = 2507,
 }

--- a/src/Core/Tools/SendFeatures/Commands/NonAnonymousSendCommand.cs
+++ b/src/Core/Tools/SendFeatures/Commands/NonAnonymousSendCommand.cs
@@ -52,17 +52,20 @@ public class NonAnonymousSendCommand : INonAnonymousSendCommand
         // Make sure user can save Sends
         await _sendValidationService.ValidateUserCanSaveAsync(send.UserId, send);
 
+        // New Send
         if (send.Id == default(Guid))
         {
             await _sendRepository.CreateAsync(send);
             await _pushNotificationService.PushSyncSendCreateAsync(send);
             await LogSendCreatedEventAsync(send);
         }
+        // Edit existing Send
         else
         {
             send.RevisionDate = DateTime.UtcNow;
             await _sendRepository.UpsertAsync(send);
             await _pushNotificationService.PushSyncSendUpdateAsync(send);
+            await LogSendUpdatedEventAsync(send);
         }
     }
 
@@ -74,6 +77,23 @@ public class NonAnonymousSendCommand : INonAnonymousSendCommand
         }
 
         await _eventService.LogUserEventAsync(send.UserId.Value, ResolveSendCreatedEventType(send));
+    }
+
+    private async Task LogSendUpdatedEventAsync(Send send)
+    {
+        if (!send.UserId.HasValue || !_featureService.IsEnabled(FeatureFlagKeys.SendEventLogging))
+        {
+            return;
+        }
+
+        if (send.Type == SendType.Text)
+        {
+            await _eventService.LogUserEventAsync(send.UserId.Value, EventType.Send_Edited_Text);
+        }
+        else
+        {
+            await _eventService.LogUserEventAsync(send.UserId.Value, EventType.Send_Edited_File);
+        }
     }
 
     private static EventType ResolveSendCreatedEventType(Send send)

--- a/test/Core.Test/Tools/Services/NonAnonymousSendCommandTests.cs
+++ b/test/Core.Test/Tools/Services/NonAnonymousSendCommandTests.cs
@@ -1518,8 +1518,31 @@ public class NonAnonymousSendCommandTests
         await _eventService.DidNotReceiveWithAnyArgs().LogUserEventAsync(default, default);
     }
 
+    [Theory]
+    [InlineData(SendType.Text, EventType.Send_Edited_Text)]
+    [InlineData(SendType.File, EventType.Send_Edited_File)]
+    public async Task SaveSendAsync_ExistingSend_FlagOn_LogsExpectedEventType(
+        SendType sendType, EventType expectedEventType)
+    {
+        var userId = Guid.NewGuid();
+        var send = new Send
+        {
+            Id = Guid.NewGuid(),
+            Type = sendType,
+            UserId = userId,
+        };
+
+        _featureService.IsEnabled(FeatureFlagKeys.SendEventLogging).Returns(true);
+        _sendValidationService.ValidateUserCanSaveAsync(userId, send).Returns(Task.CompletedTask);
+
+        await _nonAnonymousSendCommand.SaveSendAsync(send);
+
+        await _sendRepository.Received(1).UpsertAsync(send);
+        await _eventService.Received(1).LogUserEventAsync(userId, expectedEventType);
+    }
+
     [Fact]
-    public async Task SaveSendAsync_ExistingSend_FlagOn_DoesNotLogEvent()
+    public async Task SaveSendAsync_ExistingSend_FlagOff_DoesNotLogEvent()
     {
         var userId = Guid.NewGuid();
         var send = new Send
@@ -1529,7 +1552,7 @@ public class NonAnonymousSendCommandTests
             UserId = userId,
         };
 
-        _featureService.IsEnabled(FeatureFlagKeys.SendEventLogging).Returns(true);
+        _featureService.IsEnabled(FeatureFlagKeys.SendEventLogging).Returns(false);
         _sendValidationService.ValidateUserCanSaveAsync(userId, send).Returns(Task.CompletedTask);
 
         await _nonAnonymousSendCommand.SaveSendAsync(send);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36561

## 📔 Objective

This PR introduces an `EventType` and control flow in order to log Send edit events. 

See companion `clients` PR: https://github.com/bitwarden/clients/pull/20728
