### PR TITLE
fix broken auto confirm policyRequirement check for org scoped request

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptMembership/AcceptOrganizationMembershipValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptMembership/AcceptOrganizationMembershipValidator.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
+﻿using Bit.Core.AdminConsole.Enums;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.Enforcement.AutoConfirm;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
 using Bit.Core.AdminConsole.Utilities.v2.Validation;
@@ -11,7 +12,8 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.AcceptMem
 public class AcceptOrganizationMembershipValidator(
     IPolicyRequirementQuery policyRequirementQuery,
     IAutomaticUserConfirmationPolicyEnforcementHandler automaticUserConfirmationPolicyEnforcementHandler,
-    ITwoFactorIsEnabledQuery twoFactorIsEnabledQuery)
+    ITwoFactorIsEnabledQuery twoFactorIsEnabledQuery,
+    IPolicyQuery policyQuery)
     : IAcceptOrganizationMembershipValidator
 {
     public async Task<ValidationResult<AcceptOrganizationMembershipValidationResult>> ValidateAsync(
@@ -54,9 +56,12 @@ public class AcceptOrganizationMembershipValidator(
             }
         }
 
+        var autoConfirmPolicyStatus = await policyQuery.RunAsync(
+            request.OrganizationId, PolicyType.AutomaticUserConfirmation);
+
         return Valid(new AcceptOrganizationMembershipValidationResult
         {
-            AutoConfirmPolicyEnabled = autoConfirmRequirement.IsEnabled(request.OrganizationId)
+            AutoConfirmPolicyEnabled = autoConfirmPolicyStatus.Enabled
         });
     }
 

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptOrgUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptOrgUserCommand.cs
@@ -178,10 +178,7 @@ public class AcceptOrgUserCommand : IAcceptOrgUserCommand
             await _mailService.SendOrganizationAcceptedEmailAsync(organization, user.Email, adminEmails);
         }
 
-        if (membershipValidationResult.AutoConfirmPolicyEnabled)
-        {
-            await _pushAutoConfirmNotificationCommand.PushAsync(user.Id, orgUser.OrganizationId);
-        }
+        await _pushAutoConfirmNotificationCommand.PushAsync(user.Id, orgUser.OrganizationId);
 
         return orgUser;
     }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/Interfaces/IPushAutoConfirmNotificationCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/Interfaces/IPushAutoConfirmNotificationCommand.cs
@@ -2,5 +2,16 @@
 
 public interface IPushAutoConfirmNotificationCommand
 {
+    /// <summary>
+    /// Sends auto-confirm push notifications to all admins and custom users with ManageUsers permission
+    /// for the given organization, prompting them to confirm the newly accepted user.
+    /// </summary>
+    /// <remarks>
+    /// No notifications are sent if any of the following conditions are not met:
+    /// <list type="bullet">
+    /// <item>The organization has the <c>UseAutomaticUserConfirmation</c> ability enabled.</item>
+    /// <item>The organization has the <c>AutomaticUserConfirmation</c> policy enabled.</item>
+    /// </list>
+    /// </remarks>
     Task PushAsync(Guid userId, Guid organizationId);
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/Interfaces/IPushAutoConfirmNotificationCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/Interfaces/IPushAutoConfirmNotificationCommand.cs
@@ -11,6 +11,7 @@ public interface IPushAutoConfirmNotificationCommand
     /// <list type="bullet">
     /// <item>The organization has the <c>UseAutomaticUserConfirmation</c> ability enabled.</item>
     /// <item>The organization has the <c>AutomaticUserConfirmation</c> policy enabled.</item>
+    /// <item>The user being confirmed has the <c>User</c> role (owners, admins, and custom are excluded).</item>
     /// </list>
     /// </remarks>
     Task PushAsync(Guid userId, Guid organizationId);

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/PushAutoConfirmNotificationCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/PushAutoConfirmNotificationCommand.cs
@@ -1,8 +1,11 @@
-﻿using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interfaces;
+﻿using Bit.Core.AdminConsole.Enums;
+using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interfaces;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
 using Bit.Core.Enums;
 using Bit.Core.Models;
 using Bit.Core.Platform.Push;
 using Bit.Core.Repositories;
+using Bit.Core.Services;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers;
 
@@ -10,17 +13,35 @@ public class PushAutoConfirmNotificationCommand : IPushAutoConfirmNotificationCo
 {
     private readonly IOrganizationUserRepository _organizationUserRepository;
     private readonly IPushNotificationService _pushNotificationService;
+    private readonly IApplicationCacheService _applicationCacheService;
+    private readonly IPolicyQuery _policyQuery;
 
     public PushAutoConfirmNotificationCommand(
         IOrganizationUserRepository organizationUserRepository,
-        IPushNotificationService pushNotificationService)
+        IPushNotificationService pushNotificationService,
+        IApplicationCacheService applicationCacheService,
+        IPolicyQuery policyQuery)
     {
         _organizationUserRepository = organizationUserRepository;
         _pushNotificationService = pushNotificationService;
+        _applicationCacheService = applicationCacheService;
+        _policyQuery = policyQuery;
     }
 
     public async Task PushAsync(Guid userId, Guid organizationId)
     {
+        var orgAbility = await _applicationCacheService.GetOrganizationAbilityAsync(organizationId);
+        if (orgAbility is not { UseAutomaticUserConfirmation: true })
+        {
+            return;
+        }
+
+        var policy = await _policyQuery.RunAsync(organizationId, PolicyType.AutomaticUserConfirmation);
+        if (!policy.Enabled)
+        {
+            return;
+        }
+
         var organizationUser = await _organizationUserRepository.GetByOrganizationAsync(organizationId, userId);
         if (organizationUser == null)
         {

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/PushAutoConfirmNotificationCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/PushAutoConfirmNotificationCommand.cs
@@ -48,6 +48,11 @@ public class PushAutoConfirmNotificationCommand : IPushAutoConfirmNotificationCo
             throw new Exception("Organization user not found");
         }
 
+        if (organizationUser.Type != OrganizationUserType.User)
+        {
+            return;
+        }
+
         var admins = await _organizationUserRepository.GetManyByMinimumRoleAsync(
             organizationId,
             OrganizationUserType.Admin);

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptMembership/AcceptOrganizationMembershipValidatorTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/AcceptMembership/AcceptOrganizationMembershipValidatorTests.cs
@@ -14,6 +14,7 @@ using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
 using Xunit;
 using static Bit.Core.AdminConsole.Utilities.v2.Validation.ValidationResultHelpers;
+using PolicyStatus = Bit.Core.AdminConsole.Models.Data.Organizations.Policies.PolicyStatus;
 
 namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.OrganizationUsers.AcceptMembership;
 
@@ -160,17 +161,54 @@ public class AcceptOrganizationMembershipValidatorTests
     {
         SetupHappyPath(organizationId, user, sutProvider);
 
-        sutProvider.GetDependency<IPolicyRequirementQuery>()
-            .GetAsync<AutomaticUserConfirmationPolicyRequirement>(user.Id)
-            .Returns(new AutomaticUserConfirmationPolicyRequirement(
-            [
-                new PolicyDetails { OrganizationId = organizationId }
-            ]));
+        sutProvider.GetDependency<IPolicyQuery>()
+            .RunAsync(organizationId, PolicyType.AutomaticUserConfirmation)
+            .Returns(new PolicyStatus(organizationId, PolicyType.AutomaticUserConfirmation,
+                new Bit.Core.AdminConsole.Entities.Policy { Enabled = true }));
 
         var request = new AcceptOrganizationMembershipValidationRequest
         {
             OrganizationId = organizationId,
             User = user,
+            AllOrganizationMemberships = [],
+        };
+
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        Assert.True(result.IsValid);
+        Assert.True(result.Request.AutoConfirmPolicyEnabled);
+    }
+
+    /// <summary>
+    /// JIT SSO-provisioned org users have Status=Invited, UserId=set, Email=null, which satisfies neither
+    /// the UserId-matched nor the Email-matched branch in the user-keyed policy details query. Using the
+    /// org-keyed IPolicyQuery instead avoids the broken user→OrgUser matching entirely.
+    /// </summary>
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_WhenAutoConfirmEnabledAndUserHasNoMatchingPolicyDetails_SetsAutoConfirmPolicyEnabledTrue(
+        Guid organizationId,
+        SutProvider<AcceptOrganizationMembershipValidator> sutProvider)
+    {
+        // Simulate a JIT SSO user whose org user record has Status=Invited/UserId=set/Email=null,
+        // so the user-keyed requirement returns empty (neither UserId nor Email branch matches).
+        var jitUser = new User { Id = Guid.NewGuid(), Email = null! };
+        SetupHappyPath(organizationId, jitUser, sutProvider);
+
+        // User-keyed requirement returns empty — the broken state for JIT SSO users.
+        sutProvider.GetDependency<IPolicyRequirementQuery>()
+            .GetAsync<AutomaticUserConfirmationPolicyRequirement>(jitUser.Id)
+            .Returns(new AutomaticUserConfirmationPolicyRequirement([]));
+
+        // But the org has auto-confirm enabled.
+        sutProvider.GetDependency<IPolicyQuery>()
+            .RunAsync(organizationId, PolicyType.AutomaticUserConfirmation)
+            .Returns(new PolicyStatus(organizationId, PolicyType.AutomaticUserConfirmation,
+                new Bit.Core.AdminConsole.Entities.Policy { Enabled = true }));
+
+        var request = new AcceptOrganizationMembershipValidationRequest
+        {
+            OrganizationId = organizationId,
+            User = jitUser,
             AllOrganizationMemberships = [],
         };
 
@@ -321,6 +359,10 @@ public class AcceptOrganizationMembershipValidatorTests
                 Arg.Any<AutomaticUserConfirmationPolicyEnforcementRequest>(),
                 Arg.Any<AutomaticUserConfirmationPolicyRequirement>())
             .Returns(callInfo => Valid(callInfo.Arg<AutomaticUserConfirmationPolicyEnforcementRequest>()));
+
+        sutProvider.GetDependency<IPolicyQuery>()
+            .RunAsync(organizationId, PolicyType.AutomaticUserConfirmation)
+            .Returns(new PolicyStatus(organizationId, PolicyType.AutomaticUserConfirmation));
     }
 
     [Theory, BitAutoData]

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/PushAutoConfirmNotificationCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/PushAutoConfirmNotificationCommandTests.cs
@@ -1,10 +1,17 @@
-﻿using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers;
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Enums;
+using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
+using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Models;
+using Bit.Core.Models.Data.Organizations;
 using Bit.Core.Models.Data.Organizations.OrganizationUsers;
 using Bit.Core.Platform.Push;
 using Bit.Core.Repositories;
+using Bit.Core.Services;
+using Bit.Core.Test.AdminConsole.AutoFixture;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
@@ -15,6 +22,23 @@ namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.OrganizationUsers;
 [SutProviderCustomize]
 public class PushAutoConfirmNotificationCommandTests
 {
+    private static void SetupPassingGuards(
+        SutProvider<PushAutoConfirmNotificationCommand> sutProvider,
+        Guid organizationId,
+        OrganizationUser orgUser)
+    {
+        sutProvider.GetDependency<IApplicationCacheService>()
+            .GetOrganizationAbilityAsync(organizationId)
+            .Returns(new OrganizationAbility { UseAutomaticUserConfirmation = true });
+
+        sutProvider.GetDependency<IPolicyQuery>()
+            .RunAsync(organizationId, PolicyType.AutomaticUserConfirmation)
+            .Returns(new PolicyStatus(organizationId, PolicyType.AutomaticUserConfirmation,
+                new Policy { Enabled = true }));
+
+        orgUser.Type = OrganizationUserType.User;
+    }
+
     [Theory]
     [BitAutoData]
     public async Task PushAsync_SendsNotificationToAdminsAndOwners(
@@ -30,6 +54,7 @@ public class PushAutoConfirmNotificationCommandTests
         }
 
         orgUser.Id = Guid.NewGuid();
+        SetupPassingGuards(sutProvider, organizationId, orgUser);
 
         sutProvider.GetDependency<IOrganizationUserRepository>()
             .GetByOrganizationAsync(organizationId, userId)
@@ -72,6 +97,7 @@ public class PushAutoConfirmNotificationCommandTests
         }
 
         orgUser.Id = Guid.NewGuid();
+        SetupPassingGuards(sutProvider, organizationId, orgUser);
 
         sutProvider.GetDependency<IOrganizationUserRepository>()
             .GetByOrganizationAsync(organizationId, userId)
@@ -114,6 +140,7 @@ public class PushAutoConfirmNotificationCommandTests
         }
 
         orgUser.Id = Guid.NewGuid();
+        SetupPassingGuards(sutProvider, organizationId, orgUser);
 
         sutProvider.GetDependency<IOrganizationUserRepository>()
             .GetByOrganizationAsync(organizationId, userId)
@@ -163,6 +190,7 @@ public class PushAutoConfirmNotificationCommandTests
         }
 
         orgUser.Id = Guid.NewGuid();
+        SetupPassingGuards(sutProvider, organizationId, orgUser);
 
         var allCustomUsers = customUsersWithPermission.Concat(customUsersWithoutPermission).ToList();
 
@@ -206,6 +234,7 @@ public class PushAutoConfirmNotificationCommandTests
         admins[2].UserId = Guid.NewGuid();
 
         orgUser.Id = Guid.NewGuid();
+        SetupPassingGuards(sutProvider, organizationId, orgUser);
 
         sutProvider.GetDependency<IOrganizationUserRepository>()
             .GetByOrganizationAsync(organizationId, userId)
@@ -245,6 +274,7 @@ public class PushAutoConfirmNotificationCommandTests
         };
 
         orgUser.Id = Guid.NewGuid();
+        SetupPassingGuards(sutProvider, organizationId, orgUser);
 
         sutProvider.GetDependency<IOrganizationUserRepository>()
             .GetByOrganizationAsync(organizationId, userId)
@@ -271,8 +301,11 @@ public class PushAutoConfirmNotificationCommandTests
     public async Task PushAsync_OrganizationUserNotFound_ThrowsException(
         SutProvider<PushAutoConfirmNotificationCommand> sutProvider,
         Guid userId,
-        Guid organizationId)
+        Guid organizationId,
+        OrganizationUser orgUser)
     {
+        SetupPassingGuards(sutProvider, organizationId, orgUser);
+
         sutProvider.GetDependency<IOrganizationUserRepository>()
             .GetByOrganizationAsync(organizationId, userId)
             .Returns((OrganizationUser)null);
@@ -286,4 +319,76 @@ public class PushAutoConfirmNotificationCommandTests
             .DidNotReceiveWithAnyArgs()
             .PushAsync(Arg.Any<PushNotification<AutoConfirmPushNotification>>());
     }
+
+    // Guard 1: org ability checks
+
+    [Theory]
+    [BitAutoData]
+    public async Task PushAsync_OrgAbilityIsNull_ReturnsEarlyWithoutNotification(
+        SutProvider<PushAutoConfirmNotificationCommand> sutProvider,
+        Guid userId,
+        Guid organizationId)
+    {
+        sutProvider.GetDependency<IApplicationCacheService>()
+            .GetOrganizationAbilityAsync(organizationId)
+            .Returns((OrganizationAbility?)null);
+
+        await sutProvider.Sut.PushAsync(userId, organizationId);
+
+        await sutProvider.GetDependency<IPushNotificationService>()
+            .DidNotReceiveWithAnyArgs()
+            .PushAsync(Arg.Any<PushNotification<AutoConfirmPushNotification>>());
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .GetByOrganizationAsync(Arg.Any<Guid>(), Arg.Any<Guid>());
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task PushAsync_UseAutomaticUserConfirmationDisabled_ReturnsEarlyWithoutNotification(
+        SutProvider<PushAutoConfirmNotificationCommand> sutProvider,
+        Guid userId,
+        Guid organizationId)
+    {
+        sutProvider.GetDependency<IApplicationCacheService>()
+            .GetOrganizationAbilityAsync(organizationId)
+            .Returns(new OrganizationAbility { UseAutomaticUserConfirmation = false });
+
+        await sutProvider.Sut.PushAsync(userId, organizationId);
+
+        await sutProvider.GetDependency<IPushNotificationService>()
+            .DidNotReceiveWithAnyArgs()
+            .PushAsync(Arg.Any<PushNotification<AutoConfirmPushNotification>>());
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .GetByOrganizationAsync(Arg.Any<Guid>(), Arg.Any<Guid>());
+    }
+
+    // Guard 2: policy check
+
+    [Theory, BitAutoData]
+    public async Task PushAsync_PolicyDisabled_ReturnsEarlyWithoutNotification(
+        Guid organizationId,
+        Guid userId,
+        [Policy(PolicyType.AutomaticUserConfirmation, false)] PolicyStatus disabledPolicy,
+        SutProvider<PushAutoConfirmNotificationCommand> sutProvider)
+    {
+        sutProvider.GetDependency<IApplicationCacheService>()
+            .GetOrganizationAbilityAsync(organizationId)
+            .Returns(new OrganizationAbility { UseAutomaticUserConfirmation = true });
+
+        sutProvider.GetDependency<IPolicyQuery>()
+            .RunAsync(organizationId, PolicyType.AutomaticUserConfirmation)
+            .Returns(disabledPolicy);
+
+        await sutProvider.Sut.PushAsync(userId, organizationId);
+
+        await sutProvider.GetDependency<IPushNotificationService>()
+            .DidNotReceiveWithAnyArgs()
+            .PushAsync(Arg.Any<PushNotification<AutoConfirmPushNotification>>());
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .GetByOrganizationAsync(Arg.Any<Guid>(), Arg.Any<Guid>());
+    }
+
 }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/PushAutoConfirmNotificationCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/PushAutoConfirmNotificationCommandTests.cs
@@ -391,4 +391,32 @@ public class PushAutoConfirmNotificationCommandTests
             .GetByOrganizationAsync(Arg.Any<Guid>(), Arg.Any<Guid>());
     }
 
+    // Guard 3: target user role check
+
+    [Theory]
+    [BitAutoData(OrganizationUserType.Admin)]
+    [BitAutoData(OrganizationUserType.Owner)]
+    [BitAutoData(OrganizationUserType.Custom)]
+    public async Task PushAsync_TargetUserIsNotMember_ReturnsEarlyWithoutNotification(
+        OrganizationUserType privilegedType,
+        SutProvider<PushAutoConfirmNotificationCommand> sutProvider,
+        Guid userId,
+        Guid organizationId,
+        OrganizationUser orgUser)
+    {
+        orgUser.Type = privilegedType;
+        SetupPassingGuards(sutProvider, organizationId, orgUser);
+        orgUser.Type = privilegedType; // override after SetupPassingGuards sets User
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByOrganizationAsync(organizationId, userId)
+            .Returns(orgUser);
+
+        await sutProvider.Sut.PushAsync(userId, organizationId);
+
+        await sutProvider.GetDependency<IPushNotificationService>()
+            .DidNotReceiveWithAnyArgs()
+            .PushAsync(Arg.Any<PushNotification<AutoConfirmPushNotification>>());
+    }
+
 }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-39254
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
**Root cause:** `autoConfirmRequirement.IsEnabled()` calls into the user-keyed `IPolicyRequirementQuery`, which looks up policy rows by `OrganizationUser.UserId` (for confirmed users) or `OrganizationUser.Email == User.Email` (for invited users). JIT SSO-provisioned org users have `Status=Invited`, `UserId=set`, `Email=null` satisfying neither branch, so zero rows are returned and `IsEnabled()` returns `false`. The auto-confirm push is then suppressed, leaving JIT users stuck in "Needs Confirmation".

**Fix:** The question being asked, "does this org have auto-confirm turned on?" is org-scoped, not user-scoped. `IPolicyQuery.RunAsync` does an org-keyed lookup (`GetByOrganizationIdTypeAsync`) which is immune to the broken user→OrgUser matching. This pattern is already used in `AutomaticallyConfirmOrganizationUsersValidator` for the same policy.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
