### PR TITLE
Dirt/pm 38134 access intelligence report not generating

### DIFF
--- a/src/Api/appsettings.Development.json
+++ b/src/Api/appsettings.Development.json
@@ -33,6 +33,9 @@
       "connectionString": "UseDevelopmentStorage=true",
       "baseUrl": "http://localhost:4000/sendfiles/"
     },
+    "organizationReport": {
+      "connectionString": "UseDevelopmentStorage=true"
+    },
     "notifications": {
       "connectionString": "UseDevelopmentStorage=true"
     },

--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -32,6 +32,9 @@
     "send": {
       "connectionString": "SECRET"
     },
+    "organizationReports": {
+      "connectionString": "SECRET"
+    },
     "notificationHub": {
       "connectionString": "SECRET",
       "hubName": "SECRET"

--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -32,7 +32,7 @@
     "send": {
       "connectionString": "SECRET"
     },
-    "organizationReports": {
+    "organizationReport": {
       "connectionString": "SECRET"
     },
     "notificationHub": {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38134](https://bitwarden.atlassian.net/browse/PM-38134)

## 📔 Objective

In US Dev Access Intelligence is not able to work properly due to appsettings.json files not having the organizationReport field.



[PM-38134]: https://bitwarden.atlassian.net/browse/PM-38134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ