### PR TITLE
[PM-37228] feat: Add scheduled price increase to organization warnings

### DIFF
--- a/src/Core/Billing/Organizations/Models/OrganizationWarnings.cs
+++ b/src/Core/Billing/Organizations/Models/OrganizationWarnings.cs
@@ -6,6 +6,7 @@ public record OrganizationWarnings
     public InactiveSubscriptionWarning? InactiveSubscription { get; set; }
     public ResellerRenewalWarning? ResellerRenewal { get; set; }
     public TaxIdWarning? TaxId { get; set; }
+    public ScheduledPriceIncreaseWarning? ScheduledPriceIncrease { get; set; }
 
     public record FreeTrialWarning
     {
@@ -44,5 +45,12 @@ public record OrganizationWarnings
     public record TaxIdWarning
     {
         public required string Type { get; set; }
+    }
+
+    public record ScheduledPriceIncreaseWarning
+    {
+        public required decimal SeatPrice { get; set; }
+        public required DateTime EffectiveDate { get; set; }
+        public required string Cadence { get; set; }
     }
 }

--- a/src/Core/Billing/Organizations/Queries/GetOrganizationWarningsQuery.cs
+++ b/src/Core/Billing/Organizations/Queries/GetOrganizationWarningsQuery.cs
@@ -342,6 +342,28 @@ public class GetOrganizationWarningsQuery(
             return null;
         }
 
+        var assignment = await assignmentRepository.GetByOrganizationIdAsync(organization.Id);
+
+        if (assignment == null)
+        {
+            return null;
+        }
+
+        var cohort = await cohortRepository.GetByIdAsync(assignment.CohortId);
+
+        // A null MigrationPathId is a churn-only cohort, which never schedules a price increase.
+        if (cohort?.MigrationPathId == null)
+        {
+            return null;
+        }
+
+        var migrationPath = MigrationPaths.FromId(cohort.MigrationPathId.Value);
+
+        if (migrationPath == null)
+        {
+            return null;
+        }
+
         var schedules = await stripeAdapter.ListSubscriptionSchedulesAsync(
             new SubscriptionScheduleListOptions { Customer = subscription.CustomerId });
 
@@ -363,28 +385,6 @@ public class GetOrganizationWarningsQuery(
             .MinBy(phase => phase.StartDate);
 
         if (upcomingPhase == null)
-        {
-            return null;
-        }
-
-        var assignment = await assignmentRepository.GetByOrganizationIdAsync(organization.Id);
-
-        if (assignment == null)
-        {
-            return null;
-        }
-
-        var cohort = await cohortRepository.GetByIdAsync(assignment.CohortId);
-
-        // A null MigrationPathId is a churn-only cohort, which never schedules a price increase.
-        if (cohort?.MigrationPathId == null)
-        {
-            return null;
-        }
-
-        var migrationPath = MigrationPaths.FromId(cohort.MigrationPathId.Value);
-
-        if (migrationPath == null)
         {
             return null;
         }

--- a/src/Core/Billing/Organizations/Queries/GetOrganizationWarningsQuery.cs
+++ b/src/Core/Billing/Organizations/Queries/GetOrganizationWarningsQuery.cs
@@ -6,7 +6,10 @@ using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Extensions;
 using Bit.Core.Billing.Organizations.Models;
+using Bit.Core.Billing.Organizations.PlanMigration.Repositories;
+using Bit.Core.Billing.Organizations.PlanMigration.ValueObjects;
 using Bit.Core.Billing.Payment.Queries;
+using Bit.Core.Billing.Pricing;
 using Bit.Core.Billing.Services;
 using Bit.Core.Billing.Tax.Utilities;
 using Bit.Core.Context;
@@ -21,6 +24,7 @@ using CountryAbbreviations = Bit.Core.Constants.CountryAbbreviations;
 using FreeTrialWarning = OrganizationWarnings.FreeTrialWarning;
 using InactiveSubscriptionWarning = OrganizationWarnings.InactiveSubscriptionWarning;
 using ResellerRenewalWarning = OrganizationWarnings.ResellerRenewalWarning;
+using ScheduledPriceIncreaseWarning = OrganizationWarnings.ScheduledPriceIncreaseWarning;
 using TaxIdWarning = OrganizationWarnings.TaxIdWarning;
 
 public interface IGetOrganizationWarningsQuery
@@ -30,9 +34,12 @@ public interface IGetOrganizationWarningsQuery
 }
 
 public class GetOrganizationWarningsQuery(
+    IOrganizationPlanMigrationCohortAssignmentRepository assignmentRepository,
+    IOrganizationPlanMigrationCohortRepository cohortRepository,
     ICurrentContext currentContext,
     IFeatureService featureService,
     IHasPaymentMethodQuery hasPaymentMethodQuery,
+    IPricingClient pricingClient,
     IProviderRepository providerRepository,
     IStripeAdapter stripeAdapter,
     ISubscriberService subscriberService) : IGetOrganizationWarningsQuery
@@ -60,6 +67,8 @@ public class GetOrganizationWarningsQuery(
         warnings.ResellerRenewal = await GetResellerRenewalWarningAsync(organization, provider, subscription);
 
         warnings.TaxId = await GetTaxIdWarningAsync(organization, subscription.Customer, provider);
+
+        warnings.ScheduledPriceIncrease = await GetScheduledPriceIncreaseWarningAsync(organization, subscription);
 
         return warnings;
     }
@@ -311,6 +320,87 @@ public class GetOrganizationWarningsQuery(
             // Customer's tax ID failed verification
             not null when taxId.Verification.Status == TaxIdVerificationStatus.Unverified => new TaxIdWarning { Type = "tax_id_failed_verification" },
             _ => null
+        };
+    }
+
+    private async Task<ScheduledPriceIncreaseWarning?> GetScheduledPriceIncreaseWarningAsync(
+        Organization organization,
+        Subscription subscription)
+    {
+        if (!featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration))
+        {
+            return null;
+        }
+
+        if (!await currentContext.EditSubscription(organization.Id))
+        {
+            return null;
+        }
+
+        if (subscription.Status != SubscriptionStatus.Active)
+        {
+            return null;
+        }
+
+        var schedules = await stripeAdapter.ListSubscriptionSchedulesAsync(
+            new SubscriptionScheduleListOptions { Customer = subscription.CustomerId });
+
+        var activeSchedule = schedules.Data.FirstOrDefault(schedule =>
+            schedule.Status == SubscriptionScheduleStatus.Active && schedule.SubscriptionId == subscription.Id);
+
+        if (activeSchedule is not { Phases.Count: > 0 })
+        {
+            return null;
+        }
+
+        var now = subscription.TestClock?.FrozenTime ?? DateTime.UtcNow;
+
+        // Select by StartDate > now (earliest future phase), not EndDate > now: with EndBehavior=Release
+        // the schedule stays Active through the post-renewal period, and an EndDate filter would keep
+        // surfacing the past renewal date as the "effective date" until the period closed.
+        var upcomingPhase = activeSchedule.Phases
+            .Where(phase => phase.StartDate > now)
+            .MinBy(phase => phase.StartDate);
+
+        if (upcomingPhase == null)
+        {
+            return null;
+        }
+
+        var assignment = await assignmentRepository.GetByOrganizationIdAsync(organization.Id);
+
+        if (assignment == null)
+        {
+            return null;
+        }
+
+        var cohort = await cohortRepository.GetByIdAsync(assignment.CohortId);
+
+        // A null MigrationPathId is a churn-only cohort, which never schedules a price increase.
+        if (cohort?.MigrationPathId == null)
+        {
+            return null;
+        }
+
+        var migrationPath = MigrationPaths.FromId(cohort.MigrationPathId.Value);
+
+        if (migrationPath == null)
+        {
+            return null;
+        }
+
+        var targetPlan = await pricingClient.GetPlanOrThrow(migrationPath.ToPlan);
+
+        // SeatPrice is per-year on annual plans and per-month on monthly plans.
+        var seatPrice = targetPlan.IsAnnual
+            ? targetPlan.PasswordManager.SeatPrice / 12
+            : targetPlan.PasswordManager.SeatPrice;
+
+        return new ScheduledPriceIncreaseWarning
+        {
+            SeatPrice = seatPrice,
+            EffectiveDate = upcomingPhase.StartDate,
+            Cadence = targetPlan.IsAnnual ? "annually" : "monthly"
         };
     }
 }

--- a/test/Core.Test/Billing/Organizations/Queries/GetOrganizationWarningsQueryTests.cs
+++ b/test/Core.Test/Billing/Organizations/Queries/GetOrganizationWarningsQueryTests.cs
@@ -4,11 +4,16 @@ using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Enums;
+using Bit.Core.Billing.Organizations.PlanMigration.Entities;
+using Bit.Core.Billing.Organizations.PlanMigration.Enums;
+using Bit.Core.Billing.Organizations.PlanMigration.Repositories;
 using Bit.Core.Billing.Organizations.Queries;
 using Bit.Core.Billing.Payment.Queries;
+using Bit.Core.Billing.Pricing;
 using Bit.Core.Billing.Services;
 using Bit.Core.Context;
 using Bit.Core.Services;
+using Bit.Core.Test.Billing.Mocks;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
@@ -44,7 +49,8 @@ public class GetOrganizationWarningsQueryTests
         {
             FreeTrial: null,
             InactiveSubscription: null,
-            ResellerRenewal: null
+            ResellerRenewal: null,
+            ScheduledPriceIncrease: null
         });
     }
 
@@ -1261,5 +1267,336 @@ public class GetOrganizationWarningsQueryTests
         var response = await sutProvider.Sut.Run(organization);
 
         Assert.Null(response.ResellerRenewal);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_ScheduledPriceIncrease_Monthly_ReturnsWarning(
+        Organization organization,
+        SutProvider<GetOrganizationWarningsQuery> sutProvider)
+    {
+        var now = DateTime.UtcNow;
+        var renewalDate = now.AddDays(10);
+
+        SetupScheduledPriceIncrease(sutProvider, organization, now, renewalDate,
+            MigrationPathId.Teams2020MonthlyToCurrent, PlanType.TeamsMonthly);
+
+        var response = await sutProvider.Sut.Run(organization);
+
+        Assert.NotNull(response.ScheduledPriceIncrease);
+        Assert.Equal("monthly", response.ScheduledPriceIncrease.Cadence);
+        Assert.Equal(5M, response.ScheduledPriceIncrease.SeatPrice);
+        Assert.Equal(renewalDate, response.ScheduledPriceIncrease.EffectiveDate);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_ScheduledPriceIncrease_Annual_ReturnsWarning(
+        Organization organization,
+        SutProvider<GetOrganizationWarningsQuery> sutProvider)
+    {
+        var now = DateTime.UtcNow;
+        var renewalDate = now.AddDays(20);
+
+        SetupScheduledPriceIncrease(sutProvider, organization, now, renewalDate,
+            MigrationPathId.Enterprise2020AnnualToCurrent, PlanType.EnterpriseAnnually);
+
+        var response = await sutProvider.Sut.Run(organization);
+
+        Assert.NotNull(response.ScheduledPriceIncrease);
+        Assert.Equal("annually", response.ScheduledPriceIncrease.Cadence);
+        // Enterprise annual seat price is 72/yr -> 6.00/mo.
+        Assert.Equal(6M, response.ScheduledPriceIncrease.SeatPrice);
+        Assert.Equal(renewalDate, response.ScheduledPriceIncrease.EffectiveDate);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_NoScheduleAttached_NullWarning(
+        Organization organization,
+        SutProvider<GetOrganizationWarningsQuery> sutProvider)
+    {
+        var now = DateTime.UtcNow;
+
+        SetupScheduledPriceIncrease(sutProvider, organization, now, now.AddDays(10),
+            MigrationPathId.Teams2020MonthlyToCurrent, PlanType.TeamsMonthly);
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [] });
+
+        var response = await sutProvider.Sut.Run(organization);
+
+        Assert.Null(response.ScheduledPriceIncrease);
+        await sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>()
+            .DidNotReceive().GetByOrganizationIdAsync(Arg.Any<Guid>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_SchedulePresentButNotMigration_NullWarning(
+        Organization organization,
+        SutProvider<GetOrganizationWarningsQuery> sutProvider)
+    {
+        var now = DateTime.UtcNow;
+
+        var (_, assignment) = SetupScheduledPriceIncrease(sutProvider, organization, now, now.AddDays(10),
+            MigrationPathId.Teams2020MonthlyToCurrent, PlanType.TeamsMonthly);
+
+        // Churn-only cohort: null MigrationPathId.
+        sutProvider.GetDependency<IOrganizationPlanMigrationCohortRepository>()
+            .GetByIdAsync(assignment.CohortId)
+            .Returns(new OrganizationPlanMigrationCohort { Id = assignment.CohortId, MigrationPathId = null });
+
+        var response = await sutProvider.Sut.Run(organization);
+
+        Assert.Null(response.ScheduledPriceIncrease);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_NoCohortAssignment_NullWarning(
+        Organization organization,
+        SutProvider<GetOrganizationWarningsQuery> sutProvider)
+    {
+        var now = DateTime.UtcNow;
+
+        SetupScheduledPriceIncrease(sutProvider, organization, now, now.AddDays(10),
+            MigrationPathId.Teams2020MonthlyToCurrent, PlanType.TeamsMonthly);
+
+        sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>()
+            .GetByOrganizationIdAsync(organization.Id)
+            .ReturnsNull();
+
+        var response = await sutProvider.Sut.Run(organization);
+
+        Assert.Null(response.ScheduledPriceIncrease);
+    }
+
+    [Theory]
+    [BitAutoData(SubscriptionStatus.Canceled)]
+    [BitAutoData(SubscriptionStatus.PastDue)]
+    [BitAutoData(SubscriptionStatus.Unpaid)]
+    public async Task Run_InactiveSubscription_NullWarning(
+        string status,
+        Organization organization,
+        SutProvider<GetOrganizationWarningsQuery> sutProvider)
+    {
+        var now = DateTime.UtcNow;
+
+        SetupScheduledPriceIncrease(sutProvider, organization, now, now.AddDays(10),
+            MigrationPathId.Teams2020MonthlyToCurrent, PlanType.TeamsMonthly, status);
+
+        var response = await sutProvider.Sut.Run(organization);
+
+        Assert.Null(response.ScheduledPriceIncrease);
+        await sutProvider.GetDependency<IStripeAdapter>()
+            .DidNotReceive().ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_FeatureFlagOff_NullWarning(
+        Organization organization,
+        SutProvider<GetOrganizationWarningsQuery> sutProvider)
+    {
+        var now = DateTime.UtcNow;
+
+        SetupScheduledPriceIncrease(sutProvider, organization, now, now.AddDays(10),
+            MigrationPathId.Teams2020MonthlyToCurrent, PlanType.TeamsMonthly);
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration)
+            .Returns(false);
+
+        var response = await sutProvider.Sut.Run(organization);
+
+        Assert.Null(response.ScheduledPriceIncrease);
+        await sutProvider.GetDependency<IStripeAdapter>()
+            .DidNotReceive().ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>());
+        await sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>()
+            .DidNotReceive().GetByOrganizationIdAsync(Arg.Any<Guid>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_UpcomingPhaseSelection_BeforeRenewal_UsesTargetPhase(
+        Organization organization,
+        SutProvider<GetOrganizationWarningsQuery> sutProvider)
+    {
+        var now = DateTime.UtcNow;
+        var renewalDate = now.AddDays(15);
+
+        SetupScheduledPriceIncrease(sutProvider, organization, now, renewalDate,
+            MigrationPathId.Enterprise2020AnnualToCurrent, PlanType.EnterpriseAnnually);
+
+        // Normalized 3-phase schedule: anchor + current both start <= now and must be excluded.
+        var schedule = new SubscriptionSchedule
+        {
+            Id = "sub_sched_123",
+            SubscriptionId = "sub_123",
+            Status = SubscriptionScheduleStatus.Active,
+            Phases =
+            [
+                new SubscriptionSchedulePhase { StartDate = now.AddDays(-40), EndDate = now.AddDays(-30) },
+                new SubscriptionSchedulePhase { StartDate = now.AddDays(-30), EndDate = renewalDate },
+                new SubscriptionSchedulePhase { StartDate = renewalDate, EndDate = renewalDate.AddYears(1) }
+            ]
+        };
+        sutProvider.GetDependency<IStripeAdapter>()
+            .ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
+
+        var response = await sutProvider.Sut.Run(organization);
+
+        Assert.NotNull(response.ScheduledPriceIncrease);
+        Assert.Equal(renewalDate, response.ScheduledPriceIncrease.EffectiveDate);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_UnknownMigrationPathId_NullWarning(
+        Organization organization,
+        SutProvider<GetOrganizationWarningsQuery> sutProvider)
+    {
+        var now = DateTime.UtcNow;
+
+        var (_, assignment) = SetupScheduledPriceIncrease(sutProvider, organization, now, now.AddDays(10),
+            MigrationPathId.Teams2020MonthlyToCurrent, PlanType.TeamsMonthly);
+
+        // A MigrationPathId value that MigrationPaths.FromId does not resolve.
+        sutProvider.GetDependency<IOrganizationPlanMigrationCohortRepository>()
+            .GetByIdAsync(assignment.CohortId)
+            .Returns(new OrganizationPlanMigrationCohort
+            {
+                Id = assignment.CohortId,
+                MigrationPathId = (MigrationPathId)200
+            });
+
+        var response = await sutProvider.Sut.Run(organization);
+
+        Assert.Null(response.ScheduledPriceIncrease);
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_CallerCannotManageBilling_NullWarning(
+        Organization organization,
+        SutProvider<GetOrganizationWarningsQuery> sutProvider)
+    {
+        var now = DateTime.UtcNow;
+
+        SetupScheduledPriceIncrease(sutProvider, organization, now, now.AddDays(10),
+            MigrationPathId.Teams2020MonthlyToCurrent, PlanType.TeamsMonthly);
+
+        sutProvider.GetDependency<ICurrentContext>().EditSubscription(organization.Id).Returns(false);
+
+        var response = await sutProvider.Sut.Run(organization);
+
+        Assert.Null(response.ScheduledPriceIncrease);
+        await sutProvider.GetDependency<IStripeAdapter>()
+            .DidNotReceive().ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>());
+        await sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>()
+            .DidNotReceive().GetByOrganizationIdAsync(Arg.Any<Guid>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_AfterRenewalBoundary_NullWarning(
+        Organization organization,
+        SutProvider<GetOrganizationWarningsQuery> sutProvider)
+    {
+        var now = DateTime.UtcNow;
+        var renewalDate = now.AddDays(-5);
+
+        SetupScheduledPriceIncrease(sutProvider, organization, now, renewalDate,
+            MigrationPathId.Enterprise2020AnnualToCurrent, PlanType.EnterpriseAnnually);
+
+        // Schedule still Active (EndBehavior=Release): current phase already ended at the past
+        // renewal; target phase [renewalDate, renewalDate + period] still present but starts <= now.
+        var schedule = new SubscriptionSchedule
+        {
+            Id = "sub_sched_123",
+            SubscriptionId = "sub_123",
+            Status = SubscriptionScheduleStatus.Active,
+            Phases =
+            [
+                new SubscriptionSchedulePhase { StartDate = now.AddDays(-370), EndDate = renewalDate },
+                new SubscriptionSchedulePhase { StartDate = renewalDate, EndDate = now.AddDays(360) }
+            ]
+        };
+        sutProvider.GetDependency<IStripeAdapter>()
+            .ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
+
+        var response = await sutProvider.Sut.Run(organization);
+
+        Assert.Null(response.ScheduledPriceIncrease);
+    }
+
+    private static (Subscription Subscription, OrganizationPlanMigrationCohortAssignment Assignment) SetupScheduledPriceIncrease(
+        SutProvider<GetOrganizationWarningsQuery> sutProvider,
+        Organization organization,
+        DateTime now,
+        DateTime renewalDate,
+        MigrationPathId migrationPathId,
+        PlanType targetPlanType,
+        string subscriptionStatus = SubscriptionStatus.Active)
+    {
+        var subscription = new Subscription
+        {
+            Id = "sub_123",
+            CustomerId = "cus_123",
+            Status = subscriptionStatus,
+            Customer = new Customer
+            {
+                InvoiceSettings = new CustomerInvoiceSettings(),
+                Metadata = new Dictionary<string, string>()
+            },
+            Metadata = new Dictionary<string, string>(),
+            TestClock = new TestClock { FrozenTime = now }
+        };
+
+        sutProvider.GetDependency<ISubscriberService>()
+            .GetSubscription(organization, Arg.Is<SubscriptionGetOptions>(options =>
+                options.Expand.SequenceEqual(_requiredExpansions)))
+            .Returns(subscription);
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration)
+            .Returns(true);
+
+        sutProvider.GetDependency<ICurrentContext>().EditSubscription(organization.Id).Returns(true);
+
+        var schedule = new SubscriptionSchedule
+        {
+            Id = "sub_sched_123",
+            SubscriptionId = subscription.Id,
+            Status = SubscriptionScheduleStatus.Active,
+            Phases =
+            [
+                new SubscriptionSchedulePhase { StartDate = now.AddDays(-30), EndDate = renewalDate },
+                new SubscriptionSchedulePhase { StartDate = renewalDate, EndDate = renewalDate.AddYears(1) }
+            ]
+        };
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
+
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organization.Id,
+            CohortId = Guid.NewGuid()
+        };
+
+        sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>()
+            .GetByOrganizationIdAsync(organization.Id)
+            .Returns(assignment);
+
+        sutProvider.GetDependency<IOrganizationPlanMigrationCohortRepository>()
+            .GetByIdAsync(assignment.CohortId)
+            .Returns(new OrganizationPlanMigrationCohort
+            {
+                Id = assignment.CohortId,
+                MigrationPathId = migrationPathId
+            });
+
+        sutProvider.GetDependency<IPricingClient>()
+            .GetPlanOrThrow(targetPlanType)
+            .Returns(MockPlans.Get(targetPlanType));
+
+        return (subscription, assignment);
     }
 }

--- a/test/Core.Test/Billing/Organizations/Queries/GetOrganizationWarningsQueryTests.cs
+++ b/test/Core.Test/Billing/Organizations/Queries/GetOrganizationWarningsQueryTests.cs
@@ -1325,8 +1325,6 @@ public class GetOrganizationWarningsQueryTests
         var response = await sutProvider.Sut.Run(organization);
 
         Assert.Null(response.ScheduledPriceIncrease);
-        await sutProvider.GetDependency<IOrganizationPlanMigrationCohortAssignmentRepository>()
-            .DidNotReceive().GetByOrganizationIdAsync(Arg.Any<Guid>());
     }
 
     [Theory, BitAutoData]
@@ -1366,6 +1364,8 @@ public class GetOrganizationWarningsQueryTests
         var response = await sutProvider.Sut.Run(organization);
 
         Assert.Null(response.ScheduledPriceIncrease);
+        await sutProvider.GetDependency<IStripeAdapter>()
+            .DidNotReceive().ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>());
     }
 
     [Theory]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37228

## 📔 Objective

Part of the [PM-35215](https://bitwarden.atlassian.net/browse/PM-35215) business-plan price migration. Surfaces an upcoming scheduled price increase on the organization subscription page by adding a new nullable `ScheduledPriceIncrease` warning to the existing `GET organizations/{id}/billing/vnext/warnings` response (`OrganizationWarnings`).

When an organization has an active migration schedule with an upcoming price increase, the warning carries the data the web client needs to render the callout:

- `SeatPrice` — the new per-seat price as a monthly-equivalent (annual plans ÷ 12), matching the figure the renewal email quotes
- `EffectiveDate` — the renewal instant the increase takes effect (raw UTC)
- `Cadence` — `"monthly"` or `"annually"`, selecting the copy variant

The warning is computed in `GetOrganizationWarningsQuery` and is fully gated: feature flag `PM35215_BusinessPlanPriceMigration`, then `EditSubscription` (billing-management) permission, then an active subscription. It returns `null` (no callout) for non-migration orgs, churn-only cohorts, inactive subscriptions, or when the flag is off, so older and newer clients degrade gracefully (additive, V±2-safe).

No new endpoint, DI registration, or database changes. The Angular callout rendering is client-side and out of scope for this PR.


[PM-35215]: https://bitwarden.atlassian.net/browse/PM-35215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ