### PR TITLE
[PM-39293] Remove v2 naming from account recovery command

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -12,6 +12,7 @@ using Bit.Api.Models.Response;
 using Bit.Core;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Models.Data;
+using Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
 using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
 using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
 using Bit.Core.AdminConsole.OrganizationFeatures.Organizations;
@@ -45,7 +46,6 @@ using Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interfaces;
 using Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Requests;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using AccountRecoveryV2 = Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery.v2;
 using V1_RevokeOrganizationUserCommand = Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.RevokeUser.v1.IRevokeOrganizationUserCommand;
 using V2_RevokeOrganizationUserCommand = Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.RevokeUser.v2;
 
@@ -85,7 +85,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
     private readonly IRestoreOrganizationUserCommand _restoreOrganizationUserCommand;
     private readonly IInitPendingOrganizationCommand _initPendingOrganizationCommand;
     private readonly V1_RevokeOrganizationUserCommand _revokeOrganizationUserCommand;
-    private readonly AccountRecoveryV2.IAdminRecoverAccountCommand _adminRecoverAccountCommandV2;
+    private readonly IAdminRecoverAccountCommand _adminRecoverAccountCommand;
     private readonly ISelfRevokeOrganizationUserCommand _selfRevokeOrganizationUserCommand;
     private readonly IUpdateUserResetPasswordEnrollmentCommand _updateUserResetPasswordEnrollmentCommand;
     private readonly IAcceptOrganizationInviteLinkCommand _acceptOrganizationInviteLinkCommand;
@@ -116,7 +116,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
         V1_RevokeOrganizationUserCommand revokeOrganizationUserCommand,
         IResendOrganizationInviteCommand resendOrganizationInviteCommand,
         IBulkResendOrganizationInvitesCommand bulkResendOrganizationInvitesCommand,
-        AccountRecoveryV2.IAdminRecoverAccountCommand adminRecoverAccountCommandV2,
+        IAdminRecoverAccountCommand adminRecoverAccountCommand,
         IAutomaticallyConfirmOrganizationUserCommand automaticallyConfirmOrganizationUserCommand,
         IBulkAutomaticallyConfirmOrganizationUsersCommand bulkAutomaticallyConfirmOrganizationUsersCommand,
         V2_RevokeOrganizationUserCommand.IRevokeOrganizationUserCommand revokeOrganizationUserCommandVNext,
@@ -155,7 +155,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
         _restoreOrganizationUserCommand = restoreOrganizationUserCommand;
         _initPendingOrganizationCommand = initPendingOrganizationCommand;
         _revokeOrganizationUserCommand = revokeOrganizationUserCommand;
-        _adminRecoverAccountCommandV2 = adminRecoverAccountCommandV2;
+        _adminRecoverAccountCommand = adminRecoverAccountCommand;
         _selfRevokeOrganizationUserCommand = selfRevokeOrganizationUserCommand;
         _updateUserResetPasswordEnrollmentCommand = updateUserResetPasswordEnrollmentCommand;
         _acceptOrganizationInviteLinkCommand = acceptOrganizationInviteLinkCommand;
@@ -519,7 +519,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
         }
 
         var commandRequest = model.ToCommandRequest(orgId, targetOrganizationUser);
-        return Handle(await _adminRecoverAccountCommandV2.RecoverAccountAsync(commandRequest));
+        return Handle(await _adminRecoverAccountCommand.RecoverAccountAsync(commandRequest));
     }
 #nullable disable
 

--- a/src/Api/AdminConsole/Models/Request/Organizations/OrganizationUserResetPasswordRequestModel.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/OrganizationUserResetPasswordRequestModel.cs
@@ -1,5 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery.v2;
+using Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
 using Bit.Core.Auth.Utilities;
 using Bit.Core.Entities;
 using Bit.Core.KeyManagement.Models.Api.Request;

--- a/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommand.cs
@@ -15,7 +15,7 @@ using Bit.Core.Repositories;
 using Bit.Core.Services;
 using OneOf.Types;
 
-namespace Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery.v2;
+namespace Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
 
 public class AdminRecoverAccountCommand(
     IAdminRecoverAccountValidator validator,

--- a/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountValidator.cs
@@ -5,7 +5,7 @@ using Bit.Core.Enums;
 using Bit.Core.Repositories;
 using static Bit.Core.AdminConsole.Utilities.v2.Validation.ValidationResultHelpers;
 
-namespace Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery.v2;
+namespace Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
 
 public class AdminRecoverAccountValidator(
     IOrganizationRepository organizationRepository,

--- a/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/Errors.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/Errors.cs
@@ -1,6 +1,6 @@
 ﻿using Bit.Core.AdminConsole.Utilities.v2;
 
-namespace Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery.v2;
+namespace Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
 
 public record NoActionRequestedError() : BadRequestError("At least one recovery action must be requested.");
 public record MissingPasswordFieldsError() : BadRequestError("Master password hash and key are required when resetting master password.");

--- a/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/IAdminRecoverAccountCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/IAdminRecoverAccountCommand.cs
@@ -1,6 +1,6 @@
 ﻿using Bit.Core.AdminConsole.Utilities.v2.Results;
 
-namespace Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery.v2;
+namespace Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
 
 /// <summary>
 /// A command used to recover an organization user's account by an organization admin.

--- a/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/IAdminRecoverAccountValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/IAdminRecoverAccountValidator.cs
@@ -1,6 +1,6 @@
 ﻿using Bit.Core.AdminConsole.Utilities.v2.Validation;
 
-namespace Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery.v2;
+namespace Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
 
 public interface IAdminRecoverAccountValidator
 {

--- a/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/RecoverAccountRequest.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/AccountRecovery/RecoverAccountRequest.cs
@@ -1,7 +1,7 @@
 ﻿using Bit.Core.Entities;
 using Bit.Core.KeyManagement.Models.Data;
 
-namespace Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery.v2;
+namespace Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
 
 public record RecoverAccountRequest
 {

--- a/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
+++ b/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Core.AdminConsole.OrganizationAuth;
 using Bit.Core.AdminConsole.OrganizationAuth.Interfaces;
+using Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
 using Bit.Core.AdminConsole.OrganizationFeatures.Collections;
 using Bit.Core.AdminConsole.OrganizationFeatures.Collections.Interfaces;
 using Bit.Core.AdminConsole.OrganizationFeatures.Groups;
@@ -50,7 +51,6 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
-using AccountRecoveryV2 = Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery.v2;
 using V1_RevokeUsersCommand = Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.RevokeUser.v1;
 using V2_RevokeUsersCommand = Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.RevokeUser.v2;
 
@@ -155,8 +155,8 @@ public static class OrganizationServiceCollectionExtensions
         services.AddScoped<IUpdateOrganizationUserGroupsCommand, UpdateOrganizationUserGroupsCommand>();
         services.AddScoped<IConfirmOrganizationUserCommand, ConfirmOrganizationUserCommand>();
         services.AddScoped<ISendOrganizationConfirmationCommand, SendOrganizationConfirmationCommand>();
-        services.AddScoped<AccountRecoveryV2.IAdminRecoverAccountCommand, AccountRecoveryV2.AdminRecoverAccountCommand>();
-        services.AddScoped<AccountRecoveryV2.IAdminRecoverAccountValidator, AccountRecoveryV2.AdminRecoverAccountValidator>();
+        services.AddScoped<IAdminRecoverAccountCommand, AdminRecoverAccountCommand>();
+        services.AddScoped<IAdminRecoverAccountValidator, AdminRecoverAccountValidator>();
         services.AddScoped<IAutomaticallyConfirmOrganizationUserCommand, AutomaticallyConfirmOrganizationUserCommand>();
         services.AddScoped<IAutomaticallyConfirmOrganizationUsersValidator, AutomaticallyConfirmOrganizationUsersValidator>();
         services.AddScoped<IBulkAutomaticallyConfirmOrganizationUsersValidator, BulkAutomaticallyConfirmOrganizationUsersValidator>();

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
@@ -5,7 +5,7 @@ using Bit.Api.AdminConsole.Controllers;
 using Bit.Api.AdminConsole.Models.Request.Organizations;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
-using Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery.v2;
+using Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.AutoConfirmUser;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interfaces;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.InviteUsers;

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountCommandTests.cs
@@ -1,5 +1,5 @@
 ﻿using Bit.Core.AdminConsole.Entities;
-using Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery.v2;
+using Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
 using Bit.Core.AdminConsole.Utilities.v2.Validation;
@@ -18,7 +18,7 @@ using Microsoft.AspNetCore.Identity;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.AccountRecovery.v2;
+namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.AccountRecovery;
 
 [SutProviderCustomize]
 public class AdminRecoverAccountCommandTests

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountValidatorTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/AccountRecovery/AdminRecoverAccountValidatorTests.cs
@@ -1,7 +1,7 @@
 ﻿using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
-using Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery.v2;
+using Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
@@ -13,7 +13,7 @@ using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
 using Xunit;
 
-namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.AccountRecovery.v2;
+namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.AccountRecovery;
 
 [SutProviderCustomize]
 public class AdminRecoverAccountValidatorTests


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-39293

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Drop the v2 suffix from the new account recovery command. The old version was already removed when the feature flag was removed.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
