### PR TITLE
[PM-38456]: Allow License Generation for Sales Trial Orgs

### DIFF
--- a/src/Core/Billing/Organizations/Queries/GetCloudOrganizationLicenseQuery.cs
+++ b/src/Core/Billing/Organizations/Queries/GetCloudOrganizationLicenseQuery.cs
@@ -51,10 +51,12 @@ public class GetCloudOrganizationLicenseQuery : IGetCloudOrganizationLicenseQuer
 
         if (subscriptionInfo.Subscription is null)
         {
-            throw new BadRequestException("No active subscription found.");
+            if (!organization.ExpirationDate.HasValue || organization.ExpirationDate <= DateTime.UtcNow)
+            {
+                throw new BadRequestException("No active subscription found.");
+            }
         }
-
-        if (subscriptionInfo.Subscription.Status is StripeConstants.SubscriptionStatus.Canceled
+        else if (subscriptionInfo.Subscription.Status is StripeConstants.SubscriptionStatus.Canceled
             or StripeConstants.SubscriptionStatus.Incomplete
             or StripeConstants.SubscriptionStatus.IncompleteExpired)
         {

--- a/test/Core.Test/Billing/Organizations/Queries/GetCloudOrganizationLicenseQueryTests.cs
+++ b/test/Core.Test/Billing/Organizations/Queries/GetCloudOrganizationLicenseQueryTests.cs
@@ -196,11 +196,12 @@ public class GetCloudOrganizationLicenseQueryTests
 
     [Theory]
     [BitAutoData]
-    public async Task GetLicenseAsync_NullSubscription_Throws(
+    public async Task GetLicenseAsync_NullSubscription_NoExpirationDate_Throws(
         SutProvider<GetCloudOrganizationLicenseQuery> sutProvider,
         Organization organization, Guid installationId, Installation installation)
     {
         installation.Enabled = true;
+        organization.ExpirationDate = null;
         var subInfo = new SubscriptionInfo { Subscription = null };
 
         sutProvider.GetDependency<IInstallationRepository>().GetByIdAsync(installationId).Returns(installation);
@@ -209,6 +210,47 @@ public class GetCloudOrganizationLicenseQueryTests
         var exception = await Assert.ThrowsAsync<BadRequestException>(async () =>
             await sutProvider.Sut.GetLicenseAsync(organization, installationId));
         Assert.Contains("No active subscription found", exception.Message);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetLicenseAsync_NullSubscription_PastExpirationDate_Throws(
+        SutProvider<GetCloudOrganizationLicenseQuery> sutProvider,
+        Organization organization, Guid installationId, Installation installation)
+    {
+        installation.Enabled = true;
+        organization.ExpirationDate = DateTime.UtcNow.AddDays(-1);
+        var subInfo = new SubscriptionInfo { Subscription = null };
+
+        sutProvider.GetDependency<IInstallationRepository>().GetByIdAsync(installationId).Returns(installation);
+        sutProvider.GetDependency<IStripePaymentService>().GetSubscriptionAsync(organization).Returns(subInfo);
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(async () =>
+            await sutProvider.Sut.GetLicenseAsync(organization, installationId));
+        Assert.Contains("No active subscription found", exception.Message);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetLicenseAsync_NullSubscription_FutureExpirationDate_CreatesLicense(
+        SutProvider<GetCloudOrganizationLicenseQuery> sutProvider,
+        Organization organization, Guid installationId, Installation installation,
+        byte[] licenseSignature)
+    {
+        installation.Enabled = true;
+        organization.ExpirationDate = DateTime.UtcNow.AddDays(30);
+        var subInfo = new SubscriptionInfo { Subscription = null };
+
+        sutProvider.GetDependency<IInstallationRepository>().GetByIdAsync(installationId).Returns(installation);
+        sutProvider.GetDependency<IStripePaymentService>().GetSubscriptionAsync(organization).Returns(subInfo);
+        sutProvider.GetDependency<ILicensingService>().SignLicense(Arg.Any<ILicense>()).Returns(licenseSignature);
+
+        var result = await sutProvider.Sut.GetLicenseAsync(organization, installationId);
+
+        Assert.Equal(LicenseType.Organization, result.LicenseType);
+        Assert.Equal(organization.Id, result.Id);
+        Assert.Equal(installationId, result.InstallationId);
+        Assert.Equal(organization.ExpirationDate!.Value.Date, result.Expires!.Value.Date);
     }
 
     [Theory]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38456

## 📔 Objective

Some Sales-assisted trial organizations are created with no Stripe subscription — the sales team sets an `ExpirationDate` directly in the Admin portal instead. `GetCloudOrganizationLicenseQuery.GetLicenseAsync` was throwing `"No active subscription found."` unconditionally whenever `subscriptionInfo.Subscription is null`, which blocked license file generation for these orgs entirely.

The fix relaxes that guard to pass through when the org has a future `ExpirationDate`, allowing `LicenseExtensions.CalculateFreshExpirationDate` (which already had the correct fallback from PM-21415) to use `org.ExpirationDate` directly.

**Before:** Any org without a Stripe subscription → `BadRequestException`

**After:**
- No subscription + no expiration → `BadRequestException("No active subscription found.")`
- No subscription + past expiration → `BadRequestException("No active subscription found.")`
- No subscription + future expiration → license generated with `org.ExpirationDate` as the expiration

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
### No Subscription with Future Expiration Date
https://github.com/user-attachments/assets/01aee81b-93cd-4b48-85b8-493c23f3716a
### No Subscription with Expire Expiration Date
https://github.com/user-attachments/assets/4e0f0640-c195-4573-a5ea-016225a2474e

