### PR TITLE
[PM-37875] Make webauthn available on all platforms

### DIFF
--- a/src/Api/Auth/Controllers/WebAuthnController.cs
+++ b/src/Api/Auth/Controllers/WebAuthnController.cs
@@ -53,7 +53,7 @@ public class WebAuthnController : Controller
         _policyRequirementQuery = policyRequirementQuery;
     }
 
-    [Authorize(Policies.Web)]
+    [Authorize(Policies.Application)]
     [HttpGet("")]
     public async Task<ListResponseModel<WebAuthnCredentialResponseModel>> Get()
     {
@@ -81,7 +81,7 @@ public class WebAuthnController : Controller
         };
     }
 
-    [Authorize(Policies.Web)]
+    [Authorize(Policies.Application)]
     [HttpPost("assertion-options")]
     public async Task<WebAuthnLoginAssertionOptionsResponseModel> AssertionOptions([FromBody] SecretVerificationRequestModel model)
     {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-37875

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
V2 upgrade migrations are essentially key rotations. Key rotations need to get all webauthn credentials first, in order to upload the rotated credentials. This necessitates making the endpoints available on all platforms - not just web.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
