### PR TITLE
[PM-37182] Fix bug that prevents re-sending of NDV email

### DIFF
--- a/src/Api/Auth/Controllers/AccountsController.cs
+++ b/src/Api/Auth/Controllers/AccountsController.cs
@@ -786,8 +786,8 @@ public class AccountsController : Controller
     [HttpPost("resend-new-device-otp")]
     public async Task ResendNewDeviceOtpAsync([FromBody] UnauthenticatedSecretVerificationRequestModel request)
     {
-        var user = await _userService.GetUserByPrincipalAsync(User) ?? throw new UnauthorizedAccessException();
-        if (!await _userService.VerifySecretAsync(user, request.Secret))
+        var user = await _userRepository.GetByEmailAsync(request.Email);
+        if (user == null || !await _userService.VerifySecretAsync(user, request.Secret))
         {
             await Task.Delay(2000);
             throw new BadRequestException(string.Empty, "User verification failed.");

--- a/src/Api/Auth/Controllers/AccountsController.cs
+++ b/src/Api/Auth/Controllers/AccountsController.cs
@@ -789,10 +789,11 @@ public class AccountsController : Controller
         var user = await _userRepository.GetByEmailAsync(request.Email);
         if (user == null || !await _userService.VerifySecretAsync(user, request.Secret))
         {
-            await Task.Delay(2000);
-            throw new BadRequestException(string.Empty, "User verification failed.");
+            // If the user is not found, or the secret is not valid, we still return
+            // a success response, to avoid account enumeration; account existence
+            // cannot be signaled by response shape.
+            return;
         }
-
         await _twoFactorEmailService.SendNewDeviceVerificationEmailAsync(user);
     }
 

--- a/src/Api/Auth/Controllers/AccountsController.cs
+++ b/src/Api/Auth/Controllers/AccountsController.cs
@@ -790,8 +790,7 @@ public class AccountsController : Controller
         if (user == null || !await _userService.VerifySecretAsync(user, request.Secret))
         {
             // If the user is not found, or the secret is not valid, we still return
-            // a success response, to avoid account enumeration; account existence
-            // cannot be signaled by response shape.
+            // a success response, to avoid account enumeration via response shape.
             return;
         }
         await _twoFactorEmailService.SendNewDeviceVerificationEmailAsync(user);

--- a/test/Api.IntegrationTest/Controllers/AccountsControllerTest.cs
+++ b/test/Api.IntegrationTest/Controllers/AccountsControllerTest.cs
@@ -1608,26 +1608,28 @@ public class AccountsControllerTest : IClassFixture<ApiApplicationFactory>, IAsy
     }
 
     [Fact]
-    public async Task PostResendNewDeviceOtp_WrongSecret_BadRequest_AndDoesNotSendEmail()
+    public async Task PostResendNewDeviceOtp_WrongSecret_SilentlySucceedsWithoutSendingEmail()
     {
         var user = await _userRepository.GetByEmailAsync(_ownerEmail);
         Assert.NotNull(user);
 
         var response = await PostResendNewDeviceOtpAsync(_ownerEmail, "wrong-master-password-hash");
 
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        // Silent 200 to avoid account enumeration via response shape.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         await _twoFactorEmailService.DidNotReceive()
             .SendNewDeviceVerificationEmailAsync(Arg.Is<User>(u => u.Id == user.Id));
     }
 
     [Fact]
-    public async Task PostResendNewDeviceOtp_UnknownEmail_BadRequest()
+    public async Task PostResendNewDeviceOtp_UnknownEmail_SilentlySucceeds()
     {
         var response = await PostResendNewDeviceOtpAsync(
             $"does-not-exist-{Guid.NewGuid()}@bitwarden.com",
             _masterPasswordHash);
 
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        // Silent 200 to avoid account enumeration via response shape.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     private async Task<HttpResponseMessage> PostResendNewDeviceOtpAsync(string email, string masterPasswordHash)

--- a/test/Api.IntegrationTest/Controllers/AccountsControllerTest.cs
+++ b/test/Api.IntegrationTest/Controllers/AccountsControllerTest.cs
@@ -9,6 +9,7 @@ using Bit.Core.Auth.Entities;
 using Bit.Core.Auth.Enums;
 using Bit.Core.Auth.Models.Data;
 using Bit.Core.Auth.Repositories;
+using Bit.Core.Auth.Services;
 using Bit.Core.Billing.Services;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
@@ -53,6 +54,7 @@ public class AccountsControllerTest : IClassFixture<ApiApplicationFactory>, IAsy
     private readonly IEventRepository _eventRepository;
     private readonly IOrganizationUserRepository _organizationUserRepository;
     private readonly IStripeSyncService _stripeSyncService;
+    private readonly ITwoFactorEmailService _twoFactorEmailService;
 
     private string _ownerEmail = null!;
 
@@ -62,6 +64,7 @@ public class AccountsControllerTest : IClassFixture<ApiApplicationFactory>, IAsy
         _factory.SubstituteService<IPushNotificationService>(_ => { });
         _factory.SubstituteService<IFeatureService>(_ => { });
         _factory.SubstituteService<IStripeSyncService>(_ => { });
+        _factory.SubstituteService<ITwoFactorEmailService>(_ => { });
         _client = factory.CreateClient();
         _loginHelper = new LoginHelper(_factory, _client);
         _userRepository = _factory.GetService<IUserRepository>();
@@ -74,6 +77,7 @@ public class AccountsControllerTest : IClassFixture<ApiApplicationFactory>, IAsy
         _eventRepository = _factory.GetService<IEventRepository>();
         _organizationUserRepository = _factory.GetService<IOrganizationUserRepository>();
         _stripeSyncService = _factory.GetService<IStripeSyncService>();
+        _twoFactorEmailService = _factory.GetService<ITwoFactorEmailService>();
     }
 
     public async Task InitializeAsync()
@@ -1586,6 +1590,53 @@ public class AccountsControllerTest : IClassFixture<ApiApplicationFactory>, IAsy
         message.Content = JsonContent.Create(new SecretVerificationRequestModel
         {
             MasterPasswordHash = masterPasswordHash
+        });
+        return await _client.SendAsync(message);
+    }
+
+    [Fact]
+    public async Task PostResendNewDeviceOtp_ValidEmailAndSecret_OkAndSendsEmail()
+    {
+        var user = await _userRepository.GetByEmailAsync(_ownerEmail);
+        Assert.NotNull(user);
+
+        var response = await PostResendNewDeviceOtpAsync(_ownerEmail, _masterPasswordHash);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        await _twoFactorEmailService.Received(1)
+            .SendNewDeviceVerificationEmailAsync(Arg.Is<User>(u => u.Id == user.Id));
+    }
+
+    [Fact]
+    public async Task PostResendNewDeviceOtp_WrongSecret_BadRequest_AndDoesNotSendEmail()
+    {
+        var user = await _userRepository.GetByEmailAsync(_ownerEmail);
+        Assert.NotNull(user);
+
+        var response = await PostResendNewDeviceOtpAsync(_ownerEmail, "wrong-master-password-hash");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        await _twoFactorEmailService.DidNotReceive()
+            .SendNewDeviceVerificationEmailAsync(Arg.Is<User>(u => u.Id == user.Id));
+    }
+
+    [Fact]
+    public async Task PostResendNewDeviceOtp_UnknownEmail_BadRequest()
+    {
+        var response = await PostResendNewDeviceOtpAsync(
+            $"does-not-exist-{Guid.NewGuid()}@bitwarden.com",
+            _masterPasswordHash);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    private async Task<HttpResponseMessage> PostResendNewDeviceOtpAsync(string email, string masterPasswordHash)
+    {
+        using var message = new HttpRequestMessage(HttpMethod.Post, "/accounts/resend-new-device-otp");
+        message.Content = JsonContent.Create(new UnauthenticatedSecretVerificationRequestModel
+        {
+            Email = email,
+            MasterPasswordHash = masterPasswordHash,
         });
         return await _client.SendAsync(message);
     }

--- a/test/Api.Test/Auth/Controllers/AccountsControllerTests.cs
+++ b/test/Api.Test/Auth/Controllers/AccountsControllerTests.cs
@@ -648,19 +648,21 @@ public class AccountsControllerTests : IDisposable
 
     [Theory]
     [BitAutoData]
-    public async Task ResendNewDeviceVerificationEmail_WhenUserNotFound_ShouldFail(
+    public async Task ResendNewDeviceVerificationEmail_WhenUserNotFound_SilentlySucceedsWithoutSendingEmail(
     UnauthenticatedSecretVerificationRequestModel model)
     {
         // Arrange
         _userRepository.GetByEmailAsync(Arg.Any<string>()).Returns(Task.FromResult((User)null));
 
-        // Act & Assert
-        await Assert.ThrowsAsync<BadRequestException>(() => _sut.ResendNewDeviceOtpAsync(model));
+        // Act
+        await _sut.ResendNewDeviceOtpAsync(model);
+
+        // Assert
         await _twoFactorEmailService.DidNotReceiveWithAnyArgs().SendNewDeviceVerificationEmailAsync(default);
     }
 
     [Theory, BitAutoData]
-    public async Task ResendNewDeviceVerificationEmail_WhenSecretNotValid_ShouldFail(
+    public async Task ResendNewDeviceVerificationEmail_WhenSecretNotValid_SilentlySucceedsWithoutSendingEmail(
         User user,
         UnauthenticatedSecretVerificationRequestModel model)
     {
@@ -668,8 +670,11 @@ public class AccountsControllerTests : IDisposable
         _userRepository.GetByEmailAsync(model.Email).Returns(Task.FromResult(user));
         _userService.VerifySecretAsync(user, Arg.Any<string>()).Returns(Task.FromResult(false));
 
-        // Act & Assert
-        await Assert.ThrowsAsync<BadRequestException>(() => _sut.ResendNewDeviceOtpAsync(model));
+        // Act
+        await _sut.ResendNewDeviceOtpAsync(model);
+
+        // Assert
+        await _twoFactorEmailService.DidNotReceiveWithAnyArgs().SendNewDeviceVerificationEmailAsync(default);
     }
 
     [Theory, BitAutoData]

--- a/test/Api.Test/Auth/Controllers/AccountsControllerTests.cs
+++ b/test/Api.Test/Auth/Controllers/AccountsControllerTests.cs
@@ -652,10 +652,11 @@ public class AccountsControllerTests : IDisposable
     UnauthenticatedSecretVerificationRequestModel model)
     {
         // Arrange
-        _userService.GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>()).Returns(Task.FromResult((User)null));
+        _userRepository.GetByEmailAsync(Arg.Any<string>()).Returns(Task.FromResult((User)null));
 
         // Act & Assert
-        await Assert.ThrowsAsync<UnauthorizedAccessException>(() => _sut.ResendNewDeviceOtpAsync(model));
+        await Assert.ThrowsAsync<BadRequestException>(() => _sut.ResendNewDeviceOtpAsync(model));
+        await _twoFactorEmailService.DidNotReceiveWithAnyArgs().SendNewDeviceVerificationEmailAsync(default);
     }
 
     [Theory, BitAutoData]
@@ -664,7 +665,7 @@ public class AccountsControllerTests : IDisposable
         UnauthenticatedSecretVerificationRequestModel model)
     {
         // Arrange
-        _userService.GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>()).Returns(Task.FromResult(user));
+        _userRepository.GetByEmailAsync(model.Email).Returns(Task.FromResult(user));
         _userService.VerifySecretAsync(user, Arg.Any<string>()).Returns(Task.FromResult(false));
 
         // Act & Assert
@@ -676,7 +677,7 @@ public class AccountsControllerTests : IDisposable
         UnauthenticatedSecretVerificationRequestModel model)
     {
         // Arrange
-        _userService.GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>()).Returns(Task.FromResult(user));
+        _userRepository.GetByEmailAsync(model.Email).Returns(Task.FromResult(user));
         _userService.VerifySecretAsync(user, Arg.Any<string>()).Returns(Task.FromResult(true));
 
         // Act


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37182
fixes https://github.com/bitwarden/clients/issues/20611

## 📔 Objective

In https://github.com/bitwarden/server/pull/5964/changes#diff-19ca62a64f34d8a3f432d8d76e1f578f5dc87d1ff2859eb789faf6ae41fb1c20, the method to send New Device Verification OTPs was changed to use the authenticated user principal, which does not have a user context on unauthenticated endpoints.  This caused any requests to return a `401` response to the client.

This change looks up by email instead.  The secret verification for both MP and OTP verifies that the email address matches the requestor/owner of the secret.

## 📸 Screenshots


https://github.com/user-attachments/assets/31a87d0d-2092-4ba9-935e-c549382c8155

