### PR TITLE
[PM-38424] Add Kerberos library dependency to setup

### DIFF
--- a/util/Setup/Dockerfile
+++ b/util/Setup/Dockerfile
@@ -45,6 +45,7 @@ ENV SSL_CERT_DIR=/etc/bitwarden/ca-certificates
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
 RUN apk add --no-cache curl \
+    krb5 \
     openssl \
     icu-libs \
     tzdata \


### PR DESCRIPTION
## 📔 Objective

The setup container runs database migrations, either manually via the updatedb verb in bitwarden.sh/.ps1, or during a full upgrade. When the database is external and Kerberos authentication is configured, the setup container needs to load the Kerberos libraries need to be installed in order to handle that authentication to the database
