### PR TITLE
[PM-34502] Remove the IPolicyValidator pattern

### DIFF
--- a/src/Admin/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Admin/AdminConsole/Controllers/OrganizationsController.cs
@@ -67,7 +67,7 @@ public class OrganizationsController : Controller
     private readonly IResendOrganizationInviteCommand _resendOrganizationInviteCommand;
     private readonly IOrganizationBillingService _organizationBillingService;
     private readonly IEventService _eventService;
-    private readonly IAutomaticUserConfirmationOrganizationPolicyComplianceValidator _automaticUserConfirmationOrganizationPolicyComplianceValidator;
+    private readonly IAutomaticUserConfirmationOrganizationPolicyComplianceHandler _automaticUserConfirmationOrganizationPolicyComplianceHandler;
     private readonly IOrganizationAutoConfirmEnabledNotificationCommand _organizationAutoConfirmEnabledNotificationCommand;
     private readonly ISubscriberService _subscriberService;
     private readonly IOrganizationPlanMigrationCohortRepository _organizationPlanMigrationCohortRepository;
@@ -100,7 +100,7 @@ public class OrganizationsController : Controller
         IResendOrganizationInviteCommand resendOrganizationInviteCommand,
         IOrganizationBillingService organizationBillingService,
         IEventService eventService,
-        IAutomaticUserConfirmationOrganizationPolicyComplianceValidator automaticUserConfirmationOrganizationPolicyComplianceValidator,
+        IAutomaticUserConfirmationOrganizationPolicyComplianceHandler automaticUserConfirmationOrganizationPolicyComplianceHandler,
         IOrganizationAutoConfirmEnabledNotificationCommand organizationAutoConfirmEnabledNotificationCommand,
         ISubscriberService subscriberService,
         IOrganizationPlanMigrationCohortRepository organizationPlanMigrationCohortRepository,
@@ -132,7 +132,7 @@ public class OrganizationsController : Controller
         _resendOrganizationInviteCommand = resendOrganizationInviteCommand;
         _organizationBillingService = organizationBillingService;
         _eventService = eventService;
-        _automaticUserConfirmationOrganizationPolicyComplianceValidator = automaticUserConfirmationOrganizationPolicyComplianceValidator;
+        _automaticUserConfirmationOrganizationPolicyComplianceHandler = automaticUserConfirmationOrganizationPolicyComplianceHandler;
         _organizationAutoConfirmEnabledNotificationCommand = organizationAutoConfirmEnabledNotificationCommand;
         _subscriberService = subscriberService;
         _organizationPlanMigrationCohortRepository = organizationPlanMigrationCohortRepository;
@@ -492,8 +492,8 @@ public class OrganizationsController : Controller
     {
         if (!existingOrganizationData.UseAutomaticUserConfirmation && updatedOrganization.UseAutomaticUserConfirmation)
         {
-            var validationResult = await _automaticUserConfirmationOrganizationPolicyComplianceValidator.IsOrganizationCompliantAsync(
-                new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(existingOrganizationData.Id));
+            var validationResult = await _automaticUserConfirmationOrganizationPolicyComplianceHandler.IsOrganizationCompliantAsync(
+                new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(existingOrganizationData.Id));
 
             return validationResult.Match(error => error, _ => null);
         }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptOrgUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptOrgUserCommand.cs
@@ -29,7 +29,7 @@ public class AcceptOrgUserCommand : IAcceptOrgUserCommand
     private readonly ITwoFactorIsEnabledQuery _twoFactorIsEnabledQuery;
     private readonly IDataProtectorTokenFactory<OrgUserInviteTokenable> _orgUserInviteTokenDataFactory;
     private readonly IPolicyRequirementQuery _policyRequirementQuery;
-    private readonly IAutomaticUserConfirmationPolicyEnforcementValidator _automaticUserConfirmationPolicyEnforcementValidator;
+    private readonly IAutomaticUserConfirmationPolicyEnforcementHandler _automaticUserConfirmationPolicyEnforcementHandler;
     private readonly IPushAutoConfirmNotificationCommand _pushAutoConfirmNotificationCommand;
     private readonly IDeleteEmergencyAccessCommand _deleteEmergencyAccessCommand;
 
@@ -41,7 +41,7 @@ public class AcceptOrgUserCommand : IAcceptOrgUserCommand
         ITwoFactorIsEnabledQuery twoFactorIsEnabledQuery,
         IDataProtectorTokenFactory<OrgUserInviteTokenable> orgUserInviteTokenDataFactory,
         IPolicyRequirementQuery policyRequirementQuery,
-        IAutomaticUserConfirmationPolicyEnforcementValidator automaticUserConfirmationPolicyEnforcementValidator,
+        IAutomaticUserConfirmationPolicyEnforcementHandler automaticUserConfirmationPolicyEnforcementHandler,
         IPushAutoConfirmNotificationCommand pushAutoConfirmNotificationCommand,
         IDeleteEmergencyAccessCommand deleteEmergencyAccessCommand)
     {
@@ -52,7 +52,7 @@ public class AcceptOrgUserCommand : IAcceptOrgUserCommand
         _twoFactorIsEnabledQuery = twoFactorIsEnabledQuery;
         _orgUserInviteTokenDataFactory = orgUserInviteTokenDataFactory;
         _policyRequirementQuery = policyRequirementQuery;
-        _automaticUserConfirmationPolicyEnforcementValidator = automaticUserConfirmationPolicyEnforcementValidator;
+        _automaticUserConfirmationPolicyEnforcementHandler = automaticUserConfirmationPolicyEnforcementHandler;
         _pushAutoConfirmNotificationCommand = pushAutoConfirmNotificationCommand;
         _deleteEmergencyAccessCommand = deleteEmergencyAccessCommand;
     }
@@ -238,7 +238,7 @@ public class AcceptOrgUserCommand : IAcceptOrgUserCommand
             allOrgUsers.Add(orgUser);
         }
 
-        var error = (await _automaticUserConfirmationPolicyEnforcementValidator.IsCompliantAsync(
+        var error = (await _automaticUserConfirmationPolicyEnforcementHandler.IsCompliantAsync(
                 new AutomaticUserConfirmationPolicyEnforcementRequest(orgUser.OrganizationId,
                     allOrgUsers,
                     user),

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/AutoConfirmUser/AutomaticallyConfirmOrganizationUsersValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/AutoConfirmUser/AutomaticallyConfirmOrganizationUsersValidator.cs
@@ -17,7 +17,7 @@ public class AutomaticallyConfirmOrganizationUsersValidator(
     IOrganizationUserRepository organizationUserRepository,
     ITwoFactorIsEnabledQuery twoFactorIsEnabledQuery,
     IPolicyRequirementQuery policyRequirementQuery,
-    IAutomaticUserConfirmationPolicyEnforcementValidator automaticUserConfirmationPolicyEnforcementValidator,
+    IAutomaticUserConfirmationPolicyEnforcementHandler automaticUserConfirmationPolicyEnforcementHandler,
     IUserService userService,
     IPolicyQuery policyQuery) : IAutomaticallyConfirmOrganizationUsersValidator
 {
@@ -111,7 +111,7 @@ public class AutomaticallyConfirmOrganizationUsersValidator(
 
         var user = await userService.GetUserByIdAsync(request.OrganizationUser!.UserId!.Value);
 
-        return (await automaticUserConfirmationPolicyEnforcementValidator.IsCompliantAsync(
+        return (await automaticUserConfirmationPolicyEnforcementHandler.IsCompliantAsync(
                 new AutomaticUserConfirmationPolicyEnforcementRequest(
                     request.OrganizationId,
                     allOrganizationUsersForUser,

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/ConfirmOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/ConfirmOrganizationUserCommand.cs
@@ -32,7 +32,7 @@ public class ConfirmOrganizationUserCommand : IConfirmOrganizationUserCommand
     private readonly IDeviceRepository _deviceRepository;
     private readonly IPolicyRequirementQuery _policyRequirementQuery;
     private readonly ICollectionRepository _collectionRepository;
-    private readonly IAutomaticUserConfirmationPolicyEnforcementValidator _automaticUserConfirmationPolicyEnforcementValidator;
+    private readonly IAutomaticUserConfirmationPolicyEnforcementHandler _automaticUserConfirmationPolicyEnforcementHandler;
     private readonly ISendOrganizationConfirmationCommand _sendOrganizationConfirmationCommand;
     private readonly IDeleteEmergencyAccessCommand _deleteEmergencyAccessCommand;
 
@@ -47,7 +47,7 @@ public class ConfirmOrganizationUserCommand : IConfirmOrganizationUserCommand
         IDeviceRepository deviceRepository,
         IPolicyRequirementQuery policyRequirementQuery,
         ICollectionRepository collectionRepository,
-        IAutomaticUserConfirmationPolicyEnforcementValidator automaticUserConfirmationPolicyEnforcementValidator,
+        IAutomaticUserConfirmationPolicyEnforcementHandler automaticUserConfirmationPolicyEnforcementHandler,
         ISendOrganizationConfirmationCommand sendOrganizationConfirmationCommand,
         IDeleteEmergencyAccessCommand deleteEmergencyAccessCommand)
     {
@@ -61,7 +61,7 @@ public class ConfirmOrganizationUserCommand : IConfirmOrganizationUserCommand
         _deviceRepository = deviceRepository;
         _policyRequirementQuery = policyRequirementQuery;
         _collectionRepository = collectionRepository;
-        _automaticUserConfirmationPolicyEnforcementValidator = automaticUserConfirmationPolicyEnforcementValidator;
+        _automaticUserConfirmationPolicyEnforcementHandler = automaticUserConfirmationPolicyEnforcementHandler;
         _sendOrganizationConfirmationCommand = sendOrganizationConfirmationCommand;
         _deleteEmergencyAccessCommand = deleteEmergencyAccessCommand;
     }
@@ -188,7 +188,7 @@ public class ConfirmOrganizationUserCommand : IConfirmOrganizationUserCommand
         var policyRequirement = await _policyRequirementQuery.GetAsync<AutomaticUserConfirmationPolicyRequirement>(
             user.Id);
 
-        var error = (await _automaticUserConfirmationPolicyEnforcementValidator.IsCompliantAsync(
+        var error = (await _automaticUserConfirmationPolicyEnforcementHandler.IsCompliantAsync(
                 new AutomaticUserConfirmationPolicyEnforcementRequest(
                     organizationId,
                     orgUsers,

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RestoreUser/v1/RestoreOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RestoreUser/v1/RestoreOrganizationUserCommand.cs
@@ -30,7 +30,7 @@ public class RestoreOrganizationUserCommand(
     IOrganizationService organizationService,
     IPolicyRequirementQuery policyRequirementQuery,
     ICollectionRepository collectionRepository,
-    IAutomaticUserConfirmationPolicyEnforcementValidator automaticUserConfirmationPolicyEnforcementValidator,
+    IAutomaticUserConfirmationPolicyEnforcementHandler automaticUserConfirmationPolicyEnforcementHandler,
     IDeleteEmergencyAccessCommand deleteEmergencyAccessCommand) : IRestoreOrganizationUserCommand
 {
     public async Task RestoreUserAsync(OrganizationUser organizationUser, Guid? restoringUserId, string defaultCollectionName)
@@ -357,7 +357,7 @@ public class RestoreOrganizationUserCommand(
         var policyRequirement = await policyRequirementQuery.GetAsync<AutomaticUserConfirmationPolicyRequirement>(
             user.Id);
 
-        var validationResult = await automaticUserConfirmationPolicyEnforcementValidator.IsCompliantAsync(
+        var validationResult = await automaticUserConfirmationPolicyEnforcementHandler.IsCompliantAsync(
             new AutomaticUserConfirmationPolicyEnforcementRequest(orgUser.OrganizationId, allOrgUsers, user!),
             policyRequirement);
 

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/AutomaticUserConfirmationOrganizationPolicyComplianceHandler.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/AutomaticUserConfirmationOrganizationPolicyComplianceHandler.cs
@@ -8,13 +8,13 @@ using static Bit.Core.AdminConsole.Utilities.v2.Validation.ValidationResultHelpe
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.Enforcement.AutoConfirm;
 
-public class AutomaticUserConfirmationOrganizationPolicyComplianceValidator(
+public class AutomaticUserConfirmationOrganizationPolicyComplianceHandler(
     IOrganizationUserRepository organizationUserRepository,
     IProviderUserRepository providerUserRepository)
-    : IAutomaticUserConfirmationOrganizationPolicyComplianceValidator
+    : IAutomaticUserConfirmationOrganizationPolicyComplianceHandler
 {
-    public async Task<ValidationResult<AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest>>
-        IsOrganizationCompliantAsync(AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest request)
+    public async Task<ValidationResult<AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest>>
+        IsOrganizationCompliantAsync(AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest request)
     {
         var organizationUsers = await organizationUserRepository.GetManyDetailsByOrganizationAsync(request.OrganizationId);
 
@@ -32,7 +32,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidator(
     }
 
     private async Task<Error?> ValidateUserComplianceWithSingleOrgAsync(
-        AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest request,
+        AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest request,
         ICollection<OrganizationUserUserDetails> organizationUsers)
     {
         var userIds = organizationUsers

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest.cs
@@ -1,0 +1,3 @@
+﻿namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.Enforcement.AutoConfirm;
+
+public record AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(Guid OrganizationId);

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest.cs
@@ -1,3 +1,0 @@
-﻿namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.Enforcement.AutoConfirm;
-
-public record AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(Guid OrganizationId);

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/AutomaticUserConfirmationPolicyEnforcementHandler.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/AutomaticUserConfirmationPolicyEnforcementHandler.cs
@@ -6,10 +6,10 @@ using static Bit.Core.AdminConsole.Utilities.v2.Validation.ValidationResultHelpe
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.Enforcement.AutoConfirm;
 
-public class AutomaticUserConfirmationPolicyEnforcementValidator(
+public class AutomaticUserConfirmationPolicyEnforcementHandler(
     IPolicyRequirementQuery policyRequirementQuery,
     IProviderUserRepository providerUserRepository)
-    : IAutomaticUserConfirmationPolicyEnforcementValidator
+    : IAutomaticUserConfirmationPolicyEnforcementHandler
 {
     public async Task<ValidationResult<AutomaticUserConfirmationPolicyEnforcementRequest>> IsCompliantAsync(
         AutomaticUserConfirmationPolicyEnforcementRequest request)

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/AutomaticUserConfirmationPolicyEnforcementRequest.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/AutomaticUserConfirmationPolicyEnforcementRequest.cs
@@ -3,7 +3,7 @@
 namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.Enforcement.AutoConfirm;
 
 /// <summary>
-/// Request object for <see cref="AutomaticUserConfirmationPolicyEnforcementValidator"/>
+/// Request object for <see cref="AutomaticUserConfirmationPolicyEnforcementHandler"/>
 /// </summary>
 public record AutomaticUserConfirmationPolicyEnforcementRequest
 {
@@ -23,7 +23,7 @@ public record AutomaticUserConfirmationPolicyEnforcementRequest
     public User User { get; }
 
     /// <summary>
-    /// Request object for <see cref="AutomaticUserConfirmationPolicyEnforcementValidator"/>.
+    /// Request object for <see cref="AutomaticUserConfirmationPolicyEnforcementHandler"/>.
     /// </summary>
     /// <remarks>
     /// This record is used to encapsulate the data required for handling the automatic confirmation policy enforcement.

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/IAutomaticUserConfirmationOrganizationPolicyComplianceHandler.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/IAutomaticUserConfirmationOrganizationPolicyComplianceHandler.cs
@@ -12,7 +12,7 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.Enforcement.AutoCo
 ///     <item>No organization users are provider members</item>
 /// </list>
 /// </remarks>
-public interface IAutomaticUserConfirmationOrganizationPolicyComplianceValidator
+public interface IAutomaticUserConfirmationOrganizationPolicyComplianceHandler
 {
     /// <summary>
     /// Checks whether the organization is compliant with the Automatic User Confirmation policy prerequisites.
@@ -23,6 +23,6 @@ public interface IAutomaticUserConfirmationOrganizationPolicyComplianceValidator
     /// or contains a <see cref="UserNotCompliantWithSingleOrganization"/> or <see cref="ProviderExistsInOrganization"/>
     /// error if validation fails.
     /// </returns>
-    Task<ValidationResult<AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest>>
-        IsOrganizationCompliantAsync(AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest request);
+    Task<ValidationResult<AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest>>
+        IsOrganizationCompliantAsync(AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest request);
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/IAutomaticUserConfirmationPolicyEnforcementHandler.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/IAutomaticUserConfirmationPolicyEnforcementHandler.cs
@@ -9,7 +9,7 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.Enforcement.AutoCo
 /// valid for the Automatic User Confirmation policy. It also validates that the given user is not a provider
 /// or a member of another organization regardless of status or type.
 /// </summary>
-public interface IAutomaticUserConfirmationPolicyEnforcementValidator
+public interface IAutomaticUserConfirmationPolicyEnforcementHandler
 {
 
     /// <summary>

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/AutomaticUserConfirmationPolicyEventHandler.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/AutomaticUserConfirmationPolicyEventHandler.cs
@@ -19,7 +19,7 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyEventHandler
 /// </ul>
 /// </summary>
 public class AutomaticUserConfirmationPolicyEventHandler(
-    IAutomaticUserConfirmationOrganizationPolicyComplianceValidator validator,
+    IAutomaticUserConfirmationOrganizationPolicyComplianceHandler handler,
     IOrganizationUserRepository organizationUserRepository,
     IDeleteEmergencyAccessCommand deleteEmergencyAccessCommand)
     : IPolicyValidationEvent, IEnforceDependentPoliciesEvent, IOnPolicyPreUpdateEvent
@@ -39,8 +39,8 @@ public class AutomaticUserConfirmationPolicyEventHandler(
             return string.Empty;
         }
 
-        return (await validator.IsOrganizationCompliantAsync(
-            new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(policyUpdate.OrganizationId)))
+        return (await handler.IsOrganizationCompliantAsync(
+            new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(policyUpdate.OrganizationId)))
             .Match(
                 error => error.Message,
                 _ => string.Empty);

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyServiceCollectionExtensions.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyServiceCollectionExtensions.cs
@@ -17,8 +17,8 @@ public static class PolicyServiceCollectionExtensions
         services.AddScoped<IPolicyQuery, PolicyQuery>();
         services.AddScoped<IPolicyEventHandlerFactory, PolicyEventHandlerHandlerFactory>();
 
-        services.AddScoped<IAutomaticUserConfirmationPolicyEnforcementValidator, AutomaticUserConfirmationPolicyEnforcementValidator>();
-        services.AddScoped<IAutomaticUserConfirmationOrganizationPolicyComplianceValidator, AutomaticUserConfirmationOrganizationPolicyComplianceValidator>();
+        services.AddScoped<IAutomaticUserConfirmationPolicyEnforcementHandler, AutomaticUserConfirmationPolicyEnforcementHandler>();
+        services.AddScoped<IAutomaticUserConfirmationOrganizationPolicyComplianceHandler, AutomaticUserConfirmationOrganizationPolicyComplianceHandler>();
 
         services.AddPolicyRequirements();
         services.AddPolicyUpdateEvents();

--- a/test/Admin.Test/AdminConsole/Controllers/OrganizationsControllerTests.cs
+++ b/test/Admin.Test/AdminConsole/Controllers/OrganizationsControllerTests.cs
@@ -322,9 +322,9 @@ public class OrganizationsControllerTests
         var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
         organizationRepository.GetByIdAsync(organization.Id).Returns(organization);
 
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(organization.Id);
-        sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceValidator>()
-            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest>())
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(organization.Id);
+        sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceHandler>()
+            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest>())
             .Returns(Valid(request));
 
         // Act
@@ -358,9 +358,9 @@ public class OrganizationsControllerTests
         var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
         organizationRepository.GetByIdAsync(organization.Id).Returns(organization);
 
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(organization.Id);
-        sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceValidator>()
-            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest>())
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(organization.Id);
+        sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceHandler>()
+            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest>())
             .Returns(Invalid(request, new UserNotCompliantWithSingleOrganization()));
 
         sutProvider.Sut.TempData = new TempDataDictionary(new DefaultHttpContext(), Substitute.For<ITempDataProvider>());
@@ -399,9 +399,9 @@ public class OrganizationsControllerTests
         var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
         organizationRepository.GetByIdAsync(organization.Id).Returns(organization);
 
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(organization.Id);
-        sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceValidator>()
-            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest>())
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(organization.Id);
+        sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceHandler>()
+            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest>())
             .Returns(Invalid(request, new ProviderExistsInOrganization()));
 
         sutProvider.Sut.TempData = new TempDataDictionary(new DefaultHttpContext(), Substitute.For<ITempDataProvider>());
@@ -443,9 +443,9 @@ public class OrganizationsControllerTests
         _ = await sutProvider.Sut.Edit(organizationId, update);
 
         // Assert
-        await sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceValidator>()
+        await sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceHandler>()
             .DidNotReceive()
-            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest>());
+            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest>());
     }
 
     [BitAutoData]
@@ -475,9 +475,9 @@ public class OrganizationsControllerTests
         _ = await sutProvider.Sut.Edit(organizationId, update);
 
         // Assert
-        await sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceValidator>()
+        await sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceHandler>()
             .DidNotReceive()
-            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest>());
+            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest>());
     }
 
     [BitAutoData]
@@ -504,9 +504,9 @@ public class OrganizationsControllerTests
         var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
         organizationRepository.GetByIdAsync(organization.Id).Returns(organization);
 
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(organization.Id);
-        sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceValidator>()
-            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest>())
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(organization.Id);
+        sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceHandler>()
+            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest>())
             .Returns(Valid(request));
 
         _ = await sutProvider.Sut.Edit(organization.Id, update);

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptOrgUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptOrgUserCommandTests.cs
@@ -680,7 +680,7 @@ public class AcceptOrgUserCommandTests
         // Assert
         AssertValidAcceptedOrgUser(resultOrgUser, orgUser, user);
 
-        await sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>().DidNotReceiveWithAnyArgs()
+        await sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>().DidNotReceiveWithAnyArgs()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>());
     }
 
@@ -694,7 +694,7 @@ public class AcceptOrgUserCommandTests
         SetupCommonAcceptOrgUserMocks(sutProvider, user, org, orgUser, adminUserDetails);
 
         // Mock auto-confirm enforcement query to return valid (no auto-confirm restrictions)
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser], user)));
 
@@ -718,7 +718,7 @@ public class AcceptOrgUserCommandTests
         // Arrange
         SetupCommonAcceptOrgUserMocks(sutProvider, user, org, orgUser, adminUserDetails);
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Invalid(
                 new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser, otherOrgUser], user),
@@ -762,7 +762,7 @@ public class AcceptOrgUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([new PolicyDetails { OrganizationId = org.Id }]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(
                 Arg.Is<AutomaticUserConfirmationPolicyEnforcementRequest>(r =>
                     r.AllOrganizationUsers.Count == 1 &&
@@ -775,7 +775,7 @@ public class AcceptOrgUserCommandTests
 
         // Assert
         Assert.NotNull(result);
-        await sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        await sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .Received(1)
             .IsCompliantAsync(
                 Arg.Is<AutomaticUserConfirmationPolicyEnforcementRequest>(r => r.AllOrganizationUsers.Count == 1),
@@ -795,7 +795,7 @@ public class AcceptOrgUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([new PolicyDetails { OrganizationId = org.Id }]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser], user)));
 
@@ -821,7 +821,7 @@ public class AcceptOrgUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser], user)));
 
@@ -861,7 +861,7 @@ public class AcceptOrgUserCommandTests
     {
         SetupCommonAcceptOrgUserMocks(sutProvider, user, org, orgUser, adminUserDetails);
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser], user)));
 
@@ -942,7 +942,7 @@ public class AcceptOrgUserCommandTests
             .Returns(new AutomaticUserConfirmationPolicyRequirement([]));
 
         // Auto-confirm enforcement query returns valid by default (no restrictions)
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser], user)));
     }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/AutoConfirmUsers/AutomaticallyConfirmOrganizationUsersValidatorTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/AutoConfirmUsers/AutomaticallyConfirmOrganizationUsersValidatorTests.cs
@@ -152,7 +152,7 @@ public class AutomaticallyConfirmOrganizationUsersValidatorTests
             .GetUserByIdAsync(user.Id)
             .Returns(user);
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>())
             .Returns(Valid(
                 new AutomaticUserConfirmationPolicyEnforcementRequest(organization.Id,
@@ -366,7 +366,7 @@ public class AutomaticallyConfirmOrganizationUsersValidatorTests
             .GetUserByIdAsync(user.Id)
             .Returns(user);
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>())
             .Returns(Valid(
                 new AutomaticUserConfirmationPolicyEnforcementRequest(organization.Id,
@@ -425,7 +425,7 @@ public class AutomaticallyConfirmOrganizationUsersValidatorTests
             .GetUserByIdAsync(user.Id)
             .Returns(user);
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>())
             .Returns(Valid(
                 new AutomaticUserConfirmationPolicyEnforcementRequest(organization.Id,
@@ -480,7 +480,7 @@ public class AutomaticallyConfirmOrganizationUsersValidatorTests
             .GetUserByIdAsync(user.Id)
             .Returns(user);
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>())
             .Returns(Valid(
                 new AutomaticUserConfirmationPolicyEnforcementRequest(organization.Id,
@@ -622,7 +622,7 @@ public class AutomaticallyConfirmOrganizationUsersValidatorTests
             .GetUserByIdAsync(user.Id)
             .Returns(user);
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>())
             .Returns(Valid(
                 new AutomaticUserConfirmationPolicyEnforcementRequest(organization.Id,

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/ConfirmOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/ConfirmOrganizationUserCommandTests.cs
@@ -150,7 +150,7 @@ public class ConfirmOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser], user)));
 
@@ -200,7 +200,7 @@ public class ConfirmOrganizationUserCommandTests
         sutProvider.GetDependency<IPolicyRequirementQuery>()
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([]));
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser, orgUserAnotherOrg], user)));
 
@@ -246,7 +246,7 @@ public class ConfirmOrganizationUserCommandTests
         sutProvider.GetDependency<IPolicyRequirementQuery>()
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([]));
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser, orgUserAnotherOrg], user)));
 
@@ -293,7 +293,7 @@ public class ConfirmOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser], user)));
 
@@ -375,7 +375,7 @@ public class ConfirmOrganizationUserCommandTests
             .Returns(new SingleOrganizationPolicyRequirement([]));
         policyRequirementQuery.GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([]));
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser], user)));
         twoFactorIsEnabledQuery.TwoFactorIsEnabledAsync(Arg.Is<IEnumerable<Guid>>(ids => ids.Contains(user.Id)))
@@ -421,7 +421,7 @@ public class ConfirmOrganizationUserCommandTests
             .Returns(new SingleOrganizationPolicyRequirement([]));
         policyRequirementQuery.GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([]));
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser], user)));
         twoFactorIsEnabledQuery.TwoFactorIsEnabledAsync(Arg.Is<IEnumerable<Guid>>(ids => ids.Contains(user.Id)))
@@ -474,7 +474,7 @@ public class ConfirmOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(organization.Id, [orgUser], user)));
 
@@ -514,7 +514,7 @@ public class ConfirmOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser], user)));
 
@@ -556,7 +556,7 @@ public class ConfirmOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(orgUser.UserId!.Value)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser], user)));
 
@@ -591,7 +591,7 @@ public class ConfirmOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([new PolicyDetails { OrganizationId = org.Id }]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Invalid(
                 new AutomaticUserConfirmationPolicyEnforcementRequest(orgUser.Id, [orgUser, otherOrgUser], user),
@@ -635,7 +635,7 @@ public class ConfirmOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([new PolicyDetails { OrganizationId = org.Id }]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Invalid(
                 new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser, otherOrgUser], user),
@@ -678,7 +678,7 @@ public class ConfirmOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([new PolicyDetails { OrganizationId = org.Id }]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Invalid(
                 new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser], user),
@@ -721,7 +721,7 @@ public class ConfirmOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([new PolicyDetails { OrganizationId = org.Id }]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser], user)));
 
@@ -770,7 +770,7 @@ public class ConfirmOrganizationUserCommandTests
             .GetAsync<SingleOrganizationPolicyRequirement>(user.Id)
             .Returns(SingleOrganizationPolicyRequirementTestFactory.NoSinglePolicyOrganizationsForUser());
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser], user)));
 
@@ -814,7 +814,7 @@ public class ConfirmOrganizationUserCommandTests
             .GetAsync<SingleOrganizationPolicyRequirement>(user.Id)
             .Returns(SingleOrganizationPolicyRequirementTestFactory.NoSinglePolicyOrganizationsForUser());
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser], user)));
 
@@ -857,7 +857,7 @@ public class ConfirmOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([new PolicyDetails { OrganizationId = org.Id }]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Invalid(
                 new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser, otherOrgUser], user),
@@ -908,15 +908,15 @@ public class ConfirmOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(Arg.Any<Guid>())
             .Returns(new AutomaticUserConfirmationPolicyRequirement([new PolicyDetails { OrganizationId = org.Id }]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Is<AutomaticUserConfirmationPolicyEnforcementRequest>(r => r.User.Id == user1.Id), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser1], user1)));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Is<AutomaticUserConfirmationPolicyEnforcementRequest>(r => r.User.Id == user2.Id), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser2], user2)));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Is<AutomaticUserConfirmationPolicyEnforcementRequest>(r => r.User.Id == user3.Id), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Invalid(
                 new AutomaticUserConfirmationPolicyEnforcementRequest(org.Id, [orgUser3, otherOrgUser], user3),
@@ -975,7 +975,7 @@ public class ConfirmOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(orgUser.UserId!.Value)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(organization.Id, [orgUser], user)));
 
@@ -1031,7 +1031,7 @@ public class ConfirmOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(orgUser.UserId!.Value)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(organization.Id, [orgUser], user)));
 
@@ -1085,7 +1085,7 @@ public class ConfirmOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(Arg.Any<Guid>())
             .Returns(new AutomaticUserConfirmationPolicyRequirement([]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(x => Valid(x.Arg<AutomaticUserConfirmationPolicyEnforcementRequest>()));
 
@@ -1161,7 +1161,7 @@ public class ConfirmOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(Arg.Any<Guid>())
             .Returns(new AutomaticUserConfirmationPolicyRequirement([]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(x => Valid(x.Arg<AutomaticUserConfirmationPolicyEnforcementRequest>()));
 

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RestoreUser/RestoreOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RestoreUser/RestoreOrganizationUserCommandTests.cs
@@ -657,7 +657,7 @@ public class RestoreOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([new PolicyDetails { OrganizationId = organization.Id }]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(organization.Id, [organizationUser], user)));
 
@@ -688,7 +688,7 @@ public class RestoreOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(organization.Id, [organizationUser], user)));
 
@@ -719,7 +719,7 @@ public class RestoreOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
             .Returns(new AutomaticUserConfirmationPolicyRequirement([new PolicyDetails { OrganizationId = organization.Id }]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Invalid(
                 new AutomaticUserConfirmationPolicyEnforcementRequest(organization.Id, [organizationUser], user),
@@ -1154,7 +1154,7 @@ public class RestoreOrganizationUserCommandTests
             .GetAsync<AutomaticUserConfirmationPolicyRequirement>(Arg.Any<Guid>())
             .Returns(new AutomaticUserConfirmationPolicyRequirement([]));
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementValidator>()
+        sutProvider.GetDependency<IAutomaticUserConfirmationPolicyEnforcementHandler>()
             .IsCompliantAsync(Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(), Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(Valid(new AutomaticUserConfirmationPolicyEnforcementRequest(targetOrganizationUser.OrganizationId, [], null!)));
 

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/AutomaticUserConfirmationOrganizationPolicyComplianceHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/AutomaticUserConfirmationOrganizationPolicyComplianceHandlerTests.cs
@@ -13,13 +13,13 @@ using Xunit;
 namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.Policies.Enforcement.AutoConfirm;
 
 [SutProviderCustomize]
-public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
+public class AutomaticUserConfirmationOrganizationPolicyComplianceHandlerTests
 {
     [Theory, BitAutoData]
     public async Task IsOrganizationCompliantAsync_AllUsersCompliant_NoProviders_ReturnsValid(
         Guid organizationId,
         Guid userId,
-        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceValidator> sutProvider)
+        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceHandler> sutProvider)
     {
         // Arrange
         var orgUser = new OrganizationUserUserDetails
@@ -42,7 +42,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
             .GetManyByManyUsersAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns([]);
 
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(organizationId);
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(organizationId);
 
         // Act
         var result = await sutProvider.Sut.IsOrganizationCompliantAsync(request);
@@ -55,7 +55,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
     public async Task IsOrganizationCompliantAsync_UserInAnotherOrg_ReturnsUserNotCompliantWithSingleOrganization(
         Guid organizationId,
         Guid userId,
-        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceValidator> sutProvider)
+        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceHandler> sutProvider)
     {
         // Arrange
         var orgUser = new OrganizationUserUserDetails
@@ -82,7 +82,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
             .GetManyByManyUsersAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns([otherOrgUser]);
 
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(organizationId);
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(organizationId);
 
         // Act
         var result = await sutProvider.Sut.IsOrganizationCompliantAsync(request);
@@ -96,7 +96,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
     public async Task IsOrganizationCompliantAsync_ProviderUsersExist_ReturnsProviderExistsInOrganization(
         Guid organizationId,
         Guid userId,
-        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceValidator> sutProvider)
+        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceHandler> sutProvider)
     {
         // Arrange
         var orgUser = new OrganizationUserUserDetails
@@ -126,7 +126,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
             .GetManyByManyUsersAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns([providerUser]);
 
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(organizationId);
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(organizationId);
 
         // Act
         var result = await sutProvider.Sut.IsOrganizationCompliantAsync(request);
@@ -139,7 +139,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
     [Theory, BitAutoData]
     public async Task IsOrganizationCompliantAsync_InvitedUsersExcluded_FromSingleOrgCheck(
         Guid organizationId,
-        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceValidator> sutProvider)
+        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceHandler> sutProvider)
     {
         // Arrange - invited user has null UserId and Invited status
         var invitedUser = new OrganizationUserUserDetails
@@ -159,7 +159,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
             .GetManyByManyUsersAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns([]);
 
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(organizationId);
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(organizationId);
 
         // Act
         var result = await sutProvider.Sut.IsOrganizationCompliantAsync(request);
@@ -177,7 +177,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
     public async Task IsOrganizationCompliantAsync_InvitedUserWithUserId_ExcludedFromSingleOrgCheck(
         Guid organizationId,
         Guid userId,
-        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceValidator> sutProvider)
+        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceHandler> sutProvider)
     {
         // Arrange - Invited status users are excluded regardless of UserId
         var invitedUser = new OrganizationUserUserDetails
@@ -200,7 +200,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
             .GetManyByManyUsersAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns([]);
 
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(organizationId);
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(organizationId);
 
         // Act
         var result = await sutProvider.Sut.IsOrganizationCompliantAsync(request);
@@ -218,7 +218,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
     public async Task IsOrganizationCompliantAsync_UserInAnotherOrgWithInvitedStatus_ReturnsValid(
         Guid organizationId,
         Guid userId,
-        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceValidator> sutProvider)
+        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceHandler> sutProvider)
     {
         // Arrange
         var orgUser = new OrganizationUserUserDetails
@@ -250,7 +250,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
             .GetManyByManyUsersAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns([]);
 
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(organizationId);
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(organizationId);
 
         // Act
         var result = await sutProvider.Sut.IsOrganizationCompliantAsync(request);
@@ -263,7 +263,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
     public async Task IsOrganizationCompliantAsync_SingleOrgViolationTakesPrecedence_OverProviderCheck(
         Guid organizationId,
         Guid userId,
-        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceValidator> sutProvider)
+        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceHandler> sutProvider)
     {
         // Arrange - user is in another org AND is a provider user
         var orgUser = new OrganizationUserUserDetails
@@ -290,7 +290,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
             .GetManyByManyUsersAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns([otherOrgUser]);
 
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(organizationId);
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(organizationId);
 
         // Act
         var result = await sutProvider.Sut.IsOrganizationCompliantAsync(request);
@@ -310,7 +310,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
         Guid organizationId,
         Guid confirmedUserId,
         Guid acceptedUserId,
-        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceValidator> sutProvider)
+        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceHandler> sutProvider)
     {
         // Arrange
         var invitedUser = new OrganizationUserUserDetails
@@ -350,7 +350,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
             .GetManyByManyUsersAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns([]);
 
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(organizationId);
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(organizationId);
 
         // Act
         var result = await sutProvider.Sut.IsOrganizationCompliantAsync(request);
@@ -370,7 +370,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
     [Theory, BitAutoData]
     public async Task IsOrganizationCompliantAsync_NoOrganizationUsers_ReturnsValid(
         Guid organizationId,
-        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceValidator> sutProvider)
+        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceHandler> sutProvider)
     {
         // Arrange
         sutProvider.GetDependency<IOrganizationUserRepository>()
@@ -385,7 +385,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
             .GetManyByManyUsersAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns([]);
 
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(organizationId);
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(organizationId);
 
         // Act
         var result = await sutProvider.Sut.IsOrganizationCompliantAsync(request);
@@ -398,7 +398,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
     public async Task IsOrganizationCompliantAsync_UserInSameOrgOnly_ReturnsValid(
         Guid organizationId,
         Guid userId,
-        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceValidator> sutProvider)
+        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceHandler> sutProvider)
     {
         // Arrange
         var orgUser = new OrganizationUserUserDetails
@@ -430,7 +430,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
             .GetManyByManyUsersAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns([]);
 
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(organizationId);
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(organizationId);
 
         // Act
         var result = await sutProvider.Sut.IsOrganizationCompliantAsync(request);
@@ -444,7 +444,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
         Guid organizationId,
         Guid userId1,
         Guid userId2,
-        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceValidator> sutProvider)
+        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceHandler> sutProvider)
     {
         // Arrange - provider check includes users regardless of Invited status (only excludes null UserId)
         var confirmedUser = new OrganizationUserUserDetails
@@ -484,7 +484,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
             .GetManyByManyUsersAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns([]);
 
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(organizationId);
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(organizationId);
 
         // Act
         var result = await sutProvider.Sut.IsOrganizationCompliantAsync(request);
@@ -505,7 +505,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
     public async Task IsOrganizationCompliantAsync_RevokedUserInAnotherOrg_ReturnsUserNotCompliant(
         Guid organizationId,
         Guid userId,
-        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceValidator> sutProvider)
+        SutProvider<AutomaticUserConfirmationOrganizationPolicyComplianceHandler> sutProvider)
     {
         // Arrange
         var revokedUser = new OrganizationUserUserDetails
@@ -532,7 +532,7 @@ public class AutomaticUserConfirmationOrganizationPolicyComplianceValidatorTests
             .GetManyByManyUsersAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns([otherOrgUser]);
 
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(organizationId);
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(organizationId);
 
         // Act
         var result = await sutProvider.Sut.IsOrganizationCompliantAsync(request);

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/AutomaticUserConfirmationPolicyEnforcementHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/Enforcement/AutoConfirm/AutomaticUserConfirmationPolicyEnforcementHandlerTests.cs
@@ -15,12 +15,12 @@ using Xunit;
 namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.Policies.Enforcement.AutoConfirm;
 
 [SutProviderCustomize]
-public class AutomaticUserConfirmationPolicyEnforcementValidatorTests
+public class AutomaticUserConfirmationPolicyEnforcementHandlerTests
 {
     [Theory]
     [BitAutoData]
     public async Task IsCompliantAsync_WithPolicyEnabledAndUserIsProviderMember_ReturnsProviderUsersCannotJoinError(
-        SutProvider<AutomaticUserConfirmationPolicyEnforcementValidator> sutProvider,
+        SutProvider<AutomaticUserConfirmationPolicyEnforcementHandler> sutProvider,
         OrganizationUser organizationUser,
         ProviderUser providerUser,
         User user)
@@ -58,7 +58,7 @@ public class AutomaticUserConfirmationPolicyEnforcementValidatorTests
     [Theory]
     [BitAutoData]
     public async Task IsCompliantAsync_WithPolicyEnabledOnOtherOrganization_ReturnsOtherOrganizationDoesNotAllowOtherMembershipError(
-        SutProvider<AutomaticUserConfirmationPolicyEnforcementValidator> sutProvider,
+        SutProvider<AutomaticUserConfirmationPolicyEnforcementHandler> sutProvider,
         OrganizationUser organizationUser,
         OrganizationUser otherOrganizationUser,
         User user)
@@ -98,7 +98,7 @@ public class AutomaticUserConfirmationPolicyEnforcementValidatorTests
     [Theory]
     [BitAutoData]
     public async Task IsCompliantAsync_WithPolicyDisabledUserIsAMemberOfAnotherOrgReturnsValid(
-        SutProvider<AutomaticUserConfirmationPolicyEnforcementValidator> sutProvider,
+        SutProvider<AutomaticUserConfirmationPolicyEnforcementHandler> sutProvider,
         OrganizationUser organizationUser,
         OrganizationUser otherOrgUser,
         User user)
@@ -130,7 +130,7 @@ public class AutomaticUserConfirmationPolicyEnforcementValidatorTests
     [Theory]
     [BitAutoData]
     public async Task IsCompliantAsync_WithPolicyEnabledUserIsAMemberOfAnotherOrg_ReturnsCannotBeMemberOfAnotherOrgError(
-        SutProvider<AutomaticUserConfirmationPolicyEnforcementValidator> sutProvider,
+        SutProvider<AutomaticUserConfirmationPolicyEnforcementHandler> sutProvider,
         OrganizationUser organizationUser,
         OrganizationUser otherOrgUser,
         User user)
@@ -169,7 +169,7 @@ public class AutomaticUserConfirmationPolicyEnforcementValidatorTests
     [Theory]
     [BitAutoData]
     public async Task IsCompliantAsync_WithPolicyEnabledAndChecksConditionsInCorrectOrder_ReturnsFirstFailure(
-        SutProvider<AutomaticUserConfirmationPolicyEnforcementValidator> sutProvider,
+        SutProvider<AutomaticUserConfirmationPolicyEnforcementHandler> sutProvider,
         OrganizationUser organizationUser,
         OrganizationUser otherOrgUser,
         ProviderUser providerUser,
@@ -207,7 +207,7 @@ public class AutomaticUserConfirmationPolicyEnforcementValidatorTests
     [Theory]
     [BitAutoData]
     public async Task IsCompliantAsync_WithPolicyIsEnabledNoOtherOrganizationsAndNotAProvider_ReturnsValid(
-        SutProvider<AutomaticUserConfirmationPolicyEnforcementValidator> sutProvider,
+        SutProvider<AutomaticUserConfirmationPolicyEnforcementHandler> sutProvider,
         OrganizationUser organizationUser,
         User user)
     {
@@ -244,7 +244,7 @@ public class AutomaticUserConfirmationPolicyEnforcementValidatorTests
     [Theory]
     [BitAutoData]
     public async Task IsCompliantAsync_WithPolicyDisabledForCurrentAndOtherOrg_ReturnsValid(
-        SutProvider<AutomaticUserConfirmationPolicyEnforcementValidator> sutProvider,
+        SutProvider<AutomaticUserConfirmationPolicyEnforcementHandler> sutProvider,
         OrganizationUser organizationUser,
         OrganizationUser otherOrgUser,
         User user)
@@ -275,7 +275,7 @@ public class AutomaticUserConfirmationPolicyEnforcementValidatorTests
     [Theory]
     [BitAutoData]
     public async Task IsCompliantAsync_WithPolicyDisabledForCurrentAndOtherOrgAndIsProvider_ReturnsValid(
-        SutProvider<AutomaticUserConfirmationPolicyEnforcementValidator> sutProvider,
+        SutProvider<AutomaticUserConfirmationPolicyEnforcementHandler> sutProvider,
         OrganizationUser organizationUser,
         OrganizationUser otherOrgUser,
         ProviderUser providerUser,

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/AutomaticUserConfirmationPolicyEventHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/AutomaticUserConfirmationPolicyEventHandlerTests.cs
@@ -35,10 +35,10 @@ public class AutomaticUserConfirmationPolicyEventHandlerTests
         SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(policyUpdate.OrganizationId);
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(policyUpdate.OrganizationId);
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceValidator>()
-            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest>())
+        sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceHandler>()
+            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest>())
             .Returns(Invalid(request, new UserNotCompliantWithSingleOrganization()));
 
         // Act
@@ -54,10 +54,10 @@ public class AutomaticUserConfirmationPolicyEventHandlerTests
         SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(policyUpdate.OrganizationId);
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(policyUpdate.OrganizationId);
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceValidator>()
-            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest>())
+        sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceHandler>()
+            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest>())
             .Returns(Invalid(request, new ProviderExistsInOrganization()));
 
         // Act
@@ -73,10 +73,10 @@ public class AutomaticUserConfirmationPolicyEventHandlerTests
         SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(policyUpdate.OrganizationId);
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(policyUpdate.OrganizationId);
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceValidator>()
-            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest>())
+        sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceHandler>()
+            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest>())
             .Returns(Valid(request));
 
         // Act
@@ -101,9 +101,9 @@ public class AutomaticUserConfirmationPolicyEventHandlerTests
         // Assert
         Assert.True(string.IsNullOrEmpty(result));
 
-        await sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceValidator>()
+        await sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceHandler>()
             .DidNotReceive()
-            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest>());
+            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest>());
     }
 
     [Theory, BitAutoData]
@@ -120,9 +120,9 @@ public class AutomaticUserConfirmationPolicyEventHandlerTests
 
         // Assert
         Assert.True(string.IsNullOrEmpty(result));
-        await sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceValidator>()
+        await sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceHandler>()
             .DidNotReceive()
-            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest>());
+            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest>());
     }
 
     [Theory, BitAutoData]
@@ -131,19 +131,19 @@ public class AutomaticUserConfirmationPolicyEventHandlerTests
         SutProvider<AutomaticUserConfirmationPolicyEventHandler> sutProvider)
     {
         // Arrange
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(policyUpdate.OrganizationId);
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(policyUpdate.OrganizationId);
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceValidator>()
-            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest>())
+        sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceHandler>()
+            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest>())
             .Returns(Valid(request));
 
         // Act
         await sutProvider.Sut.ValidateAsync(new SavePolicyModel(policyUpdate), null);
 
         // Assert
-        await sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceValidator>()
+        await sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceHandler>()
             .Received(1)
-            .IsOrganizationCompliantAsync(Arg.Is<AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest>(
+            .IsOrganizationCompliantAsync(Arg.Is<AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest>(
                 r => r.OrganizationId == policyUpdate.OrganizationId));
     }
 
@@ -154,10 +154,10 @@ public class AutomaticUserConfirmationPolicyEventHandlerTests
     {
         // Arrange
         var savePolicyModel = new SavePolicyModel(policyUpdate);
-        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest(policyUpdate.OrganizationId);
+        var request = new AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest(policyUpdate.OrganizationId);
 
-        sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceValidator>()
-            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceValidatorRequest>())
+        sutProvider.GetDependency<IAutomaticUserConfirmationOrganizationPolicyComplianceHandler>()
+            .IsOrganizationCompliantAsync(Arg.Any<AutomaticUserConfirmationOrganizationPolicyComplianceHandlerRequest>())
             .Returns(Valid(request));
 
         // Act


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34502

## 📔 Objective

The goal was to remove the IPolicyValidator pattern. It looks like most of the work was done in this [PR](https://github.com/bitwarden/server/pull/7364), but some of the classes still have “validator” in their names instead of “handler.” This PR addresses that.

No testing needed. Just file name changes.
