### PR TITLE
[PM-29658]: Remove PUT Policy vNext

### DIFF
--- a/src/Api/AdminConsole/Controllers/PoliciesController.cs
+++ b/src/Api/AdminConsole/Controllers/PoliciesController.cs
@@ -142,15 +142,4 @@ public class PoliciesController : Controller
 
         return new PolicyResponseModel(policy);
     }
-
-    [HttpPut("{type}/vnext")]
-    [Authorize<ManagePoliciesRequirement>]
-    public async Task<PolicyResponseModel> PutVNext(Guid orgId, PolicyType type, [FromBody] SavePolicyRequest model)
-    {
-        var savePolicyRequest = await model.ToSavePolicyModelAsync(orgId, type, _currentContext);
-
-        var policy = await _savePolicyCommand.SaveAsync(savePolicyRequest);
-
-        return new PolicyResponseModel(policy);
-    }
 }

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/PoliciesControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/PoliciesControllerTests.cs
@@ -51,7 +51,7 @@ public class PoliciesControllerTests : IClassFixture<ApiApplicationFactory>, IAs
     }
 
     [Fact]
-    public async Task PutVNext_OrganizationDataOwnershipPolicy_Success()
+    public async Task Put_OrganizationDataOwnershipPolicy_Success()
     {
         // Arrange
         const PolicyType policyType = PolicyType.OrganizationDataOwnership;
@@ -76,7 +76,7 @@ public class PoliciesControllerTests : IClassFixture<ApiApplicationFactory>, IAs
             _organization.Id, OrganizationUserType.User);
 
         // Act
-        var response = await _client.PutAsync($"/organizations/{_organization.Id}/policies/{policyType}/vnext",
+        var response = await _client.PutAsync($"/organizations/{_organization.Id}/policies/{policyType}",
             JsonContent.Create(request));
 
         // Assert
@@ -133,7 +133,7 @@ public class PoliciesControllerTests : IClassFixture<ApiApplicationFactory>, IAs
     }
 
     [Fact]
-    public async Task PutVNext_MasterPasswordPolicy_Success()
+    public async Task Put_MasterPasswordPolicy_Success()
     {
         // Arrange
         var policyType = PolicyType.MasterPassword;
@@ -156,7 +156,7 @@ public class PoliciesControllerTests : IClassFixture<ApiApplicationFactory>, IAs
         };
 
         // Act
-        var response = await _client.PutAsync($"/organizations/{_organization.Id}/policies/{policyType}/vnext",
+        var response = await _client.PutAsync($"/organizations/{_organization.Id}/policies/{policyType}",
             JsonContent.Create(request));
 
         // Assert
@@ -282,84 +282,6 @@ public class PoliciesControllerTests : IClassFixture<ApiApplicationFactory>, IAs
     }
 
     [Fact]
-    public async Task PutVNext_MasterPasswordPolicy_InvalidDataType_ReturnsBadRequest()
-    {
-        // Arrange
-        var policyType = PolicyType.MasterPassword;
-        var request = new SavePolicyRequest
-        {
-            Policy = new PolicyRequestModel
-            {
-                Enabled = true,
-                Data = new Dictionary<string, object>
-                {
-                    { "minComplexity", "not a number" }, // Wrong type - should be int
-                    { "minLength", 12 }
-                }
-            }
-        };
-
-        // Act
-        var response = await _client.PutAsync($"/organizations/{_organization.Id}/policies/{policyType}/vnext",
-            JsonContent.Create(request));
-
-        // Assert
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var content = await response.Content.ReadAsStringAsync();
-        Assert.Contains("minComplexity", content); // Verify field name is in error message
-    }
-
-    [Fact]
-    public async Task PutVNext_SendOptionsPolicy_InvalidDataType_ReturnsBadRequest()
-    {
-        // Arrange
-        var policyType = PolicyType.SendOptions;
-        var request = new SavePolicyRequest
-        {
-            Policy = new PolicyRequestModel
-            {
-                Enabled = true,
-                Data = new Dictionary<string, object>
-                {
-                    { "disableHideEmail", "not a boolean" } // Wrong type - should be bool
-                }
-            }
-        };
-
-        // Act
-        var response = await _client.PutAsync($"/organizations/{_organization.Id}/policies/{policyType}/vnext",
-            JsonContent.Create(request));
-
-        // Assert
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task PutVNext_ResetPasswordPolicy_InvalidDataType_ReturnsBadRequest()
-    {
-        // Arrange
-        var policyType = PolicyType.ResetPassword;
-        var request = new SavePolicyRequest
-        {
-            Policy = new PolicyRequestModel
-            {
-                Enabled = true,
-                Data = new Dictionary<string, object>
-                {
-                    { "autoEnrollEnabled", 123 } // Wrong type - should be bool
-                }
-            }
-        };
-
-        // Act
-        var response = await _client.PutAsync($"/organizations/{_organization.Id}/policies/{policyType}/vnext",
-            JsonContent.Create(request));
-
-        // Assert
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-    }
-
-    [Fact]
     public async Task Put_PolicyWithNullData_Success()
     {
         // Arrange
@@ -375,29 +297,6 @@ public class PoliciesControllerTests : IClassFixture<ApiApplicationFactory>, IAs
 
         // Act
         var response = await _client.PutAsync($"/organizations/{_organization.Id}/policies/{policyType}",
-            JsonContent.Create(request));
-
-        // Assert
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task PutVNext_PolicyWithNullData_Success()
-    {
-        // Arrange
-        var policyType = PolicyType.TwoFactorAuthentication;
-        var request = new SavePolicyRequest
-        {
-            Policy = new PolicyRequestModel
-            {
-                Enabled = true,
-                Data = null
-            },
-            Metadata = null
-        };
-
-        // Act
-        var response = await _client.PutAsync($"/organizations/{_organization.Id}/policies/{policyType}/vnext",
             JsonContent.Create(request));
 
         // Assert

--- a/test/Api.Test/AdminConsole/Controllers/PoliciesControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/PoliciesControllerTests.cs
@@ -429,42 +429,4 @@ public class PoliciesControllerTests
         Assert.Equal(policy.Id, result.Id);
         Assert.Equal(policy.Type, result.Type);
     }
-
-    [Theory]
-    [BitAutoData]
-    public async Task PutVNext_SavesPolicyWithCorrectArguments(
-        SutProvider<PoliciesController> sutProvider, Guid orgId,
-        SavePolicyRequest model, Policy policy, Guid userId)
-    {
-        // Arrange
-        policy.Data = null;
-
-        sutProvider.GetDependency<ICurrentContext>()
-            .UserId
-            .Returns(userId);
-
-        sutProvider.GetDependency<ICurrentContext>()
-            .OrganizationOwner(orgId)
-            .Returns(true);
-
-        sutProvider.GetDependency<ISavePolicyCommand>()
-            .SaveAsync(Arg.Any<SavePolicyModel>())
-            .Returns(policy);
-
-        // Act
-        var result = await sutProvider.Sut.PutVNext(orgId, policy.Type, model);
-
-        // Assert
-        await sutProvider.GetDependency<ISavePolicyCommand>()
-            .Received(1)
-            .SaveAsync(Arg.Is<SavePolicyModel>(m => m.PolicyUpdate.OrganizationId == orgId &&
-                                                    m.PolicyUpdate.Type == policy.Type &&
-                                                    m.PolicyUpdate.Enabled == model.Policy.Enabled &&
-                                                    m.PerformedBy.UserId == userId &&
-                                                    m.PerformedBy.IsOrganizationOwnerOrProvider == true));
-
-        Assert.NotNull(result);
-        Assert.Equal(policy.Id, result.Id);
-        Assert.Equal(policy.Type, result.Type);
-    }
 }


### PR DESCRIPTION
## 🎟️ Tracking
[PM-29658](https://bitwarden.atlassian.net/browse/PM-29658)

## 📔 Objective
This PR finalizes the new AC Policy work by removing the transitory vNext endpoint. No callers are present in clients, they are all pointing at the now-refactored vCurrent endpoint.


[PM-29658]: https://bitwarden.atlassian.net/browse/PM-29658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ