### PR TITLE
[DBOPS-177] Update MSSQL Docker image to SQL Server 2025 CU5

### DIFF
--- a/util/MsSql/Dockerfile
+++ b/util/MsSql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/mssql/server:2022-CU22-ubuntu-22.04
+FROM mcr.microsoft.com/mssql/server:2025-CU5-ubuntu-24.04
 
 LABEL com.bitwarden.product="bitwarden"
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/DBOPS-177

## 📔 Objective

Update SQL Server to version SQL Server 2025 CU5 for self-host.