### PR TITLE
[PM-38452] Refactor Yubico OTP validation and add unit tests

### DIFF
--- a/src/Api/Auth/Models/Request/TwoFactorRequestModels.cs
+++ b/src/Api/Auth/Models/Request/TwoFactorRequestModels.cs
@@ -182,35 +182,19 @@ public class UpdateTwoFactorYubicoOtpRequestModel : SecretVerificationRequestMod
 
     public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
-        if (string.IsNullOrWhiteSpace(Key1) && string.IsNullOrWhiteSpace(Key2) && string.IsNullOrWhiteSpace(Key3) &&
-            string.IsNullOrWhiteSpace(Key4) && string.IsNullOrWhiteSpace(Key5))
+        string[] keys = [Key1, Key2, Key3, Key4, Key5];
+
+        if (keys.All(string.IsNullOrWhiteSpace))
         {
-            yield return new ValidationResult("A key is required.", new string[] { nameof(Key1) });
+            yield return new ValidationResult("A key is required.", [nameof(Key1)]);
         }
 
-        if (!string.IsNullOrWhiteSpace(Key1) && Key1.Length < 12)
+        for (var i = 0; i < keys.Length; i++)
         {
-            yield return new ValidationResult("Key 1 in invalid.", new string[] { nameof(Key1) });
-        }
-
-        if (!string.IsNullOrWhiteSpace(Key2) && Key2.Length < 12)
-        {
-            yield return new ValidationResult("Key 2 in invalid.", new string[] { nameof(Key2) });
-        }
-
-        if (!string.IsNullOrWhiteSpace(Key3) && Key3.Length < 12)
-        {
-            yield return new ValidationResult("Key 3 in invalid.", new string[] { nameof(Key3) });
-        }
-
-        if (!string.IsNullOrWhiteSpace(Key4) && Key4.Length < 12)
-        {
-            yield return new ValidationResult("Key 4 in invalid.", new string[] { nameof(Key4) });
-        }
-
-        if (!string.IsNullOrWhiteSpace(Key5) && Key5.Length < 12)
-        {
-            yield return new ValidationResult("Key 5 in invalid.", new string[] { nameof(Key5) });
+            if (!string.IsNullOrWhiteSpace(keys[i]) && keys[i].Length < 12)
+            {
+                yield return new ValidationResult($"Key {i + 1} is invalid.", [$"Key{i + 1}"]);
+            }
         }
     }
 }

--- a/test/Api.Test/Auth/Models/Request/UpdateTwoFactorYubicoOtpRequestModelTests.cs
+++ b/test/Api.Test/Auth/Models/Request/UpdateTwoFactorYubicoOtpRequestModelTests.cs
@@ -1,0 +1,72 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Api.Auth.Models.Request;
+using Xunit;
+
+namespace Bit.Api.Test.Auth.Models.Request;
+
+public class UpdateTwoFactorYubicoOtpRequestModelTests
+{
+    [Fact]
+    public void Validate_AllKeysEmpty_ReturnsValidationError()
+    {
+        // Arrange
+        var model = new UpdateTwoFactorYubicoOtpRequestModel();
+
+        // Act
+        var result = model.Validate(new ValidationContext(model)).ToList();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("A key is required.", result.First().ErrorMessage);
+        Assert.Equal("Key1", result.First().MemberNames.First());
+    }
+
+    [Theory]
+    [InlineData("short", "Key 1 is invalid.", "Key1")]
+    [InlineData("12345678901", "Key 1 is invalid.", "Key1")]
+    public void Validate_KeyLengthLessThan12_ReturnsValidationError(string invalidKey, string expectedMessage, string expectedMemberName)
+    {
+        // Arrange
+        var model = new UpdateTwoFactorYubicoOtpRequestModel { Key1 = invalidKey };
+
+        // Act
+        var result = model.Validate(new ValidationContext(model)).ToList();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(expectedMessage, result.First().ErrorMessage);
+        Assert.Equal(expectedMemberName, result.First().MemberNames.First());
+    }
+
+    [Fact]
+    public void Validate_MultipleInvalidKeys_ReturnsMultipleValidationErrors()
+    {
+        // Arrange
+        var model = new UpdateTwoFactorYubicoOtpRequestModel
+        {
+            Key1 = "short",
+            Key2 = "also_short"
+        };
+
+        // Act
+        var result = model.Validate(new ValidationContext(model)).ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, r => r.ErrorMessage == "Key 1 is invalid.");
+        Assert.Contains(result, r => r.ErrorMessage == "Key 2 is invalid.");
+    }
+
+    [Fact]
+    public void Validate_ValidKey_ReturnsSuccess()
+    {
+        // Arrange
+        var model = new UpdateTwoFactorYubicoOtpRequestModel { Key1 = "123456789012" };
+
+        // Act
+        var result = model.Validate(new ValidationContext(model));
+
+        // Assert
+        Assert.Empty(result);
+    }
+}

--- a/test/Api.Test/Auth/Models/Request/UpdateTwoFactorYubicoOtpRequestModelTests.cs
+++ b/test/Api.Test/Auth/Models/Request/UpdateTwoFactorYubicoOtpRequestModelTests.cs
@@ -6,33 +6,36 @@ namespace Bit.Api.Test.Auth.Models.Request;
 
 public class UpdateTwoFactorYubicoOtpRequestModelTests
 {
-    [Fact]
-    public void Validate_AllKeysEmpty_ReturnsValidationError()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("            ")]
+    public void Validate_NullOrWhiteSpaceKeys_ReturnsKeyRequiredError(string? emptyValue)
     {
-        // Arrange
-        var model = new UpdateTwoFactorYubicoOtpRequestModel();
+        var model = new UpdateTwoFactorYubicoOtpRequestModel
+        {
+            Key1 = emptyValue,
+            Key2 = emptyValue,
+            Key3 = emptyValue,
+            Key4 = emptyValue,
+            Key5 = emptyValue
+        };
 
-        // Act
         var result = model.Validate(new ValidationContext(model)).ToList();
 
-        // Assert
         Assert.Single(result);
         Assert.Equal("A key is required.", result.First().ErrorMessage);
         Assert.Equal("Key1", result.First().MemberNames.First());
     }
 
     [Theory]
-    [InlineData("short", "Key 1 is invalid.", "Key1")]
+    [InlineData("a", "Key 1 is invalid.", "Key1")]
     [InlineData("12345678901", "Key 1 is invalid.", "Key1")]
     public void Validate_KeyLengthLessThan12_ReturnsValidationError(string invalidKey, string expectedMessage, string expectedMemberName)
     {
-        // Arrange
         var model = new UpdateTwoFactorYubicoOtpRequestModel { Key1 = invalidKey };
-
-        // Act
         var result = model.Validate(new ValidationContext(model)).ToList();
 
-        // Assert
         Assert.Single(result);
         Assert.Equal(expectedMessage, result.First().ErrorMessage);
         Assert.Equal(expectedMemberName, result.First().MemberNames.First());
@@ -41,17 +44,13 @@ public class UpdateTwoFactorYubicoOtpRequestModelTests
     [Fact]
     public void Validate_MultipleInvalidKeys_ReturnsMultipleValidationErrors()
     {
-        // Arrange
         var model = new UpdateTwoFactorYubicoOtpRequestModel
         {
-            Key1 = "short",
-            Key2 = "also_short"
+            Key1 = "a",
+            Key2 = "ab"
         };
-
-        // Act
         var result = model.Validate(new ValidationContext(model)).ToList();
 
-        // Assert
         Assert.Equal(2, result.Count);
         Assert.Contains(result, r => r.ErrorMessage == "Key 1 is invalid.");
         Assert.Contains(result, r => r.ErrorMessage == "Key 2 is invalid.");
@@ -60,13 +59,9 @@ public class UpdateTwoFactorYubicoOtpRequestModelTests
     [Fact]
     public void Validate_ValidKey_ReturnsSuccess()
     {
-        // Arrange
         var model = new UpdateTwoFactorYubicoOtpRequestModel { Key1 = "123456789012" };
-
-        // Act
         var result = model.Validate(new ValidationContext(model));
 
-        // Assert
         Assert.Empty(result);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->



## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fix typo "Key **in** invalid" to "Key **is** invalid".

Refactor Validate function to use a loop instead of multiple if statements.

Introduce unit tests for this validate function. 