### PR TITLE
Gate Admin database migrations behind environment variable instead of self-hosted check

### DIFF
--- a/src/Admin/AdminSettings.cs
+++ b/src/Admin/AdminSettings.cs
@@ -7,4 +7,5 @@ public class AdminSettings
 {
     public virtual string Admins { get; set; }
     public int? DeleteTrashDaysAgo { get; set; }
+    public bool RunDatabaseMigrations { get; set; }
 }

--- a/src/Admin/HostedServices/DatabaseMigrationHostedService.cs
+++ b/src/Admin/HostedServices/DatabaseMigrationHostedService.cs
@@ -6,18 +6,23 @@ namespace Bit.Admin.HostedServices;
 
 public class DatabaseMigrationHostedService : IHostedService, IDisposable
 {
+    private static readonly TimeSpan _migrationDelay = TimeSpan.FromSeconds(20);
+
     private readonly ILogger<DatabaseMigrationHostedService> _logger;
     private readonly IDbMigrator _dbMigrator;
     private readonly AdminSettings _adminSettings;
+    private readonly TimeProvider _timeProvider;
 
     public DatabaseMigrationHostedService(
         IDbMigrator dbMigrator,
         IOptions<AdminSettings> adminSettings,
+        TimeProvider timeProvider,
         ILogger<DatabaseMigrationHostedService> logger)
     {
         _logger = logger;
         _dbMigrator = dbMigrator;
         _adminSettings = adminSettings.Value;
+        _timeProvider = timeProvider;
     }
 
     public virtual async Task StartAsync(CancellationToken cancellationToken)
@@ -27,8 +32,8 @@ public class DatabaseMigrationHostedService : IHostedService, IDisposable
             return;
         }
 
-        // Wait 20 seconds to allow database to come online
-        await Task.Delay(20000, cancellationToken);
+        // Wait to allow database to come online
+        await Task.Delay(_migrationDelay, _timeProvider, cancellationToken);
 
         var maxMigrationAttempts = 10;
         for (var i = 1; i <= maxMigrationAttempts; i++)
@@ -50,7 +55,7 @@ public class DatabaseMigrationHostedService : IHostedService, IDisposable
                 {
                     _logger.LogError(e,
                         "Database unavailable for migration. Trying again (attempt #{AttemptNumber})...", i + 1);
-                    await Task.Delay(20000, cancellationToken);
+                    await Task.Delay(_migrationDelay, _timeProvider, cancellationToken);
                 }
             }
         }

--- a/src/Admin/HostedServices/DatabaseMigrationHostedService.cs
+++ b/src/Admin/HostedServices/DatabaseMigrationHostedService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Data.Common;
 using Bit.Core.Utilities;
+using Microsoft.Extensions.Options;
 
 namespace Bit.Admin.HostedServices;
 
@@ -7,17 +8,25 @@ public class DatabaseMigrationHostedService : IHostedService, IDisposable
 {
     private readonly ILogger<DatabaseMigrationHostedService> _logger;
     private readonly IDbMigrator _dbMigrator;
+    private readonly AdminSettings _adminSettings;
 
     public DatabaseMigrationHostedService(
         IDbMigrator dbMigrator,
+        IOptions<AdminSettings> adminSettings,
         ILogger<DatabaseMigrationHostedService> logger)
     {
         _logger = logger;
         _dbMigrator = dbMigrator;
+        _adminSettings = adminSettings.Value;
     }
 
     public virtual async Task StartAsync(CancellationToken cancellationToken)
     {
+        if (!_adminSettings.RunDatabaseMigrations)
+        {
+            return;
+        }
+
         // Wait 20 seconds to allow database to come online
         await Task.Delay(20000, cancellationToken);
 

--- a/src/Admin/Startup.cs
+++ b/src/Admin/Startup.cs
@@ -119,16 +119,10 @@ public class Startup
         // Jobs service
         Jobs.JobsHostedService.AddJobsServices(services, globalSettings.SelfHosted);
         services.AddHostedService<Jobs.JobsHostedService>();
-        if (globalSettings.SelfHosted)
+        services.AddHostedService<HostedServices.DatabaseMigrationHostedService>();
+        if (!globalSettings.SelfHosted && CoreHelpers.SettingHasValue(globalSettings.Mail.ConnectionString))
         {
-            services.AddHostedService<HostedServices.DatabaseMigrationHostedService>();
-        }
-        else
-        {
-            if (CoreHelpers.SettingHasValue(globalSettings.Mail.ConnectionString))
-            {
-                services.AddHostedService<HostedServices.AzureQueueMailHostedService>();
-            }
+            services.AddHostedService<HostedServices.AzureQueueMailHostedService>();
         }
     }
 

--- a/src/Admin/Startup.cs
+++ b/src/Admin/Startup.cs
@@ -35,6 +35,7 @@ public class Startup
     {
         // Options
         services.AddOptions();
+        services.TryAddSingleton(TimeProvider.System);
 
         // Settings
         var globalSettings = services.AddGlobalSettingsServices(Configuration, Environment);

--- a/test/Admin.Test/HostedServices/DatabaseMigrationHostedServiceTests.cs
+++ b/test/Admin.Test/HostedServices/DatabaseMigrationHostedServiceTests.cs
@@ -1,0 +1,63 @@
+using Bit.Admin;
+using Bit.Admin.HostedServices;
+using Bit.Core.Utilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Admin.Test.HostedServices;
+
+public class DatabaseMigrationHostedServiceTests
+{
+    private readonly IDbMigrator _dbMigrator = Substitute.For<IDbMigrator>();
+    private readonly ILogger<DatabaseMigrationHostedService> _logger =
+        Substitute.For<ILogger<DatabaseMigrationHostedService>>();
+
+    [Fact]
+    public async Task StartAsync_WhenRunDatabaseMigrationsFalse_DoesNotCallMigrator()
+    {
+        var sut = new DatabaseMigrationHostedService(
+            _dbMigrator,
+            Options.Create(new AdminSettings { RunDatabaseMigrations = false }),
+            _logger);
+
+        await sut.StartAsync(CancellationToken.None);
+
+        _dbMigrator.DidNotReceive().MigrateDatabase(Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenRunDatabaseMigrationsUnset_DoesNotCallMigrator()
+    {
+        var sut = new DatabaseMigrationHostedService(
+            _dbMigrator,
+            Options.Create(new AdminSettings()),
+            _logger);
+
+        await sut.StartAsync(CancellationToken.None);
+
+        _dbMigrator.DidNotReceive().MigrateDatabase(Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    // Proves the gate does not short-circuit when the flag is true: StartAsync must
+    // reach the Task.Delay after the gate. A pre-cancelled token makes that delay
+    // throw immediately, so the test runs in milliseconds. We deliberately do not
+    // exercise the full migrate-and-retry path here — that would require waiting
+    // through the real 20s delay or refactoring the service to inject a time
+    // abstraction.
+    [Fact]
+    public async Task StartAsync_WhenRunDatabaseMigrationsTrue_ExcecutesMigrations()
+    {
+        var sut = new DatabaseMigrationHostedService(
+            _dbMigrator,
+            Options.Create(new AdminSettings { RunDatabaseMigrations = true }),
+            _logger);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<TaskCanceledException>(() => sut.StartAsync(cts.Token));
+
+        _dbMigrator.DidNotReceive().MigrateDatabase(Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/test/Admin.Test/HostedServices/DatabaseMigrationHostedServiceTests.cs
+++ b/test/Admin.Test/HostedServices/DatabaseMigrationHostedServiceTests.cs
@@ -1,25 +1,30 @@
-﻿using Bit.Admin;
+﻿using System.Data.Common;
+using Bit.Admin;
 using Bit.Admin.HostedServices;
 using Bit.Core.Utilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 
 namespace Admin.Test.HostedServices;
 
 public class DatabaseMigrationHostedServiceTests
 {
+    private static readonly TimeSpan _migrationDelay = TimeSpan.FromSeconds(20);
+
     private readonly IDbMigrator _dbMigrator = Substitute.For<IDbMigrator>();
     private readonly ILogger<DatabaseMigrationHostedService> _logger =
         Substitute.For<ILogger<DatabaseMigrationHostedService>>();
+    private readonly FakeTimeProvider _timeProvider = new();
+
+    private DatabaseMigrationHostedService BuildSut(AdminSettings adminSettings) =>
+        new(_dbMigrator, Options.Create(adminSettings), _timeProvider, _logger);
 
     [Fact]
     public async Task StartAsync_WhenRunDatabaseMigrationsFalse_DoesNotCallMigrator()
     {
-        var sut = new DatabaseMigrationHostedService(
-            _dbMigrator,
-            Options.Create(new AdminSettings { RunDatabaseMigrations = false }),
-            _logger);
+        var sut = BuildSut(new AdminSettings { RunDatabaseMigrations = false });
 
         await sut.StartAsync(CancellationToken.None);
 
@@ -29,35 +34,64 @@ public class DatabaseMigrationHostedServiceTests
     [Fact]
     public async Task StartAsync_WhenRunDatabaseMigrationsUnset_DoesNotCallMigrator()
     {
-        var sut = new DatabaseMigrationHostedService(
-            _dbMigrator,
-            Options.Create(new AdminSettings()),
-            _logger);
+        var sut = BuildSut(new AdminSettings());
 
         await sut.StartAsync(CancellationToken.None);
 
         _dbMigrator.DidNotReceive().MigrateDatabase(Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
-    // Proves the gate does not short-circuit when the flag is true: StartAsync must
-    // reach the Task.Delay after the gate. A pre-cancelled token makes that delay
-    // throw immediately, so the test runs in milliseconds. We deliberately do not
-    // exercise the full migrate-and-retry path here — that would require waiting
-    // through the real 20s delay or refactoring the service to inject a time
-    // abstraction.
     [Fact]
-    public async Task StartAsync_WhenRunDatabaseMigrationsTrue_WillRunMigrations()
+    public async Task StartAsync_WhenRunDatabaseMigrationsTrue_CallsMigratorAfterInitialDelay()
     {
-        var sut = new DatabaseMigrationHostedService(
-            _dbMigrator,
-            Options.Create(new AdminSettings { RunDatabaseMigrations = true }),
-            _logger);
+        var sut = BuildSut(new AdminSettings { RunDatabaseMigrations = true });
 
-        using var cts = new CancellationTokenSource();
-        cts.Cancel();
+        var startTask = sut.StartAsync(CancellationToken.None);
+        _timeProvider.Advance(_migrationDelay);
+        await startTask;
 
-        await Assert.ThrowsAsync<TaskCanceledException>(() => sut.StartAsync(cts.Token));
+        _dbMigrator.Received(1).MigrateDatabase(true, Arg.Any<CancellationToken>());
+    }
 
-        _dbMigrator.DidNotReceive().MigrateDatabase(Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    [Fact]
+    public async Task StartAsync_WhenMigratorThrowsDbException_RetriesAfterDelay()
+    {
+        var sut = BuildSut(new AdminSettings { RunDatabaseMigrations = true });
+        var attempt = 0;
+        _dbMigrator
+            .When(x => x.MigrateDatabase(true, Arg.Any<CancellationToken>()))
+            .Do(_ =>
+            {
+                attempt++;
+                if (attempt == 1)
+                {
+                    throw Substitute.For<DbException>();
+                }
+            });
+
+        var startTask = sut.StartAsync(CancellationToken.None);
+        _timeProvider.Advance(_migrationDelay); // initial delay
+        _timeProvider.Advance(_migrationDelay); // retry delay after first failure
+        await startTask;
+
+        _dbMigrator.Received(2).MigrateDatabase(true, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenMigratorAlwaysThrowsDbException_RethrowsAfterMaxAttempts()
+    {
+        var sut = BuildSut(new AdminSettings { RunDatabaseMigrations = true });
+        _dbMigrator
+            .When(x => x.MigrateDatabase(true, Arg.Any<CancellationToken>()))
+            .Throw(_ => Substitute.For<DbException>());
+
+        var startTask = sut.StartAsync(CancellationToken.None);
+        for (var i = 0; i < 10; i++)
+        {
+            _timeProvider.Advance(_migrationDelay);
+        }
+
+        await Assert.ThrowsAnyAsync<DbException>(() => startTask);
+        _dbMigrator.Received(10).MigrateDatabase(true, Arg.Any<CancellationToken>());
     }
 }

--- a/test/Admin.Test/HostedServices/DatabaseMigrationHostedServiceTests.cs
+++ b/test/Admin.Test/HostedServices/DatabaseMigrationHostedServiceTests.cs
@@ -46,7 +46,7 @@ public class DatabaseMigrationHostedServiceTests
     // through the real 20s delay or refactoring the service to inject a time
     // abstraction.
     [Fact]
-    public async Task StartAsync_WhenRunDatabaseMigrationsTrue_ExcecutesMigrations()
+    public async Task StartAsync_WhenRunDatabaseMigrationsTrue_WillRunMigrations()
     {
         var sut = new DatabaseMigrationHostedService(
             _dbMigrator,

--- a/test/Admin.Test/HostedServices/DatabaseMigrationHostedServiceTests.cs
+++ b/test/Admin.Test/HostedServices/DatabaseMigrationHostedServiceTests.cs
@@ -1,4 +1,4 @@
-using Bit.Admin;
+﻿using Bit.Admin;
 using Bit.Admin.HostedServices;
 using Bit.Core.Utilities;
 using Microsoft.Extensions.Logging;

--- a/util/Setup/EnvironmentFileBuilder.cs
+++ b/util/Setup/EnvironmentFileBuilder.cs
@@ -20,6 +20,7 @@ public class EnvironmentFileBuilder
         _context = context;
         _globalValues = new Dictionary<string, string>
         {
+            ["adminSettings__runDatabaseMigrations"] = "true",
             ["ASPNETCORE_ENVIRONMENT"] = "Production",
             ["globalSettings__selfHosted"] = "true",
             ["globalSettings__baseServiceUri__vault"] = "http://localhost",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38758

## 📔 Objective

Helm deployments are self-hosted, but we do not want them to run the Admin-controlled database migrations.

To support this, we disconnect the running of migrations from the user's hosting method, and instead rely on an environment variable.

The value of the variable will be as follows:
| Environment | Value | Result |
| --- | --- | --- |
| Self-Hosted Docker deployment | Set to `true` in Docker initialization. | Same behavior as today, the migrations run. 👍 |
| Self-Hosted Helm deployment | Not set (defaults to `false`) | Changed behavior - will NOT run now. 👍 |
| Cloud | Not set (defaults to `false`) | Same behavior as today, the migrations do **not** run. 👍 |

### Implementation Notes:
- I elected to move the check into the service, so that it could be tested and so that we can avoid having to use magic strings for the configuration value; if it's checked within `Startup.cs` the config pipeline hasn't run.
- As I introduced tests, and the service had a hard-coded 20-second startup and retry delay, I added a `TimeProvider` to allow testability without making every test run wait the full 20 seconds.
