### PR TITLE
refactor(server): move CloudRegion enum from Setup to Core

### DIFF
--- a/src/Core/Enums/CloudRegion.cs
+++ b/src/Core/Enums/CloudRegion.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace Bit.Setup.Enums;
+namespace Bit.Core.Enums;
 
 public enum CloudRegion
 {

--- a/util/Setup/Context.cs
+++ b/util/Setup/Context.cs
@@ -1,7 +1,7 @@
 ﻿// FIXME: Update this file to be null safe and then delete the line below
 #nullable disable
 
-using Bit.Setup.Enums;
+using Bit.Core.Enums;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 

--- a/util/Setup/Program.cs
+++ b/util/Setup/Program.cs
@@ -3,8 +3,8 @@
 
 using System.Globalization;
 using System.Net.Http.Json;
+using Bit.Core.Enums;
 using Bit.Migrator;
-using Bit.Setup.Enums;
 
 namespace Bit.Setup;
 

--- a/util/Setup/Setup.csproj
+++ b/util/Setup/Setup.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Core\Core.csproj" />
     <ProjectReference Include="..\Migrator\Migrator.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38015

## 📔 Objective

Decouple CloudRegion from Bit.Setup.Enums so any project consuming Core can reference it without a reference back into the Setup utility. Updates the three downstream Setup references (Context.cs, Program.cs, Setup.csproj) to point at the new Bit.Core.Enums namespace. This migration is isolated from the rest of PM-38015 so SHOT can review just the pieces relevant to your team. Platform will be using this enum from Core in related in progress work.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
