### PR TITLE
[PM-38416] Add `Bitwarden-Region` to HTTP request to the pricing service

### DIFF
--- a/src/Core/Billing/Pricing/ServiceCollectionExtensions.cs
+++ b/src/Core/Billing/Pricing/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.Settings;
+﻿using System.Globalization;
+using Bit.Core.Settings;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Bit.Core.Billing.Pricing;
@@ -16,6 +17,10 @@ public static class ServiceCollectionExtensions
             }
             httpClient.BaseAddress = new Uri(globalSettings.PricingUri);
             httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            httpClient.DefaultRequestHeaders.Add(
+                "Bitwarden-Region",
+                globalSettings.BaseServiceUri.CloudRegion?.ToLower(CultureInfo.InvariantCulture) ?? "us"
+            );
         });
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-38416

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds the cloudRegion from config for the currently running bitwarden service. This value is already set for all environments, even in QA/dev. This value can be used to have a conditional feature flag depending on the origin server. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
