### PR TITLE
[PM-37513] feat: Add Enterprise 2019 to current pricing migration path

### DIFF
--- a/src/Core/Billing/Organizations/PlanMigration/Enums/MigrationPathId.cs
+++ b/src/Core/Billing/Organizations/PlanMigration/Enums/MigrationPathId.cs
@@ -21,4 +21,6 @@ public enum MigrationPathId : byte
     Enterprise2020MonthlyToCurrent = 2,
     Teams2020AnnualToCurrent = 3,
     Teams2020MonthlyToCurrent = 4,
+    Enterprise2019AnnualToCurrent = 5,
+    Enterprise2019MonthlyToCurrent = 6,
 }

--- a/src/Core/Billing/Organizations/PlanMigration/ValueObjects/MigrationPaths.cs
+++ b/src/Core/Billing/Organizations/PlanMigration/ValueObjects/MigrationPaths.cs
@@ -36,12 +36,26 @@ public static class MigrationPaths
         FromPlan: PlanType.TeamsMonthly2020,
         ToPlan: PlanType.TeamsMonthly);
 
+    public static readonly MigrationPath Enterprise2019AnnualToCurrent = new(
+        Id: MigrationPathId.Enterprise2019AnnualToCurrent,
+        Name: nameof(Enterprise2019AnnualToCurrent),
+        FromPlan: PlanType.EnterpriseAnnually2019,
+        ToPlan: PlanType.EnterpriseAnnually);
+
+    public static readonly MigrationPath Enterprise2019MonthlyToCurrent = new(
+        Id: MigrationPathId.Enterprise2019MonthlyToCurrent,
+        Name: nameof(Enterprise2019MonthlyToCurrent),
+        FromPlan: PlanType.EnterpriseMonthly2019,
+        ToPlan: PlanType.EnterpriseMonthly);
+
     public static IReadOnlyList<MigrationPath> All { get; } =
     [
         Enterprise2020AnnualToCurrent,
         Enterprise2020MonthlyToCurrent,
         Teams2020AnnualToCurrent,
         Teams2020MonthlyToCurrent,
+        Enterprise2019AnnualToCurrent,
+        Enterprise2019MonthlyToCurrent,
     ];
 
     /// <summary>

--- a/test/Billing.Test/Services/SubscriptionUpdatedHandlerTests.cs
+++ b/test/Billing.Test/Services/SubscriptionUpdatedHandlerTests.cs
@@ -4924,4 +4924,415 @@ public class SubscriptionUpdatedHandlerTests
         Assert.NotEqual(default, assignment.RevisionDate);
         Assert.True(assignment.MigratedDate > DateTime.UtcNow.AddMinutes(-1));
     }
+
+    [Fact]
+    public async Task HandleAsync_BusinessMigration_EnterpriseAnnual2019ToCurrent_AppliesAndMarksMigrated()
+    {
+        // Arrange
+        var organizationId = Guid.NewGuid();
+        var cohortId = Guid.NewGuid();
+        var assignmentId = Guid.NewGuid();
+        var enterprise2019Annual = new Enterprise2019Plan(true);
+        var enterpriseAnnual = new EnterprisePlan(true);
+
+        var previousSubscription = new Subscription
+        {
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = enterprise2019Annual.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = enterprise2019Annual.PasswordManager.StripeSeatPlanId }
+                    }
+                ]
+            }
+        };
+
+        var subscription = new Subscription
+        {
+            Id = "sub_happy_ea19",
+            ScheduleId = "sub_sched_x",
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = enterpriseAnnual.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = enterpriseAnnual.PasswordManager.StripeSeatPlanId }
+                    }
+                ]
+            },
+            Metadata = new Dictionary<string, string> { { "organizationId", organizationId.ToString() } },
+            LatestInvoice = new Invoice { BillingReason = BillingReasons.SubscriptionCycle }
+        };
+
+        var organization = new Organization
+        {
+            Id = organizationId,
+            PlanType = PlanType.EnterpriseAnnually2019,
+            Plan = enterprise2019Annual.Name,
+            Seats = 200,
+            MaxStorageGb = 50,
+        };
+
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = assignmentId,
+            OrganizationId = organizationId,
+            CohortId = cohortId
+        };
+
+        var parsedEvent = new Event
+        {
+            Data = new EventData
+            {
+                Object = subscription,
+                PreviousAttributes = JObject.FromObject(previousSubscription)
+            }
+        };
+
+        _stripeEventService.GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(subscription);
+        _organizationRepository.GetByIdAsync(organizationId).Returns(organization);
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+        _pricingClient.GetPlanOrThrow(PlanType.EnterpriseAnnually2019).Returns(enterprise2019Annual);
+        _pricingClient.GetPlanOrThrow(PlanType.EnterpriseAnnually).Returns(enterpriseAnnual);
+        _pricingClient.ListPlans().Returns(MockPlans.Plans);
+        _cohortAssignmentRepository.GetByOrganizationIdAsync(organizationId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohortId).Returns(new OrganizationPlanMigrationCohort
+        {
+            Id = cohortId,
+            Name = "Enterprise2019Annual",
+            MigrationPathId = MigrationPathId.Enterprise2019AnnualToCurrent,
+            IsActive = true
+        });
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert — plan shape applied
+        Assert.Equal(PlanType.EnterpriseAnnually, organization.PlanType);
+        Assert.Equal(enterpriseAnnual.Name, organization.Plan);
+        Assert.Equal(enterpriseAnnual.HasScim, organization.UseScim);
+        Assert.True(organization.UsePasswordManager);
+        Assert.Equal(enterpriseAnnual.UsersGetPremium, organization.UsersGetPremium);
+        Assert.Equal(enterpriseAnnual.PasswordManager.MaxCollections, organization.MaxCollections);
+
+        // Allocation preserved
+        Assert.Equal((short)200, organization.Seats);
+        Assert.Equal((short)50, organization.MaxStorageGb);
+
+        await _organizationRepository.Received(1).ReplaceAsync(Arg.Is<Organization>(o =>
+            o.Id == organizationId && o.PlanType == PlanType.EnterpriseAnnually));
+
+        Assert.NotNull(assignment.MigratedDate);
+        Assert.NotEqual(default, assignment.RevisionDate);
+        await _cohortAssignmentRepository.Received(1).ReplaceAsync(
+            Arg.Is<OrganizationPlanMigrationCohortAssignment>(a => a.Id == assignmentId && a.MigratedDate.HasValue));
+    }
+
+    // PM-37513: Enterprise 2019 (SM base 200) -> current (SM base 50) writes grace 150 onto the
+    // subscription metadata, merged with the existing metadata, with no item/quantity change. The
+    // grace is computed from plan baselines regardless of the org's actual SM usage (matches Ent 2020).
+    [Fact]
+    public async Task HandleAsync_BusinessMigration_EnterpriseAnnual2019ToCurrent_WritesGraceMetadata()
+    {
+        // Arrange
+        var organizationId = Guid.NewGuid();
+        var cohortId = Guid.NewGuid();
+        var enterprise2019Annual = new Enterprise2019Plan(true);
+        var enterpriseAnnual = new EnterprisePlan(true);
+
+        var previousSubscription = new Subscription
+        {
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = enterprise2019Annual.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = enterprise2019Annual.PasswordManager.StripeSeatPlanId }
+                    }
+                ]
+            }
+        };
+
+        var subscription = new Subscription
+        {
+            Id = "sub_grace_ea19",
+            ScheduleId = "sub_sched_g",
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = enterpriseAnnual.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = enterpriseAnnual.PasswordManager.StripeSeatPlanId }
+                    }
+                ]
+            },
+            Metadata = new Dictionary<string, string> { { "organizationId", organizationId.ToString() } },
+            LatestInvoice = new Invoice { BillingReason = BillingReasons.SubscriptionCycle }
+        };
+
+        var organization = new Organization
+        {
+            Id = organizationId,
+            PlanType = PlanType.EnterpriseAnnually2019,
+            Plan = enterprise2019Annual.Name,
+        };
+
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            CohortId = cohortId
+        };
+
+        var parsedEvent = new Event
+        {
+            Data = new EventData
+            {
+                Object = subscription,
+                PreviousAttributes = JObject.FromObject(previousSubscription)
+            }
+        };
+
+        _stripeEventService.GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(subscription);
+        _organizationRepository.GetByIdAsync(organizationId).Returns(organization);
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+        _pricingClient.GetPlanOrThrow(PlanType.EnterpriseAnnually2019).Returns(enterprise2019Annual);
+        _pricingClient.GetPlanOrThrow(PlanType.EnterpriseAnnually).Returns(enterpriseAnnual);
+        _pricingClient.ListPlans().Returns(MockPlans.Plans);
+        _cohortAssignmentRepository.GetByOrganizationIdAsync(organizationId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohortId).Returns(new OrganizationPlanMigrationCohort
+        {
+            Id = cohortId,
+            Name = "Enterprise2019Annual",
+            MigrationPathId = MigrationPathId.Enterprise2019AnnualToCurrent,
+            IsActive = true
+        });
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert — grace metadata written (200 - 50 = 150), merged with the org id key.
+        await _stripeAdapter.Received(1).UpdateSubscriptionAsync(
+            subscription.Id,
+            Arg.Is<SubscriptionUpdateOptions>(options =>
+                options.Metadata[MetadataKeys.MigrationGraceServiceAccounts] == "150" &&
+                options.Metadata["organizationId"] == organizationId.ToString()));
+    }
+
+    // PM-37513: the monthly path (MigrationPathId = 6) writes the same grace as the annual path — the SM
+    // baseline delta (200 -> 50) is cadence-independent, so grace is 150 for both. Exercises the monthly
+    // MigrationPathId, which the annual grace test above does not cover.
+    [Fact]
+    public async Task HandleAsync_BusinessMigration_EnterpriseMonthly2019ToCurrent_WritesGraceMetadata()
+    {
+        // Arrange
+        var organizationId = Guid.NewGuid();
+        var cohortId = Guid.NewGuid();
+        var enterprise2019Monthly = new Enterprise2019Plan(false);
+        var enterpriseMonthly = new EnterprisePlan(false);
+
+        var previousSubscription = new Subscription
+        {
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = enterprise2019Monthly.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = enterprise2019Monthly.PasswordManager.StripeSeatPlanId }
+                    }
+                ]
+            }
+        };
+
+        var subscription = new Subscription
+        {
+            Id = "sub_grace_em19",
+            ScheduleId = "sub_sched_gm",
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = enterpriseMonthly.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = enterpriseMonthly.PasswordManager.StripeSeatPlanId }
+                    }
+                ]
+            },
+            Metadata = new Dictionary<string, string> { { "organizationId", organizationId.ToString() } },
+            LatestInvoice = new Invoice { BillingReason = BillingReasons.SubscriptionCycle }
+        };
+
+        var organization = new Organization
+        {
+            Id = organizationId,
+            PlanType = PlanType.EnterpriseMonthly2019,
+            Plan = enterprise2019Monthly.Name,
+        };
+
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            CohortId = cohortId
+        };
+
+        var parsedEvent = new Event
+        {
+            Data = new EventData
+            {
+                Object = subscription,
+                PreviousAttributes = JObject.FromObject(previousSubscription)
+            }
+        };
+
+        _stripeEventService.GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(subscription);
+        _organizationRepository.GetByIdAsync(organizationId).Returns(organization);
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+        _pricingClient.GetPlanOrThrow(PlanType.EnterpriseMonthly2019).Returns(enterprise2019Monthly);
+        _pricingClient.GetPlanOrThrow(PlanType.EnterpriseMonthly).Returns(enterpriseMonthly);
+        _pricingClient.ListPlans().Returns(MockPlans.Plans);
+        _cohortAssignmentRepository.GetByOrganizationIdAsync(organizationId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohortId).Returns(new OrganizationPlanMigrationCohort
+        {
+            Id = cohortId,
+            Name = "Enterprise2019Monthly",
+            MigrationPathId = MigrationPathId.Enterprise2019MonthlyToCurrent,
+            IsActive = true
+        });
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert — grace metadata written (200 - 50 = 150), merged with the org id key.
+        await _stripeAdapter.Received(1).UpdateSubscriptionAsync(
+            subscription.Id,
+            Arg.Is<SubscriptionUpdateOptions>(options =>
+                options.Metadata[MetadataKeys.MigrationGraceServiceAccounts] == "150" &&
+                options.Metadata["organizationId"] == organizationId.ToString()));
+    }
+
+    // PM-37513: an Enterprise 2019 org with no SM line items (PM seat only) still migrates its plan
+    // shape and marks migrated. Grace metadata is computed from plan baselines (150) and written
+    // regardless of SM usage; this confirms that write does not disrupt the no-SM migration path.
+    [Fact]
+    public async Task HandleAsync_BusinessMigration_EnterpriseAnnual2019NoSecretsManager_MigratesCleanly()
+    {
+        // Arrange
+        var organizationId = Guid.NewGuid();
+        var cohortId = Guid.NewGuid();
+        var assignmentId = Guid.NewGuid();
+        var enterprise2019Annual = new Enterprise2019Plan(true);
+        var enterpriseAnnual = new EnterprisePlan(true);
+
+        // Previous + current subscriptions carry ONLY the PM seat item — no SM service-account item.
+        var previousSubscription = new Subscription
+        {
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = enterprise2019Annual.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = enterprise2019Annual.PasswordManager.StripeSeatPlanId }
+                    }
+                ]
+            }
+        };
+
+        var subscription = new Subscription
+        {
+            Id = "sub_nosm_ea19",
+            ScheduleId = "sub_sched_n",
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = enterpriseAnnual.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = enterpriseAnnual.PasswordManager.StripeSeatPlanId }
+                    }
+                ]
+            },
+            Metadata = new Dictionary<string, string> { { "organizationId", organizationId.ToString() } },
+            LatestInvoice = new Invoice { BillingReason = BillingReasons.SubscriptionCycle }
+        };
+
+        var organization = new Organization
+        {
+            Id = organizationId,
+            PlanType = PlanType.EnterpriseAnnually2019,
+            Plan = enterprise2019Annual.Name,
+            UseSecretsManager = false,
+            Seats = 10,
+        };
+
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = assignmentId,
+            OrganizationId = organizationId,
+            CohortId = cohortId
+        };
+
+        var parsedEvent = new Event
+        {
+            Data = new EventData
+            {
+                Object = subscription,
+                PreviousAttributes = JObject.FromObject(previousSubscription)
+            }
+        };
+
+        _stripeEventService.GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(subscription);
+        _organizationRepository.GetByIdAsync(organizationId).Returns(organization);
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+        _pricingClient.GetPlanOrThrow(PlanType.EnterpriseAnnually2019).Returns(enterprise2019Annual);
+        _pricingClient.GetPlanOrThrow(PlanType.EnterpriseAnnually).Returns(enterpriseAnnual);
+        _pricingClient.ListPlans().Returns(MockPlans.Plans);
+        _cohortAssignmentRepository.GetByOrganizationIdAsync(organizationId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohortId).Returns(new OrganizationPlanMigrationCohort
+        {
+            Id = cohortId,
+            Name = "Enterprise2019Annual",
+            MigrationPathId = MigrationPathId.Enterprise2019AnnualToCurrent,
+            IsActive = true
+        });
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert — plan shape applied and assignment marked, despite no SM line items.
+        Assert.Equal(PlanType.EnterpriseAnnually, organization.PlanType);
+        Assert.False(organization.UseSecretsManager); // ChangePlan does not touch this column
+        await _organizationRepository.Received(1).ReplaceAsync(Arg.Is<Organization>(o =>
+            o.Id == organizationId && o.PlanType == PlanType.EnterpriseAnnually));
+        Assert.NotNull(assignment.MigratedDate);
+        await _cohortAssignmentRepository.Received(1).ReplaceAsync(
+            Arg.Is<OrganizationPlanMigrationCohortAssignment>(a => a.Id == assignmentId && a.MigratedDate.HasValue));
+
+        // Grace metadata is still written from the plan baselines (200 - 50 = 150) even though this org
+        // carries no SM line items. This is intentional and matches Enterprise 2020 behavior — pinning it
+        // here so the no-SM grace write is a deliberate contract, not an accident a future change silences.
+        await _stripeAdapter.Received(1).UpdateSubscriptionAsync(
+            subscription.Id,
+            Arg.Is<SubscriptionUpdateOptions>(options =>
+                options.Metadata[MetadataKeys.MigrationGraceServiceAccounts] == "150"));
+    }
 }

--- a/test/Core.Test/Billing/Organizations/Extensions/OrganizationPlanExtensionsTests.cs
+++ b/test/Core.Test/Billing/Organizations/Extensions/OrganizationPlanExtensionsTests.cs
@@ -77,6 +77,77 @@ public class OrganizationPlanExtensionsTests
     }
 
     [Fact]
+    public void ChangePlan_EnterpriseAnnually2019ToEnterpriseAnnually_AppliesStructuralFields()
+    {
+        // Enterprise 2019 -> Current adds and removes NO capability flags (the 2019 set is
+        // already full). This asserts every flag the helper writes lands on the current value,
+        // i.e. nothing in active use is dropped.
+        var organization = new Organization
+        {
+            PlanType = PlanType.EnterpriseAnnually2019,
+            Plan = "Enterprise (Annually) 2019"
+        };
+        var targetPlan = new EnterprisePlan(isAnnual: true);
+
+        organization.ChangePlan(targetPlan);
+
+        Assert.Equal(PlanType.EnterpriseAnnually, organization.PlanType);
+        Assert.Equal(targetPlan.Name, organization.Plan);
+        Assert.Equal(targetPlan.HasGroups, organization.UseGroups);
+        Assert.Equal(targetPlan.HasDirectory, organization.UseDirectory);
+        Assert.Equal(targetPlan.HasEvents, organization.UseEvents);
+        Assert.Equal(targetPlan.HasTotp, organization.UseTotp);
+        Assert.Equal(targetPlan.Has2fa, organization.Use2fa);
+        Assert.Equal(targetPlan.HasApi, organization.UseApi);
+        Assert.Equal(targetPlan.HasSelfHost, organization.SelfHost);
+        Assert.Equal(targetPlan.HasPolicies, organization.UsePolicies);
+        Assert.Equal(targetPlan.HasMyItems, organization.UseMyItems);
+        Assert.Equal(targetPlan.HasInviteLinks, organization.UseInviteLinks);
+        Assert.Equal(targetPlan.HasSso, organization.UseSso);
+        Assert.Equal(targetPlan.HasOrganizationDomains, organization.UseOrganizationDomains);
+        Assert.Equal(targetPlan.HasScim, organization.UseScim);
+        Assert.Equal(targetPlan.HasResetPassword, organization.UseResetPassword);
+        Assert.Equal(targetPlan.HasCustomPermissions, organization.UseCustomPermissions);
+        Assert.Equal(targetPlan.UsersGetPremium, organization.UsersGetPremium);
+        Assert.Equal(targetPlan.PasswordManager.MaxCollections, organization.MaxCollections);
+        Assert.True(organization.UsePasswordManager);
+    }
+
+    [Fact]
+    public void ChangePlan_EnterpriseMonthly2019ToEnterpriseMonthly_AppliesStructuralFields()
+    {
+        var organization = new Organization
+        {
+            PlanType = PlanType.EnterpriseMonthly2019,
+            Plan = "Enterprise (Monthly) 2019"
+        };
+        var targetPlan = new EnterprisePlan(isAnnual: false);
+
+        organization.ChangePlan(targetPlan);
+
+        Assert.Equal(PlanType.EnterpriseMonthly, organization.PlanType);
+        Assert.Equal(targetPlan.Name, organization.Plan);
+        Assert.Equal(targetPlan.HasGroups, organization.UseGroups);
+        Assert.Equal(targetPlan.HasDirectory, organization.UseDirectory);
+        Assert.Equal(targetPlan.HasEvents, organization.UseEvents);
+        Assert.Equal(targetPlan.HasTotp, organization.UseTotp);
+        Assert.Equal(targetPlan.Has2fa, organization.Use2fa);
+        Assert.Equal(targetPlan.HasApi, organization.UseApi);
+        Assert.Equal(targetPlan.HasSelfHost, organization.SelfHost);
+        Assert.Equal(targetPlan.HasPolicies, organization.UsePolicies);
+        Assert.Equal(targetPlan.HasMyItems, organization.UseMyItems);
+        Assert.Equal(targetPlan.HasInviteLinks, organization.UseInviteLinks);
+        Assert.Equal(targetPlan.HasSso, organization.UseSso);
+        Assert.Equal(targetPlan.HasOrganizationDomains, organization.UseOrganizationDomains);
+        Assert.Equal(targetPlan.HasScim, organization.UseScim);
+        Assert.Equal(targetPlan.HasResetPassword, organization.UseResetPassword);
+        Assert.Equal(targetPlan.HasCustomPermissions, organization.UseCustomPermissions);
+        Assert.Equal(targetPlan.UsersGetPremium, organization.UsersGetPremium);
+        Assert.Equal(targetPlan.PasswordManager.MaxCollections, organization.MaxCollections);
+        Assert.True(organization.UsePasswordManager);
+    }
+
+    [Fact]
     public void ChangePlan_TeamsAnnually2020ToTeamsAnnually_AppliesStructuralFields()
     {
         // Headline capability gain for Teams Track A: UseScim flips false -> true.

--- a/test/Core.Test/Billing/Organizations/PlanMigration/OrganizationPlanMigrationPriceMapperTests.cs
+++ b/test/Core.Test/Billing/Organizations/PlanMigration/OrganizationPlanMigrationPriceMapperTests.cs
@@ -58,6 +58,62 @@ public class OrganizationPlanMigrationPriceMapperTests
         Assert.Null(result);
     }
 
+    // PM-37513: Enterprise 2019 PM seat id swaps to the current ("2023-") seat id. The ids differ,
+    // so this is a real swap, not a pass-through.
+    [Fact]
+    public void MapOrNull_Enterprise2019AnnualPmSeat_ReturnsTargetPmSeat()
+    {
+        var source = MockPlans.Get(PlanType.EnterpriseAnnually2019);
+        var target = MockPlans.Get(PlanType.EnterpriseAnnually);
+
+        var result = OrganizationPlanMigrationPriceMapper.MapOrNull(
+            source.PasswordManager.StripeSeatPlanId, source, target);
+
+        Assert.Equal(target.PasswordManager.StripeSeatPlanId, result);
+        Assert.NotEqual(source.PasswordManager.StripeSeatPlanId, result);
+    }
+
+    [Fact]
+    public void MapOrNull_Enterprise2019MonthlyPmSeat_ReturnsTargetPmSeat()
+    {
+        var source = MockPlans.Get(PlanType.EnterpriseMonthly2019);
+        var target = MockPlans.Get(PlanType.EnterpriseMonthly);
+
+        var result = OrganizationPlanMigrationPriceMapper.MapOrNull(
+            source.PasswordManager.StripeSeatPlanId, source, target);
+
+        Assert.Equal(target.PasswordManager.StripeSeatPlanId, result);
+        Assert.NotEqual(source.PasswordManager.StripeSeatPlanId, result);
+    }
+
+    // Storage id is identical across Enterprise generations; mapping must still resolve (not null)
+    // so a storage line item is never silently dropped during the price swap.
+    [Fact]
+    public void MapOrNull_Enterprise2019AnnualStorage_ResolvesToTargetStorage()
+    {
+        var source = MockPlans.Get(PlanType.EnterpriseAnnually2019);
+        var target = MockPlans.Get(PlanType.EnterpriseAnnually);
+
+        var result = OrganizationPlanMigrationPriceMapper.MapOrNull(
+            source.PasswordManager.StripeStoragePlanId, source, target);
+
+        Assert.Equal(target.PasswordManager.StripeStoragePlanId, result);
+    }
+
+    // PM-37513: if an Enterprise 2019 org carries an SM service-account line item, it must swap to the
+    // current ("-2024-") service-account id, not silently drop.
+    [Fact]
+    public void MapOrNull_Enterprise2019AnnualSmServiceAccount_ReturnsTargetSmServiceAccount()
+    {
+        var source = MockPlans.Get(PlanType.EnterpriseAnnually2019);
+        var target = MockPlans.Get(PlanType.EnterpriseAnnually);
+
+        var result = OrganizationPlanMigrationPriceMapper.MapOrNull(
+            source.SecretsManager.StripeServiceAccountPlanId, source, target);
+
+        Assert.Equal(target.SecretsManager.StripeServiceAccountPlanId, result);
+    }
+
     [Fact]
     public void MapOrNull_SmSeatWhenSourceSmIsNull_ReturnsNull()
     {

--- a/test/Core.Test/Billing/Organizations/PlanMigration/ValueObjects/MigrationPathIdsSnapshotTests.cs
+++ b/test/Core.Test/Billing/Organizations/PlanMigration/ValueObjects/MigrationPathIdsSnapshotTests.cs
@@ -37,6 +37,8 @@ public class MigrationPathIdsSnapshotTests
         Assert.Equal((byte)2, (byte)MigrationPathId.Enterprise2020MonthlyToCurrent);
         Assert.Equal((byte)3, (byte)MigrationPathId.Teams2020AnnualToCurrent);
         Assert.Equal((byte)4, (byte)MigrationPathId.Teams2020MonthlyToCurrent);
+        Assert.Equal((byte)5, (byte)MigrationPathId.Enterprise2019AnnualToCurrent);
+        Assert.Equal((byte)6, (byte)MigrationPathId.Enterprise2019MonthlyToCurrent);
     }
 
     [Fact]
@@ -53,6 +55,10 @@ public class MigrationPathIdsSnapshotTests
             MigrationPaths.Teams2020AnnualToCurrent.Id);
         Assert.Equal(MigrationPathId.Teams2020MonthlyToCurrent,
             MigrationPaths.Teams2020MonthlyToCurrent.Id);
+        Assert.Equal(MigrationPathId.Enterprise2019AnnualToCurrent,
+            MigrationPaths.Enterprise2019AnnualToCurrent.Id);
+        Assert.Equal(MigrationPathId.Enterprise2019MonthlyToCurrent,
+            MigrationPaths.Enterprise2019MonthlyToCurrent.Id);
     }
 
     [Fact]
@@ -78,6 +84,14 @@ public class MigrationPathIdsSnapshotTests
             MigrationPaths.Teams2020MonthlyToCurrent.FromPlan);
         Assert.Equal(PlanType.TeamsMonthly,
             MigrationPaths.Teams2020MonthlyToCurrent.ToPlan);
+        Assert.Equal(PlanType.EnterpriseAnnually2019,
+            MigrationPaths.Enterprise2019AnnualToCurrent.FromPlan);
+        Assert.Equal(PlanType.EnterpriseAnnually,
+            MigrationPaths.Enterprise2019AnnualToCurrent.ToPlan);
+        Assert.Equal(PlanType.EnterpriseMonthly2019,
+            MigrationPaths.Enterprise2019MonthlyToCurrent.FromPlan);
+        Assert.Equal(PlanType.EnterpriseMonthly,
+            MigrationPaths.Enterprise2019MonthlyToCurrent.ToPlan);
     }
 
     [Fact]
@@ -85,7 +99,7 @@ public class MigrationPathIdsSnapshotTests
     {
         // Guards against accidental removal. Increment when intentionally adding a
         // new path.
-        Assert.Equal(4, MigrationPaths.All.Count);
+        Assert.Equal(6, MigrationPaths.All.Count);
     }
 
     [Fact]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37513

## 📔 Objective

Adds the **Enterprise 2019 → Enterprise Current** pricing-migration path (Annual and Monthly) to the registry-driven plan-migration framework introduced in PM-37092.

The framework resolves all runtime behavior from `MigrationPaths.All` via `MigrationPaths.FromId(cohort.MigrationPathId)`, so this change is purely additive registration — two new `MigrationPathId` enum values (appended `5`/`6`; the bytes are persisted on `OrganizationPlanMigrationCohort.MigrationPathId`, so existing `1`–`4` are untouched) and two `MigrationPath` records. The Phase 2 webhook handler (`SubscriptionUpdatedHandler`), the price-increase scheduler, the renewal email (`UpcomingInvoiceHandler`), and the Admin cohort dropdown all pick up the new paths automatically, with no new plan-type branches.

Spike findings (resolved from code):
- Enterprise 2019 and Enterprise Current share an **identical capability-flag set**, so `Organization.ChangePlan` drops no flag in active use — the only structural writes are `PlanType`/`Plan`/`MaxCollections` (unchanged).
- The SM service-account baseline shrinks **200 → 50**. The existing generic grace logic handles this (grace `150`) for any org carrying SM line items, matching the Enterprise 2020 "preserve / grace-forever" policy. No SM-specific code added.
- Renewal email reused as-is (`BusinessPlanRenewal2020Migration`) — the selection is already path-agnostic; a dedicated email, if needed, is a separate story.

Server-only. `MigrationPathId` is consumed by Core/Billing, the Billing webhook handlers, the Admin cohort UI, and the EF repositories — never `src/Api` — so no client change and no API-contract impact.

Tests: snapshot fixture extended (byte/Id/From-To, count 4→6); `ChangePlan` structural-field coverage for both 2019 cadences; price-mapper no-silent-gap coverage (PM seat + storage pass-through + SM service-account); handler tests for both paths (applies + marks migrated, grace `150` for annual and monthly, and a no-Secrets-Manager org migrating cleanly). Full Core.Test (5538) and Billing.Test (282) suites pass; build clean.

## 📸 Screenshots

Not applicable — no UI changes.
