### PR TITLE
Seeder: add --owner-email and --org-name CLI override flags

### DIFF
--- a/test/SeederApi.IntegrationTest/Cli/OrganizationArgsTests.cs
+++ b/test/SeederApi.IntegrationTest/Cli/OrganizationArgsTests.cs
@@ -1,0 +1,56 @@
+﻿using Bit.SeederUtility.Commands;
+using Xunit;
+
+namespace Bit.SeederApi.IntegrationTest.Cli;
+
+public class OrganizationArgsTests
+{
+    [Theory]
+    [InlineData("noatsign.example")]
+    [InlineData("just-text")]
+    public void Validate_OwnerEmailWithoutAtSign_Throws(string badEmail)
+    {
+        var args = BaseArgs();
+        args.OwnerEmail = badEmail;
+        var ex = Assert.Throws<ArgumentException>(args.Validate);
+        Assert.Contains("--owner-email", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("ok@example.com")]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Validate_OwnerEmailValidOrEmpty_Passes(string? email)
+    {
+        var args = BaseArgs();
+        args.OwnerEmail = email;
+        args.Validate();
+    }
+
+    [Fact]
+    public void ToOptions_PropagatesOwnerEmail()
+    {
+        var args = BaseArgs();
+        args.OwnerEmail = "specific@bw.example";
+        var options = args.ToOptions();
+        Assert.Equal("specific@bw.example", options.OwnerEmail);
+    }
+
+    [Fact]
+    public void ToOptions_NullOwnerEmail_StaysNull()
+    {
+        var args = BaseArgs();
+        args.OwnerEmail = null;
+        var options = args.ToOptions();
+        Assert.Null(options.OwnerEmail);
+    }
+
+    private static OrganizationArgs BaseArgs() => new()
+    {
+        Name = "Org",
+        Domain = "demo.example",
+        Users = 1,
+        PlanType = "enterprise-annually",
+        KdfIterations = 5_000,
+    };
+}

--- a/test/SeederApi.IntegrationTest/Cli/PresetArgsTests.cs
+++ b/test/SeederApi.IntegrationTest/Cli/PresetArgsTests.cs
@@ -1,0 +1,40 @@
+﻿using Bit.SeederUtility.Commands;
+using Xunit;
+
+namespace Bit.SeederApi.IntegrationTest.Cli;
+
+public class PresetArgsTests
+{
+    [Theory]
+    [InlineData("noatsign.example")]
+    [InlineData("just-text")]
+    public void Validate_OwnerEmailWithoutAtSign_Throws(string badEmail)
+    {
+        var args = new PresetArgs { Name = "any", OwnerEmail = badEmail };
+        var ex = Assert.Throws<ArgumentException>(args.Validate);
+        Assert.Contains("--owner-email", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("ok@example.com")]
+    [InlineData("with+tag@bitwarden.example")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_OwnerEmailValidOrEmpty_Passes(string? email)
+    {
+        var args = new PresetArgs { Name = "any", OwnerEmail = email };
+        args.Validate();
+    }
+
+    [Fact]
+    public void Validate_OrgNameUnvalidated_Passes()
+    {
+        // OrgName has no format constraints — anything (including null/empty) is accepted.
+        var args = new PresetArgs { Name = "any", OrgName = "" };
+        args.Validate();
+
+        args = new PresetArgs { Name = "any", OrgName = "Anything goes 🎉" };
+        args.Validate();
+    }
+}

--- a/test/SeederApi.IntegrationTest/Pipeline/RecipeOrchestratorIntegrationTests.cs
+++ b/test/SeederApi.IntegrationTest/Pipeline/RecipeOrchestratorIntegrationTests.cs
@@ -1,0 +1,130 @@
+﻿using Bit.Core.Entities;
+using Bit.Infrastructure.EntityFramework.Repositories;
+using Bit.Seeder.Options;
+using Bit.Seeder.Pipeline;
+using Bit.Seeder.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using EfUser = Bit.Infrastructure.EntityFramework.Models.User;
+
+namespace Bit.SeederApi.IntegrationTest.Pipeline;
+
+/// <summary>
+/// Verifies that BOTH <see cref="RecipeOrchestrator"/> <c>Execute</c> overloads
+/// (preset path + options path) actually invoke <c>EnsureOwnerEmailUnique</c>
+/// against the real database. Regression protection against a future change that
+/// silently removes the guard call from one overload.
+/// </summary>
+public sealed class RecipeOrchestratorIntegrationTests : IDisposable
+{
+    private const string CollidingEmail = "exists@bw.example";
+
+    private readonly SqliteConnection _connection;
+    private readonly ServiceProvider _provider;
+    private readonly DatabaseContext _db;
+
+    public RecipeOrchestratorIntegrationTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        // DatabaseContext.OnModelCreating resolves IDataProtectionProvider for the
+        // User.Key / User.MasterPassword field converters, so DI must include it.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDataProtection();
+        services.AddDbContext<DatabaseContext>(opts => opts.UseSqlite(_connection));
+
+        _provider = services.BuildServiceProvider();
+        _db = _provider.GetRequiredService<DatabaseContext>();
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        _provider.Dispose();
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public void Execute_Preset_OwnerEmailCollidesWithExistingUser_Throws()
+    {
+        SeedExistingUser(CollidingEmail);
+        var orchestrator = NewOrchestrator(new NoOpManglerService());
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            orchestrator.Execute(
+                presetName: "any-preset-never-read",
+                ownerEmailOverride: CollidingEmail));
+
+        Assert.Contains(CollidingEmail, ex.Message);
+        Assert.Contains("--mangle", ex.Message);
+    }
+
+    [Fact]
+    public void Execute_Options_OwnerEmailCollidesWithExistingUser_Throws()
+    {
+        SeedExistingUser(CollidingEmail);
+        var orchestrator = NewOrchestrator(new NoOpManglerService());
+
+        var options = new OrganizationVaultOptions
+        {
+            Name = "Test Org",
+            Domain = "test.example",
+            Users = 1,
+            OwnerEmail = CollidingEmail,
+        };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => orchestrator.Execute(options));
+
+        Assert.Contains(CollidingEmail, ex.Message);
+    }
+
+    [Fact]
+    public void Execute_Preset_ManglingEnabled_SkipsGuardEvenIfEmailExists()
+    {
+        // With --mangle, the per-run unique tag prevents collisions, so the guard
+        // is skipped. We prove execution proceeded past the guard by using an
+        // unknown preset name: failure comes from SeedReader ("not found"), not the
+        // guard ("already exists"). Both throw InvalidOperationException, so we
+        // discriminate by message content.
+        SeedExistingUser(CollidingEmail);
+        var orchestrator = NewOrchestrator(new ManglerService());
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            orchestrator.Execute(
+                presetName: "non-existent-preset",
+                ownerEmailOverride: CollidingEmail));
+
+        Assert.Contains("not found", ex.Message);
+        Assert.DoesNotContain("already exists", ex.Message);
+    }
+
+    private void SeedExistingUser(string email)
+    {
+        _db.Users.Add(new EfUser
+        {
+            Id = Guid.NewGuid(),
+            Email = email,
+            SecurityStamp = Guid.NewGuid().ToString(),
+            ApiKey = "test-api-key",
+        });
+        _db.SaveChanges();
+    }
+
+    private RecipeOrchestrator NewOrchestrator(IManglerService mangler)
+    {
+        // Mapper + PasswordHasher are not exercised by the pre-flight guard,
+        // which fires before BulkCommitter or any AutoMapper usage. Null-forgive
+        // them; if the guard ever stops being the first thing in Execute, these
+        // tests will fail loudly.
+        var deps = new SeederDependencies(
+            _db,
+            null!,
+            new PasswordHasher<User>(),
+            mangler);
+        return new RecipeOrchestrator(deps);
+    }
+}

--- a/test/SeederApi.IntegrationTest/Pipeline/RecipeOrchestratorTests.cs
+++ b/test/SeederApi.IntegrationTest/Pipeline/RecipeOrchestratorTests.cs
@@ -1,0 +1,84 @@
+﻿using Bit.Seeder.Pipeline;
+using Xunit;
+
+namespace Bit.SeederApi.IntegrationTest.Pipeline;
+
+public class RecipeOrchestratorTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EnsureOwnerEmailUnique_NullOrWhitespaceOverride_DoesNotInvokePredicate(string? override_)
+    {
+        var predicateCalled = false;
+        RecipeOrchestrator.EnsureOwnerEmailUnique(
+            override_,
+            manglingEnabled: false,
+            email =>
+            {
+                predicateCalled = true;
+                return true;
+            });
+
+        Assert.False(predicateCalled);
+    }
+
+    [Fact]
+    public void EnsureOwnerEmailUnique_ManglingEnabled_SkipsCheck()
+    {
+        // When mangling is on, the per-run unique tag prevents collisions, so the
+        // pre-flight check is unnecessary even if the override email exists.
+        var predicateCalled = false;
+
+        RecipeOrchestrator.EnsureOwnerEmailUnique(
+            "would-collide@bw.example",
+            manglingEnabled: true,
+            email =>
+            {
+                predicateCalled = true;
+                return true;
+            });
+
+        Assert.False(predicateCalled);
+    }
+
+    [Fact]
+    public void EnsureOwnerEmailUnique_NoCollision_DoesNotThrow()
+    {
+        RecipeOrchestrator.EnsureOwnerEmailUnique(
+            "fresh@bw.example",
+            manglingEnabled: false,
+            email => false);
+    }
+
+    [Fact]
+    public void EnsureOwnerEmailUnique_Collision_ThrowsInvalidOperationException()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            RecipeOrchestrator.EnsureOwnerEmailUnique(
+                "existing@bw.example",
+                manglingEnabled: false,
+                email => true));
+
+        Assert.Contains("existing@bw.example", ex.Message);
+        Assert.Contains("--mangle", ex.Message);
+    }
+
+    [Fact]
+    public void EnsureOwnerEmailUnique_PassesOverrideEmailToPredicate()
+    {
+        string? capturedEmail = null;
+
+        RecipeOrchestrator.EnsureOwnerEmailUnique(
+            "specific@bw.example",
+            manglingEnabled: false,
+            email =>
+            {
+                capturedEmail = email;
+                return false;
+            });
+
+        Assert.Equal("specific@bw.example", capturedEmail);
+    }
+}

--- a/test/SeederApi.IntegrationTest/Pipeline/SeederSettingsTests.cs
+++ b/test/SeederApi.IntegrationTest/Pipeline/SeederSettingsTests.cs
@@ -1,0 +1,48 @@
+﻿using Bit.Core.Entities;
+using Bit.Seeder.Pipeline;
+using Bit.Seeder.Services;
+using Microsoft.AspNetCore.Identity;
+using Xunit;
+
+namespace Bit.SeederApi.IntegrationTest.Pipeline;
+
+public class SeederSettingsTests
+{
+    [Fact]
+    public void Defaults_OverridesAreNull()
+    {
+        var settings = new SeederSettings();
+        Assert.Null(settings.OrgNameOverride);
+        Assert.Null(settings.OwnerEmailOverride);
+    }
+
+    [Fact]
+    public void ContextExtensions_ReadOverridesFromSettings()
+    {
+        var context = NewContext(new SeederSettings(
+            Password: null,
+            KdfIterations: 5_000,
+            OrgNameOverride: "OrgFromSettings",
+            OwnerEmailOverride: "owner-from-settings@bw.example"));
+
+        Assert.Equal("OrgFromSettings", context.GetOrgNameOverride());
+        Assert.Equal("owner-from-settings@bw.example", context.GetOwnerEmailOverride());
+    }
+
+    [Fact]
+    public void ContextExtensions_NoOverrides_ReturnsNull()
+    {
+        var context = NewContext(new SeederSettings());
+        Assert.Null(context.GetOrgNameOverride());
+        Assert.Null(context.GetOwnerEmailOverride());
+    }
+
+    private static SeederContext NewContext(SeederSettings settings)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IPasswordHasher<User>, PasswordHasher<User>>();
+        services.AddSingleton<IManglerService, NoOpManglerService>();
+        services.AddSingleton(settings);
+        return new SeederContext(services.BuildServiceProvider());
+    }
+}

--- a/test/SeederApi.IntegrationTest/SeederApi.IntegrationTest.csproj
+++ b/test/SeederApi.IntegrationTest/SeederApi.IntegrationTest.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\util\SeederApi\SeederApi.csproj" />
     <ProjectReference Include="..\..\util\Seeder\Seeder.csproj" />
+    <ProjectReference Include="..\..\util\SeederUtility\SeederUtility.csproj" />
     <ProjectReference Include="..\IntegrationTestCommon\IntegrationTestCommon.csproj" />
 
     <Content Include="..\..\util\SeederApi\appsettings.*.json">

--- a/test/SeederApi.IntegrationTest/Steps/CreateOrganizationStepTests.cs
+++ b/test/SeederApi.IntegrationTest/Steps/CreateOrganizationStepTests.cs
@@ -1,0 +1,58 @@
+﻿using Bit.Seeder.Models;
+using Bit.Seeder.Pipeline;
+using Bit.Seeder.Steps;
+using Xunit;
+using static Bit.SeederApi.IntegrationTest.Steps.SeederStepTestHelpers;
+
+namespace Bit.SeederApi.IntegrationTest.Steps;
+
+public class CreateOrganizationStepTests
+{
+    [Fact]
+    public void NoOverride_FromParams_UsesProvidedName()
+    {
+        var context = NewContext(new SeederSettings());
+        var step = CreateOrganizationStep.FromParams(TestOrgName, TestDomain);
+
+        step.Execute(context);
+
+        Assert.NotNull(context.Organization);
+        Assert.Equal(TestOrgName, context.Organization!.Name);
+    }
+
+    [Fact]
+    public void WithOrgNameOverride_FromParams_UsesOverrideName()
+    {
+        var context = NewContext(new SeederSettings(OrgNameOverride: "Override Org"));
+        var step = CreateOrganizationStep.FromParams(TestOrgName, TestDomain);
+
+        step.Execute(context);
+
+        Assert.Equal("Override Org", context.Organization!.Name);
+    }
+
+    [Fact]
+    public void WhitespaceOverride_IgnoredAndFixtureNameWins()
+    {
+        var context = NewContext(new SeederSettings(OrgNameOverride: "   "));
+        var step = CreateOrganizationStep.FromParams(TestOrgName, TestDomain);
+
+        step.Execute(context);
+
+        Assert.Equal(TestOrgName, context.Organization!.Name);
+    }
+
+    [Fact]
+    public void WithOrgNameOverride_FromFixture_UsesOverrideName()
+    {
+        var reader = new StubSeedReader()
+            .Add("organizations.acme", new SeedOrganization { Name = "Acme From Fixture", Domain = TestDomain });
+        var context = NewContext(new SeederSettings(OrgNameOverride: "Renamed Acme"), reader);
+
+        var step = CreateOrganizationStep.FromFixture("acme");
+        step.Execute(context);
+
+        Assert.Equal("Renamed Acme", context.Organization!.Name);
+        Assert.Equal(TestDomain, context.Domain);
+    }
+}

--- a/test/SeederApi.IntegrationTest/Steps/CreateOwnerStepTests.cs
+++ b/test/SeederApi.IntegrationTest/Steps/CreateOwnerStepTests.cs
@@ -1,0 +1,79 @@
+﻿using System.Text.RegularExpressions;
+using Bit.Core.Enums;
+using Bit.Seeder.Pipeline;
+using Bit.Seeder.Services;
+using Bit.Seeder.Steps;
+using Xunit;
+using static Bit.SeederApi.IntegrationTest.Steps.SeederStepTestHelpers;
+
+namespace Bit.SeederApi.IntegrationTest.Steps;
+
+public class CreateOwnerStepTests
+{
+    [Fact]
+    public void NoOverride_OwnerEmailIsOwnerAtDomain()
+    {
+        var context = NewContext(new SeederSettings());
+        PreloadOrganization(context);
+
+        new CreateOwnerStep().Execute(context);
+
+        Assert.NotNull(context.Owner);
+        Assert.Equal($"owner@{TestDomain}", context.Owner!.Email);
+    }
+
+    [Fact]
+    public void WithOwnerEmailOverride_OwnerEmailIsOverride()
+    {
+        var context = NewContext(new SeederSettings(OwnerEmailOverride: "jared@bw.example"));
+        PreloadOrganization(context);
+
+        new CreateOwnerStep().Execute(context);
+
+        Assert.Equal("jared@bw.example", context.Owner!.Email);
+    }
+
+    [Fact]
+    public void WithOwnerEmailOverride_AndManglingEnabled_OverrideIsMangledNotLiteral()
+    {
+        var mangler = new ManglerService();
+        var context = NewContextWithMangler(
+            new SeederSettings(OwnerEmailOverride: "jared@bw.example"),
+            mangler);
+        PreloadOrganization(context);
+
+        new CreateOwnerStep().Execute(context);
+
+        // Mangler prepends `{8hexChars}+` to the local part; original literal is gone.
+        Assert.NotEqual("jared@bw.example", context.Owner!.Email);
+        Assert.Matches(new Regex(@"^[a-f0-9]{8}\+jared@bw\.example$"), context.Owner.Email);
+    }
+
+    [Fact]
+    public void NoOverride_AndManglingEnabled_DefaultOwnerEmailIsMangled()
+    {
+        // Sanity baseline: without an override, the default owner@<domain> still gets mangled
+        // when mangling is enabled. Asserts our mangle interaction logic isn't override-specific.
+        var mangler = new ManglerService();
+        var context = NewContextWithMangler(new SeederSettings(), mangler);
+        PreloadOrganization(context);
+
+        new CreateOwnerStep().Execute(context);
+
+        Assert.Matches(new Regex($@"^[a-f0-9]{{8}}\+owner@{Regex.Escape(TestDomain)}$"), context.Owner!.Email);
+    }
+
+    [Fact]
+    public void LinksOwnerOrgUserToOrganizationAsConfirmedOwner()
+    {
+        var context = NewContext(new SeederSettings(OwnerEmailOverride: "jared@bw.example"));
+        PreloadOrganization(context);
+
+        new CreateOwnerStep().Execute(context);
+
+        Assert.NotNull(context.OwnerOrgUser);
+        Assert.Equal(context.Organization!.Id, context.OwnerOrgUser!.OrganizationId);
+        Assert.Equal(OrganizationUserType.Owner, context.OwnerOrgUser.Type);
+        Assert.Equal(OrganizationUserStatusType.Confirmed, context.OwnerOrgUser.Status);
+    }
+}

--- a/test/SeederApi.IntegrationTest/Steps/CreateRosterStepTests.cs
+++ b/test/SeederApi.IntegrationTest/Steps/CreateRosterStepTests.cs
@@ -1,0 +1,135 @@
+﻿using System.Text.RegularExpressions;
+using Bit.Seeder.Models;
+using Bit.Seeder.Pipeline;
+using Bit.Seeder.Services;
+using Bit.Seeder.Steps;
+using Xunit;
+using static Bit.SeederApi.IntegrationTest.Steps.SeederStepTestHelpers;
+
+namespace Bit.SeederApi.IntegrationTest.Steps;
+
+public class CreateRosterStepTests
+{
+    [Fact]
+    public void NoOverride_OwnerRoleUserGetsPrefixAtDomain()
+    {
+        var reader = new StubSeedReader().Add("rosters.test", TwoUserRoster());
+        var context = NewContext(new SeederSettings(), reader);
+        PreloadOrganization(context);
+
+        new CreateRosterStep("test").Execute(context);
+
+        Assert.NotNull(context.Owner);
+        Assert.Equal($"the.owner@{TestDomain}", context.Owner!.Email);
+    }
+
+    [Fact]
+    public void WithOwnerEmailOverride_FirstOwnerRoleUserGetsOverride()
+    {
+        var reader = new StubSeedReader().Add("rosters.test", TwoUserRoster());
+        var context = NewContext(new SeederSettings(OwnerEmailOverride: "owner-override@bw.example"), reader);
+        PreloadOrganization(context);
+
+        new CreateRosterStep("test").Execute(context);
+
+        Assert.Equal("owner-override@bw.example", context.Owner!.Email);
+    }
+
+    [Fact]
+    public void WithOwnerEmailOverride_NonOwnerUsersKeepPrefixAtDomain()
+    {
+        var reader = new StubSeedReader().Add("rosters.test", TwoUserRoster());
+        var context = NewContext(new SeederSettings(OwnerEmailOverride: "owner-override@bw.example"), reader);
+        PreloadOrganization(context);
+
+        new CreateRosterStep("test").Execute(context);
+
+        var nonOwner = context.Users.Single(u => u.Email != "owner-override@bw.example");
+        Assert.Equal($"member.one@{TestDomain}", nonOwner.Email);
+    }
+
+    [Fact]
+    public void WithOwnerEmailOverride_GroupMembershipResolvedByPrefix()
+    {
+        // Group "Everyone" references both users by FirstName.LastName prefix, NOT by email.
+        // Override changes the stored email but not the lookup key, so membership must remain intact.
+        var reader = new StubSeedReader().Add("rosters.test", RosterWithGroup());
+        var context = NewContext(new SeederSettings(OwnerEmailOverride: "owner-override@bw.example"), reader);
+        PreloadOrganization(context);
+
+        new CreateRosterStep("test").Execute(context);
+
+        Assert.Single(context.Groups);
+        Assert.Equal(2, context.GroupUsers.Count);
+        var orgUserIds = context.OrganizationUsers.Select(ou => ou.Id).ToHashSet();
+        Assert.All(context.GroupUsers, gu => Assert.Contains(gu.OrganizationUserId, orgUserIds));
+    }
+
+    [Fact]
+    public void WithOwnerEmailOverride_AndManglingEnabled_OverrideIsMangled()
+    {
+        var mangler = new ManglerService();
+        var reader = new StubSeedReader().Add("rosters.test", TwoUserRoster());
+        var context = NewContextWithMangler(
+            new SeederSettings(OwnerEmailOverride: "jared@bw.example"),
+            mangler,
+            reader);
+        PreloadOrganization(context);
+
+        new CreateRosterStep("test").Execute(context);
+
+        Assert.NotEqual("jared@bw.example", context.Owner!.Email);
+        Assert.Matches(new Regex(@"^[a-f0-9]{8}\+jared@bw\.example$"), context.Owner.Email);
+
+        // Non-owner roster users still get the mangled {prefix}@{domain} form, not the override.
+        var nonOwner = context.Users.Single(u => u.Id != context.Owner.Id);
+        Assert.Matches(new Regex($@"^[a-f0-9]{{8}}\+member\.one@{Regex.Escape(TestDomain)}$"), nonOwner.Email);
+    }
+
+    [Fact]
+    public void WithOwnerEmailOverride_OnlyFirstOwnerRoleUserGetsOverride()
+    {
+        // If a roster declares two owner-role users, only the first one receives the override.
+        // Second owner falls back to firstname.lastname@domain.
+        var roster = new SeedRoster
+        {
+            Users =
+            [
+                new SeedRosterUser { FirstName = "First", LastName = "Owner", Role = "owner" },
+                new SeedRosterUser { FirstName = "Second", LastName = "Owner", Role = "owner" }
+            ]
+        };
+        var reader = new StubSeedReader().Add("rosters.test", roster);
+        var context = NewContext(new SeederSettings(OwnerEmailOverride: "override@bw.example"), reader);
+        PreloadOrganization(context);
+
+        new CreateRosterStep("test").Execute(context);
+
+        var emails = context.Users.Select(u => u.Email).OrderBy(e => e).ToList();
+        Assert.Contains("override@bw.example", emails);
+        Assert.Contains($"second.owner@{TestDomain}", emails);
+        Assert.Equal(2, emails.Count);
+    }
+
+    private static SeedRoster TwoUserRoster() => new()
+    {
+        Users =
+        [
+            new SeedRosterUser { FirstName = "The", LastName = "Owner", Role = "owner" },
+            new SeedRosterUser { FirstName = "Member", LastName = "One", Role = "user" }
+        ]
+    };
+
+    private static SeedRoster RosterWithGroup() => new()
+    {
+        Users =
+        [
+            new SeedRosterUser { FirstName = "The", LastName = "Owner", Role = "owner" },
+            new SeedRosterUser { FirstName = "Member", LastName = "One", Role = "user" }
+        ],
+        Groups =
+        [
+            new SeedRosterGroup { Name = "Everyone", Members = ["the.owner", "member.one"] }
+        ]
+    };
+}

--- a/test/SeederApi.IntegrationTest/Steps/SeederStepTestHelpers.cs
+++ b/test/SeederApi.IntegrationTest/Steps/SeederStepTestHelpers.cs
@@ -1,0 +1,64 @@
+﻿using Bit.Core.Billing.Enums;
+using Bit.Core.Entities;
+using Bit.RustSDK;
+using Bit.Seeder.Factories;
+using Bit.Seeder.Pipeline;
+using Bit.Seeder.Services;
+using Microsoft.AspNetCore.Identity;
+
+namespace Bit.SeederApi.IntegrationTest.Steps;
+
+/// <summary>
+/// Shared harness for step-level tests under <c>Steps/</c>. Provides a minimal in-memory
+/// <see cref="SeederContext"/> wired with the services every step needs, plus a stub
+/// <see cref="ISeedReader"/> for tests that load fixtures by name.
+/// </summary>
+internal static class SeederStepTestHelpers
+{
+    internal const string TestDomain = "test.example";
+    internal const string TestOrgName = "Test Org";
+
+    internal static SeederContext NewContext(SeederSettings settings, ISeedReader? reader = null)
+        => NewContextWithMangler(settings, new NoOpManglerService(), reader);
+
+    internal static SeederContext NewContextWithMangler(
+        SeederSettings settings, IManglerService mangler, ISeedReader? reader = null)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IPasswordHasher<User>, PasswordHasher<User>>();
+        services.AddSingleton(mangler);
+        services.AddSingleton(settings);
+        if (reader is not null)
+        {
+            services.AddSingleton(reader);
+        }
+        return new SeederContext(services.BuildServiceProvider());
+    }
+
+    internal static void PreloadOrganization(SeederContext context, string name = TestOrgName, string domain = TestDomain)
+    {
+        var orgKeys = RustSdkService.GenerateOrganizationKeys();
+        var org = OrganizationSeeder.Create(
+            name, domain, seats: 10, context.GetMangler(),
+            orgKeys.PublicKey, orgKeys.PrivateKey, PlanType.EnterpriseAnnually);
+        context.Organization = org;
+        context.OrgKeys = orgKeys;
+        context.Domain = domain;
+        context.Organizations.Add(org);
+    }
+
+    internal sealed class StubSeedReader : ISeedReader
+    {
+        private readonly Dictionary<string, object> _seeds = new();
+
+        public StubSeedReader Add<T>(string name, T value)
+        {
+            _seeds[name] = value!;
+            return this;
+        }
+
+        public T Read<T>(string seedName) => (T)_seeds[seedName];
+
+        public IReadOnlyList<string> ListAvailable() => _seeds.Keys.ToArray();
+    }
+}

--- a/test/SeederApi.IntegrationTest/packages.lock.json
+++ b/test/SeederApi.IntegrationTest/packages.lock.json
@@ -238,6 +238,11 @@
         "resolved": "5.1.1",
         "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g=="
       },
+      "CommandDotNet": {
+        "type": "Transitive",
+        "resolved": "7.0.5",
+        "contentHash": "ylfToPNWZLw29qe1NCI6Rc7ixWp3MzKNqmMwERBnfB2iS8U4QI9mgV3Zrj3/ZbIWBhJAZlOwDIR66nGFPggAvg=="
+      },
       "CsvHelper": {
         "type": "Transitive",
         "resolved": "33.1.0",
@@ -1085,6 +1090,19 @@
           "Serilog.Sinks.File": "3.2.0"
         }
       },
+      "Spectre.Console": {
+        "type": "Transitive",
+        "resolved": "0.55.2",
+        "contentHash": "yc0g12YJpmZHofGJLTQX02/uqfzJ6XHRx6pe9rANNjleQptXMHPxD9KI2/DWkXiJWddc+4oizEdGox15c89hhw==",
+        "dependencies": {
+          "Spectre.Console.Ansi": "0.55.2"
+        }
+      },
+      "Spectre.Console.Ansi": {
+        "type": "Transitive",
+        "resolved": "0.55.2",
+        "contentHash": "tN3KEJQQZwLW9HJnG5YTSAxfBwxsmg1wVuGvhGG2rM+pbl+NGaHU8pDcNofPlOXlgpkbpBMxI5t9o9qPfy3sHQ=="
+      },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
         "resolved": "2.1.6",
@@ -1408,6 +1426,14 @@
           "Core": "[2026.6.1, )",
           "Seeder": "[2026.6.1, )",
           "SharedWeb": "[2026.6.1, )"
+        }
+      },
+      "seederutility": {
+        "type": "Project",
+        "dependencies": {
+          "CommandDotNet": "[7.0.5, 7.0.5]",
+          "Seeder": "[2026.6.1, )",
+          "Spectre.Console": "[0.55.2, 0.55.2]"
         }
       },
       "sharedweb": {

--- a/util/Seeder/Options/OrganizationVaultOptions.cs
+++ b/util/Seeder/Options/OrganizationVaultOptions.cs
@@ -106,6 +106,12 @@ public class OrganizationVaultOptions
     public string? Password { get; init; }
 
     /// <summary>
+    /// Override email for the organization owner. When null, defaults to <c>owner@&lt;Domain&gt;</c>.
+    /// Passed through the mangler, so <c>--mangle</c> applies a unique prefix when enabled.
+    /// </summary>
+    public string? OwnerEmail { get; init; }
+
+    /// <summary>
     /// Billing plan type for the organization.
     /// </summary>
     public PlanType PlanType { get; init; } = PlanType.EnterpriseAnnually;

--- a/util/Seeder/Pipeline/RecipeOrchestrator.cs
+++ b/util/Seeder/Pipeline/RecipeOrchestrator.cs
@@ -16,12 +16,21 @@ internal sealed class RecipeOrchestrator(SeederDependencies deps)
     /// <param name="presetName">Name of the embedded preset (e.g., "dunder-mifflin-full")</param>
     /// <param name="password">Optional password for all seeded accounts</param>
     /// <param name="kdfIterations">Optional KDF iteration count. Defaults to 5,000 for fast seeding.</param>
+    /// <param name="orgNameOverride">Optional organization name. Replaces the fixture/preset-supplied name when provided.</param>
+    /// <param name="ownerEmailOverride">Optional owner email. Replaces the default <c>owner@&lt;domain&gt;</c> when provided.</param>
     /// <returns>Execution result with organization ID and entity counts</returns>
     internal PipelineExecutionResult Execute(
         string presetName,
         string? password = null,
-        int? kdfIterations = null)
+        int? kdfIterations = null,
+        string? orgNameOverride = null,
+        string? ownerEmailOverride = null)
     {
+        EnsureOwnerEmailUnique(
+            ownerEmailOverride,
+            deps.ManglerService.IsEnabled,
+            email => deps.Db.Users.Any(u => u.Email == email));
+
         var reader = new SeedReader();
 
         // Read preset to extract kdfIterations before building services.
@@ -33,7 +42,7 @@ internal sealed class RecipeOrchestrator(SeederDependencies deps)
         services.AddSingleton(deps.PasswordHasher);
         services.AddSingleton(deps.ManglerService);
         services.AddSingleton<ISeedReader>(reader);
-        services.AddSingleton(new SeederSettings(password, effectiveKdf));
+        services.AddSingleton(new SeederSettings(password, effectiveKdf, orgNameOverride, ownerEmailOverride));
         services.AddSingleton(deps.Db);
         if (deps.Progress is not null)
         {
@@ -50,10 +59,19 @@ internal sealed class RecipeOrchestrator(SeederDependencies deps)
     /// </summary>
     internal PipelineExecutionResult Execute(OrganizationVaultOptions options)
     {
+        EnsureOwnerEmailUnique(
+            options.OwnerEmail,
+            deps.ManglerService.IsEnabled,
+            email => deps.Db.Users.Any(u => u.Email == email));
+
         var services = new ServiceCollection();
         services.AddSingleton(deps.PasswordHasher);
         services.AddSingleton(deps.ManglerService);
-        services.AddSingleton(new SeederSettings(options.Password, options.KdfIterations));
+        services.AddSingleton(new SeederSettings(
+            options.Password,
+            options.KdfIterations,
+            OrgNameOverride: null,
+            OwnerEmailOverride: options.OwnerEmail));
         if (deps.Progress is not null)
         {
             services.AddSingleton(deps.Progress);
@@ -149,4 +167,29 @@ internal sealed class RecipeOrchestrator(SeederDependencies deps)
         return executor.Execute();
     }
 
+    /// <summary>
+    /// Fails fast when <c>--owner-email</c> resolves to a User.Email that already exists, producing an
+    /// actionable error instead of a SQL unique-constraint exception from the BulkCommitter.
+    /// </summary>
+    /// <remarks>
+    /// Skipped when mangling is enabled — the mangler prepends a per-run unique tag, so collisions are
+    /// effectively impossible regardless of the override value.
+    /// </remarks>
+    internal static void EnsureOwnerEmailUnique(
+        string? ownerEmailOverride,
+        bool manglingEnabled,
+        Func<string, bool> userExists)
+    {
+        if (manglingEnabled || string.IsNullOrWhiteSpace(ownerEmailOverride))
+        {
+            return;
+        }
+
+        if (userExists(ownerEmailOverride))
+        {
+            throw new InvalidOperationException(
+                $"A User with email '{ownerEmailOverride}' already exists in the database. " +
+                "Choose a different --owner-email, delete the existing user, or add --mangle for test isolation.");
+        }
+    }
 }

--- a/util/Seeder/Pipeline/SeederContextExtensions.cs
+++ b/util/Seeder/Pipeline/SeederContextExtensions.cs
@@ -29,6 +29,12 @@ internal static class SeederContextExtensions
     internal static int GetKdfIterations(this SeederContext context) =>
         context.GetSettings().KdfIterations;
 
+    internal static string? GetOrgNameOverride(this SeederContext context) =>
+        context.GetSettings().OrgNameOverride;
+
+    internal static string? GetOwnerEmailOverride(this SeederContext context) =>
+        context.GetSettings().OwnerEmailOverride;
+
     /// <summary>
     /// Resolves the optional progress reporter. Returns null when no UI is attached.
     /// Callers should null-check before constructing events to keep the no-reporter path allocation-free.
@@ -40,4 +46,12 @@ internal static class SeederContextExtensions
 /// <summary>
 /// Runtime settings for a seeding operation, registered in DI.
 /// </summary>
-internal sealed record SeederSettings(string? Password = null, int KdfIterations = 5_000);
+/// <param name="Password">Override for all seeded account passwords. Null falls back to <see cref="Factories.UserSeeder.DefaultPassword"/>.</param>
+/// <param name="KdfIterations">KDF iteration count for all seeded users.</param>
+/// <param name="OrgNameOverride">When set, replaces the fixture/preset-supplied organization name before the mangler runs. Literal without <c>--mangle</c>; gets a unique prefix (e.g. <c>abc12345-MyOrg</c>) with it.</param>
+/// <param name="OwnerEmailOverride">When set, replaces the default <c>owner@&lt;domain&gt;</c> owner email before the mangler runs. Literal without <c>--mangle</c>; with mangling the email becomes <c>&lt;mangleId&gt;+&lt;local&gt;@&lt;domain&gt;</c> — note this is a structurally distinct mailbox, not standard plus-addressing (which would strip the suffix back to the original).</param>
+internal sealed record SeederSettings(
+    string? Password = null,
+    int KdfIterations = 5_000,
+    string? OrgNameOverride = null,
+    string? OwnerEmailOverride = null);

--- a/util/Seeder/Recipes/OrganizationRecipe.cs
+++ b/util/Seeder/Recipes/OrganizationRecipe.cs
@@ -22,10 +22,17 @@ public class OrganizationRecipe(SeederDependencies deps)
     /// <param name="presetName">Name of the embedded preset (e.g., "dunder-mifflin-full")</param>
     /// <param name="password">Optional password for all seeded accounts</param>
     /// <param name="kdfIterations">Optional KDF iteration count override</param>
+    /// <param name="orgName">Optional organization name override. Replaces the preset/fixture name when provided.</param>
+    /// <param name="ownerEmail">Optional owner email override. Replaces the default <c>owner@&lt;domain&gt;</c> when provided.</param>
     /// <returns>The organization ID and summary statistics.</returns>
-    public OrganizationSeedResult Seed(string presetName, string? password = null, int? kdfIterations = null)
+    public OrganizationSeedResult Seed(
+        string presetName,
+        string? password = null,
+        int? kdfIterations = null,
+        string? orgName = null,
+        string? ownerEmail = null)
     {
-        var result = _orchestrator.Execute(presetName, password, kdfIterations);
+        var result = _orchestrator.Execute(presetName, password, kdfIterations, orgName, ownerEmail);
 
         if (result.OrganizationId is null)
         {

--- a/util/Seeder/Steps/CreateOrganizationStep.cs
+++ b/util/Seeder/Steps/CreateOrganizationStep.cs
@@ -72,6 +72,12 @@ internal sealed class CreateOrganizationStep : IStep
             domain = _domain!;
         }
 
+        var nameOverride = context.GetOrgNameOverride();
+        if (!string.IsNullOrWhiteSpace(nameOverride))
+        {
+            name = nameOverride;
+        }
+
         var seats = _seats ?? PlanFeatures.GenerateRealisticSeatCount(_planType, domain);
         var orgKeys = RustSdkService.GenerateOrganizationKeys();
         var organization = OrganizationSeeder.Create(name, domain, seats, context.GetMangler(), orgKeys.PublicKey, orgKeys.PrivateKey, _planType);

--- a/util/Seeder/Steps/CreateOwnerStep.cs
+++ b/util/Seeder/Steps/CreateOwnerStep.cs
@@ -15,7 +15,10 @@ internal sealed class CreateOwnerStep : IStep
         var org = context.RequireOrganization();
         var password = context.GetPassword();
         var kdfIterations = context.GetKdfIterations();
-        var ownerEmail = context.GetMangler().Mangle($"owner@{context.RequireDomain()}");
+        var emailOverride = context.GetOwnerEmailOverride();
+        var ownerEmail = !string.IsNullOrWhiteSpace(emailOverride)
+            ? context.GetMangler().Mangle(emailOverride)
+            : context.GetMangler().Mangle($"owner@{context.RequireDomain()}");
         var userKeys = RustSdkService.GenerateUserKeys(ownerEmail, password, kdfIterations, poolIndex: 0);
         var (owner, _) = UserSeeder.Create(ownerEmail, context.GetPasswordHasher(), context.GetMangler(), keys: userKeys, password: password, kdfIterations: kdfIterations);
 

--- a/util/Seeder/Steps/CreateRosterStep.cs
+++ b/util/Seeder/Steps/CreateRosterStep.cs
@@ -24,6 +24,8 @@ internal sealed class CreateRosterStep(string fixtureName) : IStep
         var userLookup = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase);
         var emailPrefixes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+        var ownerEmailOverride = context.GetOwnerEmailOverride();
+
         var rosterIndex = 0;
         foreach (var rosterUser in roster.Users)
         {
@@ -36,13 +38,21 @@ internal sealed class CreateRosterStep(string fixtureName) : IStep
                     "Each user must have a unique FirstName.LastName combination.");
             }
 
-            var email = $"{emailPrefix}@{domain}";
+            var orgUserType = ParseRole(rosterUser.Role);
+
+            // Apply --owner-email override to the first owner-role user in the roster.
+            // Roster references (groups, collections) still resolve by FirstName.LastName prefix, so only the
+            // stored email changes; downstream lookups continue to work.
+            var useOwnerOverride = orgUserType == OrganizationUserType.Owner
+                && context.Owner is null
+                && !string.IsNullOrWhiteSpace(ownerEmailOverride);
+            var email = useOwnerOverride ? ownerEmailOverride! : $"{emailPrefix}@{domain}";
+
             var mangledEmail = context.GetMangler().Mangle(email);
             var password = context.GetPassword();
             var userKeys = RustSdkService.GenerateUserKeys(mangledEmail, password, kdfIterations, (uint)rosterIndex++);
             var (user, _) = UserSeeder.Create(mangledEmail, context.GetPasswordHasher(), context.GetMangler(), keys: userKeys, password: password, kdfIterations: kdfIterations);
             var userOrgKey = RustSdkService.GenerateUserOrganizationKey(user.PublicKey!, orgKey);
-            var orgUserType = ParseRole(rosterUser.Role);
             var orgUser = org.CreateOrganizationUserWithKey(
                 user, orgUserType, OrganizationUserStatusType.Confirmed, userOrgKey);
 

--- a/util/SeederUtility/Commands/OrganizationArgs.cs
+++ b/util/SeederUtility/Commands/OrganizationArgs.cs
@@ -51,6 +51,9 @@ public class OrganizationArgs : IArgumentModel
     [Option("password", Description = "Password for all seeded accounts (default: asdfasdfasdf)")]
     public string? Password { get; set; }
 
+    [Option("owner-email", Description = "Override the organization owner email (default: owner@<domain>). Must not already exist in the User table; add --mangle to make repeat runs unique.")]
+    public string? OwnerEmail { get; set; }
+
     [Option("plan-type", Description = "Billing plan type: free, teams-monthly, teams-annually, enterprise-monthly, enterprise-annually, teams-starter, families-annually. Defaults to enterprise-annually.")]
     public string PlanType { get; set; } = "enterprise-annually";
 
@@ -105,6 +108,11 @@ public class OrganizationArgs : IArgumentModel
         {
             throw new ArgumentException("KDF iterations must be at least 5,000.");
         }
+
+        if (!string.IsNullOrWhiteSpace(OwnerEmail) && !OwnerEmail.Contains('@'))
+        {
+            throw new ArgumentException("--owner-email must be a valid email address (must contain '@').");
+        }
     }
 
     public OrganizationVaultOptions ToOptions() => new()
@@ -121,6 +129,7 @@ public class OrganizationArgs : IArgumentModel
         Region = ParseGeographicRegion(Region),
         Density = DensityProfiles.Parse(Density),
         Password = Password,
+        OwnerEmail = OwnerEmail,
         PlanType = PlanFeatures.Parse(PlanType),
         KdfIterations = KdfIterations,
         Overrides = new()

--- a/util/SeederUtility/Commands/PresetArgs.cs
+++ b/util/SeederUtility/Commands/PresetArgs.cs
@@ -28,6 +28,12 @@ public class PresetArgs : IArgumentModel
     [Option("password", Description = "Password for all seeded accounts (default: asdfasdfasdf)")]
     public string? Password { get; set; }
 
+    [Option("org-name", Description = "Override the organization display name from the preset/fixture")]
+    public string? OrgName { get; set; }
+
+    [Option("owner-email", Description = "Override the organization owner email (default: owner@<preset-domain>). Must not already exist in the User table; add --mangle to make repeat runs unique.")]
+    public string? OwnerEmail { get; set; }
+
     [Option("kdf-iterations", Description = "KDF iteration count for all seeded users. Overrides the preset value if specified. Use 600000 for production-realistic e2e testing.")]
     public int? KdfIterations { get; set; }
 
@@ -52,6 +58,11 @@ public class PresetArgs : IArgumentModel
         if (KdfIterations.HasValue && KdfIterations.Value < 5_000)
         {
             throw new ArgumentException("KDF iterations must be at least 5,000.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(OwnerEmail) && !OwnerEmail.Contains('@'))
+        {
+            throw new ArgumentException("--owner-email must be a valid email address (must contain '@').");
         }
     }
 }

--- a/util/SeederUtility/Commands/PresetCommand.cs
+++ b/util/SeederUtility/Commands/PresetCommand.cs
@@ -46,7 +46,7 @@ public class PresetCommand
         Console.Error.WriteLine($"Seeding organization from preset '{args.Name}'...");
         var result = ConsoleProgressReporter.RunWithProgress(
             deps.ToDependencies(),
-            d => new OrganizationRecipe(d).Seed(args.Name!, args.Password, args.KdfIterations));
+            d => new OrganizationRecipe(d).Seed(args.Name!, args.Password, args.KdfIterations, args.OrgName, args.OwnerEmail));
 
         ConsoleOutput.PrintRow("Organization", result.OrganizationId);
         if (result.OwnerEmail is not null)


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
n/a

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add --owner-email and --org-name overrides to the seeder CLI (originally motivated by needing a known owner email for enterprise SSO testing) with a pre-flight collision check.

## Detailed Changes

<details>
<summary>Library plumbing — overrides + pre-flight guard</summary>

**`util/Seeder/Options/OrganizationVaultOptions.cs`**
1. Added `OwnerEmail` init-only property so the `organization` CLI command can forward an owner-email override through to the orchestrator.

**`util/Seeder/Pipeline/SeederContextExtensions.cs`**
1. Extended the `SeederSettings` record with `OrgNameOverride` and `OwnerEmailOverride` so override values can flow from the CLI through DI to any step.
2. Added `GetOrgNameOverride()` / `GetOwnerEmailOverride()` extension methods on `SeederContext` so steps can read the overrides without coupling to `SeederSettings` directly.
3. Updated the xmldoc to describe the mangling interaction precisely — values are literal without `--mangle` and get a unique prefix (`{mangleId}+local@domain`) when mangled; explicitly notes this is *not* standard plus-addressing routing.

**`util/Seeder/Pipeline/RecipeOrchestrator.cs`**
1. Added `orgNameOverride` and `ownerEmailOverride` parameters to the preset `Execute` overload and threaded both into `SeederSettings` registered in DI.
2. Mapped `OrganizationVaultOptions.OwnerEmail` into `SeederSettings.OwnerEmailOverride` on the options `Execute` overload so the `organization` command path picks up the override.
3. Added a new `EnsureOwnerEmailUnique` static helper that throws `InvalidOperationException` when `--owner-email` collides with an existing `User.Email`, replacing the previous deep SQL unique-constraint failure with an actionable message that names the email and points at `--mangle`.
4. Invoked the guard as the *first* statement in both `Execute` overloads, before any crypto, preset reads, or DI setup — fails fast and avoids wasted work.
5. Guard short-circuits when mangling is enabled or the override is null/whitespace, since the mangler's per-run tag already guarantees uniqueness in those cases.

**`util/Seeder/Recipes/OrganizationRecipe.cs`**
1. Extended `Seed(presetName, ...)` with optional `orgName` and `ownerEmail` parameters and forwarded them to the orchestrator.

**`util/Seeder/Steps/CreateOrganizationStep.cs`**
1. After resolving the org name from a fixture or params, replaces it with `SeederSettings.OrgNameOverride` when set — guarded by `IsNullOrWhiteSpace` so empty/whitespace overrides fall through to the original name.

**`util/Seeder/Steps/CreateOwnerStep.cs`**
1. Reads `SeederSettings.OwnerEmailOverride` and uses it (instead of the default `owner@<domain>`) when constructing the owner user.
2. Override still flows through the mangler so `--mangle` interaction stays consistent with the rest of the seeder.

**`util/Seeder/Steps/CreateRosterStep.cs`**
1. Applies `SeederSettings.OwnerEmailOverride` to the *first* roster user with `role: "owner"` — covers the case where presets with a roster-declared owner bypass `CreateOwnerStep` entirely (this was the mid-development bug surfaced during e2e testing).
2. Non-owner roster users keep their `firstname.lastname@domain` email pattern, and group/collection lookups continue to resolve by `FirstName.LastName` prefix so membership stays intact.

</details>

<details>
<summary>CLI surface — new override flags</summary>

**`util/SeederUtility/Commands/PresetArgs.cs`**
1. Added `--org-name` flag for overriding the preset/fixture organization name.
2. Added `--owner-email` flag for overriding the default owner email; help text calls out the `User.Email` uniqueness constraint and points at `--mangle` for repeat runs.
3. Added validation rejecting `--owner-email` values that don't contain `@`, matching the existing arg-validation style.

**`util/SeederUtility/Commands/OrganizationArgs.cs`**
1. Added `--owner-email` flag (org name is already controllable via `-n`) with the same uniqueness-aware help text.
2. Added the same `@`-presence validation as `PresetArgs`.
3. Wired `OwnerEmail` into `ToOptions()` so it lands on `OrganizationVaultOptions.OwnerEmail`.

**`util/SeederUtility/Commands/PresetCommand.cs`**
1. Forwarded `args.OrgName` and `args.OwnerEmail` to `OrganizationRecipe.Seed(...)` so the preset path picks up the overrides.

</details>

<details>
<summary>Tests — new structure under test/SeederApi.IntegrationTest</summary>

**`test/SeederApi.IntegrationTest/Cli/PresetArgsTests.cs`** *(new)*
1. Theory rejecting `--owner-email` values without `@`.
2. Theory accepting valid emails plus null/empty/whitespace values (treated as not provided).
3. Fact confirming `--org-name` is unvalidated and accepts arbitrary strings.

**`test/SeederApi.IntegrationTest/Cli/OrganizationArgsTests.cs`** *(new)*
1. Theories mirroring `PresetArgs` for `--owner-email` validation.
2. Fact confirming `ToOptions()` propagates `OwnerEmail` to `OrganizationVaultOptions`.
3. Fact confirming null `OwnerEmail` stays null in `ToOptions()`.

**`test/SeederApi.IntegrationTest/Pipeline/SeederSettingsTests.cs`** *(new)*
1. Default `SeederSettings` has null `OrgNameOverride` and `OwnerEmailOverride`.
2. `SeederContext` extension getters return the configured overrides from DI.
3. Extension getters return null when overrides are unset.

**`test/SeederApi.IntegrationTest/Pipeline/RecipeOrchestratorTests.cs`** *(new)*
1. Theory verifying `EnsureOwnerEmailUnique` skips the existence predicate entirely for null/empty/whitespace overrides.
2. Fact verifying the predicate is skipped when mangling is enabled, regardless of override value.
3. Fact verifying no throw when the predicate reports no collision.
4. Fact verifying `InvalidOperationException` with the override email + `--mangle` hint when the predicate reports a collision.
5. Fact verifying the predicate receives the override email verbatim.

**`test/SeederApi.IntegrationTest/Pipeline/RecipeOrchestratorIntegrationTests.cs`** *(new)*
1. SQLite-backed `IDisposable` fixture wires a real `DatabaseContext` plus `IDataProtectionProvider` (required by `OnModelCreating` for User field converters).
2. Fact proving the preset `Execute` overload invokes the guard against a real DB and throws when a colliding `User.Email` exists.
3. Fact proving the options `Execute` overload (used by the `organization` command) invokes the guard the same way — regression protection against silently removing the call from one overload.
4. Fact proving `--mangle` short-circuits the guard end-to-end: with mangling on plus a colliding email, execution reaches `SeedReader` and fails with a "not found" message rather than the guard's "already exists" message.
5. Uses `null!` for `IMapper` in `SeederDependencies` since the guard fires before any AutoMapper usage; documented in the test as a deliberate regression-trip if the guard ever stops being first.

**`test/SeederApi.IntegrationTest/Steps/SeederStepTestHelpers.cs`** *(new)*
1. Shared harness exposing `NewContext` (default `NoOpManglerService`) and `NewContextWithMangler` (custom `IManglerService`) so step tests can opt into mangling.
2. `PreloadOrganization` helper that wires a real Rust SDK-keyed org into the context for steps that require one.
3. `StubSeedReader` for tests that need to feed a `SeedRoster` or `SeedOrganization` to `ISeedReader` without filesystem/embedded-resource setup.

**`test/SeederApi.IntegrationTest/Steps/CreateOrganizationStepTests.cs`** *(new)*
1. Default (no override) keeps the fixture/param name.
2. Override replaces the name from `FromParams`.
3. Whitespace override is ignored — falls back to the fixture/param name.
4. Override replaces the fixture-supplied name when using `FromFixture`.

**`test/SeederApi.IntegrationTest/Steps/CreateOwnerStepTests.cs`** *(new)*
1. Default owner email is `owner@<domain>` when no override is set.
2. Override replaces the owner email.
3. With mangling enabled, the override is mangled to `{8hex}+local@domain` form rather than stored literal.
4. Baseline: with mangling enabled and no override, the default `owner@<domain>` still gets mangled.
5. `OwnerOrgUser` is linked to the org as `OrganizationUserType.Owner` with `Confirmed` status regardless of override path.

**`test/SeederApi.IntegrationTest/Steps/CreateRosterStepTests.cs`** *(new)*
1. Without override, the first owner-role roster user gets `firstname.lastname@domain`.
2. With override, the first owner-role roster user gets the override email.
3. With override, non-owner users keep `firstname.lastname@domain` — only the owner is substituted.
4. With override, group membership resolves correctly: `Everyone` group still contains both users because lookups key by `FirstName.LastName` prefix, not by email.
5. With override and *two* owner-role users in the roster, only the first one receives the override; the second falls back to `firstname.lastname@domain`.
6. With override + mangling enabled, the owner email becomes `{8hex}+override@domain` and non-owner users get `{8hex}+prefix@domain`.

</details>

<details>
<summary>Build configuration</summary>

**`test/SeederApi.IntegrationTest/SeederApi.IntegrationTest.csproj`**
1. Added `ProjectReference` to `util/SeederUtility` so the new `Cli/*` tests can construct `PresetArgs`/`OrganizationArgs` directly and exercise `Validate()` / `ToOptions()`.

**`test/SeederApi.IntegrationTest/packages.lock.json`**
1. Lock file auto-updated to reflect the new transitive dependency on `CommandDotNet` introduced by the `SeederUtility` project reference; the CLI parser is not invoked at test time — only the `[Option]` attributes on the args classes are touched.

</details>


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
n/a my test after the changes worked though
