### PR TITLE
[PM-38265] Enhance TwoFactorIsEnabledQuery to use a dictionary for two-factor authentication results

### DIFF
--- a/src/Core/Auth/UserFeatures/TwoFactorAuth/Implementations/TwoFactorIsEnabledQuery.cs
+++ b/src/Core/Auth/UserFeatures/TwoFactorAuth/Implementations/TwoFactorIsEnabledQuery.cs
@@ -74,6 +74,7 @@ public class TwoFactorIsEnabledQuery : ITwoFactorIsEnabledQuery
             .ToList();
 
         var twoFactorResults = await TwoFactorIsEnabledAsync(userIds);
+        var byUserId = twoFactorResults.ToDictionary(r => r.userId, r => r.twoFactorIsEnabled);
 
         var result = new List<(T user, bool twoFactorIsEnabled)>();
 
@@ -82,7 +83,7 @@ public class TwoFactorIsEnabledQuery : ITwoFactorIsEnabledQuery
             var userId = user.GetUserId();
             if (userId.HasValue)
             {
-                var hasTwoFactor = twoFactorResults.FirstOrDefault(res => res.userId == userId.Value).twoFactorIsEnabled;
+                byUserId.TryGetValue(userId.Value, out var hasTwoFactor);
                 result.Add((user, hasTwoFactor));
             }
             else


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38265

## 📔 Objective

Replace a per-user linear scan over the 2FA results list with a dictionary built once before the loop, reducing the Members page load time
