### PR TITLE
[PM-36079] fix: re-introduce PayPal IPN postback verification

### DIFF
--- a/src/Billing/Controllers/PayPalController.cs
+++ b/src/Billing/Controllers/PayPalController.cs
@@ -3,6 +3,8 @@
 
 using System.Text;
 using Bit.Billing.Models;
+using Bit.Billing.Services;
+using Bit.Core;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Billing.Services;
 using Bit.Core.Entities;
@@ -28,6 +30,8 @@ public class PayPalController : Controller
     private readonly IUserRepository _userRepository;
     private readonly IProviderRepository _providerRepository;
     private readonly IPremiumUserBillingService _premiumUserBillingService;
+    private readonly IPayPalIPNClient _payPalIPNClient;
+    private readonly IFeatureService _featureService;
 
     public PayPalController(
         IOptions<BillingSettings> billingSettings,
@@ -38,7 +42,9 @@ public class PayPalController : Controller
         ITransactionRepository transactionRepository,
         IUserRepository userRepository,
         IProviderRepository providerRepository,
-        IPremiumUserBillingService premiumUserBillingService)
+        IPremiumUserBillingService premiumUserBillingService,
+        IPayPalIPNClient payPalIPNClient,
+        IFeatureService featureService)
     {
         _billingSettings = billingSettings?.Value;
         _logger = logger;
@@ -49,6 +55,8 @@ public class PayPalController : Controller
         _userRepository = userRepository;
         _providerRepository = providerRepository;
         _premiumUserBillingService = premiumUserBillingService;
+        _payPalIPNClient = payPalIPNClient;
+        _featureService = featureService;
     }
 
     [HttpPost("ipn")]
@@ -139,6 +147,30 @@ public class PayPalController : Controller
                 transactionModel.MerchantCurrency);
 
             return Ok();
+        }
+
+        if (_featureService.IsEnabled(FeatureFlagKeys.PM36079_PayPalIpnVerification))
+        {
+            var verificationResult = await _payPalIPNClient.VerifyIPN(transactionModel.TransactionId, requestContent);
+
+            switch (verificationResult)
+            {
+                case PayPalIPNVerificationResult.Invalid:
+                    _logger.LogError(
+                        "PayPal IPN ({Id}): Verification returned INVALID; skipping processing",
+                        transactionModel.TransactionId);
+                    return Ok();
+                case PayPalIPNVerificationResult.Unverified:
+                    // Fail open: a transient verification failure must not drop a legitimate payment. The request is
+                    // still gated by the webhook key and the network ACL, so log and continue processing.
+                    _logger.LogWarning(
+                        "PayPal IPN ({Id}): Verification could not be completed; processing without postback confirmation",
+                        transactionModel.TransactionId);
+                    break;
+                case PayPalIPNVerificationResult.Verified:
+                default:
+                    break;
+            }
         }
 
         switch (transactionModel.PaymentStatus)

--- a/src/Billing/Services/IPayPalIPNClient.cs
+++ b/src/Billing/Services/IPayPalIPNClient.cs
@@ -2,5 +2,5 @@
 
 public interface IPayPalIPNClient
 {
-    Task<bool> VerifyIPN(string transactionId, string formData);
+    Task<PayPalIPNVerificationResult> VerifyIPN(string transactionId, string formData);
 }

--- a/src/Billing/Services/Implementations/PayPalIPNClient.cs
+++ b/src/Billing/Services/Implementations/PayPalIPNClient.cs
@@ -15,13 +15,15 @@ public class PayPalIPNClient : IPayPalIPNClient
         ILogger<PayPalIPNClient> logger)
     {
         _httpClient = httpClient;
+        // PayPal IPN postback verification must target the dedicated ipnpb host; the legacy www.paypal.com/cgi-bin/webscr
+        // endpoint redirects and is not the documented postback target.
         _ipnEndpoint = new Uri(billingSettings.Value.PayPal.Production
-            ? "https://www.paypal.com/cgi-bin/webscr"
-            : "https://www.sandbox.paypal.com/cgi-bin/webscr");
+            ? "https://ipnpb.paypal.com/cgi-bin/webscr"
+            : "https://ipnpb.sandbox.paypal.com/cgi-bin/webscr");
         _logger = logger;
     }
 
-    public async Task<bool> VerifyIPN(string transactionId, string formData)
+    public async Task<PayPalIPNVerificationResult> VerifyIPN(string transactionId, string formData)
     {
         LogInfo(transactionId, $"Verifying IPN against {_ipnEndpoint}");
 
@@ -36,40 +38,51 @@ public class PayPalIPNClient : IPayPalIPNClient
 
         requestMessage.Content = new StringContent(requestContent, Encoding.UTF8, "application/x-www-form-urlencoded");
 
-        var response = await _httpClient.SendAsync(requestMessage);
+        HttpResponseMessage response;
+
+        try
+        {
+            response = await _httpClient.SendAsync(requestMessage);
+        }
+        // Any failure to reach PayPal (network error, timeout, etc.) is transient and must not be treated as a forged
+        // message: report it as Unverified so the caller can fail open instead of dropping a legitimate payment.
+        catch (Exception exception)
+        {
+            LogError(transactionId, $"Verification request failed | {exception.Message}");
+            return PayPalIPNVerificationResult.Unverified;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            LogError(transactionId, $"Unsuccessful Response | Status Code: {response.StatusCode}");
+            return PayPalIPNVerificationResult.Unverified;
+        }
 
         var responseContent = await response.Content.ReadAsStringAsync();
 
-        if (response.IsSuccessStatusCode)
+        return responseContent switch
         {
-            return responseContent switch
-            {
-                "VERIFIED" => Verified(),
-                "INVALID" => Invalid(),
-                _ => Unhandled(responseContent)
-            };
-        }
+            "VERIFIED" => Verified(),
+            "INVALID" => Invalid(),
+            _ => Unhandled(responseContent)
+        };
 
-        LogError(transactionId, $"Unsuccessful Response | Status Code: {response.StatusCode} | Content: {responseContent}");
-
-        return false;
-
-        bool Verified()
+        PayPalIPNVerificationResult Verified()
         {
             LogInfo(transactionId, "Verified");
-            return true;
+            return PayPalIPNVerificationResult.Verified;
         }
 
-        bool Invalid()
+        PayPalIPNVerificationResult Invalid()
         {
             LogError(transactionId, "Verification Invalid");
-            return false;
+            return PayPalIPNVerificationResult.Invalid;
         }
 
-        bool Unhandled(string content)
+        PayPalIPNVerificationResult Unhandled(string content)
         {
             LogWarning(transactionId, $"Unhandled Response Content: {content}");
-            return false;
+            return PayPalIPNVerificationResult.Unverified;
         }
     }
 

--- a/src/Billing/Services/PayPalIPNVerificationResult.cs
+++ b/src/Billing/Services/PayPalIPNVerificationResult.cs
@@ -1,0 +1,24 @@
+﻿namespace Bit.Billing.Services;
+
+/// <summary>
+/// The outcome of verifying a PayPal IPN message via the <c>cmd=_notify-validate</c> postback handshake.
+/// </summary>
+public enum PayPalIPNVerificationResult
+{
+    /// <summary>
+    /// PayPal confirmed the message is authentic (postback returned <c>VERIFIED</c>).
+    /// </summary>
+    Verified,
+
+    /// <summary>
+    /// PayPal reported the message is not genuine (postback returned <c>INVALID</c>). The message must not be processed.
+    /// </summary>
+    Invalid,
+
+    /// <summary>
+    /// The postback could not be completed (network error, timeout, non-success status code, or an unrecognized
+    /// response body). This is a transient/indeterminate outcome: callers should fail open rather than drop a
+    /// legitimate payment, because the postback is a defense-in-depth layer behind the network ACL and webhook key.
+    /// </summary>
+    Unverified
+}

--- a/src/Billing/Startup.cs
+++ b/src/Billing/Startup.cs
@@ -51,7 +51,12 @@ public class Startup
         services.AddTestPlayIdTracking(globalSettings);
 
         // PayPal IPN Client
-        services.AddHttpClient<IPayPalIPNClient, PayPalIPNClient>();
+        services.AddHttpClient<IPayPalIPNClient, PayPalIPNClient>(client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(10);
+            // PayPal rejects postback verification requests that do not include a descriptive User-Agent (HTTP 403).
+            client.DefaultRequestHeaders.Add("User-Agent", "Bitwarden-IPN-VerificationScript");
+        });
 
         // Context
         services.AddScoped<ICurrentContext, CurrentContext>();

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -188,6 +188,7 @@ public static class FeatureFlagKeys
     public const string PM32645_DeferPriceMigrationToRenewal = "pm-32645-defer-price-migration-to-renewal";
     public const string PM34515_BrowserDesktopCheckout = "pm-34515-browser-desktop-checkout";
     public const string PM35215_BusinessPlanPriceMigration = "pm-35215-business-plan-price-migration";
+    public const string PM36079_PayPalIpnVerification = "pm-36079-paypal-ipn-postback-verification";
     public const string PM37597_AlwaysEnableStripeAutomaticTax = "pm-37597-always-enable-stripe-automatic-tax";
 
     /* Key Management Team */

--- a/test/Billing.Test/Controllers/PayPalControllerTests.cs
+++ b/test/Billing.Test/Controllers/PayPalControllerTests.cs
@@ -1,7 +1,9 @@
 ﻿using System.Globalization;
 using System.Text;
 using Bit.Billing.Controllers;
+using Bit.Billing.Services;
 using Bit.Billing.Test.Utilities;
+using Bit.Core;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Billing.Services;
@@ -34,6 +36,8 @@ public class PayPalControllerTests(ITestOutputHelper testOutputHelper)
     private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
     private readonly IProviderRepository _providerRepository = Substitute.For<IProviderRepository>();
     private readonly IPremiumUserBillingService _premiumUserBillingService = Substitute.For<IPremiumUserBillingService>();
+    private readonly IPayPalIPNClient _payPalIPNClient = Substitute.For<IPayPalIPNClient>();
+    private readonly IFeatureService _featureService = Substitute.For<IFeatureService>();
 
     private const string _defaultWebhookKey = "webhook-key";
 
@@ -505,6 +509,170 @@ public class PayPalControllerTests(ITestOutputHelper testOutputHelper)
             transaction.Type == TransactionType.Refund));
     }
 
+    [Fact]
+    public async Task PostIpn_VerificationEnabled_Invalid_DoesNotProcess_Ok()
+    {
+        var logger = testOutputHelper.BuildLoggerFor<PayPalController>();
+
+        _billingSettings.Value.Returns(new BillingSettings
+        {
+            PayPal =
+            {
+                WebhookKey = _defaultWebhookKey,
+                BusinessId = "NHDYKLQ3L4LWL"
+            }
+        });
+
+        _featureService.IsEnabled(FeatureFlagKeys.PM36079_PayPalIpnVerification).Returns(true);
+        _payPalIPNClient.VerifyIPN(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(PayPalIPNVerificationResult.Invalid);
+
+        var ipnBody = await PayPalTestIPN.GetAsync(IPNBody.SuccessfulPayment);
+
+        var controller = ConfigureControllerContextWith(logger, _defaultWebhookKey, ipnBody);
+
+        var result = await controller.PostIpn();
+
+        HasStatusCode(result, 200);
+
+        await _payPalIPNClient.Received(1).VerifyIPN("2PK15573S8089712Y", Arg.Any<string>());
+        await _transactionRepository.DidNotReceiveWithAnyArgs().CreateAsync(Arg.Any<Transaction>());
+        await _paymentService.DidNotReceiveWithAnyArgs().CreditAccountAsync(Arg.Any<ISubscriber>(), Arg.Any<decimal>());
+
+        LoggedError(logger, "PayPal IPN (2PK15573S8089712Y): Verification returned INVALID; skipping processing");
+    }
+
+    [Fact]
+    public async Task PostIpn_VerificationEnabled_Unverified_StillProcesses_Ok()
+    {
+        var logger = testOutputHelper.BuildLoggerFor<PayPalController>();
+
+        _billingSettings.Value.Returns(new BillingSettings
+        {
+            PayPal =
+            {
+                WebhookKey = _defaultWebhookKey,
+                BusinessId = "NHDYKLQ3L4LWL"
+            }
+        });
+
+        _featureService.IsEnabled(FeatureFlagKeys.PM36079_PayPalIpnVerification).Returns(true);
+        _payPalIPNClient.VerifyIPN(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(PayPalIPNVerificationResult.Unverified);
+
+        var ipnBody = await PayPalTestIPN.GetAsync(IPNBody.SuccessfulPayment);
+
+        _transactionRepository.GetByGatewayIdAsync(
+            GatewayType.PayPal,
+            "2PK15573S8089712Y").ReturnsNull();
+
+        var controller = ConfigureControllerContextWith(logger, _defaultWebhookKey, ipnBody);
+
+        var result = await controller.PostIpn();
+
+        HasStatusCode(result, 200);
+
+        await _payPalIPNClient.Received(1).VerifyIPN("2PK15573S8089712Y", Arg.Any<string>());
+        await _transactionRepository.Received().CreateAsync(Arg.Any<Transaction>());
+    }
+
+    [Fact]
+    public async Task PostIpn_VerificationEnabled_Verified_Processes_Ok()
+    {
+        var logger = testOutputHelper.BuildLoggerFor<PayPalController>();
+
+        _billingSettings.Value.Returns(new BillingSettings
+        {
+            PayPal =
+            {
+                WebhookKey = _defaultWebhookKey,
+                BusinessId = "NHDYKLQ3L4LWL"
+            }
+        });
+
+        _featureService.IsEnabled(FeatureFlagKeys.PM36079_PayPalIpnVerification).Returns(true);
+        _payPalIPNClient.VerifyIPN(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(PayPalIPNVerificationResult.Verified);
+
+        var ipnBody = await PayPalTestIPN.GetAsync(IPNBody.SuccessfulPayment);
+
+        _transactionRepository.GetByGatewayIdAsync(
+            GatewayType.PayPal,
+            "2PK15573S8089712Y").ReturnsNull();
+
+        var controller = ConfigureControllerContextWith(logger, _defaultWebhookKey, ipnBody);
+
+        var result = await controller.PostIpn();
+
+        HasStatusCode(result, 200);
+
+        await _payPalIPNClient.Received(1).VerifyIPN("2PK15573S8089712Y", Arg.Any<string>());
+        await _transactionRepository.Received().CreateAsync(Arg.Any<Transaction>());
+    }
+
+    [Fact]
+    public async Task PostIpn_VerificationDisabled_DoesNotVerify_Ok()
+    {
+        var logger = testOutputHelper.BuildLoggerFor<PayPalController>();
+
+        _billingSettings.Value.Returns(new BillingSettings
+        {
+            PayPal =
+            {
+                WebhookKey = _defaultWebhookKey,
+                BusinessId = "NHDYKLQ3L4LWL"
+            }
+        });
+
+        _featureService.IsEnabled(FeatureFlagKeys.PM36079_PayPalIpnVerification).Returns(false);
+
+        var ipnBody = await PayPalTestIPN.GetAsync(IPNBody.SuccessfulPayment);
+
+        _transactionRepository.GetByGatewayIdAsync(
+            GatewayType.PayPal,
+            "2PK15573S8089712Y").ReturnsNull();
+
+        var controller = ConfigureControllerContextWith(logger, _defaultWebhookKey, ipnBody);
+
+        var result = await controller.PostIpn();
+
+        HasStatusCode(result, 200);
+
+        await _payPalIPNClient.DidNotReceiveWithAnyArgs().VerifyIPN(Arg.Any<string>(), Arg.Any<string>());
+        await _transactionRepository.Received().CreateAsync(Arg.Any<Transaction>());
+    }
+
+    [Fact]
+    public async Task PostIpn_VerificationEnabled_Invalid_DoesNotProcessRefund_Ok()
+    {
+        var logger = testOutputHelper.BuildLoggerFor<PayPalController>();
+
+        _billingSettings.Value.Returns(new BillingSettings
+        {
+            PayPal =
+            {
+                WebhookKey = _defaultWebhookKey,
+                BusinessId = "NHDYKLQ3L4LWL"
+            }
+        });
+
+        _featureService.IsEnabled(FeatureFlagKeys.PM36079_PayPalIpnVerification).Returns(true);
+        _payPalIPNClient.VerifyIPN(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(PayPalIPNVerificationResult.Invalid);
+
+        var ipnBody = await PayPalTestIPN.GetAsync(IPNBody.SuccessfulRefund);
+
+        var controller = ConfigureControllerContextWith(logger, _defaultWebhookKey, ipnBody);
+
+        var result = await controller.PostIpn();
+
+        HasStatusCode(result, 200);
+
+        await _payPalIPNClient.Received(1).VerifyIPN("2PK15573S8089712Y", Arg.Any<string>());
+        await _transactionRepository.DidNotReceiveWithAnyArgs().ReplaceAsync(Arg.Any<Transaction>());
+        await _transactionRepository.DidNotReceiveWithAnyArgs().CreateAsync(Arg.Any<Transaction>());
+    }
+
     private PayPalController ConfigureControllerContextWith(
         ILogger<PayPalController> logger,
         string? webhookKey,
@@ -519,7 +687,9 @@ public class PayPalControllerTests(ITestOutputHelper testOutputHelper)
             _transactionRepository,
             _userRepository,
             _providerRepository,
-            _premiumUserBillingService);
+            _premiumUserBillingService,
+            _payPalIPNClient,
+            _featureService);
 
         var httpContext = new DefaultHttpContext();
 

--- a/test/Billing.Test/Services/PayPalIPNClientTests.cs
+++ b/test/Billing.Test/Services/PayPalIPNClientTests.cs
@@ -11,7 +11,7 @@ namespace Bit.Billing.Test.Services;
 
 public class PayPalIPNClientTests
 {
-    private readonly Uri _endpoint = new("https://www.sandbox.paypal.com/cgi-bin/webscr");
+    private readonly Uri _endpoint = new("https://ipnpb.sandbox.paypal.com/cgi-bin/webscr");
     private readonly MockHttpMessageHandler _mockHttpMessageHandler = new();
 
     private readonly IOptions<BillingSettings> _billingSettings = Substitute.For<IOptions<BillingSettings>>();
@@ -37,7 +37,7 @@ public class PayPalIPNClientTests
         => await Assert.ThrowsAsync<ArgumentNullException>(() => _payPalIPNClient.VerifyIPN(string.Empty, null));
 
     [Fact]
-    public async Task VerifyIPN_Unauthorized_ReturnsFalse()
+    public async Task VerifyIPN_Unauthorized_ReturnsUnverified()
     {
         const string formData = "form=data";
 
@@ -46,14 +46,14 @@ public class PayPalIPNClientTests
             .WithFormData(new Dictionary<string, string> { { "cmd", "_notify-validate" }, { "form", "data" } })
             .Respond(HttpStatusCode.Unauthorized);
 
-        var verified = await _payPalIPNClient.VerifyIPN(string.Empty, formData);
+        var result = await _payPalIPNClient.VerifyIPN(string.Empty, formData);
 
-        Assert.False(verified);
+        Assert.Equal(PayPalIPNVerificationResult.Unverified, result);
         Assert.Equal(1, _mockHttpMessageHandler.GetMatchCount(request));
     }
 
     [Fact]
-    public async Task VerifyIPN_OK_Invalid_ReturnsFalse()
+    public async Task VerifyIPN_OK_Invalid_ReturnsInvalid()
     {
         const string formData = "form=data";
 
@@ -62,14 +62,14 @@ public class PayPalIPNClientTests
             .WithFormData(new Dictionary<string, string> { { "cmd", "_notify-validate" }, { "form", "data" } })
             .Respond("application/text", "INVALID");
 
-        var verified = await _payPalIPNClient.VerifyIPN(string.Empty, formData);
+        var result = await _payPalIPNClient.VerifyIPN(string.Empty, formData);
 
-        Assert.False(verified);
+        Assert.Equal(PayPalIPNVerificationResult.Invalid, result);
         Assert.Equal(1, _mockHttpMessageHandler.GetMatchCount(request));
     }
 
     [Fact]
-    public async Task VerifyIPN_OK_Verified_ReturnsTrue()
+    public async Task VerifyIPN_OK_Verified_ReturnsVerified()
     {
         const string formData = "form=data";
 
@@ -78,9 +78,23 @@ public class PayPalIPNClientTests
             .WithFormData(new Dictionary<string, string> { { "cmd", "_notify-validate" }, { "form", "data" } })
             .Respond("application/text", "VERIFIED");
 
-        var verified = await _payPalIPNClient.VerifyIPN(string.Empty, formData);
+        var result = await _payPalIPNClient.VerifyIPN(string.Empty, formData);
 
-        Assert.True(verified);
+        Assert.Equal(PayPalIPNVerificationResult.Verified, result);
         Assert.Equal(1, _mockHttpMessageHandler.GetMatchCount(request));
+    }
+
+    [Fact]
+    public async Task VerifyIPN_RequestThrows_ReturnsUnverified()
+    {
+        const string formData = "form=data";
+
+        _mockHttpMessageHandler
+            .When(HttpMethod.Post, _endpoint.ToString())
+            .Throw(new HttpRequestException("Simulated network failure"));
+
+        var result = await _payPalIPNClient.VerifyIPN(string.Empty, formData);
+
+        Assert.Equal(PayPalIPNVerificationResult.Unverified, result);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

Resolves [PM-36079](https://bitwarden.atlassian.net/browse/PM-36079) (originating finding: VULN-550 / HackerOne).

## 📔 Objective

`POST /paypal/ipn` previously authenticated inbound PayPal IPN messages only with the static `?key=` query-string secret (plus a `ReceiverId == BusinessId` check, where `BusinessId` is public). The repository shipped a real PayPal postback validator (`IPayPalIPNClient.VerifyIPN`, the `cmd=_notify-validate` round-trip), but it was dead code — wired up in #3619 and removed in #3882 because the previous implementation broke constantly and, being fail-closed, dropped legitimate payments.

This PR re-introduces postback verification as a **defense-in-depth** layer, implemented to PayPal's current spec so it no longer regresses payment reliability:

- **Correct endpoint:** posts to the dedicated `ipnpb.paypal.com` / `ipnpb.sandbox.paypal.com` host (the legacy `www.paypal.com/cgi-bin/webscr` redirects and silently drops the POST body).
- **Required header:** the typed `HttpClient` now sends a descriptive `User-Agent` (PayPal returns `403` without one) and a 10s timeout.
- **Safe failure semantics:** `VerifyIPN` returns a tri-state result. `Invalid` (PayPal reports the message is not genuine) blocks processing; a transient failure (`Unverified` — network error / timeout / non-200) **fails open** and still processes, so a PayPal-side hiccup can never again drop legitimate credit.
- **Feature-flagged kill-switch:** enforcement is gated behind `FeatureFlagKeys.PM36079_PayPalIpnVerification` (default off) for gradual rollout and instant disable without a deploy.

A forged / `INVALID` IPN now returns `200 OK` without crediting — this acknowledges PayPal (avoiding retry storms) and gives an attacker no detection oracle. Verification is placed before the credit/refund switch, so both the credit and refund paths are protected.

**Ops follow-up:** alert on the `Unverified` warning log line — a sustained spike is the only signature of the fail-open path being exercised.

### Testing

- `PayPalIPNClientTests`: updated for the `ipnpb` endpoint and tri-state result, including a transient-exception case.
- `PayPalControllerTests`: added coverage for `INVALID` blocking a payment, `INVALID` blocking a refund, `Unverified` still processing (fail-open), `Verified` processing, and the flag-disabled path skipping verification.


[PM-36079]: https://bitwarden.atlassian.net/browse/PM-36079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ