### PR TITLE
[PM-38224] Add claimed domain functionality to seeder

### DIFF
--- a/util/Seeder/Factories/OrganizationDomainSeeder.cs
+++ b/util/Seeder/Factories/OrganizationDomainSeeder.cs
@@ -1,5 +1,5 @@
-﻿using Bit.Core.Utilities;
-using Bit.Infrastructure.EntityFramework.Models;
+﻿using Bit.Core.Entities;
+using Bit.Core.Utilities;
 
 namespace Bit.Seeder.Factories;
 

--- a/util/Seeder/Models/SeedPreset.cs
+++ b/util/Seeder/Models/SeedPreset.cs
@@ -25,6 +25,7 @@ internal record SeedPresetOrganization
     public string? Fixture { get; init; }
     public string? Name { get; init; }
     public string? Domain { get; init; }
+    public List<string>? ClaimedDomains { get; init; }
     public int? Seats { get; init; }
     public string? PlanType { get; init; }
     public bool? UseAutomaticUserConfirmation { get; init; }

--- a/util/Seeder/Options/OrganizationVaultOptions.cs
+++ b/util/Seeder/Options/OrganizationVaultOptions.cs
@@ -21,6 +21,11 @@ public class OrganizationVaultOptions
     public required string Domain { get; init; }
 
     /// <summary>
+    /// Claimed (verified) domains to seed for the organization. Each becomes a verified <see cref="Bit.Core.Entities.OrganizationDomain"/> row.
+    /// </summary>
+    public IReadOnlyList<string> ClaimedDomains { get; init; } = [];
+
+    /// <summary>
     /// Number of member users to create.
     /// </summary>
     public required int Users { get; init; }

--- a/util/Seeder/Pipeline/BulkCommitter.cs
+++ b/util/Seeder/Pipeline/BulkCommitter.cs
@@ -12,6 +12,7 @@ using EfGroup = Bit.Infrastructure.EntityFramework.Models.Group;
 using EfGroupUser = Bit.Infrastructure.EntityFramework.Models.GroupUser;
 using EfOrganization = Bit.Infrastructure.EntityFramework.AdminConsole.Models.Organization;
 using EfOrganizationApiKey = Bit.Infrastructure.EntityFramework.Models.OrganizationApiKey;
+using EfOrganizationDomain = Bit.Infrastructure.EntityFramework.Models.OrganizationDomain;
 using EfOrganizationUser = Bit.Infrastructure.EntityFramework.Models.OrganizationUser;
 using EfUser = Bit.Infrastructure.EntityFramework.Models.User;
 
@@ -39,6 +40,8 @@ internal sealed class BulkCommitter(DatabaseContext db, IMapper mapper)
     internal void Commit(SeederContext context)
     {
         MapCopyAndClear<Core.AdminConsole.Entities.Organization, EfOrganization>(context.Organizations);
+
+        MapCopyAndClear<Core.Entities.OrganizationDomain, EfOrganizationDomain>(context.OrganizationDomains);
 
         MapAndCopy<Core.Entities.OrganizationApiKey, EfOrganizationApiKey>(context.OrganizationApiKey);
 

--- a/util/Seeder/Pipeline/PresetLoader.cs
+++ b/util/Seeder/Pipeline/PresetLoader.cs
@@ -87,7 +87,7 @@ internal static class PresetLoader
     /// Builds a recipe from preset configuration, resolving fixtures and generation counts.
     /// </summary>
     /// <remarks>
-    /// Resolution order: Org → OrgApiKey → Roster → Owner (if no roster owner) → Generator → Users → Groups → Collections → Folders → Ciphers → CipherCollections → CipherFolders → CipherFavorites → PersonalCiphers
+    /// Resolution order: Org → OrgApiKey → ClaimedDomains → Roster → Owner (if no roster owner) → Generator → Users → Groups → Collections → Folders → Ciphers → CipherCollections → CipherFolders → CipherFavorites → PersonalCiphers
     /// </remarks>
     private static void BuildRecipe(string presetName, SeedPreset preset, ISeedReader reader, IServiceCollection services)
     {
@@ -116,6 +116,11 @@ internal static class PresetLoader
         }
 
         builder.AddOrganizationApiKey();
+
+        if (org.ClaimedDomains is { Count: > 0 })
+        {
+            builder.WithOrganizationDomain(org.ClaimedDomains);
+        }
 
         if (preset.Roster?.Fixture is not null)
         {

--- a/util/Seeder/Pipeline/RecipeBuilderExtensions.cs
+++ b/util/Seeder/Pipeline/RecipeBuilderExtensions.cs
@@ -77,6 +77,39 @@ public static class RecipeBuilderExtensions
     }
 
     /// <summary>
+    /// Seed one or more claimed (verified) organization domains.
+    /// Domain names are trimmed; empty entries are dropped and duplicates removed case-insensitively.
+    /// </summary>
+    /// <param name="builder">The recipe builder</param>
+    /// <param name="domainNames">Domain names to seed. Empty (or all-empty/whitespace) is a no-op.</param>
+    /// <returns>The builder for fluent chaining</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no organization exists.</exception>
+    public static RecipeBuilder WithOrganizationDomain(
+        this RecipeBuilder builder,
+        IReadOnlyList<string> domainNames)
+    {
+        if (!builder.HasOrg)
+        {
+            throw new InvalidOperationException(
+                "Organization domains require an organization. Call UseOrganization() or CreateOrganization() first.");
+        }
+
+        var unique = domainNames
+            .Select(d => d.Trim())
+            .Where(d => !string.IsNullOrWhiteSpace(d))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (unique.Count == 0)
+        {
+            return builder;
+        }
+
+        builder.AddStep(_ => new CreateOrganizationDomainsStep(unique));
+        return builder;
+    }
+
+    /// <summary>
     /// Add an organization owner user with admin privileges.
     /// </summary>
     /// <param name="builder">The recipe builder</param>

--- a/util/Seeder/Pipeline/RecipeOrchestrator.cs
+++ b/util/Seeder/Pipeline/RecipeOrchestrator.cs
@@ -64,6 +64,12 @@ internal sealed class RecipeOrchestrator(SeederDependencies deps)
 
         builder.CreateOrganization(options.Name, options.Domain, options.Users + 1, options.PlanType, options.Overrides);
         builder.AddOrganizationApiKey();
+
+        if (options.ClaimedDomains.Count > 0)
+        {
+            builder.WithOrganizationDomain(options.ClaimedDomains);
+        }
+
         builder.AddOwner();
         builder.WithGenerator(options.Domain);
         builder.AddUsers(options.Users, options.RealisticStatusMix);

--- a/util/Seeder/Pipeline/SeederContext.cs
+++ b/util/Seeder/Pipeline/SeederContext.cs
@@ -56,6 +56,8 @@ public sealed class SeederContext(IServiceProvider services)
 
     internal List<Organization> Organizations { get; } = [];
 
+    internal List<OrganizationDomain> OrganizationDomains { get; } = [];
+
     internal List<User> Users { get; } = [];
 
     internal List<OrganizationUser> OrganizationUsers { get; } = [];

--- a/util/Seeder/Seeds/schemas/preset.schema.json
+++ b/util/Seeder/Seeds/schemas/preset.schema.json
@@ -30,6 +30,12 @@
           "type": "string",
           "description": "Organization domain (used with inline creation and generator seeding)."
         },
+        "claimedDomains": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true,
+          "description": "Claimed (verified) organization domains to seed. Each becomes a verified OrganizationDomain row."
+        },
         "seats": {
           "type": "integer",
           "minimum": 1,

--- a/util/Seeder/Steps/CreateOrganizationDomainsStep.cs
+++ b/util/Seeder/Steps/CreateOrganizationDomainsStep.cs
@@ -1,0 +1,17 @@
+using Bit.Seeder.Factories;
+using Bit.Seeder.Pipeline;
+
+namespace Bit.Seeder.Steps;
+
+internal sealed class CreateOrganizationDomainsStep(IReadOnlyList<string> domainNames) : IStep
+{
+    public void Execute(SeederContext context)
+    {
+        var orgId = context.RequireOrgId();
+
+        foreach (var name in domainNames)
+        {
+            context.OrganizationDomains.Add(OrganizationDomainSeeder.Create(orgId, name));
+        }
+    }
+}

--- a/util/Seeder/Steps/CreateOrganizationDomainsStep.cs
+++ b/util/Seeder/Steps/CreateOrganizationDomainsStep.cs
@@ -1,4 +1,4 @@
-using Bit.Seeder.Factories;
+﻿using Bit.Seeder.Factories;
 using Bit.Seeder.Pipeline;
 
 namespace Bit.Seeder.Steps;

--- a/util/SeederUtility/Commands/OrganizationArgs.cs
+++ b/util/SeederUtility/Commands/OrganizationArgs.cs
@@ -21,6 +21,9 @@ public class OrganizationArgs : IArgumentModel
     [Option('d', "domain", Description = "Email domain for users")]
     public string Domain { get; set; } = null!;
 
+    [Option("claimed-domain", Description = "Claimed (verified) domain to seed. Repeat to add multiple, e.g. --claimed-domain acme.example --claimed-domain hr.acme.example")]
+    public List<string>? ClaimedDomains { get; set; }
+
     [Option('c', "ciphers", Description = "Number of ciphers to create (default: 0, no vault data)")]
     public int? Ciphers { get; set; }
 
@@ -112,6 +115,7 @@ public class OrganizationArgs : IArgumentModel
         Ciphers = Ciphers ?? 0,
         Groups = Groups ?? 0,
         Collections = Collections ?? 0,
+        ClaimedDomains = ClaimedDomains ?? [],
         RealisticStatusMix = MixStatuses,
         StructureModel = ParseOrgStructure(Structure),
         Region = ParseGeographicRegion(Region),


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-38224

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The seeder contains some `OrganizationDomain` seeder/recipe code, but it's not exposed for use via presets or the cli util. Add this wiring so that we can create orgs with claimed domains for testing purposes.

This is particularly useful because otherwise we have no other way of testing claimed domains: you either have to have a real domain and claim it, or run a SQL query to insert a row in your local database. Perfect use case for the seeder.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
