### PR TITLE
[PM-39789] fix: allow SCIM POST to create users disabled in the IdP

### DIFF
--- a/bitwarden_license/src/Scim/Users/PostUserCommand.cs
+++ b/bitwarden_license/src/Scim/Users/PostUserCommand.cs
@@ -94,7 +94,7 @@ public class PostUserCommand(
         var email = invite.Emails.Single();
         var externalId = model.ExternalIdForInvite();
 
-        if (string.IsNullOrWhiteSpace(email) || !model.Active)
+        if (string.IsNullOrWhiteSpace(email))
         {
             throw new BadRequestException();
         }


### PR DESCRIPTION
## 📔 Objective

Remove the `!model.Active` condition from the legacy InviteScimOrganizationUserAsync in PostUserCommand.cs. Previously a SCIM POST /Users with `active: false` was rejected with a 400, so accounts disabled in the IdP (e.g. staged onboarding or intentionally inactive shared accounts) could never be created in the organization.

Our provisioning process requires support for accounts that are pre-created in a disabled state (for example, users staged ahead of onboarding). These accounts need to exist in Bitwarden so they can be activated later. Additionally, the BadRequestException() makes it harder to identify real provisioning issues.

## 📸 Screenshots

N/A
