### PR TITLE
[PM-37168] Filter UserPremiumAccessView by confirmed users.

### DIFF
--- a/src/Infrastructure.EntityFramework/Repositories/UserRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/UserRepository.cs
@@ -397,7 +397,8 @@ public class UserRepository : Repository<Core.Entities.User, User, Guid>, IUserR
                 Id = user.Id,
                 PersonalPremium = user.Premium,
                 OrganizationPremium = user.OrganizationUsers
-                    .Any(ou => ou.Organization != null &&
+                    .Any(ou => ou.Status == OrganizationUserStatusType.Confirmed &&
+                               ou.Organization != null &&
                                ou.Organization.Enabled == true &&
                                ou.Organization.UsersGetPremium == true)
             }).ToList();

--- a/src/Sql/dbo/Views/UserPremiumAccessView.sql
+++ b/src/Sql/dbo/Views/UserPremiumAccessView.sql
@@ -13,6 +13,7 @@ FROM
     [dbo].[User] U
 LEFT JOIN 
     [dbo].[OrganizationUser] OU ON OU.[UserId] = U.[Id]
+    AND OU.[Status] = 2 -- Confirmed
 LEFT JOIN 
     [dbo].[Organization] O ON O.[Id] = OU.[OrganizationId]
     AND O.[UsersGetPremium] = 1

--- a/test/Infrastructure.IntegrationTest/Repositories/UserRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/Repositories/UserRepositoryTests.cs
@@ -299,6 +299,34 @@ public class UserRepositoryTests
     }
 
     [Theory, DatabaseData]
+    public async Task GetPremiumAccessAsync_WithRevokedOrganizationUser_ReturnsNoOrganizationPremium(
+        IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository)
+    {
+        // Arrange
+        var user = await userRepository.CreateAsync(new User
+        {
+            Name = "Revoked User",
+            Email = $"revoked+{Guid.NewGuid()}@example.com",
+            ApiKey = "TEST",
+            SecurityStamp = "stamp",
+            Premium = false
+        });
+
+        var organization = await organizationRepository.CreateTestOrganizationAsync();
+        await organizationUserRepository.CreateRevokedTestOrganizationUserAsync(organization, user);
+
+        // Act
+        var result = await userRepository.GetPremiumAccessAsync(user.Id);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.False(result.OrganizationPremium);
+        Assert.False(result.HasPremiumAccess);
+    }
+
+    [Theory, DatabaseData]
     public async Task GetPremiumAccessAsync_WithMultipleOrganizations_OneProvidesPremium_ReturnsOrganizationPremium(
         IUserRepository userRepository,
         IOrganizationRepository organizationRepository,

--- a/util/Migrator/DbScripts/2026-06-18_00_FixUserPremiumAccessViewRevokedStatus.sql
+++ b/util/Migrator/DbScripts/2026-06-18_00_FixUserPremiumAccessViewRevokedStatus.sql
@@ -1,0 +1,27 @@
+-- Restrict organization-sourced premium access to Confirmed members only.
+-- Previously the view joined OrganizationUser without checking Status, so Revoked
+-- (and other non-Confirmed) members continued to receive organization premium access.
+
+CREATE OR ALTER VIEW [dbo].[UserPremiumAccessView]
+AS
+SELECT
+    U.[Id],
+    U.[Premium] AS [PersonalPremium],
+    CAST(
+        MAX(CASE
+            WHEN O.[Id] IS NOT NULL THEN 1
+            ELSE 0
+        END) AS BIT
+    ) AS [OrganizationPremium]
+FROM
+    [dbo].[User] U
+LEFT JOIN
+    [dbo].[OrganizationUser] OU ON OU.[UserId] = U.[Id]
+    AND OU.[Status] = 2 -- Confirmed
+LEFT JOIN
+    [dbo].[Organization] O ON O.[Id] = OU.[OrganizationId]
+    AND O.[UsersGetPremium] = 1
+    AND O.[Enabled] = 1
+GROUP BY
+    U.[Id], U.[Premium];
+GO


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37168

## 📔 Objective

1. Filter `UserPremiumAccessView` to include only confirmed users in both EF and the stored procedure.
2. Add automated test coverage for the new change.
3. There are no breaking changes to the stored procedure, so no additional steps are required for the [EDD process](https://contributing.bitwarden.com/contributing/database-migrations/edd#destructive-changes).

