### PR TITLE
Migrate Web Frontend to Official Aspire JavaScript Hosting

### DIFF
--- a/AppHost/AppHost.cs
+++ b/AppHost/AppHost.cs
@@ -13,9 +13,7 @@ builder.ConfigureRedis();
 builder.ConfigureIdp();
 var services = builder.ConfigureServices(db, secretsSetup, mail, azurite);
 
-#if ENABLE_NODEJS_COMMUNITY_PLUGIN
 builder.ConfigureWebFrontend(services["api"]);
-#endif
 
 #if ENABLE_NGROK_COMMUNITY_PLUGIN
 builder.ConfigureNgrok((services["billing"], "http"));

--- a/AppHost/AppHost.csproj
+++ b/AppHost/AppHost.csproj
@@ -11,8 +11,6 @@
     <!-- Disable community plugins by default -->
     <EnableNgrokCommunityPlugin>false</EnableNgrokCommunityPlugin>
     <DefineConstants Condition="'$(EnableNgrokCommunityPlugin)' == 'true'">$(DefineConstants);ENABLE_NGROK_COMMUNITY_PLUGIN</DefineConstants>
-    <EnableNodeJsCommunityPlugin>false</EnableNodeJsCommunityPlugin>
-    <DefineConstants Condition="'$(EnableNodeJsCommunityPlugin)' == 'true'">$(DefineConstants);ENABLE_NODEJS_COMMUNITY_PLUGIN</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,10 +22,6 @@
 
   <ItemGroup Condition="'$(EnableNgrokCommunityPlugin)' == 'true'">
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.Ngrok" Version="[13.3.0]" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(EnableNodeJsCommunityPlugin)' == 'true'">
-    <PackageReference Include="CommunityToolkit.Aspire.Hosting.NodeJS.Extensions" Version="[9.9.0]"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/AppHost/BuilderExtensions.cs
+++ b/AppHost/BuilderExtensions.cs
@@ -278,7 +278,7 @@ public static class BuilderExtensions
         return builder
             .AddJavaScriptApp(name, $"{builder.Required("ClientsPath")}/{path}", scriptName)
             .WithHttpsEndpoint(port, port, "angular-http", isProxied: false)
-            .WithNpm(install:false)
+            .WithNpm(install: false)
             .WithReference(api)
             .WaitFor(api)
             .WithExplicitStart();

--- a/AppHost/BuilderExtensions.cs
+++ b/AppHost/BuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Aspire.Hosting.Azure;
+using Aspire.Hosting.JavaScript;
 using Azure.Provisioning;
 using Azure.Provisioning.Storage;
 
@@ -256,7 +257,6 @@ public static class BuilderExtensions
     private static bool IsSelfHosted(this IDistributedApplicationBuilder builder) =>
         builder.Configuration["SelfHost"]?.Equals("true", StringComparison.OrdinalIgnoreCase) == true;
 
-#if ENABLE_NODEJS_COMMUNITY_PLUGIN
     public static void ConfigureWebFrontend(this IDistributedApplicationBuilder builder,
         IResourceBuilder<ProjectResource> api)
     {
@@ -264,22 +264,22 @@ public static class BuilderExtensions
             throw new InvalidOperationException("Invalid value for WebFrontend:Port.");
 
         builder
-            .AddBitwardenNpmApp("web-frontend", "web", api)
-            .WithHttpsEndpoint(port, port, "angular-http", isProxied: false)
+            .AddBitwardenNpmApp("web-frontend", "web", api, port: port)
             .WithUrl(builder.Required("WebFrontend:Url"))
             .WithExternalHttpEndpoints();
     }
 
-    private static IResourceBuilder<NodeAppResource> AddBitwardenNpmApp(this IDistributedApplicationBuilder builder,
-        string name, string path, IResourceBuilder<ProjectResource> api, string scriptName = "build:bit:watch")
+    private static IResourceBuilder<JavaScriptAppResource> AddBitwardenNpmApp(this IDistributedApplicationBuilder builder,
+        string name, string path, IResourceBuilder<ProjectResource> api, int port, string scriptName = "build:bit:watch")
     {
         return builder
-            .AddNpmApp(name, $"{builder.Required("ClientsPath")}/{path}", scriptName)
+            .AddJavaScriptApp(name, $"{builder.Required("ClientsPath")}/{path}", scriptName)
+            .WithHttpsEndpoint(port, port, "angular-http", isProxied: false)
+            .WithNpm(install:false)
             .WithReference(api)
             .WaitFor(api)
             .WithExplicitStart();
     }
-#endif
 
 #if ENABLE_NGROK_COMMUNITY_PLUGIN
     public static void ConfigureNgrok(this IDistributedApplicationBuilder builder,

--- a/AppHost/BuilderExtensions.cs
+++ b/AppHost/BuilderExtensions.cs
@@ -67,11 +67,14 @@ public static class BuilderExtensions
                     MaxAgeInSeconds = new BicepValue<int>("30")
                 }));
             })
-            .RunAsEmulator(c =>
+            .RunAsEmulator(emulator =>
             {
-                c.WithBlobPort(10000)
+                emulator
+                    .WithBlobPort(10000)
                     .WithQueuePort(10001)
-                    .WithTablePort(10002);
+                    .WithTablePort(10002)
+                    .WithDataVolume()
+                    .WithLifetime(ContainerLifetime.Persistent);
             });
 
         builder

--- a/AppHost/README.md
+++ b/AppHost/README.md
@@ -71,7 +71,7 @@ dotnet user-secrets set "Database:Password" "<your-sa-password>"
 | Key                         | Default                            | Description                                                                          |
 |-----------------------------|------------------------------------|--------------------------------------------------------------------------------------|
 | `SelfHost`                  | `false`                            | Switch to self-hosted mode (see [Self-Hosted Mode](#self-hosted-mode))               |
-| `ClientsPath`               | `../../clients/apps`               | Path to the `clients` repo's `apps/` directory; override in `appsettings.local.json` if using worktrees |
+| `ClientsPath`               | `../../clients/apps`               | Path to the `clients` repo's `apps/` directory (see [Git Worktrees](#git-worktrees)) |
 | `WorkingDirectory`          | `../dev`                           | Directory where dev scripts are resolved                                             |
 | `Services:<name>:BasePort`  | see `appsettings.Development.json` | HTTP port for each service; pre-filled to match each service's `launchSettings.json` |
 | `Database:Image`            | `mssql/server:2022-latest`         | Docker image for SQL Server                                                          |

--- a/AppHost/README.md
+++ b/AppHost/README.md
@@ -71,7 +71,7 @@ dotnet user-secrets set "Database:Password" "<your-sa-password>"
 | Key                         | Default                            | Description                                                                          |
 |-----------------------------|------------------------------------|--------------------------------------------------------------------------------------|
 | `SelfHost`                  | `false`                            | Switch to self-hosted mode (see [Self-Hosted Mode](#self-hosted-mode))               |
-| `ClientsPath`               | `../../clients/apps`               | Path to the `clients` repo's `apps/` directory (used by the Node.js plugin)          |
+| `ClientsPath`               | `../../clients/apps`               | Path to the `clients` repo's `apps/` directory; override in `appsettings.local.json` if using worktrees |
 | `WorkingDirectory`          | `../dev`                           | Directory where dev scripts are resolved                                             |
 | `Services:<name>:BasePort`  | see `appsettings.Development.json` | HTTP port for each service; pre-filled to match each service's `launchSettings.json` |
 | `Database:Image`            | `mssql/server:2022-latest`         | Docker image for SQL Server                                                          |
@@ -85,33 +85,23 @@ dotnet user-secrets set "Database:Password" "<your-sa-password>"
 | `MailCatcher:SmtpPort`      | `10250`                            | Host SMTP port                                                                       |
 | `MailCatcher:WebPort`       | `1080`                             | MailCatcher web UI port                                                              |
 | `NgrokAuthToken`            | _(empty)_                          | ngrok auth token (used only when ngrok plugin is enabled)                            |
-| `WebFrontend:Port`          | `8080`                             | Web frontend port (used only when Node.js plugin is enabled)                         |
+| `WebFrontend:Port`          | `8080`                             | Web frontend port                                                                    |
 | `WebFrontend:Url`           | `https://bitwarden.test:8080`      | Web frontend URL shown in the dashboard                                              |
 
 ## Optional Features
 
-### Web Frontend (Node.js community plugin)
+### Web Frontend
 
 Runs the web client alongside the server services. Requires the Bitwarden
 [clients](https://github.com/bitwarden/clients) repo cloned as a sibling to `server`.
 
-1. Create an `AppHost.csproj.user` file next to `AppHost.csproj` (it is covered by `.gitignore`):
-
-   ```xml
-   <Project>
-     <PropertyGroup>
-       <EnableNodeJsCommunityPlugin>true</EnableNodeJsCommunityPlugin>
-     </PropertyGroup>
-   </Project>
-   ```
-
-2. If the clients repo is not at `../../clients/apps`, override the path:
+1. If the clients repo is not at `../../clients/apps`, override the path:
 
    ```bash
    dotnet user-secrets set "ClientsPath" "<path/to/clients/apps>"
    ```
 
-3. Run `dotnet run` as normal. The `web-frontend` resource starts with **explicit start** — open
+2. Run `dotnet run` as normal. The `web-frontend` resource starts with **explicit start** — open
    the Aspire dashboard and start it manually when you're ready.
 
 ### Ngrok (Billing Webhook Tunneling)
@@ -193,6 +183,26 @@ variables for every resource.
   `AppHost.csproj`, and are never tracked by git.
 - If you create an `appsettings.local.json`, add it to `.gitignore` before writing any values
   to it.
+
+## Git Worktrees
+
+Path-based settings resolve relative to where you run `dotnet run`. If your worktree lives in
+a different location than the main checkout, those paths won't resolve correctly. Use absolute
+paths for any such setting:
+
+- **`ClientsPath`** defaults to `../../clients/apps` — override if your worktree is not
+  alongside the `clients` repo:
+
+  ```bash
+  dotnet user-secrets set "ClientsPath" "<absolute/path/to/clients/apps>"
+  ```
+
+- **`AdditionalProjects:<name>:Path`** — use an absolute path when adding projects via user
+  secrets in a worktree:
+
+  ```bash
+  dotnet user-secrets set "AdditionalProjects:<name>:Path" "<absolute/path/to/Project.csproj>"
+  ```
 
 ## Troubleshooting
 

--- a/AppHost/README.md
+++ b/AppHost/README.md
@@ -30,7 +30,7 @@ the services wait for the database and secrets setup to finish before launching.
 | `setup-secrets`     | Executable                | Runs `dev/setup_secrets.ps1` — applies `dev/secrets.json` to all projects |
 | `mssql`             | SQL Server 2022 container | Persistent data volume, port 1433                                         |
 | `run-db-migrations` | Executable                | Runs `dev/migrate.ps1` against `vault_dev` (or `self_host_dev`)           |
-| `azurite`           | Azure Storage emulator    | Blob :10000 · Queue :10001 · Table :10002                                 |
+| `azurite`           | Azure Storage emulator    | Blob :10000 · Queue :10001 · Table :10002 · persistent data volume        |
 | `azurite-setup`     | Executable                | Runs `dev/setup_azurite.ps1` after Azurite is ready                       |
 | `mailcatcher`       | Container                 | SMTP :10250 · Web UI :1080                                                |
 | `redis`             | Container                 | Redis with AOF persistence, port 6379                                     |


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Replaces the third-party `CommunityToolkit.Aspire.Hosting.NodeJS.Extensions` package with the
official `Aspire.Hosting.JavaScript` package that ships as part of the Aspire SDK.

The community extension has been deprecated in favor of this first-party package, which also
removes the need for the `ENABLE_NODEJS_COMMUNITY_PLUGIN` compile-time guard and the
`.csproj.user` opt-in flow — the web frontend is now always available without any extra setup.

**Changes:**
- Removes the deprecated `CommunityToolkit.Aspire.Hosting.NodeJS.Extensions` package and its
  opt-in compile-time guard
- Switches `AddNpmApp`/`NodeAppResource` to `AddJavaScriptApp`/`JavaScriptAppResource` with
  `.WithNpm(install:false)`
- Adds Azurite data persistence (`WithDataVolume()` + `WithLifetime(ContainerLifetime.Persistent)`)
  to match the existing SQL Server and Redis behavior
- Updates README to reflect the simplified web frontend setup, document Azurite persistence, and
  add a Git Worktrees section with guidance on using absolute paths for `ClientsPath` and
  `AdditionalProjects` paths