### PR TITLE
[PM-38116] Harden SSRF protection in IPAddressExtensions

### DIFF
--- a/src/Core/Utilities/IPAddressExtensions.cs
+++ b/src/Core/Utilities/IPAddressExtensions.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using System.Net.Sockets;
 
 namespace Bit.Core.Utilities;

--- a/src/Core/Utilities/IPAddressExtensions.cs
+++ b/src/Core/Utilities/IPAddressExtensions.cs
@@ -1,52 +1,112 @@
-﻿using System.Net;
+using System.Net;
+using System.Net.Sockets;
 
 namespace Bit.Core.Utilities;
 
 /// <summary>
 /// Extension methods for <see cref="IPAddress"/> to determine if an address is internal/private.
-/// Used for SSRF protection to block requests to private network ranges.
+/// Used for SSRF protection to block requests to reserved network ranges defined by the
+/// IANA IPv4 and IPv6 Special-Purpose Address Registries.
 /// </summary>
 public static class IPAddressExtensions
 {
-    /// <summary>
-    /// Determines whether the given IP address is an internal/private/reserved address.
-    /// This includes loopback, private RFC 1918, link-local, CGNAT (RFC 6598),
-    /// IPv6 unique local, and other reserved ranges.
-    /// </summary>
-    /// <param name="ip">The IP address to check.</param>
-    /// <returns>True if the IP is internal/private/reserved; otherwise false.</returns>
+    private static readonly IPNetwork[] _reservedIPv4Networks =
+    [
+        new(IPAddress.Parse("0.0.0.0"), 8),           // RFC 1122 "This" network
+        new(IPAddress.Parse("10.0.0.0"), 8),          // RFC 1918 Private
+        new(IPAddress.Parse("100.64.0.0"), 10),       // RFC 6598 CGNAT
+        new(IPAddress.Parse("127.0.0.0"), 8),         // RFC 1122 Loopback
+        new(IPAddress.Parse("169.254.0.0"), 16),      // RFC 3927 Link-local / cloud metadata
+        new(IPAddress.Parse("172.16.0.0"), 12),       // RFC 1918 Private
+        new(IPAddress.Parse("192.0.0.0"), 24),        // RFC 6890 IETF Protocol Assignments (includes Oracle Cloud metadata 192.0.0.192)
+        new(IPAddress.Parse("192.0.2.0"), 24),        // RFC 5737 TEST-NET-1
+        new(IPAddress.Parse("192.88.99.0"), 24),      // RFC 7526 6to4 Relay Anycast (deprecated)
+        new(IPAddress.Parse("192.168.0.0"), 16),      // RFC 1918 Private
+        new(IPAddress.Parse("198.18.0.0"), 15),       // RFC 2544 Benchmarking
+        new(IPAddress.Parse("198.51.100.0"), 24),     // RFC 5737 TEST-NET-2
+        new(IPAddress.Parse("203.0.113.0"), 24),      // RFC 5737 TEST-NET-3
+        new(IPAddress.Parse("224.0.0.0"), 4),         // RFC 5771 Multicast
+        new(IPAddress.Parse("240.0.0.0"), 4),         // RFC 1112 Reserved (includes 255.255.255.255 limited broadcast)
+    ];
+
+    private static readonly IPNetwork[] _reservedIPv6Networks =
+    [
+        new(IPAddress.Parse("::"), 128),              // RFC 4291 Unspecified
+        new(IPAddress.Parse("::1"), 128),             // RFC 4291 Loopback
+        new(IPAddress.Parse("64:ff9b:1::"), 48),      // RFC 8215 NAT64 local-use
+        new(IPAddress.Parse("100::"), 64),            // RFC 6666 Discard-only
+        new(IPAddress.Parse("2001::"), 32),           // RFC 4380 Teredo
+        new(IPAddress.Parse("2001:2::"), 48),         // RFC 5180 Benchmarking
+        new(IPAddress.Parse("2001:3::"), 32),         // RFC 7450 AMT
+        new(IPAddress.Parse("2001:10::"), 28),        // RFC 4843 ORCHID (deprecated)
+        new(IPAddress.Parse("2001:20::"), 28),        // RFC 7343 ORCHIDv2
+        new(IPAddress.Parse("2001:db8::"), 32),       // RFC 3849 Documentation
+        new(IPAddress.Parse("3fff::"), 20),           // RFC 9637 Documentation
+        new(IPAddress.Parse("5f00::"), 16),           // RFC 9602 Segment Routing
+        new(IPAddress.Parse("fc00::"), 7),            // RFC 4193 Unique Local Address
+        new(IPAddress.Parse("fe80::"), 10),           // RFC 4291 Link-local
+        new(IPAddress.Parse("ff00::"), 8),            // RFC 4291 Multicast
+    ];
+
+    // IPv6 prefixes whose addresses embed an IPv4 destination. When the embedded IPv4 is itself
+    // reserved (e.g., RFC 1918), the IPv6 address is treated as internal because a NAT64 or 6to4
+    // gateway on the path would translate it back to the internal IPv4 host.
+    private static readonly (IPNetwork Prefix, int IPv4ByteOffset)[] _ipv4EmbeddedIPv6Networks =
+    [
+        (new IPNetwork(IPAddress.Parse("64:ff9b::"), 96), 12),    // RFC 6052 NAT64 well-known: IPv4 at bytes 12-15
+        (new IPNetwork(IPAddress.Parse("2002::"), 16), 2),        // RFC 3056 6to4: IPv4 at bytes 2-5
+    ];
+
     public static bool IsInternal(this IPAddress ip)
     {
-        if (IPAddress.IsLoopback(ip))
+        if (ip.AddressFamily == AddressFamily.InterNetwork)
         {
-            return true;
+            return IsReservedIPv4(ip);
         }
 
-        var ipString = ip.ToString();
-        if (ipString == "::1" || ipString == "::" || ipString.StartsWith("::ffff:"))
+        if (ip.AddressFamily != AddressFamily.InterNetworkV6)
         {
-            return true;
+            return false;
         }
 
-        // IPv6
-        if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6)
+        if (ip.IsIPv4MappedToIPv6)
         {
-            return ipString.StartsWith("fc") || ipString.StartsWith("fd") ||
-                ipString.StartsWith("fe") || ipString.StartsWith("ff");
+            return IsReservedIPv4(ip.MapToIPv4());
         }
 
-        // IPv4
-        var bytes = ip.GetAddressBytes();
-        return bytes[0] switch
+        foreach (var (prefix, offset) in _ipv4EmbeddedIPv6Networks)
         {
-            0 => true,                                      // "This" network (RFC 1122)
-            10 => true,                                     // Private (RFC 1918)
-            100 => bytes[1] >= 64 && bytes[1] < 128,       // CGNAT (RFC 6598) - 100.64.0.0/10
-            127 => true,                                    // Loopback (RFC 1122)
-            169 => bytes[1] == 254,                         // Link-local / cloud metadata (RFC 3927)
-            172 => bytes[1] >= 16 && bytes[1] < 32,        // Private (RFC 1918)
-            192 => bytes[1] == 168,                         // Private (RFC 1918)
-            _ => false,
-        };
+            if (prefix.Contains(ip))
+            {
+                var bytes = ip.GetAddressBytes();
+                var embedded = new IPAddress(bytes.AsSpan(offset, 4));
+                if (IsReservedIPv4(embedded))
+                {
+                    return true;
+                }
+            }
+        }
+
+        foreach (var network in _reservedIPv6Networks)
+        {
+            if (network.Contains(ip))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsReservedIPv4(IPAddress ip)
+    {
+        foreach (var network in _reservedIPv4Networks)
+        {
+            if (network.Contains(ip))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/test/Core.Test/Utilities/IPAddressExtensionsTests.cs
+++ b/test/Core.Test/Utilities/IPAddressExtensionsTests.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using Bit.Core.Utilities;
 using Xunit;
 

--- a/test/Core.Test/Utilities/IPAddressExtensionsTests.cs
+++ b/test/Core.Test/Utilities/IPAddressExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using Bit.Core.Utilities;
 using Xunit;
 
@@ -33,7 +33,7 @@ public class IPAddressExtensionsTests
     [Theory]
     [InlineData("100.64.0.0", true)]      // CGNAT start
     [InlineData("100.64.0.1", true)]      // CGNAT
-    [InlineData("100.100.0.1", true)]     // CGNAT middle
+    [InlineData("100.100.0.1", true)]     // CGNAT middle (also Alibaba Cloud metadata range)
     [InlineData("100.127.255.254", true)] // CGNAT near end
     [InlineData("100.127.255.255", true)] // CGNAT end
     [InlineData("100.63.255.255", false)] // Just below CGNAT
@@ -46,12 +46,40 @@ public class IPAddressExtensionsTests
     }
 
     [Theory]
-    [InlineData("::1", true)]             // IPv6 loopback
-    [InlineData("::", true)]              // IPv6 unspecified
-    [InlineData("fc00::1", true)]         // IPv6 unique local
-    [InlineData("fd00::1", true)]         // IPv6 unique local
-    [InlineData("fe80::1", true)]         // IPv6 link-local
-    [InlineData("ff02::1", true)]         // IPv6 multicast
+    [InlineData("192.0.0.0", true)]       // RFC 6890 IETF Protocol Assignments start
+    [InlineData("192.0.0.192", true)]     // Oracle Cloud metadata
+    [InlineData("192.0.0.255", true)]     // IETF Protocol Assignments end
+    [InlineData("192.0.1.0", false)]      // Gap between 192.0.0.0/24 and 192.0.2.0/24
+    [InlineData("192.0.2.5", true)]       // TEST-NET-1
+    [InlineData("192.88.99.1", true)]     // 6to4 Relay Anycast
+    [InlineData("198.18.0.0", true)]      // Benchmarking start
+    [InlineData("198.19.255.255", true)]  // Benchmarking end
+    [InlineData("198.20.0.0", false)]     // Just above benchmarking
+    [InlineData("198.51.100.5", true)]    // TEST-NET-2
+    [InlineData("203.0.113.5", true)]     // TEST-NET-3
+    [InlineData("224.0.0.1", true)]       // Multicast start
+    [InlineData("223.255.255.255", false)] // Just below multicast
+    [InlineData("239.255.255.255", true)] // Multicast end
+    [InlineData("240.0.0.1", true)]       // Reserved future
+    [InlineData("255.255.255.254", true)] // Reserved future
+    [InlineData("255.255.255.255", true)] // Limited broadcast
+    public void IsInternal_IPv4Reserved_ReturnsExpected(string ipString, bool expected)
+    {
+        var ip = IPAddress.Parse(ipString);
+        Assert.Equal(expected, ip.IsInternal());
+    }
+
+    [Theory]
+    [InlineData("::1", true)]                       // Loopback
+    [InlineData("::", true)]                        // Unspecified
+    [InlineData("::2", false)]                      // Adjacent to unspecified, not reserved
+    [InlineData("fc00::1", true)]                   // ULA
+    [InlineData("fd00::1", true)]                   // ULA
+    [InlineData("fe80::1", true)]                   // Link-local
+    [InlineData("febf:ffff::1", true)]              // Link-local end (fe80::/10)
+    [InlineData("fec0::1", false)]                  // Above link-local (old fe-prefix bug)
+    [InlineData("fe00::1", false)]                  // Below link-local (old fe-prefix bug)
+    [InlineData("ff02::1", true)]                   // Multicast
     [InlineData("2607:f8b0:4004:800::200e", false)] // Google public IPv6
     public void IsInternal_IPv6_ReturnsExpected(string ipString, bool expected)
     {
@@ -60,9 +88,66 @@ public class IPAddressExtensionsTests
     }
 
     [Theory]
-    [InlineData("::ffff:127.0.0.1", true)]   // IPv4-mapped IPv6 loopback
-    [InlineData("::ffff:10.0.0.1", true)]     // IPv4-mapped IPv6 private
-    [InlineData("::ffff:192.168.1.1", true)]  // IPv4-mapped IPv6 private
+    [InlineData("100::1", true)]            // RFC 6666 Discard-only
+    [InlineData("2001::1", true)]           // Teredo
+    [InlineData("2001:2::1", true)]         // Benchmarking
+    [InlineData("2001:3::1", true)]         // AMT
+    [InlineData("2001:10::1", true)]        // ORCHID
+    [InlineData("2001:20::1", true)]        // ORCHIDv2
+    [InlineData("2001:db8::1", true)]       // RFC 3849 Documentation
+    [InlineData("3fff::1", true)]           // RFC 9637 Documentation start
+    [InlineData("3fff:fff:ffff:ffff:ffff:ffff:ffff:ffff", true)] // RFC 9637 Documentation end
+    [InlineData("4000::1", false)]          // Just above RFC 9637 Documentation
+    [InlineData("5f00::1", true)]           // Segment Routing
+    [InlineData("64:ff9b:1::aabb:ccdd", true)] // NAT64 local-use (whole prefix reserved)
+    public void IsInternal_IPv6Reserved_ReturnsExpected(string ipString, bool expected)
+    {
+        var ip = IPAddress.Parse(ipString);
+        Assert.Equal(expected, ip.IsInternal());
+    }
+
+    [Theory]
+    [InlineData("64:ff9b::a00:1", true)]      // NAT64 well-known alias of 10.0.0.1
+    [InlineData("64:ff9b::a7b:2", true)]      // NAT64 well-known alias of 10.123.0.2
+    [InlineData("64:ff9b::a63:1e2a", true)]   // NAT64 well-known alias of 10.99.30.42
+    [InlineData("64:ff9b::a9fe:a9fe", true)]  // NAT64 well-known alias of 169.254.169.254 (cloud metadata)
+    [InlineData("64:ff9b::7f00:1", true)]     // NAT64 well-known alias of 127.0.0.1
+    [InlineData("64:ff9b::c0a8:1", true)]     // NAT64 well-known alias of 192.168.0.1
+    [InlineData("64:ff9b::6440:1", true)]     // NAT64 well-known alias of 100.64.0.1 (CGNAT)
+    [InlineData("64:ff9b::c000:c0", true)]    // NAT64 well-known alias of 192.0.0.192 (Oracle metadata)
+    [InlineData("64:ff9b::808:808", false)]   // NAT64 well-known alias of 8.8.8.8 (public)
+    [InlineData("64:ff9b::101:101", false)]   // NAT64 well-known alias of 1.1.1.1 (public)
+    public void IsInternal_NAT64_DecodesEmbeddedIPv4(string ipString, bool expected)
+    {
+        var ip = IPAddress.Parse(ipString);
+        Assert.Equal(expected, ip.IsInternal());
+    }
+
+    [Theory]
+    [InlineData("2002:a00:1::", true)]       // 6to4 of 10.0.0.1
+    [InlineData("2002:7f00:1::", true)]      // 6to4 of 127.0.0.1
+    [InlineData("2002:c0a8:1::", true)]      // 6to4 of 192.168.0.1
+    [InlineData("2002:a9fe:a9fe::", true)]   // 6to4 of 169.254.169.254
+    [InlineData("2002:808:808::", false)]    // 6to4 of 8.8.8.8 (public)
+    [InlineData("2002:101:101::", false)]    // 6to4 of 1.1.1.1 (public)
+    public void IsInternal_6to4_DecodesEmbeddedIPv4(string ipString, bool expected)
+    {
+        var ip = IPAddress.Parse(ipString);
+        Assert.Equal(expected, ip.IsInternal());
+    }
+
+    [Theory]
+    [InlineData("::ffff:127.0.0.1", true)]            // IPv4-mapped loopback
+    [InlineData("::ffff:10.0.0.1", true)]             // IPv4-mapped RFC 1918
+    [InlineData("::ffff:192.168.1.1", true)]          // IPv4-mapped RFC 1918
+    [InlineData("::ffff:169.254.169.254", true)]      // IPv4-mapped cloud metadata
+    [InlineData("::ffff:100.64.0.1", true)]           // IPv4-mapped CGNAT
+    [InlineData("::ffff:192.0.0.192", true)]          // IPv4-mapped Oracle Cloud metadata
+    [InlineData("::ffff:198.18.0.1", true)]           // IPv4-mapped benchmarking
+    [InlineData("::ffff:224.0.0.1", true)]            // IPv4-mapped multicast
+    [InlineData("::ffff:255.255.255.255", true)]      // IPv4-mapped limited broadcast
+    [InlineData("::ffff:8.8.8.8", false)]             // IPv4-mapped public
+    [InlineData("::ffff:1.1.1.1", false)]             // IPv4-mapped public
     public void IsInternal_IPv4MappedIPv6_ReturnsExpected(string ipString, bool expected)
     {
         var ip = IPAddress.Parse(ipString);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38116

## 📔 Objective

Tighten the SSRF block list used by `IPAddressExtensions.IsInternal()` so it matches the IANA IPv4 and IPv6 Special-Purpose Address Registries, and close two classes of bypass:

1. **IPv6 embedded IPv4.** An attacker could previously target an internal IPv4 host (e.g. `169.254.169.254` cloud metadata, `10.0.0.0/8`) by encoding it inside an RFC 6052 NAT64 (`64:ff9b::/96`) or RFC 3056 6to4 (`2002::/16`) address. The IPv6 wrapper passed the old prefix checks and the gateway on the path would translate the destination back to the internal IPv4 host. The new implementation extracts the embedded IPv4 and re-runs the IPv4 reserved-range check.
2. **Over- and under-blocking from prefix string matching.** The old `StartsWith("fe")` check treated all of `fe00::/8` as link-local, when only `fe80::/10` is. Several reserved ranges (192.0.0.0/24 incl. Oracle Cloud metadata, TEST-NETs, 6to4 anycast, benchmarking, multicast, 240.0.0.0/4, RFC 9637 documentation, Teredo, ORCHID, etc.) were not blocked at all.

Implementation uses `System.Net.IPNetwork.Contains` against an explicit table of CIDR ranges per IANA registry.
