### PR TITLE
[PM-27298] Remove consolidated-session-timeout-component feature flag

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -227,7 +227,6 @@ public static class FeatureFlagKeys
     public const string UnlockWithMasterPasswordUnlockData = "pm-23246-unlock-with-master-password-unlock-data";
     public const string LinuxBiometricsV2 = "pm-26340-linux-biometrics-v2";
     public const string NoLogoutOnKdfChange = "pm-23995-no-logout-on-kdf-change";
-    public const string ConsolidatedSessionTimeoutComponent = "pm-26056-consolidated-session-timeout-component";
     public const string V2RegistrationTDEJIT = "pm-27279-v2-registration-tde-jit";
     public const string EnableAccountEncryptionV2KeyConnectorRegistration = "enable-account-encryption-v2-key-connector-registration";
     public const string SdkKeyRotation = "pm-30144-sdk-key-rotation";


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27298

## 📔 Objective

Removes the `ConsolidatedSessionTimeoutComponent` feature flag (`pm-26056-consolidated-session-timeout-component`) from `Constants.cs`.