### PR TITLE
[PM-38393] feat: Add disable-self-host-premium-check feature flag key

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -189,6 +189,7 @@ public static class FeatureFlagKeys
     public const string PM34515_BrowserDesktopCheckout = "pm-34515-browser-desktop-checkout";
     public const string PM35215_BusinessPlanPriceMigration = "pm-35215-business-plan-price-migration";
     public const string PM37597_AlwaysEnableStripeAutomaticTax = "pm-37597-always-enable-stripe-automatic-tax";
+    public const string PM38393_DisableSelfHostPremiumCheck = "pm-38393-disable-self-host-premium-check";
 
     /* Key Management Team */
     public const string PrivateKeyRegeneration = "pm-12241-private-key-regeneration";


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38393

## 📔 Objective

Registers `pm-38393-disable-self-host-premium-check` in `FeatureFlagKeys` so LaunchDarkly can serve it to clients in QA environments. The flag makes clients treat self-hosted-classified environments (e.g. Bitwarden's QA cloud environments, whose URLs are not production cloud regions) as cloud for premium upgrade and pricing purposes, enabling QA to test the browser/desktop Stripe checkout flow (PM-35229). Mirrors the mobile precedent (bitwarden/android#6954).

The flag is consumed client-side only — no server behavior changes. Companion clients PR: https://github.com/bitwarden/clients/pull/21159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)