### PR TITLE
[PM-37087] Release migration schedule before adding org to provider"

### DIFF
--- a/bitwarden_license/src/Commercial.Core/Billing/Providers/Services/ProviderBillingService.cs
+++ b/bitwarden_license/src/Commercial.Core/Billing/Providers/Services/ProviderBillingService.cs
@@ -12,7 +12,6 @@ using Bit.Core.Billing;
 using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Extensions;
-using Bit.Core.Billing.Organizations.PlanMigration.Repositories;
 using Bit.Core.Billing.Payment.Models;
 using Bit.Core.Billing.Pricing;
 using Bit.Core.Billing.Providers.Entities;
@@ -44,7 +43,6 @@ public class ProviderBillingService(
     IFeatureService featureService,
     IGlobalSettings globalSettings,
     ILogger<ProviderBillingService> logger,
-    IOrganizationPlanMigrationCohortAssignmentRepository organizationPlanMigrationCohortAssignmentRepository,
     IOrganizationRepository organizationRepository,
     IPriceIncreaseScheduler priceIncreaseScheduler,
     IPricingClient pricingClient,
@@ -63,7 +61,8 @@ public class ProviderBillingService(
     {
         await priceIncreaseScheduler.Release(
             organization.GatewayCustomerId,
-            organization.GatewaySubscriptionId);
+            organization.GatewaySubscriptionId,
+            organization.Id);
 
         await stripeAdapter.UpdateSubscriptionAsync(organization.GatewaySubscriptionId,
             new SubscriptionUpdateOptions { CancelAtPeriodEnd = false });
@@ -155,21 +154,6 @@ public class ProviderBillingService(
         await eventService.LogProviderOrganizationEventAsync(
             providerOrganization,
             EventType.ProviderOrganization_Added);
-
-        // TODO(PM-37085): once Release(customerId, subscriptionId, organizationId) lands, pass
-        // organization.Id to the Release call above and delete this cohort cleanup block.
-        if (featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration))
-        {
-            var cohortAssignment =
-                await organizationPlanMigrationCohortAssignmentRepository.GetByOrganizationIdAsync(organization.Id);
-            if (cohortAssignment is not null)
-            {
-                await organizationPlanMigrationCohortAssignmentRepository.DeleteAsync(cohortAssignment);
-                logger.LogInformation(
-                    "Dropped plan-migration cohort assignment ({AssignmentId}) from cohort ({CohortId}) for organization ({OrganizationId}) added to provider ({ProviderId})",
-                    cohortAssignment.Id, cohortAssignment.CohortId, organization.Id, provider.Id);
-            }
-        }
     }
 
     public async Task ChangePlan(ChangeProviderPlanCommand command)

--- a/bitwarden_license/src/Commercial.Core/Billing/Providers/Services/ProviderBillingService.cs
+++ b/bitwarden_license/src/Commercial.Core/Billing/Providers/Services/ProviderBillingService.cs
@@ -156,13 +156,8 @@ public class ProviderBillingService(
             providerOrganization,
             EventType.ProviderOrganization_Added);
 
-        // Drop any stale cohort assignment after the org transition commits. Placing the
-        // cleanup here (rather than alongside Release) makes a failure here a reconciliation
-        // problem — stale assignment row — rather than a half-transitioned org. Gated on
-        // PM35215 because the cohort table is only populated when the epic is enabled.
-        // TODO(PM-37085): once Release(customerId, subscriptionId, organizationId) lands,
-        //   1) pass organization.Id as the third arg to the Release call above, and
-        //   2) delete this cohortAssignment lookup/delete block.
+        // TODO(PM-37085): once Release(customerId, subscriptionId, organizationId) lands, pass
+        // organization.Id to the Release call above and delete this cohort cleanup block.
         if (featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration))
         {
             var cohortAssignment =

--- a/bitwarden_license/src/Commercial.Core/Billing/Providers/Services/ProviderBillingService.cs
+++ b/bitwarden_license/src/Commercial.Core/Billing/Providers/Services/ProviderBillingService.cs
@@ -12,6 +12,7 @@ using Bit.Core.Billing;
 using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Extensions;
+using Bit.Core.Billing.Organizations.PlanMigration.Repositories;
 using Bit.Core.Billing.Payment.Models;
 using Bit.Core.Billing.Pricing;
 using Bit.Core.Billing.Providers.Entities;
@@ -43,7 +44,9 @@ public class ProviderBillingService(
     IFeatureService featureService,
     IGlobalSettings globalSettings,
     ILogger<ProviderBillingService> logger,
+    IOrganizationPlanMigrationCohortAssignmentRepository organizationPlanMigrationCohortAssignmentRepository,
     IOrganizationRepository organizationRepository,
+    IPriceIncreaseScheduler priceIncreaseScheduler,
     IPricingClient pricingClient,
     IProviderInvoiceItemRepository providerInvoiceItemRepository,
     IProviderOrganizationRepository providerOrganizationRepository,
@@ -58,6 +61,10 @@ public class ProviderBillingService(
         Organization organization,
         string key)
     {
+        await priceIncreaseScheduler.Release(
+            organization.GatewayCustomerId,
+            organization.GatewaySubscriptionId);
+
         await stripeAdapter.UpdateSubscriptionAsync(organization.GatewaySubscriptionId,
             new SubscriptionUpdateOptions { CancelAtPeriodEnd = false });
 
@@ -148,6 +155,26 @@ public class ProviderBillingService(
         await eventService.LogProviderOrganizationEventAsync(
             providerOrganization,
             EventType.ProviderOrganization_Added);
+
+        // Drop any stale cohort assignment after the org transition commits. Placing the
+        // cleanup here (rather than alongside Release) makes a failure here a reconciliation
+        // problem — stale assignment row — rather than a half-transitioned org. Gated on
+        // PM35215 because the cohort table is only populated when the epic is enabled.
+        // TODO(PM-37085): once Release(customerId, subscriptionId, organizationId) lands,
+        //   1) pass organization.Id as the third arg to the Release call above, and
+        //   2) delete this cohortAssignment lookup/delete block.
+        if (featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration))
+        {
+            var cohortAssignment =
+                await organizationPlanMigrationCohortAssignmentRepository.GetByOrganizationIdAsync(organization.Id);
+            if (cohortAssignment is not null)
+            {
+                await organizationPlanMigrationCohortAssignmentRepository.DeleteAsync(cohortAssignment);
+                logger.LogInformation(
+                    "Dropped plan-migration cohort assignment ({AssignmentId}) from cohort ({CohortId}) for organization ({OrganizationId}) added to provider ({ProviderId})",
+                    cohortAssignment.Id, cohortAssignment.CohortId, organization.Id, provider.Id);
+            }
+        }
     }
 
     public async Task ChangePlan(ChangeProviderPlanCommand command)

--- a/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Services/ProviderBillingServiceTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Services/ProviderBillingServiceTests.cs
@@ -29,6 +29,7 @@ using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using Braintree;
 using CsvHelper;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Stripe;
@@ -2927,6 +2928,119 @@ public class ProviderBillingServiceTests
         await providerOrganizationRepository.Received(1).CreateAsync(Arg.Any<ProviderOrganization>());
         await eventService.Received(1).LogProviderOrganizationEventAsync(
             Arg.Any<ProviderOrganization>(), EventType.ProviderOrganization_Added);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AddExistingOrganization_StripeCancelSucceeds_OnlyWhenReleasePrecedesIt(
+        Provider provider,
+        Organization organization,
+        string key,
+        SutProvider<ProviderBillingService> sutProvider)
+    {
+        // Arrange — simulates the Stripe-side contract this PR exists to satisfy:
+        // CancelSubscriptionAsync throws when an active SubscriptionSchedule is attached.
+        // The mock returns success only after Release has run; without Release, the cancel
+        // call throws the same error shape Stripe would produce in production. This locks
+        // in the "Release must precede cancel" invariant at the contract level, not just
+        // at the call-order level — a refactor that removes the Release call but preserves
+        // call order would still fail this test.
+        provider.Type = ProviderType.Msp;
+        organization.GatewayCustomerId = "cus_stripe_contract";
+        organization.GatewaySubscriptionId = "sub_stripe_contract";
+        organization.PlanType = PlanType.EnterpriseAnnually2020;
+        organization.Seats = 10;
+
+        var releaseHasRun = false;
+        var priceIncreaseScheduler = sutProvider.GetDependency<IPriceIncreaseScheduler>();
+        priceIncreaseScheduler
+            .When(s => s.Release(organization.GatewayCustomerId, organization.GatewaySubscriptionId))
+            .Do(_ => releaseHasRun = true);
+
+        var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
+        stripeAdapter
+            .CancelSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionCancelOptions>())
+            .Returns(_ => releaseHasRun
+                ? Task.FromResult(new Subscription
+                {
+                    Id = organization.GatewaySubscriptionId,
+                    LatestInvoice = new Invoice { Status = StripeConstants.InvoiceStatus.Open }
+                })
+                : Task.FromException<Subscription>(new StripeException(
+                    "This subscription is owned by an active subscription schedule.")));
+
+        sutProvider.GetDependency<IPricingClient>()
+            .GetPlanOrThrow(Arg.Any<PlanType>())
+            .Returns(MockPlans.Get(PlanType.EnterpriseMonthly));
+        sutProvider.GetDependency<IProviderPlanRepository>()
+            .GetByProviderId(provider.Id)
+            .Returns([
+                new ProviderPlan
+                {
+                    PlanType = PlanType.EnterpriseMonthly,
+                    SeatMinimum = 100,
+                    AllocatedSeats = 0,
+                    PurchasedSeats = 0
+                }
+            ]);
+        sutProvider.GetDependency<IProviderOrganizationRepository>()
+            .GetManyDetailsByProviderAsync(provider.Id)
+            .Returns([]);
+        sutProvider.GetDependency<ISubscriberService>()
+            .GetCustomer(organization)
+            .Returns(new Customer { Balance = 0 });
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration)
+            .Returns(true);
+
+        // Act — must not throw. If Release were removed or moved after Cancel, the
+        // arranged StripeException would surface and Assert.ThrowsAsync would be needed.
+        await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
+
+        // Assert — both calls fired, Release first.
+        await priceIncreaseScheduler.Received(1)
+            .Release(organization.GatewayCustomerId, "sub_stripe_contract");
+        await stripeAdapter.Received(1)
+            .CancelSubscriptionAsync("sub_stripe_contract", Arg.Any<SubscriptionCancelOptions>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task AddExistingOrganization_LogsDroppedAssignment_WithProviderAndCohortContext(
+        Provider provider,
+        Organization organization,
+        string key,
+        SutProvider<ProviderBillingService> sutProvider)
+    {
+        // Arrange — happy path with a cohort assignment present. Verifies the
+        // information log fires with the expected level when the assignment is dropped.
+        // Guards against a refactor that silently removes the operator-facing audit
+        // signal that a stale row was cleaned up.
+        provider.Type = ProviderType.Msp;
+        organization.GatewayCustomerId = "cus_log_check";
+        organization.GatewaySubscriptionId = "sub_log_check";
+        ArrangeAddExistingOrganizationHappyPath(sutProvider, provider, organization);
+
+        var assignmentRepository =
+            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
+        var existingAssignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organization.Id,
+            CohortId = Guid.NewGuid()
+        };
+        assignmentRepository.GetByOrganizationIdAsync(organization.Id).Returns(existingAssignment);
+
+        var logger = sutProvider.GetDependency<ILogger<ProviderBillingService>>();
+
+        // Act
+        await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
+
+        // Assert — exactly one Information log fired on the cohort drop path.
+        logger.Received(1).Log(
+            LogLevel.Information,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception>(),
+            Arg.Any<Func<object, Exception, string>>());
     }
 
     #endregion

--- a/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Services/ProviderBillingServiceTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Services/ProviderBillingServiceTests.cs
@@ -9,6 +9,8 @@ using Bit.Core.AdminConsole.Models.Data.Provider;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Enums;
+using Bit.Core.Billing.Organizations.PlanMigration.Entities;
+using Bit.Core.Billing.Organizations.PlanMigration.Repositories;
 using Bit.Core.Billing.Payment.Models;
 using Bit.Core.Billing.Pricing;
 using Bit.Core.Billing.Providers.Entities;
@@ -2407,6 +2409,524 @@ public class ProviderBillingServiceTests
             Arg.Is<CustomerUpdateOptions>(options =>
                 options.Email == null &&
                 options.Description == provider.Name));
+    }
+
+    #endregion
+
+    #region AddExistingOrganization
+
+    // Releasing any active migration subscription schedule before the Stripe cancel keeps
+    // 2020-plan orgs with an attached SubscriptionSchedule from tripping a Stripe-side cancel
+    // failure. The cohort assignment is dropped after the org has been fully transitioned
+    // to provider-managed, so a failure during the cleanup leaves a stale row to reconcile
+    // rather than a half-transitioned org.
+
+    private static void ArrangeAddExistingOrganizationHappyPath(
+        SutProvider<ProviderBillingService> sutProvider,
+        Provider provider,
+        Organization organization,
+        PlanType planType = PlanType.EnterpriseAnnually2020)
+    {
+        organization.PlanType = planType;
+        organization.Seats = 10;
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .CancelSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionCancelOptions>())
+            .Returns(new Subscription
+            {
+                Id = organization.GatewaySubscriptionId,
+                LatestInvoice = new Invoice { Status = StripeConstants.InvoiceStatus.Open }
+            });
+
+        sutProvider.GetDependency<IPricingClient>()
+            .GetPlanOrThrow(Arg.Any<PlanType>())
+            .Returns(MockPlans.Get(PlanType.EnterpriseMonthly));
+
+        sutProvider.GetDependency<IProviderPlanRepository>()
+            .GetByProviderId(provider.Id)
+            .Returns([
+                new ProviderPlan
+                {
+                    PlanType = PlanType.EnterpriseMonthly,
+                    SeatMinimum = 100,
+                    AllocatedSeats = 0,
+                    PurchasedSeats = 0
+                }
+            ]);
+
+        sutProvider.GetDependency<IProviderOrganizationRepository>()
+            .GetManyDetailsByProviderAsync(provider.Id)
+            .Returns([]);
+
+        sutProvider.GetDependency<ISubscriberService>()
+            .GetCustomer(organization)
+            .Returns(new Customer { Balance = 0 });
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration)
+            .Returns(true);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AddExistingOrganization_ReleasesMigrationScheduleWithOrgGatewayIds_BeforeStripeOperations(
+        Provider provider,
+        Organization organization,
+        string key,
+        SutProvider<ProviderBillingService> sutProvider)
+    {
+        // Arrange — provider and org have distinct gateway IDs so a regression that passed
+        // the provider's IDs to Release instead of the org's would fail the Received check.
+        provider.Type = ProviderType.Msp;
+        provider.GatewayCustomerId = "cus_provider_msp";
+        provider.GatewaySubscriptionId = "sub_provider_msp";
+        organization.GatewayCustomerId = "cus_org_msp";
+        organization.GatewaySubscriptionId = "sub_org_msp";
+        ArrangeAddExistingOrganizationHappyPath(sutProvider, provider, organization);
+
+        var priceIncreaseScheduler = sutProvider.GetDependency<IPriceIncreaseScheduler>();
+        var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
+        var orgCustomerId = organization.GatewayCustomerId;
+        var orgSubscriptionId = organization.GatewaySubscriptionId;
+
+        // Act
+        await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
+
+        // Assert — Release must run first, with the Organization's own gateway IDs
+        // (not the Provider's), and must precede both Stripe mutations.
+        Received.InOrder(() =>
+        {
+            priceIncreaseScheduler.Release(orgCustomerId, orgSubscriptionId);
+            stripeAdapter.UpdateSubscriptionAsync(orgSubscriptionId, Arg.Any<SubscriptionUpdateOptions>());
+            stripeAdapter.CancelSubscriptionAsync(orgSubscriptionId, Arg.Any<SubscriptionCancelOptions>());
+        });
+        await priceIncreaseScheduler.Received(1).Release(orgCustomerId, orgSubscriptionId);
+        await priceIncreaseScheduler.Received(0)
+            .Release(provider.GatewayCustomerId, Arg.Any<string>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task AddExistingOrganization_DropsCohortAssignment_AfterOrgTransitionCommits(
+        Provider provider,
+        Organization organization,
+        string key,
+        SutProvider<ProviderBillingService> sutProvider)
+    {
+        // Arrange — 2020-plan org with an existing cohort assignment.
+        provider.Type = ProviderType.Msp;
+        organization.GatewayCustomerId = "cus_with_assignment";
+        organization.GatewaySubscriptionId = "sub_with_assignment";
+        ArrangeAddExistingOrganizationHappyPath(sutProvider, provider, organization);
+
+        var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
+        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
+        var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
+        var assignmentRepository =
+            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
+        var existingAssignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organization.Id,
+            CohortId = Guid.NewGuid()
+        };
+        assignmentRepository.GetByOrganizationIdAsync(organization.Id).Returns(existingAssignment);
+        var subscriptionId = organization.GatewaySubscriptionId;
+
+        // Act
+        await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
+
+        // Assert — the assignment lookup and delete fire AFTER the org transition commits
+        // (ReplaceAsync + ProviderOrganization create). Drift in the assignment row is a
+        // reconciliation problem; a half-transitioned org is not.
+        Received.InOrder(() =>
+        {
+            stripeAdapter.CancelSubscriptionAsync(subscriptionId, Arg.Any<SubscriptionCancelOptions>());
+            organizationRepository.ReplaceAsync(organization);
+            providerOrganizationRepository.CreateAsync(Arg.Any<ProviderOrganization>());
+            assignmentRepository.GetByOrganizationIdAsync(organization.Id);
+            assignmentRepository.DeleteAsync(existingAssignment);
+        });
+        await assignmentRepository.Received(1).DeleteAsync(existingAssignment);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AddExistingOrganization_DoesNotCallDelete_AndCompletesFlow_WhenNoCohortAssignment(
+        Provider provider,
+        Organization organization,
+        string key,
+        SutProvider<ProviderBillingService> sutProvider)
+    {
+        // Arrange — org with no cohort assignment (the common case).
+        provider.Type = ProviderType.Msp;
+        organization.GatewayCustomerId = "cus_no_assignment";
+        organization.GatewaySubscriptionId = "sub_no_assignment";
+        ArrangeAddExistingOrganizationHappyPath(sutProvider, provider, organization);
+
+        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
+        var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
+        var eventService = sutProvider.GetDependency<IEventService>();
+        var assignmentRepository =
+            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
+        assignmentRepository.GetByOrganizationIdAsync(organization.Id)
+            .Returns((OrganizationPlanMigrationCohortAssignment?)null);
+
+        // Act
+        await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
+
+        // Assert — no delete fired, and the rest of the flow ran to completion.
+        await assignmentRepository.Received(0)
+            .DeleteAsync(Arg.Any<OrganizationPlanMigrationCohortAssignment>());
+        await organizationRepository.Received(1).ReplaceAsync(organization);
+        await providerOrganizationRepository.Received(1).CreateAsync(Arg.Is<ProviderOrganization>(po =>
+            po.ProviderId == provider.Id && po.OrganizationId == organization.Id && po.Key == key));
+        await eventService.Received(1).LogProviderOrganizationEventAsync(
+            Arg.Is<ProviderOrganization>(po => po.OrganizationId == organization.Id),
+            EventType.ProviderOrganization_Added);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AddExistingOrganization_ContinuesEntireFlow_AfterReleaseSucceeds(
+        Provider provider,
+        Organization organization,
+        string key,
+        SutProvider<ProviderBillingService> sutProvider)
+    {
+        // Arrange
+        provider.Type = ProviderType.Msp;
+        organization.GatewayCustomerId = "cus_full_flow";
+        organization.GatewaySubscriptionId = "sub_full_flow";
+        ArrangeAddExistingOrganizationHappyPath(sutProvider, provider, organization);
+
+        var priceIncreaseScheduler = sutProvider.GetDependency<IPriceIncreaseScheduler>();
+        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
+        var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
+        var eventService = sutProvider.GetDependency<IEventService>();
+        // Capture before Act — AddExistingOrganization clears GatewaySubscriptionId
+        // on the entity as part of the transition to provider-managed.
+        var customerId = organization.GatewayCustomerId;
+        var subscriptionId = organization.GatewaySubscriptionId;
+
+        // Act
+        await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
+
+        // Assert
+        await priceIncreaseScheduler.Received(1).Release(customerId, subscriptionId);
+        await organizationRepository.Received(1).ReplaceAsync(organization);
+        await providerOrganizationRepository.Received(1).CreateAsync(Arg.Is<ProviderOrganization>(po =>
+            po.ProviderId == provider.Id && po.OrganizationId == organization.Id && po.Key == key));
+        await eventService.Received(1).LogProviderOrganizationEventAsync(
+            Arg.Is<ProviderOrganization>(po => po.OrganizationId == organization.Id),
+            EventType.ProviderOrganization_Added);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AddExistingOrganization_DropsCohortAssignmentAndCompletes_ForMoeProvider(
+        Provider provider,
+        Organization organization,
+        string key,
+        SutProvider<ProviderBillingService> sutProvider)
+    {
+        // Arrange — same flow under a BusinessUnit (MOE) provider, with an existing
+        // cohort assignment. Exercises the BusinessUnit branch of GetManagedPlanTypeAsync
+        // and confirms the cohort drop applies regardless of provider type.
+        //
+        // The discriminating setup: provider plan is TeamsMonthly while the org is on
+        // EnterpriseAnnually2020. The MSP switch would map EnterpriseAnnually2020 →
+        // EnterpriseMonthly, so a final PlanType of TeamsMonthly can only have come
+        // from the BusinessUnit branch reading the provider's first plan. Without this
+        // mismatch, deleting the entire BusinessUnit branch would still pass the test.
+        provider.Type = ProviderType.BusinessUnit;
+        organization.GatewayCustomerId = "cus_moe_baseline";
+        organization.GatewaySubscriptionId = "sub_moe_baseline";
+        ArrangeAddExistingOrganizationHappyPath(sutProvider, provider, organization);
+
+        sutProvider.GetDependency<IProviderPlanRepository>()
+            .GetByProviderId(provider.Id)
+            .Returns([
+                new ProviderPlan
+                {
+                    PlanType = PlanType.TeamsMonthly,
+                    SeatMinimum = 100,
+                    AllocatedSeats = 0,
+                    PurchasedSeats = 0
+                }
+            ]);
+        sutProvider.GetDependency<IPricingClient>()
+            .GetPlanOrThrow(PlanType.TeamsMonthly)
+            .Returns(MockPlans.Get(PlanType.TeamsMonthly));
+
+        var priceIncreaseScheduler = sutProvider.GetDependency<IPriceIncreaseScheduler>();
+        var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
+        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
+        var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
+        var assignmentRepository =
+            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
+        var existingAssignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organization.Id,
+            CohortId = Guid.NewGuid()
+        };
+        assignmentRepository.GetByOrganizationIdAsync(organization.Id).Returns(existingAssignment);
+        var customerId = organization.GatewayCustomerId;
+        var subscriptionId = organization.GatewaySubscriptionId;
+
+        // Act
+        await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
+
+        // Assert — Release-before-Stripe ordering is preserved, the cohort assignment is
+        // dropped only after the org transition commits, and the org lands on the
+        // provider's first plan (TeamsMonthly) — proving the BusinessUnit branch ran.
+        Received.InOrder(() =>
+        {
+            priceIncreaseScheduler.Release(customerId, subscriptionId);
+            stripeAdapter.UpdateSubscriptionAsync(subscriptionId, Arg.Any<SubscriptionUpdateOptions>());
+            stripeAdapter.CancelSubscriptionAsync(subscriptionId, Arg.Any<SubscriptionCancelOptions>());
+            organizationRepository.ReplaceAsync(organization);
+            providerOrganizationRepository.CreateAsync(Arg.Any<ProviderOrganization>());
+            assignmentRepository.DeleteAsync(existingAssignment);
+        });
+        await priceIncreaseScheduler.Received(1).Release(customerId, subscriptionId);
+        await assignmentRepository.Received(1).DeleteAsync(existingAssignment);
+        await organizationRepository.Received(1).ReplaceAsync(Arg.Is<Organization>(o =>
+            o.Id == organization.Id && o.PlanType == PlanType.TeamsMonthly));
+    }
+
+    [Theory, BitAutoData]
+    public async Task AddExistingOrganization_DoesNotDropAssignment_ForCurrentGenOrg(
+        Provider provider,
+        Organization organization,
+        string key,
+        SutProvider<ProviderBillingService> sutProvider)
+    {
+        // Arrange — current-gen plan with no cohort assignment. Release still runs (the
+        // production code calls it unconditionally; Release itself no-ops when no active
+        // schedule exists), but no assignment row exists so DeleteAsync must not fire.
+        provider.Type = ProviderType.Msp;
+        organization.GatewayCustomerId = "cus_current_gen";
+        organization.GatewaySubscriptionId = "sub_current_gen";
+        ArrangeAddExistingOrganizationHappyPath(
+            sutProvider, provider, organization, PlanType.EnterpriseAnnually);
+
+        var priceIncreaseScheduler = sutProvider.GetDependency<IPriceIncreaseScheduler>();
+        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
+        var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
+        var assignmentRepository =
+            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
+        assignmentRepository.GetByOrganizationIdAsync(organization.Id)
+            .Returns((OrganizationPlanMigrationCohortAssignment?)null);
+        var customerId = organization.GatewayCustomerId;
+        var subscriptionId = organization.GatewaySubscriptionId;
+
+        // Act
+        await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
+
+        // Assert — Release was called, no assignment was deleted, the rest of the flow
+        // ran to completion.
+        await priceIncreaseScheduler.Received(1).Release(customerId, subscriptionId);
+        await assignmentRepository.Received(0)
+            .DeleteAsync(Arg.Any<OrganizationPlanMigrationCohortAssignment>());
+        await organizationRepository.Received(1).ReplaceAsync(organization);
+        await providerOrganizationRepository.Received(1).CreateAsync(Arg.Any<ProviderOrganization>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task AddExistingOrganization_DropsStaleAssignment_ForCurrentGenOrg(
+        Provider provider,
+        Organization organization,
+        string key,
+        SutProvider<ProviderBillingService> sutProvider)
+    {
+        // Arrange — current-gen plan that nevertheless has a stale cohort assignment row
+        // (e.g., from a prior failed flow). The cohort drop is independent of plan tier;
+        // the assignment must still be deleted so reconciliation stays clean.
+        //
+        // Guards against a future "optimization" that gates the assignment lookup behind
+        // a plan-type check — that would silently leak stale rows for data-drift cases.
+        provider.Type = ProviderType.Msp;
+        organization.GatewayCustomerId = "cus_current_gen_stale";
+        organization.GatewaySubscriptionId = "sub_current_gen_stale";
+        ArrangeAddExistingOrganizationHappyPath(
+            sutProvider, provider, organization, PlanType.EnterpriseAnnually);
+
+        var assignmentRepository =
+            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
+        var staleAssignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organization.Id,
+            CohortId = Guid.NewGuid()
+        };
+        assignmentRepository.GetByOrganizationIdAsync(organization.Id).Returns(staleAssignment);
+
+        // Act
+        await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
+
+        // Assert — stale assignment row is dropped regardless of the org's plan tier.
+        await assignmentRepository.Received(1).DeleteAsync(staleAssignment);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AddExistingOrganization_SkipsCohortCleanup_WhenBusinessPlanMigrationFlagOff(
+        Provider provider,
+        Organization organization,
+        string key,
+        SutProvider<ProviderBillingService> sutProvider)
+    {
+        // Arrange — PM-35215 OFF. The cohort assignment table only gets populated when the
+        // epic is enabled, so we skip the lookup entirely. Even if a stale row exists, it
+        // must not be touched while the flag is off (and the rest of the flow completes).
+        provider.Type = ProviderType.Msp;
+        organization.GatewayCustomerId = "cus_ff_off";
+        organization.GatewaySubscriptionId = "sub_ff_off";
+        ArrangeAddExistingOrganizationHappyPath(sutProvider, provider, organization);
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration)
+            .Returns(false);
+
+        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
+        var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
+        var assignmentRepository =
+            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
+        var staleAssignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organization.Id,
+            CohortId = Guid.NewGuid()
+        };
+        assignmentRepository.GetByOrganizationIdAsync(organization.Id).Returns(staleAssignment);
+
+        // Act
+        await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
+
+        // Assert — no cohort I/O happened, and the rest of the flow ran to completion.
+        await assignmentRepository.Received(0).GetByOrganizationIdAsync(Arg.Any<Guid>());
+        await assignmentRepository.Received(0)
+            .DeleteAsync(Arg.Any<OrganizationPlanMigrationCohortAssignment>());
+        await organizationRepository.Received(1).ReplaceAsync(organization);
+        await providerOrganizationRepository.Received(1).CreateAsync(Arg.Any<ProviderOrganization>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task AddExistingOrganization_PropagatesAndShortCircuits_WhenReleaseFails(
+        Provider provider,
+        Organization organization,
+        string key,
+        SutProvider<ProviderBillingService> sutProvider)
+    {
+        // Arrange — Release throws before any other I/O. No Stripe cancel, no repo writes,
+        // no assignment lookup should fire.
+        provider.Type = ProviderType.Msp;
+        organization.GatewayCustomerId = "cus_release_fails";
+        organization.GatewaySubscriptionId = "sub_release_fails";
+
+        var priceIncreaseScheduler = sutProvider.GetDependency<IPriceIncreaseScheduler>();
+        var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
+        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
+        var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
+        var eventService = sutProvider.GetDependency<IEventService>();
+        var assignmentRepository =
+            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
+        var subscriptionId = organization.GatewaySubscriptionId;
+
+        priceIncreaseScheduler
+            .Release(organization.GatewayCustomerId, subscriptionId)
+            .ThrowsAsync(new StripeException("simulated release failure"));
+
+        // Act
+        await Assert.ThrowsAsync<StripeException>(() =>
+            sutProvider.Sut.AddExistingOrganization(provider, organization, key));
+
+        // Assert — nothing downstream of Release fired.
+        await stripeAdapter.Received(0)
+            .UpdateSubscriptionAsync(subscriptionId, Arg.Any<SubscriptionUpdateOptions>());
+        await stripeAdapter.Received(0)
+            .CancelSubscriptionAsync(subscriptionId, Arg.Any<SubscriptionCancelOptions>());
+        await organizationRepository.Received(0).ReplaceAsync(Arg.Any<Organization>());
+        await providerOrganizationRepository.Received(0).CreateAsync(Arg.Any<ProviderOrganization>());
+        await eventService.Received(0).LogProviderOrganizationEventAsync(
+            Arg.Any<ProviderOrganization>(), Arg.Any<EventType>());
+        await assignmentRepository.Received(0).GetByOrganizationIdAsync(Arg.Any<Guid>());
+        await assignmentRepository.Received(0)
+            .DeleteAsync(Arg.Any<OrganizationPlanMigrationCohortAssignment>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task AddExistingOrganization_CompletesOrgTransition_BeforeAssignmentLookupFails(
+        Provider provider,
+        Organization organization,
+        string key,
+        SutProvider<ProviderBillingService> sutProvider)
+    {
+        // Arrange — Stripe cancel succeeds and the org transition commits (ReplaceAsync
+        // + ProviderOrganization create + event log) before the assignment lookup runs.
+        // The lookup then throws. The exception must propagate, but the org transition
+        // has already happened — the failure leaves a stale assignment row to reconcile,
+        // not a half-transitioned org.
+        provider.Type = ProviderType.Msp;
+        organization.GatewayCustomerId = "cus_get_fails";
+        organization.GatewaySubscriptionId = "sub_get_fails";
+        ArrangeAddExistingOrganizationHappyPath(sutProvider, provider, organization);
+
+        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
+        var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
+        var eventService = sutProvider.GetDependency<IEventService>();
+        var assignmentRepository =
+            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
+        assignmentRepository.GetByOrganizationIdAsync(organization.Id)
+            .ThrowsAsync(new InvalidOperationException("simulated repo failure"));
+
+        // Act
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sutProvider.Sut.AddExistingOrganization(provider, organization, key));
+
+        // Assert — the org transition committed before the lookup threw.
+        await organizationRepository.Received(1).ReplaceAsync(organization);
+        await providerOrganizationRepository.Received(1).CreateAsync(Arg.Any<ProviderOrganization>());
+        await eventService.Received(1).LogProviderOrganizationEventAsync(
+            Arg.Any<ProviderOrganization>(), EventType.ProviderOrganization_Added);
+        await assignmentRepository.Received(0)
+            .DeleteAsync(Arg.Any<OrganizationPlanMigrationCohortAssignment>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task AddExistingOrganization_CompletesOrgTransition_BeforeDeleteAssignmentFails(
+        Provider provider,
+        Organization organization,
+        string key,
+        SutProvider<ProviderBillingService> sutProvider)
+    {
+        // Arrange — DeleteAsync throws after the org transition has already committed.
+        // The org is already provider-managed; the failed cleanup just leaves a stale
+        // assignment row to reconcile.
+        provider.Type = ProviderType.Msp;
+        organization.GatewayCustomerId = "cus_delete_fails";
+        organization.GatewaySubscriptionId = "sub_delete_fails";
+        ArrangeAddExistingOrganizationHappyPath(sutProvider, provider, organization);
+
+        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
+        var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
+        var eventService = sutProvider.GetDependency<IEventService>();
+        var assignmentRepository =
+            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
+        var existingAssignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organization.Id,
+            CohortId = Guid.NewGuid()
+        };
+        assignmentRepository.GetByOrganizationIdAsync(organization.Id).Returns(existingAssignment);
+        assignmentRepository.DeleteAsync(existingAssignment)
+            .ThrowsAsync(new InvalidOperationException("simulated repo failure"));
+
+        // Act
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sutProvider.Sut.AddExistingOrganization(provider, organization, key));
+
+        // Assert — the org transition committed before DeleteAsync threw.
+        await organizationRepository.Received(1).ReplaceAsync(organization);
+        await providerOrganizationRepository.Received(1).CreateAsync(Arg.Any<ProviderOrganization>());
+        await eventService.Received(1).LogProviderOrganizationEventAsync(
+            Arg.Any<ProviderOrganization>(), EventType.ProviderOrganization_Added);
     }
 
     #endregion

--- a/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Services/ProviderBillingServiceTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Services/ProviderBillingServiceTests.cs
@@ -9,8 +9,6 @@ using Bit.Core.AdminConsole.Models.Data.Provider;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Enums;
-using Bit.Core.Billing.Organizations.PlanMigration.Entities;
-using Bit.Core.Billing.Organizations.PlanMigration.Repositories;
 using Bit.Core.Billing.Payment.Models;
 using Bit.Core.Billing.Pricing;
 using Bit.Core.Billing.Providers.Entities;
@@ -29,7 +27,6 @@ using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using Braintree;
 using CsvHelper;
-using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Stripe;
@@ -2418,9 +2415,9 @@ public class ProviderBillingServiceTests
 
     // Releasing any active migration subscription schedule before the Stripe cancel keeps
     // 2020-plan orgs with an attached SubscriptionSchedule from tripping a Stripe-side cancel
-    // failure. The cohort assignment is dropped after the org has been fully transitioned
-    // to provider-managed, so a failure during the cleanup leaves a stale row to reconcile
-    // rather than a half-transitioned org.
+    // failure. Dropping the org's migration cohort assignment is delegated to Release by
+    // passing organization.Id; the assignment-cleanup behavior itself is owned and covered by
+    // PriceIncreaseScheduler.Release (see PriceIncreaseSchedulerTests).
 
     private static void ArrangeAddExistingOrganizationHappyPath(
         SutProvider<ProviderBillingService> sutProvider,
@@ -2462,10 +2459,6 @@ public class ProviderBillingServiceTests
         sutProvider.GetDependency<ISubscriberService>()
             .GetCustomer(organization)
             .Returns(new Customer { Balance = 0 });
-
-        sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration)
-            .Returns(true);
     }
 
     [Theory, BitAutoData]
@@ -2488,100 +2481,60 @@ public class ProviderBillingServiceTests
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
         var orgCustomerId = organization.GatewayCustomerId;
         var orgSubscriptionId = organization.GatewaySubscriptionId;
+        var orgId = organization.Id;
 
         // Act
         await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
 
-        // Assert — Release must run first, with the Organization's own gateway IDs
-        // (not the Provider's), and must precede both Stripe mutations.
+        // Assert — Release must run first, with the Organization's own gateway IDs and its
+        // own Id (not the Provider's), and must precede both Stripe mutations. Passing
+        // organization.Id is what delegates the migration cohort cleanup to Release.
         Received.InOrder(() =>
         {
-            priceIncreaseScheduler.Release(orgCustomerId, orgSubscriptionId);
+            priceIncreaseScheduler.Release(orgCustomerId, orgSubscriptionId, orgId);
             stripeAdapter.UpdateSubscriptionAsync(orgSubscriptionId, Arg.Any<SubscriptionUpdateOptions>());
             stripeAdapter.CancelSubscriptionAsync(orgSubscriptionId, Arg.Any<SubscriptionCancelOptions>());
         });
-        await priceIncreaseScheduler.Received(1).Release(orgCustomerId, orgSubscriptionId);
+        await priceIncreaseScheduler.Received(1).Release(orgCustomerId, orgSubscriptionId, orgId);
         await priceIncreaseScheduler.Received(0)
-            .Release(provider.GatewayCustomerId, Arg.Any<string>());
+            .Release(provider.GatewayCustomerId, Arg.Any<string>(), Arg.Any<Guid?>());
     }
 
     [Theory, BitAutoData]
-    public async Task AddExistingOrganization_DropsCohortAssignment_AfterOrgTransitionCommits(
+    public async Task AddExistingOrganization_DelegatesCohortCleanupToRelease_AfterStripeCancel(
         Provider provider,
         Organization organization,
         string key,
         SutProvider<ProviderBillingService> sutProvider)
     {
-        // Arrange — 2020-plan org with an existing cohort assignment.
+        // Arrange — 2020-plan org. The service no longer touches the cohort assignment
+        // repository directly; it hands organization.Id to Release, which owns the cleanup.
         provider.Type = ProviderType.Msp;
         organization.GatewayCustomerId = "cus_with_assignment";
         organization.GatewaySubscriptionId = "sub_with_assignment";
         ArrangeAddExistingOrganizationHappyPath(sutProvider, provider, organization);
 
+        var priceIncreaseScheduler = sutProvider.GetDependency<IPriceIncreaseScheduler>();
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
         var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
         var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
-        var assignmentRepository =
-            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
-        var existingAssignment = new OrganizationPlanMigrationCohortAssignment
-        {
-            Id = Guid.NewGuid(),
-            OrganizationId = organization.Id,
-            CohortId = Guid.NewGuid()
-        };
-        assignmentRepository.GetByOrganizationIdAsync(organization.Id).Returns(existingAssignment);
+        var customerId = organization.GatewayCustomerId;
         var subscriptionId = organization.GatewaySubscriptionId;
+        var orgId = organization.Id;
 
         // Act
         await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
 
-        // Assert — the assignment lookup and delete fire AFTER the org transition commits
-        // (ReplaceAsync + ProviderOrganization create). Drift in the assignment row is a
-        // reconciliation problem; a half-transitioned org is not.
+        // Assert — Release is invoked once with organization.Id (delegating cohort cleanup)
+        // before the Stripe cancel and the org-transition writes.
         Received.InOrder(() =>
         {
+            priceIncreaseScheduler.Release(customerId, subscriptionId, orgId);
             stripeAdapter.CancelSubscriptionAsync(subscriptionId, Arg.Any<SubscriptionCancelOptions>());
             organizationRepository.ReplaceAsync(organization);
             providerOrganizationRepository.CreateAsync(Arg.Any<ProviderOrganization>());
-            assignmentRepository.GetByOrganizationIdAsync(organization.Id);
-            assignmentRepository.DeleteAsync(existingAssignment);
         });
-        await assignmentRepository.Received(1).DeleteAsync(existingAssignment);
-    }
-
-    [Theory, BitAutoData]
-    public async Task AddExistingOrganization_DoesNotCallDelete_AndCompletesFlow_WhenNoCohortAssignment(
-        Provider provider,
-        Organization organization,
-        string key,
-        SutProvider<ProviderBillingService> sutProvider)
-    {
-        // Arrange — org with no cohort assignment (the common case).
-        provider.Type = ProviderType.Msp;
-        organization.GatewayCustomerId = "cus_no_assignment";
-        organization.GatewaySubscriptionId = "sub_no_assignment";
-        ArrangeAddExistingOrganizationHappyPath(sutProvider, provider, organization);
-
-        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
-        var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
-        var eventService = sutProvider.GetDependency<IEventService>();
-        var assignmentRepository =
-            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
-        assignmentRepository.GetByOrganizationIdAsync(organization.Id)
-            .Returns((OrganizationPlanMigrationCohortAssignment?)null);
-
-        // Act
-        await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
-
-        // Assert — no delete fired, and the rest of the flow ran to completion.
-        await assignmentRepository.Received(0)
-            .DeleteAsync(Arg.Any<OrganizationPlanMigrationCohortAssignment>());
-        await organizationRepository.Received(1).ReplaceAsync(organization);
-        await providerOrganizationRepository.Received(1).CreateAsync(Arg.Is<ProviderOrganization>(po =>
-            po.ProviderId == provider.Id && po.OrganizationId == organization.Id && po.Key == key));
-        await eventService.Received(1).LogProviderOrganizationEventAsync(
-            Arg.Is<ProviderOrganization>(po => po.OrganizationId == organization.Id),
-            EventType.ProviderOrganization_Added);
+        await priceIncreaseScheduler.Received(1).Release(customerId, subscriptionId, orgId);
     }
 
     [Theory, BitAutoData]
@@ -2605,12 +2558,13 @@ public class ProviderBillingServiceTests
         // on the entity as part of the transition to provider-managed.
         var customerId = organization.GatewayCustomerId;
         var subscriptionId = organization.GatewaySubscriptionId;
+        var orgId = organization.Id;
 
         // Act
         await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
 
         // Assert
-        await priceIncreaseScheduler.Received(1).Release(customerId, subscriptionId);
+        await priceIncreaseScheduler.Received(1).Release(customerId, subscriptionId, orgId);
         await organizationRepository.Received(1).ReplaceAsync(organization);
         await providerOrganizationRepository.Received(1).CreateAsync(Arg.Is<ProviderOrganization>(po =>
             po.ProviderId == provider.Id && po.OrganizationId == organization.Id && po.Key == key));
@@ -2620,15 +2574,15 @@ public class ProviderBillingServiceTests
     }
 
     [Theory, BitAutoData]
-    public async Task AddExistingOrganization_DropsCohortAssignmentAndCompletes_ForMoeProvider(
+    public async Task AddExistingOrganization_CompletesAndDelegatesCohortCleanup_ForMoeProvider(
         Provider provider,
         Organization organization,
         string key,
         SutProvider<ProviderBillingService> sutProvider)
     {
-        // Arrange — same flow under a BusinessUnit (MOE) provider, with an existing
-        // cohort assignment. Exercises the BusinessUnit branch of GetManagedPlanTypeAsync
-        // and confirms the cohort drop applies regardless of provider type.
+        // Arrange — same flow under a BusinessUnit (MOE) provider. Exercises the
+        // BusinessUnit branch of GetManagedPlanTypeAsync and confirms Release receives
+        // organization.Id (delegating cohort cleanup) regardless of provider type.
         //
         // The discriminating setup: provider plan is TeamsMonthly while the org is on
         // EnterpriseAnnually2020. The MSP switch would map EnterpriseAnnually2020 →
@@ -2659,152 +2613,27 @@ public class ProviderBillingServiceTests
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
         var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
         var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
-        var assignmentRepository =
-            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
-        var existingAssignment = new OrganizationPlanMigrationCohortAssignment
-        {
-            Id = Guid.NewGuid(),
-            OrganizationId = organization.Id,
-            CohortId = Guid.NewGuid()
-        };
-        assignmentRepository.GetByOrganizationIdAsync(organization.Id).Returns(existingAssignment);
         var customerId = organization.GatewayCustomerId;
         var subscriptionId = organization.GatewaySubscriptionId;
+        var orgId = organization.Id;
 
         // Act
         await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
 
-        // Assert — Release-before-Stripe ordering is preserved, the cohort assignment is
-        // dropped only after the org transition commits, and the org lands on the
-        // provider's first plan (TeamsMonthly) — proving the BusinessUnit branch ran.
+        // Assert — Release (with organization.Id) precedes the Stripe operations and the
+        // org transition commits, and the org lands on the provider's first plan
+        // (TeamsMonthly) — proving the BusinessUnit branch ran.
         Received.InOrder(() =>
         {
-            priceIncreaseScheduler.Release(customerId, subscriptionId);
+            priceIncreaseScheduler.Release(customerId, subscriptionId, orgId);
             stripeAdapter.UpdateSubscriptionAsync(subscriptionId, Arg.Any<SubscriptionUpdateOptions>());
             stripeAdapter.CancelSubscriptionAsync(subscriptionId, Arg.Any<SubscriptionCancelOptions>());
             organizationRepository.ReplaceAsync(organization);
             providerOrganizationRepository.CreateAsync(Arg.Any<ProviderOrganization>());
-            assignmentRepository.DeleteAsync(existingAssignment);
         });
-        await priceIncreaseScheduler.Received(1).Release(customerId, subscriptionId);
-        await assignmentRepository.Received(1).DeleteAsync(existingAssignment);
+        await priceIncreaseScheduler.Received(1).Release(customerId, subscriptionId, orgId);
         await organizationRepository.Received(1).ReplaceAsync(Arg.Is<Organization>(o =>
             o.Id == organization.Id && o.PlanType == PlanType.TeamsMonthly));
-    }
-
-    [Theory, BitAutoData]
-    public async Task AddExistingOrganization_DoesNotDropAssignment_ForCurrentGenOrg(
-        Provider provider,
-        Organization organization,
-        string key,
-        SutProvider<ProviderBillingService> sutProvider)
-    {
-        // Arrange — current-gen plan with no cohort assignment. Release still runs (the
-        // production code calls it unconditionally; Release itself no-ops when no active
-        // schedule exists), but no assignment row exists so DeleteAsync must not fire.
-        provider.Type = ProviderType.Msp;
-        organization.GatewayCustomerId = "cus_current_gen";
-        organization.GatewaySubscriptionId = "sub_current_gen";
-        ArrangeAddExistingOrganizationHappyPath(
-            sutProvider, provider, organization, PlanType.EnterpriseAnnually);
-
-        var priceIncreaseScheduler = sutProvider.GetDependency<IPriceIncreaseScheduler>();
-        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
-        var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
-        var assignmentRepository =
-            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
-        assignmentRepository.GetByOrganizationIdAsync(organization.Id)
-            .Returns((OrganizationPlanMigrationCohortAssignment?)null);
-        var customerId = organization.GatewayCustomerId;
-        var subscriptionId = organization.GatewaySubscriptionId;
-
-        // Act
-        await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
-
-        // Assert — Release was called, no assignment was deleted, the rest of the flow
-        // ran to completion.
-        await priceIncreaseScheduler.Received(1).Release(customerId, subscriptionId);
-        await assignmentRepository.Received(0)
-            .DeleteAsync(Arg.Any<OrganizationPlanMigrationCohortAssignment>());
-        await organizationRepository.Received(1).ReplaceAsync(organization);
-        await providerOrganizationRepository.Received(1).CreateAsync(Arg.Any<ProviderOrganization>());
-    }
-
-    [Theory, BitAutoData]
-    public async Task AddExistingOrganization_DropsStaleAssignment_ForCurrentGenOrg(
-        Provider provider,
-        Organization organization,
-        string key,
-        SutProvider<ProviderBillingService> sutProvider)
-    {
-        // Arrange — current-gen plan that nevertheless has a stale cohort assignment row
-        // (e.g., from a prior failed flow). The cohort drop is independent of plan tier;
-        // the assignment must still be deleted so reconciliation stays clean.
-        //
-        // Guards against a future "optimization" that gates the assignment lookup behind
-        // a plan-type check — that would silently leak stale rows for data-drift cases.
-        provider.Type = ProviderType.Msp;
-        organization.GatewayCustomerId = "cus_current_gen_stale";
-        organization.GatewaySubscriptionId = "sub_current_gen_stale";
-        ArrangeAddExistingOrganizationHappyPath(
-            sutProvider, provider, organization, PlanType.EnterpriseAnnually);
-
-        var assignmentRepository =
-            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
-        var staleAssignment = new OrganizationPlanMigrationCohortAssignment
-        {
-            Id = Guid.NewGuid(),
-            OrganizationId = organization.Id,
-            CohortId = Guid.NewGuid()
-        };
-        assignmentRepository.GetByOrganizationIdAsync(organization.Id).Returns(staleAssignment);
-
-        // Act
-        await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
-
-        // Assert — stale assignment row is dropped regardless of the org's plan tier.
-        await assignmentRepository.Received(1).DeleteAsync(staleAssignment);
-    }
-
-    [Theory, BitAutoData]
-    public async Task AddExistingOrganization_SkipsCohortCleanup_WhenBusinessPlanMigrationFlagOff(
-        Provider provider,
-        Organization organization,
-        string key,
-        SutProvider<ProviderBillingService> sutProvider)
-    {
-        // Arrange — PM-35215 OFF. The cohort assignment table only gets populated when the
-        // epic is enabled, so we skip the lookup entirely. Even if a stale row exists, it
-        // must not be touched while the flag is off (and the rest of the flow completes).
-        provider.Type = ProviderType.Msp;
-        organization.GatewayCustomerId = "cus_ff_off";
-        organization.GatewaySubscriptionId = "sub_ff_off";
-        ArrangeAddExistingOrganizationHappyPath(sutProvider, provider, organization);
-        sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration)
-            .Returns(false);
-
-        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
-        var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
-        var assignmentRepository =
-            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
-        var staleAssignment = new OrganizationPlanMigrationCohortAssignment
-        {
-            Id = Guid.NewGuid(),
-            OrganizationId = organization.Id,
-            CohortId = Guid.NewGuid()
-        };
-        assignmentRepository.GetByOrganizationIdAsync(organization.Id).Returns(staleAssignment);
-
-        // Act
-        await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
-
-        // Assert — no cohort I/O happened, and the rest of the flow ran to completion.
-        await assignmentRepository.Received(0).GetByOrganizationIdAsync(Arg.Any<Guid>());
-        await assignmentRepository.Received(0)
-            .DeleteAsync(Arg.Any<OrganizationPlanMigrationCohortAssignment>());
-        await organizationRepository.Received(1).ReplaceAsync(organization);
-        await providerOrganizationRepository.Received(1).CreateAsync(Arg.Any<ProviderOrganization>());
     }
 
     [Theory, BitAutoData]
@@ -2815,7 +2644,7 @@ public class ProviderBillingServiceTests
         SutProvider<ProviderBillingService> sutProvider)
     {
         // Arrange — Release throws before any other I/O. No Stripe cancel, no repo writes,
-        // no assignment lookup should fire.
+        // no event log should fire.
         provider.Type = ProviderType.Msp;
         organization.GatewayCustomerId = "cus_release_fails";
         organization.GatewaySubscriptionId = "sub_release_fails";
@@ -2825,12 +2654,10 @@ public class ProviderBillingServiceTests
         var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
         var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
         var eventService = sutProvider.GetDependency<IEventService>();
-        var assignmentRepository =
-            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
         var subscriptionId = organization.GatewaySubscriptionId;
 
         priceIncreaseScheduler
-            .Release(organization.GatewayCustomerId, subscriptionId)
+            .Release(organization.GatewayCustomerId, subscriptionId, organization.Id)
             .ThrowsAsync(new StripeException("simulated release failure"));
 
         // Act
@@ -2846,88 +2673,6 @@ public class ProviderBillingServiceTests
         await providerOrganizationRepository.Received(0).CreateAsync(Arg.Any<ProviderOrganization>());
         await eventService.Received(0).LogProviderOrganizationEventAsync(
             Arg.Any<ProviderOrganization>(), Arg.Any<EventType>());
-        await assignmentRepository.Received(0).GetByOrganizationIdAsync(Arg.Any<Guid>());
-        await assignmentRepository.Received(0)
-            .DeleteAsync(Arg.Any<OrganizationPlanMigrationCohortAssignment>());
-    }
-
-    [Theory, BitAutoData]
-    public async Task AddExistingOrganization_CompletesOrgTransition_BeforeAssignmentLookupFails(
-        Provider provider,
-        Organization organization,
-        string key,
-        SutProvider<ProviderBillingService> sutProvider)
-    {
-        // Arrange — Stripe cancel succeeds and the org transition commits (ReplaceAsync
-        // + ProviderOrganization create + event log) before the assignment lookup runs.
-        // The lookup then throws. The exception must propagate, but the org transition
-        // has already happened — the failure leaves a stale assignment row to reconcile,
-        // not a half-transitioned org.
-        provider.Type = ProviderType.Msp;
-        organization.GatewayCustomerId = "cus_get_fails";
-        organization.GatewaySubscriptionId = "sub_get_fails";
-        ArrangeAddExistingOrganizationHappyPath(sutProvider, provider, organization);
-
-        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
-        var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
-        var eventService = sutProvider.GetDependency<IEventService>();
-        var assignmentRepository =
-            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
-        assignmentRepository.GetByOrganizationIdAsync(organization.Id)
-            .ThrowsAsync(new InvalidOperationException("simulated repo failure"));
-
-        // Act
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            sutProvider.Sut.AddExistingOrganization(provider, organization, key));
-
-        // Assert — the org transition committed before the lookup threw.
-        await organizationRepository.Received(1).ReplaceAsync(organization);
-        await providerOrganizationRepository.Received(1).CreateAsync(Arg.Any<ProviderOrganization>());
-        await eventService.Received(1).LogProviderOrganizationEventAsync(
-            Arg.Any<ProviderOrganization>(), EventType.ProviderOrganization_Added);
-        await assignmentRepository.Received(0)
-            .DeleteAsync(Arg.Any<OrganizationPlanMigrationCohortAssignment>());
-    }
-
-    [Theory, BitAutoData]
-    public async Task AddExistingOrganization_CompletesOrgTransition_BeforeDeleteAssignmentFails(
-        Provider provider,
-        Organization organization,
-        string key,
-        SutProvider<ProviderBillingService> sutProvider)
-    {
-        // Arrange — DeleteAsync throws after the org transition has already committed.
-        // The org is already provider-managed; the failed cleanup just leaves a stale
-        // assignment row to reconcile.
-        provider.Type = ProviderType.Msp;
-        organization.GatewayCustomerId = "cus_delete_fails";
-        organization.GatewaySubscriptionId = "sub_delete_fails";
-        ArrangeAddExistingOrganizationHappyPath(sutProvider, provider, organization);
-
-        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
-        var providerOrganizationRepository = sutProvider.GetDependency<IProviderOrganizationRepository>();
-        var eventService = sutProvider.GetDependency<IEventService>();
-        var assignmentRepository =
-            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
-        var existingAssignment = new OrganizationPlanMigrationCohortAssignment
-        {
-            Id = Guid.NewGuid(),
-            OrganizationId = organization.Id,
-            CohortId = Guid.NewGuid()
-        };
-        assignmentRepository.GetByOrganizationIdAsync(organization.Id).Returns(existingAssignment);
-        assignmentRepository.DeleteAsync(existingAssignment)
-            .ThrowsAsync(new InvalidOperationException("simulated repo failure"));
-
-        // Act
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            sutProvider.Sut.AddExistingOrganization(provider, organization, key));
-
-        // Assert — the org transition committed before DeleteAsync threw.
-        await organizationRepository.Received(1).ReplaceAsync(organization);
-        await providerOrganizationRepository.Received(1).CreateAsync(Arg.Any<ProviderOrganization>());
-        await eventService.Received(1).LogProviderOrganizationEventAsync(
-            Arg.Any<ProviderOrganization>(), EventType.ProviderOrganization_Added);
     }
 
     [Theory, BitAutoData]
@@ -2953,7 +2698,8 @@ public class ProviderBillingServiceTests
         var releaseHasRun = false;
         var priceIncreaseScheduler = sutProvider.GetDependency<IPriceIncreaseScheduler>();
         priceIncreaseScheduler
-            .When(s => s.Release(organization.GatewayCustomerId, organization.GatewaySubscriptionId))
+            .When(s => s.Release(
+                organization.GatewayCustomerId, organization.GatewaySubscriptionId, organization.Id))
             .Do(_ => releaseHasRun = true);
 
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
@@ -2988,9 +2734,6 @@ public class ProviderBillingServiceTests
         sutProvider.GetDependency<ISubscriberService>()
             .GetCustomer(organization)
             .Returns(new Customer { Balance = 0 });
-        sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration)
-            .Returns(true);
 
         // Act — must not throw. If Release were removed or moved after Cancel, the
         // arranged StripeException would surface and Assert.ThrowsAsync would be needed.
@@ -2998,49 +2741,9 @@ public class ProviderBillingServiceTests
 
         // Assert — both calls fired, Release first.
         await priceIncreaseScheduler.Received(1)
-            .Release(organization.GatewayCustomerId, "sub_stripe_contract");
+            .Release(organization.GatewayCustomerId, "sub_stripe_contract", organization.Id);
         await stripeAdapter.Received(1)
             .CancelSubscriptionAsync("sub_stripe_contract", Arg.Any<SubscriptionCancelOptions>());
-    }
-
-    [Theory, BitAutoData]
-    public async Task AddExistingOrganization_LogsDroppedAssignment_WithProviderAndCohortContext(
-        Provider provider,
-        Organization organization,
-        string key,
-        SutProvider<ProviderBillingService> sutProvider)
-    {
-        // Arrange — happy path with a cohort assignment present. Verifies the
-        // information log fires with the expected level when the assignment is dropped.
-        // Guards against a refactor that silently removes the operator-facing audit
-        // signal that a stale row was cleaned up.
-        provider.Type = ProviderType.Msp;
-        organization.GatewayCustomerId = "cus_log_check";
-        organization.GatewaySubscriptionId = "sub_log_check";
-        ArrangeAddExistingOrganizationHappyPath(sutProvider, provider, organization);
-
-        var assignmentRepository =
-            sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>();
-        var existingAssignment = new OrganizationPlanMigrationCohortAssignment
-        {
-            Id = Guid.NewGuid(),
-            OrganizationId = organization.Id,
-            CohortId = Guid.NewGuid()
-        };
-        assignmentRepository.GetByOrganizationIdAsync(organization.Id).Returns(existingAssignment);
-
-        var logger = sutProvider.GetDependency<ILogger<ProviderBillingService>>();
-
-        // Act
-        await sutProvider.Sut.AddExistingOrganization(provider, organization, key);
-
-        // Assert — exactly one Information log fired on the cohort drop path.
-        logger.Received(1).Log(
-            LogLevel.Information,
-            Arg.Any<EventId>(),
-            Arg.Any<object>(),
-            Arg.Any<Exception>(),
-            Arg.Any<Func<object, Exception, string>>());
     }
 
     #endregion


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-37087

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
`ProviderBillingService.AddExistingOrganization` cancels and overwrites a standalone Stripe subscription when moving an org under provider management. Both `UpdateSubscriptionAsync(CancelAtPeriodEnd = false)` and `CancelSubscriptionAsync` fail outright when an active migration `SubscriptionSchedule` is attached — which can happen for Track A 2020 orgs (`PlanType` 8–11) that are both eligible for provider addition (per `Organization_ReadAddableToProviderByUserId.sql`) and eligible for a deferred price migration.

This PR applies the canonical "release migration schedule before mutating subscription" pattern used across the epic (PM-37083, PM-37084, PM-37085, PM-37068):

- Inject `IPriceIncreaseScheduler` into `ProviderBillingService` and call `Release(customerId, subscriptionId)` at the top of `AddExistingOrganization`, before the Stripe `UpdateSubscriptionAsync` and `CancelSubscriptionAsync`. `Release` is internally idempotent — no-ops if no active schedule exists.
- After the org transition commits (`ReplaceAsync` + `ProviderOrganization` create + event log), drop any stale cohort assignment row. Placing the cleanup at the bottom of the method means a failure on the assignment delete leaves a stale row to reconcile rather than a half-transitioned org.

### Note on deviation from the ticket spec

The ticket described a single 3-arg `Release(customerId, subscriptionId, organizationId)` call at the top of the method, with the cohort drop as a side effect inside `Release`. That 3-arg overload is shipping in PM-37085 and has not yet merged. This PR adapts by splitting the work into two operations (Release at top, cohort drop at bottom), with a `TODO(PM-37085)` at the cleanup block naming the exact mechanical follow-up — pass `organization.Id` as the third arg to `Release` and delete the cleanup block — once the 3-arg overload lands.

### Tests added

`bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Services/ProviderBillingServiceTests.cs` — 11 tests in the new `AddExistingOrganization` region:

- `_ReleasesMigrationScheduleWithOrgGatewayIds_BeforeStripeOperations` — order regression; verifies `Release` is called with the org's gateway IDs (not the provider's) and runs before the Stripe mutations.
- `_DropsCohortAssignment_AfterOrgTransitionCommits` — Track A 2020 + assignment exists; verifies the assignment is deleted after `ReplaceAsync` + `ProviderOrganization` create + event log commit.
- `_DoesNotCallDelete_AndCompletesFlow_WhenNoCohortAssignment` — Track A 2020 + no assignment; verifies the rest of the flow completes.
- `_ContinuesEntireFlow_AfterReleaseSucceeds` — end-to-end happy path.
- `_DropsCohortAssignmentAndCompletes_ForMoeProvider` — MOE/BusinessUnit branch with discriminating provider plan (`TeamsMonthly`) vs MSP switch fallback (`EnterpriseMonthly`); proves the BusinessUnit branch of `GetManagedPlanTypeAsync` actually ran.
- `_DoesNotDropAssignment_ForCurrentGenOrg` — current-gen plan + no assignment.
- `_DropsStaleAssignment_ForCurrentGenOrg` — current-gen plan + stale assignment row from data drift; verifies the cleanup is plan-tier independent.
- `_SkipsCohortCleanup_WhenBusinessPlanMigrationFlagOff` — verifies the FF gate; even a stale row is not touched when the flag is off.
- `_PropagatesAndShortCircuits_WhenReleaseFails` — Release throws; nothing else runs.
- `_CompletesOrgTransition_BeforeAssignmentLookupFails` — assignment lookup throws after the org transition commits; the failure leaves a reconciliation problem, not a half-transitioned org.
- `_CompletesOrgTransition_BeforeDeleteAssignmentFails` — same invariant for the delete path.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
