### PR TITLE
chore(server): add FedRampGovRegion feature flag constant

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -262,6 +262,7 @@ public static class FeatureFlagKeys
     public const string WebAuthnRelatedOrigins = "pm-30529-webauthn-related-origins";
     public const string ElectronStorageCache = "pm-32783-electron-storage-cache";
     public const string AttachmentUploadProgress = "pm-34410-attachment-upload-progress";
+    public const string FedRampGovRegion = "fedramp-gov-region";
 
     /* Tools Team */
     /// <summary>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35088
https://github.com/bitwarden/sdk-internal/pull/1144
https://github.com/bitwarden/clients/pull/20880

## 📔 Objective

Adds the fedramp-gov-region feature flag key to FeatureFlagKeys in the Platform Team section. This flag gates Gov region visibility in the client-side environment selector, preventing bitwarden-gov.com from appearing to users before the feature is enabled.
