### PR TITLE
Update EmergencyAccessInviteQuery to return encoded URLs and a JSON object

### DIFF
--- a/test/SeederApi.IntegrationTest/QueryControllerTests.cs
+++ b/test/SeederApi.IntegrationTest/QueryControllerTests.cs
@@ -51,7 +51,6 @@ public class QueryControllerTests : IClassFixture<SeederApiApplicationFactory>, 
             new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
         Assert.NotNull(response2);
         Assert.NotNull(response2.Urls);
-        // For a non-existent email, we expect an empty list
         Assert.Empty(response2.Urls);
     }
 

--- a/test/SeederApi.IntegrationTest/QueryControllerTests.cs
+++ b/test/SeederApi.IntegrationTest/QueryControllerTests.cs
@@ -47,10 +47,12 @@ public class QueryControllerTests : IClassFixture<SeederApiApplicationFactory>, 
 
         Assert.NotNull(result);
 
-        var urls = System.Text.Json.JsonSerializer.Deserialize<List<string>>(result);
-        Assert.NotNull(urls);
+        var response2 = System.Text.Json.JsonSerializer.Deserialize<EmergencyAccessInviteResponse>(result,
+            new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(response2);
+        Assert.NotNull(response2.Urls);
         // For a non-existent email, we expect an empty list
-        Assert.Empty(urls);
+        Assert.Empty(response2.Urls);
     }
 
     [Fact]
@@ -77,4 +79,6 @@ public class QueryControllerTests : IClassFixture<SeederApiApplicationFactory>, 
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
+
+    private sealed record EmergencyAccessInviteResponse(List<string> Urls);
 }

--- a/util/Seeder/Queries/EmergencyAccessInviteQuery.cs
+++ b/util/Seeder/Queries/EmergencyAccessInviteQuery.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Net;
 using Bit.Core.Auth.Models.Business.Tokenables;

--- a/util/Seeder/Queries/EmergencyAccessInviteQuery.cs
+++ b/util/Seeder/Queries/EmergencyAccessInviteQuery.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Net;
 using Bit.Core.Auth.Models.Business.Tokenables;
 using Bit.Core.Tokens;
 using Bit.Infrastructure.EntityFramework.Repositories;
@@ -11,7 +13,7 @@ namespace Bit.Seeder.Queries;
 public class EmergencyAccessInviteQuery(
     DatabaseContext db,
     IDataProtectorTokenFactory<EmergencyAccessInviteTokenable> dataProtectorTokenizer)
-    : IQuery<EmergencyAccessInviteQuery.Request, IEnumerable<string>>
+    : IQuery<EmergencyAccessInviteQuery.Request, EmergencyAccessInviteQuery.Response>
 {
     public class Request
     {
@@ -19,17 +21,26 @@ public class EmergencyAccessInviteQuery(
         public required string Email { get; set; }
     }
 
-    public Task<IEnumerable<string>> Execute(Request request)
+    public class Response
     {
-        var invites = db.EmergencyAccesses
+        public required List<string> Urls { get; set; }
+    }
+
+    public Task<Response> Execute(Request request)
+    {
+        var urls = db.EmergencyAccesses
             .Where(ea => ea.Email == request.Email).ToList().Select(ea =>
             {
                 var token = dataProtectorTokenizer.Protect(
                     new EmergencyAccessInviteTokenable(ea, hoursTillExpiration: 1)
                 );
-                return $"/accept-emergency?id={ea.Id}&name=Dummy&email={ea.Email}&token={token}";
-            });
+                return string.Format(CultureInfo.InvariantCulture,
+                    "/accept-emergency?id={0}&name=Dummy&email={1}&token={2}",
+                    WebUtility.UrlEncode(ea.Id.ToString()),
+                    WebUtility.UrlEncode(ea.Email),
+                    WebUtility.UrlEncode(token));
+            }).ToList();
 
-        return Task.FromResult(invites);
+        return Task.FromResult(new Response { Urls = urls });
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
- Update EmergencyAccessInviteQuery to return encoded URLs in a JSON object for easier consumption from the API
- Update test to account for the change

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
