### PR TITLE
[PM-38830] fix: Surface fixed-amount and time-bounded discounts in billing API

### DIFF
--- a/src/Api/Models/Response/BillingCustomerDiscount.cs
+++ b/src/Api/Models/Response/BillingCustomerDiscount.cs
@@ -41,6 +41,12 @@ public class BillingCustomerDiscount
     /// </summary>
     public decimal? AmountOff { get; }
 
+    /// <summary>The instant the discount stops applying (Stripe Discount.end). Null = no end date / perpetual.</summary>
+    public DateTime? End { get; }
+
+    /// <summary>For a repeating coupon, the number of months it applies. Null for once/forever.</summary>
+    public long? DurationInMonths { get; }
+
     /// <summary>
     /// List of Stripe product IDs that this discount applies to (e.g., ["prod_premium", "prod_families"]).
     /// <para>
@@ -64,6 +70,8 @@ public class BillingCustomerDiscount
         Active = discount.Active;
         PercentOff = discount.PercentOff;
         AmountOff = discount.AmountOff;
+        End = discount.End;
+        DurationInMonths = discount.DurationInMonths;
         AppliesTo = discount.AppliesTo;
     }
 }

--- a/src/Core/Billing/Organizations/PlanMigration/Models/ChurnMitigationOfferResult.cs
+++ b/src/Core/Billing/Organizations/PlanMigration/Models/ChurnMitigationOfferResult.cs
@@ -3,6 +3,7 @@
 public sealed record ChurnMitigationOfferResult(
     string CouponId,
     decimal? PercentOff,
+    decimal? AmountOff,
     string Duration,
     int? DurationInMonths,
     string Name);

--- a/src/Core/Billing/Organizations/PlanMigration/Queries/GetChurnMitigationOfferQuery.cs
+++ b/src/Core/Billing/Organizations/PlanMigration/Queries/GetChurnMitigationOfferQuery.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Core.AdminConsole.Entities;
 using Bit.Core.Billing.Constants;
+using Bit.Core.Billing.Extensions;
 using Bit.Core.Billing.Organizations.PlanMigration.Models;
 using Bit.Core.Billing.Organizations.PlanMigration.Repositories;
 using Bit.Core.Billing.Services;
@@ -189,6 +190,7 @@ public class GetChurnMitigationOfferQuery(
         new(
             CouponId: coupon.Id,
             PercentOff: coupon.PercentOff,
+            AmountOff: coupon.AmountOff.ToMajor(),
             Duration: coupon.Duration,
             DurationInMonths: (int?)coupon.DurationInMonths,
             Name: coupon.Name);

--- a/src/Core/Models/Business/SubscriptionInfo.cs
+++ b/src/Core/Models/Business/SubscriptionInfo.cs
@@ -46,6 +46,8 @@ public class SubscriptionInfo
             // Active = true only for perpetual/recurring discounts (no end date)
             // This is intentional for Milestone 2 - only perpetual discounts are shown in UI
             Active = discount.End == null;
+            End = discount.End;
+            DurationInMonths = discount.Coupon?.DurationInMonths;
             PercentOff = discount.Coupon?.PercentOff;
             AmountOff = ConvertFromStripeMinorUnits(discount.Coupon?.AmountOff);
             // Stripe's CouponAppliesTo.Products is already IReadOnlyList<string>, so no conversion needed
@@ -61,6 +63,8 @@ public class SubscriptionInfo
         {
             Id = coupon.Id;
             Active = true;
+            End = null;
+            DurationInMonths = coupon.DurationInMonths;
             PercentOff = coupon.PercentOff;
             AmountOff = ConvertFromStripeMinorUnits(coupon.AmountOff);
             AppliesTo = coupon.AppliesTo?.Products;
@@ -79,6 +83,19 @@ public class SubscriptionInfo
         /// Product decision for Milestone 2: only show perpetual discounts in UI.
         /// </summary>
         public bool Active { get; set; }
+
+        /// <summary>
+        /// The instant the discount stops applying, from Stripe's Discount.end.
+        /// Null when the discount has no end date (perpetual) or when constructed from a
+        /// Coupon directly (Phase-2 scheduled discount — no Discount wrapper available).
+        /// </summary>
+        public DateTime? End { get; set; }
+
+        /// <summary>
+        /// For a `repeating` coupon, the number of months the discount applies (Stripe Coupon.duration_in_months).
+        /// Null for `once`/`forever` coupons.
+        /// </summary>
+        public long? DurationInMonths { get; set; }
 
         /// <summary>
         /// Percentage discount applied to the subscription (e.g., 20.0 for 20% off).

--- a/test/Api.Test/Billing/Controllers/VNext/OrganizationBillingVNextControllerTests.cs
+++ b/test/Api.Test/Billing/Controllers/VNext/OrganizationBillingVNextControllerTests.cs
@@ -51,6 +51,7 @@ public class OrganizationBillingVNextControllerTests
         var offer = new ChurnMitigationOfferResult(
             CouponId: "churn-15-percent-once",
             PercentOff: 15m,
+            AmountOff: null,
             Duration: "once",
             DurationInMonths: null,
             Name: "Churn 15% off");
@@ -62,6 +63,7 @@ public class OrganizationBillingVNextControllerTests
         Assert.NotNull(okResult.Value);
         Assert.Equal("churn-15-percent-once", okResult.Value!.CouponId);
         Assert.Equal(15m, okResult.Value.PercentOff);
+        Assert.Null(okResult.Value.AmountOff);
         Assert.Equal("once", okResult.Value.Duration);
         Assert.Null(okResult.Value.DurationInMonths);
         Assert.Equal("Churn 15% off", okResult.Value.Name);

--- a/test/Api.Test/Models/Response/BillingCustomerDiscountTests.cs
+++ b/test/Api.Test/Models/Response/BillingCustomerDiscountTests.cs
@@ -1,0 +1,62 @@
+﻿using Bit.Api.Models.Response;
+using Bit.Core.Models.Business;
+using Stripe;
+using Xunit;
+
+namespace Bit.Api.Test.Models.Response;
+
+public class BillingCustomerDiscountTests
+{
+    [Fact]
+    public void Constructor_FromDomainDiscount_MirrorsEndDurationAndLeavesActiveIntact()
+    {
+        // Arrange - domain discount built from a Stripe Discount with an end date
+        var end = DateTime.UtcNow.AddMonths(12);
+        var domainDiscount = new SubscriptionInfo.BillingCustomerDiscount(new Discount
+        {
+            End = end,
+            Coupon = new Coupon
+            {
+                Id = "churn_15_repeating",
+                PercentOff = 10m,
+                Duration = "repeating",
+                DurationInMonths = 12
+            }
+        });
+
+        // Act
+        var result = new BillingCustomerDiscount(domainDiscount);
+
+        // Assert - API model copies End/DurationInMonths and preserves Active unchanged
+        Assert.Equal(domainDiscount.End, result.End);
+        Assert.Equal(domainDiscount.DurationInMonths, result.DurationInMonths);
+        Assert.Equal(domainDiscount.Active, result.Active);
+        Assert.False(result.Active);   // End != null => not perpetual (UNCHANGED semantics)
+        Assert.Equal(domainDiscount.Id, result.Id);
+        Assert.Equal(domainDiscount.PercentOff, result.PercentOff);
+        Assert.Equal(domainDiscount.AmountOff, result.AmountOff);
+    }
+
+    [Fact]
+    public void Constructor_FromPerpetualDomainDiscount_EndNullAndActiveTrue()
+    {
+        // Arrange - perpetual domain discount (no end date)
+        var domainDiscount = new SubscriptionInfo.BillingCustomerDiscount(new Discount
+        {
+            End = null,
+            Coupon = new Coupon
+            {
+                Id = "perpetual_10",
+                PercentOff = 10m,
+                Duration = "forever"
+            }
+        });
+
+        // Act
+        var result = new BillingCustomerDiscount(domainDiscount);
+
+        // Assert
+        Assert.Null(result.End);
+        Assert.True(result.Active);   // End == null => perpetual (UNCHANGED semantics)
+    }
+}

--- a/test/Core.Test/Billing/Organizations/PlanMigration/Commands/RedeemChurnMitigationOfferCommandTests.cs
+++ b/test/Core.Test/Billing/Organizations/PlanMigration/Commands/RedeemChurnMitigationOfferCommandTests.cs
@@ -583,6 +583,7 @@ public class RedeemChurnMitigationOfferCommandTests
         _getOfferQuery.Run(Arg.Any<Organization>()).Returns(new ChurnMitigationOfferResult(
             CouponId: ChurnCouponCode,
             PercentOff: 15m,
+            AmountOff: null,
             Duration: "once",
             DurationInMonths: null,
             Name: "Churn 15% off"));

--- a/test/Core.Test/Billing/Organizations/PlanMigration/Queries/GetChurnMitigationOfferQueryTests.cs
+++ b/test/Core.Test/Billing/Organizations/PlanMigration/Queries/GetChurnMitigationOfferQueryTests.cs
@@ -85,11 +85,12 @@ public class GetChurnMitigationOfferQueryTests
         Assert.NotNull(result);
         Assert.Equal(ChurnCouponCode, result.CouponId);
         Assert.Equal(15m, result.PercentOff);
+        Assert.Null(result.AmountOff);
         Assert.Equal(CouponDurations.Once, result.Duration);
     }
 
     [Fact]
-    public async Task Run_MigrationCohort_AmountOffCoupon_PercentOffIsNull_ResultStillConstructs()
+    public async Task Run_MigrationCohort_AmountOffCoupon_MapsAmountOffToDollars()
     {
         var organization = CreateOrganization();
         SetupMigrationCohort(organization);
@@ -111,6 +112,7 @@ public class GetChurnMitigationOfferQueryTests
 
         Assert.NotNull(result);
         Assert.Null(result.PercentOff);
+        Assert.Equal(5m, result.AmountOff);   // 500 cents -> $5.00
         Assert.Equal(ChurnCouponCode, result.CouponId);
     }
 
@@ -308,6 +310,45 @@ public class GetChurnMitigationOfferQueryTests
     }
 
     [Fact]
+    public async Task Run_ChurnOnlyCohort_AmountOffOnceCouponNeverRedeemed_ReturnsOfferWithAmountOff()
+    {
+        var organization = CreateOrganization();
+        SetupChurnOnlyCohort(organization);
+
+        SetupGetCoupon(CreateAmountOffCoupon(duration: CouponDurations.Once));
+
+        var subscription = CreateSubscription();
+        SetupGetSubscription(organization, subscription);
+
+        var result = await _query.Run(organization);
+
+        Assert.NotNull(result);
+        Assert.Equal(15m, result.AmountOff);   // 1500 cents -> $15.00
+        Assert.Null(result.PercentOff);
+        Assert.Equal(CouponDurations.Once, result.Duration);
+    }
+
+    [Fact]
+    public async Task Run_ChurnOnlyCohort_AmountOffRepeatingCoupon_ReturnsOfferWithAmountOffAndDuration()
+    {
+        var organization = CreateOrganization();
+        SetupChurnOnlyCohort(organization);
+
+        SetupGetCoupon(CreateAmountOffCoupon(duration: CouponDurations.Repeating, durationInMonths: 3));
+
+        var subscription = CreateSubscription();
+        SetupGetSubscription(organization, subscription);
+
+        var result = await _query.Run(organization);
+
+        Assert.NotNull(result);
+        Assert.Equal(15m, result.AmountOff);   // amount + duration coexist on the offer
+        Assert.Null(result.PercentOff);
+        Assert.Equal(CouponDurations.Repeating, result.Duration);
+        Assert.Equal(3, result.DurationInMonths);
+    }
+
+    [Fact]
     public async Task Run_ChurnOnlyCohort_ForeverCouponNotOnSubscription_ReturnsOffer()
     {
         var organization = CreateOrganization();
@@ -422,6 +463,20 @@ public class GetChurnMitigationOfferQueryTests
             Duration = duration,
             DurationInMonths = durationInMonths,
             Name = "Churn 15% off",
+            Valid = true
+        };
+
+    private static Coupon CreateAmountOffCoupon(
+        string duration = CouponDurations.Once,
+        long? durationInMonths = null) =>
+        new()
+        {
+            Id = ChurnCouponCode,
+            AmountOff = 1500,
+            PercentOff = null,
+            Duration = duration,
+            DurationInMonths = durationInMonths,
+            Name = "Churn $15 off",
             Valid = true
         };
 

--- a/test/Core.Test/Models/Business/SubscriptionInfoTests.cs
+++ b/test/Core.Test/Models/Business/SubscriptionInfoTests.cs
@@ -121,5 +121,101 @@ public class SubscriptionInfoTests
         Assert.Equal(25.00m, result.Amount); // Converted from cents
         Assert.NotNull(result.Date);
     }
+
+    [Fact]
+    public void BillingCustomerDiscount_DiscountCtor_WithEndDate_SetsEndAndDurationAndActiveFalse()
+    {
+        // Arrange - repeating discount with an absolute end date
+        var end = DateTime.UtcNow.AddMonths(12);
+        var discount = new Discount
+        {
+            End = end,
+            Coupon = new Coupon
+            {
+                PercentOff = 10m,
+                Duration = "repeating",
+                DurationInMonths = 12
+            }
+        };
+
+        // Act
+        var result = new SubscriptionInfo.BillingCustomerDiscount(discount);
+
+        // Assert
+        Assert.Equal(end, result.End);
+        Assert.Equal(12, result.DurationInMonths);
+        Assert.False(result.Active);   // End != null => not perpetual (UNCHANGED semantics)
+        Assert.Equal(10m, result.PercentOff);
+    }
+
+    [Fact]
+    public void BillingCustomerDiscount_DiscountCtor_NoEndDate_SetsEndNullAndActiveTrue()
+    {
+        // Arrange - perpetual discount (no end date)
+        var discount = new Discount
+        {
+            End = null,
+            Coupon = new Coupon
+            {
+                PercentOff = 10m,
+                Duration = "forever"
+            }
+        };
+
+        // Act
+        var result = new SubscriptionInfo.BillingCustomerDiscount(discount);
+
+        // Assert
+        Assert.Null(result.End);
+        Assert.True(result.Active);   // End == null => perpetual (UNCHANGED semantics)
+    }
+
+    [Fact]
+    public void BillingCustomerDiscount_CouponCtor_SetsEndNullDurationAndActiveTrue()
+    {
+        // Arrange - Phase-2 scheduled discount: a Coupon with no Discount wrapper
+        var coupon = new Coupon
+        {
+            PercentOff = 10m,
+            Duration = "repeating",
+            DurationInMonths = 12
+        };
+
+        // Act
+        var result = new SubscriptionInfo.BillingCustomerDiscount(coupon);
+
+        // Assert
+        Assert.Null(result.End);            // no Discount wrapper => no end date
+        Assert.Equal(12, result.DurationInMonths);
+        Assert.True(result.Active);         // Coupon ctor: Active unconditionally true (UNCHANGED)
+    }
+
+    [Fact]
+    public void BillingCustomerDiscount_DiscountCtor_AmountOffRepeatingWithEnd_AmountEndAndDurationCoexist()
+    {
+        // Arrange - amount-off repeating discount with an end date
+        var end = DateTime.UtcNow.AddMonths(6);
+        var discount = new Discount
+        {
+            End = end,
+            Coupon = new Coupon
+            {
+                AmountOff = 1500, // $15.00
+                PercentOff = null,
+                Duration = "repeating",
+                DurationInMonths = 6
+            }
+        };
+
+        // Act
+        var result = new SubscriptionInfo.BillingCustomerDiscount(discount);
+
+        // Assert - amount (in dollars), end, and duration all present on one discount
+        Assert.Equal(15.00m, result.AmountOff);
+        Assert.Null(result.PercentOff);
+        Assert.Equal(end, result.End);
+        Assert.Equal(6, result.DurationInMonths);
+        Assert.False(result.Active);
+    }
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38830

## 📔 Objective

Fixed-amount (Stripe `amount_off`) churn-mitigation coupons — and `repeating` / time-bounded discounts — are billed correctly in Stripe but were never rendered in the Web Vault billing UI, because the server's billing contracts dropped the underlying values. This PR adds the missing data so the clients can format and display them. It is the **server-side** portion; a companion client PR consumes the new fields.

**Churn offer (`amount_off`)**
- Add `AmountOff` (`decimal?`, USD dollars) to `ChurnMitigationOfferResult` and map it from Stripe `Coupon.AmountOff` (minor units → dollars via `/ 100M`) in `GetChurnMitigationOfferQuery`. `null` for percentage coupons.

**Customer discount (time-bounded)**
- Add `End` (`DateTime?`) and `DurationInMonths` (`long?`) to both the domain `SubscriptionInfo.BillingCustomerDiscount` and the API `BillingCustomerDiscount` response model, populated in both the `Discount` and `Coupon` constructors. These let the subscription page apply/show `repeating` discounts (e.g. the 10% × 12-month monthly-plan churn case) instead of suppressing them.

All new fields are additive and nullable — safe for the V±2 client matrix. The existing `Active` flag is intentionally left unchanged (it keeps its "perpetual / no end date" meaning; other consumers such as `sm-subscribe.component.ts` still depend on it). No feature-flag, DI, or migration changes. Unit tests cover the cents→dollars conversion, amount + duration coexistence, and an explicit `Active`-unchanged regression guard.
