### PR TITLE
[PM-38769] Fix OrganizationConnectionsController logic

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationConnectionsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationConnectionsController.cs
@@ -1,7 +1,4 @@
-﻿// FIXME: Update this file to be null safe and then delete the line below
-#nullable disable
-
-using Bit.Api.AdminConsole.Models.Request.Organizations;
+﻿using Bit.Api.AdminConsole.Models.Request.Organizations;
 using Bit.Api.AdminConsole.Models.Response.Organizations;
 using Bit.Core.AdminConsole.Models.OrganizationConnectionConfigs;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationConnections.Interfaces;
@@ -57,7 +54,7 @@ public class OrganizationConnectionsController : Controller
     [HttpPost]
     public async Task<OrganizationConnectionResponseModel> CreateConnection([FromBody] OrganizationConnectionRequestModel model)
     {
-        if (!await HasPermissionAsync(model?.OrganizationId, model?.Type))
+        if (!await HasPermissionAsync(model.OrganizationId, model.Type))
         {
             throw new BadRequestException($"You do not have permission to create a connection of type {model.Type}.");
         }
@@ -162,13 +159,6 @@ public class OrganizationConnectionsController : Controller
         await _deleteOrganizationConnectionCommand.DeleteAsync(connection);
     }
 
-    [HttpPost("{organizationConnectionId}/delete")]
-    [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
-    public async Task PostDeleteConnection(Guid organizationConnectionId)
-    {
-        await DeleteConnection(organizationConnectionId);
-    }
-
     private async Task<ICollection<OrganizationConnection>> GetConnectionsAsync(Guid organizationId, OrganizationConnectionType type) =>
         await _organizationConnectionRepository.GetByOrganizationIdTypeAsync(organizationId, type);
 
@@ -209,7 +199,8 @@ public class OrganizationConnectionsController : Controller
             throw new BadRequestException($"Cannot create a {typedModel.Type} connection outside of a self-hosted instance.");
         }
         var license = await _licensingService.ReadOrganizationLicenseAsync(typedModel.OrganizationId);
-        if (!_licensingService.VerifyLicense(license))
+
+        if (license == null || !_licensingService.VerifyLicense(license))
         {
             throw new BadRequestException("Cannot verify license file.");
         }
@@ -219,7 +210,7 @@ public class OrganizationConnectionsController : Controller
     private async Task<OrganizationConnectionResponseModel> CreateOrUpdateOrganizationConnectionAsync<T>(
         Guid? organizationConnectionId,
         OrganizationConnectionRequestModel model,
-        Func<OrganizationConnectionRequestModel<T>, Task> validateAction = null)
+        Func<OrganizationConnectionRequestModel<T>, Task>? validateAction = null)
         where T : IConnectionConfig
     {
         var typedModel = new OrganizationConnectionRequestModel<T>(model);

--- a/src/Api/AdminConsole/Controllers/OrganizationConnectionsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationConnectionsController.cs
@@ -92,9 +92,14 @@ public class OrganizationConnectionsController : Controller
             throw new NotFoundException();
         }
 
-        if (!await HasPermissionAsync(model?.OrganizationId, model?.Type))
+        if (!await HasPermissionAsync(existingOrganizationConnection.OrganizationId, existingOrganizationConnection.Type))
         {
             throw new BadRequestException("You do not have permission to update this connection.");
+        }
+
+        if (model.Type != existingOrganizationConnection.Type)
+        {
+            throw new BadRequestException("The connection type cannot be changed.");
         }
 
         if (await HasConnectionTypeAsync(model, organizationConnectionId, model.Type))
@@ -175,6 +180,15 @@ public class OrganizationConnectionsController : Controller
         return existingConnections.Any(c => c.Type == model.Type && (!connectionId.HasValue || c.Id != connectionId.Value));
     }
 
+    /// <summary>
+    /// Returns whether the current user has permission to manage a connection of the given <paramref name="type"/>
+    /// in the given organization. The required permission varies by connection type (e.g. Scim requires Manage SCIM,
+    /// while CloudBillingSync requires Organization Owner).
+    /// </summary>
+    /// <remarks>
+    /// When authorizing an update or delete against an existing connection, <paramref name="type"/> MUST be sourced
+    /// from the persisted connection — never from the request body.
+    /// </remarks>
     private async Task<bool> HasPermissionAsync(Guid? organizationId, OrganizationConnectionType? type = null)
     {
         if (!organizationId.HasValue)

--- a/src/Api/AdminConsole/Models/Response/Organizations/OrganizationConnectionResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/Organizations/OrganizationConnectionResponseModel.cs
@@ -2,6 +2,7 @@
 #nullable disable
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 
@@ -14,6 +15,9 @@ public class OrganizationConnectionResponseModel
     public Guid OrganizationId { get; set; }
     public bool Enabled { get; set; }
     public JsonDocument Config { get; set; }
+
+    [JsonConstructor]
+    public OrganizationConnectionResponseModel() { }
 
     public OrganizationConnectionResponseModel(OrganizationConnection connection, Type configType)
     {

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationConnectionsControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationConnectionsControllerTests.cs
@@ -1,5 +1,4 @@
-using System.Net;
-using System.Net.Http.Json;
+﻿using System.Net;
 using Bit.Api.AdminConsole.Models.Response.Organizations;
 using Bit.Api.IntegrationTest.Factories;
 using Bit.Api.IntegrationTest.Helpers;

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationConnectionsControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationConnectionsControllerTests.cs
@@ -1,0 +1,177 @@
+using System.Net;
+using System.Net.Http.Json;
+using Bit.Api.AdminConsole.Models.Response.Organizations;
+using Bit.Api.IntegrationTest.Factories;
+using Bit.Api.IntegrationTest.Helpers;
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Models.OrganizationConnectionConfigs;
+using Bit.Core.Billing.Enums;
+using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Repositories;
+using Xunit;
+
+namespace Bit.Api.IntegrationTest.AdminConsole.Controllers;
+
+public class OrganizationConnectionsControllerTests : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
+{
+    private readonly HttpClient _client;
+    private readonly ApiApplicationFactory _factory;
+    private readonly LoginHelper _loginHelper;
+
+    private Organization _organization = null!;
+    private string _ownerEmail = null!;
+
+    public OrganizationConnectionsControllerTests(ApiApplicationFactory apiFactory)
+    {
+        _factory = apiFactory;
+        _client = _factory.CreateClient();
+        _loginHelper = new LoginHelper(_factory, _client);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _ownerEmail = $"org-connections-test-{Guid.NewGuid()}@example.com";
+        await _factory.LoginWithNewAccount(_ownerEmail);
+
+        (_organization, _) = await OrganizationTestHelpers.SignUpAsync(_factory, plan: PlanType.EnterpriseAnnually,
+            ownerEmail: _ownerEmail, passwordManagerSeats: 5, paymentMethod: PaymentMethodType.Card);
+    }
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task CreateConnection_AsOwner_Succeeds()
+    {
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var response = await _client.PostAsJsonAsync(
+            "organizations/connections",
+            BuildScimRequest(_organization.Id, enabled: true));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var responseBody = await response.Content.ReadFromJsonAsync<OrganizationConnectionResponseModel>();
+        Assert.NotNull(responseBody);
+        Assert.Equal(OrganizationConnectionType.Scim, responseBody!.Type);
+        Assert.Equal(_organization.Id, responseBody.OrganizationId);
+
+        var connectionRepository = _factory.GetService<IOrganizationConnectionRepository>();
+        var persisted = await connectionRepository.GetByOrganizationIdTypeAsync(
+            _organization.Id, OrganizationConnectionType.Scim);
+        var single = Assert.Single(persisted);
+        Assert.True(single.GetConfig<ScimConfig>()!.Enabled);
+    }
+
+    [Fact]
+    public async Task CreateConnection_AsRegularUser_Forbidden()
+    {
+        var (regularUserEmail, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.User);
+        await _loginHelper.LoginAsync(regularUserEmail);
+
+        var response = await _client.PostAsJsonAsync(
+            "organizations/connections",
+            BuildScimRequest(_organization.Id, enabled: true));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("You do not have permission to create a connection of type", body);
+    }
+
+    [Fact]
+    public async Task UpdateConnection_AsOwner_Succeeds()
+    {
+        var existing = await SeedScimConnectionAsync(enabled: false);
+
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var response = await _client.PutAsJsonAsync(
+            $"organizations/connections/{existing.Id}",
+            BuildScimRequest(_organization.Id, enabled: true));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var connectionRepository = _factory.GetService<IOrganizationConnectionRepository>();
+        var persisted = await connectionRepository.GetByIdAsync(existing.Id);
+        Assert.NotNull(persisted);
+        Assert.True(persisted!.Enabled);
+        Assert.True(persisted.GetConfig<ScimConfig>()!.Enabled);
+    }
+
+    [Fact]
+    public async Task UpdateConnection_AsRegularUser_Forbidden()
+    {
+        var existing = await SeedScimConnectionAsync();
+
+        var (regularUserEmail, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(
+            _factory, _organization.Id, OrganizationUserType.User);
+        await _loginHelper.LoginAsync(regularUserEmail);
+
+        var response = await _client.PutAsJsonAsync(
+            $"organizations/connections/{existing.Id}",
+            BuildScimRequest(_organization.Id, enabled: false));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("You do not have permission to update this connection.", body);
+    }
+
+    [Fact]
+    public async Task GetConnection_AsOwner_Succeeds()
+    {
+        var existing = await SeedScimConnectionAsync();
+
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var response = await _client.GetAsync(
+            $"organizations/connections/{_organization.Id}/{(int)OrganizationConnectionType.Scim}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var responseBody = await response.Content.ReadFromJsonAsync<OrganizationConnectionResponseModel>();
+        Assert.NotNull(responseBody);
+        Assert.Equal(existing.Id, responseBody!.Id);
+        Assert.Equal(OrganizationConnectionType.Scim, responseBody.Type);
+    }
+
+    [Fact]
+    public async Task DeleteConnection_AsOwner_Succeeds()
+    {
+        var existing = await SeedScimConnectionAsync();
+
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var response = await _client.DeleteAsync($"organizations/connections/{existing.Id}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var connectionRepository = _factory.GetService<IOrganizationConnectionRepository>();
+        var persisted = await connectionRepository.GetByIdAsync(existing.Id);
+        Assert.Null(persisted);
+    }
+
+    private async Task<OrganizationConnection> SeedScimConnectionAsync(bool enabled = true)
+    {
+        var connectionRepository = _factory.GetService<IOrganizationConnectionRepository>();
+        var connection = new OrganizationConnection
+        {
+            OrganizationId = _organization.Id,
+            Type = OrganizationConnectionType.Scim,
+            Enabled = enabled,
+        };
+        connection.SetConfig(new ScimConfig { Enabled = enabled });
+        return await connectionRepository.CreateAsync(connection);
+    }
+
+    private static object BuildScimRequest(Guid organizationId, bool enabled) =>
+        new
+        {
+            type = OrganizationConnectionType.Scim,
+            organizationId,
+            enabled,
+            config = new ScimConfig { Enabled = enabled },
+        };
+}

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationConnectionsControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationConnectionsControllerTests.cs
@@ -10,7 +10,6 @@ using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
-using Bit.Core.Models.Data.Organizations.OrganizationConnections;
 using Bit.Core.Models.OrganizationConnectionConfigs;
 using Bit.Core.Repositories;
 using Bit.Core.Settings;
@@ -453,16 +452,10 @@ public class OrganizationConnectionsControllerTests
 
     [Theory]
     [BitAutoData]
-    public async Task UpdateConnection_IgnoresChangeToType(
-        Guid connectionId, Guid organizationId,
-        BillingSyncConfig config, OrganizationLicense organizationLicense,
+    public async Task UpdateConnection_TypeCannotBeChanged(
+        Guid connectionId, Guid organizationId, BillingSyncConfig config,
         SutProvider<OrganizationConnectionsController> sutProvider)
     {
-        organizationLicense.Id = config.CloudOrganizationId;
-        organizationLicense.Issued = DateTime.UtcNow.AddDays(-1);
-        organizationLicense.Expires = DateTime.UtcNow.AddDays(1);
-        organizationLicense.Version = 1;
-
         var existing = new OrganizationConnection
         {
             Id = connectionId,
@@ -484,25 +477,14 @@ public class OrganizationConnectionsControllerTests
             .Returns(existing);
         sutProvider.GetDependency<ICurrentContext>().OrganizationOwner(organizationId).Returns(true);
         sutProvider.GetDependency<ICurrentContext>().ManageScim(organizationId).Returns(true);
-        sutProvider.GetDependency<IGlobalSettings>().SelfHosted.Returns(true);
-        sutProvider.GetDependency<ILicensingService>()
-            .ReadOrganizationLicenseAsync(Arg.Any<Guid>())
-            .Returns(organizationLicense);
-        sutProvider.GetDependency<ILicensingService>()
-            .VerifyLicense(organizationLicense)
-            .Returns(true);
-        sutProvider.GetDependency<IUpdateOrganizationConnectionCommand>()
-            .UpdateAsync<BillingSyncConfig>(default)
-            .ReturnsForAnyArgs(existing);
 
-        await sutProvider.Sut.UpdateConnection(connectionId, request);
+        var exception = await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.UpdateConnection(connectionId, request));
 
-        // Expect: connection type has not changed
-        await sutProvider.GetDependency<IUpdateOrganizationConnectionCommand>().Received(1)
-            .UpdateAsync(Arg.Is<OrganizationConnectionData<BillingSyncConfig>>(d =>
-                d.Type == OrganizationConnectionType.CloudBillingSync
-                && d.OrganizationId == organizationId
-                && d.Id == connectionId));
+        Assert.Contains("The connection type cannot be changed.", exception.Message);
+        await sutProvider.GetDependency<IUpdateOrganizationConnectionCommand>()
+            .DidNotReceiveWithAnyArgs()
+            .UpdateAsync<BillingSyncConfig>(default);
         await sutProvider.GetDependency<IUpdateOrganizationConnectionCommand>()
             .DidNotReceiveWithAnyArgs()
             .UpdateAsync<ScimConfig>(default);

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationConnectionsControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationConnectionsControllerTests.cs
@@ -10,6 +10,7 @@ using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
+using Bit.Core.Models.Data.Organizations.OrganizationConnections;
 using Bit.Core.Models.OrganizationConnectionConfigs;
 using Bit.Core.Repositories;
 using Bit.Core.Settings;
@@ -406,6 +407,105 @@ public class OrganizationConnectionsControllerTests
         await sutProvider.Sut.DeleteConnection(connection.Id);
 
         await sutProvider.GetDependency<IDeleteOrganizationConnectionCommand>().DeleteAsync(connection);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task UpdateConnection_PermissionCheckUsesPersistedType_NotRequestType(
+        Guid connectionId, Guid organizationId, BillingSyncConfig config,
+        SutProvider<OrganizationConnectionsController> sutProvider)
+    {
+        var existing = new OrganizationConnection
+        {
+            Id = connectionId,
+            Type = OrganizationConnectionType.CloudBillingSync,
+            OrganizationId = organizationId,
+            Config = JsonSerializer.Serialize(config),
+        };
+
+        var request = new OrganizationConnectionRequestModel
+        {
+            Type = OrganizationConnectionType.Scim,
+            OrganizationId = organizationId,
+            Enabled = true,
+            Config = JsonDocumentFromObject(new ScimConfig()),
+        };
+
+        sutProvider.GetDependency<IOrganizationConnectionRepository>()
+            .GetByIdOrganizationIdAsync(connectionId, organizationId)
+            .Returns(existing);
+
+        // The user can update a Scim connection but not a Cloud Billing Sync connection
+        sutProvider.GetDependency<ICurrentContext>().ManageScim(organizationId).Returns(true);
+        sutProvider.GetDependency<ICurrentContext>().OrganizationOwner(organizationId).Returns(false);
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.UpdateConnection(connectionId, request));
+
+        Assert.Contains("You do not have permission to update this connection.", exception.Message);
+        await sutProvider.GetDependency<IUpdateOrganizationConnectionCommand>()
+            .DidNotReceiveWithAnyArgs()
+            .UpdateAsync<BillingSyncConfig>(default);
+        await sutProvider.GetDependency<IUpdateOrganizationConnectionCommand>()
+            .DidNotReceiveWithAnyArgs()
+            .UpdateAsync<ScimConfig>(default);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task UpdateConnection_IgnoresChangeToType(
+        Guid connectionId, Guid organizationId,
+        BillingSyncConfig config, OrganizationLicense organizationLicense,
+        SutProvider<OrganizationConnectionsController> sutProvider)
+    {
+        organizationLicense.Id = config.CloudOrganizationId;
+        organizationLicense.Issued = DateTime.UtcNow.AddDays(-1);
+        organizationLicense.Expires = DateTime.UtcNow.AddDays(1);
+        organizationLicense.Version = 1;
+
+        var existing = new OrganizationConnection
+        {
+            Id = connectionId,
+            Type = OrganizationConnectionType.CloudBillingSync,
+            OrganizationId = organizationId,
+            Config = JsonSerializer.Serialize(config),
+        };
+
+        var request = new OrganizationConnectionRequestModel
+        {
+            Type = OrganizationConnectionType.Scim,
+            OrganizationId = organizationId,
+            Enabled = true,
+            Config = JsonDocumentFromObject(new ScimConfig()),
+        };
+
+        sutProvider.GetDependency<IOrganizationConnectionRepository>()
+            .GetByIdOrganizationIdAsync(connectionId, organizationId)
+            .Returns(existing);
+        sutProvider.GetDependency<ICurrentContext>().OrganizationOwner(organizationId).Returns(true);
+        sutProvider.GetDependency<ICurrentContext>().ManageScim(organizationId).Returns(true);
+        sutProvider.GetDependency<IGlobalSettings>().SelfHosted.Returns(true);
+        sutProvider.GetDependency<ILicensingService>()
+            .ReadOrganizationLicenseAsync(Arg.Any<Guid>())
+            .Returns(organizationLicense);
+        sutProvider.GetDependency<ILicensingService>()
+            .VerifyLicense(organizationLicense)
+            .Returns(true);
+        sutProvider.GetDependency<IUpdateOrganizationConnectionCommand>()
+            .UpdateAsync<BillingSyncConfig>(default)
+            .ReturnsForAnyArgs(existing);
+
+        await sutProvider.Sut.UpdateConnection(connectionId, request);
+
+        // Expect: connection type has not changed
+        await sutProvider.GetDependency<IUpdateOrganizationConnectionCommand>().Received(1)
+            .UpdateAsync(Arg.Is<OrganizationConnectionData<BillingSyncConfig>>(d =>
+                d.Type == OrganizationConnectionType.CloudBillingSync
+                && d.OrganizationId == organizationId
+                && d.Id == connectionId));
+        await sutProvider.GetDependency<IUpdateOrganizationConnectionCommand>()
+            .DidNotReceiveWithAnyArgs()
+            .UpdateAsync<ScimConfig>(default);
     }
 
     private static OrganizationConnectionRequestModel<T> RequestModelFromEntity<T>(OrganizationConnection entity)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-38769
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fixes for `OrganizationConnectionsController` logic - see Jira ticket for more details. I avoided any more comprehensive refactors because this code rarely changes, and aligning this with our current practices would require a rewrite of the controller and related commands. Better to make the surgical fix with an xmldoc signpost for the future.

That said, I did already add a bunch of tests before I decided on this route, so I've included them here.

I've also removed the `#nullable disable` directive and the obsolete PUT delete endpoint, because they were quick wins. This is only consumed by clients, and [it uses the `DELETE` verb](https://github.com/bitwarden/clients/blob/main/libs/common/src/services/api.service.ts#L844-L846).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
