### PR TITLE
[PM-33940] Enforce per-secret access checks in SecretVersionsController

### DIFF
--- a/src/Api/SecretsManager/Controllers/SecretVersionsController.cs
+++ b/src/Api/SecretsManager/Controllers/SecretVersionsController.cs
@@ -141,7 +141,7 @@ public class SecretVersionsController : Controller
         var accessClient = AccessClientHelper.ToAccessClient(_currentContext.IdentityClientType, isAdmin);
 
         var accessResults = await _secretRepository.AccessToSecretsAsync(secretIds, userId.Value, accessClient);
-        if (accessResults.Values.Any(access => !access.Read))
+        if (accessResults.Count != secretIds.Count || accessResults.Values.Any(access => !access.Read))
         {
             throw new NotFoundException();
         }
@@ -267,7 +267,7 @@ public class SecretVersionsController : Controller
         var accessClient = AccessClientHelper.ToAccessClient(_currentContext.IdentityClientType, orgAdmin);
 
         var accessResults = await _secretRepository.AccessToSecretsAsync(secretIds, userId.Value, accessClient);
-        if (accessResults.Values.Any(access => !access.Write))
+        if (accessResults.Count != secretIds.Count || accessResults.Values.Any(access => !access.Write))
         {
             throw new NotFoundException();
         }

--- a/src/Api/SecretsManager/Controllers/SecretVersionsController.cs
+++ b/src/Api/SecretsManager/Controllers/SecretVersionsController.cs
@@ -45,16 +45,6 @@ public class SecretVersionsController : Controller
             throw new NotFoundException();
         }
 
-        // For service accounts and organization API, skip user-level access checks
-        if (_currentContext.IdentityClientType == IdentityClientType.ServiceAccount ||
-            _currentContext.IdentityClientType == IdentityClientType.Organization)
-        {
-            // Already verified Secrets Manager access above
-            var versionList = await _secretVersionRepository.GetManyBySecretIdAsync(secretId);
-            var responseList = versionList.Select(v => new SecretVersionResponseModel(v));
-            return new ListResponseModel<SecretVersionResponseModel>(responseList);
-        }
-
         var userId = _userService.GetProperUserId(User);
         if (!userId.HasValue)
         {
@@ -89,14 +79,6 @@ public class SecretVersionsController : Controller
         if (secret == null || !_currentContext.AccessSecretsManager(secret.OrganizationId))
         {
             throw new NotFoundException();
-        }
-
-        // For service accounts and organization API, skip user-level access checks
-        if (_currentContext.IdentityClientType == IdentityClientType.ServiceAccount ||
-            _currentContext.IdentityClientType == IdentityClientType.Organization)
-        {
-            // Already verified Secrets Manager access above
-            return new SecretVersionResponseModel(secretVersion);
         }
 
         var userId = _userService.GetProperUserId(User);
@@ -149,15 +131,6 @@ public class SecretVersionsController : Controller
             throw new NotFoundException();
         }
 
-        // For service accounts and organization API, skip user-level access checks
-        if (_currentContext.IdentityClientType == IdentityClientType.ServiceAccount ||
-            _currentContext.IdentityClientType == IdentityClientType.Organization)
-        {
-            // Already verified Secrets Manager access and organization ownership above
-            var serviceAccountResponses = versions.Select(v => new SecretVersionResponseModel(v));
-            return new ListResponseModel<SecretVersionResponseModel>(serviceAccountResponses);
-        }
-
         var userId = _userService.GetProperUserId(User);
         if (!userId.HasValue)
         {
@@ -167,7 +140,6 @@ public class SecretVersionsController : Controller
         var isAdmin = await _currentContext.OrganizationAdmin(organizationId);
         var accessClient = AccessClientHelper.ToAccessClient(_currentContext.IdentityClientType, isAdmin);
 
-        // Verify read access to all associated secrets
         var accessResults = await _secretRepository.AccessToSecretsAsync(secretIds, userId.Value, accessClient);
         if (accessResults.Values.Any(access => !access.Read))
         {
@@ -192,42 +164,10 @@ public class SecretVersionsController : Controller
             throw new NotFoundException();
         }
 
-        // Get the version first to validate it belongs to this secret
         var version = await _secretVersionRepository.GetByIdAsync(request.VersionId);
         if (version == null || version.SecretId != secretId)
         {
             throw new NotFoundException();
-        }
-
-        // Store the current value before restoration
-        var currentValue = secret.Value;
-
-        // For service accounts and organization API, skip user-level access checks
-        if (_currentContext.IdentityClientType == IdentityClientType.ServiceAccount)
-        {
-            // Save current value as a version before restoring
-            if (currentValue != version.Value)
-            {
-                var editorUserId = _userService.GetProperUserId(User);
-                if (editorUserId.HasValue)
-                {
-                    var currentVersionSnapshot = new Core.SecretsManager.Entities.SecretVersion
-                    {
-                        SecretId = secretId,
-                        Value = currentValue!,
-                        VersionDate = DateTime.UtcNow,
-                        EditorServiceAccountId = editorUserId.Value
-                    };
-
-                    await _secretVersionRepository.CreateAsync(currentVersionSnapshot);
-                }
-            }
-
-            // Already verified Secrets Manager access above
-            secret.Value = version.Value;
-            secret.RevisionDate = DateTime.UtcNow;
-            var updatedSec = await _secretRepository.UpdateAsync(secret);
-            return new SecretResponseModel(updatedSec, true, true);
         }
 
         var userId = _userService.GetProperUserId(User);
@@ -245,13 +185,25 @@ public class SecretVersionsController : Controller
             throw new NotFoundException();
         }
 
-        // Save current value as a version before restoring
+        var currentValue = secret.Value;
         if (currentValue != version.Value)
         {
-            var orgUser = await _organizationUserRepository.GetByOrganizationAsync(secret.OrganizationId, userId.Value);
-            if (orgUser == null)
+            Guid? editorServiceAccountId = null;
+            Guid? editorOrganizationUserId = null;
+
+            if (_currentContext.IdentityClientType == IdentityClientType.ServiceAccount)
             {
-                throw new NotFoundException();
+                editorServiceAccountId = userId.Value;
+            }
+            else
+            {
+                var orgUser = await _organizationUserRepository.GetByOrganizationAsync(secret.OrganizationId, userId.Value);
+                if (orgUser == null)
+                {
+                    throw new NotFoundException();
+                }
+
+                editorOrganizationUserId = orgUser.Id;
             }
 
             var currentVersionSnapshot = new Core.SecretsManager.Entities.SecretVersion
@@ -259,13 +211,13 @@ public class SecretVersionsController : Controller
                 SecretId = secretId,
                 Value = currentValue!,
                 VersionDate = DateTime.UtcNow,
-                EditorOrganizationUserId = orgUser.Id
+                EditorServiceAccountId = editorServiceAccountId,
+                EditorOrganizationUserId = editorOrganizationUserId
             };
 
             await _secretVersionRepository.CreateAsync(currentVersionSnapshot);
         }
 
-        // Update the secret with the version's value
         secret.Value = version.Value;
         secret.RevisionDate = DateTime.UtcNow;
 
@@ -305,15 +257,6 @@ public class SecretVersionsController : Controller
             throw new NotFoundException();
         }
 
-        // For service accounts and organization API, skip user-level access checks
-        if (_currentContext.IdentityClientType == IdentityClientType.ServiceAccount ||
-            _currentContext.IdentityClientType == IdentityClientType.Organization)
-        {
-            // Already verified Secrets Manager access and organization ownership above
-            await _secretVersionRepository.DeleteManyByIdAsync(ids);
-            return Ok();
-        }
-
         var userId = _userService.GetProperUserId(User);
         if (!userId.HasValue)
         {
@@ -323,7 +266,6 @@ public class SecretVersionsController : Controller
         var orgAdmin = await _currentContext.OrganizationAdmin(organizationId);
         var accessClient = AccessClientHelper.ToAccessClient(_currentContext.IdentityClientType, orgAdmin);
 
-        // Verify write access to all associated secrets
         var accessResults = await _secretRepository.AccessToSecretsAsync(secretIds, userId.Value, accessClient);
         if (accessResults.Values.Any(access => !access.Write))
         {

--- a/test/Api.Test/SecretsManager/Controllers/SecretVersionsControllerTests.cs
+++ b/test/Api.Test/SecretsManager/Controllers/SecretVersionsControllerTests.cs
@@ -3,6 +3,7 @@ using Bit.Api.SecretsManager.Models.Request;
 using Bit.Core.Auth.Identity;
 using Bit.Core.Context;
 using Bit.Core.Entities;
+using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 using Bit.Core.SecretsManager.Entities;
@@ -260,19 +261,23 @@ public class SecretVersionsControllerTests
         foreach (var version in versions)
         {
             version.SecretId = secret.Id;
-            sutProvider.GetDependency<ISecretVersionRepository>().GetByIdAsync(version.Id).Returns(version);
         }
 
+        sutProvider.GetDependency<ISecretVersionRepository>().GetManyByIdsAsync(ids).Returns(versions);
         sutProvider.GetDependency<ISecretRepository>().GetManyByIds(Arg.Any<IEnumerable<Guid>>())
             .Returns(new List<Secret> { secret });
         sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(secret.OrganizationId).Returns(true);
         sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(userId);
         sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(secret.OrganizationId).Returns(false);
-        sutProvider.GetDependency<ISecretRepository>().AccessToSecretAsync(secret.Id, userId, default)
-            .ReturnsForAnyArgs((true, false));
+        sutProvider.GetDependency<ISecretRepository>()
+            .AccessToSecretsAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<Guid>(), Arg.Any<AccessClientType>())
+            .Returns(new Dictionary<Guid, (bool Read, bool Write)> { { secret.Id, (true, false) } });
 
         await Assert.ThrowsAsync<NotFoundException>(() =>
             sutProvider.Sut.BulkDeleteAsync(ids));
+
+        await sutProvider.GetDependency<ISecretVersionRepository>().DidNotReceiveWithAnyArgs()
+            .DeleteManyByIdAsync(default!);
     }
 
     [Theory]
@@ -295,13 +300,196 @@ public class SecretVersionsControllerTests
         sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(secret.OrganizationId).Returns(true);
         sutProvider.GetDependency<ICurrentContext>().IdentityClientType.Returns(IdentityClientType.ServiceAccount);
         sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(userId);
-        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(secret.OrganizationId).Returns(true);
-        sutProvider.GetDependency<ISecretRepository>().AccessToSecretAsync(secret.Id, userId, default)
-            .ReturnsForAnyArgs((true, true));
+        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(secret.OrganizationId).Returns(false);
+        sutProvider.GetDependency<ISecretRepository>()
+            .AccessToSecretsAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<Guid>(), Arg.Any<AccessClientType>())
+            .Returns(new Dictionary<Guid, (bool Read, bool Write)> { { secret.Id, (true, true) } });
 
         await sutProvider.Sut.BulkDeleteAsync(ids);
 
         await sutProvider.GetDependency<ISecretVersionRepository>().Received(1)
             .DeleteManyByIdAsync(Arg.Is<IEnumerable<Guid>>(x => x.SequenceEqual(ids)));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetVersionsBySecretId_ServiceAccount_NoReadAccess_Throws(
+        SutProvider<SecretVersionsController> sutProvider,
+        Secret secret,
+        Guid serviceAccountId)
+    {
+        sutProvider.GetDependency<ISecretRepository>().GetByIdAsync(secret.Id).Returns(secret);
+        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(secret.OrganizationId).Returns(true);
+        sutProvider.GetDependency<ICurrentContext>().IdentityClientType.Returns(IdentityClientType.ServiceAccount);
+        sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(serviceAccountId);
+        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(secret.OrganizationId).Returns(false);
+        sutProvider.GetDependency<ISecretRepository>().AccessToSecretAsync(secret.Id, serviceAccountId, AccessClientType.ServiceAccount)
+            .Returns((false, false));
+
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            sutProvider.Sut.GetVersionsBySecretIdAsync(secret.Id));
+
+        await sutProvider.GetDependency<ISecretVersionRepository>().DidNotReceiveWithAnyArgs()
+            .GetManyBySecretIdAsync(default);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task RestoreVersion_ServiceAccount_NoWriteAccess_Throws(
+        SutProvider<SecretVersionsController> sutProvider,
+        Secret secret,
+        SecretVersion version,
+        RestoreSecretVersionRequestModel request,
+        Guid serviceAccountId)
+    {
+        version.SecretId = secret.Id;
+        request.VersionId = version.Id;
+
+        sutProvider.GetDependency<ISecretRepository>().GetByIdAsync(secret.Id).Returns(secret);
+        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(secret.OrganizationId).Returns(true);
+        sutProvider.GetDependency<ICurrentContext>().IdentityClientType.Returns(IdentityClientType.ServiceAccount);
+        sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(serviceAccountId);
+        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(secret.OrganizationId).Returns(false);
+        sutProvider.GetDependency<ISecretVersionRepository>().GetByIdAsync(request.VersionId).Returns(version);
+        sutProvider.GetDependency<ISecretRepository>().AccessToSecretAsync(secret.Id, serviceAccountId, AccessClientType.ServiceAccount)
+            .Returns((true, false));
+
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            sutProvider.Sut.RestoreVersionAsync(secret.Id, request));
+
+        await sutProvider.GetDependency<ISecretRepository>().DidNotReceiveWithAnyArgs().UpdateAsync(default!);
+        await sutProvider.GetDependency<ISecretVersionRepository>().DidNotReceiveWithAnyArgs().CreateAsync(default!);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task RestoreVersion_ServiceAccount_Success_RecordsSnapshotAsServiceAccount(
+        SutProvider<SecretVersionsController> sutProvider,
+        Secret secret,
+        SecretVersion version,
+        RestoreSecretVersionRequestModel request,
+        Guid serviceAccountId)
+    {
+        version.SecretId = secret.Id;
+        request.VersionId = version.Id;
+        var originalValue = secret.Value;
+
+        sutProvider.GetDependency<ISecretRepository>().GetByIdAsync(secret.Id).Returns(secret);
+        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(secret.OrganizationId).Returns(true);
+        sutProvider.GetDependency<ICurrentContext>().IdentityClientType.Returns(IdentityClientType.ServiceAccount);
+        sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(serviceAccountId);
+        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(secret.OrganizationId).Returns(false);
+        sutProvider.GetDependency<ISecretVersionRepository>().GetByIdAsync(request.VersionId).Returns(version);
+        sutProvider.GetDependency<ISecretRepository>().AccessToSecretAsync(secret.Id, serviceAccountId, AccessClientType.ServiceAccount)
+            .Returns((true, true));
+        sutProvider.GetDependency<ISecretRepository>().UpdateAsync(Arg.Any<Secret>()).Returns(x => x.Arg<Secret>());
+
+        await sutProvider.Sut.RestoreVersionAsync(secret.Id, request);
+
+        await sutProvider.GetDependency<ISecretRepository>().Received(1)
+            .UpdateAsync(Arg.Is<Secret>(s => s.Value == version.Value));
+        await sutProvider.GetDependency<ISecretVersionRepository>().Received(1)
+            .CreateAsync(Arg.Is<SecretVersion>(v =>
+                v.SecretId == secret.Id &&
+                v.Value == originalValue &&
+                v.EditorServiceAccountId == serviceAccountId &&
+                v.EditorOrganizationUserId == null));
+        await sutProvider.GetDependency<IOrganizationUserRepository>().DidNotReceiveWithAnyArgs()
+            .GetByOrganizationAsync(default, default);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task BulkDelete_ServiceAccount_NoWriteAccess_Throws(
+        SutProvider<SecretVersionsController> sutProvider,
+        List<SecretVersion> versions,
+        Secret secret,
+        Guid serviceAccountId)
+    {
+        var ids = versions.Select(v => v.Id).ToList();
+        foreach (var version in versions)
+        {
+            version.SecretId = secret.Id;
+        }
+
+        sutProvider.GetDependency<ISecretVersionRepository>().GetManyByIdsAsync(ids).Returns(versions);
+        sutProvider.GetDependency<ISecretRepository>().GetManyByIds(Arg.Any<IEnumerable<Guid>>())
+            .Returns(new List<Secret> { secret });
+        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(secret.OrganizationId).Returns(true);
+        sutProvider.GetDependency<ICurrentContext>().IdentityClientType.Returns(IdentityClientType.ServiceAccount);
+        sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(serviceAccountId);
+        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(secret.OrganizationId).Returns(false);
+        sutProvider.GetDependency<ISecretRepository>()
+            .AccessToSecretsAsync(Arg.Any<IEnumerable<Guid>>(), serviceAccountId, AccessClientType.ServiceAccount)
+            .Returns(new Dictionary<Guid, (bool Read, bool Write)> { { secret.Id, (true, false) } });
+
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            sutProvider.Sut.BulkDeleteAsync(ids));
+
+        await sutProvider.GetDependency<ISecretVersionRepository>().DidNotReceiveWithAnyArgs()
+            .DeleteManyByIdAsync(default!);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetById_ServiceAccount_NoReadAccess_Throws(
+        SutProvider<SecretVersionsController> sutProvider,
+        SecretVersion version,
+        Secret secret,
+        Guid serviceAccountId)
+    {
+        version.SecretId = secret.Id;
+
+        sutProvider.GetDependency<ISecretVersionRepository>().GetByIdAsync(version.Id).Returns(version);
+        sutProvider.GetDependency<ISecretRepository>().GetByIdAsync(secret.Id).Returns(secret);
+        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(secret.OrganizationId).Returns(true);
+        sutProvider.GetDependency<ICurrentContext>().IdentityClientType.Returns(IdentityClientType.ServiceAccount);
+        sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(serviceAccountId);
+        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(secret.OrganizationId).Returns(false);
+        sutProvider.GetDependency<ISecretRepository>().AccessToSecretAsync(secret.Id, serviceAccountId, AccessClientType.ServiceAccount)
+            .Returns((false, false));
+
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            sutProvider.Sut.GetByIdAsync(version.Id));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetManyByIds_ServiceAccount_MissingAccessToOneSecret_Throws(
+        SutProvider<SecretVersionsController> sutProvider,
+        List<SecretVersion> versions,
+        Guid serviceAccountId,
+        Guid organizationId)
+    {
+        var accessibleSecretId = Guid.NewGuid();
+        var inaccessibleSecretId = Guid.NewGuid();
+        versions[0].SecretId = accessibleSecretId;
+        for (var i = 1; i < versions.Count; i++)
+        {
+            versions[i].SecretId = inaccessibleSecretId;
+        }
+        var versionIds = versions.Select(v => v.Id).ToList();
+        var secrets = new List<Secret>
+        {
+            new() { Id = accessibleSecretId, OrganizationId = organizationId },
+            new() { Id = inaccessibleSecretId, OrganizationId = organizationId },
+        };
+
+        sutProvider.GetDependency<ISecretVersionRepository>().GetManyByIdsAsync(versionIds).Returns(versions);
+        sutProvider.GetDependency<ISecretRepository>().GetManyByIds(Arg.Any<IEnumerable<Guid>>()).Returns(secrets);
+        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(organizationId).Returns(true);
+        sutProvider.GetDependency<ICurrentContext>().IdentityClientType.Returns(IdentityClientType.ServiceAccount);
+        sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(serviceAccountId);
+        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(organizationId).Returns(false);
+        sutProvider.GetDependency<ISecretRepository>()
+            .AccessToSecretsAsync(Arg.Any<IEnumerable<Guid>>(), serviceAccountId, AccessClientType.ServiceAccount)
+            .Returns(new Dictionary<Guid, (bool Read, bool Write)>
+            {
+                { accessibleSecretId, (true, false) },
+                { inaccessibleSecretId, (false, false) },
+            });
+
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            sutProvider.Sut.GetManyByIdsAsync(versionIds));
     }
 }

--- a/test/Api.Test/SecretsManager/Controllers/SecretVersionsControllerTests.cs
+++ b/test/Api.Test/SecretsManager/Controllers/SecretVersionsControllerTests.cs
@@ -492,4 +492,87 @@ public class SecretVersionsControllerTests
         await Assert.ThrowsAsync<NotFoundException>(() =>
             sutProvider.Sut.GetManyByIdsAsync(versionIds));
     }
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetManyByIds_AccessResultMissingSecret_Throws(
+        SutProvider<SecretVersionsController> sutProvider,
+        List<SecretVersion> versions,
+        Guid serviceAccountId,
+        Guid organizationId)
+    {
+        var accessibleSecretId = Guid.NewGuid();
+        var otherSecretId = Guid.NewGuid();
+        versions[0].SecretId = accessibleSecretId;
+        for (var i = 1; i < versions.Count; i++)
+        {
+            versions[i].SecretId = otherSecretId;
+        }
+        var versionIds = versions.Select(v => v.Id).ToList();
+        var secrets = new List<Secret>
+        {
+            new() { Id = accessibleSecretId, OrganizationId = organizationId },
+            new() { Id = otherSecretId, OrganizationId = organizationId },
+        };
+
+        sutProvider.GetDependency<ISecretVersionRepository>().GetManyByIdsAsync(versionIds).Returns(versions);
+        sutProvider.GetDependency<ISecretRepository>().GetManyByIds(Arg.Any<IEnumerable<Guid>>()).Returns(secrets);
+        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(organizationId).Returns(true);
+        sutProvider.GetDependency<ICurrentContext>().IdentityClientType.Returns(IdentityClientType.ServiceAccount);
+        sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(serviceAccountId);
+        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(organizationId).Returns(false);
+        // Only one of the two derived secrets produces a row, even though it grants read.
+        sutProvider.GetDependency<ISecretRepository>()
+            .AccessToSecretsAsync(Arg.Any<IEnumerable<Guid>>(), serviceAccountId, AccessClientType.ServiceAccount)
+            .Returns(new Dictionary<Guid, (bool Read, bool Write)>
+            {
+                { accessibleSecretId, (true, false) },
+            });
+
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            sutProvider.Sut.GetManyByIdsAsync(versionIds));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task BulkDelete_AccessResultMissingSecret_Throws(
+        SutProvider<SecretVersionsController> sutProvider,
+        List<SecretVersion> versions,
+        Guid serviceAccountId,
+        Guid organizationId)
+    {
+        var accessibleSecretId = Guid.NewGuid();
+        var otherSecretId = Guid.NewGuid();
+        versions[0].SecretId = accessibleSecretId;
+        for (var i = 1; i < versions.Count; i++)
+        {
+            versions[i].SecretId = otherSecretId;
+        }
+        var ids = versions.Select(v => v.Id).ToList();
+        var secrets = new List<Secret>
+        {
+            new() { Id = accessibleSecretId, OrganizationId = organizationId },
+            new() { Id = otherSecretId, OrganizationId = organizationId },
+        };
+
+        sutProvider.GetDependency<ISecretVersionRepository>().GetManyByIdsAsync(ids).Returns(versions);
+        sutProvider.GetDependency<ISecretRepository>().GetManyByIds(Arg.Any<IEnumerable<Guid>>()).Returns(secrets);
+        sutProvider.GetDependency<ICurrentContext>().AccessSecretsManager(organizationId).Returns(true);
+        sutProvider.GetDependency<ICurrentContext>().IdentityClientType.Returns(IdentityClientType.ServiceAccount);
+        sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(serviceAccountId);
+        sutProvider.GetDependency<ICurrentContext>().OrganizationAdmin(organizationId).Returns(false);
+        // Only one of the two derived secrets produces a row, even though it grants write.
+        sutProvider.GetDependency<ISecretRepository>()
+            .AccessToSecretsAsync(Arg.Any<IEnumerable<Guid>>(), serviceAccountId, AccessClientType.ServiceAccount)
+            .Returns(new Dictionary<Guid, (bool Read, bool Write)>
+            {
+                { accessibleSecretId, (true, true) },
+            });
+
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            sutProvider.Sut.BulkDeleteAsync(ids));
+
+        await sutProvider.GetDependency<ISecretVersionRepository>().DidNotReceiveWithAnyArgs()
+            .DeleteManyByIdAsync(default!);
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33940](https://bitwarden.atlassian.net/browse/PM-33940)

## 📔 Objective

All five secret-version endpoints previously short-circuited the per-secret access check whenever the caller was a `ServiceAccount` or `Organization` client, falling back to only the coarse org-level `AccessSecretsManager` gate. That let any service account in the org read, restore, or delete version history for secrets it had no access policy on, including write impact via the restore endpoint.

The fix removes the bypass branches from `GetVersionsBySecretIdAsync`, `GetByIdAsync`, `GetManyByIdsAsync`, `RestoreVersionAsync`, and `BulkDeleteAsync`. Every endpoint now runs `AccessToSecretAsync` / `AccessToSecretsAsync` against the caller's `AccessClientType`, matching the pattern used by `SecretsController.GetAsync`. `RestoreVersionAsync` keeps a `ServiceAccount` vs `User` split only for snapshot attribution (`EditorServiceAccountId` vs `EditorOrganizationUserId`), after the write check has passed.

### Why this approach over the alternative

`SecretAuthorizationHandler.CanUpdateSecretAsync` would also have worked, but `SecretsController.GetAsync` already calls `AccessToSecretAsync` directly. Matching that pattern keeps the controller readable and the diff minimal. Both paths land in the same `BuildSecretAccessQuery`.

### Tests

- Fixed two pre-existing `BulkDelete` tests that mocked `GetByIdAsync` / `AccessToSecretAsync` while the controller calls `GetManyByIdsAsync` / `AccessToSecretsAsync`. They were passing for the wrong reason.
- Added service-account regression tests for all five endpoints, plus a mixed-batch bulk-read case where the caller has access to one of two secrets in the batch.
- All 20 tests in `SecretVersionsControllerTests` pass.

### Not addressed in this PR

`CurrentContext.AccessSecretsManager` returns `true` for any service account in the same org. It's used very broadly across the codebase, and changing it would have a large blast radius. The controller-layer per-secret check is the correct place to enforce, and matches how every other Secrets Manager endpoint already works.

## 📸 Screenshots

N/A, no UI changes.


[PM-33940]: https://bitwarden.atlassian.net/browse/PM-33940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ