### PR TITLE
Seeder - add favorite for card, identity, secure note, and sshkey scenes

### DIFF
--- a/util/Seeder/Scenes/UserCardCipherScene.cs
+++ b/util/Seeder/Scenes/UserCardCipherScene.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 using Bit.Core.Repositories;
 using Bit.Core.Vault.Enums;
 using Bit.Core.Vault.Repositories;
@@ -25,6 +26,7 @@ public class UserCardCipherScene(IUserRepository userRepository, ICipherReposito
         public required string Code { get; set; }
         public string? Notes { get; set; }
         public bool Reprompt { get; set; }
+        public bool Favorite { get; set; }
         public Guid? FolderId { get; set; }
     }
 
@@ -61,6 +63,13 @@ public class UserCardCipherScene(IUserRepository userRepository, ICipherReposito
         if (request.Reprompt)
         {
             cipher.Reprompt = CipherRepromptType.Password;
+        }
+        if (request.Favorite)
+        {
+            cipher.Favorites = JsonSerializer.Serialize(new Dictionary<string, bool>
+            {
+                { request.UserId.ToString().ToUpperInvariant(), true}
+            });
         }
         if (request.FolderId.HasValue)
         {

--- a/util/Seeder/Scenes/UserIdentityCipherScene.cs
+++ b/util/Seeder/Scenes/UserIdentityCipherScene.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 using Bit.Core.Repositories;
 using Bit.Core.Vault.Enums;
 using Bit.Core.Vault.Repositories;
@@ -38,6 +39,7 @@ public class UserIdentityCipherScene(IUserRepository userRepository, ICipherRepo
         public string? Country { get; set; }
         public string? Notes { get; set; }
         public bool Reprompt { get; set; }
+        public bool Favorite { get; set; }
         public Guid? FolderId { get; set; }
     }
 
@@ -87,6 +89,13 @@ public class UserIdentityCipherScene(IUserRepository userRepository, ICipherRepo
         if (request.Reprompt)
         {
             cipher.Reprompt = CipherRepromptType.Password;
+        }
+        if (request.Favorite)
+        {
+            cipher.Favorites = JsonSerializer.Serialize(new Dictionary<string, bool>
+            {
+                { request.UserId.ToString().ToUpperInvariant(), true}
+            });
         }
         if (request.FolderId.HasValue)
         {

--- a/util/Seeder/Scenes/UserSecureNoteCipherScene.cs
+++ b/util/Seeder/Scenes/UserSecureNoteCipherScene.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 using Bit.Core.Repositories;
 using Bit.Core.Vault.Enums;
 using Bit.Core.Vault.Repositories;
@@ -20,6 +21,7 @@ public class UserSecureNoteCipherScene(IUserRepository userRepository, ICipherRe
         public required string Name { get; set; }
         public string? Notes { get; set; }
         public bool Reprompt { get; set; }
+        public bool Favorite { get; set; }
         public Guid? FolderId { get; set; }
     }
 
@@ -47,6 +49,13 @@ public class UserSecureNoteCipherScene(IUserRepository userRepository, ICipherRe
         if (request.Reprompt)
         {
             cipher.Reprompt = CipherRepromptType.Password;
+        }
+        if (request.Favorite)
+        {
+            cipher.Favorites = JsonSerializer.Serialize(new Dictionary<string, bool>
+            {
+                { request.UserId.ToString().ToUpperInvariant(), true}
+            });
         }
         if (request.FolderId.HasValue)
         {

--- a/util/Seeder/Scenes/UserSshKeyCipherScene.cs
+++ b/util/Seeder/Scenes/UserSshKeyCipherScene.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 using Bit.Core.Repositories;
 using Bit.Core.Vault.Enums;
 using Bit.Core.Vault.Repositories;
@@ -22,6 +23,7 @@ public class UserSshKeyCipherScene(IUserRepository userRepository, ICipherReposi
         public string? PublicKey { get; set; }
         public string? Fingerprint { get; set; }
         public bool Reprompt { get; set; }
+        public bool Favorite { get; set; }
         public string? Notes { get; set; }
         public Guid? FolderId { get; set; }
     }
@@ -57,6 +59,13 @@ public class UserSshKeyCipherScene(IUserRepository userRepository, ICipherReposi
         if (request.Reprompt)
         {
             cipher.Reprompt = CipherRepromptType.Password;
+        }
+        if (request.Favorite)
+        {
+            cipher.Favorites = JsonSerializer.Serialize(new Dictionary<string, bool>
+            {
+                { request.UserId.ToString().ToUpperInvariant(), true}
+            });
         }
         if (request.FolderId.HasValue)
         {


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/QA-1723

## 📔 Objective
- Adds Favorite to Card, Identity, Secure Note, and SshKey item type scenes

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
