### PR TITLE
[bre-1835] update SeederApi Base Image

### DIFF
--- a/util/SeederApi/Dockerfile
+++ b/util/SeederApi/Dockerfile
@@ -89,7 +89,7 @@ RUN . /etc/build-env \
 ###############################################
 #                  App stage                  #
 ###############################################
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-azurelinux3.0-distroless-extra AS app
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-bookworm-slim AS app
 
 ARG TARGETPLATFORM
 LABEL com.bitwarden.product="bitwarden"
@@ -100,16 +100,17 @@ ENV ASPNETCORE_ENVIRONMENT=Production
 ENV ASPNETCORE_URLS=http://+:5000
 EXPOSE 5000
 
-# Set up health check wrapper
-# Get the executable and copy it to any path you want
-COPY --from=ghcr.io/alexaka1/distroless-dotnet-healthchecks:1@sha256:d2a71a595020f13a9283f5e1f93c5f92bc2385c1d9b36e128a00d35863995aba / /healthcheck
-# Setup your healthcheck endpoints via environment variable in Dockerfile, or at runtime via `docker run -e DISTROLESS_HEALTHCHECKS_URIS__0="http://localhost/healthz" -e DISTROLESS_HEALTHCHECKS_URIS__1="http://localhost/some/other/endpoint"`
-ENV DISTROLESS_HEALTHCHECKS_URI="http://localhost:5000/alive"
-# Setup the healthcheck using the EXEC array syntax
-HEALTHCHECK CMD ["/healthcheck/Distroless.HealthChecks"]
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    gosu \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy app from the build stage
 WORKDIR /app
 COPY --from=build /app/out /app
+COPY ./util/SeederApi/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
-ENTRYPOINT ["/app/SeederApi"]
+HEALTHCHECK CMD curl -f http://localhost:5000/alive || exit 1
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/util/SeederApi/Dockerfile
+++ b/util/SeederApi/Dockerfile
@@ -89,7 +89,7 @@ RUN . /etc/build-env \
 ###############################################
 #                  App stage                  #
 ###############################################
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-bookworm-slim AS app
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble AS app
 
 ARG TARGETPLATFORM
 LABEL com.bitwarden.product="bitwarden"

--- a/util/SeederApi/entrypoint.sh
+++ b/util/SeederApi/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+GROUPNAME="bitwarden"
+USERNAME="bitwarden"
+
+LUID=${LOCAL_UID:-0}
+LGID=${LOCAL_GID:-0}
+
+# Step down from host root to well-known nobody/nogroup user
+if [ $LUID -eq 0 ]
+then
+    LUID=65534
+fi
+if [ $LGID -eq 0 ]
+then
+    LGID=65534
+fi
+
+if [ "$(id -u)" = "0" ]
+then
+    groupadd -o -g $LGID $GROUPNAME >/dev/null 2>&1 ||
+    groupmod -o -g $LGID $GROUPNAME >/dev/null 2>&1
+    useradd -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1 ||
+    usermod -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1
+
+    chown -R $USERNAME:$GROUPNAME /app
+    mkdir -p /etc/bitwarden/core
+    mkdir -p /etc/bitwarden/logs
+    mkdir -p /etc/bitwarden/ca-certificates
+    chown -R $USERNAME:$GROUPNAME /etc/bitwarden
+
+    gosu_cmd="gosu $USERNAME:$GROUPNAME"
+else
+    gosu_cmd=""
+fi
+
+exec $gosu_cmd /app/SeederApi


### PR DESCRIPTION
## 🎟️ Tracking

[bre-1835](https://bitwarden.atlassian.net/browse/bre-1835)

## 📔 Objective
Replace SeederApi distroless base image with aspnet:10.0-noble

The distroless runtime image runs as a hardcoded non-root UID that conflicts with the UID-matching pattern used by other services in the stack. This caused SeederApi to be unable to read shared DataProtection key files at their default permissions, requiring a non-standard filesystem workaround to operate.

This PR swaps the runtime base image to aspnet:10.0-noble and adds the same entrypoint.sh + gosu pattern used by api and identity, so SeederApi runs as the correct UID and reads those files without any workaround.

 See BRE-1835 for full context.
  
Changes:
  - util/SeederApi/Dockerfile — runtime stage only, build stage untouched
  - util/SeederApi/entrypoint.sh — new file, mirrors the api/identity pattern