### PR TITLE
[PM-37510] feat: Grandfather Secrets Manager machine accounts for Enterprise 2020 migrations

### DIFF
--- a/src/Billing/Services/Implementations/SubscriptionUpdatedHandler.cs
+++ b/src/Billing/Services/Implementations/SubscriptionUpdatedHandler.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core;
+﻿using System.Globalization;
+using Bit.Core;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.OrganizationFeatures.Organizations.Interfaces;
@@ -646,6 +647,38 @@ public class SubscriptionUpdatedHandler : ISubscriptionUpdatedHandler
 
             organization.ChangePlan(targetPlan);
             await _organizationRepository.ReplaceAsync(organization);
+
+            var sourceProvidedServiceAccounts = sourcePlan.SecretsManager?.BaseServiceAccount ?? 0;
+            var targetProvidedServiceAccounts = targetPlan.SecretsManager?.BaseServiceAccount ?? 0;
+            var grace = Math.Max(0, sourceProvidedServiceAccounts - targetProvidedServiceAccounts);
+
+            if (grace > 0)
+            {
+                var metadata = new Dictionary<string, string>(subscription.Metadata)
+                {
+                    [MetadataKeys.MigrationGraceServiceAccounts] = grace.ToString(CultureInfo.InvariantCulture)
+                };
+
+                try
+                {
+                    await _stripeAdapter.UpdateSubscriptionAsync(subscription.Id,
+                        new SubscriptionUpdateOptions { Metadata = metadata });
+                }
+                catch (Exception graceException)
+                {
+                    // Surface as a BillingException so the generic catch below does not swallow it; the
+                    // webhook returns 500 and Stripe retries. Because MigratedDate is not yet stamped,
+                    // the replay re-runs this method: re-ChangePlan is a structural no-op and re-writing
+                    // the same metadata key/value is idempotent.
+                    _logger.LogError(
+                        graceException,
+                        "Business migration applied to organization ({OrganizationId}) but failed to write SM grace metadata; Stripe retry will re-apply",
+                        organizationId);
+                    throw new BillingException(
+                        message: "Partial business migration write: organization updated but grace metadata write failed.",
+                        innerException: graceException);
+                }
+            }
 
             try
             {

--- a/src/Core/Billing/Constants/StripeConstants.cs
+++ b/src/Core/Billing/Constants/StripeConstants.cs
@@ -106,6 +106,7 @@ public static class StripeConstants
         public const string CancelledDuringDeferredPriceIncrease = "cancelled_during_deferred_price_increase";
         public const string MigrationCohortId = "migration_cohort_id";
         public const string MigrationCohortName = "migration_cohort_name";
+        public const string MigrationGraceServiceAccounts = "migration_grace_service_accounts";
         public const string CancellingUserId = "cancellingUserId";
     }
 

--- a/src/Core/Billing/Extensions/SubscriptionExtensions.cs
+++ b/src/Core/Billing/Extensions/SubscriptionExtensions.cs
@@ -1,9 +1,18 @@
-﻿using Stripe;
+﻿using System.Globalization;
+using Bit.Core.Billing.Constants;
+using Stripe;
 
 namespace Bit.Core.Billing.Extensions;
 
 public static class SubscriptionExtensions
 {
+    public static int GetMigrationGraceServiceAccounts(this Subscription subscription) =>
+        subscription.Metadata.TryGetValue(StripeConstants.MetadataKeys.MigrationGraceServiceAccounts, out var raw)
+        && int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var grace)
+        && grace > 0
+            ? grace
+            : 0;
+
     /*
      * For the time being, this is the simplest migration approach from v45 to v48 as
      * we do not support multi-cadence subscriptions. Each subscription item should be on the

--- a/src/Core/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommand.cs
+++ b/src/Core/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommand.cs
@@ -30,13 +30,19 @@ public interface IUpdateOrganizationSubscriptionCommand
     /// </summary>
     /// <param name="organization">The organization whose subscription will be updated.</param>
     /// <param name="changeSet">The set of changes to apply to the subscription.</param>
+    /// <param name="subscription">
+    /// An optional pre-fetched subscription. When supplied and it carries the required expansions
+    /// (an expanded <see cref="Subscription.Customer"/>), it is reused to avoid a redundant Stripe
+    /// call; otherwise the subscription is re-fetched.
+    /// </param>
     /// <returns>
     /// A <see cref="BillingCommandResult{T}"/> containing the updated <see cref="Subscription"/>
     /// on success, or an error result if validation or the Stripe operation fails.
     /// </returns>
     Task<BillingCommandResult<Subscription>> Run(
         Organization organization,
-        OrganizationSubscriptionChangeSet changeSet);
+        OrganizationSubscriptionChangeSet changeSet,
+        Subscription? subscription = null);
 }
 
 public class UpdateOrganizationSubscriptionCommand(
@@ -61,9 +67,10 @@ public class UpdateOrganizationSubscriptionCommand(
 
     public Task<BillingCommandResult<Subscription>> Run(
         Organization organization,
-        OrganizationSubscriptionChangeSet changeSet) => HandleAsync<Subscription>(async () =>
+        OrganizationSubscriptionChangeSet changeSet,
+        Subscription? subscription = null) => HandleAsync<Subscription>(async () =>
     {
-        var subscription = await FetchSubscriptionAsync(organization);
+        subscription = HasRequiredExpansions(subscription) ? subscription : await FetchSubscriptionAsync(organization);
 
         if (subscription is null)
         {
@@ -204,6 +211,11 @@ public class UpdateOrganizationSubscriptionCommand(
 
         return updatedSubscription;
     });
+
+    // PM-37510: the command body dereferences subscription.Customer for tax reconciliation, so a
+    // reused subscription is only safe when Customer is expanded. test_clock is optional here.
+    private static bool HasRequiredExpansions(Subscription? subscription) =>
+        subscription is { Customer: not null };
 
     private async Task<Subscription?> FetchSubscriptionAsync(Organization organization)
     {

--- a/src/Core/Billing/Organizations/Commands/UpgradeOrganizationPlanVNextCommand.cs
+++ b/src/Core/Billing/Organizations/Commands/UpgradeOrganizationPlanVNextCommand.cs
@@ -5,12 +5,15 @@ using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Organizations.Models;
 using Bit.Core.Billing.Organizations.Services;
 using Bit.Core.Billing.Pricing;
+using Bit.Core.Billing.Services;
 using Bit.Core.KeyManagement.Models.Data;
 using Bit.Core.Models.Business;
 using Bit.Core.Models.StaticStore;
 using Bit.Core.Services;
 using Microsoft.Extensions.Logging;
 using OneOf.Types;
+using static Bit.Core.Billing.Constants.StripeConstants;
+using SubscriptionUpdateOptions = Stripe.SubscriptionUpdateOptions;
 
 namespace Bit.Core.Billing.Organizations.Commands;
 
@@ -44,6 +47,7 @@ public class UpgradeOrganizationPlanVNextCommand(
     IOrganizationService organizationService,
     IPricingClient pricingClient,
     IPriceIncreaseScheduler priceIncreaseScheduler,
+    IStripeAdapter stripeAdapter,
     IUpdateOrganizationSubscriptionCommand updateOrganizationSubscriptionCommand) : BaseBillingCommand<UpgradeOrganizationPlanVNextCommand>(logger), IUpgradeOrganizationPlanVNextCommand
 {
     protected override Conflict DefaultConflict => new("We had a problem upgrading your plan. Please contact support for assistance.");
@@ -105,6 +109,13 @@ public class UpgradeOrganizationPlanVNextCommand(
         }
 
         await priceIncreaseScheduler.Release(organization.GatewayCustomerId, organization.GatewaySubscriptionId!, organization.Id);
+
+        await stripeAdapter.UpdateSubscriptionAsync(
+            organization.GatewaySubscriptionId!,
+            new SubscriptionUpdateOptions
+            {
+                Metadata = new Dictionary<string, string> { [MetadataKeys.MigrationGraceServiceAccounts] = string.Empty }
+            });
 
         var builder = OrganizationSubscriptionChangeSet.Builder(currentPlan);
 

--- a/src/Core/Billing/Organizations/Commands/UpgradeOrganizationPlanVNextCommand.cs
+++ b/src/Core/Billing/Organizations/Commands/UpgradeOrganizationPlanVNextCommand.cs
@@ -110,13 +110,6 @@ public class UpgradeOrganizationPlanVNextCommand(
 
         await priceIncreaseScheduler.Release(organization.GatewayCustomerId, organization.GatewaySubscriptionId!, organization.Id);
 
-        await stripeAdapter.UpdateSubscriptionAsync(
-            organization.GatewaySubscriptionId!,
-            new SubscriptionUpdateOptions
-            {
-                Metadata = new Dictionary<string, string> { [MetadataKeys.MigrationGraceServiceAccounts] = string.Empty }
-            });
-
         var builder = OrganizationSubscriptionChangeSet.Builder(currentPlan);
 
         builder.ChangePasswordManagerPrice(plan);
@@ -145,6 +138,13 @@ public class UpgradeOrganizationPlanVNextCommand(
         }
 
         await UpdateOrganizationFeaturesAsync(organization, plan, keys);
+
+        await stripeAdapter.UpdateSubscriptionAsync(
+            organization.GatewaySubscriptionId!,
+            new SubscriptionUpdateOptions
+            {
+                Metadata = new Dictionary<string, string> { [MetadataKeys.MigrationGraceServiceAccounts] = string.Empty }
+            });
 
         return result.Map(_ => new None());
     });

--- a/src/Core/Models/Business/SecretsManagerSubscriptionUpdate.cs
+++ b/src/Core/Models/Business/SecretsManagerSubscriptionUpdate.cs
@@ -36,6 +36,12 @@ public class SecretsManagerSubscriptionUpdate
     public bool Autoscaling { get; }
 
     /// <summary>
+    /// Free service accounts beyond the plan's baseline, granted to organizations migrated from a
+    /// plan with a higher baseline.
+    /// </summary>
+    public int ServiceAccountGrace { get; set; }
+
+    /// <summary>
     /// The seats the organization will have after the update, excluding the base seats included in the plan
     /// Usually this is what the organization is billed for
     /// </summary>
@@ -44,7 +50,7 @@ public class SecretsManagerSubscriptionUpdate
     /// The seats the organization will have after the update, excluding the base seats included in the plan
     /// Usually this is what the organization is billed for
     /// </summary>
-    public int SmServiceAccountsExcludingBase => SmServiceAccounts.HasValue ? SmServiceAccounts.Value - Plan.SecretsManager!.BaseServiceAccount : 0;
+    public int SmServiceAccountsExcludingBase => SmServiceAccounts.HasValue ? Math.Max(0, SmServiceAccounts.Value - Plan.SecretsManager!.BaseServiceAccount - ServiceAccountGrace) : 0;
     public bool SmSeatsChanged => SmSeats != Organization.SmSeats;
     public bool SmServiceAccountsChanged => SmServiceAccounts != Organization.SmServiceAccounts;
     public bool MaxAutoscaleSmSeatsChanged => MaxAutoscaleSmSeats != Organization.MaxAutoscaleSmSeats;

--- a/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpdateSecretsManagerSubscriptionCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationSubscriptions/UpdateSecretsManagerSubscriptionCommand.cs
@@ -2,7 +2,9 @@
 #nullable disable
 
 using Bit.Core.AdminConsole.Entities;
+using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Enums;
+using Bit.Core.Billing.Extensions;
 using Bit.Core.Billing.Organizations.Commands;
 using Bit.Core.Billing.Organizations.Models;
 using Bit.Core.Billing.Services;
@@ -15,6 +17,7 @@ using Bit.Core.SecretsManager.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Settings;
 using Microsoft.Extensions.Logging;
+using Stripe;
 
 namespace Bit.Core.OrganizationFeatures.OrganizationSubscriptions;
 
@@ -31,6 +34,7 @@ public class UpdateSecretsManagerSubscriptionCommand : IUpdateSecretsManagerSubs
     private readonly IEventService _eventService;
     private readonly IFeatureService _featureService;
     private readonly IUpdateOrganizationSubscriptionCommand _updateOrganizationSubscriptionCommand;
+    private readonly IStripeAdapter _stripeAdapter;
 
     public UpdateSecretsManagerSubscriptionCommand(
         IOrganizationUserRepository organizationUserRepository,
@@ -43,7 +47,8 @@ public class UpdateSecretsManagerSubscriptionCommand : IUpdateSecretsManagerSubs
         IApplicationCacheService applicationCacheService,
         IEventService eventService,
         IUpdateOrganizationSubscriptionCommand updateOrganizationSubscriptionCommand,
-        IFeatureService featureService)
+        IFeatureService featureService,
+        IStripeAdapter stripeAdapter)
     {
         _organizationUserRepository = organizationUserRepository;
         _paymentService = paymentService;
@@ -56,6 +61,7 @@ public class UpdateSecretsManagerSubscriptionCommand : IUpdateSecretsManagerSubs
         _eventService = eventService;
         _updateOrganizationSubscriptionCommand = updateOrganizationSubscriptionCommand;
         _featureService = featureService;
+        _stripeAdapter = stripeAdapter;
     }
 
     public async Task UpdateSubscriptionAsync(SecretsManagerSubscriptionUpdate update)
@@ -71,30 +77,58 @@ public class UpdateSecretsManagerSubscriptionCommand : IUpdateSecretsManagerSubs
     {
         if (_featureService.IsEnabled(FeatureFlagKeys.PM32581_UseUpdateOrganizationSubscriptionCommand))
         {
-            var builder = OrganizationSubscriptionChangeSet.Builder(update.Plan);
-
-            if (update.SmSeatsChanged)
+            if (update.SmSeatsChanged || update.SmServiceAccountsChanged)
             {
-                builder.UpdateSecretsManagerSeats(update.SmSeatsExcludingBase);
-            }
-
-            if (update.SmServiceAccountsChanged)
-            {
-                if (update.Organization.SmServiceAccounts > update.Plan.SecretsManager.BaseServiceAccount)
+                Subscription subscription;
+                try
                 {
-                    builder.UpdateServiceAccounts(update.SmServiceAccountsExcludingBase);
+                    subscription = await _stripeAdapter.GetSubscriptionAsync(
+                        update.Organization.GatewaySubscriptionId,
+                        new SubscriptionGetOptions { Expand = ["customer", "test_clock"] });
                 }
-                else
+                catch (StripeException stripeException) when (stripeException.StripeError?.Code == StripeConstants.ErrorCodes.ResourceMissing)
                 {
-                    builder.AddServiceAccounts(update.SmServiceAccountsExcludingBase);
+                    _logger.LogError(
+                        "Subscription ({SubscriptionId}) for organization ({OrganizationId}) was not found",
+                        update.Organization.GatewaySubscriptionId, update.Organization.Id);
+                    throw new BadRequestException("We couldn't find your subscription.");
                 }
-            }
 
-            var changeSet = builder.Build();
-            if (changeSet.Changes.Any())
-            {
-                var result = await _updateOrganizationSubscriptionCommand.Run(update.Organization, changeSet);
-                result.GetValueOrThrow();
+                update.ServiceAccountGrace = subscription.GetMigrationGraceServiceAccounts();
+
+                var builder = OrganizationSubscriptionChangeSet.Builder(update.Plan);
+
+                if (update.SmSeatsChanged)
+                {
+                    builder.UpdateSecretsManagerSeats(update.SmSeatsExcludingBase);
+                }
+
+                if (update.SmServiceAccountsChanged)
+                {
+                    // The free ceiling is the plan's base allotment plus any migration grace. At or
+                    // below the ceiling there is no additional service-account line item to update, so
+                    // the change is an Add; above the ceiling the line item exists and the change is an
+                    // Update (Update with quantity 0 deletes it).
+                    var serviceAccountCeiling = update.Plan.SecretsManager.BaseServiceAccount + update.ServiceAccountGrace;
+
+                    if (update.Organization.SmServiceAccounts > serviceAccountCeiling)
+                    {
+                        builder.UpdateServiceAccounts(update.SmServiceAccountsExcludingBase);
+                    }
+                    else if (update.SmServiceAccountsExcludingBase > 0)
+                    {
+                        // Guard against AddServiceAccounts(0): adding a zero-quantity line item when
+                        // none exists is invalid. A zero excluding-base quantity means nothing to bill.
+                        builder.AddServiceAccounts(update.SmServiceAccountsExcludingBase);
+                    }
+                }
+
+                var changeSet = builder.Build();
+                if (changeSet.Changes.Any())
+                {
+                    var result = await _updateOrganizationSubscriptionCommand.Run(update.Organization, changeSet, subscription);
+                    result.GetValueOrThrow();
+                }
             }
         }
         else

--- a/test/Billing.Test/Services/SubscriptionUpdatedHandlerTests.cs
+++ b/test/Billing.Test/Services/SubscriptionUpdatedHandlerTests.cs
@@ -3090,6 +3090,443 @@ public class SubscriptionUpdatedHandlerTests
             Arg.Is<OrganizationPlanMigrationCohortAssignment>(a => a.Id == assignmentId && a.MigratedDate.HasValue));
     }
 
+    // PM-37510 (T2): migrating Enterprise 2020 (base 200) to current (base 50) writes a grace of 150
+    // onto the subscription metadata, merged with the existing metadata, with no item/quantity change.
+    [Fact]
+    public async Task HandleAsync_BusinessMigration_EnterpriseAnnual2020ToCurrent_WritesGraceMetadata()
+    {
+        // Arrange
+        var organizationId = Guid.NewGuid();
+        var cohortId = Guid.NewGuid();
+        var enterprise2020Annual = new Enterprise2020Plan(true);
+        var enterpriseAnnual = new EnterprisePlan(true);
+
+        var previousSubscription = new Subscription
+        {
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = enterprise2020Annual.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = enterprise2020Annual.PasswordManager.StripeSeatPlanId }
+                    }
+                ]
+            }
+        };
+
+        var subscription = new Subscription
+        {
+            Id = "sub_grace_ea",
+            ScheduleId = "sub_sched_x",
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = enterpriseAnnual.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = enterpriseAnnual.PasswordManager.StripeSeatPlanId }
+                    }
+                ]
+            },
+            Metadata = new Dictionary<string, string> { { "organizationId", organizationId.ToString() } },
+            LatestInvoice = new Invoice { BillingReason = BillingReasons.SubscriptionCycle }
+        };
+
+        var organization = new Organization
+        {
+            Id = organizationId,
+            PlanType = PlanType.EnterpriseAnnually2020,
+            Plan = enterprise2020Annual.Name,
+            Seats = 200,
+            SmServiceAccounts = 200
+        };
+
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            CohortId = cohortId
+        };
+
+        var parsedEvent = new Event
+        {
+            Data = new EventData
+            {
+                Object = subscription,
+                PreviousAttributes = JObject.FromObject(previousSubscription)
+            }
+        };
+
+        _stripeEventService.GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(subscription);
+        _organizationRepository.GetByIdAsync(organizationId).Returns(organization);
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+        _pricingClient.GetPlanOrThrow(PlanType.EnterpriseAnnually2020).Returns(enterprise2020Annual);
+        _pricingClient.GetPlanOrThrow(PlanType.EnterpriseAnnually).Returns(enterpriseAnnual);
+        _pricingClient.ListPlans().Returns(MockPlans.Plans);
+        _cohortAssignmentRepository.GetByOrganizationIdAsync(organizationId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohortId).Returns(new OrganizationPlanMigrationCohort
+        {
+            Id = cohortId,
+            Name = "Enterprise2020Annual",
+            MigrationPathId = MigrationPathId.Enterprise2020AnnualToCurrent,
+            IsActive = true
+        });
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert — grace of 150 written, merged with existing metadata, no item change.
+        await _stripeAdapter.Received(1).UpdateSubscriptionAsync(
+            subscription.Id,
+            Arg.Is<SubscriptionUpdateOptions>(options =>
+                options.Metadata[MetadataKeys.MigrationGraceServiceAccounts] == "150" &&
+                options.Metadata["organizationId"] == organizationId.ToString() &&
+                options.Items == null));
+
+        Assert.NotNull(assignment.MigratedDate);
+    }
+
+    // PM-37510 (T3): grace is entitlement-based (200 -> 50 => 150), independent of the org's actual
+    // SmServiceAccounts. A 250-account org still gets grace 150, and the handler writes only metadata —
+    // it never forces a billed quantity (the scheduler's 1:1 price mapping already carried it forward).
+    [Fact]
+    public async Task HandleAsync_BusinessMigration_OrgAboveBaseline_GraceIsEntitlementBased_NoQuantityForced()
+    {
+        // Arrange
+        var organizationId = Guid.NewGuid();
+        var cohortId = Guid.NewGuid();
+        var enterprise2020Annual = new Enterprise2020Plan(true);
+        var enterpriseAnnual = new EnterprisePlan(true);
+
+        var previousSubscription = new Subscription
+        {
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = enterprise2020Annual.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = enterprise2020Annual.PasswordManager.StripeSeatPlanId }
+                    }
+                ]
+            }
+        };
+
+        var subscription = new Subscription
+        {
+            Id = "sub_grace_250",
+            ScheduleId = "sub_sched_x",
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = enterpriseAnnual.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = enterpriseAnnual.PasswordManager.StripeSeatPlanId }
+                    }
+                ]
+            },
+            Metadata = new Dictionary<string, string> { { "organizationId", organizationId.ToString() } },
+            LatestInvoice = new Invoice { BillingReason = BillingReasons.SubscriptionCycle }
+        };
+
+        var organization = new Organization
+        {
+            Id = organizationId,
+            PlanType = PlanType.EnterpriseAnnually2020,
+            Plan = enterprise2020Annual.Name,
+            Seats = 200,
+            SmServiceAccounts = 250
+        };
+
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            CohortId = cohortId
+        };
+
+        var parsedEvent = new Event
+        {
+            Data = new EventData
+            {
+                Object = subscription,
+                PreviousAttributes = JObject.FromObject(previousSubscription)
+            }
+        };
+
+        _stripeEventService.GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(subscription);
+        _organizationRepository.GetByIdAsync(organizationId).Returns(organization);
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+        _pricingClient.GetPlanOrThrow(PlanType.EnterpriseAnnually2020).Returns(enterprise2020Annual);
+        _pricingClient.GetPlanOrThrow(PlanType.EnterpriseAnnually).Returns(enterpriseAnnual);
+        _pricingClient.ListPlans().Returns(MockPlans.Plans);
+        _cohortAssignmentRepository.GetByOrganizationIdAsync(organizationId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohortId).Returns(new OrganizationPlanMigrationCohort
+        {
+            Id = cohortId,
+            Name = "Enterprise2020Annual",
+            MigrationPathId = MigrationPathId.Enterprise2020AnnualToCurrent,
+            IsActive = true
+        });
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert — grace is still the entitlement constant (150), not derived from 250; no items forced.
+        await _stripeAdapter.Received(1).UpdateSubscriptionAsync(
+            subscription.Id,
+            Arg.Is<SubscriptionUpdateOptions>(options =>
+                options.Metadata[MetadataKeys.MigrationGraceServiceAccounts] == "150" &&
+                options.Items == null));
+    }
+
+    // PM-37510 (T10): if the grace metadata write fails, MigratedDate must NOT be stamped so Stripe
+    // retries. This also proves the grace write happens before the MigratedDate stamp.
+    [Fact]
+    public async Task HandleAsync_BusinessMigration_GraceWriteFails_DoesNotStampMigratedDate()
+    {
+        // Arrange
+        var organizationId = Guid.NewGuid();
+        var cohortId = Guid.NewGuid();
+        var enterprise2020Annual = new Enterprise2020Plan(true);
+        var enterpriseAnnual = new EnterprisePlan(true);
+
+        var previousSubscription = new Subscription
+        {
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = enterprise2020Annual.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = enterprise2020Annual.PasswordManager.StripeSeatPlanId }
+                    }
+                ]
+            }
+        };
+
+        var subscription = new Subscription
+        {
+            Id = "sub_grace_fail",
+            ScheduleId = "sub_sched_x",
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = enterpriseAnnual.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = enterpriseAnnual.PasswordManager.StripeSeatPlanId }
+                    }
+                ]
+            },
+            Metadata = new Dictionary<string, string> { { "organizationId", organizationId.ToString() } },
+            LatestInvoice = new Invoice { BillingReason = BillingReasons.SubscriptionCycle }
+        };
+
+        var organization = new Organization
+        {
+            Id = organizationId,
+            PlanType = PlanType.EnterpriseAnnually2020,
+            Plan = enterprise2020Annual.Name,
+            Seats = 200,
+            SmServiceAccounts = 200
+        };
+
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            CohortId = cohortId
+        };
+
+        var parsedEvent = new Event
+        {
+            Data = new EventData
+            {
+                Object = subscription,
+                PreviousAttributes = JObject.FromObject(previousSubscription)
+            }
+        };
+
+        _stripeEventService.GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(subscription);
+        _organizationRepository.GetByIdAsync(organizationId).Returns(organization);
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+        _pricingClient.GetPlanOrThrow(PlanType.EnterpriseAnnually2020).Returns(enterprise2020Annual);
+        _pricingClient.GetPlanOrThrow(PlanType.EnterpriseAnnually).Returns(enterpriseAnnual);
+        _pricingClient.ListPlans().Returns(MockPlans.Plans);
+        _cohortAssignmentRepository.GetByOrganizationIdAsync(organizationId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohortId).Returns(new OrganizationPlanMigrationCohort
+        {
+            Id = cohortId,
+            Name = "Enterprise2020Annual",
+            MigrationPathId = MigrationPathId.Enterprise2020AnnualToCurrent,
+            IsActive = true
+        });
+
+        _stripeAdapter.UpdateSubscriptionAsync(subscription.Id, Arg.Any<SubscriptionUpdateOptions>())
+            .Throws(new StripeException("boom"));
+
+        // Act — the grace write fails. It is surfaced as a BillingException, which the method's
+        // BillingException catch rethrows so the webhook 500s and Stripe retries (rather than the
+        // generic catch swallowing it).
+        await Assert.ThrowsAsync<BillingException>(() => _sut.HandleAsync(parsedEvent));
+
+        // Assert — the assignment is left unstamped (grace write happens before the MigratedDate stamp),
+        // so the Stripe replay re-runs idempotently.
+        Assert.Null(assignment.MigratedDate);
+        await _cohortAssignmentRepository.DidNotReceiveWithAnyArgs().ReplaceAsync(default);
+    }
+
+    // PM-37510 (T4): reduction-aware. When the target SM baseline is not smaller than the source
+    // baseline, grace is 0 and no metadata write occurs. No current real migration path is
+    // reduction-neutral, so the target plan here is a local double whose SM baseline matches the
+    // source (200) while keeping a distinct PasswordManager price for the schedule-item matching.
+    [Fact]
+    public async Task HandleAsync_BusinessMigration_TargetBaselineNotSmaller_DoesNotWriteGrace()
+    {
+        // Arrange
+        var organizationId = Guid.NewGuid();
+        var cohortId = Guid.NewGuid();
+        var enterprise2020Annual = new Enterprise2020Plan(true); // source SM base 200
+        var neutralTarget = new NeutralBaselineEnterprisePlan();  // target SM base 200, distinct PM price
+
+        var previousSubscription = new Subscription
+        {
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = enterprise2020Annual.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = enterprise2020Annual.PasswordManager.StripeSeatPlanId }
+                    }
+                ]
+            }
+        };
+
+        var subscription = new Subscription
+        {
+            Id = "sub_no_grace",
+            ScheduleId = "sub_sched_x",
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = neutralTarget.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = neutralTarget.PasswordManager.StripeSeatPlanId }
+                    }
+                ]
+            },
+            Metadata = new Dictionary<string, string> { { "organizationId", organizationId.ToString() } },
+            LatestInvoice = new Invoice { BillingReason = BillingReasons.SubscriptionCycle }
+        };
+
+        var organization = new Organization
+        {
+            Id = organizationId,
+            PlanType = PlanType.EnterpriseAnnually2020,
+            Plan = enterprise2020Annual.Name,
+            Seats = 200,
+            SmServiceAccounts = 200
+        };
+
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            CohortId = cohortId
+        };
+
+        var parsedEvent = new Event
+        {
+            Data = new EventData
+            {
+                Object = subscription,
+                PreviousAttributes = JObject.FromObject(previousSubscription)
+            }
+        };
+
+        _stripeEventService.GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(subscription);
+        _organizationRepository.GetByIdAsync(organizationId).Returns(organization);
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+        _pricingClient.GetPlanOrThrow(PlanType.EnterpriseAnnually2020).Returns(enterprise2020Annual);
+        // Target plan resolves to one whose SM baseline equals the source (no reduction => grace 0).
+        _pricingClient.GetPlanOrThrow(PlanType.EnterpriseAnnually).Returns(neutralTarget);
+        _pricingClient.ListPlans().Returns(MockPlans.Plans);
+        _cohortAssignmentRepository.GetByOrganizationIdAsync(organizationId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohortId).Returns(new OrganizationPlanMigrationCohort
+        {
+            Id = cohortId,
+            Name = "Enterprise2020Annual",
+            MigrationPathId = MigrationPathId.Enterprise2020AnnualToCurrent,
+            IsActive = true
+        });
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert — no grace metadata write; migration still completes.
+        await _stripeAdapter.DidNotReceive().UpdateSubscriptionAsync(
+            subscription.Id,
+            Arg.Is<SubscriptionUpdateOptions>(options =>
+                options.Metadata != null &&
+                options.Metadata.ContainsKey(MetadataKeys.MigrationGraceServiceAccounts)));
+
+        Assert.NotNull(assignment.MigratedDate);
+    }
+
+    // Target-plan double for the reduction-neutral case: SM base 200 (== Enterprise 2020 source) but a
+    // distinct PasswordManager seat price so the handler's source/target schedule-item matching works.
+    private sealed record NeutralBaselineEnterprisePlan : Bit.Core.Models.StaticStore.Plan
+    {
+        public NeutralBaselineEnterprisePlan()
+        {
+            var enterprise = new EnterprisePlan(true);
+            Type = enterprise.Type;
+            ProductTier = enterprise.ProductTier;
+            Name = enterprise.Name;
+            IsAnnual = true;
+            PasswordManager = new PasswordManagerFeatures();
+            SecretsManager = new SecretsManagerFeatures();
+        }
+
+        private sealed record PasswordManagerFeatures : PasswordManagerPlanFeatures
+        {
+            public PasswordManagerFeatures()
+            {
+                BaseSeats = 0;
+                StripeSeatPlanId = "neutral-enterprise-seat-annually";
+                StripeStoragePlanId = "storage-gb-annually";
+            }
+        }
+
+        private sealed record SecretsManagerFeatures : SecretsManagerPlanFeatures
+        {
+            public SecretsManagerFeatures()
+            {
+                BaseSeats = 0;
+                BaseServiceAccount = 200; // equal to Enterprise 2020 => no reduction => grace 0
+                StripeSeatPlanId = "neutral-secrets-manager-seat-annually";
+                StripeServiceAccountPlanId = "neutral-secrets-manager-service-account-annually";
+            }
+        }
+    }
+
     [Fact]
     public async Task HandleAsync_BusinessMigration_EnterpriseMonthly2020ToCurrent_AppliesAndMarksMigrated()
     {

--- a/test/Core.Test/Billing/Organizations/Commands/PreviewOrganizationTaxCommandTests.cs
+++ b/test/Core.Test/Billing/Organizations/Commands/PreviewOrganizationTaxCommandTests.cs
@@ -1437,6 +1437,63 @@ public class PreviewOrganizationTaxCommandTests
             options.Discounts == null));
     }
 
+    // PM-37510 (T7): the plan-change preview copies the existing subscription's already-materialized
+    // (grace-reduced) SM service-account quantity verbatim — no grace recompute happens here. A
+    // migrated Enterprise org billed for only 20 accounts above its 200 free ceiling previews exactly
+    // those 20.
+    [Fact]
+    public async Task Run_OrganizationPlanChange_MigratedOrg_CopiesGraceReducedServiceAccountQuantity()
+    {
+        var organization = new Organization
+        {
+            Id = Guid.NewGuid(),
+            PlanType = PlanType.EnterpriseAnnually,
+            GatewayCustomerId = "cus_test123",
+            GatewaySubscriptionId = "sub_test123",
+            UseSecretsManager = true
+        };
+
+        var planChange = new OrganizationSubscriptionPlanChange
+        {
+            Tier = ProductTierType.Enterprise,
+            Cadence = PlanCadenceType.Annually
+        };
+
+        var billingAddress = new BillingAddress { Country = "US", PostalCode = "12345" };
+
+        var plan = new EnterprisePlan(true);
+        _pricingClient.GetPlanOrThrow(organization.PlanType).Returns(plan);
+        _pricingClient.GetPlanOrThrow(planChange.PlanType).Returns(plan);
+
+        var subscriptionItems = new List<SubscriptionItem>
+        {
+            new() { Price = new Price { Id = plan.PasswordManager.StripeSeatPlanId }, Quantity = 10 },
+            new() { Price = new Price { Id = plan.SecretsManager.StripeSeatPlanId }, Quantity = 5 },
+            // Already grace-reduced: 220 accounts - 200 free ceiling => 20 billed.
+            new() { Price = new Price { Id = plan.SecretsManager.StripeServiceAccountPlanId }, Quantity = 20 }
+        };
+
+        var subscription = new Subscription
+        {
+            Id = "sub_test123",
+            Items = new StripeList<SubscriptionItem> { Data = subscriptionItems },
+            Customer = new Customer { Discount = null }
+        };
+
+        _stripeAdapter.GetSubscriptionAsync("sub_test123", Arg.Any<SubscriptionGetOptions>()).Returns(subscription);
+
+        var invoice = new Invoice { TotalTaxes = [new InvoiceTotalTax { Amount = 0 }], Total = 0 };
+        _stripeAdapter.CreateInvoicePreviewAsync(Arg.Any<InvoiceCreatePreviewOptions>()).Returns(invoice);
+
+        var result = await _command.Run(organization, planChange, billingAddress);
+
+        Assert.True(result.IsT0);
+
+        await _stripeAdapter.Received(1).CreateInvoicePreviewAsync(Arg.Is<InvoiceCreatePreviewOptions>(options =>
+            options.SubscriptionDetails.Items.Any(item =>
+                item.Price == plan.SecretsManager.StripeServiceAccountPlanId && item.Quantity == 20)));
+    }
+
     [Fact]
     public async Task Run_OrganizationPlanChange_ExistingSubscriptionWithDiscount_PreservesCoupon()
     {

--- a/test/Core.Test/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommandTests.cs
+++ b/test/Core.Test/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommandTests.cs
@@ -2160,4 +2160,71 @@ public class UpdateOrganizationSubscriptionCommandTests
         };
     }
 
+    // PM-37510 (T8): a caller-supplied subscription carrying an expanded Customer is reused, so the
+    // command makes zero GetSubscriptionAsync calls of its own.
+    [Fact]
+    public async Task Run_SuppliedSubscriptionWithCustomer_DoesNotRefetch()
+    {
+        var organization = CreateOrganization();
+        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
+        SetupUpdateSubscription(subscription);
+
+        var changeSet = new OrganizationSubscriptionChangeSet
+        {
+            Changes = [new UpdateItemQuantity("price_seats", 10)]
+        };
+
+        var result = await _command.Run(organization, changeSet, subscription);
+
+        Assert.True(result.Success);
+        await _stripeAdapter.DidNotReceiveWithAnyArgs()
+            .GetSubscriptionAsync(default, default);
+    }
+
+    // PM-37510 (T8): a supplied subscription missing its expanded Customer is not safe to reuse, so
+    // the command re-fetches exactly once.
+    [Fact]
+    public async Task Run_SuppliedSubscriptionWithoutCustomer_RefetchesOnce()
+    {
+        var organization = CreateOrganization();
+        var suppliedWithoutCustomer = CreateSubscription(items: [("price_seats", "si_1", 5)]);
+        suppliedWithoutCustomer.Customer = null;
+
+        var refetched = CreateSubscription(items: [("price_seats", "si_1", 5)]);
+        SetupGetSubscription(organization, refetched);
+        SetupUpdateSubscription(refetched);
+
+        var changeSet = new OrganizationSubscriptionChangeSet
+        {
+            Changes = [new UpdateItemQuantity("price_seats", 10)]
+        };
+
+        var result = await _command.Run(organization, changeSet, suppliedWithoutCustomer);
+
+        Assert.True(result.Success);
+        await _stripeAdapter.Received(1)
+            .GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>());
+    }
+
+    // PM-37510 (T8): with no supplied subscription the command fetches exactly once (existing default
+    // behavior preserved).
+    [Fact]
+    public async Task Run_NoSuppliedSubscription_FetchesOnce()
+    {
+        var organization = CreateOrganization();
+        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
+        SetupGetSubscription(organization, subscription);
+        SetupUpdateSubscription(subscription);
+
+        var changeSet = new OrganizationSubscriptionChangeSet
+        {
+            Changes = [new UpdateItemQuantity("price_seats", 10)]
+        };
+
+        var result = await _command.Run(organization, changeSet);
+
+        Assert.True(result.Success);
+        await _stripeAdapter.Received(1)
+            .GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>());
+    }
 }

--- a/test/Core.Test/Billing/Organizations/Commands/UpgradeOrganizationPlanVNextCommandTests.cs
+++ b/test/Core.Test/Billing/Organizations/Commands/UpgradeOrganizationPlanVNextCommandTests.cs
@@ -395,6 +395,27 @@ public class UpgradeOrganizationPlanVNextCommandTests
     }
 
     [Fact]
+    public async Task Run_PaidUpgrade_CommandFailure_DoesNotForfeitGraceMetadata()
+    {
+        var organization = CreateOrganization(PlanType.TeamsAnnually);
+        var currentPlan = MockPlans.Get(PlanType.TeamsAnnually);
+        var targetPlan = MockPlans.Get(PlanType.EnterpriseAnnually);
+
+        _pricingClient.GetPlanOrThrow(organization.PlanType).Returns(currentPlan);
+
+        BillingCommandResult<Subscription> failureResult = new BadRequest("Stripe error");
+        _updateOrganizationSubscriptionCommand
+            .Run(organization, Arg.Any<OrganizationSubscriptionChangeSet>())
+            .Returns(failureResult);
+
+        var result = await _command.Run(organization, targetPlan, null);
+
+        Assert.True(result.IsT1);
+        await _stripeAdapter.DidNotReceive().UpdateSubscriptionAsync(
+            Arg.Any<string>(), Arg.Any<SubscriptionUpdateOptions>());
+    }
+
+    [Fact]
     public async Task Run_PaidUpgrade_TwentyTwentyToTwentyTwenty_ReleasesScheduleWithOrganizationId()
     {
         // 2020-era source upgrading to a 2020-era target across ascending tiers

--- a/test/Core.Test/Billing/Organizations/Commands/UpgradeOrganizationPlanVNextCommandTests.cs
+++ b/test/Core.Test/Billing/Organizations/Commands/UpgradeOrganizationPlanVNextCommandTests.cs
@@ -5,6 +5,7 @@ using Bit.Core.Billing.Organizations.Commands;
 using Bit.Core.Billing.Organizations.Models;
 using Bit.Core.Billing.Organizations.Services;
 using Bit.Core.Billing.Pricing;
+using Bit.Core.Billing.Services;
 using Bit.Core.Enums;
 using Bit.Core.KeyManagement.Models.Data;
 using Bit.Core.Services;
@@ -14,6 +15,7 @@ using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Stripe;
 using Xunit;
+using static Bit.Core.Billing.Constants.StripeConstants;
 
 namespace Bit.Core.Test.Billing.Organizations.Commands;
 
@@ -23,6 +25,7 @@ public class UpgradeOrganizationPlanVNextCommandTests
     private readonly IOrganizationService _organizationService = Substitute.For<IOrganizationService>();
     private readonly IPricingClient _pricingClient = Substitute.For<IPricingClient>();
     private readonly IPriceIncreaseScheduler _priceIncreaseScheduler = Substitute.For<IPriceIncreaseScheduler>();
+    private readonly IStripeAdapter _stripeAdapter = Substitute.For<IStripeAdapter>();
     private readonly IUpdateOrganizationSubscriptionCommand _updateOrganizationSubscriptionCommand = Substitute.For<IUpdateOrganizationSubscriptionCommand>();
     private readonly UpgradeOrganizationPlanVNextCommand _command;
 
@@ -34,6 +37,7 @@ public class UpgradeOrganizationPlanVNextCommandTests
             _organizationService,
             _pricingClient,
             _priceIncreaseScheduler,
+            _stripeAdapter,
             _updateOrganizationSubscriptionCommand);
     }
 
@@ -367,6 +371,27 @@ public class UpgradeOrganizationPlanVNextCommandTests
             organization.GatewayCustomerId!,
             organization.GatewaySubscriptionId!,
             organization.Id);
+    }
+
+    // PM-37510 (T11): a voluntary paid upgrade forfeits SM service-account grace by clearing the
+    // metadata key (empty string removes it in Stripe). Subsequent billing math then reads grace 0.
+    [Fact]
+    public async Task Run_PaidUpgrade_ForfeitsGraceMetadata()
+    {
+        var organization = CreateOrganization(PlanType.TeamsAnnually2020);
+        var currentPlan = MockPlans.Get(PlanType.TeamsAnnually2020);
+        var targetPlan = MockPlans.Get(PlanType.EnterpriseAnnually);
+
+        _pricingClient.GetPlanOrThrow(organization.PlanType).Returns(currentPlan);
+        SetupSubscriptionCommandSuccess();
+
+        var result = await _command.Run(organization, targetPlan, null);
+
+        Assert.True(result.IsT0);
+        await _stripeAdapter.Received(1).UpdateSubscriptionAsync(
+            organization.GatewaySubscriptionId!,
+            Arg.Is<SubscriptionUpdateOptions>(options =>
+                options.Metadata[MetadataKeys.MigrationGraceServiceAccounts] == string.Empty));
     }
 
     [Fact]

--- a/test/Core.Test/Billing/Subscriptions/RestartSubscriptionCommandTests.cs
+++ b/test/Core.Test/Billing/Subscriptions/RestartSubscriptionCommandTests.cs
@@ -595,6 +595,65 @@ public class RestartSubscriptionCommandTests
             org.Enabled == true));
     }
 
+    // PM-37510 (T7): restart copies the canceled subscription's SM service-account quantity verbatim
+    // (already grace-reduced when it was billed) and carries the whole metadata over, so the grace key
+    // survives onto the new subscription. No quantity recompute occurs.
+    [Fact]
+    public async Task Run_Organization_WithSecretsManager_PreservesServiceAccountQuantityAndGraceMetadata()
+    {
+        var organizationId = Guid.NewGuid();
+        var currentPeriodEnd = DateTime.UtcNow.AddMonths(1);
+        var organization = new Organization
+        {
+            Id = organizationId,
+            PlanType = PlanType.EnterpriseMonthly
+        };
+
+        var plan = MockPlans.Get(PlanType.EnterpriseMonthly);
+
+        var existingSubscription = new Subscription
+        {
+            Status = SubscriptionStatus.Canceled,
+            CustomerId = "cus_grace",
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem { Price = new Price { Id = plan.PasswordManager.StripeSeatPlanId }, Quantity = 15 },
+                    new SubscriptionItem { Price = new Price { Id = plan.SecretsManager.StripeSeatPlanId }, Quantity = 10 },
+                    new SubscriptionItem { Price = new Price { Id = plan.SecretsManager.StripeServiceAccountPlanId }, Quantity = 20 }
+                ]
+            },
+            Metadata = new Dictionary<string, string>
+            {
+                ["organizationId"] = organizationId.ToString(),
+                [MetadataKeys.MigrationGraceServiceAccounts] = "150"
+            }
+        };
+
+        var newSubscription = new Subscription
+        {
+            Id = "sub_grace_new",
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data = [new SubscriptionItem { CurrentPeriodEnd = currentPeriodEnd }]
+            }
+        };
+
+        _subscriberService.GetSubscription(organization).Returns(existingSubscription);
+        _pricingClient.ListPlans().Returns([plan]);
+        _stripeAdapter.CreateSubscriptionAsync(Arg.Any<SubscriptionCreateOptions>()).Returns(newSubscription);
+
+        var result = await _command.Run(organization);
+
+        Assert.True(result.IsT0);
+
+        await _stripeAdapter.Received(1).CreateSubscriptionAsync(Arg.Is<SubscriptionCreateOptions>(options =>
+            options.Items.Any(item =>
+                item.Price == plan.SecretsManager.StripeServiceAccountPlanId && item.Quantity == 20) &&
+            options.Metadata[MetadataKeys.MigrationGraceServiceAccounts] == "150"));
+    }
+
     private record DisabledEnterprisePlan2023 : Bit.Core.Models.StaticStore.Plan
     {
         public DisabledEnterprisePlan2023(bool isAnnual)

--- a/test/Core.Test/Models/Business/SecretsManagerSubscriptionUpdateTests.cs
+++ b/test/Core.Test/Models/Business/SecretsManagerSubscriptionUpdateTests.cs
@@ -68,4 +68,112 @@ public class SecretsManagerSubscriptionUpdateTests
         // Assert
         Assert.Null(ex);
     }
+
+    // PM-37510: the SmServiceAccountsExcludingBase clamp prevents a negative billed quantity when the
+    // service-account count is at or below the (base + grace) ceiling.
+
+    [Theory]
+    [BitAutoData]
+    public void SmServiceAccountsExcludingBase_AtBaseline_WithNoGrace_ReturnsZero(Organization organization)
+    {
+        // Arrange
+        var plan = MockPlans.Get(PlanType.EnterpriseAnnually); // BaseServiceAccount = 50
+        organization.PlanType = plan.Type;
+
+        var sut = new SecretsManagerSubscriptionUpdate(organization, plan, false)
+        {
+            SmServiceAccounts = plan.SecretsManager.BaseServiceAccount
+        };
+
+        // Act / Assert
+        Assert.Equal(0, sut.SmServiceAccountsExcludingBase);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public void SmServiceAccountsExcludingBase_BelowBaseline_WithNoGrace_ClampsToZero(Organization organization)
+    {
+        // Arrange — regression for the new Math.Max(0, ...) clamp. Without it this would be negative.
+        var plan = MockPlans.Get(PlanType.EnterpriseAnnually); // BaseServiceAccount = 50
+        organization.PlanType = plan.Type;
+
+        var sut = new SecretsManagerSubscriptionUpdate(organization, plan, false)
+        {
+            SmServiceAccounts = plan.SecretsManager.BaseServiceAccount - 10
+        };
+
+        // Act / Assert
+        Assert.Equal(0, sut.SmServiceAccountsExcludingBase);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public void SmServiceAccountsExcludingBase_AtBaselinePlusGrace_ReturnsZero(Organization organization)
+    {
+        // Arrange — migrated Enterprise org: base 50, grace 150 => free ceiling of 200.
+        var plan = MockPlans.Get(PlanType.EnterpriseAnnually);
+        organization.PlanType = plan.Type;
+
+        var sut = new SecretsManagerSubscriptionUpdate(organization, plan, false)
+        {
+            ServiceAccountGrace = 150,
+            SmServiceAccounts = plan.SecretsManager.BaseServiceAccount + 150
+        };
+
+        // Act / Assert
+        Assert.Equal(0, sut.SmServiceAccountsExcludingBase);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public void SmServiceAccountsExcludingBase_BelowBaselinePlusGrace_ReturnsZero(Organization organization)
+    {
+        // Arrange
+        var plan = MockPlans.Get(PlanType.EnterpriseAnnually);
+        organization.PlanType = plan.Type;
+
+        var sut = new SecretsManagerSubscriptionUpdate(organization, plan, false)
+        {
+            ServiceAccountGrace = 150,
+            SmServiceAccounts = plan.SecretsManager.BaseServiceAccount + 100
+        };
+
+        // Act / Assert
+        Assert.Equal(0, sut.SmServiceAccountsExcludingBase);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public void SmServiceAccountsExcludingBase_AboveBaselinePlusGrace_ReturnsExcess(Organization organization)
+    {
+        // Arrange — 220 accounts, base 50, grace 150 => bill for 20.
+        var plan = MockPlans.Get(PlanType.EnterpriseAnnually);
+        organization.PlanType = plan.Type;
+
+        var sut = new SecretsManagerSubscriptionUpdate(organization, plan, false)
+        {
+            ServiceAccountGrace = 150,
+            SmServiceAccounts = 220
+        };
+
+        // Act / Assert
+        Assert.Equal(20, sut.SmServiceAccountsExcludingBase);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public void SmServiceAccountsExcludingBase_AboveBaseline_WithNoGrace_ReturnsExcess(Organization organization)
+    {
+        // Arrange — ServiceAccountGrace defaults to 0, preserving the original (clamped) behavior.
+        var plan = MockPlans.Get(PlanType.EnterpriseAnnually);
+        organization.PlanType = plan.Type;
+
+        var sut = new SecretsManagerSubscriptionUpdate(organization, plan, false)
+        {
+            SmServiceAccounts = 70
+        };
+
+        // Act / Assert
+        Assert.Equal(20, sut.SmServiceAccountsExcludingBase);
+    }
 }

--- a/test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/UpdateSecretsManagerSubscriptionCommandTests.cs
+++ b/test/Core.Test/OrganizationFeatures/OrganizationSubscriptionUpdate/UpdateSecretsManagerSubscriptionCommandTests.cs
@@ -20,7 +20,10 @@ using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
 using Xunit;
+using Customer = Stripe.Customer;
+using StripeConstants = Bit.Core.Billing.Constants.StripeConstants;
 using Subscription = Stripe.Subscription;
+using SubscriptionGetOptions = Stripe.SubscriptionGetOptions;
 
 namespace Bit.Core.Test.OrganizationFeatures.OrganizationSubscriptionUpdate;
 
@@ -808,9 +811,13 @@ public class UpdateSecretsManagerSubscriptionCommandTests
             .IsEnabled(FeatureFlagKeys.PM32581_UseUpdateOrganizationSubscriptionCommand)
             .Returns(true);
 
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(new Subscription { Customer = new Customer(), Metadata = new Dictionary<string, string>() });
+
         BillingCommandResult<Subscription> successResult = new Subscription();
         sutProvider.GetDependency<IUpdateOrganizationSubscriptionCommand>()
-            .Run(organization, Arg.Any<OrganizationSubscriptionChangeSet>())
+            .Run(organization, Arg.Any<OrganizationSubscriptionChangeSet>(), Arg.Any<Subscription>())
             .Returns(successResult);
 
         await sutProvider.Sut.UpdateSubscriptionAsync(update);
@@ -818,7 +825,7 @@ public class UpdateSecretsManagerSubscriptionCommandTests
         await sutProvider.GetDependency<IUpdateOrganizationSubscriptionCommand>().Received(1)
             .Run(organization, Arg.Is<OrganizationSubscriptionChangeSet>(cs =>
                 cs.Changes.Count == 2 &&
-                !cs.ChargeImmediately));
+                !cs.ChargeImmediately), Arg.Any<Subscription>());
         await sutProvider.GetDependency<IStripePaymentService>().DidNotReceiveWithAnyArgs()
             .AdjustSmSeatsAsync(default, default, default);
         await sutProvider.GetDependency<IStripePaymentService>().DidNotReceiveWithAnyArgs()
@@ -851,9 +858,13 @@ public class UpdateSecretsManagerSubscriptionCommandTests
             .IsEnabled(FeatureFlagKeys.PM32581_UseUpdateOrganizationSubscriptionCommand)
             .Returns(true);
 
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(new Subscription { Customer = new Customer(), Metadata = new Dictionary<string, string>() });
+
         BillingCommandResult<Subscription> successResult = new Subscription();
         sutProvider.GetDependency<IUpdateOrganizationSubscriptionCommand>()
-            .Run(organization, Arg.Any<OrganizationSubscriptionChangeSet>())
+            .Run(organization, Arg.Any<OrganizationSubscriptionChangeSet>(), Arg.Any<Subscription>())
             .Returns(successResult);
 
         await sutProvider.Sut.UpdateSubscriptionAsync(update);
@@ -861,11 +872,201 @@ public class UpdateSecretsManagerSubscriptionCommandTests
         await sutProvider.GetDependency<IUpdateOrganizationSubscriptionCommand>().Received(1)
             .Run(organization, Arg.Is<OrganizationSubscriptionChangeSet>(cs =>
                 cs.Changes.Count == 2 &&
-                !cs.ChargeImmediately));
+                !cs.ChargeImmediately), Arg.Any<Subscription>());
         await sutProvider.GetDependency<IStripePaymentService>().DidNotReceiveWithAnyArgs()
             .AdjustSmSeatsAsync(default, default, default);
         await sutProvider.GetDependency<IStripePaymentService>().DidNotReceiveWithAnyArgs()
             .AdjustServiceAccountsAsync(default, default, default);
+    }
+
+    private static Subscription SubscriptionWithGrace(int grace) => new()
+    {
+        Customer = new Customer(),
+        Metadata = new Dictionary<string, string>
+        {
+            [StripeConstants.MetadataKeys.MigrationGraceServiceAccounts] = grace.ToString()
+        }
+    };
+
+    // PM-37510 (T5): a migrated Enterprise org (base 50 + grace 150 => 200 free) increasing to 220
+    // accounts is billed for 20 — the excess above the free ceiling.
+    [Theory]
+    [BitAutoData]
+    public async Task UpdateSubscriptionAsync_WithFeatureFlag_WithGrace_AboveCeiling_UpdatesExcessQuantity(
+        Organization organization,
+        SutProvider<UpdateSecretsManagerSubscriptionCommand> sutProvider)
+    {
+        var plan = MockPlans.Get(PlanType.EnterpriseAnnually); // BaseServiceAccount = 50
+        organization.PlanType = plan.Type;
+        organization.Seats = 400;
+        organization.SmSeats = 10;
+        organization.MaxAutoscaleSmSeats = 20;
+        organization.SmServiceAccounts = 210;
+        organization.MaxAutoscaleSmServiceAccounts = 400;
+
+        var update = new SecretsManagerSubscriptionUpdate(organization, plan, false)
+        {
+            SmServiceAccounts = 220,
+            MaxAutoscaleSmServiceAccounts = 400
+        };
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM32581_UseUpdateOrganizationSubscriptionCommand)
+            .Returns(true);
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(SubscriptionWithGrace(150));
+
+        BillingCommandResult<Subscription> successResult = new Subscription();
+        sutProvider.GetDependency<IUpdateOrganizationSubscriptionCommand>()
+            .Run(organization, Arg.Any<OrganizationSubscriptionChangeSet>(), Arg.Any<Subscription>())
+            .Returns(successResult);
+
+        await sutProvider.Sut.UpdateSubscriptionAsync(update);
+
+        Assert.Equal(150, update.ServiceAccountGrace);
+        Assert.Equal(20, update.SmServiceAccountsExcludingBase);
+
+        await sutProvider.GetDependency<IUpdateOrganizationSubscriptionCommand>().Received(1)
+            .Run(organization, Arg.Is<OrganizationSubscriptionChangeSet>(cs =>
+                cs.Changes.Count == 1 &&
+                cs.Changes.Single().IsT3 &&
+                cs.Changes.Single().AsT3.Quantity == 20), Arg.Any<Subscription>());
+    }
+
+    // PM-37510 (T6): at the free ceiling (200), the excess is 0 — the existing line item is updated
+    // to quantity 0 (delete), never an AddItem(0).
+    [Theory]
+    [BitAutoData]
+    public async Task UpdateSubscriptionAsync_WithFeatureFlag_WithGrace_AtCeiling_UpdatesToZero(
+        Organization organization,
+        SutProvider<UpdateSecretsManagerSubscriptionCommand> sutProvider)
+    {
+        var plan = MockPlans.Get(PlanType.EnterpriseAnnually);
+        organization.PlanType = plan.Type;
+        organization.Seats = 400;
+        organization.SmSeats = 10;
+        organization.MaxAutoscaleSmSeats = 20;
+        organization.SmServiceAccounts = 210; // above ceiling => existing line item present
+        organization.MaxAutoscaleSmServiceAccounts = 400;
+
+        var update = new SecretsManagerSubscriptionUpdate(organization, plan, false)
+        {
+            SmServiceAccounts = 200, // back down to the ceiling
+            MaxAutoscaleSmServiceAccounts = 400
+        };
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM32581_UseUpdateOrganizationSubscriptionCommand)
+            .Returns(true);
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(SubscriptionWithGrace(150));
+
+        BillingCommandResult<Subscription> successResult = new Subscription();
+        sutProvider.GetDependency<IUpdateOrganizationSubscriptionCommand>()
+            .Run(organization, Arg.Any<OrganizationSubscriptionChangeSet>(), Arg.Any<Subscription>())
+            .Returns(successResult);
+
+        await sutProvider.Sut.UpdateSubscriptionAsync(update);
+
+        Assert.Equal(0, update.SmServiceAccountsExcludingBase);
+
+        // The org count (210) is still above the ceiling (200), so an Update (quantity 0 => delete) is
+        // emitted, not an Add.
+        await sutProvider.GetDependency<IUpdateOrganizationSubscriptionCommand>().Received(1)
+            .Run(organization, Arg.Is<OrganizationSubscriptionChangeSet>(cs =>
+                cs.Changes.Count == 1 &&
+                cs.Changes.Single().IsT3 &&
+                cs.Changes.Single().AsT3.Quantity == 0), Arg.Any<Subscription>());
+    }
+
+    // PM-37510 (T6): just above the ceiling (201 with base 50 + grace 150) bills exactly 1, and an
+    // org sitting at the ceiling that adds its first billable account uses Add (never Add(0)).
+    [Theory]
+    [BitAutoData]
+    public async Task UpdateSubscriptionAsync_WithFeatureFlag_WithGrace_FirstAccountAboveCeiling_AddsQuantityOne(
+        Organization organization,
+        SutProvider<UpdateSecretsManagerSubscriptionCommand> sutProvider)
+    {
+        var plan = MockPlans.Get(PlanType.EnterpriseAnnually);
+        organization.PlanType = plan.Type;
+        organization.Seats = 400;
+        organization.SmSeats = 10;
+        organization.MaxAutoscaleSmSeats = 20;
+        organization.SmServiceAccounts = 200; // at the ceiling => no existing additional line item
+        organization.MaxAutoscaleSmServiceAccounts = 400;
+
+        var update = new SecretsManagerSubscriptionUpdate(organization, plan, true)
+        {
+            SmServiceAccounts = 201,
+            MaxAutoscaleSmServiceAccounts = 400
+        };
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM32581_UseUpdateOrganizationSubscriptionCommand)
+            .Returns(true);
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(SubscriptionWithGrace(150));
+
+        BillingCommandResult<Subscription> successResult = new Subscription();
+        sutProvider.GetDependency<IUpdateOrganizationSubscriptionCommand>()
+            .Run(organization, Arg.Any<OrganizationSubscriptionChangeSet>(), Arg.Any<Subscription>())
+            .Returns(successResult);
+
+        await sutProvider.Sut.UpdateSubscriptionAsync(update);
+
+        Assert.Equal(1, update.SmServiceAccountsExcludingBase);
+
+        await sutProvider.GetDependency<IUpdateOrganizationSubscriptionCommand>().Received(1)
+            .Run(organization, Arg.Is<OrganizationSubscriptionChangeSet>(cs =>
+                cs.Changes.Count == 1 &&
+                cs.Changes.Single().IsT0 &&
+                cs.Changes.Single().AsT0.Quantity == 1), Arg.Any<Subscription>());
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task UpdateSubscriptionAsync_WithFeatureFlag_SubscriptionDeletedInStripe_ThrowsBadRequestException(
+        Organization organization,
+        SutProvider<UpdateSecretsManagerSubscriptionCommand> sutProvider)
+    {
+        var plan = MockPlans.Get(PlanType.EnterpriseAnnually);
+        organization.PlanType = plan.Type;
+        organization.Seats = 400;
+        organization.SmSeats = 10;
+        organization.MaxAutoscaleSmSeats = 20;
+        organization.SmServiceAccounts = 210;
+        organization.MaxAutoscaleSmServiceAccounts = 400;
+
+        var update = new SecretsManagerSubscriptionUpdate(organization, plan, false)
+        {
+            SmServiceAccounts = 220,
+            MaxAutoscaleSmServiceAccounts = 400
+        };
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM32581_UseUpdateOrganizationSubscriptionCommand)
+            .Returns(true);
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionAsync(organization.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns<Subscription>(_ => throw new Stripe.StripeException
+            {
+                StripeError = new Stripe.StripeError { Code = StripeConstants.ErrorCodes.ResourceMissing }
+            });
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.UpdateSubscriptionAsync(update));
+        Assert.Contains("We couldn't find your subscription.", exception.Message);
+
+        await sutProvider.GetDependency<IUpdateOrganizationSubscriptionCommand>().DidNotReceiveWithAnyArgs()
+            .Run(default, default, default);
+        await sutProvider.GetDependency<IOrganizationRepository>().DidNotReceiveWithAnyArgs().ReplaceAsync(default);
     }
 
     [Theory]
@@ -897,7 +1098,10 @@ public class UpdateSecretsManagerSubscriptionCommandTests
         await sutProvider.Sut.UpdateSubscriptionAsync(update);
 
         await sutProvider.GetDependency<IUpdateOrganizationSubscriptionCommand>().DidNotReceiveWithAnyArgs()
-            .Run(default, default);
+            .Run(default, default, default);
+        // No billable change, so the subscription is never fetched.
+        await sutProvider.GetDependency<IStripeAdapter>().DidNotReceiveWithAnyArgs()
+            .GetSubscriptionAsync(default, default);
         await sutProvider.GetDependency<IStripePaymentService>().DidNotReceiveWithAnyArgs()
             .AdjustSmSeatsAsync(default, default, default);
         await sutProvider.GetDependency<IStripePaymentService>().DidNotReceiveWithAnyArgs()
@@ -943,7 +1147,10 @@ public class UpdateSecretsManagerSubscriptionCommandTests
         await sutProvider.GetDependency<IStripePaymentService>().Received(1)
             .AdjustServiceAccountsAsync(organization, plan, update.SmServiceAccountsExcludingBase);
         await sutProvider.GetDependency<IUpdateOrganizationSubscriptionCommand>().DidNotReceiveWithAnyArgs()
-            .Run(default, default);
+            .Run(default, default, default);
+        // PM-37510 (T9): the legacy FF-off path never reads grace from Stripe.
+        await sutProvider.GetDependency<IStripeAdapter>().DidNotReceiveWithAnyArgs()
+            .GetSubscriptionAsync(default, default);
     }
 
     private static async Task VerifyDependencyNotCalledAsync(SutProvider<UpdateSecretsManagerSubscriptionCommand> sutProvider)


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37510

## 📔 Objective

When an **Enterprise 2020 + Secrets Manager** organization is migrated to current pricing, the plan's included machine (service) accounts drop from **200 → 50**. A naive migration would immediately bill the org for everything above 50 — capacity it was promised as included. This PR preserves that entitlement: the org keeps its full prior allotment **free in perpetuity**, and pays only for accounts added beyond it.

**Mechanism.** At migration we record a fixed _grace_ on the Stripe subscription metadata equal to the drop in the included baseline (`sourceBaseline − targetBaseline` — e.g. `200 − 50 = 150` for Enterprise, a per-migration-path constant, **not** derived from the org's own count). Everywhere we bill, the SM service-account quantity becomes `max(0, SmServiceAccounts − baseline − grace)`. No coupon, no new DB column.

The change reads as six sequential commits:

1. **Primitive** — the `migration_grace_service_accounts` metadata key, the `ServiceAccountGrace` field + grace-aware `SmServiceAccountsExcludingBase`, and a defensive metadata parser. Grace defaults to 0, so non-migrated orgs are unaffected.
2. **Reuse enabler** — `UpdateOrganizationSubscriptionCommand.Run` optionally accepts a pre-fetched subscription (0 net new Stripe calls).
3. **Enforce** — the SM-update funnel injects grace into the Update-vs-Add decision, and surfaces a controlled error if the subscription is missing.
4. **Read-site coverage** — tests pinning that the plan-change preview and subscription restart already reflect grace via materialized quantities.
5. **Establish** — the Phase 2 completion handler writes the grace constant to subscription metadata (gated on `PM35215_BusinessPlanPriceMigration`, reduction-aware, before stamping `MigratedDate`, idempotent on Stripe retry).
6. **Forfeit** — a voluntary plan change clears the grace metadata.

**Feature flags.** Establishment is gated behind `PM35215_BusinessPlanPriceMigration`; the grace-aware math lands unconditionally (a no-op at grace 0). All grace logic lives on the FF-on side of `PM32581_UseUpdateOrganizationSubscriptionCommand`.

**Reviewer notes / follow-ups**

- `SmServiceAccountsExcludingBase` now clamps at 0 — new vs. today, but a no-op in the validated input domain (validators already reject counts below baseline). Regression-tested.
- **PM32581 cleanup:** the grace wiring sits on the FF-on branch of `PM32581_UseUpdateOrganizationSubscriptionCommand`, which is slated for removal — when that flag is cleaned up, the wiring must move to the surviving branch, not be dropped with the dead one.
- **`charge_automatically` boundary:** automated establishment only covers auto-charged orgs (the `invoice.upcoming` → Phase 2 path). Invoice-billed cohorts are migrated manually and would have grace set in the Stripe Dashboard.
- **Renewal email is intentionally untouched** — it's owned by PM-37070.
- **Preview (latent):** the org-update tax-preview endpoint reads a client-supplied service-account count without applying grace, but that endpoint is currently unused by every client (the web client even calls it `POST` vs. the server's `PUT`). If it's ever wired up for migrated orgs it must be made grace-aware (cleanest: subtract grace server-side).
- **Product decision (locked):** a voluntary cross-tier upgrade forfeits the grace.

**Testing.** Full solution builds clean (0 errors); the touched Core/Billing test classes pass (386 unit tests).
