### PR TITLE
[PM-34779] Add accept invite link endpoint

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -13,6 +13,8 @@ using Bit.Core;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Models.Data;
 using Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
+using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
+using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
 using Bit.Core.AdminConsole.OrganizationFeatures.Organizations;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.AutoConfirmUser;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.DeleteClaimedAccount;
@@ -90,6 +92,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
     private readonly AccountRecoveryV2.IAdminRecoverAccountCommand _adminRecoverAccountCommandV2;
     private readonly ISelfRevokeOrganizationUserCommand _selfRevokeOrganizationUserCommand;
     private readonly IUpdateUserResetPasswordEnrollmentCommand _updateUserResetPasswordEnrollmentCommand;
+    private readonly IAcceptOrganizationInviteLinkCommand _acceptOrganizationInviteLinkCommand;
 
     public OrganizationUsersController(IOrganizationRepository organizationRepository,
         IOrganizationUserRepository organizationUserRepository,
@@ -125,7 +128,8 @@ public class OrganizationUsersController : BaseAdminConsoleController
         V2_RevokeOrganizationUserCommand.IRevokeOrganizationUserCommand revokeOrganizationUserCommandVNext,
         ISelfRevokeOrganizationUserCommand selfRevokeOrganizationUserCommand,
         IUpdateUserResetPasswordEnrollmentCommand updateUserResetPasswordEnrollmentCommand,
-        IGetPendingAutoConfirmUsersQuery getPendingAutoConfirmUsersQuery)
+        IGetPendingAutoConfirmUsersQuery getPendingAutoConfirmUsersQuery,
+        IAcceptOrganizationInviteLinkCommand acceptOrganizationInviteLinkCommand)
     {
         _organizationRepository = organizationRepository;
         _organizationUserRepository = organizationUserRepository;
@@ -162,6 +166,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
         _adminRecoverAccountCommandV2 = adminRecoverAccountCommandV2;
         _selfRevokeOrganizationUserCommand = selfRevokeOrganizationUserCommand;
         _updateUserResetPasswordEnrollmentCommand = updateUserResetPasswordEnrollmentCommand;
+        _acceptOrganizationInviteLinkCommand = acceptOrganizationInviteLinkCommand;
     }
 
     [HttpGet("{id}")]
@@ -888,5 +893,25 @@ public class OrganizationUsersController : BaseAdminConsoleController
     {
         var usersOrganizationClaimedStatus = await _getOrganizationUsersClaimedStatusQuery.GetUsersOrganizationClaimedStatusAsync(orgId, userIds);
         return usersOrganizationClaimedStatus;
+    }
+
+    [HttpPost("/organizations/users/invite-link/accept")]
+    [RequireFeature(FeatureFlagKeys.GenerateInviteLink)]
+    public async Task<IResult> AcceptInviteLink([FromBody] AcceptOrganizationInviteLinkRequestModel model)
+    {
+        var user = await _userService.GetUserByPrincipalAsync(User);
+        if (user == null)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
+        var result = await _acceptOrganizationInviteLinkCommand.AcceptAsync(new AcceptOrganizationInviteLinkRequest
+        {
+            Code = model.Code,
+            User = user,
+            ResetPasswordKey = model.ResetPasswordKey,
+        });
+
+        return Handle(result, _ => TypedResults.Ok());
     }
 }

--- a/src/Api/AdminConsole/Models/Request/Organizations/AcceptOrganizationInviteLinkRequestModel.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/AcceptOrganizationInviteLinkRequestModel.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Bit.Api.AdminConsole.Models.Request.Organizations;
+
+public class AcceptOrganizationInviteLinkRequestModel
+{
+    [Required]
+    public required Guid Code { get; set; }
+    public string? ResetPasswordKey { get; set; }
+}

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerAcceptInviteLinkTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerAcceptInviteLinkTests.cs
@@ -1,0 +1,102 @@
+﻿using System.Net;
+using Bit.Api.AdminConsole.Models.Request.Organizations;
+using Bit.Api.AdminConsole.Models.Response.Organizations;
+using Bit.Api.IntegrationTest.Factories;
+using Bit.Api.IntegrationTest.Helpers;
+using Bit.Core;
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.Billing.Enums;
+using Bit.Core.Enums;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Api.IntegrationTest.AdminConsole.Controllers;
+
+public class OrganizationUsersControllerAcceptInviteLinkTests : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
+{
+    private readonly HttpClient _client;
+    private readonly ApiApplicationFactory _factory;
+    private readonly LoginHelper _loginHelper;
+
+    private const string _validEncryptedKey =
+        "2.AOs41Hd8OQiCPXjyJKCiDA==|O6OHgt2U2hJGBSNGnimJmg==|iD33s8B69C8JhYYhSa4V1tArjvLr8eEaGqOV7BRo5Jk=";
+
+    private Organization _organization = null!;
+    private string _ownerEmail = null!;
+
+    public OrganizationUsersControllerAcceptInviteLinkTests(ApiApplicationFactory factory)
+    {
+        _factory = factory;
+        _factory.SubstituteService<IFeatureService>(featureService =>
+        {
+            featureService
+                .IsEnabled(FeatureFlagKeys.GenerateInviteLink)
+                .Returns(true);
+        });
+        _client = factory.CreateClient();
+        _loginHelper = new LoginHelper(_factory, _client);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _ownerEmail = $"integration-test{Guid.NewGuid()}@example.com";
+        await _factory.LoginWithNewAccount(_ownerEmail);
+
+        (_organization, _) = await OrganizationTestHelpers.SignUpAsync(
+            _factory,
+            plan: PlanType.EnterpriseAnnually,
+            ownerEmail: _ownerEmail,
+            passwordManagerSeats: 10,
+            paymentMethod: PaymentMethodType.Card);
+
+        var organizationRepository = _factory.GetService<IOrganizationRepository>();
+        _organization.UseInviteLinks = true;
+        await organizationRepository.ReplaceAsync(_organization);
+
+        await _loginHelper.LoginAsync(_ownerEmail);
+    }
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task AcceptInviteLink_WithValidRequest_ReturnsOk()
+    {
+        var createRequest = new CreateOrganizationInviteLinkRequestModel
+        {
+            AllowedDomains = ["example.com"],
+            EncryptedInviteKey = _validEncryptedKey,
+        };
+        var createResponse = await _client.PostAsJsonAsync(
+            $"/organizations/{_organization.Id}/invite-link", createRequest);
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+        var created = await createResponse.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
+        Assert.NotNull(created);
+
+        var joinerEmail = $"integration-test{Guid.NewGuid()}@example.com";
+        await _factory.LoginWithNewAccount(joinerEmail);
+        var joinerClient = _factory.CreateClient();
+        var joinerLoginHelper = new LoginHelper(_factory, joinerClient);
+        await joinerLoginHelper.LoginAsync(joinerEmail);
+
+        var acceptRequest = new AcceptOrganizationInviteLinkRequestModel { Code = created.Code };
+        var response = await joinerClient.PostAsJsonAsync(
+            "/organizations/users/invite-link/accept", acceptRequest);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var userRepository = _factory.GetService<IUserRepository>();
+        var organizationUserRepository = _factory.GetService<IOrganizationUserRepository>();
+        var joiner = await userRepository.GetByEmailAsync(joinerEmail);
+        Assert.NotNull(joiner);
+
+        var organizationUser = await organizationUserRepository.GetByOrganizationAsync(_organization.Id, joiner.Id);
+        Assert.NotNull(organizationUser);
+        Assert.Equal(OrganizationUserStatusType.Accepted, organizationUser.Status);
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34779

## 📔 Objective

Add a `POST /organizations/users/invite-link/accept` endpoint to `OrganizationUsersController` that allows an authenticated user to join an organization via a share link. The endpoint accepts a `{ code, resetPasswordKey? }` body, delegates to `AcceptOrganizationInviteLinkCommand`, and maps command errors to `404` (link not found) or `400` (domain mismatch / business rule violation). Gated behind the `GenerateInviteLink` feature flag.

[Clients PR](https://github.com/bitwarden/clients/pull/21266).