### PR TITLE
Seeder: fix RecipeOrchestratorIntegrationTests build after SeederDependencies arity change

### DIFF
--- a/test/SeederApi.IntegrationTest/Pipeline/RecipeOrchestratorIntegrationTests.cs
+++ b/test/SeederApi.IntegrationTest/Pipeline/RecipeOrchestratorIntegrationTests.cs
@@ -116,7 +116,7 @@ public sealed class RecipeOrchestratorIntegrationTests : IDisposable
 
     private RecipeOrchestrator NewOrchestrator(IManglerService mangler)
     {
-        // Mapper + PasswordHasher are not exercised by the pre-flight guard,
+        // Mapper + LicensingService are not exercised by the pre-flight guard,
         // which fires before BulkCommitter or any AutoMapper usage. Null-forgive
         // them; if the guard ever stops being the first thing in Execute, these
         // tests will fail loudly.
@@ -124,7 +124,8 @@ public sealed class RecipeOrchestratorIntegrationTests : IDisposable
             _db,
             null!,
             new PasswordHasher<User>(),
-            mangler);
+            mangler,
+            null!);
         return new RecipeOrchestrator(deps);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
Fixes main after PR #7780 broke tests. 


## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
SeederDependencies gained a 5th ILicensingService parameter before PR #7870 merged; the new integration test file still used the 4-arg ctor, breaking the main build. Pass null! for LicensingService alongside Mapper - neither is touched by the pre-flight guard these tests exercise.


## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
n/a