### PR TITLE
[PM-32116] Remove pm-32111-provider-ability-extended-cache logic

### DIFF
--- a/bitwarden_license/src/Commercial.Core/AdminConsole/Services/ProviderService.cs
+++ b/bitwarden_license/src/Commercial.Core/AdminConsole/Services/ProviderService.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel.DataAnnotations;
 using Bit.Core;
+using Bit.Core.AdminConsole.AbilitiesCache;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
@@ -59,6 +60,7 @@ public class ProviderService : IProviderService
     private readonly IStripeAdapter _stripeAdapter;
     private readonly IDataProtectorTokenFactory<ProviderDeleteTokenable> _providerDeleteTokenDataFactory;
     private readonly IApplicationCacheService _applicationCacheService;
+    private readonly IProviderAbilityCacheService _providerAbilityCacheService;
     private readonly IProviderBillingService _providerBillingService;
     private readonly IPricingClient _pricingClient;
     private readonly IProviderClientOrganizationSignUpCommand _providerClientOrganizationSignUpCommand;
@@ -71,7 +73,8 @@ public class ProviderService : IProviderService
         IOrganizationRepository organizationRepository, GlobalSettings globalSettings,
         ICurrentContext currentContext, IStripeAdapter stripeAdapter,
         IDataProtectorTokenFactory<ProviderDeleteTokenable> providerDeleteTokenDataFactory,
-        IApplicationCacheService applicationCacheService, IProviderBillingService providerBillingService, IPricingClient pricingClient,
+        IApplicationCacheService applicationCacheService, IProviderAbilityCacheService providerAbilityCacheService,
+        IProviderBillingService providerBillingService, IPricingClient pricingClient,
         IProviderClientOrganizationSignUpCommand providerClientOrganizationSignUpCommand,
         IPolicyRequirementQuery policyRequirementQuery)
     {
@@ -90,6 +93,7 @@ public class ProviderService : IProviderService
         _stripeAdapter = stripeAdapter;
         _providerDeleteTokenDataFactory = providerDeleteTokenDataFactory;
         _applicationCacheService = applicationCacheService;
+        _providerAbilityCacheService = providerAbilityCacheService;
         _providerBillingService = providerBillingService;
         _pricingClient = pricingClient;
         _providerClientOrganizationSignUpCommand = providerClientOrganizationSignUpCommand;
@@ -707,7 +711,7 @@ public class ProviderService : IProviderService
     public async Task DeleteAsync(Provider provider)
     {
         await _providerRepository.DeleteAsync(provider);
-        await _applicationCacheService.DeleteProviderAbilityAsync(provider.Id);
+        await _providerAbilityCacheService.DeleteProviderAbilityAsync(provider.Id);
     }
 
     private async Task SendInviteAsync(ProviderUser providerUser, Provider provider)

--- a/bitwarden_license/test/Commercial.Core.Test/AdminConsole/Services/ProviderServiceTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/AdminConsole/Services/ProviderServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Commercial.Core.AdminConsole.Services;
 using Bit.Commercial.Core.Test.AdminConsole.AutoFixture;
+using Bit.Core.AdminConsole.AbilitiesCache;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
@@ -1245,12 +1246,12 @@ public class ProviderServiceTests
     public async Task Delete_Success(Provider provider, SutProvider<ProviderService> sutProvider)
     {
         var providerRepository = sutProvider.GetDependency<IProviderRepository>();
-        var applicationCacheService = sutProvider.GetDependency<IApplicationCacheService>();
+        var providerAbilityCacheService = sutProvider.GetDependency<IProviderAbilityCacheService>();
 
         await sutProvider.Sut.DeleteAsync(provider);
 
         await providerRepository.Received().DeleteAsync(provider);
-        await applicationCacheService.Received().DeleteProviderAbilityAsync(provider.Id);
+        await providerAbilityCacheService.Received().DeleteProviderAbilityAsync(provider.Id);
     }
 
     [Theory, BitAutoData]

--- a/src/Admin/AdminConsole/Controllers/ProvidersController.cs
+++ b/src/Admin/AdminConsole/Controllers/ProvidersController.cs
@@ -7,6 +7,7 @@ using Bit.Admin.AdminConsole.Models;
 using Bit.Admin.Enums;
 using Bit.Admin.Services;
 using Bit.Admin.Utilities;
+using Bit.Core.AdminConsole.AbilitiesCache;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.AdminConsole.OrganizationFeatures.Organizations;
@@ -25,7 +26,6 @@ using Bit.Core.Billing.Services;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
-using Bit.Core.Services;
 using Bit.Core.Settings;
 using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Authorization;
@@ -48,7 +48,7 @@ public class ProvidersController : Controller
     private readonly IProviderOrganizationRepository _providerOrganizationRepository;
     private readonly IProviderService _providerService;
     private readonly GlobalSettings _globalSettings;
-    private readonly IApplicationCacheService _applicationCacheService;
+    private readonly IProviderAbilityCacheService _providerAbilityCacheService;
     private readonly ICreateProviderCommand _createProviderCommand;
     private readonly IProviderPlanRepository _providerPlanRepository;
     private readonly IProviderBillingService _providerBillingService;
@@ -65,7 +65,7 @@ public class ProvidersController : Controller
         IProviderOrganizationRepository providerOrganizationRepository,
         IProviderService providerService,
         GlobalSettings globalSettings,
-        IApplicationCacheService applicationCacheService,
+        IProviderAbilityCacheService providerAbilityCacheService,
         ICreateProviderCommand createProviderCommand,
         IProviderPlanRepository providerPlanRepository,
         IProviderBillingService providerBillingService,
@@ -83,7 +83,7 @@ public class ProvidersController : Controller
         _providerOrganizationRepository = providerOrganizationRepository;
         _providerService = providerService;
         _globalSettings = globalSettings;
-        _applicationCacheService = applicationCacheService;
+        _providerAbilityCacheService = providerAbilityCacheService;
         _createProviderCommand = createProviderCommand;
         _providerPlanRepository = providerPlanRepository;
         _providerBillingService = providerBillingService;
@@ -325,7 +325,7 @@ public class ProvidersController : Controller
             ? model.Enabled : originalProviderStatus;
 
         await _providerService.UpdateAsync(provider);
-        await _applicationCacheService.UpsertProviderAbilityAsync(provider);
+        await _providerAbilityCacheService.UpsertProviderAbilityAsync(provider);
 
         // Sync billing email changes to Stripe
         if (!string.IsNullOrEmpty(provider.GatewayCustomerId) && originalBillingEmail != provider.BillingEmail)

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -140,7 +140,6 @@ public static class FeatureFlagKeys
     public const string PublicMembersInviteRefactor = "pm-33398-refactor-members-invite-org-users-command";
     public const string GenerateInviteLink = "pm-32497-generate-invite-link";
     public const string OrgAbilityExtendedCache = "pm-32104-org-ability-extended-cache";
-    public const string ProviderAbilityExtendedCache = "pm-32111-provider-ability-extended-cache";
     public const string PolicyDrawers = "pm-34804-policy-drawers";
     public const string PM35153CollectionSdkDecryption = "pm-35153-collection-sdk-decryption";
     public const string PoliciesInAcceptedState = "pm-34145-policies-in-accepted-state";

--- a/src/Core/Dirt/Services/Implementations/EventService.cs
+++ b/src/Core/Dirt/Services/Implementations/EventService.cs
@@ -1,6 +1,7 @@
 ﻿// FIXME: Update this file to be null safe and then delete the line below
 #nullable disable
 
+using Bit.Core.AdminConsole.AbilitiesCache;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Interfaces;
@@ -25,6 +26,7 @@ public class EventService : IEventService
     private readonly IOrganizationUserRepository _organizationUserRepository;
     private readonly IProviderUserRepository _providerUserRepository;
     private readonly IApplicationCacheService _applicationCacheService;
+    private readonly IProviderAbilityCacheService _providerAbilityCacheService;
     private readonly ICurrentContext _currentContext;
     private readonly GlobalSettings _globalSettings;
 
@@ -33,6 +35,7 @@ public class EventService : IEventService
         IOrganizationUserRepository organizationUserRepository,
         IProviderUserRepository providerUserRepository,
         IApplicationCacheService applicationCacheService,
+        IProviderAbilityCacheService providerAbilityCacheService,
         ICurrentContext currentContext,
         GlobalSettings globalSettings)
     {
@@ -40,6 +43,7 @@ public class EventService : IEventService
         _organizationUserRepository = organizationUserRepository;
         _providerUserRepository = providerUserRepository;
         _applicationCacheService = applicationCacheService;
+        _providerAbilityCacheService = providerAbilityCacheService;
         _currentContext = currentContext;
         _globalSettings = globalSettings;
     }
@@ -92,7 +96,7 @@ public class EventService : IEventService
         }
 
         var providers = await _currentContext.ProviderMembershipAsync(_providerUserRepository, userId);
-        var providerAbilities = await _applicationCacheService.GetProviderAbilitiesAsync(providers.Select(provider => provider.Id));
+        var providerAbilities = await _providerAbilityCacheService.GetProviderAbilitiesAsync(providers.Select(provider => provider.Id));
         var providerEvents = providers.Where(o => CanUseProviderEvents(providerAbilities, o.Id))
             .Select(p => new EventMessage(_currentContext)
             {
@@ -383,7 +387,7 @@ public class EventService : IEventService
     public async Task LogProviderUsersEventAsync(IEnumerable<(ProviderUser, EventType, DateTime?)> events)
     {
         var materializedEvents = events.ToList();
-        var providerAbilities = await _applicationCacheService.GetProviderAbilitiesAsync(
+        var providerAbilities = await _providerAbilityCacheService.GetProviderAbilitiesAsync(
             materializedEvents.Select(materializedEvent => materializedEvent.Item1.ProviderId));
         var eventMessages = new List<IEvent>();
         foreach (var (providerUser, type, date) in materializedEvents)
@@ -415,7 +419,7 @@ public class EventService : IEventService
     public async Task LogProviderOrganizationEventsAsync(IEnumerable<(ProviderOrganization, EventType, DateTime?)> events)
     {
         var materializedEvents = events.ToList();
-        var providerAbilities = await _applicationCacheService.GetProviderAbilitiesAsync(
+        var providerAbilities = await _providerAbilityCacheService.GetProviderAbilitiesAsync(
             materializedEvents.Select(materializedEvent => materializedEvent.Item1.ProviderId));
         var eventMessages = new List<IEvent>();
         foreach (var (providerOrganization, type, date) in materializedEvents)

--- a/src/Core/Services/IApplicationCacheService.cs
+++ b/src/Core/Services/IApplicationCacheService.cs
@@ -1,5 +1,4 @@
 ﻿using Bit.Core.AdminConsole.Entities;
-using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Models.Data.Provider;
 using Bit.Core.Models.Data.Organizations;
 
@@ -11,22 +10,9 @@ public interface IApplicationCacheService
     Task<IDictionary<Guid, OrganizationAbility>> GetOrganizationAbilitiesAsync();
 #nullable enable
     Task<OrganizationAbility?> GetOrganizationAbilityAsync(Guid orgId);
-    /// <summary>
-    /// Gets the cached <see cref="ProviderAbility"/> for the specified provider.
-    /// </summary>
-    /// <param name="providerId">The ID of the provider.</param>
-    /// <returns>The <see cref="ProviderAbility"/> if found; otherwise, <c>null</c>.</returns>
-    Task<ProviderAbility?> GetProviderAbilityAsync(Guid providerId);
 #nullable disable
     [Obsolete("We are transitioning to a new cache pattern. Please consult the Admin Console team before using.", false)]
     Task<IDictionary<Guid, ProviderAbility>> GetProviderAbilitiesAsync();
-    /// <summary>
-    /// Gets cached <see cref="ProviderAbility"/> entries for the specified providers.
-    /// Provider IDs not found in the cache are silently excluded from the result.
-    /// </summary>
-    /// <param name="providerIds">The IDs of the providers to look up.</param>
-    /// <returns>A dictionary mapping each found provider ID to its <see cref="ProviderAbility"/>.</returns>
-    Task<IDictionary<Guid, ProviderAbility>> GetProviderAbilitiesAsync(IEnumerable<Guid> providerIds);
     /// <summary>
     /// Gets cached <see cref="OrganizationAbility"/> entries for the specified organizations.
     /// Organization IDs not found in the cache are silently excluded from the result.
@@ -35,7 +21,5 @@ public interface IApplicationCacheService
     /// <returns>A dictionary mapping each found organization ID to its <see cref="OrganizationAbility"/>.</returns>
     Task<IDictionary<Guid, OrganizationAbility>> GetOrganizationAbilitiesAsync(IEnumerable<Guid> orgIds);
     Task UpsertOrganizationAbilityAsync(Organization organization);
-    Task UpsertProviderAbilityAsync(Provider provider);
     Task DeleteOrganizationAbilityAsync(Guid organizationId);
-    Task DeleteProviderAbilityAsync(Guid providerId);
 }

--- a/src/Core/Services/Implementations/FeatureRoutedCacheService.cs
+++ b/src/Core/Services/Implementations/FeatureRoutedCacheService.cs
@@ -1,6 +1,5 @@
 ﻿using Bit.Core.AdminConsole.AbilitiesCache;
 using Bit.Core.AdminConsole.Entities;
-using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Models.Data.Provider;
 using Bit.Core.Models.Data.Organizations;
 
@@ -9,7 +8,6 @@ namespace Bit.Core.Services.Implementations;
 public class FeatureRoutedCacheService(
     IVCurrentInMemoryApplicationCacheService inMemoryApplicationCacheService,
     IOrganizationAbilityCacheService extendedOrgAbilityCacheService,
-    IProviderAbilityCacheService providerAbilityCacheService,
     IFeatureService featureService)
     : IApplicationCacheService
 {
@@ -23,31 +21,6 @@ public class FeatureRoutedCacheService(
 
     public Task<IDictionary<Guid, ProviderAbility>> GetProviderAbilitiesAsync() =>
         inMemoryApplicationCacheService.GetProviderAbilitiesAsync();
-
-    public async Task<ProviderAbility?> GetProviderAbilityAsync(Guid providerId)
-    {
-        if (featureService.IsEnabled(FeatureFlagKeys.ProviderAbilityExtendedCache))
-        {
-            return await providerAbilityCacheService.GetProviderAbilityAsync(providerId);
-        }
-
-        (await GetProviderAbilitiesAsync([providerId])).TryGetValue(providerId, out var providerAbility);
-        return providerAbility;
-    }
-
-    public async Task<IDictionary<Guid, ProviderAbility>> GetProviderAbilitiesAsync(IEnumerable<Guid> providerIds)
-    {
-        if (featureService.IsEnabled(FeatureFlagKeys.ProviderAbilityExtendedCache))
-        {
-            return await providerAbilityCacheService.GetProviderAbilitiesAsync(providerIds);
-        }
-
-        var allProviderAbilities = await inMemoryApplicationCacheService.GetProviderAbilitiesAsync();
-        return providerIds
-            .Distinct()
-            .Where(allProviderAbilities.ContainsKey)
-            .ToDictionary(id => id, id => allProviderAbilities[id]);
-    }
 
     public async Task<IDictionary<Guid, OrganizationAbility>> GetOrganizationAbilitiesAsync(IEnumerable<Guid> orgIds)
     {
@@ -68,30 +41,10 @@ public class FeatureRoutedCacheService(
             ? extendedOrgAbilityCacheService.UpsertOrganizationAbilityAsync(organization)
             : inMemoryApplicationCacheService.UpsertOrganizationAbilityAsync(organization);
 
-    public Task UpsertProviderAbilityAsync(Provider provider)
-    {
-        if (featureService.IsEnabled(FeatureFlagKeys.ProviderAbilityExtendedCache))
-        {
-            return providerAbilityCacheService.UpsertProviderAbilityAsync(provider);
-        }
-
-        return inMemoryApplicationCacheService.UpsertProviderAbilityAsync(provider);
-    }
-
     public Task DeleteOrganizationAbilityAsync(Guid organizationId) =>
         featureService.IsEnabled(FeatureFlagKeys.OrgAbilityExtendedCache)
             ? extendedOrgAbilityCacheService.DeleteOrganizationAbilityAsync(organizationId)
             : inMemoryApplicationCacheService.DeleteOrganizationAbilityAsync(organizationId);
-
-    public Task DeleteProviderAbilityAsync(Guid providerId)
-    {
-        if (featureService.IsEnabled(FeatureFlagKeys.ProviderAbilityExtendedCache))
-        {
-            return providerAbilityCacheService.DeleteProviderAbilityAsync(providerId);
-        }
-
-        return inMemoryApplicationCacheService.DeleteProviderAbilityAsync(providerId);
-    }
 
     public async Task BaseUpsertOrganizationAbilityAsync(Organization organization)
     {

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/ProviderAbilityCacheTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/ProviderAbilityCacheTests.cs
@@ -2,13 +2,11 @@
 using Bit.Api.AdminConsole.Models.Request.Providers;
 using Bit.Api.IntegrationTest.Factories;
 using Bit.Api.IntegrationTest.Helpers;
-using Bit.Core;
+using Bit.Core.AdminConsole.AbilitiesCache;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Repositories;
-using Bit.Core.Services;
-using NSubstitute;
 using Xunit;
 
 namespace Bit.Api.IntegrationTest.AdminConsole.Controllers;
@@ -25,12 +23,6 @@ public class ProviderAbilityCacheTests : IClassFixture<ApiApplicationFactory>, I
     public ProviderAbilityCacheTests(ApiApplicationFactory factory)
     {
         _factory = factory;
-        _factory.SubstituteService<IFeatureService>(featureService =>
-        {
-            featureService
-                .IsEnabled(FeatureFlagKeys.ProviderAbilityExtendedCache)
-                .Returns(true);
-        });
         _client = factory.CreateClient();
         _loginHelper = new LoginHelper(_factory, _client);
     }
@@ -87,7 +79,7 @@ public class ProviderAbilityCacheTests : IClassFixture<ApiApplicationFactory>, I
         // Assert - endpoint succeeded and cache was populated
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        var cacheService = _factory.GetService<IApplicationCacheService>();
+        var cacheService = _factory.GetService<IProviderAbilityCacheService>();
         var ability = await cacheService.GetProviderAbilityAsync(_provider.Id);
         Assert.NotNull(ability);
         Assert.Equal(_provider.Id, ability.Id);
@@ -97,7 +89,7 @@ public class ProviderAbilityCacheTests : IClassFixture<ApiApplicationFactory>, I
     public async Task Delete_RemovesProvider_CacheReturnsNull()
     {
         // Arrange - populate the cache before deletion
-        var cacheService = _factory.GetService<IApplicationCacheService>();
+        var cacheService = _factory.GetService<IProviderAbilityCacheService>();
         await cacheService.UpsertProviderAbilityAsync(_provider);
 
         var abilityBeforeDelete = await cacheService.GetProviderAbilityAsync(_provider.Id);

--- a/test/Core.Test/Dirt/Services/EventServiceTests.cs
+++ b/test/Core.Test/Dirt/Services/EventServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.AdminConsole.Context;
+﻿using Bit.Core.AdminConsole.AbilitiesCache;
+using Bit.Core.AdminConsole.Context;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Models.Data.Provider;
@@ -214,7 +215,7 @@ public class EventServiceTests
         {
             {providerUser.ProviderId, new ProviderAbility() { UseEvents = true, Enabled = true } }
         };
-        sutProvider.GetDependency<IApplicationCacheService>().GetProviderAbilitiesAsync(Arg.Any<IEnumerable<Guid>>()).Returns(providerAbilities);
+        sutProvider.GetDependency<IProviderAbilityCacheService>().GetProviderAbilitiesAsync(Arg.Any<IEnumerable<Guid>>()).Returns(providerAbilities);
         sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
         sutProvider.GetDependency<ICurrentContext>().IpAddress.Returns(ipAddress);
         sutProvider.GetDependency<ICurrentContext>().DeviceType.Returns(deviceType);
@@ -347,7 +348,7 @@ public class EventServiceTests
         {
             { provider.Id, new ProviderAbility() { UseEvents = true, Enabled = true } }
         };
-        sutProvider.GetDependency<IApplicationCacheService>().GetProviderAbilitiesAsync(Arg.Any<IEnumerable<Guid>>()).Returns(providerAbilities);
+        sutProvider.GetDependency<IProviderAbilityCacheService>().GetProviderAbilitiesAsync(Arg.Any<IEnumerable<Guid>>()).Returns(providerAbilities);
         sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
         sutProvider.GetDependency<ICurrentContext>().IpAddress.Returns(ipAddress);
         sutProvider.GetDependency<ICurrentContext>().DeviceType.Returns(deviceType);
@@ -385,7 +386,7 @@ public class EventServiceTests
         sutProvider.GetDependency<IApplicationCacheService>()
             .GetOrganizationAbilitiesAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns(orgAbilities);
-        sutProvider.GetDependency<IApplicationCacheService>()
+        sutProvider.GetDependency<IProviderAbilityCacheService>()
             .GetProviderAbilitiesAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns(new Dictionary<Guid, ProviderAbility>());
         sutProvider.GetDependency<IOrganizationUserRepository>()
@@ -420,7 +421,7 @@ public class EventServiceTests
         sutProvider.GetDependency<IApplicationCacheService>()
             .GetOrganizationAbilitiesAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns(orgAbilities);
-        sutProvider.GetDependency<IApplicationCacheService>()
+        sutProvider.GetDependency<IProviderAbilityCacheService>()
             .GetProviderAbilitiesAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns(new Dictionary<Guid, ProviderAbility>());
         sutProvider.GetDependency<IOrganizationUserRepository>()
@@ -457,7 +458,7 @@ public class EventServiceTests
         {
             { provider.Id, new ProviderAbility() { UseEvents = true, Enabled = true } }
         };
-        sutProvider.GetDependency<IApplicationCacheService>()
+        sutProvider.GetDependency<IProviderAbilityCacheService>()
             .GetProviderAbilitiesAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns(providerAbilities);
         sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
@@ -495,7 +496,7 @@ public class EventServiceTests
             providerUser.ProviderId = provider.Id;
         }
 
-        sutProvider.GetDependency<IApplicationCacheService>()
+        sutProvider.GetDependency<IProviderAbilityCacheService>()
             .GetProviderAbilitiesAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns(new Dictionary<Guid, ProviderAbility>
             {
@@ -516,7 +517,7 @@ public class EventServiceTests
         SutProvider<EventService> sutProvider)
     {
         // Arrange
-        sutProvider.GetDependency<IApplicationCacheService>()
+        sutProvider.GetDependency<IProviderAbilityCacheService>()
             .GetProviderAbilitiesAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns(new Dictionary<Guid, ProviderAbility>());
 
@@ -525,7 +526,7 @@ public class EventServiceTests
 
         // Assert
         var expectedIds = providerUsers.Select(pu => pu.ProviderId).Distinct();
-        await sutProvider.GetDependency<IApplicationCacheService>().Received(1)
+        await sutProvider.GetDependency<IProviderAbilityCacheService>().Received(1)
             .GetProviderAbilitiesAsync(Arg.Is<IEnumerable<Guid>>(ids => ids.OrderBy(x => x).SequenceEqual(expectedIds.OrderBy(x => x))));
     }
 
@@ -540,7 +541,7 @@ public class EventServiceTests
             providerOrganization.ProviderId = provider.Id;
         }
 
-        sutProvider.GetDependency<IApplicationCacheService>()
+        sutProvider.GetDependency<IProviderAbilityCacheService>()
             .GetProviderAbilitiesAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns(new Dictionary<Guid, ProviderAbility>
             {
@@ -562,7 +563,7 @@ public class EventServiceTests
         SutProvider<EventService> sutProvider)
     {
         // Arrange
-        sutProvider.GetDependency<IApplicationCacheService>()
+        sutProvider.GetDependency<IProviderAbilityCacheService>()
             .GetProviderAbilitiesAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns(new Dictionary<Guid, ProviderAbility>());
 
@@ -572,7 +573,7 @@ public class EventServiceTests
 
         // Assert
         var expectedIds = providerOrganizations.Select(po => po.ProviderId).Distinct();
-        await sutProvider.GetDependency<IApplicationCacheService>().Received(1)
+        await sutProvider.GetDependency<IProviderAbilityCacheService>().Received(1)
             .GetProviderAbilitiesAsync(Arg.Is<IEnumerable<Guid>>(ids => ids.OrderBy(x => x).SequenceEqual(expectedIds.OrderBy(x => x))));
     }
 
@@ -590,7 +591,7 @@ public class EventServiceTests
         sutProvider.GetDependency<IApplicationCacheService>()
             .GetOrganizationAbilitiesAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns(new Dictionary<Guid, OrganizationAbility>());
-        sutProvider.GetDependency<IApplicationCacheService>()
+        sutProvider.GetDependency<IProviderAbilityCacheService>()
             .GetProviderAbilitiesAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns(providerAbilities);
         sutProvider.GetDependency<ICurrentContext>()
@@ -618,7 +619,7 @@ public class EventServiceTests
         sutProvider.GetDependency<IApplicationCacheService>()
             .GetOrganizationAbilitiesAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns(new Dictionary<Guid, OrganizationAbility>());
-        sutProvider.GetDependency<IApplicationCacheService>()
+        sutProvider.GetDependency<IProviderAbilityCacheService>()
             .GetProviderAbilitiesAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns(new Dictionary<Guid, ProviderAbility>());
         sutProvider.GetDependency<ICurrentContext>()
@@ -633,7 +634,7 @@ public class EventServiceTests
 
         // Assert
         var expectedIds = providers.Select(provider => provider.Id);
-        await sutProvider.GetDependency<IApplicationCacheService>().Received(1)
+        await sutProvider.GetDependency<IProviderAbilityCacheService>().Received(1)
             .GetProviderAbilitiesAsync(Arg.Is<IEnumerable<Guid>>(ids => ids.OrderBy(x => x).SequenceEqual(expectedIds.OrderBy(x => x))));
     }
 }

--- a/test/Core.Test/Services/Implementations/FeatureRoutedCacheServiceTests.cs
+++ b/test/Core.Test/Services/Implementations/FeatureRoutedCacheServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿using Bit.Core.AdminConsole.AbilitiesCache;
 using Bit.Core.AdminConsole.Entities;
-using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Models.Data.Provider;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Models.Data.Organizations;
@@ -109,237 +108,6 @@ public class FeatureRoutedCacheServiceTests
         Assert.Equal(expectedResult, result);
         await sutProvider.GetDependency<IVCurrentInMemoryApplicationCacheService>()
             .Received(1)
-            .GetProviderAbilitiesAsync();
-    }
-
-    [Theory, BitAutoData]
-    public async Task GetProviderAbilityAsync_WhenFeatureFlagEnabled_UsesExtendedCacheService(
-        SutProvider<FeatureRoutedCacheService> sutProvider,
-        Guid providerId,
-        ProviderAbility expectedAbility)
-    {
-        // Arrange
-        sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.ProviderAbilityExtendedCache)
-            .Returns(true);
-        sutProvider.GetDependency<IProviderAbilityCacheService>()
-            .GetProviderAbilityAsync(providerId)
-            .Returns(expectedAbility);
-
-        // Act
-        var result = await sutProvider.Sut.GetProviderAbilityAsync(providerId);
-
-        // Assert
-        Assert.Equal(expectedAbility, result);
-        await sutProvider.GetDependency<IProviderAbilityCacheService>()
-            .Received(1)
-            .GetProviderAbilityAsync(providerId);
-        await sutProvider.GetDependency<IVCurrentInMemoryApplicationCacheService>()
-            .DidNotReceive()
-            .GetProviderAbilitiesAsync();
-    }
-
-    [Theory, BitAutoData]
-    public async Task GetProviderAbilityAsync_WhenFeatureFlagDisabled_UsesInMemoryService(
-        SutProvider<FeatureRoutedCacheService> sutProvider,
-        ProviderAbility providerAbility)
-    {
-        // Arrange
-        sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.ProviderAbilityExtendedCache)
-            .Returns(false);
-        var allAbilities = new Dictionary<Guid, ProviderAbility> { [providerAbility.Id] = providerAbility };
-        sutProvider.GetDependency<IVCurrentInMemoryApplicationCacheService>()
-            .GetProviderAbilitiesAsync()
-            .Returns(allAbilities);
-
-        // Act
-        var result = await sutProvider.Sut.GetProviderAbilityAsync(providerAbility.Id);
-
-        // Assert
-        Assert.Equal(providerAbility, result);
-        await sutProvider.GetDependency<IProviderAbilityCacheService>()
-            .DidNotReceive()
-            .GetProviderAbilityAsync(Arg.Any<Guid>());
-        await sutProvider.GetDependency<IVCurrentInMemoryApplicationCacheService>()
-            .Received(1)
-            .GetProviderAbilitiesAsync();
-    }
-
-    [Theory, BitAutoData]
-    public async Task UpsertProviderAbilityAsync_WhenFeatureFlagEnabled_UsesExtendedCacheService(
-        SutProvider<FeatureRoutedCacheService> sutProvider,
-        Provider provider)
-    {
-        // Arrange
-        sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.ProviderAbilityExtendedCache)
-            .Returns(true);
-
-        // Act
-        await sutProvider.Sut.UpsertProviderAbilityAsync(provider);
-
-        // Assert
-        await sutProvider.GetDependency<IProviderAbilityCacheService>()
-            .Received(1)
-            .UpsertProviderAbilityAsync(provider);
-        await sutProvider.GetDependency<IVCurrentInMemoryApplicationCacheService>()
-            .DidNotReceive()
-            .UpsertProviderAbilityAsync(Arg.Any<Provider>());
-    }
-
-    [Theory, BitAutoData]
-    public async Task UpsertProviderAbilityAsync_WhenFeatureFlagDisabled_UsesInMemoryService(
-        SutProvider<FeatureRoutedCacheService> sutProvider,
-        Provider provider)
-    {
-        // Arrange
-        sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.ProviderAbilityExtendedCache)
-            .Returns(false);
-
-        // Act
-        await sutProvider.Sut.UpsertProviderAbilityAsync(provider);
-
-        // Assert
-        await sutProvider.GetDependency<IVCurrentInMemoryApplicationCacheService>()
-            .Received(1)
-            .UpsertProviderAbilityAsync(provider);
-        await sutProvider.GetDependency<IProviderAbilityCacheService>()
-            .DidNotReceive()
-            .UpsertProviderAbilityAsync(Arg.Any<Provider>());
-    }
-
-    [Theory, BitAutoData]
-    public async Task DeleteProviderAbilityAsync_WhenFeatureFlagEnabled_UsesExtendedCacheService(
-        SutProvider<FeatureRoutedCacheService> sutProvider,
-        Guid providerId)
-    {
-        // Arrange
-        sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.ProviderAbilityExtendedCache)
-            .Returns(true);
-
-        // Act
-        await sutProvider.Sut.DeleteProviderAbilityAsync(providerId);
-
-        // Assert
-        await sutProvider.GetDependency<IProviderAbilityCacheService>()
-            .Received(1)
-            .DeleteProviderAbilityAsync(providerId);
-        await sutProvider.GetDependency<IVCurrentInMemoryApplicationCacheService>()
-            .DidNotReceive()
-            .DeleteProviderAbilityAsync(Arg.Any<Guid>());
-    }
-
-    [Theory, BitAutoData]
-    public async Task DeleteProviderAbilityAsync_WhenFeatureFlagDisabled_UsesInMemoryService(
-        SutProvider<FeatureRoutedCacheService> sutProvider,
-        Guid providerId)
-    {
-        // Arrange
-        sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.ProviderAbilityExtendedCache)
-            .Returns(false);
-
-        // Act
-        await sutProvider.Sut.DeleteProviderAbilityAsync(providerId);
-
-        // Assert
-        await sutProvider.GetDependency<IVCurrentInMemoryApplicationCacheService>()
-            .Received(1)
-            .DeleteProviderAbilityAsync(providerId);
-        await sutProvider.GetDependency<IProviderAbilityCacheService>()
-            .DidNotReceive()
-            .DeleteProviderAbilityAsync(Arg.Any<Guid>());
-    }
-
-    [Theory, BitAutoData]
-    public async Task GetProviderAbilitiesAsync_ReturnsOnlyMatchingAbilities(
-        SutProvider<FeatureRoutedCacheService> sutProvider,
-        ProviderAbility matchedAbility,
-        ProviderAbility unmatchedAbility)
-    {
-        // Arrange
-        var allAbilities = new Dictionary<Guid, ProviderAbility>
-        {
-            [matchedAbility.Id] = matchedAbility,
-            [unmatchedAbility.Id] = unmatchedAbility
-        };
-        sutProvider.GetDependency<IVCurrentInMemoryApplicationCacheService>()
-            .GetProviderAbilitiesAsync()
-            .Returns(allAbilities);
-
-        // Act
-        var result = await sutProvider.Sut.GetProviderAbilitiesAsync([matchedAbility.Id]);
-
-        // Assert
-        Assert.Single(result);
-        Assert.Equal(matchedAbility, result[matchedAbility.Id]);
-    }
-
-    [Theory, BitAutoData]
-    public async Task GetProviderAbilitiesAsync_WhenNoIdsMatched_ReturnsEmptyDictionary(
-        SutProvider<FeatureRoutedCacheService> sutProvider,
-        Guid missingProviderId)
-    {
-        // Arrange
-        sutProvider.GetDependency<IVCurrentInMemoryApplicationCacheService>()
-            .GetProviderAbilitiesAsync()
-            .Returns(new Dictionary<Guid, ProviderAbility>());
-
-        // Act
-        var result = await sutProvider.Sut.GetProviderAbilitiesAsync([missingProviderId]);
-
-        // Assert
-        Assert.Empty(result);
-    }
-
-    [Theory, BitAutoData]
-    public async Task GetProviderAbilitiesAsync_WhenDuplicateIdsProvided_DoesNotThrowAndReturnsSingleEntry(
-        SutProvider<FeatureRoutedCacheService> sutProvider,
-        ProviderAbility ability)
-    {
-        // Arrange
-        var allAbilities = new Dictionary<Guid, ProviderAbility> { [ability.Id] = ability };
-        sutProvider.GetDependency<IVCurrentInMemoryApplicationCacheService>()
-            .GetProviderAbilitiesAsync()
-            .Returns(allAbilities);
-
-        // Act - passing the same ID twice simulates a provider with duplicate entries
-        var result = await sutProvider.Sut.GetProviderAbilitiesAsync([ability.Id, ability.Id]);
-
-        // Assert
-        Assert.Single(result);
-        Assert.Equal(ability, result[ability.Id]);
-    }
-
-    [Theory, BitAutoData]
-    public async Task GetProviderAbilitiesAsync_WhenFlagOn_ReturnsFromExtendedCacheService(
-        SutProvider<FeatureRoutedCacheService> sutProvider,
-        ProviderAbility ability)
-    {
-        // Arrange
-        var providerIds = new[] { ability.Id };
-        var expectedResult = new Dictionary<Guid, ProviderAbility> { [ability.Id] = ability };
-        sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.ProviderAbilityExtendedCache)
-            .Returns(true);
-        sutProvider.GetDependency<IProviderAbilityCacheService>()
-            .GetProviderAbilitiesAsync(providerIds)
-            .Returns(expectedResult);
-
-        // Act
-        var result = await sutProvider.Sut.GetProviderAbilitiesAsync(providerIds);
-
-        // Assert
-        Assert.Single(result);
-        Assert.Equal(ability, result[ability.Id]);
-        await sutProvider.GetDependency<IProviderAbilityCacheService>()
-            .Received(1)
-            .GetProviderAbilitiesAsync(providerIds);
-        await sutProvider.GetDependency<IVCurrentInMemoryApplicationCacheService>()
-            .DidNotReceiveWithAnyArgs()
             .GetProviderAbilitiesAsync();
     }
 
@@ -542,10 +310,9 @@ public class FeatureRoutedCacheServiceTests
         // Arrange
         var currentCacheService = CreateCurrentCacheMockService();
         var extendedCacheService = Substitute.For<IOrganizationAbilityCacheService>();
-        var providerAbilityCacheService = Substitute.For<IProviderAbilityCacheService>();
         var featureService = Substitute.For<IFeatureService>();
         featureService.IsEnabled(FeatureFlagKeys.OrgAbilityExtendedCache).Returns(false);
-        var sut = new FeatureRoutedCacheService(currentCacheService, extendedCacheService, providerAbilityCacheService, featureService);
+        var sut = new FeatureRoutedCacheService(currentCacheService, extendedCacheService, featureService);
 
         // Act
         await sut.BaseUpsertOrganizationAbilityAsync(organization);
@@ -603,10 +370,9 @@ public class FeatureRoutedCacheServiceTests
         // Arrange
         var currentCacheService = CreateCurrentCacheMockService();
         var extendedCacheService = Substitute.For<IOrganizationAbilityCacheService>();
-        var providerAbilityCacheService = Substitute.For<IProviderAbilityCacheService>();
         var featureService = Substitute.For<IFeatureService>();
         featureService.IsEnabled(FeatureFlagKeys.OrgAbilityExtendedCache).Returns(false);
-        var sut = new FeatureRoutedCacheService(currentCacheService, extendedCacheService, providerAbilityCacheService, featureService);
+        var sut = new FeatureRoutedCacheService(currentCacheService, extendedCacheService, featureService);
 
         // Act
         await sut.BaseDeleteOrganizationAbilityAsync(organizationId);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32115
https://bitwarden.atlassian.net/browse/PM-32116

## 📔 Objective

Remove the feature flag and use the new provider cache in place of IApplicationCacheService.cs.

Automation tests and the build pipeline should be sufficient. No manual testing needed.