### PR TITLE
Pin nginx image to a specific version

### DIFF
--- a/util/Nginx/Dockerfile
+++ b/util/Nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM nginx:stable-alpine3.23
+FROM --platform=$BUILDPLATFORM nginx:1.30-alpine3.23
 
 ARG TARGETPLATFORM
 LABEL com.bitwarden.product="bitwarden"


### PR DESCRIPTION
## 🎟️ Tracking
None
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Pins the `nginx` image to a specific versioned tag, moving away from the floating `stable` tag. This is a no-op, since it runs the same version of nginx that our current version, but it allows for Renovate to also start managing this.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
