### PR TITLE
[PM-37085] feat: Release migration schedule on organization plan upgrade

### DIFF
--- a/src/Core/Billing/Organizations/Commands/UpgradeOrganizationPlanVNextCommand.cs
+++ b/src/Core/Billing/Organizations/Commands/UpgradeOrganizationPlanVNextCommand.cs
@@ -43,6 +43,7 @@ public class UpgradeOrganizationPlanVNextCommand(
     IOrganizationBillingService organizationBillingService,
     IOrganizationService organizationService,
     IPricingClient pricingClient,
+    IPriceIncreaseScheduler priceIncreaseScheduler,
     IUpdateOrganizationSubscriptionCommand updateOrganizationSubscriptionCommand) : BaseBillingCommand<UpgradeOrganizationPlanVNextCommand>(logger), IUpgradeOrganizationPlanVNextCommand
 {
     protected override Conflict DefaultConflict => new("We had a problem upgrading your plan. Please contact support for assistance.");
@@ -102,6 +103,8 @@ public class UpgradeOrganizationPlanVNextCommand(
 
             return new None();
         }
+
+        await priceIncreaseScheduler.Release(organization.GatewayCustomerId, organization.GatewaySubscriptionId!, organization.Id);
 
         var builder = OrganizationSubscriptionChangeSet.Builder(currentPlan);
 

--- a/src/Core/Billing/Pricing/PriceIncreaseScheduler.cs
+++ b/src/Core/Billing/Pricing/PriceIncreaseScheduler.cs
@@ -62,14 +62,22 @@ public interface IPriceIncreaseScheduler
 
     /// <summary>
     /// Releases any active subscription schedule for the given subscription, cancelling a pending
-    /// deferred price increase. Use when the subscription operation makes the scheduled migration
-    /// irrelevant (e.g., plan upgrade, sponsorship, cancellation). Runs when either
-    /// <c>PM32645_DeferPriceMigrationToRenewal</c> or <c>PM35215_BusinessPlanPriceMigration</c> is
-    /// enabled. Logs and re-throws on failure, requiring manual release via the Stripe Dashboard.
+    /// deferred price increase. When <paramref name="organizationId"/> is provided, the
+    /// organization's cohort assignment is also dropped so it leaves the deferred business
+    /// migration. Use when the subscription operation makes the scheduled migration irrelevant
+    /// (e.g., plan upgrade, sponsorship, cancellation). The release is driven by the presence of
+    /// an active schedule rather than a feature flag, so it safely no-ops when no schedule exists.
+    /// Logs and re-throws if the Stripe release fails, requiring manual release via the Stripe
+    /// Dashboard. A failure to drop the cohort assignment after a successful release is logged for
+    /// manual cleanup but does not fail the operation.
     /// </summary>
     /// <param name="customerId">The Stripe customer ID that owns the subscription.</param>
     /// <param name="subscriptionId">The Stripe subscription ID to release the schedule for.</param>
-    Task Release(string customerId, string subscriptionId);
+    /// <param name="organizationId">
+    /// When provided, the organization's cohort assignment row is also deleted after the Stripe
+    /// schedule is released, dropping it from the deferred business migration.
+    /// </param>
+    Task Release(string customerId, string subscriptionId, Guid? organizationId = null);
 }
 
 public class PriceIncreaseScheduler(
@@ -213,7 +221,7 @@ public class PriceIncreaseScheduler(
         }
     }
 
-    public async Task Release(string customerId, string subscriptionId)
+    public async Task Release(string customerId, string subscriptionId, Guid? organizationId = null)
     {
         try
         {
@@ -226,6 +234,24 @@ public class PriceIncreaseScheduler(
             if (activeSchedule != null)
             {
                 await stripeAdapter.ReleaseSubscriptionScheduleAsync(activeSchedule.Id);
+            }
+
+            if (organizationId is not null)
+            {
+                try
+                {
+                    var assignment = await assignmentRepository.GetByOrganizationIdAsync(organizationId.Value);
+                    if (assignment is not null)
+                    {
+                        await assignmentRepository.DeleteAsync(assignment);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex,
+                        "Released the subscription schedule for subscription {SubscriptionId} but failed to drop the migration cohort assignment for organization {OrganizationId}. Manual cleanup of the cohort assignment is required.",
+                        subscriptionId, organizationId.Value);
+                }
             }
         }
         catch (Exception ex)

--- a/test/Core.Test/Billing/Organizations/Commands/UpgradeOrganizationPlanVNextCommandTests.cs
+++ b/test/Core.Test/Billing/Organizations/Commands/UpgradeOrganizationPlanVNextCommandTests.cs
@@ -11,6 +11,7 @@ using Bit.Core.Services;
 using Bit.Core.Test.Billing.Mocks;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Stripe;
 using Xunit;
 
@@ -21,6 +22,7 @@ public class UpgradeOrganizationPlanVNextCommandTests
     private readonly IOrganizationBillingService _organizationBillingService = Substitute.For<IOrganizationBillingService>();
     private readonly IOrganizationService _organizationService = Substitute.For<IOrganizationService>();
     private readonly IPricingClient _pricingClient = Substitute.For<IPricingClient>();
+    private readonly IPriceIncreaseScheduler _priceIncreaseScheduler = Substitute.For<IPriceIncreaseScheduler>();
     private readonly IUpdateOrganizationSubscriptionCommand _updateOrganizationSubscriptionCommand = Substitute.For<IUpdateOrganizationSubscriptionCommand>();
     private readonly UpgradeOrganizationPlanVNextCommand _command;
 
@@ -31,6 +33,7 @@ public class UpgradeOrganizationPlanVNextCommandTests
             _organizationBillingService,
             _organizationService,
             _pricingClient,
+            _priceIncreaseScheduler,
             _updateOrganizationSubscriptionCommand);
     }
 
@@ -343,6 +346,110 @@ public class UpgradeOrganizationPlanVNextCommandTests
         // Result is mapped through — BadRequest becomes T1
         Assert.True(result.IsT1);
         await _organizationService.DidNotReceive().ReplaceAndUpdateCacheAsync(Arg.Any<Organization>(), Arg.Any<EventType?>());
+    }
+
+    [Fact]
+    public async Task Run_PaidUpgrade_TrackAOrg_ReleasesScheduleWithOrganizationId()
+    {
+        // Track A: a 2020-era source plan upgrading to a current plan. Tiers ascend
+        // (Teams sort order 3 -> Enterprise sort order 4) so the upgrade is accepted.
+        var organization = CreateOrganization(PlanType.TeamsAnnually2020);
+        var currentPlan = MockPlans.Get(PlanType.TeamsAnnually2020);
+        var targetPlan = MockPlans.Get(PlanType.EnterpriseAnnually);
+
+        _pricingClient.GetPlanOrThrow(organization.PlanType).Returns(currentPlan);
+        SetupSubscriptionCommandSuccess();
+
+        var result = await _command.Run(organization, targetPlan, null);
+
+        Assert.True(result.IsT0);
+        await _priceIncreaseScheduler.Received(1).Release(
+            organization.GatewayCustomerId!,
+            organization.GatewaySubscriptionId!,
+            organization.Id);
+    }
+
+    [Fact]
+    public async Task Run_PaidUpgrade_TwentyTwentyToTwentyTwenty_ReleasesScheduleWithOrganizationId()
+    {
+        // 2020-era source upgrading to a 2020-era target across ascending tiers
+        // (Teams 2020 sort order 3 -> Enterprise 2020 sort order 4).
+        var organization = CreateOrganization(PlanType.TeamsAnnually2020);
+        var currentPlan = MockPlans.Get(PlanType.TeamsAnnually2020);
+        var targetPlan = MockPlans.Get(PlanType.EnterpriseAnnually2020);
+
+        _pricingClient.GetPlanOrThrow(organization.PlanType).Returns(currentPlan);
+        SetupSubscriptionCommandSuccess();
+
+        var result = await _command.Run(organization, targetPlan, null);
+
+        Assert.True(result.IsT0);
+        await _priceIncreaseScheduler.Received(1).Release(
+            organization.GatewayCustomerId!,
+            organization.GatewaySubscriptionId!,
+            organization.Id);
+    }
+
+    [Fact]
+    public async Task Run_UpgradeFromFree_DoesNotReleaseSchedule()
+    {
+        var organization = CreateOrganization(
+            PlanType.Free,
+            gatewaySubscriptionId: null,
+            seats: 2);
+        var currentPlan = MockPlans.Get(PlanType.Free);
+        var targetPlan = MockPlans.Get(PlanType.TeamsAnnually);
+
+        _pricingClient.GetPlanOrThrow(organization.PlanType).Returns(currentPlan);
+
+        var result = await _command.Run(organization, targetPlan, null);
+
+        Assert.True(result.IsT0);
+        await _priceIncreaseScheduler.DidNotReceiveWithAnyArgs()
+            .Release(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>());
+    }
+
+    [Fact]
+    public async Task Run_PaidUpgrade_NonTrackAOrg_StillReleasesScheduleWithOrganizationId()
+    {
+        // Non-Track-A: a current (non-2020) source plan still releases on upgrade.
+        var organization = CreateOrganization(PlanType.TeamsAnnually);
+        var currentPlan = MockPlans.Get(PlanType.TeamsAnnually);
+        var targetPlan = MockPlans.Get(PlanType.EnterpriseAnnually);
+
+        _pricingClient.GetPlanOrThrow(organization.PlanType).Returns(currentPlan);
+        SetupSubscriptionCommandSuccess();
+
+        var result = await _command.Run(organization, targetPlan, null);
+
+        Assert.True(result.IsT0);
+        await _priceIncreaseScheduler.Received(1).Release(
+            organization.GatewayCustomerId!,
+            organization.GatewaySubscriptionId!,
+            organization.Id);
+    }
+
+    [Fact]
+    public async Task Run_PaidUpgrade_ReleaseThrows_AbortsUpgrade()
+    {
+        var organization = CreateOrganization(PlanType.TeamsAnnually);
+        var currentPlan = MockPlans.Get(PlanType.TeamsAnnually);
+        var targetPlan = MockPlans.Get(PlanType.EnterpriseAnnually);
+
+        _pricingClient.GetPlanOrThrow(organization.PlanType).Returns(currentPlan);
+
+        _priceIncreaseScheduler
+            .Release(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>())
+            .ThrowsAsync(new InvalidOperationException("release failed"));
+
+        var result = await _command.Run(organization, targetPlan, null);
+
+        // HandleAsync converts the thrown exception into an Unhandled error result.
+        Assert.True(result.IsT3);
+        await _updateOrganizationSubscriptionCommand.DidNotReceiveWithAnyArgs()
+            .Run(Arg.Any<Organization>(), Arg.Any<OrganizationSubscriptionChangeSet>());
+        await _organizationService.DidNotReceive()
+            .ReplaceAndUpdateCacheAsync(Arg.Any<Organization>(), Arg.Any<EventType?>());
     }
 
     private void SetupSubscriptionCommandSuccess()

--- a/test/Core.Test/Billing/Pricing/PriceIncreaseSchedulerTests.cs
+++ b/test/Core.Test/Billing/Pricing/PriceIncreaseSchedulerTests.cs
@@ -694,6 +694,154 @@ public class PriceIncreaseSchedulerTests
         await Assert.ThrowsAsync<StripeException>(() => sut.Release("cus_1", "sub_1"));
     }
 
+    [Fact]
+    public async Task Release_WithOrganizationId_ReleasesScheduleThenDeletesAssignment()
+    {
+        var orgId = Guid.NewGuid();
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule>
+            {
+                Data = [CreateSchedule("sched_1", "sub_1", SubscriptionScheduleStatus.Active)]
+            });
+
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = orgId,
+            CohortId = Guid.NewGuid()
+        };
+        _assignmentRepository.GetByOrganizationIdAsync(orgId).Returns(assignment);
+
+        var sut = CreateSut();
+
+        await sut.Release("cus_1", "sub_1", orgId);
+
+        await _stripeAdapter.Received(1).ReleaseSubscriptionScheduleAsync("sched_1", null);
+        await _assignmentRepository.Received(1).DeleteAsync(assignment);
+    }
+
+    [Fact]
+    public async Task Release_WithOrganizationId_NoAssignmentRow_ReleasesScheduleAndDoesNotDelete()
+    {
+        var orgId = Guid.NewGuid();
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule>
+            {
+                Data = [CreateSchedule("sched_1", "sub_1", SubscriptionScheduleStatus.Active)]
+            });
+
+        _assignmentRepository.GetByOrganizationIdAsync(orgId)
+            .Returns((OrganizationPlanMigrationCohortAssignment?)null);
+
+        var sut = CreateSut();
+
+        await sut.Release("cus_1", "sub_1", orgId);
+
+        await _stripeAdapter.Received(1).ReleaseSubscriptionScheduleAsync("sched_1", null);
+        await _assignmentRepository.DidNotReceiveWithAnyArgs()
+            .DeleteAsync(Arg.Any<OrganizationPlanMigrationCohortAssignment>());
+    }
+
+    [Fact]
+    public async Task Release_WithoutOrganizationId_NeverTouchesAssignmentRepository()
+    {
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule>
+            {
+                Data = [CreateSchedule("sched_1", "sub_1", SubscriptionScheduleStatus.Active)]
+            });
+
+        var sut = CreateSut();
+
+        await sut.Release("cus_1", "sub_1");
+
+        await _stripeAdapter.Received(1).ReleaseSubscriptionScheduleAsync("sched_1", null);
+        await _assignmentRepository.DidNotReceiveWithAnyArgs()
+            .GetByOrganizationIdAsync(Arg.Any<Guid>());
+        await _assignmentRepository.DidNotReceiveWithAnyArgs()
+            .DeleteAsync(Arg.Any<OrganizationPlanMigrationCohortAssignment>());
+    }
+
+    [Fact]
+    public async Task Release_WithOrganizationId_NoActiveSchedule_StillDeletesAssignment()
+    {
+        var orgId = Guid.NewGuid();
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [] });
+
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = orgId,
+            CohortId = Guid.NewGuid()
+        };
+        _assignmentRepository.GetByOrganizationIdAsync(orgId).Returns(assignment);
+
+        var sut = CreateSut();
+
+        await sut.Release("cus_1", "sub_1", orgId);
+
+        await _stripeAdapter.DidNotReceiveWithAnyArgs()
+            .ReleaseSubscriptionScheduleAsync(Arg.Any<string>(), Arg.Any<SubscriptionScheduleReleaseOptions>());
+        await _assignmentRepository.Received(1).DeleteAsync(assignment);
+    }
+
+    [Fact]
+    public async Task Release_WithOrganizationId_StripeReleaseThrows_DoesNotDeleteAndRethrows()
+    {
+        var orgId = Guid.NewGuid();
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule>
+            {
+                Data = [CreateSchedule("sched_1", "sub_1", SubscriptionScheduleStatus.Active)]
+            });
+
+        _stripeAdapter.ReleaseSubscriptionScheduleAsync("sched_1", null)
+            .ThrowsAsync(new StripeException("release failed"));
+
+        var sut = CreateSut();
+
+        await Assert.ThrowsAsync<StripeException>(() => sut.Release("cus_1", "sub_1", orgId));
+
+        await _assignmentRepository.DidNotReceiveWithAnyArgs()
+            .DeleteAsync(Arg.Any<OrganizationPlanMigrationCohortAssignment>());
+    }
+
+    [Fact]
+    public async Task Release_WithOrganizationId_AssignmentDeleteThrows_DoesNotRethrow()
+    {
+        var orgId = Guid.NewGuid();
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule>
+            {
+                Data = [CreateSchedule("sched_1", "sub_1", SubscriptionScheduleStatus.Active)]
+            });
+
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = orgId,
+            CohortId = Guid.NewGuid()
+        };
+        _assignmentRepository.GetByOrganizationIdAsync(orgId).Returns(assignment);
+        _assignmentRepository.DeleteAsync(assignment)
+            .ThrowsAsync(new InvalidOperationException("delete failed"));
+
+        var sut = CreateSut();
+
+        // The schedule release succeeded, so a failure to drop the cohort assignment is logged
+        // and swallowed rather than failing the operation.
+        await sut.Release("cus_1", "sub_1", orgId);
+
+        await _stripeAdapter.Received(1).ReleaseSubscriptionScheduleAsync("sched_1", null);
+        await _assignmentRepository.Received(1).DeleteAsync(assignment);
+    }
+
     // --- Business path tests ---
 
     [Fact]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37085

## 📔 Objective

Part of the business-plan price-migration workstream (the "Maintaining Subscription Updates" axis — Gap 2 of 4). When a Track A 2020 org voluntarily upgrades to a different plan while an active deferred-migration Stripe `SubscriptionSchedule` is attached, the upgrade misbehaves: with PM-37083's per-phase price resolution in place, the Phase 1 -> Phase 2 transition collapses into a no-op, and the migration's proactive discount coupon silently inherits into Phase 2 of the plan the user voluntarily chose.

`UpgradeOrganizationPlanVNextCommand` now releases any active migration schedule before delegating to `UpdateOrganizationSubscriptionCommand`, which then applies the upgrade as a normal `UpdateSubscriptionAsync`. A voluntary plan change makes the deferred migration moot.

**Details**

- `IPriceIncreaseScheduler.Release` gains an optional `Guid? organizationId = null`. When provided, after releasing the Stripe schedule it also drops the org's migration cohort assignment (load + `DeleteAsync`) so the org leaves the cohort — otherwise the row lingers with `ScheduledDate` set and cohort views still list it. Existing callers pass no org id and keep today's Stripe-only behavior.
- The cohort drop is coupled with the release (same `try`) but uses its own inner `try/catch` with a cohort-specific log message, so a cleanup failure isn't misreported as a Stripe release failure. It is best-effort: after a successful release, a failed cohort drop is logged for manual cleanup rather than aborting the upgrade (safe direction — schedule gone, cohort retained; the runtime drift check prevents a stale row from re-scheduling).
- The release is driven by the presence of an active schedule, not a feature flag, so it safely no-ops when no schedule exists.

**Testing**

- Unit tests on `PriceIncreaseScheduler.Release` (release + cohort drop, no assignment row, no org id, no active schedule, release throws -> rethrow, cohort delete throws -> swallowed) and `UpgradeOrganizationPlanVNextCommand` (paid upgrade releases with org id, Free->paid skips release, release throws -> upgrade aborts).
- Full `Core.Test` suite passes except 5 pre-existing failures in `Dirt.Services.EventIntegrationHandlerTests` that also fail on `main` (unrelated to this change).

**Out of scope**

- Per-phase price resolution (PM-37083), business-aware schedule recovery (PM-37084), and provider-org-addition release (PM-37087) are handled separately. Auditing whether the other existing `Release` callers should also pass an org id is a follow-up.
