### PR TITLE
feat(server): add Gov cloud region

### DIFF
--- a/src/Core/Enums/CloudRegion.cs
+++ b/src/Core/Enums/CloudRegion.cs
@@ -8,4 +8,6 @@ public enum CloudRegion
     US = 0,
     [Display(Name = "EU")]
     EU = 1,
+    [Display(Name = "Gov")]
+    Gov = 2,
 }

--- a/src/Core/Settings/CloudRegionConfig.cs
+++ b/src/Core/Settings/CloudRegionConfig.cs
@@ -53,6 +53,13 @@ public sealed class CloudRegionConfig
             "https://identity.bitwarden.eu",
             "https://vault.bitwarden.eu",
             "https://bitwarden.eu/sso-callback"),
+        new(
+            CloudRegion.Gov,
+            "bitwarden-gov.com",
+            "https://api.bitwarden-gov.com",
+            "https://identity.bitwarden-gov.com",
+            "https://vault.bitwarden-gov.com",
+            "https://bitwarden-gov.com/sso-callback"),
     ];
 
     public static CloudRegionConfig FindByDomain(string domain) =>

--- a/test/Core.Test/ConstantsTests.cs
+++ b/test/Core.Test/ConstantsTests.cs
@@ -1,0 +1,24 @@
+﻿using Xunit;
+
+namespace Bit.Core.Test;
+
+public class ConstantsTests
+{
+    [Theory]
+    [InlineData("bitwarden.com")]
+    [InlineData("bitwarden.eu")]
+    [InlineData("bitwarden-gov.com")]
+    public void BitwardenCloudDomains_ContainsAllProductionDomains(string domain)
+    {
+        Assert.Contains(domain, Constants.BitwardenCloudDomains);
+    }
+
+    [Theory]
+    [InlineData("https://bitwarden.com/sso-callback")]
+    [InlineData("https://bitwarden.eu/sso-callback")]
+    [InlineData("https://bitwarden-gov.com/sso-callback")]
+    public void BitwardenMobileSsoCallbackUris_ContainsAllRegionCallbacks(string uri)
+    {
+        Assert.Contains(uri, Constants.BitwardenMobileSsoCallbackUris);
+    }
+}

--- a/test/Core.Test/Services/HandlebarsMailServiceTests.cs
+++ b/test/Core.Test/Services/HandlebarsMailServiceTests.cs
@@ -364,4 +364,20 @@ public class HandlebarsMailServiceTests
         await _mailDeliveryService.Received(1).SendEmailAsync(Arg.Is<MailMessage>(m =>
             m.ToEmails.Contains(email)));
     }
+
+    [Theory]
+    [InlineData("us", "https://vault.bitwarden.com")]
+    [InlineData("eu", "https://vault.bitwarden.eu")]
+    [InlineData("gov", "https://vault.bitwarden-gov.com")]
+    public void GetCloudVaultSubscriptionUrl_ResolvesPerRegion(string cloudRegion, string expectedVaultBase)
+    {
+        // Arrange
+        _globalSettings.BaseServiceUri.CloudRegion = cloudRegion;
+
+        // Act
+        var result = _sut.GetCloudVaultSubscriptionUrl(Guid.NewGuid());
+
+        // Assert
+        Assert.StartsWith(expectedVaultBase, result);
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38016
Stacked on https://github.com/bitwarden/server/pull/7728

## 📔 Objective

Adds the Gov cloud region to `CloudRegionConfig`, following up on the refactor to create `CloudRegionConfig` on https://github.com/bitwarden/server/pull/7728. This applys the Gov region across different services in the server, like Swagger, Handlebars, `CloudDomains`, and mobile SSO.
