### PR TITLE
[PM-39562] fix: Reconcile org seats to billed quantity on packaged-plan migration

### DIFF
--- a/src/Billing/Services/Implementations/SubscriptionUpdatedHandler.cs
+++ b/src/Billing/Services/Implementations/SubscriptionUpdatedHandler.cs
@@ -646,6 +646,15 @@ public class SubscriptionUpdatedHandler : ISubscriptionUpdatedHandler
             }
 
             organization.ChangePlan(targetPlan);
+
+            // Packaged sources (e.g. Teams Starter) store a flat bundle cap in Seats; reconcile to the billed per-seat quantity.
+            if (sourcePlan.HasNonSeatBasedPasswordManagerPlan())
+            {
+                var billedSeatQuantity = subscription.Items
+                    .First(item => item.Price?.Id == targetPriceId).Quantity;
+                organization.Seats = (int)Math.Max(1, billedSeatQuantity);
+            }
+
             await _organizationRepository.ReplaceAsync(organization);
 
             var sourceProvidedServiceAccounts = sourcePlan.SecretsManager?.BaseServiceAccount ?? 0;

--- a/test/Billing.Test/Services/SubscriptionUpdatedHandlerTests.cs
+++ b/test/Billing.Test/Services/SubscriptionUpdatedHandlerTests.cs
@@ -4182,6 +4182,13 @@ public class SubscriptionUpdatedHandlerTests
             {
                 Data =
                 [
+                    // SM seat line shares the subscription; the fix must pick the PM seat line by price id, not this one.
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = teamsMonthly.SecretsManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = teamsMonthly.SecretsManager.StripeSeatPlanId },
+                        Quantity = 99
+                    },
                     new SubscriptionItem
                     {
                         Price = new Price { Id = teamsMonthly.PasswordManager.StripeSeatPlanId },

--- a/test/Billing.Test/Services/SubscriptionUpdatedHandlerTests.cs
+++ b/test/Billing.Test/Services/SubscriptionUpdatedHandlerTests.cs
@@ -4147,6 +4147,206 @@ public class SubscriptionUpdatedHandlerTests
         Assert.NotNull(assignment.MigratedDate);
     }
 
+    // PM-39562: packaged source's Seats holds a flat bundle cap; reconcile to the billed per-seat quantity.
+    [Theory]
+    [InlineData(1)]
+    [InlineData(3)]
+    public async Task HandleAsync_BusinessMigration_TeamsStarterToCurrent_ReconcilesSeatsToBilledQuantity(long billedSeats)
+    {
+        // Arrange
+        var organizationId = Guid.NewGuid();
+        var cohortId = Guid.NewGuid();
+        var teamsStarter = new TeamsStarterPlan(); // packaged source, flat bundle cap of 10 seats
+        var teamsMonthly = new TeamsPlan(false);   // per-seat target
+
+        var previousSubscription = new Subscription
+        {
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = teamsStarter.PasswordManager.StripePlanId },
+                        Plan = new Plan { Id = teamsStarter.PasswordManager.StripePlanId }
+                    }
+                ]
+            }
+        };
+
+        var subscription = new Subscription
+        {
+            Id = "sub_reconcile_ts",
+            ScheduleId = "sub_sched_x",
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = teamsMonthly.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = teamsMonthly.PasswordManager.StripeSeatPlanId },
+                        Quantity = billedSeats
+                    }
+                ]
+            },
+            Metadata = new Dictionary<string, string> { { "organizationId", organizationId.ToString() } },
+            LatestInvoice = new Invoice { BillingReason = BillingReasons.SubscriptionCycle }
+        };
+
+        var organization = new Organization
+        {
+            Id = organizationId,
+            PlanType = PlanType.TeamsStarter,
+            Plan = teamsStarter.Name,
+            Seats = 10,
+            SmServiceAccounts = 20
+        };
+
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            CohortId = cohortId
+        };
+
+        var parsedEvent = new Event
+        {
+            Data = new EventData
+            {
+                Object = subscription,
+                PreviousAttributes = JObject.FromObject(previousSubscription)
+            }
+        };
+
+        _stripeEventService.GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(subscription);
+        _organizationRepository.GetByIdAsync(organizationId).Returns(organization);
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsStarter).Returns(teamsStarter);
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsMonthly).Returns(teamsMonthly);
+        _pricingClient.ListPlans().Returns(MockPlans.Plans);
+        _cohortAssignmentRepository.GetByOrganizationIdAsync(organizationId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohortId).Returns(new OrganizationPlanMigrationCohort
+        {
+            Id = cohortId,
+            Name = "TeamsStarter",
+            MigrationPathId = MigrationPathId.TeamsStarterToCurrent,
+            IsActive = true
+        });
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert — Seats reconciled to the billed seat line item quantity and persisted.
+        Assert.Equal((int)billedSeats, organization.Seats);
+        await _organizationRepository.Received(1).ReplaceAsync(Arg.Is<Organization>(o =>
+            o.Id == organizationId &&
+            o.PlanType == PlanType.TeamsMonthly &&
+            o.Seats == (int)billedSeats));
+
+        Assert.NotNull(assignment.MigratedDate);
+    }
+
+    // PM-39562: gate is false for a per-seat source, so Seats stays put even when it differs from the billed quantity.
+    [Fact]
+    public async Task HandleAsync_BusinessMigration_PerSeatSource_LeavesSeatsUnchanged()
+    {
+        // Arrange
+        var organizationId = Guid.NewGuid();
+        var cohortId = Guid.NewGuid();
+        var teams2020Monthly = new Teams2020Plan(false); // per-seat source, gate false
+        var teamsMonthly = new TeamsPlan(false);         // per-seat target
+
+        var previousSubscription = new Subscription
+        {
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = teams2020Monthly.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = teams2020Monthly.PasswordManager.StripeSeatPlanId }
+                    }
+                ]
+            }
+        };
+
+        var subscription = new Subscription
+        {
+            Id = "sub_unchanged_seats",
+            ScheduleId = "sub_sched_x",
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = teamsMonthly.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = teamsMonthly.PasswordManager.StripeSeatPlanId },
+                        Quantity = 7
+                    }
+                ]
+            },
+            Metadata = new Dictionary<string, string> { { "organizationId", organizationId.ToString() } },
+            LatestInvoice = new Invoice { BillingReason = BillingReasons.SubscriptionCycle }
+        };
+
+        var organization = new Organization
+        {
+            Id = organizationId,
+            PlanType = PlanType.TeamsMonthly2020,
+            Plan = teams2020Monthly.Name,
+            Seats = 25,
+            SmServiceAccounts = 80
+        };
+
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            CohortId = cohortId
+        };
+
+        var parsedEvent = new Event
+        {
+            Data = new EventData
+            {
+                Object = subscription,
+                PreviousAttributes = JObject.FromObject(previousSubscription)
+            }
+        };
+
+        _stripeEventService.GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(subscription);
+        _organizationRepository.GetByIdAsync(organizationId).Returns(organization);
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsMonthly2020).Returns(teams2020Monthly);
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsMonthly).Returns(teamsMonthly);
+        _pricingClient.ListPlans().Returns(MockPlans.Plans);
+        _cohortAssignmentRepository.GetByOrganizationIdAsync(organizationId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohortId).Returns(new OrganizationPlanMigrationCohort
+        {
+            Id = cohortId,
+            Name = "Teams2020Monthly",
+            MigrationPathId = MigrationPathId.Teams2020MonthlyToCurrent,
+            IsActive = true
+        });
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert — per-seat source: Seats left untouched despite the differing line item quantity.
+        Assert.Equal(25, organization.Seats);
+        await _organizationRepository.Received(1).ReplaceAsync(Arg.Is<Organization>(o =>
+            o.Id == organizationId &&
+            o.PlanType == PlanType.TeamsMonthly &&
+            o.Seats == 25));
+
+        Assert.NotNull(assignment.MigratedDate);
+    }
+
     // Grace is the per-path entitlement constant (50 -> 20 => 30), independent of the org's own account count.
     [Fact]
     public async Task HandleAsync_BusinessMigration_TeamsMonthly_OrgAboveBaseline_GraceIsEntitlementBased_NoQuantityForced()


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39562](https://bitwarden.atlassian.net/browse/PM-39562)

## 📔 Objective

After a Teams Starter -> Teams (Monthly) migration executed, the Stripe subscription correctly billed the occupied per-seat quantity, but `organization.Seats` stayed at the Teams Starter flat-bundle cap (10). This left the org with seat capacity it wasn't paying for and bypassed normal per-seat enforcement.

This reconciles `organization.Seats` to the billed seat quantity when the migration source is a packaged/flat plan (gated on `HasNonSeatBasedPasswordManagerPlan()`, so per-seat -> per-seat paths are untouched). The value is read from the activated subscription's seat line item, so the Admin Portal seat count and the Stripe billed quantity agree by construction. The write lives in `HandleScheduleTriggeredBusinessMigrationAsync`, inside the existing `MigratedDate`-guarded block, so it is idempotent on Stripe webhook retry. `MaxAutoscaleSeats` is intentionally left untouched (packaged plans never allow seat autoscale, so it is always null for these orgs).

Tests cover occupied counts of 1 and 3, a per-seat source left unchanged, and a multi-item subscription (PM + SM seat lines) confirming the PM seat line is selected by price id.


[PM-39562]: https://bitwarden.atlassian.net/browse/PM-39562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ