### PR TITLE
[PM-37474] Include UseRiskInsights in self-host license VerifyData

### DIFF
--- a/src/Core/Billing/Organizations/Models/OrganizationLicense.cs
+++ b/src/Core/Billing/Organizations/Models/OrganizationLicense.cs
@@ -437,6 +437,7 @@ public class OrganizationLicense : ILicense
         var useDisableSmAdsForUsers = claimsPrincipal.GetValue<bool>(nameof(UseDisableSmAdsForUsers));
         var useMyItems = claimsPrincipal.GetValue<bool>(nameof(UseMyItems));
         var useInviteLinks = claimsPrincipal.GetValue<bool>(nameof(UseInviteLinks));
+        var useRiskInsights = claimsPrincipal.GetValue<bool>(nameof(UseRiskInsights));
 
         var claimedPlanType = claimsPrincipal.GetValue<PlanType>(nameof(PlanType));
 
@@ -483,7 +484,11 @@ public class OrganizationLicense : ILicense
                (!claimsPrincipal.HasClaim(c => c.Type == nameof(UseMyItems))
                    || useMyItems == organization.UseMyItems) &&
                (!claimsPrincipal.HasClaim(c => c.Type == nameof(UseInviteLinks))
-                   || useInviteLinks == organization.UseInviteLinks);
+                   || useInviteLinks == organization.UseInviteLinks) &&
+               // UseRiskInsights follows the same conditional HasClaim pattern (PM-33980):
+               // pre-existing self-host licenses lack this claim and must still validate.
+               (!claimsPrincipal.HasClaim(c => c.Type == nameof(UseRiskInsights))
+                   || useRiskInsights == organization.UseRiskInsights);
 
     }
 

--- a/test/Core.Test/Billing/Models/Business/OrganizationLicenseTests.cs
+++ b/test/Core.Test/Billing/Models/Business/OrganizationLicenseTests.cs
@@ -377,8 +377,91 @@ If you believe you need to change the version for a valid reason, please discuss
     }
 
     /// <summary>
-    /// Builds the base set of claims that VerifyData checks, excluding UseMyItems.
-    /// Callers can add or omit UseMyItems to test specific scenarios.
+    /// Regression guard (PM-37474 / PM-33980): pre-existing self-host licenses lack the
+    /// UseRiskInsights claim. VerifyData must skip the comparison when the claim is absent,
+    /// regardless of the org's DB value, so those licenses are not invalidated.
+    /// </summary>
+    [Theory]
+    [BitAutoData(true)]
+    [BitAutoData(false)]
+    public void OrganizationLicense_VerifyData_PassesWhenUseRiskInsightsClaimAbsent(bool useRiskInsightsDbValue)
+    {
+        // Arrange
+        var organization = CreateDeterministicOrganization();
+        organization.UseRiskInsights = useRiskInsightsDbValue;
+
+        var installationId = new Guid("78900000-0000-0000-0000-000000000123");
+
+        // Build a ClaimsPrincipal with all claims VerifyData checks EXCEPT UseRiskInsights,
+        // simulating a license generated before UseRiskInsights was added.
+        var claims = BuildBaseVerifyDataClaims(organization, installationId);
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+        var license = new OrganizationLicense { Token = "non-empty", Expires = DateTime.MaxValue };
+
+        var globalSettings = Substitute.For<IGlobalSettings>();
+        globalSettings.Installation.Returns(new GlobalSettings.InstallationSettings
+        {
+            Id = installationId
+        });
+
+        // Act & Assert — must pass regardless of the org's UseRiskInsights DB value
+        Assert.True(license.VerifyData(organization, claimsPrincipal, globalSettings));
+    }
+
+    [Theory]
+    [BitAutoData(true)]
+    [BitAutoData(false)]
+    public void OrganizationLicense_VerifyData_PassesWhenUseRiskInsightsClaimPresentAndMatches(bool useRiskInsightsValue)
+    {
+        var organization = CreateDeterministicOrganization();
+        organization.UseRiskInsights = useRiskInsightsValue;
+
+        var installationId = new Guid("78900000-0000-0000-0000-000000000123");
+
+        var claims = BuildBaseVerifyDataClaims(organization, installationId);
+        claims.Add(new Claim(nameof(OrganizationLicense.UseRiskInsights), useRiskInsightsValue.ToString()));
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+        var license = new OrganizationLicense { Token = "non-empty", Expires = DateTime.MaxValue };
+
+        var globalSettings = Substitute.For<IGlobalSettings>();
+        globalSettings.Installation.Returns(new GlobalSettings.InstallationSettings
+        {
+            Id = installationId
+        });
+
+        Assert.True(license.VerifyData(organization, claimsPrincipal, globalSettings));
+    }
+
+    [Fact]
+    public void OrganizationLicense_VerifyData_FailsWhenUseRiskInsightsClaimPresentAndMismatches()
+    {
+        var organization = CreateDeterministicOrganization();
+        organization.UseRiskInsights = true;
+
+        var installationId = new Guid("78900000-0000-0000-0000-000000000123");
+
+        var claims = BuildBaseVerifyDataClaims(organization, installationId);
+        // Claim says false, org says true — should fail
+        claims.Add(new Claim(nameof(OrganizationLicense.UseRiskInsights), false.ToString()));
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+        var license = new OrganizationLicense { Token = "non-empty", Expires = DateTime.MaxValue };
+
+        var globalSettings = Substitute.For<IGlobalSettings>();
+        globalSettings.Installation.Returns(new GlobalSettings.InstallationSettings
+        {
+            Id = installationId
+        });
+
+        Assert.False(license.VerifyData(organization, claimsPrincipal, globalSettings));
+    }
+
+    /// <summary>
+    /// Builds the base set of claims that VerifyData checks, excluding the conditionally-guarded
+    /// claims (UseMyItems, UseInviteLinks, UseRiskInsights). Callers can add or omit those claims
+    /// to test specific scenarios.
     /// </summary>
     private static List<Claim> BuildBaseVerifyDataClaims(Organization organization, Guid installationId)
     {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37474

## 📔 Objective

`OrganizationLicense.VerifyData()` signed the `UseRiskInsights` claim into the self-host license but never validated it against the organization, leaving the last gap in the org-ability wiring for Access Intelligence on self-host. This adds the comparison using the conditional `HasClaim` pattern introduced in PM-33980 (`!claimsPrincipal.HasClaim(...) || claimValue == orgValue`), so that:

- new licenses correctly enforce the `UseRiskInsights` ability on self-host, and
- pre-existing self-host licenses generated before this claim existed continue to validate (the claim is absent, so the comparison is skipped) rather than being treated as invalid and disabling the organization.

This mirrors the existing `UseMyItems` and `UseInviteLinks` clauses in the same method. The claim is already emitted by `OrganizationLicenseClaimsFactory` and synced onto the organization by `Organization.UpdateFromLicense()`; `VerifyData()` was the only consumer missing it.

## 📸 Screenshots

Not applicable — server-side license validation, no UI changes.

## ⏰ Reminders before review

Unit tests cover the three branches of the new clause: claim absent (pre-existing license still validates), claim present and matching, and claim present and mismatching (validation fails).