### PR TITLE
[PM-33408] Add OrganizationUser_NotificationBannerActionClicked EventType

### DIFF
--- a/src/Core/Dirt/Enums/EventType.cs
+++ b/src/Core/Dirt/Enums/EventType.cs
@@ -80,6 +80,7 @@ public enum EventType : int
     OrganizationUser_AdminResetTwoFactor = 1519,
     OrganizationUser_Revoked_TwoFactorNonCompliance = 1520,
     OrganizationUser_Revoked_SingleOrganizationNonCompliance = 1521,
+    OrganizationUser_NotificationBannerActionClicked = 1522,
 
     Organization_Updated = 1600,
     Organization_PurgedVault = 1601,

--- a/src/Events/Controllers/CollectController.cs
+++ b/src/Events/Controllers/CollectController.cs
@@ -60,6 +60,7 @@ public class CollectController : Controller
 
                 case EventType.Organization_ItemOrganization_Accepted:
                 case EventType.Organization_ItemOrganization_Declined:
+                case EventType.OrganizationUser_NotificationBannerActionClicked:
                     if (!eventModel.OrganizationId.HasValue || !_currentContext.UserId.HasValue)
                     {
                         continue;

--- a/test/Events.Test/Controllers/CollectControllerTests.cs
+++ b/test/Events.Test/Controllers/CollectControllerTests.cs
@@ -82,7 +82,8 @@ public class CollectControllerTests
     [Theory]
     [BitAutoData(EventType.Organization_ItemOrganization_Accepted)]
     [BitAutoData(EventType.Organization_ItemOrganization_Declined)]
-    public async Task Post_Organization_ItemOrganization_LogsOrganizationUserEvent(
+    [BitAutoData(EventType.OrganizationUser_NotificationBannerActionClicked)]
+    public async Task Post_OrganizationUserEvent_LogsOrganizationUserEvent(
         EventType type, Guid userId, Guid orgId, OrganizationUser orgUser)
     {
         _currentContext.UserId.Returns(userId);
@@ -103,6 +104,56 @@ public class CollectControllerTests
 
         Assert.IsType<OkResult>(result);
         await _eventService.Received(1).LogOrganizationUserEventAsync(orgUser, type, eventDate);
+    }
+
+    [Theory]
+    [BitAutoData(EventType.Organization_ItemOrganization_Accepted)]
+    [BitAutoData(EventType.Organization_ItemOrganization_Declined)]
+    [BitAutoData(EventType.OrganizationUser_NotificationBannerActionClicked)]
+    public async Task Post_OrganizationUserEvent_WithoutOrgId_SkipsEvent(EventType type, Guid userId)
+    {
+        _currentContext.UserId.Returns(userId);
+        var events = new List<EventModel>
+        {
+            new EventModel
+            {
+                Type = type,
+                OrganizationId = null,
+                Date = DateTime.UtcNow
+            }
+        };
+
+        var result = await _sut.Post(events);
+
+        Assert.IsType<OkResult>(result);
+        await _organizationUserRepository.DidNotReceiveWithAnyArgs().GetByOrganizationAsync(default, default);
+        await _eventService.DidNotReceiveWithAnyArgs().LogOrganizationUserEventAsync(Arg.Any<OrganizationUser>(), Arg.Any<EventType>(), Arg.Any<DateTime?>());
+    }
+
+    [Theory]
+    [BitAutoData(EventType.Organization_ItemOrganization_Accepted)]
+    [BitAutoData(EventType.Organization_ItemOrganization_Declined)]
+    [BitAutoData(EventType.OrganizationUser_NotificationBannerActionClicked)]
+    public async Task Post_OrganizationUserEvent_WithNullOrgUser_SkipsEvent(
+        EventType type, Guid userId, Guid orgId)
+    {
+        _currentContext.UserId.Returns(userId);
+        _organizationUserRepository.GetByOrganizationAsync(orgId, userId).Returns((OrganizationUser)null);
+        var events = new List<EventModel>
+        {
+            new EventModel
+            {
+                Type = type,
+                OrganizationId = orgId,
+                Date = DateTime.UtcNow
+            }
+        };
+
+        var result = await _sut.Post(events);
+
+        Assert.IsType<OkResult>(result);
+        await _organizationUserRepository.Received(1).GetByOrganizationAsync(orgId, userId);
+        await _eventService.DidNotReceiveWithAnyArgs().LogOrganizationUserEventAsync(Arg.Any<OrganizationUser>(), Arg.Any<EventType>(), Arg.Any<DateTime?>());
     }
 
     [Theory]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33408

## 📔 Objective

Adds new `EventType` `OrganizationUser_NotificationBannerActionClicked` which will be used by the organization vault banner to log when users click the supplied button.