### PR TITLE
[PM-36678] Add custom user check

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RestoreUser/v1/RestoreOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RestoreUser/v1/RestoreOrganizationUserCommand.cs
@@ -46,6 +46,12 @@ public class RestoreOrganizationUserCommand(
             throw new BadRequestException("Only owners can restore other owners.");
         }
 
+        if (organizationUser.Type == OrganizationUserType.Admin && restoringUserId.HasValue &&
+            !await currentContext.OrganizationAdmin(organizationUser.OrganizationId))
+        {
+            throw new BadRequestException("Custom users can not restore admins.");
+        }
+
         await RepositoryRestoreUserAsync(organizationUser, defaultCollectionName);
         await eventService.LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_Restored);
 
@@ -183,10 +189,12 @@ public class RestoreOrganizationUserCommand(
         var newSeatsRequired = organizationUserIds.Count() - availableSeats;
         await organizationService.AutoAddSeatsAsync(organization, newSeatsRequired);
 
-        var deletingUserIsOwner = false;
+        var restoringUserIsOwner = false;
+        var restoringUserIsAdminOrHigher = false;
         if (restoringUserId.HasValue)
         {
-            deletingUserIsOwner = await currentContext.OrganizationOwner(organizationId);
+            restoringUserIsOwner = await currentContext.OrganizationOwner(organizationId);
+            restoringUserIsAdminOrHigher = await currentContext.OrganizationAdmin(organizationId);
         }
 
         // Query Two Factor Authentication status for all users in the organization
@@ -213,9 +221,15 @@ public class RestoreOrganizationUserCommand(
                 }
 
                 if (organizationUser.Type == OrganizationUserType.Owner && restoringUserId.HasValue &&
-                    !deletingUserIsOwner)
+                    !restoringUserIsOwner)
                 {
                     throw new BadRequestException("Only owners can restore other owners.");
+                }
+
+                if (organizationUser.Type == OrganizationUserType.Admin && restoringUserId.HasValue &&
+                    !restoringUserIsAdminOrHigher)
+                {
+                    throw new BadRequestException("Custom users can not restore admins.");
                 }
 
                 var twoFactorIsEnabled = organizationUser.UserId.HasValue

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v1/RevokeOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v1/RevokeOrganizationUserCommand.cs
@@ -30,6 +30,12 @@ public class RevokeOrganizationUserCommand(
             throw new BadRequestException("Only owners can revoke other owners.");
         }
 
+        if (organizationUser.Type == OrganizationUserType.Admin && revokingUserId.HasValue &&
+            !await currentContext.OrganizationAdmin(organizationUser.OrganizationId))
+        {
+            throw new BadRequestException("Custom users can not revoke admins.");
+        }
+
         await RepositoryRevokeUserAsync(organizationUser, reason);
         await eventService.LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_Revoked);
 

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v2/Errors.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v2/Errors.cs
@@ -5,4 +5,5 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.RevokeUse
 public record UserAlreadyRevoked() : BadRequestError("Already revoked.");
 public record CannotRevokeYourself() : BadRequestError("You cannot revoke yourself.");
 public record OnlyOwnersCanRevokeOwners() : BadRequestError("Only owners can revoke other owners.");
+public record CustomUsersCannotRevokeAdmins() : BadRequestError("Custom users can not revoke admins.");
 public record MustHaveConfirmedOwner() : BadRequestError("Organization must have at least one confirmed owner.");

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v2/RevokeOrganizationUsersValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v2/RevokeOrganizationUsersValidator.cs
@@ -1,13 +1,16 @@
 ﻿using Bit.Core.AdminConsole.Models.Data;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interfaces;
 using Bit.Core.AdminConsole.Utilities.v2.Validation;
+using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using static Bit.Core.AdminConsole.Utilities.v2.Validation.ValidationResultHelpers;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.RevokeUser.v2;
 
-public class RevokeOrganizationUsersValidator(IHasConfirmedOwnersExceptQuery hasConfirmedOwnersExceptQuery)
+public class RevokeOrganizationUsersValidator(
+    IHasConfirmedOwnersExceptQuery hasConfirmedOwnersExceptQuery,
+    ICurrentContext currentContext)
     : IRevokeOrganizationUserValidator
 {
     public async Task<ICollection<ValidationResult<OrganizationUser>>> ValidateAsync(
@@ -17,23 +20,28 @@ public class RevokeOrganizationUsersValidator(IHasConfirmedOwnersExceptQuery has
             request.OrganizationUsersToRevoke.Select(x => x.Id) // users excluded because they are going to be revoked
             );
 
-        return request.OrganizationUsersToRevoke.Select(x =>
+        var isCustomUser = request.PerformedBy is not SystemUser
+                           && !await currentContext.OrganizationAdmin(request.OrganizationId);
+
+        return request.OrganizationUsersToRevoke.Select(organizationUser =>
         {
-            return x switch
+            return organizationUser switch
             {
                 _ when request.PerformedBy is not SystemUser
-                       && x.UserId is not null
-                       && x.UserId == request.PerformedBy.UserId =>
-                    Invalid(x, new CannotRevokeYourself()),
+                       && organizationUser.UserId is not null
+                       && organizationUser.UserId == request.PerformedBy.UserId =>
+                    Invalid(organizationUser, new CannotRevokeYourself()),
                 { Status: OrganizationUserStatusType.Revoked } =>
-                    Invalid(x, new UserAlreadyRevoked()),
+                    Invalid(organizationUser, new UserAlreadyRevoked()),
                 { Type: OrganizationUserType.Owner } when !hasRemainingOwner =>
-                    Invalid(x, new MustHaveConfirmedOwner()),
+                    Invalid(organizationUser, new MustHaveConfirmedOwner()),
                 { Type: OrganizationUserType.Owner } when request.PerformedBy is not SystemUser
                                                         && !request.PerformedBy.IsOrganizationOwnerOrProvider =>
-                    Invalid(x, new OnlyOwnersCanRevokeOwners()),
+                    Invalid(organizationUser, new OnlyOwnersCanRevokeOwners()),
+                { Type: OrganizationUserType.Admin } when isCustomUser =>
+                    Invalid(organizationUser, new CustomUsersCannotRevokeAdmins()),
 
-                _ => Valid(x)
+                _ => Valid(organizationUser)
             };
         }).ToList();
     }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RestoreUser/RestoreOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RestoreUser/RestoreOrganizationUserCommandTests.cs
@@ -126,6 +126,46 @@ public class RestoreOrganizationUserCommandTests
             .PushSyncOrgKeysAsync(Arg.Any<Guid>());
     }
 
+    [Theory, BitAutoData]
+    public async Task RestoreUser_CustomUserRestoreAdmin_Fails(
+        Organization organization,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.Custom)] OrganizationUser customUser,
+        [OrganizationUser(OrganizationUserStatusType.Revoked, OrganizationUserType.Admin)] OrganizationUser organizationUser,
+        SutProvider<RestoreOrganizationUserCommand> sutProvider)
+    {
+        // Arrange
+        RestoreUser_Setup(organization, customUser, organizationUser, sutProvider);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.RestoreUserAsync(organizationUser, customUser.Id, null));
+
+        // Assert
+        Assert.Contains("custom users can not restore admins", exception.Message.ToLowerInvariant());
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .RestoreAsync(Arg.Any<Guid>(), Arg.Any<OrganizationUserStatusType>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task RestoreUser_AdminRestoreAdmin_Success(
+        Organization organization,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.Admin)] OrganizationUser admin,
+        [OrganizationUser(OrganizationUserStatusType.Revoked, OrganizationUserType.Admin)] OrganizationUser organizationUser,
+        SutProvider<RestoreOrganizationUserCommand> sutProvider)
+    {
+        // Arrange
+        RestoreUser_Setup(organization, admin, organizationUser, sutProvider);
+
+        // Act
+        await sutProvider.Sut.RestoreUserAsync(organizationUser, admin.Id, null);
+
+        // Assert
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .Received(1)
+            .RestoreAsync(organizationUser.Id, Arg.Any<OrganizationUserStatusType>());
+    }
+
     [Theory]
     [BitAutoData(OrganizationUserStatusType.Invited)]
     [BitAutoData(OrganizationUserStatusType.Accepted)]
@@ -747,6 +787,43 @@ public class RestoreOrganizationUserCommandTests
     }
 
     [Theory, BitAutoData]
+    public async Task RestoreUsers_CustomUserRestoreAdmin_ReturnsErrorForAdmin(
+        Organization organization,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.Custom)] OrganizationUser customUser,
+        [OrganizationUser(OrganizationUserStatusType.Revoked, OrganizationUserType.Admin)] OrganizationUser adminUser,
+        [OrganizationUser(OrganizationUserStatusType.Revoked, OrganizationUserType.User)] OrganizationUser regularUser,
+        SutProvider<RestoreOrganizationUserCommand> sutProvider)
+    {
+        // Arrange
+        RestoreUser_Setup(organization, customUser, adminUser, sutProvider);
+        var organizationUserRepository = sutProvider.GetDependency<IOrganizationUserRepository>();
+        var userService = Substitute.For<IUserService>();
+
+        adminUser.Email = regularUser.Email = null;
+        adminUser.OrganizationId = regularUser.OrganizationId = organization.Id;
+        organizationUserRepository
+            .GetManyAsync(Arg.Is<IEnumerable<Guid>>(ids => ids.Contains(adminUser.Id) && ids.Contains(regularUser.Id)))
+            .Returns([adminUser, regularUser]);
+
+        // Act
+        var result = await sutProvider.Sut.RestoreUsersAsync(organization.Id, [adminUser.Id, regularUser.Id], customUser.Id, userService, null);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        var adminResult = result.Single(r => r.Item1.Id == adminUser.Id);
+        var regularResult = result.Single(r => r.Item1.Id == regularUser.Id);
+        Assert.Contains("custom users can not restore admins", adminResult.Item2.ToLowerInvariant());
+        Assert.Empty(regularResult.Item2);
+
+        await organizationUserRepository
+            .DidNotReceive()
+            .RestoreAsync(adminUser.Id, Arg.Any<OrganizationUserStatusType>());
+        await organizationUserRepository
+            .Received(1)
+            .RestoreAsync(regularUser.Id, Arg.Any<OrganizationUserStatusType>());
+    }
+
+    [Theory, BitAutoData]
     public async Task RestoreUsers_With2FAPolicy_BlocksNonCompliantUser(Organization organization,
         [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.Owner)] OrganizationUser owner,
         [OrganizationUser(OrganizationUserStatusType.Revoked)] OrganizationUser orgUser1,
@@ -1054,6 +1131,7 @@ public class RestoreOrganizationUserCommandTests
         });
 
         sutProvider.GetDependency<ICurrentContext>().OrganizationOwner(organization.Id).Returns(requestingOrganizationUser != null && requestingOrganizationUser.Type is OrganizationUserType.Owner);
+        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(organization.Id).Returns(requestingOrganizationUser != null && requestingOrganizationUser.Type is OrganizationUserType.Owner or OrganizationUserType.Admin);
         sutProvider.GetDependency<ICurrentContext>().ManageUsers(organization.Id).Returns(requestingOrganizationUser != null && (requestingOrganizationUser.Type is OrganizationUserType.Owner or OrganizationUserType.Admin));
 
         // Setup default disabled OrganizationDataOwnershipPolicyRequirement for any user

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeOrganizationUserCommandTests.cs
@@ -4,6 +4,7 @@ using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.RevokeUser.v1
 using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
+using Bit.Core.Exceptions;
 using Bit.Core.Platform.Push;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
@@ -42,6 +43,46 @@ public class RevokeOrganizationUserCommandTests
     }
 
     [Theory, BitAutoData]
+    public async Task RevokeUser_CustomUserRevokeAdmin_Fails(
+        Organization organization,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.Custom)] OrganizationUser customUser,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.Admin)] OrganizationUser organizationUser,
+        SutProvider<RevokeOrganizationUserCommand> sutProvider)
+    {
+        // Arrange
+        RestoreRevokeUser_Setup(organization, customUser, organizationUser, sutProvider);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.RevokeUserAsync(organizationUser, customUser.Id, RevocationReason.Manual));
+
+        // Assert
+        Assert.Contains("custom users can not revoke admins", exception.Message.ToLowerInvariant());
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .RevokeAsync(Arg.Any<Guid>(), Arg.Any<RevocationReason>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task RevokeUser_AdminRevokeAdmin_Success(
+        Organization organization,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.Admin)] OrganizationUser admin,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.Admin)] OrganizationUser organizationUser,
+        SutProvider<RevokeOrganizationUserCommand> sutProvider)
+    {
+        // Arrange
+        RestoreRevokeUser_Setup(organization, admin, organizationUser, sutProvider);
+
+        // Act
+        await sutProvider.Sut.RevokeUserAsync(organizationUser, admin.Id, RevocationReason.Manual);
+
+        // Assert
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .Received(1)
+            .RevokeAsync(organizationUser.Id, RevocationReason.Manual);
+    }
+
+    [Theory, BitAutoData]
     public async Task RevokeUser_WithEventSystemUser_Success(
         Organization organization,
         [OrganizationUser] OrganizationUser organizationUser,
@@ -76,6 +117,7 @@ public class RevokeOrganizationUserCommandTests
         targetOrganizationUser.OrganizationId = organization.Id;
 
         sutProvider.GetDependency<ICurrentContext>().OrganizationOwner(organization.Id).Returns(requestingOrganizationUser != null && requestingOrganizationUser.Type is OrganizationUserType.Owner);
+        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(organization.Id).Returns(requestingOrganizationUser != null && requestingOrganizationUser.Type is OrganizationUserType.Owner or OrganizationUserType.Admin);
         sutProvider.GetDependency<IHasConfirmedOwnersExceptQuery>()
             .HasConfirmedOwnersExceptAsync(organization.Id, Arg.Any<IEnumerable<Guid>>())
             .Returns(true);

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v2/RevokeOrganizationUsersValidatorTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RevokeUser/v2/RevokeOrganizationUsersValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿using Bit.Core.AdminConsole.Models.Data;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interfaces;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.RevokeUser.v2;
+using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Test.AutoFixture.OrganizationUserFixtures;
@@ -329,6 +330,103 @@ public class RevokeOrganizationUsersValidatorTests
 
         Assert.Contains(results, r => r.AsError is UserAlreadyRevoked);
         Assert.Contains(results, r => r.AsError is OnlyOwnersCanRevokeOwners);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task ValidateAsync_WhenCustomUserRevokesAdmin_ReturnsErrorForThatUser(
+        SutProvider<RevokeOrganizationUsersValidator> sutProvider,
+        Guid organizationId,
+        Guid actingUserId,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.Admin)] OrganizationUser adminUser)
+    {
+        // Arrange
+        adminUser.OrganizationId = organizationId;
+        adminUser.UserId = Guid.NewGuid();
+
+        var request = CreateValidationRequest(
+            organizationId,
+            [adminUser],
+            CreateActingUser(actingUserId, false, null));
+
+        sutProvider.GetDependency<IHasConfirmedOwnersExceptQuery>()
+            .HasConfirmedOwnersExceptAsync(organizationId, Arg.Any<IEnumerable<Guid>>())
+            .Returns(true);
+        sutProvider.GetDependency<ICurrentContext>()
+            .OrganizationAdmin(organizationId)
+            .Returns(false);
+
+        // Act
+        var results = (await sutProvider.Sut.ValidateAsync(request)).ToList();
+
+        // Assert
+        Assert.Single(results);
+        Assert.True(results.First().IsError);
+        Assert.IsType<CustomUsersCannotRevokeAdmins>(results.First().AsError);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task ValidateAsync_WhenAdminRevokesAdmin_ReturnsSuccess(
+        SutProvider<RevokeOrganizationUsersValidator> sutProvider,
+        Guid organizationId,
+        Guid actingUserId,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.Admin)] OrganizationUser adminUser)
+    {
+        // Arrange
+        adminUser.OrganizationId = organizationId;
+        adminUser.UserId = Guid.NewGuid();
+
+        var request = CreateValidationRequest(
+            organizationId,
+            [adminUser],
+            CreateActingUser(actingUserId, false, null));
+
+        sutProvider.GetDependency<IHasConfirmedOwnersExceptQuery>()
+            .HasConfirmedOwnersExceptAsync(organizationId, Arg.Any<IEnumerable<Guid>>())
+            .Returns(true);
+        sutProvider.GetDependency<ICurrentContext>()
+            .OrganizationAdmin(organizationId)
+            .Returns(true);
+
+        // Act
+        var results = (await sutProvider.Sut.ValidateAsync(request)).ToList();
+
+        // Assert
+        Assert.Single(results);
+        Assert.True(results.First().IsValid);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task ValidateAsync_WhenSystemUserRevokesAdmin_ReturnsSuccess(
+        SutProvider<RevokeOrganizationUsersValidator> sutProvider,
+        Guid organizationId,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.Admin)] OrganizationUser adminUser)
+    {
+        // Arrange
+        adminUser.OrganizationId = organizationId;
+        adminUser.UserId = Guid.NewGuid();
+
+        var actingUser = CreateActingUser(null, false, EventSystemUser.SCIM);
+        var request = CreateValidationRequest(
+            organizationId,
+            [adminUser],
+            actingUser);
+
+        sutProvider.GetDependency<IHasConfirmedOwnersExceptQuery>()
+            .HasConfirmedOwnersExceptAsync(organizationId, Arg.Any<IEnumerable<Guid>>())
+            .Returns(true);
+
+        // Act
+        var results = (await sutProvider.Sut.ValidateAsync(request)).ToList();
+
+        // Assert
+        Assert.Single(results);
+        Assert.True(results.First().IsValid);
+        await sutProvider.GetDependency<ICurrentContext>()
+            .DidNotReceiveWithAnyArgs()
+            .OrganizationAdmin(default);
     }
 
     private static IActingUser CreateActingUser(Guid? userId, bool isOwnerOrProvider, EventSystemUser? systemUserType) =>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36678

## 📔 Objective

1. Add a guard to prevent custom users from restoring or revoking admins.
2. Support both single and bulk cases.
3. Add unit tests.

It’s a simple change. The unit tests should be sufficient. No manual tests are needed.
