### PR TITLE
[PM-31107] Seeder: blob-migration preset + fido2/password-history/linked-field fixture support

### DIFF
--- a/util/Seeder/Models/CipherSeed.cs
+++ b/util/Seeder/Models/CipherSeed.cs
@@ -1,4 +1,6 @@
-﻿using Bit.Core.Vault.Enums;
+﻿using System.Globalization;
+using Bit.Core.Vault.Enums;
+using Bit.Seeder.Factories;
 
 namespace Bit.Seeder.Models;
 
@@ -97,7 +99,7 @@ internal record CipherSeed
         Notes = item.Notes,
         Reprompt = item.Reprompt == 1 ? CipherRepromptType.Password : CipherRepromptType.None,
         Fields = MapFields(item.Fields),
-        Login = MapLogin(item.Login),
+        Login = MapLogin(item.Login, item.PasswordHistory),
         Card = MapCard(item.Card),
         Identity = MapIdentity(item.Identity),
         SecureNote = item.Type == "secureNote" ? new SecureNoteViewDto { Type = 0 } : null,
@@ -119,7 +121,8 @@ internal record CipherSeed
         {
             Name = f.Name,
             Value = f.Value,
-            Type = MapFieldType(f.Type)
+            Type = MapFieldType(f.Type),
+            LinkedId = f.LinkedId
         }).ToList();
 
     private static int MapFieldType(string type) => type switch
@@ -131,7 +134,7 @@ internal record CipherSeed
         _ => throw new ArgumentException($"Unknown field type: '{type}'", nameof(type))
     };
 
-    private static LoginViewDto? MapLogin(SeedLogin? login) =>
+    private static LoginViewDto? MapLogin(SeedLogin? login, List<SeedPasswordHistory>? passwordHistory) =>
         login == null ? null : new LoginViewDto
         {
             Username = login.Username,
@@ -141,8 +144,25 @@ internal record CipherSeed
             {
                 Uri = u.Uri,
                 Match = MapUriMatchType(u.Match)
-            }).ToList()
+            }).ToList(),
+            // Key material is synthesized; the fixture only supplies the relying-party/user identifiers.
+            Fido2Credentials = login.Fido2Credentials?.Select(f => LoginCipherSeeder.CreateFido2Credential(
+                f.RpId ?? "example.com",
+                f.RpName ?? f.RpId ?? "Example",
+                f.UserName ?? login.Username ?? "user")).ToList(),
+            PasswordHistory = MapPasswordHistory(passwordHistory)
         };
+
+    private static List<PasswordHistoryViewDto>? MapPasswordHistory(List<SeedPasswordHistory>? history) =>
+        history?.Select(p =>
+        {
+            var dto = new PasswordHistoryViewDto { Password = p.Password };
+            if (p.LastUsedDate is not null)
+            {
+                dto.LastUsedDate = DateTime.Parse(p.LastUsedDate, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+            }
+            return dto;
+        }).ToList();
 
     private static int MapUriMatchType(string match) => match switch
     {

--- a/util/Seeder/Models/CipherSeed.cs
+++ b/util/Seeder/Models/CipherSeed.cs
@@ -99,7 +99,7 @@ internal record CipherSeed
         Notes = item.Notes,
         Reprompt = item.Reprompt == 1 ? CipherRepromptType.Password : CipherRepromptType.None,
         Fields = MapFields(item.Fields),
-        Login = MapLogin(item.Login, item.PasswordHistory),
+        Login = MapLogin(item.Login),
         Card = MapCard(item.Card),
         Identity = MapIdentity(item.Identity),
         SecureNote = item.Type == "secureNote" ? new SecureNoteViewDto { Type = 0 } : null,
@@ -134,7 +134,7 @@ internal record CipherSeed
         _ => throw new ArgumentException($"Unknown field type: '{type}'", nameof(type))
     };
 
-    private static LoginViewDto? MapLogin(SeedLogin? login, List<SeedPasswordHistory>? passwordHistory) =>
+    private static LoginViewDto? MapLogin(SeedLogin? login) =>
         login == null ? null : new LoginViewDto
         {
             Username = login.Username,
@@ -150,7 +150,7 @@ internal record CipherSeed
                 f.RpId ?? "example.com",
                 f.RpName ?? f.RpId ?? "Example",
                 f.UserName ?? login.Username ?? "user")).ToList(),
-            PasswordHistory = MapPasswordHistory(passwordHistory)
+            PasswordHistory = MapPasswordHistory(login.PasswordHistory)
         };
 
     private static List<PasswordHistoryViewDto>? MapPasswordHistory(List<SeedPasswordHistory>? history) =>

--- a/util/Seeder/Models/SeedModels.cs
+++ b/util/Seeder/Models/SeedModels.cs
@@ -15,7 +15,6 @@ internal record SeedVaultItem
     public SeedIdentity? Identity { get; init; }
     public SeedSshKey? SshKey { get; init; }
     public List<SeedField>? Fields { get; init; }
-    public List<SeedPasswordHistory>? PasswordHistory { get; init; }
     public bool? Favorite { get; init; }
     public int? Reprompt { get; init; }
 }
@@ -34,6 +33,7 @@ internal record SeedLogin
     public List<SeedLoginUri>? Uris { get; init; }
     public string? Totp { get; init; }
     public List<SeedFido2Credential>? Fido2Credentials { get; init; }
+    public List<SeedPasswordHistory>? PasswordHistory { get; init; }
 }
 
 internal record SeedFido2Credential

--- a/util/Seeder/Models/SeedModels.cs
+++ b/util/Seeder/Models/SeedModels.cs
@@ -15,6 +15,7 @@ internal record SeedVaultItem
     public SeedIdentity? Identity { get; init; }
     public SeedSshKey? SshKey { get; init; }
     public List<SeedField>? Fields { get; init; }
+    public List<SeedPasswordHistory>? PasswordHistory { get; init; }
     public bool? Favorite { get; init; }
     public int? Reprompt { get; init; }
 }
@@ -32,6 +33,20 @@ internal record SeedLogin
     public string? Password { get; init; }
     public List<SeedLoginUri>? Uris { get; init; }
     public string? Totp { get; init; }
+    public List<SeedFido2Credential>? Fido2Credentials { get; init; }
+}
+
+internal record SeedFido2Credential
+{
+    public string? RpId { get; init; }
+    public string? RpName { get; init; }
+    public string? UserName { get; init; }
+}
+
+internal record SeedPasswordHistory
+{
+    public required string Password { get; init; }
+    public string? LastUsedDate { get; init; }
 }
 
 internal record SeedLoginUri
@@ -76,6 +91,7 @@ internal record SeedField
     public string? Name { get; init; }
     public string? Value { get; init; }
     public string Type { get; init; } = "text";
+    public int? LinkedId { get; init; }
 }
 
 internal record SeedOrganization

--- a/util/Seeder/Seeds/docs/presets.md
+++ b/util/Seeder/Seeds/docs/presets.md
@@ -84,14 +84,15 @@ Individual user accounts with no organization. Useful for testing personal vault
 dotnet run -- preset --name individual.{name} --mangle
 ```
 
-| Preset  | Account Type  | Folders | Ciphers | Assignments |
-| ------- | ------------- | ------- | ------- | ----------- |
-| free    | Free          | —       | 0       | —           |
-| premium | Premium (1GB) | —       | 0       | —           |
+| Preset         | Account Type  | Folders | Ciphers     | Assignments |
+| -------------- | ------------- | ------- | ----------- | ----------- |
+| free           | Free          | —       | 0           | —           |
+| premium        | Premium (1GB) | —       | 0           | —           |
+| blob-migration | Premium (1GB) | —       | 7 (fixture) | —           |
 
 `free` and `premium` create accounts with no vault data — useful for testing account setup flows. Cipher count is set to 0 (TBD).
 
-**Login emails:** `free` uses `freeuser@individual.example`; `premium` uses `premuser@individual.example`.
+**Login emails:** `free` uses `freeuser@individual.example`; `premium` uses `premuser@individual.example`; `blob-migration` uses `blobmigration@individual.example`.
 
 ## Validation
 

--- a/util/Seeder/Seeds/docs/scenarios/README.md
+++ b/util/Seeder/Seeds/docs/scenarios/README.md
@@ -10,12 +10,13 @@ For CLI flag details, see the [SeederUtility reference](../../../../SeederUtilit
 
 ## Scenarios
 
-| Scenario                                    | Problem                                                        | Command type   |
-| ------------------------------------------- | -------------------------------------------------------------- | -------------- |
-| [Fresh database](fresh-database.md)         | I need a working database with realistic data                  | `preset`       |
-| [Permission testing](permission-testing.md) | I'm building a feature that touches collections or permissions | `preset`       |
-| [Scale testing](scale-testing.md)           | Will my code survive at 250 / 1,000 / 5,000+ users?            | `preset`       |
-| [Bug reproduction](bug-reproduction.md)     | I need to reproduce a customer's org shape                     | `organization` |
+| Scenario                                    | Problem                                                             | Command type   |
+| ------------------------------------------- | ------------------------------------------------------------------- | -------------- |
+| [Fresh database](fresh-database.md)         | I need a working database with realistic data                       | `preset`       |
+| [Permission testing](permission-testing.md) | I'm building a feature that touches collections or permissions      | `preset`       |
+| [Scale testing](scale-testing.md)           | Will my code survive at 250 / 1,000 / 5,000+ users?                 | `preset`       |
+| [Bug reproduction](bug-reproduction.md)     | I need to reproduce a customer's org shape                          | `organization` |
+| [Blob-migration testing](blob-migration.md) | I need to verify the SDK V1→V2 blob-encryption migration end-to-end | `preset`       |
 
 ## Contributing a Scenario
 

--- a/util/Seeder/Seeds/docs/scenarios/blob-migration.md
+++ b/util/Seeder/Seeds/docs/scenarios/blob-migration.md
@@ -1,0 +1,27 @@
+# I need to verify the SDK V1→V2 blob-encryption migration end-to-end
+
+> I'm working on the blob conversion and need a vault that exercises every `type_data` and payload branch in one account.
+
+## Quick start
+
+```bash
+dotnet run -- preset --name individual.blob-migration
+```
+
+## What you get
+
+A premium V1 individual user — log in as `blobmigration@individual.example` with password `asdfasdfasdf`. Their personal vault holds one of every cipher type (login, card, identity, secure note, SSH key) plus a passkey, password history, custom fields (text, hidden, boolean, linked), a reprompt item, and a favorite — maximizing coverage of the blob conversion's `type_data` and payload branches.
+
+## Who this is for
+
+Engineers verifying the SDK V1→V2 blob-encryption migration who need a single account that touches every cipher shape.
+
+## Variations
+
+| Scenario                                    | Command                                                          |
+| ------------------------------------------- | ---------------------------------------------------------------- |
+| Isolated re-run (randomized IDs and emails) | `dotnet run -- preset --name individual.blob-migration --mangle` |
+
+Add `--mangle` when you need to seed the scenario more than once without colliding with a prior run.
+
+For CLI flags, see the [SeederUtility reference](../../../../SeederUtility/README.md). For the full preset catalog, see [presets.md](../presets.md).

--- a/util/Seeder/Seeds/fixtures/ciphers/blob-migration.json
+++ b/util/Seeder/Seeds/fixtures/ciphers/blob-migration.json
@@ -17,6 +17,10 @@
         ],
         "fido2Credentials": [
           { "rpId": "example.com", "rpName": "Example", "userName": "blobuser@example.com" }
+        ],
+        "passwordHistory": [
+          { "password": "fakeOldPassword1", "lastUsedDate": "2023-06-01T00:00:00.000Z" },
+          { "password": "fakeOldPassword2", "lastUsedDate": "2023-09-01T00:00:00.000Z" }
         ]
       },
       "fields": [
@@ -24,10 +28,6 @@
         { "name": "Hidden Field", "value": "fakeHiddenSecret", "type": "hidden" },
         { "name": "Boolean Field", "value": "true", "type": "boolean" },
         { "name": "Linked Username", "type": "linked", "linkedId": 100 }
-      ],
-      "passwordHistory": [
-        { "password": "fakeOldPassword1", "lastUsedDate": "2023-06-01T00:00:00.000Z" },
-        { "password": "fakeOldPassword2", "lastUsedDate": "2023-09-01T00:00:00.000Z" }
       ]
     },
     {

--- a/util/Seeder/Seeds/fixtures/ciphers/blob-migration.json
+++ b/util/Seeder/Seeds/fixtures/ciphers/blob-migration.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "../../schemas/cipher.schema.json",
+  "items": [
+    {
+      "type": "login",
+      "name": "Blob Login — Full",
+      "notes": "Login with every field populated to exercise blob login type_data, custom fields, passkeys, and password history.",
+      "favorite": true,
+      "login": {
+        "username": "blobuser@example.com",
+        "password": "fakeBlobFullPassword",
+        "totp": "JBSWY3DPEHPK3PXP",
+        "uris": [
+          { "uri": "https://login.example.com", "match": "domain" },
+          { "uri": "https://accounts.example.com/signin", "match": "host" },
+          { "uri": "https://example.com/legacy", "match": "exact" }
+        ],
+        "fido2Credentials": [
+          { "rpId": "example.com", "rpName": "Example", "userName": "blobuser@example.com" }
+        ]
+      },
+      "fields": [
+        { "name": "Text Field", "value": "plain text value", "type": "text" },
+        { "name": "Hidden Field", "value": "fakeHiddenSecret", "type": "hidden" },
+        { "name": "Boolean Field", "value": "true", "type": "boolean" },
+        { "name": "Linked Username", "type": "linked", "linkedId": 100 }
+      ],
+      "passwordHistory": [
+        { "password": "fakeOldPassword1", "lastUsedDate": "2023-06-01T00:00:00.000Z" },
+        { "password": "fakeOldPassword2", "lastUsedDate": "2023-09-01T00:00:00.000Z" }
+      ]
+    },
+    {
+      "type": "login",
+      "name": "Blob Login — Reprompt",
+      "notes": "Master-password reprompt flag must survive the blob round-trip.",
+      "reprompt": 1,
+      "login": {
+        "username": "reprompt@example.com",
+        "password": "fakeRepromptPassword",
+        "uris": [{ "uri": "https://secure.example.com", "match": "domain" }]
+      }
+    },
+    {
+      "type": "login",
+      "name": "Blob Login — Minimal",
+      "login": {
+        "username": "minimal@example.com",
+        "password": "fakeMinimalPassword"
+      }
+    },
+    {
+      "type": "card",
+      "name": "Blob Card",
+      "notes": "Card type_data coverage.",
+      "card": {
+        "cardholderName": "Blob Test User",
+        "brand": "Visa",
+        "number": "4111111111111111",
+        "expMonth": "12",
+        "expYear": "2030",
+        "code": "123"
+      },
+      "fields": [{ "name": "Bank", "value": "Test Bank", "type": "text" }]
+    },
+    {
+      "type": "identity",
+      "name": "Blob Identity",
+      "notes": "Identity type_data with all sub-fields populated.",
+      "identity": {
+        "firstName": "Blob",
+        "middleName": "Test",
+        "lastName": "User",
+        "address1": "123 Test St",
+        "address2": "Apt 4",
+        "city": "Testville",
+        "state": "CA",
+        "postalCode": "90210",
+        "country": "US",
+        "company": "Bitwarden",
+        "email": "identity@example.com",
+        "phone": "+1-555-0100",
+        "ssn": "000-00-0000",
+        "username": "blobidentity",
+        "passportNumber": "X1234567",
+        "licenseNumber": "D1234567"
+      }
+    },
+    {
+      "type": "secureNote",
+      "name": "Blob Secure Note",
+      "notes": "Secure notes carry their content entirely in the notes field — verifies notes survive blob conversion."
+    },
+    {
+      "type": "sshKey",
+      "name": "Blob SSH Key",
+      "notes": "SSH key type_data coverage.",
+      "sshKey": {
+        "privateKey": "-----BEGIN OPENSSH PRIVATE KEY-----\nfakeprivatekeymaterialforblobtesting\n-----END OPENSSH PRIVATE KEY-----",
+        "publicKey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAfakepublickey blobuser@example.com",
+        "keyFingerprint": "SHA256:fakefingerprintforblobtesting"
+      }
+    }
+  ]
+}

--- a/util/Seeder/Seeds/fixtures/presets/individual/blob-migration.json
+++ b/util/Seeder/Seeds/fixtures/presets/individual/blob-migration.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../../../schemas/preset.schema.json",
+  "user": {
+    "email": "blobmigration@individual.example",
+    "premium": true,
+    "maxStorageGb": 1
+  },
+  "ciphers": { "fixture": "blob-migration" }
+}

--- a/util/Seeder/Seeds/schemas/cipher.schema.json
+++ b/util/Seeder/Seeds/schemas/cipher.schema.json
@@ -199,20 +199,12 @@
     },
     "fido2Credential": {
       "type": "object",
+      "description": "A discoverable passkey. Key material (credential id, private key, counter, user handle) is synthesized at seed time; only the relying-party and user identifiers are taken from the fixture.",
       "additionalProperties": false,
       "properties": {
-        "credentialId": { "type": "string" },
-        "keyType": { "type": "string", "default": "public-key" },
-        "keyAlgorithm": { "type": "string", "default": "ECDSA" },
-        "keyCurve": { "type": "string", "default": "P-256" },
-        "keyValue": { "type": "string" },
-        "rpId": { "type": "string" },
-        "rpName": { "type": "string" },
-        "userHandle": { "type": "string" },
-        "userName": { "type": "string" },
-        "userDisplayName": { "type": "string" },
-        "counter": { "type": "integer" },
-        "discoverable": { "type": "boolean", "default": false }
+        "rpId": { "type": "string", "description": "Relying party ID (e.g. 'example.com'). Defaults to 'example.com'." },
+        "rpName": { "type": "string", "description": "Relying party display name. Defaults to rpId." },
+        "userName": { "type": "string", "description": "Account username for the passkey. Defaults to the login username." }
       }
     }
   }

--- a/util/Seeder/Seeds/schemas/cipher.schema.json
+++ b/util/Seeder/Seeds/schemas/cipher.schema.json
@@ -62,12 +62,6 @@
           "items": {
             "$ref": "#/$defs/field"
           }
-        },
-        "passwordHistory": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/passwordHistory"
-          }
         }
       },
       "allOf": [
@@ -108,6 +102,12 @@
           "type": "array",
           "items": {
             "$ref": "#/$defs/fido2Credential"
+          }
+        },
+        "passwordHistory": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/passwordHistory"
           }
         }
       }
@@ -192,6 +192,7 @@
     "passwordHistory": {
       "type": "object",
       "additionalProperties": false,
+      "required": ["password"],
       "properties": {
         "password": { "type": "string" },
         "lastUsedDate": { "type": "string", "description": "ISO date when password was last used." }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31107](https://bitwarden.atlassian.net/browse/PM-31107)

## 📔 Objective

Adds Seeder support for testing the SDK V1→V2 blob-encryption key-rotation migration end-to-end.

Two parts:

**1. Fixture loader enhancements** — the cipher fixture schema already advertised `fido2Credentials`, `passwordHistory`, and field `linkedId`, but the deserialization model silently dropped them. The encryption DTOs already supported all three; this wires the fixture-side mapping so they're honored:
- `SeedModels.cs` — added the fields + `SeedFido2Credential`/`SeedPasswordHistory` records
- `CipherSeed.cs` — maps password history, linked-field IDs, and passkeys (key material is synthesized via the existing `CreateFido2Credential` helper; the fixture only supplies rp/user identifiers)
- `cipher.schema.json` — simplified `fido2Credential` to the honored identifiers

Any fixture can now seed passkeys, password history, and linked fields.

**2. New `individual.blob-migration` preset + `blob-migration` cipher fixture** — a premium V1 user whose personal vault holds one of every cipher type (login, card, identity, secure note, SSH key) plus a passkey, password history, custom fields (text/hidden/boolean/linked), a reprompt item, and a favorite. This maximizes coverage of the blob conversion's `type_data` + payload branches.

Usage: `dotnet run -- preset --name individual.blob-migration` → login `blobmigration@individual.example` / `asdfasdfasdf`.

[PM-31107]: https://bitwarden.atlassian.net/browse/PM-31107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ