### PR TITLE
fix(auto-enroll-status): [PM-39004] POC pass SSO identifier as query param for auto-enroll-status

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationsController.cs
@@ -150,8 +150,23 @@ public class OrganizationsController : Controller
         return new ListResponseModel<ProfileOrganizationResponseModel>(responses);
     }
 
+    // Deprecated: the org identifier is admin-chosen and may contain reserved URL characters
+    // (e.g. '/'), which break path-segment routing. Use the query-parameter route below instead.
+    [Obsolete("Path is deprecated due to encoding issues with identifiers containing reserved URL " +
+              "characters (e.g. '/'). Use GET /organizations/auto-enroll-status?identifier=... instead.")]
     [HttpGet("{identifier}/auto-enroll-status")]
-    public async Task<OrganizationAutoEnrollStatusResponseModel> GetAutoEnrollStatus(string identifier)
+    public Task<OrganizationAutoEnrollStatusResponseModel> GetAutoEnrollStatus(string identifier)
+    {
+        return GetAutoEnrollStatusByIdentifierAsync(identifier);
+    }
+
+    [HttpGet("auto-enroll-status")]
+    public Task<OrganizationAutoEnrollStatusResponseModel> GetAutoEnrollStatusByQuery([FromQuery] string identifier)
+    {
+        return GetAutoEnrollStatusByIdentifierAsync(identifier);
+    }
+
+    private async Task<OrganizationAutoEnrollStatusResponseModel> GetAutoEnrollStatusByIdentifierAsync(string identifier)
     {
         var user = await _userService.GetUserByPrincipalAsync(User);
         if (user == null)

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationsControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationsControllerTests.cs
@@ -193,4 +193,72 @@ public class OrganizationsControllerTests : IClassFixture<ApiApplicationFactory>
         Assert.Equal(_organizationName, updatedOrg.Name);
         Assert.Equal(_billingEmail, updatedOrg.BillingEmail);
     }
+
+    // PM-39004: routing behavior for org SSO identifiers containing characters that are not
+    // URL path delimiters. These exercise the real HTTP pipeline (routing + URL decoding), which
+    // the controller unit tests cannot, since they invoke the action method directly.
+
+    [Fact]
+    public async Task GetAutoEnrollStatus_IdentifierWithInnerSpace_ResolvesViaPathRoute()
+    {
+        // A space is not a path delimiter: it is percent-encoded to %20 within a single segment,
+        // so the segment count is unchanged and the {identifier}/auto-enroll-status route matches.
+        // A 200 proves the request routed to the action AND the org was resolved by this identifier.
+        await _loginHelper.LoginAsync(_ownerEmail);
+        const string identifier = "DQS bitwarden";
+        await SetOrganizationIdentifierAsync(identifier);
+
+        var response = await _client.GetAsync(
+            $"/organizations/{Uri.EscapeDataString(identifier)}/auto-enroll-status");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("Café")]            // accented Latin
+    [InlineData("Straße")]          // German eszett
+    [InlineData("Smørrebrød")]      // Danish ø
+    [InlineData("価格表")]           // CJK
+    [InlineData("Açaí Büro €")]     // mixed accents + euro sign + space
+    public async Task GetAutoEnrollStatus_IdentifierWithNonAsciiCharacters_ResolvesViaPathRoute(
+        string identifier)
+    {
+        // Non-ASCII characters are not path delimiters: they are UTF-8 percent-encoded within a
+        // single segment (e.g. "Café" -> "Caf%C3%A9"), so the segment count is unchanged and the
+        // {identifier}/auto-enroll-status route matches and resolves the org. A 200 proves it.
+        await _loginHelper.LoginAsync(_ownerEmail);
+        await SetOrganizationIdentifierAsync(identifier);
+
+        var response = await _client.GetAsync(
+            $"/organizations/{Uri.EscapeDataString(identifier)}/auto-enroll-status");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAutoEnrollStatus_IdentifierWithSlash_FailsOnPathRouteButResolvesViaQueryRoute()
+    {
+        // Same org, same slash-bearing identifier, two transports:
+        await _loginHelper.LoginAsync(_ownerEmail);
+        const string identifier = "DQS/bitwarden";
+        await SetOrganizationIdentifierAsync(identifier);
+
+        // Path route: the "/" adds a segment, so /organizations/DQS/bitwarden/auto-enroll-status has
+        // too many segments for {identifier}/auto-enroll-status -> no route matches -> 404, even
+        // though an org with this exact identifier exists (proven by the query route below).
+        var pathResponse = await _client.GetAsync("/organizations/DQS/bitwarden/auto-enroll-status");
+        Assert.Equal(HttpStatusCode.NotFound, pathResponse.StatusCode);
+
+        // Query route: the identifier travels outside the path, survives encoding, and resolves.
+        var queryResponse = await _client.GetAsync(
+            $"/organizations/auto-enroll-status?identifier={Uri.EscapeDataString(identifier)}");
+        Assert.Equal(HttpStatusCode.OK, queryResponse.StatusCode);
+    }
+
+    private async Task SetOrganizationIdentifierAsync(string identifier)
+    {
+        var organizationRepository = _factory.GetService<IOrganizationRepository>();
+        _organization.Identifier = identifier;
+        await organizationRepository.ReplaceAsync(_organization);
+    }
 }

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationsControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationsControllerTests.cs
@@ -174,7 +174,7 @@ public class OrganizationsControllerTests
     }
 
     [Theory, BitAutoData]
-    public async Task GetAutoEnrollStatus_ReturnsOrganizationAutoEnrollStatus_WithResetPasswordEnabledTrue(
+    public async Task GetAutoEnrollStatusByQuery_ReturnsOrganizationAutoEnrollStatus_WithResetPasswordEnabledTrue(
         SutProvider<OrganizationsController> sutProvider,
         User user,
         Organization organization,
@@ -186,11 +186,64 @@ public class OrganizationsControllerTests
         sutProvider.GetDependency<IOrganizationUserRepository>().GetByOrganizationAsync(organization.Id, user.Id).Returns(organizationUser);
         sutProvider.GetDependency<IPolicyQuery>().RunAsync(organization.Id, PolicyType.ResetPassword).Returns(policy);
 
-        var result = await sutProvider.Sut.GetAutoEnrollStatus(organization.Id.ToString());
+        var result = await sutProvider.Sut.GetAutoEnrollStatusByQuery(organization.Id.ToString());
 
         await sutProvider.GetDependency<IUserService>().Received(1).GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>());
         await sutProvider.GetDependency<IOrganizationRepository>().Received(1).GetByIdentifierAsync(organization.Id.ToString());
         await sutProvider.GetDependency<IPolicyQuery>().Received(1).RunAsync(organization.Id, PolicyType.ResetPassword);
+
+        Assert.True(result.ResetPasswordEnabled);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetAutoEnrollStatusByQuery_IdentifierContainsSlash_PassesIdentifierThroughUnchanged(
+        SutProvider<OrganizationsController> sutProvider,
+        User user,
+        Organization organization,
+        OrganizationUser organizationUser,
+        [Policy(PolicyType.ResetPassword, data: "{\"AutoEnrollEnabled\": true}")] PolicyStatus policy)
+    {
+        // An admin-chosen SSO identifier may contain reserved URL characters such as '/'.
+        // The query-parameter route must forward it verbatim to the repository (ticket #870106).
+        const string identifier = "DQS/bitwarden";
+        sutProvider.GetDependency<IUserService>().GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdentifierAsync(identifier).Returns(organization);
+        sutProvider.GetDependency<IOrganizationUserRepository>().GetByOrganizationAsync(organization.Id, user.Id).Returns(organizationUser);
+        sutProvider.GetDependency<IPolicyQuery>().RunAsync(organization.Id, PolicyType.ResetPassword).Returns(policy);
+
+        var result = await sutProvider.Sut.GetAutoEnrollStatusByQuery(identifier);
+
+        await sutProvider.GetDependency<IOrganizationRepository>().Received(1).GetByIdentifierAsync(identifier);
+        Assert.True(result.ResetPasswordEnabled);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetAutoEnrollStatusByQuery_OrganizationNotFound_ThrowsNotFound(
+        SutProvider<OrganizationsController> sutProvider,
+        User user)
+    {
+        sutProvider.GetDependency<IUserService>().GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdentifierAsync(Arg.Any<string>()).Returns((Organization)null);
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.GetAutoEnrollStatusByQuery("unknown"));
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetAutoEnrollStatus_DeprecatedPathRoute_StillResolvesViaIdentifier(
+        SutProvider<OrganizationsController> sutProvider,
+        User user,
+        Organization organization,
+        OrganizationUser organizationUser,
+        [Policy(PolicyType.ResetPassword, data: "{\"AutoEnrollEnabled\": true}")] PolicyStatus policy)
+    {
+        sutProvider.GetDependency<IUserService>().GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdentifierAsync(organization.Id.ToString()).Returns(organization);
+        sutProvider.GetDependency<IOrganizationUserRepository>().GetByOrganizationAsync(organization.Id, user.Id).Returns(organizationUser);
+        sutProvider.GetDependency<IPolicyQuery>().RunAsync(organization.Id, PolicyType.ResetPassword).Returns(policy);
+
+#pragma warning disable CS0618 // Type or member is obsolete - retained for backward compatibility, kept under test.
+        var result = await sutProvider.Sut.GetAutoEnrollStatus(organization.Id.ToString());
+#pragma warning restore CS0618
 
         Assert.True(result.ResetPasswordEnabled);
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39004

## 📔 Objective

The org SSO identifier is admin-chosen and may contain reserved URL characters (e.g. '/'), which break the existing {identifier}/auto-enroll-status path route (no route matches -> 404). 

1. Add a new GET /organizations/auto-enroll-status?identifier=... route sharing the same logic, and mark the old path route [Obsolete] (kept functional for backward compatibility).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
