### PR TITLE
[PM-39202] fix(nginx): add port_in_redirect off to prevent internal port leak in Docker

### DIFF
--- a/util/Setup/Templates/NginxConfig.hbs
+++ b/util/Setup/Templates/NginxConfig.hbs
@@ -19,6 +19,7 @@ server {
   listen [::]:8443 ssl;
   http2 on;
   server_name {{{Domain}}};
+  port_in_redirect off;
 
   ssl_certificate {{{CertificatePath}}};
   ssl_certificate_key {{{KeyPath}}};


### PR DESCRIPTION
## Summary

- Adds `port_in_redirect off;` to the HTTPS server block in `util/Setup/Templates/NginxConfig.hbs`

## Problem

The standard Bitwarden Docker setup maps host port 443 to container port 8443. Without `port_in_redirect off`, nginx uses `$server_port` (8443) when building internal redirect URLs. This means a request to `/api` (no trailing slash) redirects to `:8443/api/`, leaking the internal container port to clients and breaking the request for end users.

## Fix

Added `port_in_redirect off;` directly after the `server_name` directive in the HTTPS server block. This tells nginx to omit the port from redirect URLs, so redirects use the externally visible port (443) instead of the internal container port (8443).

```nginx
server_name {{{Domain}}};
port_in_redirect off;
```

## Testing

Verified no other templates in `util/Setup/Templates/` required the same change.