### PR TITLE
[PM-37598] Update Tax Id Warning Logic with Feature Flag

### DIFF
--- a/bitwarden_license/src/Commercial.Core/Billing/Providers/Queries/GetProviderWarningsQuery.cs
+++ b/bitwarden_license/src/Commercial.Core/Billing/Providers/Queries/GetProviderWarningsQuery.cs
@@ -64,9 +64,19 @@ public class GetProviderWarningsQuery(
         Provider provider,
         Customer customer)
     {
-        if (TaxHelpers.IsDirectTaxCountry(customer.Address?.Country))
+        if (featureService.IsEnabled(FeatureFlagKeys.PM37597_AlwaysEnableStripeAutomaticTax))
         {
-            return null;
+            if (customer.TaxExempt != TaxExempt.None)
+            {
+                return null;
+            }
+        }
+        else
+        {
+            if (TaxHelpers.IsDirectTaxCountry(customer.Address?.Country))
+            {
+                return null;
+            }
         }
 
         if (!currentContext.ProviderProviderAdmin(provider.Id))

--- a/bitwarden_license/src/Commercial.Core/Billing/Providers/Queries/GetProviderWarningsQuery.cs
+++ b/bitwarden_license/src/Commercial.Core/Billing/Providers/Queries/GetProviderWarningsQuery.cs
@@ -1,10 +1,12 @@
-﻿using Bit.Core.AdminConsole.Entities.Provider;
+﻿using Bit.Core;
+using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Providers.Models;
 using Bit.Core.Billing.Providers.Queries;
 using Bit.Core.Billing.Services;
 using Bit.Core.Billing.Tax.Utilities;
 using Bit.Core.Context;
+using Bit.Core.Services;
 using Stripe;
 using Stripe.Tax;
 
@@ -16,6 +18,7 @@ using TaxIdWarning = ProviderWarnings.TaxIdWarning;
 
 public class GetProviderWarningsQuery(
     ICurrentContext currentContext,
+    IFeatureService featureService,
     IStripeAdapter stripeAdapter,
     ISubscriberService subscriberService) : IGetProviderWarningsQuery
 {

--- a/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Queries/GetProviderWarningsQueryTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Queries/GetProviderWarningsQueryTests.cs
@@ -694,4 +694,189 @@ public class GetProviderWarningsQueryTests
 
         Assert.Null(response!.TaxId);
     }
+
+    [Theory, BitAutoData]
+    public async Task Run_FlagEnabled_NoRegistrationInCountry_NoTaxIdWarning(
+        Provider provider,
+        SutProvider<GetProviderWarningsQuery> sutProvider)
+    {
+        provider.Enabled = true;
+
+        sutProvider.GetDependency<ISubscriberService>()
+            .GetSubscription(provider, Arg.Is<SubscriptionGetOptions>(options =>
+                options.Expand.SequenceEqual(_requiredExpansions)
+            ))
+            .Returns(new Subscription
+            {
+                Status = SubscriptionStatus.Active,
+                Customer = new Customer
+                {
+                    TaxIds = new StripeList<TaxId> { Data = [] },
+                    Address = new Address { Country = "CA" },
+                    TaxExempt = TaxExempt.None
+                }
+            });
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM37597_AlwaysEnableStripeAutomaticTax)
+            .Returns(true);
+
+        sutProvider.GetDependency<ICurrentContext>().ProviderProviderAdmin(provider.Id).Returns(true);
+        sutProvider.GetDependency<IStripeAdapter>().ListTaxRegistrationsAsync(Arg.Any<RegistrationListOptions>())
+            .Returns(new StripeList<Registration>
+            {
+                Data = [new Registration { Country = "GB" }]
+            });
+
+        var response = await sutProvider.Sut.Run(provider);
+
+        Assert.Null(response!.TaxId);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_FlagEnabled_TaxableCustomer_Has_TaxIdPendingVerificationWarning(
+        Provider provider,
+        SutProvider<GetProviderWarningsQuery> sutProvider)
+    {
+        provider.Enabled = true;
+
+        sutProvider.GetDependency<ISubscriberService>()
+            .GetSubscription(provider, Arg.Is<SubscriptionGetOptions>(options =>
+                options.Expand.SequenceEqual(_requiredExpansions)
+            ))
+            .Returns(new Subscription
+            {
+                Status = SubscriptionStatus.Active,
+                Customer = new Customer
+                {
+                    TaxIds = new StripeList<TaxId>
+                    {
+                        Data = [new TaxId
+                        {
+                            Verification = new TaxIdVerification
+                            {
+                                Status = TaxIdVerificationStatus.Pending
+                            }
+                        }]
+                    },
+                    Address = new Address { Country = "CA" },
+                    TaxExempt = TaxExempt.None
+                }
+            });
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM37597_AlwaysEnableStripeAutomaticTax)
+            .Returns(true);
+
+        sutProvider.GetDependency<ICurrentContext>().ProviderProviderAdmin(provider.Id).Returns(true);
+        sutProvider.GetDependency<IStripeAdapter>().ListTaxRegistrationsAsync(Arg.Any<RegistrationListOptions>())
+            .Returns(new StripeList<Registration>
+            {
+                Data = [new Registration { Country = "CA" }]
+            });
+
+        var response = await sutProvider.Sut.Run(provider);
+
+        Assert.True(response is
+        {
+            TaxId.Type: "tax_id_pending_verification"
+        });
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_FlagEnabled_TaxableCustomer_Has_TaxIdFailedVerificationWarning(
+        Provider provider,
+        SutProvider<GetProviderWarningsQuery> sutProvider)
+    {
+        provider.Enabled = true;
+
+        sutProvider.GetDependency<ISubscriberService>()
+            .GetSubscription(provider, Arg.Is<SubscriptionGetOptions>(options =>
+                options.Expand.SequenceEqual(_requiredExpansions)
+            ))
+            .Returns(new Subscription
+            {
+                Status = SubscriptionStatus.Active,
+                Customer = new Customer
+                {
+                    TaxIds = new StripeList<TaxId>
+                    {
+                        Data = [new TaxId
+                        {
+                            Verification = new TaxIdVerification
+                            {
+                                Status = TaxIdVerificationStatus.Unverified
+                            }
+                        }]
+                    },
+                    Address = new Address { Country = "CA" },
+                    TaxExempt = TaxExempt.None
+                }
+            });
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM37597_AlwaysEnableStripeAutomaticTax)
+            .Returns(true);
+
+        sutProvider.GetDependency<ICurrentContext>().ProviderProviderAdmin(provider.Id).Returns(true);
+        sutProvider.GetDependency<IStripeAdapter>().ListTaxRegistrationsAsync(Arg.Any<RegistrationListOptions>())
+            .Returns(new StripeList<Registration>
+            {
+                Data = [new Registration { Country = "CA" }]
+            });
+
+        var response = await sutProvider.Sut.Run(provider);
+
+        Assert.True(response is
+        {
+            TaxId.Type: "tax_id_failed_verification"
+        });
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_FlagEnabled_TaxableCustomer_VerifiedTaxId_NoTaxIdWarning(
+        Provider provider,
+        SutProvider<GetProviderWarningsQuery> sutProvider)
+    {
+        provider.Enabled = true;
+
+        sutProvider.GetDependency<ISubscriberService>()
+            .GetSubscription(provider, Arg.Is<SubscriptionGetOptions>(options =>
+                options.Expand.SequenceEqual(_requiredExpansions)
+            ))
+            .Returns(new Subscription
+            {
+                Status = SubscriptionStatus.Active,
+                Customer = new Customer
+                {
+                    TaxIds = new StripeList<TaxId>
+                    {
+                        Data = [new TaxId
+                        {
+                            Verification = new TaxIdVerification
+                            {
+                                Status = TaxIdVerificationStatus.Verified
+                            }
+                        }]
+                    },
+                    Address = new Address { Country = "CA" },
+                    TaxExempt = TaxExempt.None
+                }
+            });
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM37597_AlwaysEnableStripeAutomaticTax)
+            .Returns(true);
+
+        sutProvider.GetDependency<ICurrentContext>().ProviderProviderAdmin(provider.Id).Returns(true);
+        sutProvider.GetDependency<IStripeAdapter>().ListTaxRegistrationsAsync(Arg.Any<RegistrationListOptions>())
+            .Returns(new StripeList<Registration>
+            {
+                Data = [new Registration { Country = "CA" }]
+            });
+
+        var response = await sutProvider.Sut.Run(provider);
+
+        Assert.Null(response!.TaxId);
+    }
 }

--- a/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Queries/GetProviderWarningsQueryTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Queries/GetProviderWarningsQueryTests.cs
@@ -1,8 +1,10 @@
-﻿using Bit.Commercial.Core.Billing.Providers.Queries;
+using Bit.Commercial.Core.Billing.Providers.Queries;
+using Bit.Core;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Services;
 using Bit.Core.Context;
+using Bit.Core.Services;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
@@ -580,6 +582,113 @@ public class GetProviderWarningsQueryTests
             {
                 Data = [new Registration { Country = "US" }]
             });
+
+        var response = await sutProvider.Sut.Run(provider);
+
+        Assert.Null(response!.TaxId);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_FlagEnabled_TaxableCustomer_Has_TaxIdWarning(
+        Provider provider,
+        SutProvider<GetProviderWarningsQuery> sutProvider)
+    {
+        provider.Enabled = true;
+
+        sutProvider.GetDependency<ISubscriberService>()
+            .GetSubscription(provider, Arg.Is<SubscriptionGetOptions>(options =>
+                options.Expand.SequenceEqual(_requiredExpansions)
+            ))
+            .Returns(new Subscription
+            {
+                Status = SubscriptionStatus.Active,
+                Customer = new Customer
+                {
+                    TaxIds = new StripeList<TaxId> { Data = [] },
+                    Address = new Address { Country = "US" },
+                    TaxExempt = TaxExempt.None
+                }
+            });
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM37597_AlwaysEnableStripeAutomaticTax)
+            .Returns(true);
+
+        sutProvider.GetDependency<ICurrentContext>().ProviderProviderAdmin(provider.Id).Returns(true);
+        sutProvider.GetDependency<IStripeAdapter>().ListTaxRegistrationsAsync(Arg.Any<RegistrationListOptions>())
+            .Returns(new StripeList<Registration>
+            {
+                Data = [new Registration { Country = "US" }]
+            });
+
+        var response = await sutProvider.Sut.Run(provider);
+
+        Assert.True(response is
+        {
+            TaxId.Type: "tax_id_missing"
+        });
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_FlagEnabled_ExemptCustomer_NoTaxIdWarning(
+        Provider provider,
+        SutProvider<GetProviderWarningsQuery> sutProvider)
+    {
+        provider.Enabled = true;
+
+        sutProvider.GetDependency<ISubscriberService>()
+            .GetSubscription(provider, Arg.Is<SubscriptionGetOptions>(options =>
+                options.Expand.SequenceEqual(_requiredExpansions)
+            ))
+            .Returns(new Subscription
+            {
+                Status = SubscriptionStatus.Active,
+                Customer = new Customer
+                {
+                    TaxIds = new StripeList<TaxId> { Data = [] },
+                    Address = new Address { Country = "CA" },
+                    TaxExempt = TaxExempt.Exempt
+                }
+            });
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM37597_AlwaysEnableStripeAutomaticTax)
+            .Returns(true);
+
+        sutProvider.GetDependency<ICurrentContext>().ProviderProviderAdmin(provider.Id).Returns(true);
+
+        var response = await sutProvider.Sut.Run(provider);
+
+        Assert.Null(response!.TaxId);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_FlagEnabled_ReverseCustomer_NoTaxIdWarning(
+        Provider provider,
+        SutProvider<GetProviderWarningsQuery> sutProvider)
+    {
+        provider.Enabled = true;
+
+        sutProvider.GetDependency<ISubscriberService>()
+            .GetSubscription(provider, Arg.Is<SubscriptionGetOptions>(options =>
+                options.Expand.SequenceEqual(_requiredExpansions)
+            ))
+            .Returns(new Subscription
+            {
+                Status = SubscriptionStatus.Active,
+                Customer = new Customer
+                {
+                    TaxIds = new StripeList<TaxId> { Data = [] },
+                    Address = new Address { Country = "CA" },
+                    TaxExempt = TaxExempt.Reverse
+                }
+            });
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM37597_AlwaysEnableStripeAutomaticTax)
+            .Returns(true);
+
+        sutProvider.GetDependency<ICurrentContext>().ProviderProviderAdmin(provider.Id).Returns(true);
 
         var response = await sutProvider.Sut.Run(provider);
 

--- a/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Queries/GetProviderWarningsQueryTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Queries/GetProviderWarningsQueryTests.cs
@@ -1,4 +1,4 @@
-using Bit.Commercial.Core.Billing.Providers.Queries;
+﻿using Bit.Commercial.Core.Billing.Providers.Queries;
 using Bit.Core;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.Billing.Constants;

--- a/src/Core/Billing/Organizations/Queries/GetOrganizationWarningsQuery.cs
+++ b/src/Core/Billing/Organizations/Queries/GetOrganizationWarningsQuery.cs
@@ -244,9 +244,19 @@ public class GetOrganizationWarningsQuery(
         Customer customer,
         Provider? provider)
     {
-        if (TaxHelpers.IsDirectTaxCountry(customer.Address?.Country))
+        if (featureService.IsEnabled(FeatureFlagKeys.PM37597_AlwaysEnableStripeAutomaticTax))
         {
-            return null;
+            if (customer.TaxExempt != TaxExempt.None)
+            {
+                return null;
+            }
+        }
+        else
+        {
+            if (TaxHelpers.IsDirectTaxCountry(customer.Address?.Country))
+            {
+                return null;
+            }
         }
 
         var productTier = organization.PlanType.GetProductTier();

--- a/src/Core/Billing/Organizations/Queries/GetOrganizationWarningsQuery.cs
+++ b/src/Core/Billing/Organizations/Queries/GetOrganizationWarningsQuery.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Core;
-using Bit.Core.AdminConsole.Entities;
+﻿using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.AdminConsole.Repositories;

--- a/src/Core/Billing/Organizations/Queries/GetOrganizationWarningsQuery.cs
+++ b/src/Core/Billing/Organizations/Queries/GetOrganizationWarningsQuery.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.AdminConsole.Entities;
+﻿using Bit.Core;
+using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.AdminConsole.Repositories;
@@ -10,6 +11,7 @@ using Bit.Core.Billing.Payment.Queries;
 using Bit.Core.Billing.Services;
 using Bit.Core.Billing.Tax.Utilities;
 using Bit.Core.Context;
+using Bit.Core.Services;
 using Stripe;
 using Stripe.Tax;
 
@@ -29,6 +31,7 @@ public interface IGetOrganizationWarningsQuery
 
 public class GetOrganizationWarningsQuery(
     ICurrentContext currentContext,
+    IFeatureService featureService,
     IHasPaymentMethodQuery hasPaymentMethodQuery,
     IProviderRepository providerRepository,
     IStripeAdapter stripeAdapter,

--- a/test/Core.Test/Billing/Organizations/Queries/GetOrganizationWarningsQueryTests.cs
+++ b/test/Core.Test/Billing/Organizations/Queries/GetOrganizationWarningsQueryTests.cs
@@ -973,6 +973,220 @@ public class GetOrganizationWarningsQueryTests
     }
 
     [Theory, BitAutoData]
+    public async Task Run_FlagEnabled_NoRegistrationInCountry_NoTaxIdWarning(
+        Organization organization,
+        SutProvider<GetOrganizationWarningsQuery> sutProvider)
+    {
+        organization.PlanType = PlanType.TeamsAnnually;
+
+        var subscription = new Subscription
+        {
+            Customer = new Customer
+            {
+                Address = new Address { Country = "CA" },
+                TaxExempt = TaxExempt.None,
+                TaxIds = new StripeList<TaxId> { Data = new List<TaxId>() },
+                InvoiceSettings = new CustomerInvoiceSettings(),
+                Metadata = new Dictionary<string, string>()
+            }
+        };
+
+        sutProvider.GetDependency<ISubscriberService>()
+            .GetSubscription(organization, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM37597_AlwaysEnableStripeAutomaticTax)
+            .Returns(true);
+
+        sutProvider.GetDependency<ICurrentContext>()
+            .OrganizationOwner(organization.Id)
+            .Returns(true);
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .ListTaxRegistrationsAsync(Arg.Any<RegistrationListOptions>())
+            .Returns(new StripeList<Registration>
+            {
+                Data = new List<Registration>
+                {
+                    new() { Country = "GB" }
+                }
+            });
+
+        var response = await sutProvider.Sut.Run(organization);
+
+        Assert.Null(response.TaxId);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_FlagEnabled_TaxableCustomer_Has_TaxIdWarning_PendingVerification(
+        Organization organization,
+        SutProvider<GetOrganizationWarningsQuery> sutProvider)
+    {
+        organization.PlanType = PlanType.TeamsAnnually;
+
+        var taxId = new TaxId
+        {
+            Verification = new TaxIdVerification
+            {
+                Status = TaxIdVerificationStatus.Pending
+            }
+        };
+
+        var subscription = new Subscription
+        {
+            Customer = new Customer
+            {
+                Address = new Address { Country = "CA" },
+                TaxExempt = TaxExempt.None,
+                TaxIds = new StripeList<TaxId> { Data = new List<TaxId> { taxId } },
+                InvoiceSettings = new CustomerInvoiceSettings(),
+                Metadata = new Dictionary<string, string>()
+            }
+        };
+
+        sutProvider.GetDependency<ISubscriberService>()
+            .GetSubscription(organization, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM37597_AlwaysEnableStripeAutomaticTax)
+            .Returns(true);
+
+        sutProvider.GetDependency<ICurrentContext>()
+            .OrganizationOwner(organization.Id)
+            .Returns(true);
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .ListTaxRegistrationsAsync(Arg.Any<RegistrationListOptions>())
+            .Returns(new StripeList<Registration>
+            {
+                Data = new List<Registration>
+                {
+                    new() { Country = "CA" }
+                }
+            });
+
+        var response = await sutProvider.Sut.Run(organization);
+
+        Assert.True(response is
+        {
+            TaxId.Type: "tax_id_pending_verification"
+        });
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_FlagEnabled_TaxableCustomer_Has_TaxIdWarning_FailedVerification(
+        Organization organization,
+        SutProvider<GetOrganizationWarningsQuery> sutProvider)
+    {
+        organization.PlanType = PlanType.TeamsAnnually;
+
+        var taxId = new TaxId
+        {
+            Verification = new TaxIdVerification
+            {
+                Status = TaxIdVerificationStatus.Unverified
+            }
+        };
+
+        var subscription = new Subscription
+        {
+            Customer = new Customer
+            {
+                Address = new Address { Country = "CA" },
+                TaxExempt = TaxExempt.None,
+                TaxIds = new StripeList<TaxId> { Data = new List<TaxId> { taxId } },
+                InvoiceSettings = new CustomerInvoiceSettings(),
+                Metadata = new Dictionary<string, string>()
+            }
+        };
+
+        sutProvider.GetDependency<ISubscriberService>()
+            .GetSubscription(organization, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM37597_AlwaysEnableStripeAutomaticTax)
+            .Returns(true);
+
+        sutProvider.GetDependency<ICurrentContext>()
+            .OrganizationOwner(organization.Id)
+            .Returns(true);
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .ListTaxRegistrationsAsync(Arg.Any<RegistrationListOptions>())
+            .Returns(new StripeList<Registration>
+            {
+                Data = new List<Registration>
+                {
+                    new() { Country = "CA" }
+                }
+            });
+
+        var response = await sutProvider.Sut.Run(organization);
+
+        Assert.True(response is
+        {
+            TaxId.Type: "tax_id_failed_verification"
+        });
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_FlagEnabled_TaxableCustomer_VerifiedTaxId_NoTaxIdWarning(
+        Organization organization,
+        SutProvider<GetOrganizationWarningsQuery> sutProvider)
+    {
+        organization.PlanType = PlanType.TeamsAnnually;
+
+        var taxId = new TaxId
+        {
+            Verification = new TaxIdVerification
+            {
+                Status = TaxIdVerificationStatus.Verified
+            }
+        };
+
+        var subscription = new Subscription
+        {
+            Customer = new Customer
+            {
+                Address = new Address { Country = "CA" },
+                TaxExempt = TaxExempt.None,
+                TaxIds = new StripeList<TaxId> { Data = new List<TaxId> { taxId } },
+                InvoiceSettings = new CustomerInvoiceSettings(),
+                Metadata = new Dictionary<string, string>()
+            }
+        };
+
+        sutProvider.GetDependency<ISubscriberService>()
+            .GetSubscription(organization, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM37597_AlwaysEnableStripeAutomaticTax)
+            .Returns(true);
+
+        sutProvider.GetDependency<ICurrentContext>()
+            .OrganizationOwner(organization.Id)
+            .Returns(true);
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .ListTaxRegistrationsAsync(Arg.Any<RegistrationListOptions>())
+            .Returns(new StripeList<Registration>
+            {
+                Data = new List<Registration>
+                {
+                    new() { Country = "CA" }
+                }
+            });
+
+        var response = await sutProvider.Sut.Run(organization);
+
+        Assert.Null(response.TaxId);
+    }
+
+    [Theory, BitAutoData]
     public async Task Run_ExemptFromBillingAutomation_NoResellerRenewalWarning(
         Organization organization,
         SutProvider<GetOrganizationWarningsQuery> sutProvider)

--- a/test/Core.Test/Billing/Organizations/Queries/GetOrganizationWarningsQueryTests.cs
+++ b/test/Core.Test/Billing/Organizations/Queries/GetOrganizationWarningsQueryTests.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Core;
-using Bit.Core.AdminConsole.Entities;
+﻿using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.AdminConsole.Repositories;

--- a/test/Core.Test/Billing/Organizations/Queries/GetOrganizationWarningsQueryTests.cs
+++ b/test/Core.Test/Billing/Organizations/Queries/GetOrganizationWarningsQueryTests.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.AdminConsole.Entities;
+﻿using Bit.Core;
+using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.AdminConsole.Repositories;
@@ -8,6 +9,7 @@ using Bit.Core.Billing.Organizations.Queries;
 using Bit.Core.Billing.Payment.Queries;
 using Bit.Core.Billing.Services;
 using Bit.Core.Context;
+using Bit.Core.Services;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
@@ -856,6 +858,119 @@ public class GetOrganizationWarningsQueryTests
         var response = await sutProvider.Sut.Run(organization);
 
         Assert.Null(response.InactiveSubscription);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_FlagEnabled_TaxableCustomer_Has_TaxIdWarning_Missing(
+        Organization organization,
+        SutProvider<GetOrganizationWarningsQuery> sutProvider)
+    {
+        organization.PlanType = PlanType.TeamsAnnually;
+
+        var subscription = new Subscription
+        {
+            Customer = new Customer
+            {
+                Address = new Address { Country = "US" },
+                TaxExempt = TaxExempt.None,
+                TaxIds = new StripeList<TaxId> { Data = new List<TaxId>() },
+                InvoiceSettings = new CustomerInvoiceSettings(),
+                Metadata = new Dictionary<string, string>()
+            }
+        };
+
+        sutProvider.GetDependency<ISubscriberService>()
+            .GetSubscription(organization, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM37597_AlwaysEnableStripeAutomaticTax)
+            .Returns(true);
+
+        sutProvider.GetDependency<ICurrentContext>()
+            .OrganizationOwner(organization.Id)
+            .Returns(true);
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .ListTaxRegistrationsAsync(Arg.Any<RegistrationListOptions>())
+            .Returns(new StripeList<Registration>
+            {
+                Data = new List<Registration>
+                {
+                    new() { Country = "US" }
+                }
+            });
+
+        var response = await sutProvider.Sut.Run(organization);
+
+        Assert.True(response is
+        {
+            TaxId.Type: "tax_id_missing"
+        });
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_FlagEnabled_ExemptCustomer_NoTaxIdWarning(
+        Organization organization,
+        SutProvider<GetOrganizationWarningsQuery> sutProvider)
+    {
+        organization.PlanType = PlanType.TeamsAnnually;
+
+        var subscription = new Subscription
+        {
+            Customer = new Customer
+            {
+                Address = new Address { Country = "CA" },
+                TaxExempt = TaxExempt.Exempt,
+                TaxIds = new StripeList<TaxId> { Data = new List<TaxId>() },
+                InvoiceSettings = new CustomerInvoiceSettings(),
+                Metadata = new Dictionary<string, string>()
+            }
+        };
+
+        sutProvider.GetDependency<ISubscriberService>()
+            .GetSubscription(organization, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM37597_AlwaysEnableStripeAutomaticTax)
+            .Returns(true);
+
+        var response = await sutProvider.Sut.Run(organization);
+
+        Assert.Null(response.TaxId);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_FlagEnabled_ReverseCustomer_NoTaxIdWarning(
+        Organization organization,
+        SutProvider<GetOrganizationWarningsQuery> sutProvider)
+    {
+        organization.PlanType = PlanType.TeamsAnnually;
+
+        var subscription = new Subscription
+        {
+            Customer = new Customer
+            {
+                Address = new Address { Country = "CA" },
+                TaxExempt = TaxExempt.Reverse,
+                TaxIds = new StripeList<TaxId> { Data = new List<TaxId>() },
+                InvoiceSettings = new CustomerInvoiceSettings(),
+                Metadata = new Dictionary<string, string>()
+            }
+        };
+
+        sutProvider.GetDependency<ISubscriberService>()
+            .GetSubscription(organization, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM37597_AlwaysEnableStripeAutomaticTax)
+            .Returns(true);
+
+        var response = await sutProvider.Sut.Run(organization);
+
+        Assert.Null(response.TaxId);
     }
 
     [Theory, BitAutoData]


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-37598

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Updates the logic for generating tax ID warnings in both provider and organization billing queries.

Key changes include:

**Feature flag integration and logic changes:**

* Updated `GetProviderWarningsQuery` and `GetOrganizationWarningsQuery` to inject `IFeatureService` and adjust the tax ID warning logic: when the `PM37597_AlwaysEnableStripeAutomaticTax` feature flag is enabled, tax ID warnings are only generated for customers who are not tax-exempt; otherwise, the previous country-based logic applies. 

**Unit test enhancements:**

* Added new unit tests in both `GetProviderWarningsQueryTests` and `GetOrganizationWarningsQueryTests` to verify that:
  - Tax ID warnings are shown only for non-exempt customers when the feature flag is enabled.
  - No warnings are shown for exempt or reverse charge customers under the same flag.
  - These tests cover various combinations of customer tax exemption status and country. 